### PR TITLE
Dataset quality: Make sure non-aggregatable message is not shown if no data matches

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_non_aggregatable_data_streams/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_non_aggregatable_data_streams/index.ts
@@ -38,6 +38,16 @@ export async function getNonAggregatableDataStreams({
   });
 
   const indices = response?.indices ?? [];
+
+  // if no indices are returned, it means there are no data streams matching the criteria
+  // so we return an empty response - aggregatable is set to true so no error is thrown in the UI
+  if (indices.length === 0) {
+    return {
+      aggregatable: true,
+      datasets: [],
+    };
+  }
+
   const nonAggregatableIndices = response.fields._ignored?._ignored?.non_aggregatable_indices ?? [];
 
   const datasets = extractNonAggregatableDatasets(indices, nonAggregatableIndices);


### PR DESCRIPTION
On the dataset quality page, a callout is shown if there are indices which don't have the `_ignored` field set as aggregatable. This can happen when some data streams existed from before the cluster got upgraded.

However, the endpoint to check this also returns `aggregatable: false` if there are no indices at all in the given time range and filter. While this might be technically correct, this triggers the display of a warning callout in the UI which is confusing for users because there isn't actually a problem.

This PR fixes this.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->