### PR TITLE
[Task Manager] Remove spaces plugin dependency in task manager plugin

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/task_manager/kibana.jsonc
@@ -17,7 +17,6 @@
     "optionalPlugins": [
       "cloud",
       "usageCollection",
-      "spaces"
     ]
   }
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.test.ts
@@ -13,8 +13,6 @@ import {
 } from './api_key_utils';
 import { coreMock } from '@kbn/core/server/mocks';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
-import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
 import type { AuthenticatedUser } from '@kbn/core/server';
 
 const mockTask = {
@@ -156,13 +154,8 @@ describe('api_key_utils', () => {
 
   describe('getUserScope', () => {
     test('should return the users scope based on their request', async () => {
-      const request = httpServerMock.createKibanaRequest();
+      const request = httpServerMock.createKibanaRequest({ path: '/s/test-space' });
       const coreStart = coreMock.createStart();
-      const spacesStart: jest.Mocked<SpacesPluginStart> = spacesMock.createStart();
-
-      spacesStart.spacesService.getActiveSpace = jest.fn().mockResolvedValue({
-        id: 'testSpace',
-      });
 
       const mockUser = {
         authentication_type: 'basic',
@@ -178,18 +171,13 @@ describe('api_key_utils', () => {
         api_key: 'apiKey',
       });
 
-      const result = await getApiKeyAndUserScope(
-        [mockTask],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      const result = await getApiKeyAndUserScope([mockTask], request, coreStart.security);
 
       expect(result.get('task')).toEqual({
         apiKey: 'YXBpS2V5SWQ6YXBpS2V5',
         userScope: {
           apiKeyId: 'apiKeyId',
-          spaceId: 'testSpace',
+          spaceId: 'test-space',
           apiKeyCreatedByUser: false,
         },
       });
@@ -198,7 +186,6 @@ describe('api_key_utils', () => {
     test('should default space to default if space is not found', async () => {
       const request = httpServerMock.createKibanaRequest();
       const coreStart = coreMock.createStart();
-      const spacesStart: jest.Mocked<SpacesPluginStart> = spacesMock.createStart();
 
       const mockUser = {
         authentication_type: 'basic',
@@ -214,12 +201,7 @@ describe('api_key_utils', () => {
         api_key: 'apiKey',
       });
 
-      const result = await getApiKeyAndUserScope(
-        [mockTask],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      const result = await getApiKeyAndUserScope([mockTask], request, coreStart.security);
 
       expect(result.get('task')).toEqual({
         apiKey: 'YXBpS2V5SWQ6YXBpS2V5',
@@ -240,7 +222,6 @@ describe('api_key_utils', () => {
       });
 
       const coreStart = coreMock.createStart();
-      const spacesStart: jest.Mocked<SpacesPluginStart> = spacesMock.createStart();
       const mockUser = {
         authentication_type: 'api_key',
         username: 'testUser',
@@ -249,12 +230,7 @@ describe('api_key_utils', () => {
       coreStart.security.authc.apiKeys.areAPIKeysEnabled = jest.fn().mockReturnValueOnce(true);
       coreStart.security.authc.getCurrentUser = jest.fn().mockReturnValue(mockUser);
 
-      const result = await getApiKeyAndUserScope(
-        [mockTask],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      const result = await getApiKeyAndUserScope([mockTask], request, coreStart.security);
 
       expect(result.get('task')).toEqual({
         apiKey: 'YXBpS2V5SWQ6YXBpS2V5',

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -23,7 +23,6 @@ import type {
 } from '@kbn/core/server';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
 import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-shared';
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import {
   registerDeleteInactiveNodesTaskDefinition,
   scheduleDeleteInactiveNodesTaskDefinition,
@@ -95,7 +94,6 @@ export type TaskManagerStartContract = Pick<
 export interface TaskManagerPluginsStart {
   cloud?: CloudStart;
   usageCollection?: UsageCollectionStart;
-  spaces?: SpacesPluginStart;
 }
 
 export interface TaskManagerPluginsSetup {
@@ -288,7 +286,7 @@ export class TaskManagerPlugin
 
   public start(
     { http, savedObjects, elasticsearch, executionContext, security }: CoreStart,
-    { cloud, spaces }: TaskManagerPluginsStart
+    { cloud }: TaskManagerPluginsStart
   ): TaskManagerStartContract {
     const savedObjectsRepository = savedObjects.createInternalRepository([
       TASK_SO_NAME,
@@ -322,7 +320,6 @@ export class TaskManagerPlugin
       requestTimeouts: this.config.request_timeouts,
       security,
       canEncryptSavedObjects: this.canEncryptSavedObjects,
-      spaces,
     });
 
     const isServerless = this.initContext.env.packageInfo.buildFlavor === 'serverless';

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -25,7 +25,7 @@ import type {
 } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
-import { addSpaceIdToPath } from '@kbn/spaces-plugin/server';
+import { addSpaceIdToPath } from '@kbn/spaces-utils';
 import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
 import type { Middleware } from '../lib/middleware';
 import type { Result } from '../lib/result_type';

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -33,7 +33,6 @@ import { asErr, asOk } from './lib/result_type';
 import type { UpdateByQueryResponse } from '@elastic/elasticsearch/lib/api/types';
 import { MsearchError } from './lib/msearch_error';
 import { getApiKeyAndUserScope } from './lib/api_key_utils';
-import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
 import type {
   EncryptedSavedObjectsClient,
   EncryptedSavedObjectsClientOptions,
@@ -75,7 +74,6 @@ const adHocTaskCounter = new AdHocTaskCounter();
 const randomId = () => `id-${_.random(1, 20)}`;
 
 const coreStart = coreMock.createStart();
-const spacesStart = spacesMock.createStart();
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -146,7 +144,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -319,12 +316,7 @@ describe('TaskStore', () => {
         }
       );
 
-      expect(getApiKeyAndUserScope).toHaveBeenCalledWith(
-        [task],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      expect(getApiKeyAndUserScope).toHaveBeenCalledWith([task], request, coreStart.security);
 
       expect(savedObjectsClient.create).not.toHaveBeenCalled();
 
@@ -363,7 +355,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: false,
       });
 
@@ -1688,7 +1679,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -1809,7 +1799,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -2123,7 +2112,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -2330,8 +2318,7 @@ describe('TaskStore', () => {
       expect(getApiKeyAndUserScope).toHaveBeenCalledWith(
         [task1, task2],
         request,
-        coreStart.security,
-        spacesStart
+        coreStart.security
       );
 
       expect(savedObjectsClient.create).not.toHaveBeenCalled();
@@ -2392,7 +2379,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: false,
       });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -30,7 +30,6 @@ import type {
 } from '@kbn/core/server';
 
 import { SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID } from '@kbn/core/server';
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 
 import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-shared';
 
@@ -79,7 +78,6 @@ export interface StoreOpts {
   security: SecurityServiceStart;
   canEncryptSavedObjects?: boolean;
   esoClient?: EncryptedSavedObjectsClient;
-  spaces?: SpacesPluginStart;
 }
 
 export interface SearchOpts {
@@ -149,7 +147,6 @@ export class TaskStore {
   private requestTimeouts: RequestTimeoutsConfig;
   private security: SecurityServiceStart;
   private canEncryptSavedObjects?: boolean;
-  private spaces?: SpacesPluginStart;
   private logger: Logger;
 
   /**
@@ -183,7 +180,6 @@ export class TaskStore {
     });
     this.requestTimeouts = opts.requestTimeouts;
     this.security = opts.security;
-    this.spaces = opts.spaces;
     this.canEncryptSavedObjects = opts.canEncryptSavedObjects;
     this.logger = opts.logger;
   }
@@ -224,12 +220,7 @@ export class TaskStore {
 
     let userScopeAndApiKey;
     try {
-      userScopeAndApiKey = await getApiKeyAndUserScope(
-        taskInstances,
-        request,
-        this.security,
-        this.spaces
-      );
+      userScopeAndApiKey = await getApiKeyAndUserScope(taskInstances, request, this.security);
     } catch (e) {
       this.errors$.next(e);
       throw e;

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -36,7 +36,8 @@
     "@kbn/core-http-server-utils",
     "@kbn/rrule",
     "@kbn/logging-mocks",
-    "@kbn/spaces-utils"
+    "@kbn/spaces-utils",
+    "@kbn/spaces-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -37,7 +37,6 @@
     "@kbn/rrule",
     "@kbn/logging-mocks",
     "@kbn/spaces-utils",
-    "@kbn/spaces-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -37,6 +37,7 @@
     "@kbn/rrule",
     "@kbn/logging-mocks",
     "@kbn/spaces-utils",
+    "@kbn/spaces-plugin",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -31,12 +31,12 @@
     "@kbn/core-elasticsearch-server",
     "@kbn/es-query",
     "@kbn/core-http-server-mocks",
-    "@kbn/spaces-plugin",
     "@kbn/encrypted-saved-objects-shared",
     "@kbn/core-saved-objects-api-server-mocks",
     "@kbn/core-http-server-utils",
     "@kbn/rrule",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/spaces-utils"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -37,7 +37,6 @@
     "@kbn/rrule",
     "@kbn/logging-mocks",
     "@kbn/spaces-utils",
-    "@kbn/spaces-plugin",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This PR removes spaces plugin dependency from task manager plugin and replaces `spacesService.getActiveSpace` with `getSpaceIdFromPath` from `@kbn/spaces-utils` package. This prevents a circular dependency from happening in https://github.com/elastic/kibana/pull/220138

> [!NOTE]  
> I'm changing the test case to use `test-space` id instead of `testSpace` as this was an invalid space id and it shouldn't have been used in the mock.





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->