### PR TITLE
[Fleet] Fix querying installed packages

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
@@ -340,15 +340,15 @@ export async function getInstalledPackageSavedObjects(
         `${PACKAGES_SAVED_OBJECT_TYPE}.attributes.install_status`,
         installationStatuses.Installed
       ),
-      // Filter for a "queryable" marker
-      buildFunctionNode(
-        'nested',
-        `${PACKAGES_SAVED_OBJECT_TYPE}.attributes.installed_es`,
-        nodeBuilder.is('type', 'index_template')
-      ),
-      // "Type" filter
       ...(dataStreamType
         ? [
+            // Filter for a "queryable" marker
+            buildFunctionNode(
+              'nested',
+              `${PACKAGES_SAVED_OBJECT_TYPE}.attributes.installed_es`,
+              nodeBuilder.is('type', 'index_template')
+            ),
+            // "Type" filter
             buildFunctionNode(
               'nested',
               `${PACKAGES_SAVED_OBJECT_TYPE}.attributes.installed_es`,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/220814

Bug introduced in https://github.com/elastic/kibana/pull/156413 where the filter on `installed_es` was introduced. It doesn't return installed packages where `installed_es` is empty.

After the fix, packages like APM are returned:
<img width="2538" alt="image" src="https://github.com/user-attachments/assets/2c3f0832-fc8c-46b1-ad3a-de6d6a9962b8" />

This also fixes the remote sync status to show the missing packages:
<img width="719" alt="image" src="https://github.com/user-attachments/assets/79606fec-cb3d-4f35-a83b-85933fd1d7d2" />

 

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->