### PR TITLE
[chore] Remove unused color libraries from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2169,12 +2169,7 @@
       "groupName": "@elastic/kibana-visualizations Color related modules",
       "matchDepNames": [
         "chroma-js",
-        "color",
-        "tinycolor2",
-        "tinygradient",
-        "@types/chroma-js",
-        "@types/color",
-        "@types/tinycolor2"
+        "@types/chroma-js"
       ],
       "reviewers": [
         "team:kibana-visualizations"


### PR DESCRIPTION
## Summary

Remove libraries from `renovate.json` as asked in https://github.com/elastic/kibana/pull/220221#discussion_r2108741950
