### PR TITLE
[8.19] [Discover] Implementing click action for Stacktrace and Degraded Fields on Discover (#214413)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/degraded_logs.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/degraded_logs.ts
@@ -17,6 +17,7 @@ import {
   getCloudRegion,
   getCloudProvider,
   MORE_THAN_1024_CHARS,
+  STACKTRACE_MESSAGE,
 } from './helpers/logs_mock_data';
 import { parseLogsScenarioOpts } from './helpers/logs_scenario_opts_parser';
 
@@ -125,6 +126,7 @@ const scenario: Scenario<LogDocument> = async (runOptions) => {
             'cloud.availability_zone': isMalformed
               ? MORE_THAN_1024_CHARS // "ignore_above": 1024 in mapping
               : `${cloudRegion}a`,
+            'error.stack_trace': isMalformed ? STACKTRACE_MESSAGE : undefined,
           })
           .timestamp(timestamp);
       };

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/helpers/logs_mock_data.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/helpers/logs_mock_data.ts
@@ -432,3 +432,24 @@ export const getWebLogs = () => {
     return `${ipv4()} - - [${moment().toISOString()}] "${httpMethod()} ${path} HTTP/1.1" ${httpStatusCode()} ${bytes} "-" "${userAgent()}"`;
   });
 };
+
+export const STACKTRACE_MESSAGE =
+  "Error: 9 FAILED_PRECONDITION: Can't access cart storage. StackExchange.Redis.RedisTimeoutException: Timeout awaiting response (outbound=0KiB, inbound=0KiB, 5467ms elapsed, timeout is 5000ms), command=HGET, next: HGET 7578fdf6-e0b1-4b60-98b3-6751dadffd01, inst: 0, qu: 0, qs: 5, aw: False, bw: SpinningDown, rs: ReadAsync, ws: Idle, in: 377, in-pipe: 0, out-pipe: 0, last-in: 0, cur-in: 0, sync-ops: 2, async-ops: 1653332, serverEndpoint: valkey:6379, conn-sec: 1292697.71, aoc: 0, mc: 1/1/0, mgr: 10 of 10 available, clientName: cartservice-6558778458-4df9q(SE.Redis-v2.8.16.12844), IOCP: (Busy=0,Free=1000,Min=1,Max=1000), WORKER: (Busy=6,Free=32761,Min=2,Max=32767), POOL: (Threads=6,QueuedItems=7,CompletedItems=28329470,Timers=8), v: 2.8.16.12844 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)\n" +
+  '   at cartservice.cartstore.ValkeyCartStore.AddItemAsync(String userId, String productId, Int32 quantity) in /usr/src/app/src/cartstore/ValkeyCartStore.cs:line 117\n' +
+  '    at callErrorFromStatus (/app/node_modules/@grpc/grpc-js/build/src/call.js:31:19)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client.js:193:76)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:360:141)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:323:181)\n' +
+  '    at /app/node_modules/@grpc/grpc-js/build/src/resolving-call.js:129:78\n' +
+  '    at process.processTicksAndRejections (node:internal/process/task_queues:77:11)\n' +
+  'for call at\n' +
+  '    at ServiceClientImpl.makeUnaryRequest (/app/node_modules/@grpc/grpc-js/build/src/client.js:161:32)\n' +
+  '    at ServiceClientImpl.<anonymous> (/app/node_modules/@grpc/grpc-js/build/src/make-client.js:105:19)\n' +
+  '    at /app/node_modules/@opentelemetry/instrumentation-grpc/build/src/clientUtils.js:131:31\n' +
+  '    at /app/node_modules/@opentelemetry/instrumentation-grpc/build/src/instrumentation.js:211:209\n' +
+  '    at AsyncLocalStorage.run (node:async_hooks:346:14)\n' +
+  '    at AsyncLocalStorageContextManager.with (/app/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\n' +
+  '    at ContextAPI.with (/app/node_modules/@opentelemetry/api/build/src/api/context.js:60:46)\n' +
+  '    at ServiceClientImpl.clientMethodTrace [as addItem] (/app/node_modules/@opentelemetry/instrumentation-grpc/build/src/instrumentation.js:211:42)\n' +
+  '    at /app/.next/server/pages/api/cart.js:1:1101\n' +
+  '    at new ZoneAwarePromise (/app/node_modules/zone.js/bundles/zone.umd.js:1340:33)';

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/test_subjects.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/test_subjects.ts
@@ -428,4 +428,18 @@ export class TestSubjects extends FtrService {
       await this.click(selector);
     }
   }
+
+  public async getAccordionState(selector: string) {
+    const container = await this.find(selector);
+    const buttons = await container.findAllByCssSelector('button');
+
+    if (buttons.length > 0) {
+      const firstButton = buttons[0];
+      return await firstButton.getAttribute('aria-expanded');
+    } else {
+      throw new Error(
+        `Container '${selector}' has no 'button' child elements, check for EUI upgrades`
+      );
+    }
+  }
 }

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -192,7 +192,7 @@ export interface UnifiedDataTableProps {
   /**
    * Function to set the expanded document, which is displayed in a flyout
    */
-  setExpandedDoc?: (doc?: DataTableRecord) => void;
+  setExpandedDoc?: (doc?: DataTableRecord, options?: { initialTabId?: string }) => void;
   /**
    * Grid display settings persisted in Elasticsearch (e.g. column width)
    */

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/index.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/index.ts
@@ -7,4 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { DocViewer, DocViewsRegistry, ElasticRequestState, FieldName } from './src';
+export {
+  DocViewer,
+  type DocViewerProps,
+  type DocViewerApi,
+  DocViewsRegistry,
+  ElasticRequestState,
+  FieldName,
+} from './src';

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
@@ -134,4 +134,26 @@ describe('<DocViewer />', () => {
 
     mockTestInitialLocalStorageValue = undefined;
   });
+
+  test('should render if a specific tab is passed as prop', () => {
+    const initialTabId = 'test2';
+
+    const registry = new DocViewsRegistry();
+    registry.add({ id: 'test1', order: 10, title: 'Render 1st Tab', render: jest.fn() });
+    registry.add({ id: initialTabId, order: 20, title: 'Render 2nd Tab', render: jest.fn() });
+    registry.add({ id: 'test3', order: 30, title: 'Render 3rd Tab', render: jest.fn() });
+
+    render(
+      <DocViewer
+        docViews={registry.getAll()}
+        initialTabId={initialTabId}
+        hit={records[0]}
+        dataView={dataViewMock}
+      />
+    );
+
+    expect(screen.getByTestId('docViewerTab-test1').getAttribute('aria-selected')).toBe('false');
+    expect(screen.getByTestId('docViewerTab-test2').getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByTestId('docViewerTab-test3').getAttribute('aria-selected')).toBe('false');
+  });
 });

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
 import { EuiTabbedContent, EuiTabbedContentTab } from '@elastic/eui';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { DocViewerTab } from './doc_viewer_tab';
@@ -15,9 +15,16 @@ import type { DocView, DocViewRenderProps } from '../../types';
 
 export const INITIAL_TAB = 'unifiedDocViewer:initialTab';
 
-export interface DocViewerProps extends DocViewRenderProps {
-  docViews: DocView[];
+export interface DocViewerApi {
+  setSelectedTabId: (tabId: string) => void;
 }
+
+interface DocViewerInternalProps extends DocViewRenderProps {
+  docViews: DocView[];
+  initialTabId?: DocView['id'];
+}
+
+const getFullTabId = (tabId: string) => `kbn_doc_viewer_tab_${tabId}`;
 
 /**
  * Rendering tabs with different views of 1 Elasticsearch hit in Discover.
@@ -25,12 +32,12 @@ export interface DocViewerProps extends DocViewRenderProps {
  * A view can contain a React `component`, or any JS framework by using
  * a `render` function.
  */
-export function DocViewer({ docViews, ...renderProps }: DocViewerProps) {
-  const tabs = docViews
-    .filter(({ enabled }) => enabled) // Filter out disabled doc views
-    .map(({ id, title, render, component }: DocView) => {
-      return {
-        id: `kbn_doc_viewer_tab_${id}`, // `id` value is used to persist the selected tab in localStorage
+export const DocViewer = forwardRef<DocViewerApi, DocViewerInternalProps>(
+  ({ docViews, initialTabId, ...renderProps }, ref) => {
+    const tabs = docViews
+      .filter(({ enabled }) => enabled) // Filter out disabled doc views
+      .map(({ id, title, render, component }: DocView) => ({
+        id: getFullTabId(id), // `id` value is used to persist the selected tab in localStorage
         name: title,
         content: (
           <DocViewerTab
@@ -42,33 +49,45 @@ export function DocViewer({ docViews, ...renderProps }: DocViewerProps) {
           />
         ),
         ['data-test-subj']: `docViewerTab-${id}`,
-      };
-    });
+      }));
 
-  const [initialTabId, setInitialTabId] = useLocalStorage<string>(INITIAL_TAB);
-  const initialSelectedTab = initialTabId ? tabs.find(({ id }) => id === initialTabId) : undefined;
+    const [storedInitialTabId, setInitialTabId] = useLocalStorage<string>(INITIAL_TAB);
+    const [selectedTabId, setSelectedTabId] = useState<string | undefined>(
+      initialTabId ? getFullTabId(initialTabId) : storedInitialTabId
+    );
+    const selectedTab = selectedTabId ? tabs.find(({ id }) => id === selectedTabId) : undefined;
 
-  const onTabClick = useCallback(
-    (tab: EuiTabbedContentTab) => {
-      setInitialTabId(tab.id);
-    },
-    [setInitialTabId]
-  );
+    useImperativeHandle(
+      ref,
+      () => ({
+        setSelectedTabId: (tabId: string) => {
+          setSelectedTabId(getFullTabId(tabId));
+          setInitialTabId(getFullTabId(tabId)); // Persist the selected tab in localStorage
+        },
+      }),
+      [setInitialTabId]
+    );
 
-  if (!tabs.length) {
-    // There's a minimum of 2 tabs active in Discover.
-    // This condition takes care of unit tests with 0 tabs.
-    return null;
+    const onTabClick = useCallback(
+      (tab: EuiTabbedContentTab) => {
+        setSelectedTabId(tab.id);
+        setInitialTabId(tab.id); // Persist the selected tab in localStorage
+      },
+      [setInitialTabId]
+    );
+
+    if (!tabs.length) {
+      // There's a minimum of 2 tabs active in Discover.
+      // This condition takes care of unit tests with 0 tabs.
+      return null;
+    }
+
+    return (
+      <div className="kbnDocViewer" data-test-subj="kbnDocViewer">
+        <EuiTabbedContent size="s" tabs={tabs} selectedTab={selectedTab} onTabClick={onTabClick} />
+      </div>
+    );
   }
+);
 
-  return (
-    <div className="kbnDocViewer" data-test-subj="kbnDocViewer">
-      <EuiTabbedContent
-        size="s"
-        tabs={tabs}
-        initialSelectedTab={initialSelectedTab}
-        onTabClick={onTabClick}
-      />
-    </div>
-  );
-}
+export type DocViewerProps = Parameters<typeof DocViewer>[0];

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/index.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { DocViewer } from './doc_viewer';
+export { DocViewer, type DocViewerProps, type DocViewerApi } from './doc_viewer';

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
@@ -48,6 +48,7 @@ export interface DocViewRenderProps {
   onRemoveColumn?: (columnName: string) => void;
   docViewsRegistry?: DocViewsRegistry | ((prevRegistry: DocViewsRegistry) => DocViewsRegistry);
   decreaseAvailableHeightBy?: number;
+  initialTabId?: string;
 }
 export type DocViewerComponent = React.FC<DocViewRenderProps>;
 export type DocViewRenderFn = (

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/types.ts
@@ -8,4 +8,4 @@
  */
 
 export type { ElasticRequestState } from '.';
-export type { DocViewFilterFn, DocViewRenderProps, FieldRecordLegacy } from './src/types';
+export type { DocViewFilterFn, DocViewRenderProps, FieldRecordLegacy, DocView } from './src/types';

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo, useRef } from 'react';
 import {
   EuiFlexItem,
   EuiLoadingSpinner,
@@ -51,6 +51,7 @@ import useObservable from 'react-use/lib/useObservable';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { DiscoverGridSettings } from '@kbn/saved-search-plugin/common';
 import { useQuerySubscriber } from '@kbn/unified-field-list';
+import type { DocViewerApi } from '@kbn/unified-doc-viewer';
 import { DiscoverGrid } from '../../../../components/discover_grid';
 import { getDefaultRowsPerPage } from '../../../../../common/constants';
 import { useAppStateSelector } from '../../state_management/discover_app_state_container';
@@ -151,6 +152,7 @@ function DiscoverDocumentsComponent({
     ];
   });
   const expandedDoc = useInternalStateSelector((state) => state.expandedDoc);
+  const initialDocViewerTabId = useInternalStateSelector((state) => state.initialDocViewerTabId);
   const isEsqlMode = useIsEsqlMode();
   const useNewFieldsApi = useMemo(() => !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE), [uiSettings]);
   const hideAnnouncements = useMemo(() => uiSettings.get(HIDE_ANNOUNCEMENTS), [uiSettings]);
@@ -223,9 +225,18 @@ function DiscoverDocumentsComponent({
     [onRemoveColumn, ebtManager, fieldsMetadata]
   );
 
+  const docViewerRef = useRef<DocViewerApi>(null);
   const setExpandedDoc = useCallback(
-    (doc: DataTableRecord | undefined) => {
-      dispatch(internalStateActions.setExpandedDoc(doc));
+    (doc: DataTableRecord | undefined, options?: { initialTabId?: string }) => {
+      dispatch(
+        internalStateActions.setExpandedDoc({
+          expandedDoc: doc,
+          initialDocViewerTabId: options?.initialTabId,
+        })
+      );
+      if (options?.initialTabId) {
+        docViewerRef.current?.setSelectedTabId(options.initialTabId);
+      }
     },
     [dispatch]
   );
@@ -321,16 +332,19 @@ function DiscoverDocumentsComponent({
         onClose={() => setExpandedDoc(undefined)}
         setExpandedDoc={setExpandedDoc}
         query={query}
+        initialTabId={initialDocViewerTabId}
+        docViewerRef={docViewerRef}
       />
     ),
     [
       dataView,
-      onAddColumnWithTracking,
+      savedSearch.id,
       onAddFilter,
       onRemoveColumnWithTracking,
-      query,
-      savedSearch.id,
+      onAddColumnWithTracking,
       setExpandedDoc,
+      query,
+      initialDocViewerTabId,
     ]
   );
 

--- a/src/platform/plugins/shared/discover/public/application/main/hooks/use_inspector.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/hooks/use_inspector.test.tsx
@@ -31,7 +31,7 @@ describe('test useInspector', () => {
     const lensRequests = new RequestAdapter();
     const stateContainer = getDiscoverStateMock({ isTimeBased: true });
     stateContainer.internalState.dispatch(
-      internalStateActions.setExpandedDoc({} as unknown as DataTableRecord)
+      internalStateActions.setExpandedDoc({ expandedDoc: {} as unknown as DataTableRecord })
     );
     const { result } = renderHook(
       () => {

--- a/src/platform/plugins/shared/discover/public/application/main/hooks/use_inspector.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/hooks/use_inspector.ts
@@ -34,7 +34,7 @@ export function useInspector({
 
   const onOpenInspector = useCallback(() => {
     // prevent overlapping
-    dispatch(internalStateActions.setExpandedDoc(undefined));
+    dispatch(internalStateActions.setExpandedDoc({ expandedDoc: undefined }));
 
     const inspectorAdapters = stateContainer.dataState.inspectorAdapters;
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -64,8 +64,15 @@ export const internalStateSlice = createSlice({
       state.savedDataViews = action.payload;
     },
 
-    setExpandedDoc: (state, action: PayloadAction<DataTableRecord | undefined>) => {
-      state.expandedDoc = action.payload;
+    setExpandedDoc: (
+      state,
+      action: PayloadAction<{
+        expandedDoc: DataTableRecord | undefined;
+        initialDocViewerTabId?: string;
+      }>
+    ) => {
+      state.expandedDoc = action.payload.expandedDoc;
+      state.initialDocViewerTabId = action.payload.initialDocViewerTabId;
     },
 
     setCustomFilters: (state, action: PayloadAction<Filter[]>) => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -22,6 +22,7 @@ export interface DiscoverInternalState {
   savedDataViews: DataViewListItem[];
   defaultProfileAdHocDataViewIds: string[];
   expandedDoc: DataTableRecord | undefined;
+  initialDocViewerTabId?: string;
   customFilters: Filter[];
   dataRequestParams: InternalStateDataRequestParams;
   overriddenVisContextAfterInvalidation: UnifiedHistogramVisContext | {} | undefined; // it will be used during saved search saving

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/change_data_view.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/change_data_view.ts
@@ -83,7 +83,7 @@ export async function changeDataView({
     appState.update(nextAppState);
 
     if (internalState.getState().expandedDoc) {
-      internalState.dispatch(internalStateActions.setExpandedDoc(undefined));
+      internalState.dispatch(internalStateActions.setExpandedDoc({ expandedDoc: undefined }));
     }
   }
 

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -33,7 +33,7 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = ({
   rowAdditionalLeadingControls: customRowAdditionalLeadingControls,
   ...props
 }) => {
-  const { dataView } = props;
+  const { dataView, setExpandedDoc } = props;
   const getRowIndicatorProvider = useProfileAccessor('getRowIndicatorProvider');
   const getRowIndicator = useMemo(() => {
     return getRowIndicatorProvider(() => undefined)({ dataView: props.dataView });
@@ -47,6 +47,7 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = ({
       dataView,
       query,
       updateESQLQuery: onUpdateESQLQuery,
+      setExpandedDoc,
     });
   }, [
     customRowAdditionalLeadingControls,
@@ -54,6 +55,7 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = ({
     getRowAdditionalLeadingControlsAccessor,
     onUpdateESQLQuery,
     query,
+    setExpandedDoc,
   ]);
 
   const getPaginationConfigAccessor = useProfileAccessor('getPaginationConfig');

--- a/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
@@ -14,7 +14,7 @@ import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { DataTableColumnsMeta } from '@kbn/unified-data-table';
-import type { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import type { DocViewerProps, DocViewsRegistry } from '@kbn/unified-doc-viewer';
 import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
 import { UnifiedDocViewerFlyout } from '@kbn/unified-doc-viewer-plugin/public';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
@@ -38,7 +38,9 @@ export interface DiscoverGridFlyoutProps {
   onClose: () => void;
   onFilter?: DocViewFilterFn;
   onRemoveColumn: (column: string) => void;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
+  setExpandedDoc: (doc?: DataTableRecord, options?: { initialTabId?: string }) => void;
+  initialTabId?: string;
+  docViewerRef?: DocViewerProps['ref'];
 }
 
 /**
@@ -58,6 +60,8 @@ export function DiscoverGridFlyout({
   onRemoveColumn,
   onAddColumn,
   setExpandedDoc,
+  initialTabId,
+  docViewerRef,
 }: DiscoverGridFlyoutProps) {
   const services = useDiscoverServices();
   const flyoutCustomization = useDiscoverCustomization('flyout');
@@ -88,7 +92,7 @@ export function DiscoverGridFlyout({
     }));
 
     return getDocViewer({ record: actualHit });
-  }, [flyoutCustomization, getDocViewerAccessor, actualHit]);
+  }, [getDocViewerAccessor, actualHit, flyoutCustomization]);
 
   useEffect(() => {
     dismissAllFlyoutsExceptFor(DiscoverFlyouts.docViewer);
@@ -118,6 +122,8 @@ export function DiscoverGridFlyout({
       onClose={onClose}
       onFilter={onFilter}
       setExpandedDoc={setExpandedDoc}
+      initialTabId={initialTabId}
+      docViewerRef={docViewerRef}
     />
   );
 }

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/accessors/get_doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/accessors/get_doc_viewer.tsx
@@ -7,15 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import React, { useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { UnifiedDocViewerLogsOverview } from '@kbn/unified-doc-viewer-plugin/public';
-import React from 'react';
-import type { DocumentProfileProvider } from '../../../../profiles';
+import {
+  UnifiedDocViewerLogsOverview,
+  type UnifiedDocViewerLogsOverviewApi,
+} from '@kbn/unified-doc-viewer-plugin/public';
+import { filter, skip } from 'rxjs';
 import type { ProfileProviderServices } from '../../../profile_provider_services';
+import type { LogDocumentProfileProvider } from '../profile';
 
 export const createGetDocViewer =
-  (services: ProfileProviderServices): DocumentProfileProvider['profile']['getDocViewer'] =>
-  (prev) =>
+  (services: ProfileProviderServices): LogDocumentProfileProvider['profile']['getDocViewer'] =>
+  (prev, { context }) =>
   (params) => {
     const prevDocViewer = prev(params);
 
@@ -34,13 +38,56 @@ export const createGetDocViewer =
             defaultMessage: 'Log overview',
           }),
           order: 0,
-          component: (props) => (
-            <UnifiedDocViewerLogsOverview
-              {...props}
-              renderAIAssistant={logsAIAssistantFeature?.render}
-              renderStreamsField={streamsFeature?.renderStreamsField}
-            />
-          ),
+          component: function LogOverviewTab(props) {
+            const [logsOverviewApi, setLogsOverviewApi] =
+              useState<UnifiedDocViewerLogsOverviewApi | null>(null);
+            const initialAccordionSection = useRef(
+              context.logOverviewContext$.getValue()?.initialAccordionSection
+            );
+
+            useEffect(() => {
+              context.logOverviewContext$.next(undefined);
+
+              if (!logsOverviewApi) {
+                return;
+              }
+
+              if (initialAccordionSection.current) {
+                logsOverviewApi.openAndScrollToSection(initialAccordionSection.current);
+              }
+
+              initialAccordionSection.current = undefined;
+
+              const subscription = context.logOverviewContext$
+                .pipe(
+                  skip(1),
+                  filter((overviewContext) => {
+                    return (
+                      overviewContext !== undefined &&
+                      overviewContext.initialAccordionSection !== undefined &&
+                      overviewContext.recordId === props.hit.id
+                    );
+                  })
+                )
+                .subscribe((overviewContext) => {
+                  logsOverviewApi.openAndScrollToSection(overviewContext!.initialAccordionSection!);
+                  context.logOverviewContext$.next(undefined);
+                });
+
+              return () => {
+                subscription.unsubscribe();
+              };
+            }, [logsOverviewApi, props.hit.id]);
+
+            return (
+              <UnifiedDocViewerLogsOverview
+                {...props}
+                ref={setLogsOverviewApi}
+                renderAIAssistant={logsAIAssistantFeature?.render}
+                renderStreamsField={streamsFeature?.renderStreamsField}
+              />
+            );
+          },
         });
 
         return prevDocViewer.docViewsRegistry(registry);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/profile.test.ts
@@ -9,6 +9,7 @@
 
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import { BehaviorSubject } from 'rxjs';
 import type {
   DataSourceContext,
   DocumentProfileProviderParams,
@@ -19,6 +20,7 @@ import { createContextAwarenessMocks } from '../../../__mocks__';
 import { createObservabilityLogDocumentProfileProvider } from './profile';
 import type { ContextWithProfileId } from '../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../consts';
+import type { LogOverviewContext } from '../logs_data_source_profile/profile';
 
 const mockServices = createContextAwarenessMocks().profileProviderServices;
 
@@ -36,6 +38,7 @@ describe('logDocumentProfileProvider', () => {
     isMatch: true,
     context: {
       type: DocumentType.Log,
+      logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
     },
   };
   const RESOLUTION_MISMATCH = {
@@ -149,7 +152,12 @@ describe('logDocumentProfileProvider', () => {
           title: 'test title',
           docViewsRegistry: (registry) => registry,
         }),
-        { context: { type: DocumentType.Log } }
+        {
+          context: {
+            type: DocumentType.Log,
+            logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+          },
+        }
       );
       const docViewer = getDocViewer({
         record: buildDataTableRecord({}),

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_row_additional_leading_controls.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_row_additional_leading_controls.ts
@@ -7,44 +7,61 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { RowControlRowProps } from '@kbn/discover-utils';
 import { createDegradedDocsControl, createStacktraceControl } from '@kbn/discover-utils';
 import { retrieveMetadataColumns } from '@kbn/esql-utils';
 import type { AggregateQuery } from '@kbn/es-query';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { BasicPrettyPrinter, mutate, parse } from '@kbn/esql-ast';
 import { IGNORED_FIELD } from '@kbn/discover-utils/src/field_constants';
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 
-export const getRowAdditionalLeadingControls: DataSourceProfileProvider['profile']['getRowAdditionalLeadingControls'] =
-  (prev) => (params) => {
-    const additionalControls = prev(params) || [];
-    const { updateESQLQuery, query } = params;
+export const getRowAdditionalLeadingControls: LogsDataSourceProfileProvider['profile']['getRowAdditionalLeadingControls'] =
 
-    const isDegradedDocsControlEnabled = isOfAggregateQueryType(query)
-      ? queryContainsMetadataIgnored(query)
-      : true;
+    (prev, { context }) =>
+    (params) => {
+      const additionalControls = prev(params) || [];
+      const { updateESQLQuery, query, setExpandedDoc } = params;
 
-    const addIgnoredMetadataToQuery = updateESQLQuery
-      ? () => {
-          updateESQLQuery((prevQuery) => {
-            const { root } = parse(prevQuery);
-            // Add _ignored field to metadata directive if not present
-            mutate.commands.from.metadata.upsert(root, IGNORED_FIELD);
+      const isDegradedDocsControlEnabled = isOfAggregateQueryType(query)
+        ? queryContainsMetadataIgnored(query)
+        : true;
 
-            return BasicPrettyPrinter.print(root);
+      const addIgnoredMetadataToQuery = updateESQLQuery
+        ? () => {
+            updateESQLQuery((prevQuery) => {
+              const { root } = parse(prevQuery);
+              // Add _ignored field to metadata directive if not present
+              mutate.commands.from.metadata.upsert(root, IGNORED_FIELD);
+
+              return BasicPrettyPrinter.print(root);
+            });
+          }
+        : undefined;
+
+      const leadingControlClick =
+        (actionName: 'stacktrace' | 'quality_issues') => (props: RowControlRowProps) => {
+          if (!setExpandedDoc) {
+            return;
+          }
+
+          context.logOverviewContext$.next({
+            recordId: props.record.id,
+            initialAccordionSection: actionName,
           });
-        }
-      : undefined;
+          setExpandedDoc(props.record, { initialTabId: 'doc_view_logs_overview' });
+        };
 
-    return [
-      ...additionalControls,
-      createDegradedDocsControl({
-        enabled: isDegradedDocsControlEnabled,
-        addIgnoredMetadataToQuery,
-      }),
-      createStacktraceControl(),
-    ];
-  };
+      return [
+        ...additionalControls,
+        createDegradedDocsControl({
+          enabled: isDegradedDocsControlEnabled,
+          addIgnoredMetadataToQuery,
+          onClick: leadingControlClick('quality_issues'),
+        }),
+        createStacktraceControl({ onClick: leadingControlClick('stacktrace') }),
+      ];
+    };
 
 const queryContainsMetadataIgnored = (query: AggregateQuery) =>
   retrieveMetadataColumns(query.esql).includes('_ignored');

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
@@ -10,11 +10,12 @@
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { EuiThemeComputed } from '@elastic/eui';
 import { createStubIndexPattern } from '@kbn/data-views-plugin/common/data_view.stub';
+import { BehaviorSubject } from 'rxjs';
 import { createDataViewDataSource, createEsqlDataSource } from '../../../../../common/data_sources';
 import type { DataSourceProfileProviderParams, RootContext } from '../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../profiles';
 import { createContextAwarenessMocks } from '../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from './profile';
+import { type LogOverviewContext, createLogsDataSourceProfileProvider } from './profile';
 import { DataGridDensity } from '@kbn/unified-data-table';
 import { dataViewWithTimefieldMock } from '../../../../__mocks__/data_view_with_timefield';
 import type { ContextWithProfileId } from '../../../profile_service';
@@ -44,7 +45,10 @@ describe('logsDataSourceProfileProvider', () => {
   };
   const RESOLUTION_MATCH = {
     isMatch: true,
-    context: { category: DataSourceCategory.Logs },
+    context: {
+      category: DataSourceCategory.Logs,
+      logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+    },
   };
   const RESOLUTION_MISMATCH = {
     isMatch: false,
@@ -161,7 +165,10 @@ describe('logsDataSourceProfileProvider', () => {
       const euiTheme = { euiTheme: { colors: {} } } as unknown as EuiThemeComputed;
       const getRowIndicatorProvider =
         logsDataSourceProfileProvider.profile.getRowIndicatorProvider?.(() => undefined, {
-          context: { category: DataSourceCategory.Logs },
+          context: {
+            category: DataSourceCategory.Logs,
+            logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+          },
         });
       const getRowIndicator = getRowIndicatorProvider?.({
         dataView: dataViewWithLogLevel,
@@ -176,7 +183,10 @@ describe('logsDataSourceProfileProvider', () => {
       const euiTheme = { euiTheme: { colors: {} } } as unknown as EuiThemeComputed;
       const getRowIndicatorProvider =
         logsDataSourceProfileProvider.profile.getRowIndicatorProvider?.(() => undefined, {
-          context: { category: DataSourceCategory.Logs },
+          context: {
+            category: DataSourceCategory.Logs,
+            logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+          },
         });
       const getRowIndicator = getRowIndicatorProvider?.({
         dataView: dataViewWithLogLevel,
@@ -189,7 +199,10 @@ describe('logsDataSourceProfileProvider', () => {
     it('should not set the color indicator handler if data view does not have log level field', () => {
       const getRowIndicatorProvider =
         logsDataSourceProfileProvider.profile.getRowIndicatorProvider?.(() => undefined, {
-          context: { category: DataSourceCategory.Logs },
+          context: {
+            category: DataSourceCategory.Logs,
+            logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+          },
         });
       const getRowIndicator = getRowIndicatorProvider?.({
         dataView: dataViewWithoutLogLevel,
@@ -204,7 +217,10 @@ describe('logsDataSourceProfileProvider', () => {
       const getCellRenderers = logsDataSourceProfileProvider.profile.getCellRenderers?.(
         () => ({}),
         {
-          context: { category: DataSourceCategory.Logs },
+          context: {
+            category: DataSourceCategory.Logs,
+            logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+          },
         }
       );
       const getCellRenderersParams = {
@@ -227,7 +243,10 @@ describe('logsDataSourceProfileProvider', () => {
     it('should return the passed additional controls', () => {
       const getRowAdditionalLeadingControls =
         logsDataSourceProfileProvider.profile.getRowAdditionalLeadingControls?.(() => undefined, {
-          context: { category: DataSourceCategory.Logs },
+          context: {
+            category: DataSourceCategory.Logs,
+            logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+          },
         });
       const rowAdditionalLeadingControls = getRowAdditionalLeadingControls?.({
         dataView: dataViewWithLogLevel,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../profiles';
+import { BehaviorSubject } from 'rxjs';
+import type { DataSourceContext, DataSourceProfileProvider } from '../../../profiles';
 import { DataSourceCategory } from '../../../profiles';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 import {
@@ -19,11 +20,32 @@ import {
 } from './accessors';
 import { extractIndexPatternFrom } from '../../extract_index_pattern_from';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../consts';
+import type { ContextWithProfileId } from '../../../profile_service';
+
+export type LogOverViewAccordionExpandedValue = 'stacktrace' | 'quality_issues' | undefined;
+
+export interface LogOverviewContext {
+  recordId: string;
+  initialAccordionSection: LogOverViewAccordionExpandedValue;
+}
+
+export interface LogsDataSourceContext {
+  logOverviewContext$: BehaviorSubject<LogOverviewContext | undefined>;
+}
+
+export type LogsDataSourceProfileProvider = DataSourceProfileProvider<LogsDataSourceContext>;
+
+const LOGS_DATA_SOURCE_PROFILE_ID = 'observability-logs-data-source-profile';
+
+export const isLogsDataSourceContext = (
+  dataSourceContext: ContextWithProfileId<DataSourceContext>
+): dataSourceContext is ContextWithProfileId<DataSourceContext> & LogsDataSourceContext =>
+  dataSourceContext.profileId === LOGS_DATA_SOURCE_PROFILE_ID;
 
 export const createLogsDataSourceProfileProvider = (
   services: ProfileProviderServices
-): DataSourceProfileProvider => ({
-  profileId: 'observability-logs-data-source-profile',
+): LogsDataSourceProfileProvider => ({
+  profileId: LOGS_DATA_SOURCE_PROFILE_ID,
   profile: {
     getDefaultAppState: createGetDefaultAppState(),
     getCellRenderers,
@@ -44,7 +66,10 @@ export const createLogsDataSourceProfileProvider = (
 
     return {
       isMatch: true,
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     };
   },
 });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/apache_error_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/apache_error_logs.test.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_with_timefield';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createContextAwarenessMocks } from '../../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from '../profile';
+import { createLogsDataSourceProfileProvider, type LogOverviewContext } from '../profile';
 import { createApacheErrorLogsDataSourceProfileProvider } from './apache_error_logs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
@@ -34,7 +35,13 @@ describe('createApacheErrorLogsDataSourceProfileProvider', () => {
       dataSource: createEsqlDataSource(),
       query: { esql: 'FROM logs-apache.error-*' },
     });
-    expect(result).toEqual({ isMatch: true, context: { category: DataSourceCategory.Logs } });
+    expect(result).toEqual({
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
+    });
   });
 
   it('should not match an invalid index pattern', async () => {
@@ -48,7 +55,10 @@ describe('createApacheErrorLogsDataSourceProfileProvider', () => {
 
   it('should return default app state', () => {
     const getDefaultAppState = dataSourceProfileProvider.profile.getDefaultAppState?.(() => ({}), {
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     });
     expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/apache_error_logs.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/apache_error_logs.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { createGetDefaultAppState } from '../accessors';
 import { CLIENT_IP_COLUMN, LOG_LEVEL_COLUMN, MESSAGE_COLUMN } from '../consts';
 import { createResolve } from './create_resolve';
 
 export const createApacheErrorLogsDataSourceProfileProvider = (
-  logsDataSourceProfileProvider: DataSourceProfileProvider
-): DataSourceProfileProvider =>
+  logsDataSourceProfileProvider: LogsDataSourceProfileProvider
+): LogsDataSourceProfileProvider =>
   extendProfileProvider(logsDataSourceProfileProvider, {
     profileId: 'observability-apache-error-logs-data-source-profile',
     profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/aws_s3access_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/aws_s3access_logs.test.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_with_timefield';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createContextAwarenessMocks } from '../../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from '../profile';
+import { createLogsDataSourceProfileProvider, type LogOverviewContext } from '../profile';
 import { createAwsS3accessLogsDataSourceProfileProvider } from './aws_s3access_logs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
@@ -34,7 +35,13 @@ describe('createAwsS3accessLogsDataSourceProfileProvider', () => {
       dataSource: createEsqlDataSource(),
       query: { esql: 'FROM logs-aws.s3access-*' },
     });
-    expect(result).toEqual({ isMatch: true, context: { category: DataSourceCategory.Logs } });
+    expect(result).toEqual({
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
+    });
   });
 
   it('should not match an invalid index pattern', async () => {
@@ -48,7 +55,10 @@ describe('createAwsS3accessLogsDataSourceProfileProvider', () => {
 
   it('should return default app state', () => {
     const getDefaultAppState = dataSourceProfileProvider.profile.getDefaultAppState?.(() => ({}), {
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     });
     expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/aws_s3access_logs.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/aws_s3access_logs.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { createGetDefaultAppState } from '../accessors';
 import { CLIENT_IP_COLUMN, MESSAGE_COLUMN } from '../consts';
 import { createResolve } from './create_resolve';
 
 export const createAwsS3accessLogsDataSourceProfileProvider = (
-  logsDataSourceProfileProvider: DataSourceProfileProvider
-): DataSourceProfileProvider =>
+  logsDataSourceProfileProvider: LogsDataSourceProfileProvider
+): LogsDataSourceProfileProvider =>
   extendProfileProvider(logsDataSourceProfileProvider, {
     profileId: 'observability-aws-s3access-logs-data-source-profile',
     profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/create_resolve.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/create_resolve.test.ts
@@ -7,12 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { DataSourceProfileProviderParams, RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createResolve } from './create_resolve';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
+import type { LogOverviewContext } from '../profile';
 
 describe('createResolve', () => {
   const VALID_INDEX_PATTERN = 'valid';
@@ -23,7 +25,10 @@ describe('createResolve', () => {
   };
   const RESOLUTION_MATCH = {
     isMatch: true,
-    context: { category: DataSourceCategory.Logs },
+    context: {
+      category: DataSourceCategory.Logs,
+      logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+    },
   };
   const RESOLUTION_MISMATCH = {
     isMatch: false,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/create_resolve.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/create_resolve.ts
@@ -8,12 +8,15 @@
  */
 
 import { createRegExpPatternFrom, testPatternAgainstAllowedList } from '@kbn/data-view-utils';
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import { BehaviorSubject } from 'rxjs';
 import { DataSourceCategory } from '../../../../profiles';
 import { extractIndexPatternFrom } from '../../../extract_index_pattern_from';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
+import type { LogOverviewContext, LogsDataSourceProfileProvider } from '../profile';
 
-export const createResolve = (baseIndexPattern: string): DataSourceProfileProvider['resolve'] => {
+export const createResolve = (
+  baseIndexPattern: string
+): LogsDataSourceProfileProvider['resolve'] => {
   const testIndexPattern = testPatternAgainstAllowedList([
     createRegExpPatternFrom(baseIndexPattern, 'data'),
   ]);
@@ -31,7 +34,10 @@ export const createResolve = (baseIndexPattern: string): DataSourceProfileProvid
 
     return {
       isMatch: true,
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     };
   };
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/kubernetes_container_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/kubernetes_container_logs.test.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_with_timefield';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createContextAwarenessMocks } from '../../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from '../profile';
+import { createLogsDataSourceProfileProvider, type LogOverviewContext } from '../profile';
 import { createKubernetesContainerLogsDataSourceProfileProvider } from './kubernetes_container_logs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
@@ -34,7 +35,13 @@ describe('createKubernetesContainerLogsDataSourceProfileProvider', () => {
       dataSource: createEsqlDataSource(),
       query: { esql: 'FROM logs-kubernetes.container_logs-*' },
     });
-    expect(result).toEqual({ isMatch: true, context: { category: DataSourceCategory.Logs } });
+    expect(result).toEqual({
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
+    });
   });
 
   it('should not match an invalid index pattern', async () => {
@@ -48,7 +55,10 @@ describe('createKubernetesContainerLogsDataSourceProfileProvider', () => {
 
   it('should return default app state', () => {
     const getDefaultAppState = dataSourceProfileProvider.profile.getDefaultAppState?.(() => ({}), {
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     });
     expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/kubernetes_container_logs.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/kubernetes_container_logs.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { createGetDefaultAppState } from '../accessors';
 import { LOG_LEVEL_COLUMN, MESSAGE_COLUMN } from '../consts';
 import { createResolve } from './create_resolve';
 
 export const createKubernetesContainerLogsDataSourceProfileProvider = (
-  logsDataSourceProfileProvider: DataSourceProfileProvider
-): DataSourceProfileProvider =>
+  logsDataSourceProfileProvider: LogsDataSourceProfileProvider
+): LogsDataSourceProfileProvider =>
   extendProfileProvider(logsDataSourceProfileProvider, {
     profileId: 'observability-kubernetes-container-logs-data-source-profile',
     profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_access_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_access_logs.test.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_with_timefield';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createContextAwarenessMocks } from '../../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from '../profile';
+import { type LogOverviewContext, createLogsDataSourceProfileProvider } from '../profile';
 import { createNginxAccessLogsDataSourceProfileProvider } from './nginx_access_logs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
@@ -34,7 +35,13 @@ describe('createNginxAccessLogsDataSourceProfileProvider', () => {
       dataSource: createEsqlDataSource(),
       query: { esql: 'FROM logs-nginx.access-*' },
     });
-    expect(result).toEqual({ isMatch: true, context: { category: DataSourceCategory.Logs } });
+    expect(result).toEqual({
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
+    });
   });
 
   it('should not match an invalid index pattern', async () => {
@@ -48,7 +55,10 @@ describe('createNginxAccessLogsDataSourceProfileProvider', () => {
 
   it('should return default app state', () => {
     const getDefaultAppState = dataSourceProfileProvider.profile.getDefaultAppState?.(() => ({}), {
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     });
     expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_access_logs.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_access_logs.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { createGetDefaultAppState } from '../accessors';
 import { CLIENT_IP_COLUMN, HOST_NAME_COLUMN, MESSAGE_COLUMN } from '../consts';
 import { createResolve } from './create_resolve';
 
 export const createNginxAccessLogsDataSourceProfileProvider = (
-  logsDataSourceProfileProvider: DataSourceProfileProvider
-): DataSourceProfileProvider =>
+  logsDataSourceProfileProvider: LogsDataSourceProfileProvider
+): LogsDataSourceProfileProvider =>
   extendProfileProvider(logsDataSourceProfileProvider, {
     profileId: 'observability-nginx-access-logs-data-source-profile',
     profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_error_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_error_logs.test.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_with_timefield';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createContextAwarenessMocks } from '../../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from '../profile';
+import { createLogsDataSourceProfileProvider, type LogOverviewContext } from '../profile';
 import { createNginxErrorLogsDataSourceProfileProvider } from './nginx_error_logs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
@@ -34,7 +35,13 @@ describe('createNginxErrorLogsDataSourceProfileProvider', () => {
       dataSource: createEsqlDataSource(),
       query: { esql: 'FROM logs-nginx.error-*' },
     });
-    expect(result).toEqual({ isMatch: true, context: { category: DataSourceCategory.Logs } });
+    expect(result).toEqual({
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
+    });
   });
 
   it('should not match an invalid index pattern', async () => {
@@ -48,7 +55,10 @@ describe('createNginxErrorLogsDataSourceProfileProvider', () => {
 
   it('should return default app state', () => {
     const getDefaultAppState = dataSourceProfileProvider.profile.getDefaultAppState?.(() => ({}), {
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     });
     expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_error_logs.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/nginx_error_logs.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { createGetDefaultAppState } from '../accessors';
 import { LOG_LEVEL_COLUMN, MESSAGE_COLUMN } from '../consts';
 import { createResolve } from './create_resolve';
 
 export const createNginxErrorLogsDataSourceProfileProvider = (
-  logsDataSourceProfileProvider: DataSourceProfileProvider
-): DataSourceProfileProvider =>
+  logsDataSourceProfileProvider: LogsDataSourceProfileProvider
+): LogsDataSourceProfileProvider =>
   extendProfileProvider(logsDataSourceProfileProvider, {
     profileId: 'observability-nginx-error-logs-data-source-profile',
     profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/system_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/system_logs.test.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_with_timefield';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createContextAwarenessMocks } from '../../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from '../profile';
+import { type LogOverviewContext, createLogsDataSourceProfileProvider } from '../profile';
 import { createSystemLogsDataSourceProfileProvider } from './system_logs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
@@ -34,7 +35,13 @@ describe('createSystemLogsDataSourceProfileProvider', () => {
       dataSource: createEsqlDataSource(),
       query: { esql: 'FROM logs-system.syslog-*' },
     });
-    expect(result).toEqual({ isMatch: true, context: { category: DataSourceCategory.Logs } });
+    expect(result).toEqual({
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
+    });
   });
 
   it('should not match an invalid index pattern', async () => {
@@ -48,7 +55,10 @@ describe('createSystemLogsDataSourceProfileProvider', () => {
 
   it('should return default app state', () => {
     const getDefaultAppState = dataSourceProfileProvider.profile.getDefaultAppState?.(() => ({}), {
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     });
     expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/system_logs.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/system_logs.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { createGetDefaultAppState } from '../accessors';
 import { HOST_NAME_COLUMN, LOG_LEVEL_COLUMN, MESSAGE_COLUMN } from '../consts';
 import { createResolve } from './create_resolve';
 
 export const createSystemLogsDataSourceProfileProvider = (
-  logsDataSourceProfileProvider: DataSourceProfileProvider
-): DataSourceProfileProvider =>
+  logsDataSourceProfileProvider: LogsDataSourceProfileProvider
+): LogsDataSourceProfileProvider =>
   extendProfileProvider(logsDataSourceProfileProvider, {
     profileId: 'observability-system-logs-data-source-profile',
     profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/windows_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/windows_logs.test.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_with_timefield';
 import { createEsqlDataSource } from '../../../../../../common/data_sources';
 import type { RootContext } from '../../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { createContextAwarenessMocks } from '../../../../__mocks__';
-import { createLogsDataSourceProfileProvider } from '../profile';
+import { createLogsDataSourceProfileProvider, type LogOverviewContext } from '../profile';
 import { createWindowsLogsDataSourceProfileProvider } from './windows_logs';
 import type { ContextWithProfileId } from '../../../../profile_service';
 import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
@@ -34,7 +35,13 @@ describe('createWindowsLogsDataSourceProfileProvider', () => {
       dataSource: createEsqlDataSource(),
       query: { esql: 'FROM logs-windows.powershell-*' },
     });
-    expect(result).toEqual({ isMatch: true, context: { category: DataSourceCategory.Logs } });
+    expect(result).toEqual({
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
+    });
   });
 
   it('should not match an invalid index pattern', async () => {
@@ -48,7 +55,10 @@ describe('createWindowsLogsDataSourceProfileProvider', () => {
 
   it('should return default app state', () => {
     const getDefaultAppState = dataSourceProfileProvider.profile.getDefaultAppState?.(() => ({}), {
-      context: { category: DataSourceCategory.Logs },
+      context: {
+        category: DataSourceCategory.Logs,
+        logOverviewContext$: new BehaviorSubject<LogOverviewContext | undefined>(undefined),
+      },
     });
     expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/windows_logs.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/windows_logs.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { LogsDataSourceProfileProvider } from '../profile';
 import { extendProfileProvider } from '../../../extend_profile_provider';
 import { createGetDefaultAppState } from '../accessors';
 import { HOST_NAME_COLUMN, LOG_LEVEL_COLUMN, MESSAGE_COLUMN } from '../consts';
 import { createResolve } from './create_resolve';
 
 export const createWindowsLogsDataSourceProfileProvider = (
-  logsDataSourceProfileProvider: DataSourceProfileProvider
-): DataSourceProfileProvider =>
+  logsDataSourceProfileProvider: LogsDataSourceProfileProvider
+): LogsDataSourceProfileProvider =>
   extendProfileProvider(logsDataSourceProfileProvider, {
     profileId: 'observability-windows-logs-data-source-profile',
     profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -181,6 +181,12 @@ export interface RowControlsExtensionParams {
    * The current query
    */
   query?: DiscoverAppState['query'];
+  /**
+   * Function to set the expanded document, which is displayed in a flyout
+   * @param record - The record to display in the flyout
+   * @param options.initialTabId - The tabId to display in the flyout
+   */
+  setExpandedDoc?: (record?: DataTableRecord, options?: { initialTabId?: string }) => void;
 }
 
 /**

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer/doc_viewer.tsx
@@ -7,22 +7,25 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import { DocViewer } from '@kbn/unified-doc-viewer';
+import { DocViewer, DocViewerApi } from '@kbn/unified-doc-viewer';
+
 import { getUnifiedDocViewerServices } from '../../plugin';
 
-export function UnifiedDocViewer({ docViewsRegistry, ...props }: DocViewRenderProps) {
-  const { unifiedDocViewer } = getUnifiedDocViewerServices();
+export const UnifiedDocViewer = forwardRef<DocViewerApi, DocViewRenderProps>(
+  ({ docViewsRegistry, ...props }, ref) => {
+    const { unifiedDocViewer } = getUnifiedDocViewerServices();
 
-  const registry = useMemo(() => {
-    if (docViewsRegistry) {
-      return typeof docViewsRegistry === 'function'
-        ? docViewsRegistry(unifiedDocViewer.registry.clone())
-        : docViewsRegistry;
-    }
-    return unifiedDocViewer.registry;
-  }, [docViewsRegistry, unifiedDocViewer.registry]);
+    const registry = useMemo(() => {
+      if (docViewsRegistry) {
+        return typeof docViewsRegistry === 'function'
+          ? docViewsRegistry(unifiedDocViewer.registry.clone())
+          : docViewsRegistry;
+      }
+      return unifiedDocViewer.registry;
+    }, [docViewsRegistry, unifiedDocViewer.registry]);
 
-  return <DocViewer docViews={registry.getAll()} {...props} />;
-}
+    return <DocViewer ref={ref} docViews={registry.getAll()} {...props} />;
+  }
+);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -32,10 +32,12 @@ import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import type { ToastsStart } from '@kbn/core-notifications-browser';
 import type { DocViewFilterFn, DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import { DocViewerProps } from '@kbn/unified-doc-viewer';
 import { UnifiedDocViewer } from '../lazy_doc_viewer';
 import { useFlyoutA11y } from './use_flyout_a11y';
 
 export interface UnifiedDocViewerFlyoutProps {
+  docViewerRef?: DocViewerProps['ref'];
   'data-test-subj'?: string;
   flyoutTitle?: string;
   flyoutDefaultWidth?: EuiFlyoutProps['size'];
@@ -62,6 +64,7 @@ export interface UnifiedDocViewerFlyoutProps {
   onFilter?: DocViewFilterFn;
   onRemoveColumn: (column: string) => void;
   setExpandedDoc: (doc?: DataTableRecord) => void;
+  initialTabId?: string;
 }
 
 function getIndexByDocId(hits: DataTableRecord[], id: string) {
@@ -76,6 +79,7 @@ export const FLYOUT_WIDTH_KEY = 'unifiedDocViewer:flyoutWidth';
  * Flyout displaying an expanded row details
  */
 export function UnifiedDocViewerFlyout({
+  docViewerRef,
   'data-test-subj': dataTestSubj,
   flyoutTitle,
   flyoutActions,
@@ -96,6 +100,7 @@ export function UnifiedDocViewerFlyout({
   onRemoveColumn,
   onAddColumn,
   setExpandedDoc,
+  initialTabId,
 }: UnifiedDocViewerFlyoutProps) {
   const { euiTheme } = useEuiTheme();
   const isXlScreen = useIsWithinMinBreakpoint('xl');
@@ -190,6 +195,7 @@ export function UnifiedDocViewerFlyout({
   const renderDefaultContent = useCallback(
     () => (
       <UnifiedDocViewer
+        ref={docViewerRef}
         columns={columns}
         columnsMeta={columnsMeta}
         dataView={dataView}
@@ -200,19 +206,22 @@ export function UnifiedDocViewerFlyout({
         textBasedHits={isEsqlQuery ? hits : undefined}
         docViewsRegistry={docViewsRegistry}
         decreaseAvailableHeightBy={80} // flyout footer height
+        initialTabId={initialTabId}
       />
     ),
     [
-      actualHit,
-      addColumn,
+      docViewerRef,
       columns,
       columnsMeta,
       dataView,
-      hits,
-      isEsqlQuery,
       onFilter,
+      actualHit,
+      addColumn,
       removeColumn,
+      isEsqlQuery,
+      hits,
       docViewsRegistry,
+      initialTabId,
     ]
   );
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview.test.tsx
@@ -9,10 +9,9 @@
 
 import React from 'react';
 import { EuiProvider } from '@elastic/eui';
-import { render, screen } from '@testing-library/react';
-import { LogsOverview } from './logs_overview';
+import { act, render, screen } from '@testing-library/react';
+import { LogsOverview, LogsOverviewApi, LogsOverviewProps } from './logs_overview';
 import { DataView } from '@kbn/data-views-plugin/common';
-import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { setUnifiedDocViewerServices } from '../../plugin';
 import { mockUnifiedDocViewerServices } from '../../__mocks__';
@@ -35,7 +34,7 @@ const DATA_STREAM_NAME = `logs-${DATASET_NAME}-${NAMESPACE}`;
 const NOW = Date.now();
 const MORE_THAN_1024_CHARS =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?';
-
+const STACKTRACE = 'Lorem ipsum dolor sit amet';
 const dataView = {
   fields: {
     getAll: () =>
@@ -145,17 +144,20 @@ setUnifiedDocViewerServices(
   merge(mockUnifiedDocViewerServices, getCustomUnifedDocViewerServices())
 );
 
-const renderLogsOverview = (props: Partial<DocViewRenderProps> = {}) => {
+const renderLogsOverview = (
+  props: Partial<LogsOverviewProps> = {},
+  ref?: (api: LogsOverviewApi) => void
+) => {
   const { rerender: baseRerender, ...tools } = render(
     <EuiProvider highContrastMode={false}>
-      <LogsOverview dataView={dataView} hit={fullHit} {...props} />
+      <LogsOverview ref={ref} dataView={dataView} hit={fullHit} {...props} />
     </EuiProvider>
   );
 
-  const rerender = (rerenderProps: Partial<DocViewRenderProps>) =>
+  const rerender = (rerenderProps: Partial<LogsOverviewProps>) =>
     baseRerender(
       <EuiProvider highContrastMode={false}>
-        <LogsOverview dataView={dataView} hit={fullHit} {...props} {...rerenderProps} />
+        <LogsOverview ref={ref} dataView={dataView} hit={fullHit} {...props} {...rerenderProps} />
       </EuiProvider>
     );
 
@@ -212,6 +214,7 @@ describe('LogsOverview', () => {
       expect(screen.queryByTestId('unifiedDocViewLogsOverviewLogShipper')).toBeInTheDocument();
     });
   });
+
   describe('Degraded Fields section', () => {
     it('should load the degraded fields container when present', async () => {
       expect(
@@ -244,6 +247,62 @@ describe('LogsOverview', () => {
         screen.queryByTestId('unifiedDocViewLogsOverviewDegradedFieldsQualityIssuesTable')
       ).toBeInTheDocument();
     });
+  });
+});
+
+describe('LogsOverview with accordion state', () => {
+  it('should open the stacktrace section when the prop is passed', async () => {
+    let api: LogsOverviewApi | undefined;
+    renderLogsOverview({ hit: buildHit({ 'error.stack_trace': STACKTRACE }) }, (newApi) => {
+      api = newApi;
+    });
+    act(() => {
+      api?.openAndScrollToSection('stacktrace');
+    });
+    expect(
+      screen.queryByTestId('unifiedDocViewLogsOverviewStacktraceAccordion')
+    ).toBeInTheDocument();
+
+    const accordion = screen.queryByTestId('unifiedDocViewLogsOverviewStacktraceAccordion');
+    if (accordion === null) {
+      return;
+    }
+    const button = accordion.querySelector('button');
+
+    if (button === null) {
+      return;
+    }
+
+    // Check the aria-expanded property of the button
+    const isExpanded = button.getAttribute('aria-expanded');
+    expect(isExpanded).toBe('true');
+  });
+
+  it('should open the quality_issues section when the prop is passed', async () => {
+    let api: LogsOverviewApi | undefined;
+    renderLogsOverview({ hit: buildHit({ 'error.stack_trace': STACKTRACE }) }, (newApi) => {
+      api = newApi;
+    });
+    act(() => {
+      api?.openAndScrollToSection('quality_issues');
+    });
+    expect(
+      screen.queryByTestId('unifiedDocViewLogsOverviewDegradedFieldsAccordion')
+    ).toBeInTheDocument();
+
+    const accordion = screen.queryByTestId('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+    if (accordion === null) {
+      return;
+    }
+    const button = accordion.querySelector('button');
+
+    if (button === null) {
+      return;
+    }
+
+    // Check the aria-expanded property of the button
+    const isExpanded = button.getAttribute('aria-expanded');
+    expect(isExpanded).toBe('true');
   });
 });
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import { getLogDocumentOverview } from '@kbn/discover-utils';
 import { EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
@@ -20,46 +20,74 @@ import { FieldActionsProvider } from '../../hooks/use_field_actions';
 import { getUnifiedDocViewerServices } from '../../plugin';
 import { LogsOverviewDegradedFields } from './logs_overview_degraded_fields';
 import { LogsOverviewStacktraceSection } from './logs_overview_stacktrace_section';
+import { ScrollableSectionWrapperApi } from './scrollable_section_wrapper';
 
 export type LogsOverviewProps = DocViewRenderProps & {
   renderAIAssistant?: (deps: ObservabilityLogsAIAssistantFeatureRenderDeps) => JSX.Element;
   renderStreamsField?: (deps: StreamsFeatureRenderDeps) => JSX.Element;
 };
 
-export function LogsOverview({
-  columns,
-  dataView,
-  hit,
-  filter,
-  onAddColumn,
-  onRemoveColumn,
-  renderAIAssistant,
-  renderStreamsField,
-}: LogsOverviewProps) {
-  const { fieldFormats } = getUnifiedDocViewerServices();
-  const parsedDoc = getLogDocumentOverview(hit, { dataView, fieldFormats });
-  const LogsOverviewAIAssistant = renderAIAssistant;
-  const stacktraceFields = getStacktraceFields(hit as LogDocument);
-  const isStacktraceAvailable = Object.values(stacktraceFields).some(Boolean);
-
-  return (
-    <FieldActionsProvider
-      columns={columns}
-      filter={filter}
-      onAddColumn={onAddColumn}
-      onRemoveColumn={onRemoveColumn}
-    >
-      <EuiSpacer size="m" />
-      <LogsOverviewHeader doc={parsedDoc} />
-      <EuiHorizontalRule margin="xs" />
-      <LogsOverviewHighlights
-        formattedDoc={parsedDoc}
-        doc={hit}
-        renderStreamsField={renderStreamsField}
-      />
-      <LogsOverviewDegradedFields rawDoc={hit.raw} />
-      {isStacktraceAvailable && <LogsOverviewStacktraceSection hit={hit} dataView={dataView} />}
-      {LogsOverviewAIAssistant && <LogsOverviewAIAssistant doc={hit} />}
-    </FieldActionsProvider>
-  );
+export interface LogsOverviewApi {
+  openAndScrollToSection: (section: 'stacktrace' | 'quality_issues') => void;
 }
+
+export const LogsOverview = forwardRef<LogsOverviewApi, LogsOverviewProps>(
+  (
+    {
+      columns,
+      dataView,
+      hit,
+      filter,
+      onAddColumn,
+      onRemoveColumn,
+      renderAIAssistant,
+      renderStreamsField,
+    },
+    ref
+  ) => {
+    const { fieldFormats } = getUnifiedDocViewerServices();
+    const parsedDoc = getLogDocumentOverview(hit, { dataView, fieldFormats });
+    const LogsOverviewAIAssistant = renderAIAssistant;
+    const stacktraceFields = getStacktraceFields(hit as LogDocument);
+    const isStacktraceAvailable = Object.values(stacktraceFields).some(Boolean);
+    const qualityIssuesSectionRef = useRef<ScrollableSectionWrapperApi>(null);
+    const stackTraceSectionRef = useRef<ScrollableSectionWrapperApi>(null);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        openAndScrollToSection: (section) => {
+          if (section === 'quality_issues') {
+            qualityIssuesSectionRef.current?.openAndScrollToSection();
+          } else if (section === 'stacktrace') {
+            stackTraceSectionRef.current?.openAndScrollToSection();
+          }
+        },
+      }),
+      []
+    );
+
+    return (
+      <FieldActionsProvider
+        columns={columns}
+        filter={filter}
+        onAddColumn={onAddColumn}
+        onRemoveColumn={onRemoveColumn}
+      >
+        <EuiSpacer size="m" />
+        <LogsOverviewHeader doc={parsedDoc} />
+        <EuiHorizontalRule margin="xs" />
+        <LogsOverviewHighlights
+          formattedDoc={parsedDoc}
+          doc={hit}
+          renderStreamsField={renderStreamsField}
+        />
+        <LogsOverviewDegradedFields ref={qualityIssuesSectionRef} rawDoc={hit.raw} />
+        {isStacktraceAvailable && (
+          <LogsOverviewStacktraceSection ref={stackTraceSectionRef} hit={hit} dataView={dataView} />
+        )}
+        {LogsOverviewAIAssistant && <LogsOverviewAIAssistant doc={hit} />}
+      </FieldActionsProvider>
+    );
+  }
+);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_degraded_fields.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_degraded_fields.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { forwardRef, useMemo, useState } from 'react';
 import { DataTableRecord } from '@kbn/discover-utils';
 import {
   EuiAccordion,
@@ -31,6 +31,10 @@ import {
 } from '@kbn/deeplinks-observability';
 import { BrowserUrlService } from '@kbn/share-plugin/public';
 import { getUnifiedDocViewerServices } from '../../plugin';
+import {
+  ScrollableSectionWrapper,
+  ScrollableSectionWrapperApi,
+} from './scrollable_section_wrapper';
 
 type Direction = 'asc' | 'desc';
 type SortField = 'issue' | 'values';
@@ -108,7 +112,10 @@ export const datasetQualityLinkTitle = i18n.translate(
   }
 );
 
-export const LogsOverviewDegradedFields = ({ rawDoc }: { rawDoc: DataTableRecord['raw'] }) => {
+export const LogsOverviewDegradedFields = forwardRef<
+  ScrollableSectionWrapperApi,
+  { rawDoc: DataTableRecord['raw'] }
+>(({ rawDoc }, ref) => {
   const { ignored_field_values: ignoredFieldValues = {}, fields: sourceFields = {} } = rawDoc;
   const countOfDegradedFields = Object.keys(ignoredFieldValues)?.length;
 
@@ -186,29 +193,34 @@ export const LogsOverviewDegradedFields = ({ rawDoc }: { rawDoc: DataTableRecord
   );
 
   return countOfDegradedFields > 0 ? (
-    <>
-      <EuiAccordion
-        id={accordionId}
-        buttonContent={accordionTitle}
-        paddingSize="m"
-        initialIsOpen={false}
-        extraAction={<DatasetQualityLink urlService={urlService} dataStream={dataStream} />}
-        data-test-subj="unifiedDocViewLogsOverviewDegradedFieldsAccordion"
-      >
-        <EuiBasicTable
-          tableLayout="fixed"
-          columns={columns}
-          items={renderedItems ?? []}
-          sorting={{ sort: tableOptions.sort }}
-          onChange={onTableChange}
-          pagination={pagination}
-          data-test-subj="unifiedDocViewLogsOverviewDegradedFieldsQualityIssuesTable"
-        />
-      </EuiAccordion>
-      <EuiHorizontalRule margin="xs" />
-    </>
+    <ScrollableSectionWrapper ref={ref}>
+      {({ forceState, onToggle }) => (
+        <>
+          <EuiAccordion
+            id={accordionId}
+            buttonContent={accordionTitle}
+            paddingSize="m"
+            forceState={forceState}
+            onToggle={onToggle}
+            extraAction={<DatasetQualityLink urlService={urlService} dataStream={dataStream} />}
+            data-test-subj="unifiedDocViewLogsOverviewDegradedFieldsAccordion"
+          >
+            <EuiBasicTable
+              tableLayout="fixed"
+              columns={columns}
+              items={renderedItems ?? []}
+              sorting={{ sort: tableOptions.sort }}
+              onChange={onTableChange}
+              pagination={pagination}
+              data-test-subj="unifiedDocViewLogsOverviewDegradedFieldsQualityIssuesTable"
+            />
+          </EuiAccordion>
+          <EuiHorizontalRule margin="xs" />
+        </>
+      )}
+    </ScrollableSectionWrapper>
   ) : null;
-};
+});
 
 const getDegradedFieldsColumns = (): Array<EuiBasicTableColumn<DegradedField>> => [
   {

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_stacktrace_section.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_stacktrace_section.tsx
@@ -10,9 +10,13 @@ import { EuiAccordion, EuiHorizontalRule, EuiTitle, useGeneratedHtmlId } from '@
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { DataTableRecord } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { StacktraceContent } from './sub_components/stacktrace/stacktrace_content';
+import {
+  ScrollableSectionWrapper,
+  ScrollableSectionWrapperApi,
+} from './scrollable_section_wrapper';
 
 const stacktraceAccordionTitle = i18n.translate(
   'unifiedDocViewer.docView.logsOverview.accordion.title.stacktrace',
@@ -21,35 +25,40 @@ const stacktraceAccordionTitle = i18n.translate(
   }
 );
 
-export function LogsOverviewStacktraceSection({
-  hit,
-  dataView,
-}: {
-  hit: DataTableRecord;
-  dataView: DataView;
-}) {
+export const LogsOverviewStacktraceSection = forwardRef<
+  ScrollableSectionWrapperApi,
+  {
+    hit: DataTableRecord;
+    dataView: DataView;
+  }
+>(({ hit, dataView }, ref) => {
   const accordionId = useGeneratedHtmlId({
     prefix: stacktraceAccordionTitle,
   });
 
   return (
-    <>
-      <EuiAccordion
-        id={accordionId}
-        buttonContent={
-          <EuiTitle size="xs">
-            <p>{stacktraceAccordionTitle}</p>
-          </EuiTitle>
-        }
-        paddingSize="m"
-        initialIsOpen={false}
-        data-test-subj="unifiedDocViewLogsOverviewStacktraceAccordion"
-      >
-        <EuiThemeProvider>
-          <StacktraceContent hit={hit} dataView={dataView} />
-        </EuiThemeProvider>
-      </EuiAccordion>
-      <EuiHorizontalRule margin="xs" />
-    </>
+    <ScrollableSectionWrapper ref={ref}>
+      {({ forceState, onToggle }) => (
+        <>
+          <EuiAccordion
+            id={accordionId}
+            buttonContent={
+              <EuiTitle size="xs">
+                <p>{stacktraceAccordionTitle}</p>
+              </EuiTitle>
+            }
+            paddingSize="m"
+            forceState={forceState}
+            onToggle={onToggle}
+            data-test-subj="unifiedDocViewLogsOverviewStacktraceAccordion"
+          >
+            <EuiThemeProvider>
+              <StacktraceContent hit={hit} dataView={dataView} />
+            </EuiThemeProvider>
+          </EuiAccordion>
+          <EuiHorizontalRule margin="xs" />
+        </>
+      )}
+    </ScrollableSectionWrapper>
   );
-}
+});

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/scrollable_section_wrapper.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/scrollable_section_wrapper.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiAccordionProps } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useCallback } from 'react';
+import { ReactElement, forwardRef, useImperativeHandle, useRef, useState } from 'react';
+
+export interface ScrollableSectionWrapperApi {
+  openAndScrollToSection: () => void;
+}
+
+export type ScrollableSectionWrapperChildrenProps = Pick<
+  EuiAccordionProps,
+  'forceState' | 'onToggle'
+>;
+
+export interface ScrollableSectionWrapperProps {
+  children: (props: ScrollableSectionWrapperChildrenProps) => ReactElement;
+}
+
+const SKIP_TRANSITION_CSS = css({
+  '.euiAccordion__childWrapper': { transition: 'none !important' },
+});
+
+export const ScrollableSectionWrapper = forwardRef<
+  ScrollableSectionWrapperApi,
+  ScrollableSectionWrapperProps
+>(({ children }, ref) => {
+  const [{ forceState, skipTransition }, setState] = useState<{
+    forceState: 'closed' | 'open';
+    skipTransition: boolean;
+  }>({
+    forceState: 'closed',
+    skipTransition: false,
+  });
+  const onToggle = useCallback(
+    (isOpen: boolean) => setState((prev) => ({ ...prev, forceState: isOpen ? 'open' : 'closed' })),
+    []
+  );
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      openAndScrollToSection: () => {
+        const wrapper = wrapperRef.current;
+
+        if (!wrapper) {
+          return;
+        }
+
+        if (forceState === 'closed') {
+          setState({ forceState: 'open', skipTransition: true });
+        }
+
+        setTimeout(() => {
+          wrapper.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          setState((prev) => ({ ...prev, skipTransition: false }));
+        }, 100);
+      },
+    }),
+    [forceState]
+  );
+
+  return (
+    <div ref={wrapperRef} css={skipTransition ? SKIP_TRANSITION_CSS : undefined}>
+      {children({ forceState, onToggle })}
+    </div>
+  );
+});

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/lazy_doc_viewer_logs_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/lazy_doc_viewer_logs_overview.tsx
@@ -10,11 +10,16 @@
 import React from 'react';
 import { EuiDelayRender, EuiSkeletonText } from '@elastic/eui';
 import { dynamic } from '@kbn/shared-ux-utility';
+import type LogsOverview from './doc_viewer_logs_overview';
+import type { LogsOverviewApi } from './doc_viewer_logs_overview/logs_overview';
 
-export const UnifiedDocViewerLogsOverview = dynamic(() => import('./doc_viewer_logs_overview'), {
-  fallback: (
-    <EuiDelayRender delay={300}>
-      <EuiSkeletonText />
-    </EuiDelayRender>
-  ),
-});
+export const UnifiedDocViewerLogsOverview = dynamic<typeof LogsOverview, LogsOverviewApi>(
+  () => import('./doc_viewer_logs_overview'),
+  {
+    fallback: (
+      <EuiDelayRender delay={300}>
+        <EuiSkeletonText />
+      </EuiDelayRender>
+    ),
+  }
+);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/index.tsx
@@ -30,7 +30,10 @@ export { useEsDocSearch } from './hooks';
 export { UnifiedDocViewer } from './components/lazy_doc_viewer';
 export { UnifiedDocViewerFlyout } from './components/lazy_doc_viewer_flyout';
 
-export type { LogsOverviewProps as UnifiedDocViewerLogsOverviewProps } from './components/doc_viewer_logs_overview/logs_overview';
+export type {
+  LogsOverviewProps as UnifiedDocViewerLogsOverviewProps,
+  LogsOverviewApi as UnifiedDocViewerLogsOverviewApi,
+} from './components/doc_viewer_logs_overview/logs_overview';
 export { UnifiedDocViewerLogsOverview } from './components/lazy_doc_viewer_logs_overview';
 
 export const plugin = () => new UnifiedDocViewerPublicPlugin();

--- a/src/platform/test/functional/apps/discover/observability/const.ts
+++ b/src/platform/test/functional/apps/discover/observability/const.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const MORE_THAN_1024_CHARS =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?';
+
+export const STACKTRACE_MESSAGE =
+  "Error: 9 FAILED_PRECONDITION: Can't access cart storage. StackExchange.Redis.RedisTimeoutException: Timeout awaiting response (outbound=0KiB, inbound=0KiB, 5467ms elapsed, timeout is 5000ms), command=HGET, next: HGET 7578fdf6-e0b1-4b60-98b3-6751dadffd01, inst: 0, qu: 0, qs: 5, aw: False, bw: SpinningDown, rs: ReadAsync, ws: Idle, in: 377, in-pipe: 0, out-pipe: 0, last-in: 0, cur-in: 0, sync-ops: 2, async-ops: 1653332, serverEndpoint: valkey:6379, conn-sec: 1292697.71, aoc: 0, mc: 1/1/0, mgr: 10 of 10 available, clientName: cartservice-6558778458-4df9q(SE.Redis-v2.8.16.12844), IOCP: (Busy=0,Free=1000,Min=1,Max=1000), WORKER: (Busy=6,Free=32761,Min=2,Max=32767), POOL: (Threads=6,QueuedItems=7,CompletedItems=28329470,Timers=8), v: 2.8.16.12844 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)\n" +
+  '   at cartservice.cartstore.ValkeyCartStore.AddItemAsync(String userId, String productId, Int32 quantity) in /usr/src/app/src/cartstore/ValkeyCartStore.cs:line 117\n' +
+  '    at callErrorFromStatus (/app/node_modules/@grpc/grpc-js/build/src/call.js:31:19)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client.js:193:76)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:360:141)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:323:181)\n' +
+  '    at /app/node_modules/@grpc/grpc-js/build/src/resolving-call.js:129:78\n' +
+  '    at process.processTicksAndRejections (node:internal/process/task_queues:77:11)\n' +
+  'for call at\n' +
+  '    at ServiceClientImpl.makeUnaryRequest (/app/node_modules/@grpc/grpc-js/build/src/client.js:161:32)\n' +
+  '    at ServiceClientImpl.<anonymous> (/app/node_modules/@grpc/grpc-js/build/src/make-client.js:105:19)\n' +
+  '    at /app/node_modules/@opentelemetry/instrumentation-grpc/build/src/clientUtils.js:131:31\n' +
+  '    at /app/node_modules/@opentelemetry/instrumentation-grpc/build/src/instrumentation.js:211:209\n' +
+  '    at AsyncLocalStorage.run (node:async_hooks:346:14)\n' +
+  '    at AsyncLocalStorageContextManager.with (/app/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\n' +
+  '    at ContextAPI.with (/app/node_modules/@opentelemetry/api/build/src/api/context.js:60:46)\n' +
+  '    at ServiceClientImpl.clientMethodTrace [as addItem] (/app/node_modules/@opentelemetry/instrumentation-grpc/build/src/instrumentation.js:211:42)\n' +
+  '    at /app/.next/server/pages/api/cart.js:1:1101\n' +
+  '    at new ZoneAwarePromise (/app/node_modules/zone.js/bundles/zone.umd.js:1340:33)';

--- a/src/platform/test/functional/apps/discover/observability/embeddable/_get_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/observability/embeddable/_get_doc_viewer.ts
@@ -1,0 +1,376 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import moment from 'moment/moment';
+import { log, timerange } from '@kbn/apm-synthtrace-client';
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { MORE_THAN_1024_CHARS, STACKTRACE_MESSAGE } from '../const';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['common', 'discover', 'dashboard', 'header']);
+  const testSubjects = getService('testSubjects');
+  const dataGrid = getService('dataGrid');
+  const dashboardAddPanel = getService('dashboardAddPanel');
+  const synthtrace = getService('logSynthtraceEsClient');
+  const queryBar = getService('queryBar');
+  const kibanaServer = getService('kibanaServer');
+  const dataViews = getService('dataViews');
+
+  const start = moment().subtract(30, 'minutes').valueOf();
+  const end = moment().valueOf();
+
+  const searchQuery = 'error.stack_trace : * and _ignored : *';
+
+  describe('discover/observability saved search embeddable triggering getDocViewer ', () => {
+    before(async () => {
+      await synthtrace.index([
+        timerange(start, end)
+          .interval('1m')
+          .rate(2)
+          .generator((timestamp: number, index: number) =>
+            log
+              .create()
+              .message('This is a log message')
+              .timestamp(timestamp)
+              .dataset('synth.1')
+              .namespace('default')
+              .logLevel(index % 2 === 0 ? MORE_THAN_1024_CHARS : 'This is a log message')
+              .defaults({
+                'service.name': 'synth-service',
+                ...(index % 2 === 0 && { 'error.stack_trace': STACKTRACE_MESSAGE }),
+              })
+          ),
+      ]);
+
+      await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        ensureCurrentUrl: false,
+      });
+
+      // Required as some other test switches data view to metric-*
+      await dataViews.switchTo('All logs');
+
+      await queryBar.setQuery(searchQuery);
+      await queryBar.submitQuery();
+      await PageObjects.discover.waitUntilSearchingHasFinished();
+
+      // Required to access Dashboard page
+      await dataViews.createFromSearchBar({
+        name: 'logs-synth',
+      });
+
+      await PageObjects.discover.saveSearch('synth-search-doc-viewer');
+
+      await PageObjects.dashboard.navigateToApp();
+      await PageObjects.dashboard.gotoDashboardLandingPage();
+      await PageObjects.dashboard.clickNewDashboard();
+
+      await dashboardAddPanel.addSavedSearch('synth-search-doc-viewer');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.dashboard.waitForRenderComplete();
+    });
+
+    after(async () => {
+      await synthtrace.clean();
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern', 'dashboard'] });
+    });
+
+    afterEach(async () => {
+      await dataGrid.closeFlyout();
+    });
+
+    describe('renders docViewer', () => {
+      it('should open the flyout with stacktrace and quality issues accordion closed when expand is clicked', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Ensure Log overview flyout is open
+        const tabButton = await testSubjects.find('docViewerTab-doc_view_logs_overview');
+        await tabButton.click();
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('true');
+      });
+
+      it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('true');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should keep old accordion open when 1st stacktrace and then quality issue control for the same row is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to quality issue accordion when 1st stacktrace and then quality issue control is clicked for different row', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('false');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should keep old accordion open when 1st quality issue and then stacktrace control for the same row is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to stacktrace accordion when 1st quality issue and then stacktrace control is clicked for different row', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+    });
+  });
+}

--- a/src/platform/test/functional/apps/discover/observability/embeddable/_saved_search_embeddable.ts
+++ b/src/platform/test/functional/apps/discover/observability/embeddable/_saved_search_embeddable.ts
@@ -16,7 +16,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
-  const { dashboard, header } = getPageObjects(['dashboard', 'header']);
+  const { common, dashboard, header } = getPageObjects(['common', 'dashboard', 'header']);
+
+  const from = 'Sep 22, 2015 @ 00:00:00.000';
+  const to = 'Sep 23, 2015 @ 00:00:00.000';
 
   describe('discover/observability saved search embeddable', () => {
     before(async () => {
@@ -27,14 +30,29 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/dashboard/current/kibana'
       );
+      await esArchiver.loadIfNeeded(
+        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
+      );
+      await kibanaServer.uiSettings.replace({
+        defaultIndex: '0bf35f60-3dc9-11e8-8660-4d65aa086b3c',
+      });
+
+      await common.setTime({
+        from,
+        to,
+      });
       await dashboard.navigateToApp();
       await dashboard.gotoDashboardLandingPage();
       await dashboard.clickNewDashboard();
     });
 
     after(async () => {
+      await common.unsetTime();
       await esArchiver.unload(
         'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
+      );
+      await esArchiver.unload(
+        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
     });

--- a/src/platform/test/functional/apps/discover/observability/index.ts
+++ b/src/platform/test/functional/apps/discover/observability/index.ts
@@ -9,26 +9,11 @@
 
 import { FtrProviderContext } from '../ftr_provider_context';
 
-export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
-  const kibanaServer = getService('kibanaServer');
-  const { common, spaceSettings } = getPageObjects(['common', 'spaceSettings']);
-
-  const from = 'Sep 22, 2015 @ 00:00:00.000';
-  const to = 'Sep 23, 2015 @ 00:00:00.000';
+export default function ({ getPageObjects, loadTestFile }: FtrProviderContext) {
+  const { spaceSettings } = getPageObjects(['common', 'spaceSettings']);
 
   describe('discover/observability', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await kibanaServer.uiSettings.replace({
-        defaultIndex: '0bf35f60-3dc9-11e8-8660-4d65aa086b3c',
-      });
-      await common.setTime({
-        from,
-        to,
-      });
       await spaceSettings.switchSpaceSolutionType({
         spaceName: 'default',
         solution: 'oblt',
@@ -40,13 +25,11 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
         spaceName: 'default',
         solution: 'classic',
       });
-      await common.unsetTime();
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./embeddable/_saved_search_embeddable'));
     loadTestFile(require.resolve('./logs/_get_pagination_config'));
+    loadTestFile(require.resolve('./embeddable/_get_doc_viewer'));
+    loadTestFile(require.resolve('./logs/_get_doc_viewer'));
   });
 }

--- a/src/platform/test/functional/apps/discover/observability/logs/_get_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/observability/logs/_get_doc_viewer.ts
@@ -1,0 +1,356 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import moment from 'moment/moment';
+import { log, timerange } from '@kbn/apm-synthtrace-client';
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { MORE_THAN_1024_CHARS, STACKTRACE_MESSAGE } from '../const';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['common', 'discover']);
+  const testSubjects = getService('testSubjects');
+  const dataGrid = getService('dataGrid');
+  const dataViews = getService('dataViews');
+  const synthtrace = getService('logSynthtraceEsClient');
+  const queryBar = getService('queryBar');
+
+  const start = moment().subtract(30, 'minutes').valueOf();
+  const end = moment().valueOf();
+
+  describe('extension getDocViewer ', () => {
+    before(async () => {
+      await synthtrace.index([
+        timerange(start, end)
+          .interval('1m')
+          .rate(2)
+          .generator((timestamp: number, index: number) =>
+            log
+              .create()
+              .message('This is a log message')
+              .timestamp(timestamp)
+              .dataset('synth.1')
+              .namespace('default')
+              .logLevel(index % 2 === 0 ? MORE_THAN_1024_CHARS : 'This is a log message')
+              .defaults({
+                'service.name': 'synth-service',
+                ...(index % 2 === 0 && { 'error.stack_trace': STACKTRACE_MESSAGE }),
+              })
+          ),
+      ]);
+
+      await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        ensureCurrentUrl: false,
+      });
+
+      // Required as some other test switches data view to metric-*
+      await dataViews.switchTo('All logs');
+
+      await queryBar.setQuery('error.stack_trace : * and _ignored : *');
+      await queryBar.submitQuery();
+      await PageObjects.discover.waitUntilSearchingHasFinished();
+    });
+
+    after(async () => {
+      await synthtrace.clean();
+    });
+
+    afterEach(async () => {
+      await dataGrid.closeFlyout();
+    });
+
+    describe('renders docViewer', () => {
+      it('should open the flyout with stacktrace and quality issues accordion closed when expand is clicked', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Ensure Log overview flyout is open
+        const tabButton = await testSubjects.find('docViewerTab-doc_view_logs_overview');
+        await tabButton.click();
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('true');
+      });
+
+      it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('true');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should keep old accordion open when 1st stacktrace and then quality issue control for the same row is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to quality issue accordion when 1st stacktrace and then quality issue control is clicked for different row', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('false');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should keep old accordion open when 1st quality issue and then stacktrace control for the same row is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to stacktrace accordion when 1st quality issue and then stacktrace control is clicked for different row', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+    });
+  });
+}

--- a/src/platform/test/functional/apps/discover/observability/logs/_get_pagination_config.ts
+++ b/src/platform/test/functional/apps/discover/observability/logs/_get_pagination_config.ts
@@ -18,11 +18,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  const resetTimeFrame = {
-    from: '2024-06-10T14:00:00.000Z',
-    to: '2024-06-10T16:30:00.000Z',
-  };
-
   const currentTimeFrame = {
     from: '2015-09-20T01:00:00.000Z',
     to: '2015-09-24T16:30:00.000Z',
@@ -43,9 +38,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await esArchiver.unload(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
-      await kibanaServer.uiSettings.update({
-        'timepicker:timeDefaults': `{ "from": "${resetTimeFrame.from}", "to": "${resetTimeFrame.to}"}`,
-      });
+      await PageObjects.common.unsetTime();
     });
 
     describe('ES|QL mode', () => {

--- a/src/platform/test/functional/page_objects/space_settings.ts
+++ b/src/platform/test/functional/page_objects/space_settings.ts
@@ -44,7 +44,5 @@ export class SpaceSettingsPageObject extends FtrService {
     await this.testSubjects.click(solutionSpecificTestSubjectMap[solution]);
     await this.testSubjects.click('save-space-button');
     await this.testSubjects.click('confirmModalConfirmButton');
-
-    await this.common.navigateToUrl('discover');
   }
 }

--- a/src/platform/test/functional/services/data_grid.ts
+++ b/src/platform/test/functional/services/data_grid.ts
@@ -424,6 +424,30 @@ export class DataGridService extends FtrService {
     return (await this.getBodyRows(options, selector))[options.rowIndex || 0];
   }
 
+  public async clickQualityIssueLeadingControl(rowIndex: number) {
+    const buttons = await this.testSubjects.findAll('docTableDegradedDocExist');
+    const selectedButton = rowIndex < buttons.length ? buttons[rowIndex] : undefined;
+
+    if (selectedButton) {
+      await selectedButton.moveMouseTo();
+      await selectedButton.click();
+    } else {
+      throw new Error(`Unable to find quality issue leading control for row index ${rowIndex}`);
+    }
+  }
+
+  public async clickStacktraceLeadingControl(rowIndex: number) {
+    const buttons = await this.testSubjects.findAll('docTableStacktraceExist');
+    const selectedButton = rowIndex < buttons.length ? buttons[rowIndex] : undefined;
+
+    if (selectedButton) {
+      await selectedButton.moveMouseTo();
+      await selectedButton.click();
+    } else {
+      throw new Error(`Unable to find stacktrace leading control for row index ${rowIndex}`);
+    }
+  }
+
   public async clickRowToggle(
     { defaultTabId, ...options }: SelectOptions & { defaultTabId?: string | false } = {
       isAnchorRow: false,

--- a/src/platform/test/functional/services/index.ts
+++ b/src/platform/test/functional/services/index.ts
@@ -56,6 +56,7 @@ import { SavedObjectsFinderService } from './saved_objects_finder';
 import { DashboardSettingsProvider } from './dashboard/dashboard_settings';
 import { ESQLService } from './esql';
 import { DataViewsService } from './data_views';
+import { LogSynthtraceEsClientProvider } from './synthtrace/logs_synthtrace_es_client';
 
 export const services = {
   ...commonFunctionalServices,
@@ -100,4 +101,5 @@ export const services = {
   usageCollection: UsageCollectionService,
   savedObjectsFinder: SavedObjectsFinderService,
   esql: ESQLService,
+  logSynthtraceEsClient: LogSynthtraceEsClientProvider,
 };

--- a/src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts
+++ b/src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createLogger, LogLevel, LogsSynthtraceEsClient } from '@kbn/apm-synthtrace';
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export function LogSynthtraceEsClientProvider({ getService }: FtrProviderContext) {
+  return new LogsSynthtraceEsClient({
+    client: getService('es'),
+    logger: createLogger(LogLevel.info),
+    refreshAfterIndex: true,
+  });
+}

--- a/src/platform/test/tsconfig.json
+++ b/src/platform/test/tsconfig.json
@@ -80,5 +80,7 @@
     "@kbn/data-grid-in-table-search",
     "@kbn/scout-info",
     "@kbn/esql-utils",
+    "@kbn/apm-synthtrace-client",
+    "@kbn/apm-synthtrace",
   ]
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/authentication.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/authentication.test.ts.snap
@@ -11,12 +11,12 @@ Object {
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-3fd0c5d5-f762-4a27-8c56-14eee0223e13",
+      "name": "indexpattern-datasource-layer-layer-authentication-success-id-generated-uuid",
       "type": "index-pattern",
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-bef502be-e5ff-442f-9e3e-229f86ca2afa",
+      "name": "indexpattern-datasource-layer-layer-authentication-failure-id-generated-uuid",
       "type": "index-pattern",
     },
     Object {
@@ -29,26 +29,26 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "3fd0c5d5-f762-4a27-8c56-14eee0223e13": Object {
+          "layer-authentication-failure-id-generated-uuid": Object {
             "columnOrder": Array [
-              "b41a2958-650b-470a-84c4-c6fd8f0c6d37",
-              "5417777d-d9d9-4268-9cdc-eb29b873bd65",
+              "column-timestamp-failure-id-generated-uuid",
+              "column-event-outcome-failure-id-generated-uuid",
             ],
             "columns": Object {
-              "5417777d-d9d9-4268-9cdc-eb29b873bd65": Object {
+              "column-event-outcome-failure-id-generated-uuid": Object {
                 "customLabel": true,
                 "dataType": "number",
                 "filter": Object {
                   "language": "kuery",
-                  "query": "event.outcome : \\"success\\"",
+                  "query": "event.outcome : \\"failure\\"",
                 },
                 "isBucketed": false,
-                "label": "Success",
+                "label": "Failure",
                 "operationType": "count",
                 "scale": "ratio",
                 "sourceField": "___records___",
               },
-              "b41a2958-650b-470a-84c4-c6fd8f0c6d37": Object {
+              "column-timestamp-failure-id-generated-uuid": Object {
                 "dataType": "date",
                 "isBucketed": true,
                 "label": "@timestamp",
@@ -62,26 +62,26 @@ Object {
             },
             "incompleteColumns": Object {},
           },
-          "bef502be-e5ff-442f-9e3e-229f86ca2afa": Object {
+          "layer-authentication-success-id-generated-uuid": Object {
             "columnOrder": Array [
-              "cded27f7-8ef8-458c-8d9b-70db48ae340d",
-              "a3bf9dc1-c8d2-42d6-9e60-31892a4c509e",
+              "column-timestamp-success-id-generated-uuid",
+              "column-event-outcome-success-id-generated-uuid",
             ],
             "columns": Object {
-              "a3bf9dc1-c8d2-42d6-9e60-31892a4c509e": Object {
+              "column-event-outcome-success-id-generated-uuid": Object {
                 "customLabel": true,
                 "dataType": "number",
                 "filter": Object {
                   "language": "kuery",
-                  "query": "event.outcome : \\"failure\\"",
+                  "query": "event.outcome : \\"success\\"",
                 },
                 "isBucketed": false,
-                "label": "Failure",
+                "label": "Success",
                 "operationType": "count",
                 "scale": "ratio",
                 "sourceField": "___records___",
               },
-              "cded27f7-8ef8-458c-8d9b-70db48ae340d": Object {
+              "column-timestamp-success-id-generated-uuid": Object {
                 "dataType": "date",
                 "isBucketed": true,
                 "label": "@timestamp",
@@ -218,33 +218,33 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "5417777d-d9d9-4268-9cdc-eb29b873bd65",
+            "column-event-outcome-success-id-generated-uuid",
           ],
-          "layerId": "3fd0c5d5-f762-4a27-8c56-14eee0223e13",
+          "layerId": "layer-authentication-success-id-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "bar_stacked",
           "showGridlines": false,
-          "xAccessor": "b41a2958-650b-470a-84c4-c6fd8f0c6d37",
+          "xAccessor": "column-timestamp-success-id-generated-uuid",
           "yConfig": Array [
             Object {
-              "color": "#54B399",
-              "forAccessor": "5417777d-d9d9-4268-9cdc-eb29b873bd65",
+              "color": "#16C5C0",
+              "forAccessor": "column-event-outcome-success-id-generated-uuid",
             },
           ],
         },
         Object {
           "accessors": Array [
-            "a3bf9dc1-c8d2-42d6-9e60-31892a4c509e",
+            "column-event-outcome-failure-id-generated-uuid",
           ],
-          "layerId": "bef502be-e5ff-442f-9e3e-229f86ca2afa",
+          "layerId": "layer-authentication-failure-id-generated-uuid",
           "layerType": "data",
           "seriesType": "bar_stacked",
-          "xAccessor": "cded27f7-8ef8-458c-8d9b-70db48ae340d",
+          "xAccessor": "column-timestamp-failure-id-generated-uuid",
           "yConfig": Array [
             Object {
-              "color": "#DA8B45",
-              "forAccessor": "a3bf9dc1-c8d2-42d6-9e60-31892a4c509e",
+              "color": "#FFC9C2",
+              "forAccessor": "column-event-outcome-failure-id-generated-uuid",
             },
           ],
         },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/authentication.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/authentication.test.ts.snap
@@ -228,7 +228,7 @@ Object {
           "xAccessor": "column-timestamp-success-id-generated-uuid",
           "yConfig": Array [
             Object {
-              "color": "#16C5C0",
+              "color": "#54B399",
               "forAccessor": "column-event-outcome-success-id-generated-uuid",
             },
           ],
@@ -243,7 +243,7 @@ Object {
           "xAccessor": "column-timestamp-failure-id-generated-uuid",
           "yConfig": Array [
             Object {
-              "color": "#FFC9C2",
+              "color": "#DA8B45",
               "forAccessor": "column-event-outcome-failure-id-generated-uuid",
             },
           ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/external_alert.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/external_alert.test.ts.snap
@@ -11,7 +11,7 @@ Object {
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-a3c54471-615f-4ff9-9fda-69b5b2ea3eef",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
     Object {
@@ -29,14 +29,14 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "a3c54471-615f-4ff9-9fda-69b5b2ea3eef": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "42334c6e-98d9-47a2-b4cb-a445abb44c93",
-              "37bdf546-3c11-4b08-8c5d-e37debc44f1d",
-              "0a923af2-c880-4aa3-aa93-a0b9c2801f6d",
+              "column-top-value-id-generated-uuid",
+              "column-timestamp-id-generated-uuid",
+              "column-count-id-generated-uuid",
             ],
             "columns": Object {
-              "0a923af2-c880-4aa3-aa93-a0b9c2801f6d": Object {
+              "column-count-id-generated-uuid": Object {
                 "dataType": "number",
                 "isBucketed": false,
                 "label": "Count of records",
@@ -47,7 +47,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "___records___",
               },
-              "37bdf546-3c11-4b08-8c5d-e37debc44f1d": Object {
+              "column-timestamp-id-generated-uuid": Object {
                 "dataType": "date",
                 "isBucketed": true,
                 "label": "@timestamp",
@@ -59,7 +59,7 @@ Object {
                 "scale": "interval",
                 "sourceField": "@timestamp",
               },
-              "42334c6e-98d9-47a2-b4cb-a445abb44c93": Object {
+              "column-top-value-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of event.dataset",
@@ -67,7 +67,7 @@ Object {
                 "params": Object {
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "0a923af2-c880-4aa3-aa93-a0b9c2801f6d",
+                    "columnId": "column-count-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -202,15 +202,15 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "0a923af2-c880-4aa3-aa93-a0b9c2801f6d",
+            "column-count-id-generated-uuid",
           ],
-          "layerId": "a3c54471-615f-4ff9-9fda-69b5b2ea3eef",
+          "layerId": "layer-id-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "bar_stacked",
           "showGridlines": false,
-          "splitAccessor": "42334c6e-98d9-47a2-b4cb-a445abb44c93",
-          "xAccessor": "37bdf546-3c11-4b08-8c5d-e37debc44f1d",
+          "splitAccessor": "column-top-value-id-generated-uuid",
+          "xAccessor": "column-timestamp-id-generated-uuid",
         },
       ],
       "legend": Object {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_by_status_donut.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_by_status_donut.test.ts.snap
@@ -6,7 +6,7 @@ Object {
   "references": Array [
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-b9b43606-7ff7-46ae-a47c-85bed80fab9a",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
     Object {
@@ -20,13 +20,13 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "b9b43606-7ff7-46ae-a47c-85bed80fab9a": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "a9b43606-7ff7-46ae-a47c-85bed80fab9a",
-              "21cc4a49-3780-4b1a-be28-f02fa5303d24",
+              "column-severity-id-generated-uuid",
+              "column-record-id-generated-uuid",
             ],
             "columns": Object {
-              "21cc4a49-3780-4b1a-be28-f02fa5303d24": Object {
+              "column-record-id-generated-uuid": Object {
                 "dataType": "number",
                 "filter": Object {
                   "language": "kuery",
@@ -41,7 +41,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "___records___",
               },
-              "a9b43606-7ff7-46ae-a47c-85bed80fab9a": Object {
+              "column-severity-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Filters",
@@ -143,17 +143,17 @@ Object {
         Object {
           "categoryDisplay": "hide",
           "emptySizeRatio": 0.85,
-          "layerId": "b9b43606-7ff7-46ae-a47c-85bed80fab9a",
+          "layerId": "layer-id-generated-uuid",
           "layerType": "data",
           "legendDisplay": "hide",
           "metrics": Array [
-            "21cc4a49-3780-4b1a-be28-f02fa5303d24",
+            "column-record-id-generated-uuid",
           ],
           "nestedLegend": true,
           "numberDisplay": "value",
           "percentDecimals": 2,
           "primaryGroups": Array [
-            "a9b43606-7ff7-46ae-a47c-85bed80fab9a",
+            "column-severity-id-generated-uuid",
           ],
         },
       ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_histogram.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_histogram.test.ts.snap
@@ -6,7 +6,7 @@ Object {
   "references": Array [
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-0039eb0c-9a1a-4687-ae54-0f4e239bec75",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -15,14 +15,37 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "0039eb0c-9a1a-4687-ae54-0f4e239bec75": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "34919782-4546-43a5-b668-06ac934d3acd",
-              "aac9d7d0-13a3-480a-892b-08207a787926",
-              "e09e0380-0740-4105-becc-0a4ca12e3944",
+              "column-top-values-id-generated-uuid",
+              "column-timestamp-id-generated-uuid",
+              "column-count-of-records-id-generated-uuid",
             ],
             "columns": Object {
-              "34919782-4546-43a5-b668-06ac934d3acd": Object {
+              "column-count-of-records-id-generated-uuid": Object {
+                "dataType": "number",
+                "isBucketed": false,
+                "label": "Count of records",
+                "operationType": "count",
+                "params": Object {
+                  "emptyAsNull": true,
+                },
+                "scale": "ratio",
+                "sourceField": "___records___",
+              },
+              "column-timestamp-id-generated-uuid": Object {
+                "dataType": "date",
+                "isBucketed": true,
+                "label": "@timestamp",
+                "operationType": "date_histogram",
+                "params": Object {
+                  "includeEmptyRows": true,
+                  "interval": "auto",
+                },
+                "scale": "interval",
+                "sourceField": "@timestamp",
+              },
+              "column-top-values-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of event.category",
@@ -30,7 +53,7 @@ Object {
                 "params": Object {
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "e09e0380-0740-4105-becc-0a4ca12e3944",
+                    "columnId": "column-count-of-records-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -43,29 +66,6 @@ Object {
                 },
                 "scale": "ordinal",
                 "sourceField": "event.category",
-              },
-              "aac9d7d0-13a3-480a-892b-08207a787926": Object {
-                "dataType": "date",
-                "isBucketed": true,
-                "label": "@timestamp",
-                "operationType": "date_histogram",
-                "params": Object {
-                  "includeEmptyRows": true,
-                  "interval": "auto",
-                },
-                "scale": "interval",
-                "sourceField": "@timestamp",
-              },
-              "e09e0380-0740-4105-becc-0a4ca12e3944": Object {
-                "dataType": "number",
-                "isBucketed": false,
-                "label": "Count of records",
-                "operationType": "count",
-                "params": Object {
-                  "emptyAsNull": true,
-                },
-                "scale": "ratio",
-                "sourceField": "___records___",
               },
             },
             "incompleteColumns": Object {},
@@ -154,15 +154,15 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "e09e0380-0740-4105-becc-0a4ca12e3944",
+            "column-count-of-records-id-generated-uuid",
           ],
-          "layerId": "0039eb0c-9a1a-4687-ae54-0f4e239bec75",
+          "layerId": "layer-id-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "bar_stacked",
           "showGridlines": false,
-          "splitAccessor": "34919782-4546-43a5-b668-06ac934d3acd",
-          "xAccessor": "aac9d7d0-13a3-480a-892b-08207a787926",
+          "splitAccessor": "column-top-values-id-generated-uuid",
+          "xAccessor": "column-timestamp-id-generated-uuid",
         },
       ],
       "legend": Object {
@@ -195,7 +195,7 @@ Object {
   "references": Array [
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-0039eb0c-9a1a-4687-ae54-0f4e239bec75",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -204,14 +204,37 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "0039eb0c-9a1a-4687-ae54-0f4e239bec75": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "34919782-4546-43a5-b668-06ac934d3acd",
-              "aac9d7d0-13a3-480a-892b-08207a787926",
-              "e09e0380-0740-4105-becc-0a4ca12e3944",
+              "column-top-values-id-generated-uuid",
+              "column-timestamp-id-generated-uuid",
+              "column-count-of-records-id-generated-uuid",
             ],
             "columns": Object {
-              "34919782-4546-43a5-b668-06ac934d3acd": Object {
+              "column-count-of-records-id-generated-uuid": Object {
+                "dataType": "number",
+                "isBucketed": false,
+                "label": "Count of records",
+                "operationType": "count",
+                "params": Object {
+                  "emptyAsNull": true,
+                },
+                "scale": "ratio",
+                "sourceField": "___records___",
+              },
+              "column-timestamp-id-generated-uuid": Object {
+                "dataType": "date",
+                "isBucketed": true,
+                "label": "@timestamp",
+                "operationType": "date_histogram",
+                "params": Object {
+                  "includeEmptyRows": true,
+                  "interval": "auto",
+                },
+                "scale": "interval",
+                "sourceField": "@timestamp",
+              },
+              "column-top-values-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of event.category",
@@ -219,7 +242,7 @@ Object {
                 "params": Object {
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "e09e0380-0740-4105-becc-0a4ca12e3944",
+                    "columnId": "column-count-of-records-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -232,29 +255,6 @@ Object {
                 },
                 "scale": "ordinal",
                 "sourceField": "event.category",
-              },
-              "aac9d7d0-13a3-480a-892b-08207a787926": Object {
-                "dataType": "date",
-                "isBucketed": true,
-                "label": "@timestamp",
-                "operationType": "date_histogram",
-                "params": Object {
-                  "includeEmptyRows": true,
-                  "interval": "auto",
-                },
-                "scale": "interval",
-                "sourceField": "@timestamp",
-              },
-              "e09e0380-0740-4105-becc-0a4ca12e3944": Object {
-                "dataType": "number",
-                "isBucketed": false,
-                "label": "Count of records",
-                "operationType": "count",
-                "params": Object {
-                  "emptyAsNull": true,
-                },
-                "scale": "ratio",
-                "sourceField": "___records___",
               },
             },
             "incompleteColumns": Object {},
@@ -319,15 +319,15 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "e09e0380-0740-4105-becc-0a4ca12e3944",
+            "column-count-of-records-id-generated-uuid",
           ],
-          "layerId": "0039eb0c-9a1a-4687-ae54-0f4e239bec75",
+          "layerId": "layer-id-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "bar_stacked",
           "showGridlines": false,
-          "splitAccessor": "34919782-4546-43a5-b668-06ac934d3acd",
-          "xAccessor": "aac9d7d0-13a3-480a-892b-08207a787926",
+          "splitAccessor": "column-top-values-id-generated-uuid",
+          "xAccessor": "column-timestamp-id-generated-uuid",
         },
       ],
       "legend": Object {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_table.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_table.test.ts.snap
@@ -6,7 +6,7 @@ Object {
   "references": Array [
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-mockLayerId",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -15,14 +15,14 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "mockLayerId": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "mockTopValuesOfStackByFieldColumnId",
-              "mockTopValuesOfBreakdownFieldColumnId",
-              "mockCountColumnId",
+              "top-values-of-stack-by-field-column-id-generated-uuid",
+              "top-values-of-breakdown-field-column-id-generated-uuid",
+              "count-column-id-generated-uuid",
             ],
             "columns": Object {
-              "mockCountColumnId": Object {
+              "count-column-id-generated-uuid": Object {
                 "dataType": "number",
                 "isBucketed": false,
                 "label": "Count of agent.type",
@@ -33,7 +33,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "agent.type",
               },
-              "mockTopValuesOfBreakdownFieldColumnId": Object {
+              "top-values-of-breakdown-field-column-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of agent.type",
@@ -45,7 +45,7 @@ Object {
                   "includeIsRegex": false,
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "mockCountColumnId",
+                    "columnId": "count-column-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -58,7 +58,7 @@ Object {
                 "scale": "ordinal",
                 "sourceField": "agent.type",
               },
-              "mockTopValuesOfStackByFieldColumnId": Object {
+              "top-values-of-stack-by-field-column-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of event.category",
@@ -70,7 +70,7 @@ Object {
                   "includeIsRegex": false,
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "mockCountColumnId",
+                    "columnId": "count-column-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -144,20 +144,20 @@ Object {
     "visualization": Object {
       "columns": Array [
         Object {
-          "columnId": "mockTopValuesOfStackByFieldColumnId",
+          "columnId": "top-values-of-stack-by-field-column-id-generated-uuid",
           "isTransposed": false,
           "width": 362,
         },
         Object {
-          "columnId": "mockCountColumnId",
+          "columnId": "count-column-id-generated-uuid",
           "isTransposed": false,
         },
         Object {
-          "columnId": "mockTopValuesOfBreakdownFieldColumnId",
+          "columnId": "top-values-of-breakdown-field-column-id-generated-uuid",
           "isTransposed": false,
         },
       ],
-      "layerId": "mockLayerId",
+      "layerId": "layer-id-generated-uuid",
       "layerType": "data",
     },
   },
@@ -172,7 +172,7 @@ Object {
   "references": Array [
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-mockLayerId",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -181,13 +181,13 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "mockLayerId": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "mockTopValuesOfStackByFieldColumnId",
-              "mockCountColumnId",
+              "top-values-of-stack-by-field-column-id-generated-uuid",
+              "count-column-id-generated-uuid",
             ],
             "columns": Object {
-              "mockCountColumnId": Object {
+              "count-column-id-generated-uuid": Object {
                 "dataType": "number",
                 "isBucketed": false,
                 "label": "Count of event.category",
@@ -198,7 +198,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "event.category",
               },
-              "mockTopValuesOfStackByFieldColumnId": Object {
+              "top-values-of-stack-by-field-column-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of event.category",
@@ -210,7 +210,7 @@ Object {
                   "includeIsRegex": false,
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "mockCountColumnId",
+                    "columnId": "count-column-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -308,16 +308,16 @@ Object {
     "visualization": Object {
       "columns": Array [
         Object {
-          "columnId": "mockTopValuesOfStackByFieldColumnId",
+          "columnId": "top-values-of-stack-by-field-column-id-generated-uuid",
           "isTransposed": false,
           "width": 362,
         },
         Object {
-          "columnId": "mockCountColumnId",
+          "columnId": "count-column-id-generated-uuid",
           "isTransposed": false,
         },
       ],
-      "layerId": "mockLayerId",
+      "layerId": "layer-id-generated-uuid",
       "layerType": "data",
     },
   },
@@ -332,7 +332,7 @@ Object {
   "references": Array [
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-mockLayerId",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -341,13 +341,13 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "mockLayerId": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "mockTopValuesOfStackByFieldColumnId",
-              "mockCountColumnId",
+              "top-values-of-stack-by-field-column-id-generated-uuid",
+              "count-column-id-generated-uuid",
             ],
             "columns": Object {
-              "mockCountColumnId": Object {
+              "count-column-id-generated-uuid": Object {
                 "dataType": "number",
                 "isBucketed": false,
                 "label": "Count of event.category",
@@ -358,7 +358,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "event.category",
               },
-              "mockTopValuesOfStackByFieldColumnId": Object {
+              "top-values-of-stack-by-field-column-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of event.category",
@@ -370,7 +370,7 @@ Object {
                   "includeIsRegex": false,
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "mockCountColumnId",
+                    "columnId": "count-column-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -444,16 +444,16 @@ Object {
     "visualization": Object {
       "columns": Array [
         Object {
-          "columnId": "mockTopValuesOfStackByFieldColumnId",
+          "columnId": "top-values-of-stack-by-field-column-id-generated-uuid",
           "isTransposed": false,
           "width": 362,
         },
         Object {
-          "columnId": "mockCountColumnId",
+          "columnId": "count-column-id-generated-uuid",
           "isTransposed": false,
         },
       ],
-      "layerId": "mockLayerId",
+      "layerId": "layer-id-generated-uuid",
       "layerType": "data",
     },
   },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/rule_preview.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/rule_preview.test.ts.snap
@@ -6,11 +6,11 @@ Object {
   "references": Array [],
   "state": Object {
     "adHocDataViews": Object {
-      "mockInternalReferenceId": Object {
+      "internal-reference-id-generated-uuid": Object {
         "allowNoIndex": false,
         "fieldAttrs": Object {},
         "fieldFormats": Object {},
-        "id": "mockInternalReferenceId",
+        "id": "internal-reference-id-generated-uuid",
         "name": ".preview.alerts-security.alerts-undefined",
         "runtimeFieldMap": Object {},
         "sourceFilters": Array [],
@@ -21,14 +21,14 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "mockLayerId": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "mockColumnTopValuesId",
-              "mockColumnTimestampId",
-              "mockColumnCountOfRecordsId",
+              "column-top-values-id-generated-uuid",
+              "column-timestamp-id-generated-uuid",
+              "column-count-of-records-id-generated-uuid",
             ],
             "columns": Object {
-              "mockColumnCountOfRecordsId": Object {
+              "column-count-of-records-id-generated-uuid": Object {
                 "dataType": "number",
                 "isBucketed": false,
                 "label": "Count of records",
@@ -39,7 +39,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "___records___",
               },
-              "mockColumnTimestampId": Object {
+              "column-timestamp-id-generated-uuid": Object {
                 "dataType": "date",
                 "isBucketed": true,
                 "label": "@timestamp",
@@ -52,7 +52,7 @@ Object {
                 "scale": "interval",
                 "sourceField": "@timestamp",
               },
-              "mockColumnTopValuesId": Object {
+              "column-top-values-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top 10 values of event.category",
@@ -64,7 +64,7 @@ Object {
                   "includeIsRegex": false,
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "mockColumnCountOfRecordsId",
+                    "columnId": "column-count-of-records-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -93,7 +93,7 @@ Object {
           "alias": null,
           "disabled": false,
           "field": "kibana.alert.rule.uuid",
-          "index": "mockInternalReferenceId",
+          "index": "internal-reference-id-generated-uuid",
           "key": "kibana.alert.rule.uuid",
           "negate": false,
           "params": Object {
@@ -127,8 +127,8 @@ Object {
     ],
     "internalReferences": Array [
       Object {
-        "id": "mockInternalReferenceId",
-        "name": "indexpattern-datasource-layer-mockLayerId",
+        "id": "internal-reference-id-generated-uuid",
+        "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
         "type": "index-pattern",
       },
     ],
@@ -145,15 +145,15 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "mockColumnCountOfRecordsId",
+            "column-count-of-records-id-generated-uuid",
           ],
-          "layerId": "mockLayerId",
+          "layerId": "layer-id-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "bar_stacked",
           "showGridlines": false,
-          "splitAccessor": "mockColumnTopValuesId",
-          "xAccessor": "mockColumnTimestampId",
+          "splitAccessor": "column-top-values-id-generated-uuid",
+          "xAccessor": "column-timestamp-id-generated-uuid",
         },
       ],
       "legend": Object {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_by_status_donut.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_by_status_donut.test.ts
@@ -13,11 +13,7 @@ import { useLensAttributes } from '../../../use_lens_attributes';
 import { getAlertsByStatusAttributes } from './alerts_by_status_donut';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('b9b43606-7ff7-46ae-a47c-85bed80fab9a')
-    .mockReturnValueOnce('a9b43606-7ff7-46ae-a47c-85bed80fab9a')
-    .mockReturnValueOnce('21cc4a49-3780-4b1a-be28-f02fa5303d24'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_by_status_donut.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_by_status_donut.ts
@@ -6,9 +6,9 @@
  */
 import { v4 as uuidv4 } from 'uuid';
 import type { GetLensAttributes } from '../../../types';
-const layerId = uuidv4();
-const columnSeverity = uuidv4();
-const columnRecord = uuidv4();
+const layerId = `layer-id-${uuidv4()}`;
+const columnSeverity = `column-severity-id-${uuidv4()}`;
+const columnRecord = `column-record-id-${uuidv4()}`;
 
 export const getAlertsByStatusAttributes: GetLensAttributes = ({
   stackByField = 'kibana.alert.workflow_status',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
@@ -13,12 +13,7 @@ import { useLensAttributes } from '../../../use_lens_attributes';
 import { getAlertsHistogramLensAttributes } from './alerts_histogram';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('0039eb0c-9a1a-4687-ae54-0f4e239bec75')
-    .mockReturnValueOnce('e09e0380-0740-4105-becc-0a4ca12e3944')
-    .mockReturnValueOnce('34919782-4546-43a5-b668-06ac934d3acd')
-    .mockReturnValueOnce('aac9d7d0-13a3-480a-892b-08207a787926'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.ts
@@ -6,10 +6,10 @@
  */
 import { v4 as uuidv4 } from 'uuid';
 import type { GetLensAttributes } from '../../../types';
-const layerId = uuidv4();
-const columnCountOfRecords = uuidv4();
-const columnTopValues = uuidv4();
-const columnTimestamp = uuidv4();
+const layerId = `layer-id-${uuidv4()}`;
+const columnCountOfRecords = `column-count-of-records-id-${uuidv4()}`;
+const columnTopValues = `column-top-values-id-${uuidv4()}`;
+const columnTimestamp = `column-timestamp-id-${uuidv4()}`;
 
 export const getAlertsHistogramLensAttributes: GetLensAttributes = ({
   stackByField = 'kibana.alert.rule.name',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_table.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_table.test.ts
@@ -20,12 +20,8 @@ interface VisualizationState {
 }
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('mockLayerId')
-    .mockReturnValueOnce('mockTopValuesOfStackByFieldColumnId')
-    .mockReturnValueOnce('mockCountColumnId')
-    .mockReturnValueOnce('mockTopValuesOfBreakdownFieldColumnId'),
+  ...jest.requireActual('uuid'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../../sourcerer/containers', () => ({
@@ -111,11 +107,12 @@ describe('getAlertsTableLensAttributes', () => {
     const state = result?.current?.state as VisualizationState;
     expect(result?.current).toMatchSnapshot();
 
-    expect(state.datasourceStates.formBased.layers.mockLayerId.columnOrder).toMatchInlineSnapshot(`
+    expect(state.datasourceStates.formBased.layers['layer-id-generated-uuid'].columnOrder)
+      .toMatchInlineSnapshot(`
       Array [
-        "mockTopValuesOfStackByFieldColumnId",
-        "mockTopValuesOfBreakdownFieldColumnId",
-        "mockCountColumnId",
+        "top-values-of-stack-by-field-column-id-generated-uuid",
+        "top-values-of-breakdown-field-column-id-generated-uuid",
+        "count-column-id-generated-uuid",
       ]
     `);
   });
@@ -135,21 +132,22 @@ describe('getAlertsTableLensAttributes', () => {
     expect(state.visualization?.columns).toMatchInlineSnapshot(`
       Array [
         Object {
-          "columnId": "mockTopValuesOfStackByFieldColumnId",
+          "columnId": "top-values-of-stack-by-field-column-id-generated-uuid",
           "isTransposed": false,
           "width": 362,
         },
         Object {
-          "columnId": "mockCountColumnId",
+          "columnId": "count-column-id-generated-uuid",
           "isTransposed": false,
         },
       ]
     `);
 
-    expect(state.datasourceStates.formBased.layers.mockLayerId.columnOrder).toMatchInlineSnapshot(`
+    expect(state.datasourceStates.formBased.layers['layer-id-generated-uuid'].columnOrder)
+      .toMatchInlineSnapshot(`
       Array [
-        "mockTopValuesOfStackByFieldColumnId",
-        "mockCountColumnId",
+        "top-values-of-stack-by-field-column-id-generated-uuid",
+        "count-column-id-generated-uuid",
       ]
     `);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_table.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_table.ts
@@ -10,10 +10,10 @@ import { isEmpty } from 'lodash';
 import type { GetLensAttributes, LensEmbeddableDataTableColumn } from '../../../types';
 import { COUNT_OF, TOP_VALUE } from '../../../translations';
 
-const layerId = uuidv4();
-const topValuesOfStackByFieldColumnId = uuidv4();
-const countColumnId = uuidv4();
-const topValuesOfBreakdownFieldColumnId = uuidv4();
+const layerId = `layer-id-${uuidv4()}`;
+const topValuesOfStackByFieldColumnId = `top-values-of-stack-by-field-column-id-${uuidv4()}`;
+const countColumnId = `count-column-id-${uuidv4()}`;
+const topValuesOfBreakdownFieldColumnId = `top-values-of-breakdown-field-column-id-${uuidv4()}`;
 const defaultColumns = [
   {
     columnId: topValuesOfStackByFieldColumnId,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/rule_preview.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/rule_preview.test.ts
@@ -11,17 +11,12 @@ import { mockRulePreviewFilter, wrapper } from '../../../mocks';
 import { useLensAttributes } from '../../../use_lens_attributes';
 
 import { getRulePreviewLensAttributes } from './rule_preview';
-const mockInternalReferenceId = 'mockInternalReferenceId';
-const mockRuleId = 'mockRuleId';
+const mockInternalReferenceId = 'internal-reference-id-generated-uuid';
+const mockRuleId = 'rule-id-generated-uuid';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('mockLayerId')
-    .mockReturnValueOnce('mockInternalReferenceId')
-    .mockReturnValueOnce('mockColumnCountOfRecordsId')
-    .mockReturnValueOnce('mockColumnTimestampId')
-    .mockReturnValueOnce('mockColumnTopValuesId'),
+  ...jest.requireActual('uuid'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/rule_preview.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/rule_preview.ts
@@ -7,11 +7,11 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { GetLensAttributes } from '../../../types';
 
-const layerId = uuidv4();
-const internalReferenceId = uuidv4();
-const columnCountOfRecords = uuidv4();
-const columnTimestamp = uuidv4();
-const columnTopValues = uuidv4();
+const layerId = `layer-id-${uuidv4()}`;
+const internalReferenceId = `internal-reference-id-${uuidv4()}`;
+const columnCountOfRecords = `column-count-of-records-id-${uuidv4()}`;
+const columnTimestamp = `column-timestamp-id-${uuidv4()}`;
+const columnTopValues = `column-top-values-id-${uuidv4()}`;
 
 export const getRulePreviewLensAttributes: GetLensAttributes = ({
   stackByField = 'event.category',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/authentication.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/authentication.test.ts
@@ -13,14 +13,7 @@ import { useLensAttributes } from '../../use_lens_attributes';
 import { getAuthenticationLensAttributes } from './authentication';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('3fd0c5d5-f762-4a27-8c56-14eee0223e13')
-    .mockReturnValueOnce('bef502be-e5ff-442f-9e3e-229f86ca2afa')
-    .mockReturnValueOnce('cded27f7-8ef8-458c-8d9b-70db48ae340d')
-    .mockReturnValueOnce('a3bf9dc1-c8d2-42d6-9e60-31892a4c509e')
-    .mockReturnValueOnce('b41a2958-650b-470a-84c4-c6fd8f0c6d37')
-    .mockReturnValueOnce('5417777d-d9d9-4268-9cdc-eb29b873bd65'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/authentication.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/authentication.ts
@@ -11,12 +11,12 @@ import {
 } from '../../translations';
 import type { LensAttributes, GetLensAttributes } from '../../types';
 
-const layerAuthenticationSuccess = uuidv4();
-const layerAuthenticationFailure = uuidv4();
-const columnTimestampFailure = uuidv4();
-const columnEventOutcomeFailure = uuidv4();
-const columnTimestampSuccess = uuidv4();
-const columnEventOutcomeSuccess = uuidv4();
+const layerAuthenticationSuccess = `layer-authentication-success-id-${uuidv4()}`;
+const layerAuthenticationFailure = `layer-authentication-failure-id-${uuidv4()}`;
+const columnTimestampFailure = `column-timestamp-failure-id-${uuidv4()}`;
+const columnEventOutcomeFailure = `column-event-outcome-failure-id-${uuidv4()}`;
+const columnTimestampSuccess = `column-timestamp-success-id-${uuidv4()}`;
+const columnEventOutcomeSuccess = `column-event-outcome-success-id-${uuidv4()}`;
 
 export const getAuthenticationLensAttributes: GetLensAttributes = ({ euiTheme }) =>
   ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.test.ts
@@ -13,12 +13,7 @@ import { useLensAttributes } from '../../use_lens_attributes';
 import { getExternalAlertLensAttributes } from './external_alert';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('a3c54471-615f-4ff9-9fda-69b5b2ea3eef')
-    .mockReturnValueOnce('37bdf546-3c11-4b08-8c5d-e37debc44f1d')
-    .mockReturnValueOnce('0a923af2-c880-4aa3-aa93-a0b9c2801f6d')
-    .mockReturnValueOnce('42334c6e-98d9-47a2-b4cb-a445abb44c93'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.ts
@@ -9,10 +9,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { COUNT, TOP_VALUE } from '../../translations';
 import type { GetLensAttributes, LensAttributes } from '../../types';
 
-const layerId = uuidv4();
-const columnTimestamp = uuidv4();
-const columnCount = uuidv4();
-const columnTopValue = uuidv4();
+const layerId = `layer-id-${uuidv4()}`;
+const columnTimestamp = `column-timestamp-id-${uuidv4()}`;
+const columnCount = `column-count-id-${uuidv4()}`;
+const columnTopValue = `column-top-value-id-${uuidv4()}`;
 
 export const getExternalAlertLensAttributes: GetLensAttributes = ({
   stackByField = 'event.module',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/dns_top_domains.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/dns_top_domains.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "references": Array [
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-b1c3efc6-c886-4fba-978f-3b6bb5e7948a",
+      "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -14,14 +14,14 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "b1c3efc6-c886-4fba-978f-3b6bb5e7948a": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
-              "e8842815-2a45-4c74-86de-c19a391e2424",
-              "d1452b87-0e9e-4fc0-a725-3727a18e0b37",
-              "2a4d5e20-f570-48e4-b9ab-ff3068919377",
+              "column-top-value-id-generated-uuid",
+              "column-timestamp-id-generated-uuid",
+              "column-dns-question-name-id-generated-uuid",
             ],
             "columns": Object {
-              "2a4d5e20-f570-48e4-b9ab-ff3068919377": Object {
+              "column-dns-question-name-id-generated-uuid": Object {
                 "dataType": "number",
                 "isBucketed": false,
                 "label": "Unique count of dns.question.name",
@@ -32,7 +32,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "dns.question.name",
               },
-              "d1452b87-0e9e-4fc0-a725-3727a18e0b37": Object {
+              "column-timestamp-id-generated-uuid": Object {
                 "dataType": "date",
                 "isBucketed": true,
                 "label": "@timestamp",
@@ -44,7 +44,7 @@ Object {
                 "scale": "interval",
                 "sourceField": "@timestamp",
               },
-              "e8842815-2a45-4c74-86de-c19a391e2424": Object {
+              "column-top-value-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Top values of event.dataset",
@@ -53,7 +53,7 @@ Object {
                   "accuracyMode": true,
                   "missingBucket": false,
                   "orderBy": Object {
-                    "columnId": "2a4d5e20-f570-48e4-b9ab-ff3068919377",
+                    "columnId": "column-dns-question-name-id-generated-uuid",
                     "type": "column",
                   },
                   "orderDirection": "desc",
@@ -218,15 +218,15 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "2a4d5e20-f570-48e4-b9ab-ff3068919377",
+            "column-dns-question-name-id-generated-uuid",
           ],
-          "layerId": "b1c3efc6-c886-4fba-978f-3b6bb5e7948a",
+          "layerId": "layer-id-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "bar_stacked",
           "showGridlines": false,
-          "splitAccessor": "e8842815-2a45-4c74-86de-c19a391e2424",
-          "xAccessor": "d1452b87-0e9e-4fc0-a725-3727a18e0b37",
+          "splitAccessor": "column-top-value-id-generated-uuid",
+          "xAccessor": "column-timestamp-id-generated-uuid",
         },
       ],
       "legend": Object {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_bar.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_bar.test.ts.snap
@@ -11,12 +11,12 @@ Object {
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-e406bf4f-942b-41ac-b516-edb5cef06ec8",
+      "name": "indexpattern-datasource-layer-layer-source-ip-id-generated-uuid",
       "type": "index-pattern",
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-38aa6532-6bf9-4c8f-b2a6-da8d32f7d0d7",
+      "name": "indexpattern-datasource-layer-layer-destination-ip-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -24,13 +24,13 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "38aa6532-6bf9-4c8f-b2a6-da8d32f7d0d7": Object {
+          "layer-destination-ip-id-generated-uuid": Object {
             "columnOrder": Array [
-              "4607c585-3af3-43b9-804f-e49b27796d79",
-              "d27e0966-daf9-41f4-9033-230cf1e76dc9",
+              "column-destination-ip-filter-id-generated-uuid",
+              "column-destination-ip-id-generated-uuid",
             ],
             "columns": Object {
-              "4607c585-3af3-43b9-804f-e49b27796d79": Object {
+              "column-destination-ip-filter-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Filters",
@@ -48,7 +48,7 @@ Object {
                 },
                 "scale": "ordinal",
               },
-              "d27e0966-daf9-41f4-9033-230cf1e76dc9": Object {
+              "column-destination-ip-id-generated-uuid": Object {
                 "dataType": "number",
                 "filter": Object {
                   "language": "kuery",
@@ -63,25 +63,13 @@ Object {
             },
             "incompleteColumns": Object {},
           },
-          "e406bf4f-942b-41ac-b516-edb5cef06ec8": Object {
+          "layer-source-ip-id-generated-uuid": Object {
             "columnOrder": Array [
-              "d9c438c5-f776-4436-9d20-d62dc8c03be8",
-              "5acd4c9d-dc3b-4b21-9632-e4407944c36d",
+              "column-source-ip-filter-id-generated-uuid",
+              "column-source-ip-id-generated-uuid",
             ],
             "columns": Object {
-              "5acd4c9d-dc3b-4b21-9632-e4407944c36d": Object {
-                "dataType": "number",
-                "filter": Object {
-                  "language": "kuery",
-                  "query": "source.ip: \\"10.0.0.0/8\\" or source.ip: \\"192.168.0.0/16\\" or source.ip: \\"172.16.0.0/12\\" or source.ip: \\"fd00::/8\\"",
-                },
-                "isBucketed": false,
-                "label": "Unique count of source.ip",
-                "operationType": "unique_count",
-                "scale": "ratio",
-                "sourceField": "source.ip",
-              },
-              "d9c438c5-f776-4436-9d20-d62dc8c03be8": Object {
+              "column-source-ip-filter-id-generated-uuid": Object {
                 "dataType": "string",
                 "isBucketed": true,
                 "label": "Filters",
@@ -98,6 +86,18 @@ Object {
                   ],
                 },
                 "scale": "ordinal",
+              },
+              "column-source-ip-id-generated-uuid": Object {
+                "dataType": "number",
+                "filter": Object {
+                  "language": "kuery",
+                  "query": "source.ip: \\"10.0.0.0/8\\" or source.ip: \\"192.168.0.0/16\\" or source.ip: \\"172.16.0.0/12\\" or source.ip: \\"fd00::/8\\"",
+                },
+                "isBucketed": false,
+                "label": "Unique count of source.ip",
+                "operationType": "unique_count",
+                "scale": "ratio",
+                "sourceField": "source.ip",
               },
             },
             "incompleteColumns": Object {},
@@ -228,33 +228,33 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "5acd4c9d-dc3b-4b21-9632-e4407944c36d",
+            "column-source-ip-id-generated-uuid",
           ],
-          "layerId": "e406bf4f-942b-41ac-b516-edb5cef06ec8",
+          "layerId": "layer-source-ip-id-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "bar_horizontal_stacked",
           "showGridlines": false,
-          "xAccessor": "d9c438c5-f776-4436-9d20-d62dc8c03be8",
+          "xAccessor": "column-source-ip-filter-id-generated-uuid",
           "yConfig": Array [
             Object {
               "color": "#d36186",
-              "forAccessor": "5acd4c9d-dc3b-4b21-9632-e4407944c36d",
+              "forAccessor": "column-source-ip-id-generated-uuid",
             },
           ],
         },
         Object {
           "accessors": Array [
-            "d27e0966-daf9-41f4-9033-230cf1e76dc9",
+            "column-destination-ip-id-generated-uuid",
           ],
-          "layerId": "38aa6532-6bf9-4c8f-b2a6-da8d32f7d0d7",
+          "layerId": "layer-destination-ip-id-generated-uuid",
           "layerType": "data",
           "seriesType": "bar_horizontal_stacked",
-          "xAccessor": "4607c585-3af3-43b9-804f-e49b27796d79",
+          "xAccessor": "column-destination-ip-filter-id-generated-uuid",
           "yConfig": Array [
             Object {
               "color": "#9170b8",
-              "forAccessor": "d27e0966-daf9-41f4-9033-230cf1e76dc9",
+              "forAccessor": "column-destination-ip-id-generated-uuid",
             },
           ],
         },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
@@ -15,12 +15,7 @@ import { useLensAttributes } from '../../use_lens_attributes';
 import { getDnsTopDomainsLensAttributes } from './dns_top_domains';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('b1c3efc6-c886-4fba-978f-3b6bb5e7948a')
-    .mockReturnValueOnce('e8842815-2a45-4c74-86de-c19a391e2424')
-    .mockReturnValueOnce('d1452b87-0e9e-4fc0-a725-3727a18e0b37')
-    .mockReturnValueOnce('2a4d5e20-f570-48e4-b9ab-ff3068919377'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.ts
@@ -8,10 +8,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { TOP_VALUE, UNIQUE_COUNT } from '../../translations';
 import type { LensAttributes, GetLensAttributes } from '../../types';
 
-const layerId = uuidv4();
-const columnTopValue = uuidv4();
-const columnTimestamp = uuidv4();
-const columnDNSQuestionName = uuidv4();
+const layerId = `layer-id-${uuidv4()}`;
+const columnTopValue = `column-top-value-id-${uuidv4()}`;
+const columnTimestamp = `column-timestamp-id-${uuidv4()}`;
+const columnDNSQuestionName = `column-dns-question-name-id-${uuidv4()}`;
 
 /* Exported from Kibana Saved Object */
 export const getDnsTopDomainsLensAttributes: GetLensAttributes = ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_bar.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_bar.test.ts
@@ -13,14 +13,7 @@ import { useLensAttributes } from '../../use_lens_attributes';
 import { getKpiUniquePrivateIpsBarLensAttributes } from './kpi_unique_private_ips_bar';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('5acd4c9d-dc3b-4b21-9632-e4407944c36d')
-    .mockReturnValueOnce('d9c438c5-f776-4436-9d20-d62dc8c03be8')
-    .mockReturnValueOnce('d27e0966-daf9-41f4-9033-230cf1e76dc9')
-    .mockReturnValueOnce('4607c585-3af3-43b9-804f-e49b27796d79')
-    .mockReturnValueOnce('e406bf4f-942b-41ac-b516-edb5cef06ec8')
-    .mockReturnValueOnce('38aa6532-6bf9-4c8f-b2a6-da8d32f7d0d7'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_bar.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_bar.ts
@@ -9,14 +9,14 @@ import { SOURCE_CHART_LABEL, DESTINATION_CHART_LABEL, UNIQUE_COUNT } from '../..
 import type { LensAttributes, GetLensAttributes } from '../../types';
 import { getDestinationIpColor, getSourceIpColor } from '../common/utils/unique_ips_palette';
 
-const columnSourceIp = uuidv4();
-const columnSourceIpFilter = uuidv4();
+const columnSourceIp = `column-source-ip-id-${uuidv4()}`;
+const columnSourceIpFilter = `column-source-ip-filter-id-${uuidv4()}`;
 
-const columnDestinationIp = uuidv4();
-const columnDestinationIpFilter = uuidv4();
+const columnDestinationIp = `column-destination-ip-id-${uuidv4()}`;
+const columnDestinationIpFilter = `column-destination-ip-filter-id-${uuidv4()}`;
 
-const layerSourceIp = uuidv4();
-const layerDestinationIp = uuidv4();
+const layerSourceIp = `layer-source-ip-id-${uuidv4()}`;
+const layerDestinationIp = `layer-destination-ip-id-${uuidv4()}`;
 
 export const getKpiUniquePrivateIpsBarLensAttributes: GetLensAttributes = ({ euiTheme }) => {
   return {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_area.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_area.test.ts.snap
@@ -11,12 +11,12 @@ Object {
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-31213ae3-905b-4e88-b987-0cccb1f3209f",
+      "name": "indexpattern-datasource-layer-layout-event-outcome-failure-id-generated-uuid",
       "type": "index-pattern",
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-4590dafb-4ac7-45aa-8641-47a3ff0b817c",
+      "name": "indexpattern-datasource-layer-layout-event-outcome-success-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -24,13 +24,13 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "31213ae3-905b-4e88-b987-0cccb1f3209f": Object {
+          "layout-event-outcome-failure-id-generated-uuid": Object {
             "columnOrder": Array [
-              "33a6163d-0c0a-451d-aa38-8ca6010dd5bf",
-              "2b27c80e-a20d-46f1-8fb2-79626ef4563c",
+              "column-event-outcome-failure-timestamp-id-generated-uuid",
+              "column-event-outcome-failure-id-generated-uuid",
             ],
             "columns": Object {
-              "2b27c80e-a20d-46f1-8fb2-79626ef4563c": Object {
+              "column-event-outcome-failure-id-generated-uuid": Object {
                 "customLabel": true,
                 "dataType": "number",
                 "filter": Object {
@@ -43,7 +43,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "___records___",
               },
-              "33a6163d-0c0a-451d-aa38-8ca6010dd5bf": Object {
+              "column-event-outcome-failure-timestamp-id-generated-uuid": Object {
                 "dataType": "date",
                 "isBucketed": true,
                 "label": "@timestamp",
@@ -57,13 +57,13 @@ Object {
             },
             "incompleteColumns": Object {},
           },
-          "4590dafb-4ac7-45aa-8641-47a3ff0b817c": Object {
+          "layout-event-outcome-success-id-generated-uuid": Object {
             "columnOrder": Array [
-              "49a42fe6-ebe8-4adb-8eed-1966a5297b7e",
-              "0eb97c09-a351-4280-97da-944e4bd30dd7",
+              "column-event-outcome-success-timestamp-id-generated-uuid",
+              "column-event-outcome-success-id-generated-uuid",
             ],
             "columns": Object {
-              "0eb97c09-a351-4280-97da-944e4bd30dd7": Object {
+              "column-event-outcome-success-id-generated-uuid": Object {
                 "customLabel": true,
                 "dataType": "number",
                 "filter": Object {
@@ -76,7 +76,7 @@ Object {
                 "scale": "ratio",
                 "sourceField": "___records___",
               },
-              "49a42fe6-ebe8-4adb-8eed-1966a5297b7e": Object {
+              "column-event-outcome-success-timestamp-id-generated-uuid": Object {
                 "dataType": "date",
                 "isBucketed": true,
                 "label": "@timestamp",
@@ -224,31 +224,31 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "0eb97c09-a351-4280-97da-944e4bd30dd7",
+            "column-event-outcome-success-id-generated-uuid",
           ],
-          "layerId": "4590dafb-4ac7-45aa-8641-47a3ff0b817c",
+          "layerId": "layout-event-outcome-success-id-generated-uuid",
           "layerType": "data",
           "seriesType": "area",
-          "xAccessor": "49a42fe6-ebe8-4adb-8eed-1966a5297b7e",
+          "xAccessor": "column-event-outcome-success-timestamp-id-generated-uuid",
           "yConfig": Array [
             Object {
               "color": "#54B399",
-              "forAccessor": "0eb97c09-a351-4280-97da-944e4bd30dd7",
+              "forAccessor": "column-event-outcome-success-id-generated-uuid",
             },
           ],
         },
         Object {
           "accessors": Array [
-            "2b27c80e-a20d-46f1-8fb2-79626ef4563c",
+            "column-event-outcome-failure-id-generated-uuid",
           ],
-          "layerId": "31213ae3-905b-4e88-b987-0cccb1f3209f",
+          "layerId": "layout-event-outcome-failure-id-generated-uuid",
           "layerType": "data",
           "seriesType": "area",
-          "xAccessor": "33a6163d-0c0a-451d-aa38-8ca6010dd5bf",
+          "xAccessor": "column-event-outcome-failure-timestamp-id-generated-uuid",
           "yConfig": Array [
             Object {
               "color": "#CA8EAE",
-              "forAccessor": "2b27c80e-a20d-46f1-8fb2-79626ef4563c",
+              "forAccessor": "column-event-outcome-failure-id-generated-uuid",
             },
           ],
         },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_bar.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_bar.test.ts.snap
@@ -11,12 +11,12 @@ Object {
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-31213ae3-905b-4e88-b987-0cccb1f3209f",
+      "name": "indexpattern-datasource-layer-layer-event-outcome-success-id-generated-uuid",
       "type": "index-pattern",
     },
     Object {
       "id": "security-solution-my-test",
-      "name": "indexpattern-datasource-layer-b9acd453-f476-4467-ad38-203e37b73e55",
+      "name": "indexpattern-datasource-layer-layer-event-outcome-failure-id-generated-uuid",
       "type": "index-pattern",
     },
   ],
@@ -24,56 +24,13 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "31213ae3-905b-4e88-b987-0cccb1f3209f": Object {
+          "layer-event-outcome-failure-id-generated-uuid": Object {
             "columnOrder": Array [
-              "430e690c-9992-414f-9bce-00812d99a5e7",
-              "938b445a-a291-4bbc-84fe-4f47b69c20e4",
+              "column-event-outcome-failure-filter-id-generated-uuid",
+              "column-event-outcome-failure-id-generated-uuid",
             ],
             "columns": Object {
-              "430e690c-9992-414f-9bce-00812d99a5e7": Object {
-                "dataType": "string",
-                "isBucketed": true,
-                "label": "Filters",
-                "operationType": "filters",
-                "params": Object {
-                  "filters": Array [
-                    Object {
-                      "input": Object {
-                        "language": "kuery",
-                        "query": "event.outcome : \\"success\\" ",
-                      },
-                      "label": "Succ.",
-                    },
-                  ],
-                },
-                "scale": "ordinal",
-              },
-              "938b445a-a291-4bbc-84fe-4f47b69c20e4": Object {
-                "dataType": "number",
-                "isBucketed": false,
-                "label": "Succ.",
-                "operationType": "count",
-                "scale": "ratio",
-                "sourceField": "___records___",
-              },
-            },
-            "incompleteColumns": Object {},
-          },
-          "b9acd453-f476-4467-ad38-203e37b73e55": Object {
-            "columnOrder": Array [
-              "e959c351-a3a2-4525-b244-9623f215a8fd",
-              "c8165fc3-7180-4f1b-8c87-bc3ea04c6df7",
-            ],
-            "columns": Object {
-              "c8165fc3-7180-4f1b-8c87-bc3ea04c6df7": Object {
-                "dataType": "number",
-                "isBucketed": false,
-                "label": "Fail",
-                "operationType": "count",
-                "scale": "ratio",
-                "sourceField": "___records___",
-              },
-              "e959c351-a3a2-4525-b244-9623f215a8fd": Object {
+              "column-event-outcome-failure-filter-id-generated-uuid": Object {
                 "customLabel": true,
                 "dataType": "string",
                 "isBucketed": true,
@@ -91,6 +48,49 @@ Object {
                   ],
                 },
                 "scale": "ordinal",
+              },
+              "column-event-outcome-failure-id-generated-uuid": Object {
+                "dataType": "number",
+                "isBucketed": false,
+                "label": "Fail",
+                "operationType": "count",
+                "scale": "ratio",
+                "sourceField": "___records___",
+              },
+            },
+            "incompleteColumns": Object {},
+          },
+          "layer-event-outcome-success-id-generated-uuid": Object {
+            "columnOrder": Array [
+              "column-event-outcome-success-filter-id-generated-uuid",
+              "column-event-outcome-success-id-generated-uuid",
+            ],
+            "columns": Object {
+              "column-event-outcome-success-filter-id-generated-uuid": Object {
+                "dataType": "string",
+                "isBucketed": true,
+                "label": "Filters",
+                "operationType": "filters",
+                "params": Object {
+                  "filters": Array [
+                    Object {
+                      "input": Object {
+                        "language": "kuery",
+                        "query": "event.outcome : \\"success\\" ",
+                      },
+                      "label": "Succ.",
+                    },
+                  ],
+                },
+                "scale": "ordinal",
+              },
+              "column-event-outcome-success-id-generated-uuid": Object {
+                "dataType": "number",
+                "isBucketed": false,
+                "label": "Succ.",
+                "operationType": "count",
+                "scale": "ratio",
+                "sourceField": "___records___",
               },
             },
             "incompleteColumns": Object {},
@@ -229,31 +229,31 @@ Object {
       "layers": Array [
         Object {
           "accessors": Array [
-            "938b445a-a291-4bbc-84fe-4f47b69c20e4",
+            "column-event-outcome-success-id-generated-uuid",
           ],
-          "layerId": "31213ae3-905b-4e88-b987-0cccb1f3209f",
+          "layerId": "layer-event-outcome-success-id-generated-uuid",
           "layerType": "data",
           "seriesType": "bar_horizontal_stacked",
-          "xAccessor": "430e690c-9992-414f-9bce-00812d99a5e7",
+          "xAccessor": "column-event-outcome-success-filter-id-generated-uuid",
           "yConfig": Array [
             Object {
               "color": "#54B399",
-              "forAccessor": "938b445a-a291-4bbc-84fe-4f47b69c20e4",
+              "forAccessor": "column-event-outcome-success-id-generated-uuid",
             },
           ],
         },
         Object {
           "accessors": Array [
-            "c8165fc3-7180-4f1b-8c87-bc3ea04c6df7",
+            "column-event-outcome-failure-id-generated-uuid",
           ],
-          "layerId": "b9acd453-f476-4467-ad38-203e37b73e55",
+          "layerId": "layer-event-outcome-failure-id-generated-uuid",
           "layerType": "data",
           "seriesType": "bar_horizontal_stacked",
-          "xAccessor": "e959c351-a3a2-4525-b244-9623f215a8fd",
+          "xAccessor": "column-event-outcome-failure-filter-id-generated-uuid",
           "yConfig": Array [
             Object {
               "color": "#CA8EAE",
-              "forAccessor": "c8165fc3-7180-4f1b-8c87-bc3ea04c6df7",
+              "forAccessor": "column-event-outcome-failure-id-generated-uuid",
             },
           ],
         },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.test.ts
@@ -13,14 +13,8 @@ import { useLensAttributes } from '../../use_lens_attributes';
 import { getKpiUserAuthenticationsAreaLensAttributes } from './kpi_user_authentications_area';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('2b27c80e-a20d-46f1-8fb2-79626ef4563c')
-    .mockReturnValueOnce('33a6163d-0c0a-451d-aa38-8ca6010dd5bf')
-    .mockReturnValueOnce('0eb97c09-a351-4280-97da-944e4bd30dd7')
-    .mockReturnValueOnce('49a42fe6-ebe8-4adb-8eed-1966a5297b7e')
-    .mockReturnValueOnce('4590dafb-4ac7-45aa-8641-47a3ff0b817c')
-    .mockReturnValueOnce('31213ae3-905b-4e88-b987-0cccb1f3209f'),
+  ...jest.requireActual('uuid'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.ts
@@ -8,13 +8,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { FAIL_CHART_LABEL, SUCCESS_CHART_LABEL } from '../../translations';
 import type { LensAttributes, GetLensAttributes } from '../../types';
 
-const columnEventOutcomeFailure = uuidv4();
-const columnEventOutcomeFailureTimestamp = uuidv4();
+const columnEventOutcomeFailure = `column-event-outcome-failure-id-${uuidv4()}`;
+const columnEventOutcomeFailureTimestamp = `column-event-outcome-failure-timestamp-id-${uuidv4()}`;
 
-const columnEventOutcomeSuccess = uuidv4();
-const columnEventOutcomeSuccessTimestamp = uuidv4();
-const layoutEventOutcomeSuccess = uuidv4();
-const layoutEventOutcomeFailure = uuidv4();
+const columnEventOutcomeSuccess = `column-event-outcome-success-id-${uuidv4()}`;
+const columnEventOutcomeSuccessTimestamp = `column-event-outcome-success-timestamp-id-${uuidv4()}`;
+const layoutEventOutcomeSuccess = `layout-event-outcome-success-id-${uuidv4()}`;
+const layoutEventOutcomeFailure = `layout-event-outcome-failure-id-${uuidv4()}`;
 
 export const getKpiUserAuthenticationsAreaLensAttributes: GetLensAttributes = ({ euiTheme }) =>
   ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_bar.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_bar.test.ts
@@ -13,14 +13,8 @@ import { useLensAttributes } from '../../use_lens_attributes';
 import { getKpiUserAuthenticationsBarLensAttributes } from './kpi_user_authentications_bar';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('c8165fc3-7180-4f1b-8c87-bc3ea04c6df7')
-    .mockReturnValueOnce('e959c351-a3a2-4525-b244-9623f215a8fd')
-    .mockReturnValueOnce('938b445a-a291-4bbc-84fe-4f47b69c20e4')
-    .mockReturnValueOnce('430e690c-9992-414f-9bce-00812d99a5e7')
-    .mockReturnValueOnce('b9acd453-f476-4467-ad38-203e37b73e55')
-    .mockReturnValueOnce('31213ae3-905b-4e88-b987-0cccb1f3209f'),
+  ...jest.requireActual('uuid'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../../../sourcerer/containers', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_bar.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_bar.ts
@@ -8,14 +8,14 @@ import { v4 as uuidv4 } from 'uuid';
 import type { LensAttributes, GetLensAttributes } from '../../types';
 import { FAIL_CHART_LABEL, SUCCESS_CHART_LABEL } from '../../translations';
 
-const columnEventOutcomeFailure = uuidv4();
-const columnEventOutcomeFailureFilter = uuidv4();
+const columnEventOutcomeFailure = `column-event-outcome-failure-id-${uuidv4()}`;
+const columnEventOutcomeFailureFilter = `column-event-outcome-failure-filter-id-${uuidv4()}`;
 
-const columnEventOutcomeSuccess = uuidv4();
-const columnEventOutcomeSuccessFilter = uuidv4();
+const columnEventOutcomeSuccess = `column-event-outcome-success-id-${uuidv4()}`;
+const columnEventOutcomeSuccessFilter = `column-event-outcome-success-filter-id-${uuidv4()}`;
 
-const layerEventOutcomeFailure = uuidv4();
-const layerEventOutcomeSuccess = uuidv4();
+const layerEventOutcomeFailure = `layer-event-outcome-failure-id-${uuidv4()}`;
+const layerEventOutcomeSuccess = `layer-event-outcome-success-id-${uuidv4()}`;
 
 export const getKpiUserAuthenticationsBarLensAttributes: GetLensAttributes = ({ euiTheme }) =>
   ({

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
@@ -27,12 +27,7 @@ import { getEventsHistogramLensAttributes } from './lens_attributes/common/event
 import type { EuiThemeComputed } from '@elastic/eui';
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('a3c54471-615f-4ff9-9fda-69b5b2ea3eef')
-    .mockReturnValueOnce('37bdf546-3c11-4b08-8c5d-e37debc44f1d')
-    .mockReturnValueOnce('0a923af2-c880-4aa3-aa93-a0b9c2801f6d')
-    .mockReturnValueOnce('42334c6e-98d9-47a2-b4cb-a445abb44c93'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 jest.mock('../../../sourcerer/containers');
@@ -211,7 +206,7 @@ describe('useLensAttributes', () => {
       {
         type: 'index-pattern',
         id: 'security-solution-default',
-        name: 'indexpattern-datasource-layer-a3c54471-615f-4ff9-9fda-69b5b2ea3eef',
+        name: 'indexpattern-datasource-layer-layer-id-generated-uuid',
       },
       {
         type: 'index-pattern',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/__snapshots__/risk_score_donut.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/__snapshots__/risk_score_donut.test.ts.snap
@@ -6,11 +6,11 @@ Object {
   "references": Array [],
   "state": Object {
     "adHocDataViews": Object {
-      "d594baeb-5eca-480c-8885-ba79eaf41372": Object {
+      "host-generated-uuid": Object {
         "allowNoIndex": false,
         "fieldAttrs": Object {},
         "fieldFormats": Object {},
-        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
+        "id": "host-generated-uuid",
         "name": "ml_host_risk_score_latest_mockSpaceId_no_timestamp",
         "runtimeFieldMap": Object {},
         "sourceFilters": Array [],
@@ -21,7 +21,7 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "2cc5663b-f062-43f8-8688-fc8166c2ca8e": Object {
+          "layer-id-generated-uuid": Object {
             "columnOrder": Array [
               "a2e8541a-c22f-4e43-8a12-caa33edc5de0",
               "75179122-96fc-40e1-93b4-8e9310af5f06",
@@ -115,8 +115,8 @@ Object {
     ],
     "internalReferences": Array [
       Object {
-        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
-        "name": "indexpattern-datasource-layer-2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+        "id": "host-generated-uuid",
+        "name": "indexpattern-datasource-layer-layer-id-generated-uuid",
         "type": "index-pattern",
       },
     ],
@@ -129,7 +129,7 @@ Object {
         Object {
           "categoryDisplay": "hide",
           "emptySizeRatio": 0.82,
-          "layerId": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+          "layerId": "layer-id-generated-uuid",
           "layerType": "data",
           "legendDisplay": "show",
           "legendPosition": "left",

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/__snapshots__/risk_score_over_time_area.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/__snapshots__/risk_score_over_time_area.test.ts.snap
@@ -6,11 +6,11 @@ Object {
   "references": Array [],
   "state": Object {
     "adHocDataViews": Object {
-      "d594baeb-5eca-480c-8885-ba79eaf41372": Object {
+      "host-generated-uuid": Object {
         "allowNoIndex": false,
         "fieldAttrs": Object {},
         "fieldFormats": Object {},
-        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
+        "id": "host-generated-uuid",
         "name": "ml_host_risk_score_mockSpaceId",
         "runtimeFieldMap": Object {},
         "sourceFilters": Array [],
@@ -21,7 +21,7 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "e614baeb-5eca-480c-8885-ba79eaf41372": Object {
+          "layer-id1-generated-uuid": Object {
             "columnOrder": Array [
               "02a55c97-d7a4-440d-ac77-33b941c16189",
               "8886a925-4419-4d9a-8498-3bda4ecf1b0a",
@@ -62,12 +62,12 @@ Object {
             "incompleteColumns": Object {},
             "sampling": 1,
           },
-          "f614baeb-5eca-480c-8885-ba79eaf52483": Object {
+          "layer-id2-generated-uuid": Object {
             "columnOrder": Array [
-              "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
+              "layer2-column-id-generated-uuid",
             ],
             "columns": Object {
-              "1dd5663b-f062-43f8-8688-fc8166c2ca8e": Object {
+              "layer2-column-id-generated-uuid": Object {
                 "customLabel": true,
                 "dataType": "number",
                 "isBucketed": false,
@@ -129,13 +129,13 @@ Object {
     ],
     "internalReferences": Array [
       Object {
-        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
-        "name": "indexpattern-datasource-layer-e614baeb-5eca-480c-8885-ba79eaf41372",
+        "id": "host-generated-uuid",
+        "name": "indexpattern-datasource-layer-layer-id1-generated-uuid",
         "type": "index-pattern",
       },
       Object {
-        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
-        "name": "indexpattern-datasource-layer-f614baeb-5eca-480c-8885-ba79eaf52483",
+        "id": "host-generated-uuid",
+        "name": "indexpattern-datasource-layer-layer-id2-generated-uuid",
         "type": "index-pattern",
       },
     ],
@@ -159,7 +159,7 @@ Object {
           "accessors": Array [
             "8886a925-4419-4d9a-8498-3bda4ecf1b0a",
           ],
-          "layerId": "e614baeb-5eca-480c-8885-ba79eaf41372",
+          "layerId": "layer-id1-generated-uuid",
           "layerType": "data",
           "position": "top",
           "seriesType": "line",
@@ -174,16 +174,16 @@ Object {
         },
         Object {
           "accessors": Array [
-            "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
+            "layer2-column-id-generated-uuid",
           ],
-          "layerId": "f614baeb-5eca-480c-8885-ba79eaf52483",
+          "layerId": "layer-id2-generated-uuid",
           "layerType": "referenceLine",
           "yConfig": Array [
             Object {
               "axisMode": "left",
               "color": "#aa6556",
               "fill": "none",
-              "forAccessor": "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
+              "forAccessor": "layer2-column-id-generated-uuid",
               "icon": "alert",
               "iconPosition": "left",
               "lineWidth": 2,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/__snapshots__/risk_score_summary.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/__snapshots__/risk_score_summary.test.ts.snap
@@ -6,11 +6,11 @@ Object {
   "references": Array [],
   "state": Object {
     "adHocDataViews": Object {
-      "2cc5663b-f062-43f8-8688-fc8166c2ca8e": Object {
+      "internal-reference-id-generated-uuid": Object {
         "allowNoIndex": false,
         "fieldAttrs": Object {},
         "fieldFormats": Object {},
-        "id": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+        "id": "internal-reference-id-generated-uuid",
         "name": "risk-score.risk-score-default",
         "runtimeFieldMap": Object {},
         "sourceFilters": Array [],
@@ -21,13 +21,55 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "2cc5663b-f062-43f8-8688-fc8166c2ca8e": Object {
+          "layer-id1-generated-uuid": Object {
             "columnOrder": Array [
-              "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
-              "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+              "column-id1-generated-uuid",
             ],
             "columns": Object {
-              "2cc5663b-f062-43f8-8688-fc8166c2ca8e": Object {
+              "column-id1-generated-uuid": Object {
+                "customLabel": true,
+                "dataType": "number",
+                "isBucketed": false,
+                "label": "User Risk",
+                "operationType": "last_value",
+                "params": Object {
+                  "emptyAsNull": true,
+                  "format": Object {
+                    "id": "number",
+                    "params": Object {
+                      "compact": false,
+                      "decimals": 2,
+                    },
+                  },
+                  "sortField": "@timestamp",
+                },
+                "reducedTimeRange": "",
+                "scale": "ratio",
+                "sourceField": "user.risk.calculated_score_norm",
+              },
+            },
+            "incompleteColumns": Object {},
+          },
+          "layer-id2-generated-uuid": Object {
+            "columnOrder": Array [
+              "column-id2-generated-uuid",
+              "column-id3-generated-uuid",
+            ],
+            "columns": Object {
+              "column-id2-generated-uuid": Object {
+                "dataType": "date",
+                "isBucketed": true,
+                "label": "@timestamp",
+                "operationType": "date_histogram",
+                "params": Object {
+                  "dropPartials": false,
+                  "includeEmptyRows": true,
+                  "interval": "auto",
+                },
+                "scale": "interval",
+                "sourceField": "@timestamp",
+              },
+              "column-id3-generated-uuid": Object {
                 "customLabel": true,
                 "dataType": "number",
                 "filter": Object {
@@ -56,7 +98,7 @@ Object {
             "ignoreGlobalFilters": false,
             "incompleteColumns": Object {},
             "linkToLayers": Array [
-              "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+              "layer-id1-generated-uuid",
             ],
             "sampling": 1,
           },
@@ -90,13 +132,13 @@ Object {
     ],
     "internalReferences": Array [
       Object {
-        "id": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
-        "name": "indexpattern-datasource-layer-2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+        "id": "internal-reference-id-generated-uuid",
+        "name": "indexpattern-datasource-layer-layer-id1-generated-uuid",
         "type": "index-pattern",
       },
       Object {
-        "id": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
-        "name": "indexpattern-datasource-layer-2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+        "id": "internal-reference-id-generated-uuid",
+        "name": "indexpattern-datasource-layer-layer-id2-generated-uuid",
         "type": "index-pattern",
       },
     ],
@@ -105,9 +147,9 @@ Object {
       "query": "host.name: *",
     },
     "visualization": Object {
-      "layerId": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+      "layerId": "layer-id1-generated-uuid",
       "layerType": "data",
-      "metricAccessor": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+      "metricAccessor": "column-id1-generated-uuid",
       "palette": Object {
         "name": "custom",
         "params": Object {
@@ -168,10 +210,10 @@ Object {
         "type": "palette",
       },
       "subtitle": "Low",
-      "trendlineLayerId": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+      "trendlineLayerId": "layer-id2-generated-uuid",
       "trendlineLayerType": "metricTrendline",
-      "trendlineMetricAccessor": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
-      "trendlineTimeAccessor": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
+      "trendlineMetricAccessor": "column-id3-generated-uuid",
+      "trendlineTimeAccessor": "column-id2-generated-uuid",
     },
   },
   "title": "Risk score summary",

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_donut.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_donut.test.ts
@@ -30,11 +30,7 @@ jest.mock('../../common/utils/route/use_route_spy', () => ({
 }));
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('d594baeb-5eca-480c-8885-ba79eaf41372')
-    .mockReturnValueOnce('1dd5663b-f062-43f8-8688-fc8166c2ca8e')
-    .mockReturnValue('2cc5663b-f062-43f8-8688-fc8166c2ca8e'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 describe('getRiskScoreDonutAttributes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_donut.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_donut.ts
@@ -8,13 +8,16 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { GetLensAttributes } from '../../common/components/visualization_actions/types';
 
-const internalReferenceIdMapping: Record<string, string> = { host: uuidv4(), user: uuidv4() };
+const internalReferenceIdMapping: Record<string, string> = {
+  host: `host-${uuidv4()}`,
+  user: `user-${uuidv4()}`,
+};
 
 export const getRiskScoreDonutAttributes: GetLensAttributes = ({
   stackByField = 'host',
   extraOptions = { spaceId: 'default' },
 }) => {
-  const layerId = uuidv4();
+  const layerId = `layer-id-${uuidv4()}`;
   const internalReferenceId = internalReferenceIdMapping[stackByField];
   return {
     title: `${stackByField} risk donut`,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_over_time_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_over_time_area.test.ts
@@ -31,13 +31,7 @@ jest.mock('../../common/utils/route/use_route_spy', () => ({
 }));
 
 jest.mock('uuid', () => ({
-  v4: jest
-    .fn()
-    .mockReturnValueOnce('d594baeb-5eca-480c-8885-ba79eaf41372')
-    .mockReturnValueOnce('c604baeb-5eca-480c-8885-ba79eaf41372')
-    .mockReturnValueOnce('e614baeb-5eca-480c-8885-ba79eaf41372')
-    .mockReturnValueOnce('f614baeb-5eca-480c-8885-ba79eaf52483')
-    .mockReturnValue('1dd5663b-f062-43f8-8688-fc8166c2ca8e'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 describe('getRiskScoreOverTimeAreaAttributes', () => {
@@ -76,12 +70,12 @@ describe('getRiskScoreOverTimeAreaAttributes', () => {
       )
     ).toEqual(
       expect.objectContaining({
-        layerId: '1dd5663b-f062-43f8-8688-fc8166c2ca8e',
+        layerId: 'layer-id2-generated-uuid',
         layerType: 'referenceLine',
-        accessors: ['1dd5663b-f062-43f8-8688-fc8166c2ca8e'],
+        accessors: ['layer2-column-id-generated-uuid'],
         yConfig: [
           {
-            forAccessor: '1dd5663b-f062-43f8-8688-fc8166c2ca8e',
+            forAccessor: 'layer2-column-id-generated-uuid',
             axisMode: 'left',
             lineWidth: 2,
             color: '#aa6556',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_over_time_area.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_over_time_area.ts
@@ -8,14 +8,17 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { GetLensAttributes } from '../../common/components/visualization_actions/types';
 
-const internalReferenceIdMapping: Record<string, string> = { host: uuidv4(), user: uuidv4() };
+const internalReferenceIdMapping: Record<string, string> = {
+  host: `host-${uuidv4()}`,
+  user: `user-${uuidv4()}`,
+};
 
 export const getRiskScoreOverTimeAreaAttributes: GetLensAttributes = ({
   stackByField = 'host',
   extraOptions = { spaceId: 'default' },
 }) => {
-  const layerIds = [uuidv4(), uuidv4()];
-  const layer2ColumnId = uuidv4();
+  const layerIds = [`layer-id1-${uuidv4()}`, `layer-id2-${uuidv4()}`];
+  const layer2ColumnId = `layer2-column-id-${uuidv4()}`;
   const internalReferenceId = internalReferenceIdMapping[stackByField];
   return {
     title: `${stackByField} risk score over time`,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.test.ts
@@ -23,7 +23,7 @@ jest.mock('../../sourcerer/containers', () => ({
 }));
 
 jest.mock('uuid', () => ({
-  v4: jest.fn().mockReturnValue('2cc5663b-f062-43f8-8688-fc8166c2ca8e'),
+  v4: jest.fn().mockReturnValue('generated-uuid'),
 }));
 
 describe('getRiskScoreSummaryAttributes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.ts
@@ -28,9 +28,9 @@ export const getRiskScoreSummaryAttributes: (
   // TODO: may need to pass riskColors in props, here, when severity palette agreed and hook created
   // https://github.com/elastic/security-team/issues/11516 hook - https://github.com/elastic/kibana/pull/206276
 ) => LensAttributes = ({ spaceId, query, severity, riskEntity }) => {
-  const layerIds = [uuidv4(), uuidv4()];
-  const internalReferenceId = uuidv4();
-  const columnIds = [uuidv4(), uuidv4(), uuidv4()];
+  const layerIds = [`layer-id1-${uuidv4()}`, `layer-id2-${uuidv4()}`];
+  const internalReferenceId = `internal-reference-id-${uuidv4()}`;
+  const columnIds = [`column-id1-${uuidv4()}`, `column-id2-${uuidv4()}`, `column-id3-${uuidv4()}`];
   const sourceField = EntityTypeToScoreField[riskEntity];
   return {
     title: 'Risk score summary',

--- a/x-pack/test_serverless/functional/test_suites/observability/discover/const.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/discover/const.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const MORE_THAN_1024_CHARS =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?';
+
+export const STACKTRACE_MESSAGE =
+  "Error: 9 FAILED_PRECONDITION: Can't access cart storage. StackExchange.Redis.RedisTimeoutException: Timeout awaiting response (outbound=0KiB, inbound=0KiB, 5467ms elapsed, timeout is 5000ms), command=HGET, next: HGET 7578fdf6-e0b1-4b60-98b3-6751dadffd01, inst: 0, qu: 0, qs: 5, aw: False, bw: SpinningDown, rs: ReadAsync, ws: Idle, in: 377, in-pipe: 0, out-pipe: 0, last-in: 0, cur-in: 0, sync-ops: 2, async-ops: 1653332, serverEndpoint: valkey:6379, conn-sec: 1292697.71, aoc: 0, mc: 1/1/0, mgr: 10 of 10 available, clientName: cartservice-6558778458-4df9q(SE.Redis-v2.8.16.12844), IOCP: (Busy=0,Free=1000,Min=1,Max=1000), WORKER: (Busy=6,Free=32761,Min=2,Max=32767), POOL: (Threads=6,QueuedItems=7,CompletedItems=28329470,Timers=8), v: 2.8.16.12844 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)\n" +
+  '   at cartservice.cartstore.ValkeyCartStore.AddItemAsync(String userId, String productId, Int32 quantity) in /usr/src/app/src/cartstore/ValkeyCartStore.cs:line 117\n' +
+  '    at callErrorFromStatus (/app/node_modules/@grpc/grpc-js/build/src/call.js:31:19)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client.js:193:76)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:360:141)\n' +
+  '    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:323:181)\n' +
+  '    at /app/node_modules/@grpc/grpc-js/build/src/resolving-call.js:129:78\n' +
+  '    at process.processTicksAndRejections (node:internal/process/task_queues:77:11)\n' +
+  'for call at\n' +
+  '    at ServiceClientImpl.makeUnaryRequest (/app/node_modules/@grpc/grpc-js/build/src/client.js:161:32)\n' +
+  '    at ServiceClientImpl.<anonymous> (/app/node_modules/@grpc/grpc-js/build/src/make-client.js:105:19)\n' +
+  '    at /app/node_modules/@opentelemetry/instrumentation-grpc/build/src/clientUtils.js:131:31\n' +
+  '    at /app/node_modules/@opentelemetry/instrumentation-grpc/build/src/instrumentation.js:211:209\n' +
+  '    at AsyncLocalStorage.run (node:async_hooks:346:14)\n' +
+  '    at AsyncLocalStorageContextManager.with (/app/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\n' +
+  '    at ContextAPI.with (/app/node_modules/@opentelemetry/api/build/src/api/context.js:60:46)\n' +
+  '    at ServiceClientImpl.clientMethodTrace [as addItem] (/app/node_modules/@opentelemetry/instrumentation-grpc/build/src/instrumentation.js:211:42)\n' +
+  '    at /app/.next/server/pages/api/cart.js:1:1101\n' +
+  '    at new ZoneAwarePromise (/app/node_modules/zone.js/bundles/zone.umd.js:1340:33)';

--- a/x-pack/test_serverless/functional/test_suites/observability/discover/embeddables/_get_doc_viewer.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/discover/embeddables/_get_doc_viewer.ts
@@ -1,0 +1,382 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment/moment';
+import { log, timerange } from '@kbn/apm-synthtrace-client';
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import { MORE_THAN_1024_CHARS, STACKTRACE_MESSAGE } from '../const';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects([
+    'common',
+    'discover',
+    'dashboard',
+    'header',
+    'svlCommonPage',
+  ]);
+  const testSubjects = getService('testSubjects');
+  const dataGrid = getService('dataGrid');
+  const dashboardAddPanel = getService('dashboardAddPanel');
+  const synthtrace = getService('svlLogsSynthtraceClient');
+  const queryBar = getService('queryBar');
+  const kibanaServer = getService('kibanaServer');
+  const dataViews = getService('dataViews');
+
+  const start = moment().subtract(30, 'minutes').valueOf();
+  const end = moment().valueOf();
+
+  const searchQuery = 'error.stack_trace : * and _ignored : *';
+
+  describe('discover/observability saved search embeddable triggering getDocViewer ', () => {
+    before(async () => {
+      await synthtrace.index([
+        timerange(start, end)
+          .interval('1m')
+          .rate(2)
+          .generator((timestamp: number, index: number) =>
+            log
+              .create()
+              .message('This is a log message')
+              .timestamp(timestamp)
+              .dataset('synth.1')
+              .namespace('default')
+              .logLevel(index % 2 === 0 ? MORE_THAN_1024_CHARS : 'This is a log message')
+              .defaults({
+                'service.name': 'synth-service',
+                ...(index % 2 === 0 && { 'error.stack_trace': STACKTRACE_MESSAGE }),
+              })
+          ),
+      ]);
+
+      await PageObjects.svlCommonPage.loginAsAdmin();
+
+      await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        ensureCurrentUrl: false,
+      });
+
+      // Required as some other test switches data view to metric-*
+      await dataViews.switchTo('All logs');
+
+      await queryBar.setQuery(searchQuery);
+      await queryBar.submitQuery();
+      await PageObjects.discover.waitUntilSearchingHasFinished();
+
+      // Required to access Dashboard page
+      await dataViews.createFromSearchBar({
+        name: 'logs-synth',
+      });
+
+      await PageObjects.discover.saveSearch('synth-search-doc-viewer');
+
+      await PageObjects.dashboard.navigateToApp();
+      await PageObjects.dashboard.gotoDashboardLandingPage();
+      await PageObjects.dashboard.clickNewDashboard();
+
+      await dashboardAddPanel.addSavedSearch('synth-search-doc-viewer');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.dashboard.waitForRenderComplete();
+    });
+
+    after(async () => {
+      await synthtrace.clean();
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern', 'dashboard'] });
+    });
+
+    afterEach(async () => {
+      await dataGrid.closeFlyout();
+    });
+
+    describe('renders docViewer', () => {
+      it('should open the flyout with stacktrace and quality issues accordion closed when expand is clicked', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Ensure Log overview flyout is open
+        const tabButton = await testSubjects.find('docViewerTab-doc_view_logs_overview');
+        await tabButton.click();
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('true');
+      });
+
+      it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('true');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should keep old accordion open when 1st stacktrace and then quality issue control for the same row is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to quality issue accordion when 1st stacktrace and then quality issue control is clicked for different row', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('false');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should keep old accordion open when 1st quality issue and then stacktrace control for the same row is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to stacktrace accordion when 1st quality issue and then stacktrace control is clicked for different row', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+    });
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/observability/discover/embeddables/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/discover/embeddables/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('discover/observabilitySolution/logs', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('./_get_doc_viewer'));
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/observability/discover/logs/_get_doc_viewer.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/discover/logs/_get_doc_viewer.ts
@@ -1,0 +1,356 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment/moment';
+import { log, timerange } from '@kbn/apm-synthtrace-client';
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import { MORE_THAN_1024_CHARS, STACKTRACE_MESSAGE } from '../const';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['common', 'discover', 'svlCommonPage']);
+  const testSubjects = getService('testSubjects');
+  const dataGrid = getService('dataGrid');
+  const dataViews = getService('dataViews');
+  const synthtrace = getService('svlLogsSynthtraceClient');
+  const queryBar = getService('queryBar');
+
+  const start = moment().subtract(30, 'minutes').valueOf();
+  const end = moment().valueOf();
+
+  describe('observability logs getDocViewer ', () => {
+    before(async () => {
+      await synthtrace.index([
+        timerange(start, end)
+          .interval('1m')
+          .rate(2)
+          .generator((timestamp: number, index: number) =>
+            log
+              .create()
+              .message('This is a log message')
+              .timestamp(timestamp)
+              .dataset('synth.1')
+              .namespace('default')
+              .logLevel(index % 2 === 0 ? MORE_THAN_1024_CHARS : 'info')
+              .defaults({
+                'service.name': 'synth-service',
+                ...(index % 2 === 0 && { 'error.stack_trace': STACKTRACE_MESSAGE }),
+              })
+          ),
+      ]);
+
+      await PageObjects.svlCommonPage.loginAsAdmin();
+
+      await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        ensureCurrentUrl: false,
+      });
+
+      // Required as some other test switches data view to metric-*
+      await dataViews.switchTo('All logs');
+
+      await queryBar.setQuery('error.stack_trace : * and _ignored : *');
+      await queryBar.submitQuery();
+      await PageObjects.discover.waitUntilSearchingHasFinished();
+    });
+
+    after(async () => {
+      await synthtrace.clean();
+    });
+
+    afterEach(async () => {
+      await dataGrid.closeFlyout();
+    });
+
+    describe('renders docViewer', () => {
+      it('should open the flyout with stacktrace and quality issues accordion closed when expand is clicked', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Ensure Log overview flyout is open
+        const tabButton = await testSubjects.find('docViewerTab-doc_view_logs_overview');
+        await tabButton.click();
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('false');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('true');
+      });
+
+      it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        // Ensure Log overview flyout is open
+        await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
+
+        // Quality Issues accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewDegradedFieldsAccordion');
+
+        const isQualityIssuesAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        expect(isQualityIssuesAccordionExpanded).to.equal('true');
+
+        // Stacktrace accordion to be present and collapsed
+        await testSubjects.existOrFail('unifiedDocViewLogsOverviewStacktraceAccordion');
+
+        const isStacktraceAccordionExpanded = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(isStacktraceAccordionExpanded).to.equal('false');
+      });
+
+      it('should keep old accordion open when 1st stacktrace and then quality issue control for the same row is clicked', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to quality issue accordion when 1st stacktrace and then quality issue control is clicked for different row', async () => {
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st stack trace accordion should be opened and quality issues should be closed
+        expect(stacktraceAccordionState).to.equal('true');
+        expect(qualityIssuesAccordionState).to.equal('false');
+
+        // Clicking on Quality Issue control of the same row while the Flyout is still open
+
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('false');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should keep old accordion open when 1st quality issue and then stacktrace control for the same row is clicked', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect the previous one to stay open and new one to also open. This shows component did not remount
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('true');
+      });
+
+      it('should toggle to stacktrace accordion when 1st quality issue and then stacktrace control is clicked for different row', async () => {
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // 1st quality issues accordion should be opened and stacktrace should be closed
+        expect(stacktraceAccordionState).to.equal('false');
+        expect(qualityIssuesAccordionState).to.equal('true');
+
+        // Clicking on Stacktrace control of the same row while the Flyout is still open
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const stacktraceAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        const qualityIssuesAccordionState2 = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+
+        // Expect toggle to have happened
+        expect(stacktraceAccordionState2).to.equal('true');
+        expect(qualityIssuesAccordionState2).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickQualityIssueLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('true');
+        expect(stacktraceAccordionState).to.equal('false');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of same row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(0);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+
+      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of different row and flyout is already open with some other tab', async () => {
+        await dataGrid.clickRowToggle({ rowIndex: 0 });
+
+        // Switch to JSON tab
+        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+        await jsonTabButton.click();
+
+        // Click to open Quality Issue control on the same row
+        await dataGrid.clickStacktraceLeadingControl(1);
+
+        const qualityIssuesAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewDegradedFieldsAccordion'
+        );
+        const stacktraceAccordionState = await testSubjects.getAccordionState(
+          'unifiedDocViewLogsOverviewStacktraceAccordion'
+        );
+
+        expect(qualityIssuesAccordionState).to.equal('false');
+        expect(stacktraceAccordionState).to.equal('true');
+      });
+    });
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/observability/discover/logs/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/discover/logs/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('discover/observabilitySolution/logs', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('./_get_doc_viewer'));
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/observability/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/index.ts
@@ -16,6 +16,8 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./observability_logs_explorer'));
     loadTestFile(require.resolve('./dataset_quality'));
     loadTestFile(require.resolve('./discover/context_awareness'));
+    loadTestFile(require.resolve('./discover/logs'));
+    loadTestFile(require.resolve('./discover/embeddables'));
     loadTestFile(require.resolve('./onboarding'));
     loadTestFile(require.resolve('./rules/rules_list'));
     loadTestFile(require.resolve('./cases'));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover] Implementing click action for Stacktrace and Degraded Fields on Discover (#214413)](https://github.com/elastic/kibana/pull/214413)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Achyut Jhunjhunwala","email":"achyut.jhunjhunwala@elastic.co"},"sourceCommit":{"committedDate":"2025-05-06T15:33:26Z","message":"[Discover] Implementing click action for Stacktrace and Degraded Fields on Discover (#214413)\n\nCloses: https://github.com/elastic/kibana/issues/190670\n\nThe PR adds click actions to Stacktrace and Degraded Fields Actions in\nDiscover.\n\nFor Eg - When you click on stacktrace icon in Discover, it opens the\nFlyout and Scroll Into View the Stacktrace Section\n\n![Mar-13-2025\n16-09-56](https://github.com/user-attachments/assets/096e0984-1d22-4e54-8f0b-b73c13f244ef)\n\n## Whats pending\n\n- [x] Stateful FTR Tests - Discover\n- [x] Stateful FTR Tests - Discover inside a Dashboard\n- [x] Serverless FTR Tests - Discover\n- [x] Serverless FTR Tests - Discover inside a Dashboard\n- [x] Appropriate Unit tests\n\n## Test Plan\n\n- 'should open the flyout with stacktrace and quality issues accordion\nclosed when expand is clicked'\n- 'should open the flyout with stacktrace accordion open and quality\nissues accordion closed when stacktrace icon is clicked',\n- 'should open the flyout with stacktrace accordion close and quality\nissues accordion open when quality issues icon is clicked'\n- 'should keep old accordion open when 1st stacktrace and then quality\nissue control for the same row is clicked'\n- 'should toggle to quality issue accordion when 1st stacktrace and then\nquality issue control is clicked for different row'\n- 'should keep old accordion open when 1st quality issue and then\nstacktrace control for the same row is clicked'\n- 'should toggle to stacktrace accordion when 1st quality issue and then\nstacktrace control is clicked for different row'\n- 'should switch tab to logs overview and open quality issues accordion,\nwhen user clicks on quality issue control of same row and flyout is\nalready open with some other tab'\n- 'should switch tab to logs overview and open quality issues accordion,\nwhen user clicks on quality issue control of different row and flyout is\nalready open with some other tab'\n- 'should switch tab to logs overview and open stacktrace accordion,\nwhen user clicks on stacktrace control of same row and flyout is already\nopen with some other tab'\n- 'should switch tab to logs overview and open stacktrace accordion,\nwhen user clicks on stacktrace control of different row and flyout is\nalready open with some other tab'\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani01@gmail.com>","sha":"a1d60ae978bf0a651c3b1d2aee601748cb3ca8a6","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","backport:skip","release_note:feature","Team:obs-ux-logs","Team:obs-ux-infra_services","v9.1.0"],"title":"[Discover] Implementing click action for Stacktrace and Degraded Fields on Discover","number":214413,"url":"https://github.com/elastic/kibana/pull/214413","mergeCommit":{"message":"[Discover] Implementing click action for Stacktrace and Degraded Fields on Discover (#214413)\n\nCloses: https://github.com/elastic/kibana/issues/190670\n\nThe PR adds click actions to Stacktrace and Degraded Fields Actions in\nDiscover.\n\nFor Eg - When you click on stacktrace icon in Discover, it opens the\nFlyout and Scroll Into View the Stacktrace Section\n\n![Mar-13-2025\n16-09-56](https://github.com/user-attachments/assets/096e0984-1d22-4e54-8f0b-b73c13f244ef)\n\n## Whats pending\n\n- [x] Stateful FTR Tests - Discover\n- [x] Stateful FTR Tests - Discover inside a Dashboard\n- [x] Serverless FTR Tests - Discover\n- [x] Serverless FTR Tests - Discover inside a Dashboard\n- [x] Appropriate Unit tests\n\n## Test Plan\n\n- 'should open the flyout with stacktrace and quality issues accordion\nclosed when expand is clicked'\n- 'should open the flyout with stacktrace accordion open and quality\nissues accordion closed when stacktrace icon is clicked',\n- 'should open the flyout with stacktrace accordion close and quality\nissues accordion open when quality issues icon is clicked'\n- 'should keep old accordion open when 1st stacktrace and then quality\nissue control for the same row is clicked'\n- 'should toggle to quality issue accordion when 1st stacktrace and then\nquality issue control is clicked for different row'\n- 'should keep old accordion open when 1st quality issue and then\nstacktrace control for the same row is clicked'\n- 'should toggle to stacktrace accordion when 1st quality issue and then\nstacktrace control is clicked for different row'\n- 'should switch tab to logs overview and open quality issues accordion,\nwhen user clicks on quality issue control of same row and flyout is\nalready open with some other tab'\n- 'should switch tab to logs overview and open quality issues accordion,\nwhen user clicks on quality issue control of different row and flyout is\nalready open with some other tab'\n- 'should switch tab to logs overview and open stacktrace accordion,\nwhen user clicks on stacktrace control of same row and flyout is already\nopen with some other tab'\n- 'should switch tab to logs overview and open stacktrace accordion,\nwhen user clicks on stacktrace control of different row and flyout is\nalready open with some other tab'\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani01@gmail.com>","sha":"a1d60ae978bf0a651c3b1d2aee601748cb3ca8a6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214413","number":214413,"mergeCommit":{"message":"[Discover] Implementing click action for Stacktrace and Degraded Fields on Discover (#214413)\n\nCloses: https://github.com/elastic/kibana/issues/190670\n\nThe PR adds click actions to Stacktrace and Degraded Fields Actions in\nDiscover.\n\nFor Eg - When you click on stacktrace icon in Discover, it opens the\nFlyout and Scroll Into View the Stacktrace Section\n\n![Mar-13-2025\n16-09-56](https://github.com/user-attachments/assets/096e0984-1d22-4e54-8f0b-b73c13f244ef)\n\n## Whats pending\n\n- [x] Stateful FTR Tests - Discover\n- [x] Stateful FTR Tests - Discover inside a Dashboard\n- [x] Serverless FTR Tests - Discover\n- [x] Serverless FTR Tests - Discover inside a Dashboard\n- [x] Appropriate Unit tests\n\n## Test Plan\n\n- 'should open the flyout with stacktrace and quality issues accordion\nclosed when expand is clicked'\n- 'should open the flyout with stacktrace accordion open and quality\nissues accordion closed when stacktrace icon is clicked',\n- 'should open the flyout with stacktrace accordion close and quality\nissues accordion open when quality issues icon is clicked'\n- 'should keep old accordion open when 1st stacktrace and then quality\nissue control for the same row is clicked'\n- 'should toggle to quality issue accordion when 1st stacktrace and then\nquality issue control is clicked for different row'\n- 'should keep old accordion open when 1st quality issue and then\nstacktrace control for the same row is clicked'\n- 'should toggle to stacktrace accordion when 1st quality issue and then\nstacktrace control is clicked for different row'\n- 'should switch tab to logs overview and open quality issues accordion,\nwhen user clicks on quality issue control of same row and flyout is\nalready open with some other tab'\n- 'should switch tab to logs overview and open quality issues accordion,\nwhen user clicks on quality issue control of different row and flyout is\nalready open with some other tab'\n- 'should switch tab to logs overview and open stacktrace accordion,\nwhen user clicks on stacktrace control of same row and flyout is already\nopen with some other tab'\n- 'should switch tab to logs overview and open stacktrace accordion,\nwhen user clicks on stacktrace control of different row and flyout is\nalready open with some other tab'\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani01@gmail.com>","sha":"a1d60ae978bf0a651c3b1d2aee601748cb3ca8a6"}}]}] BACKPORT-->