### PR TITLE
[8.19] Search for CVE id in all search params instead of only name (#221099)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/find_reference_link.util.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/find_reference_link.util.test.ts
@@ -8,9 +8,22 @@
 import { findReferenceLink } from './find_reference_link.util';
 
 describe('findReferenceLink', () => {
-  it('should find reference with ID in search params', () => {
-    const references = ['https://nvd.nist.gov/vuln/detail?name=CVE-2023-12345'];
+  it('should find reference with ID in any search param', () => {
+    const references = [
+      'https://nvd.nist.gov/vuln/detail?name=CVE-2023-12345',
+      'https://nvd.nist.gov/vuln/detail?id=CVE-2023-54321',
+    ];
     expect(findReferenceLink(references, 'CVE-2023-12345')).toBe(references[0]);
+    expect(findReferenceLink(references, 'CVE-2023-54321')).toBe(references[1]);
+  });
+
+  it('should find reference from multiple links', () => {
+    const references = [
+      'http://www.nessus.org/u?5b3cb0db',
+      'https://www.cve.org/CVERecord?id=CVE-2022-2068',
+      'https://www.openssl.org/news/secadv/20220621.txt',
+    ];
+    expect(findReferenceLink(references, 'CVE-2022-2068')).toBe(references[1]);
   });
 
   it('should find reference with ID in pathname', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Search for CVE id in all search params instead of only name (#221099)](https://github.com/elastic/kibana/pull/221099)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Kholod","email":"maxim.kholod@elastic.co"},"sourceCommit":{"committedDate":"2025-05-26T12:51:50Z","message":"Search for CVE id in all search params instead of only name (#221099)\n\n## Summary\n\nWhile reviewing Tenable mapping for CDR\nhttps://github.com/elastic/integrations/pull/13636 noticed that CVE link\nis not rendered for the following case\n\n```\nvulnerability.reference: [\n      'http://www.nessus.org/u?5b3cb0db',\n      'https://www.cve.org/CVERecord?id=CVE-2022-2068',\n      'https://www.openssl.org/news/secadv/20220621.txt',\n    ];\nvulnerability.id: ['CVE-2022-2068']\n```\n\ndue to the find utility looking only into `name` search param. Fixing\nthat by iterating over all params\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"684c87750c0c4039724434d2dfe35d3b7a567a6f","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Cloud Security","backport:version","v9.1.0","v8.19.0"],"title":"Search for CVE id in all search params instead of only name","number":221099,"url":"https://github.com/elastic/kibana/pull/221099","mergeCommit":{"message":"Search for CVE id in all search params instead of only name (#221099)\n\n## Summary\n\nWhile reviewing Tenable mapping for CDR\nhttps://github.com/elastic/integrations/pull/13636 noticed that CVE link\nis not rendered for the following case\n\n```\nvulnerability.reference: [\n      'http://www.nessus.org/u?5b3cb0db',\n      'https://www.cve.org/CVERecord?id=CVE-2022-2068',\n      'https://www.openssl.org/news/secadv/20220621.txt',\n    ];\nvulnerability.id: ['CVE-2022-2068']\n```\n\ndue to the find utility looking only into `name` search param. Fixing\nthat by iterating over all params\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"684c87750c0c4039724434d2dfe35d3b7a567a6f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221099","number":221099,"mergeCommit":{"message":"Search for CVE id in all search params instead of only name (#221099)\n\n## Summary\n\nWhile reviewing Tenable mapping for CDR\nhttps://github.com/elastic/integrations/pull/13636 noticed that CVE link\nis not rendered for the following case\n\n```\nvulnerability.reference: [\n      'http://www.nessus.org/u?5b3cb0db',\n      'https://www.cve.org/CVERecord?id=CVE-2022-2068',\n      'https://www.openssl.org/news/secadv/20220621.txt',\n    ];\nvulnerability.id: ['CVE-2022-2068']\n```\n\ndue to the find utility looking only into `name` search param. Fixing\nthat by iterating over all params\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"684c87750c0c4039724434d2dfe35d3b7a567a6f"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->