### PR TITLE
[Obs AI Assistant] Add `skipCloud` tag to upgrade tests

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.10_upgrade_test.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.10_upgrade_test.spec.ts
@@ -36,7 +36,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   describe('Knowledge base: when upgrading from 8.10 to 8.18', function () {
     // Intentionally skipped in all serverless environnments (local and MKI)
     // because the migration scenario being tested is not relevant to MKI and Serverless.
-    this.tags(['skipCloud']);
+    this.tags(['skipServerless', 'skipCloud']);
 
     before(async () => {
       // in a real environment we will use the ELSER inference endpoint (`.elser-2-elasticsearch`) which is pre-installed

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.10_upgrade_test.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.10_upgrade_test.spec.ts
@@ -36,7 +36,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   describe('Knowledge base: when upgrading from 8.10 to 8.18', function () {
     // Intentionally skipped in all serverless environnments (local and MKI)
     // because the migration scenario being tested is not relevant to MKI and Serverless.
-    this.tags(['skipServerless']);
+    this.tags(['skipCloud']);
 
     before(async () => {
       // in a real environment we will use the ELSER inference endpoint (`.elser-2-elasticsearch`) which is pre-installed

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.16_upgrade_test.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.16_upgrade_test.spec.ts
@@ -44,7 +44,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   describe('Knowledge base: when upgrading from 8.16 to 8.17', function () {
     // Intentionally skipped in all serverless environnments (local and MKI)
     // because the migration scenario being tested is not relevant to MKI and Serverless.
-    this.tags(['skipServerless']);
+    this.tags(['skipCloud']);
 
     describe('using a snapshot', () => {
       before(async () => {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.16_upgrade_test.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.16_upgrade_test.spec.ts
@@ -44,7 +44,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   describe('Knowledge base: when upgrading from 8.16 to 8.17', function () {
     // Intentionally skipped in all serverless environnments (local and MKI)
     // because the migration scenario being tested is not relevant to MKI and Serverless.
-    this.tags(['skipCloud']);
+    this.tags(['skipServerless', 'skipCloud']);
 
     describe('using a snapshot', () => {
       before(async () => {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.18_upgrade_test.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.18_upgrade_test.spec.ts
@@ -35,7 +35,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   // We need to make sure that the custom inference endpoint continues to work after the migration
 
   describe('Knowledge base: when upgrading from 8.18 to 8.19', function () {
-    this.tags(['skipServerless']);
+    this.tags(['skipCloud']);
 
     before(async () => {
       await importModel(getService, { modelId: TINY_ELSER_MODEL_ID });

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.18_upgrade_test.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_8.18_upgrade_test.spec.ts
@@ -35,7 +35,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   // We need to make sure that the custom inference endpoint continues to work after the migration
 
   describe('Knowledge base: when upgrading from 8.18 to 8.19', function () {
-    this.tags(['skipCloud']);
+    this.tags(['skipServerless', 'skipCloud']);
 
     before(async () => {
       await importModel(getService, { modelId: TINY_ELSER_MODEL_ID });

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_change_model_from_elser_to_e5.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_change_model_from_elser_to_e5.spec.ts
@@ -44,6 +44,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   type KnowledgeBaseEsEntry = Awaited<ReturnType<typeof getKnowledgeBaseEntriesFromEs>>[0];
 
   describe('Knowledge base: when changing from ELSER to E5-like model', function () {
+    this.tags(['skipCloud']);
     let elserEntriesFromApi: KnowledgeBaseEntry[];
     let elserEntriesFromEs: KnowledgeBaseEsEntry[];
     let elserInferenceId: string;


### PR DESCRIPTION
The upgrade tests are flaky in ECH and serverless environments. They should therefore be skipped for now. Hopefully we can enable them again in the near future.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->