### PR TITLE
[Security Solution][Endpoint] Fix internal connector client to uses the correct spaceId when sending requests to 3rd party EDRs while checking on pending response actions

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/normalized_external_connector_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/normalized_external_connector_client.test.ts
@@ -172,12 +172,20 @@ describe('`NormalizedExternalConnectorClient` class', () => {
       );
     });
 
+    it(`should throw an error is initialized with no spaceId option`, async () => {
+      expect(() => {
+        new NormalizedExternalConnectorClient(actionPluginConnectorClient, logger);
+      }).toThrow(
+        "Initialization of NormalizedExternalConnectorClient with an unsecured connectors client requires an 'options.spaceId' to be defined"
+      );
+    });
+
     it('should call Action Plugin client `.execute()` with expected arguments', async () => {
       const testInstance = new NormalizedExternalConnectorClient(
         actionPluginConnectorClient,
         logger,
         {
-          spaceId: 'default',
+          spaceId: 'foo',
           relatedSavedObjects: [
             {
               id: 'so-id-1',
@@ -192,7 +200,7 @@ describe('`NormalizedExternalConnectorClient` class', () => {
       expect(actionPluginConnectorClient.execute).toHaveBeenCalledWith({
         id: 'connector-mock-id-1',
         requesterId: 'background_task',
-        spaceId: 'default',
+        spaceId: 'foo',
         params: executeInputOptions.params,
         relatedSavedObjects: [
           {


### PR DESCRIPTION
## Summary

Change is in support of Space Awareness feature which is currently behind a feature flag (`endpointManagementSpaceAwarenessEnabled`):

- Updates the internal `NormalizedExternalConnectorClient` `.execute()` method to ensure that the space ID that the class instance was initialized with is used
    - It also removes the `spaceId` input option from the `.execute()` method (no longer needed)


### Testing space awareness setup

### Enable feature flags

```yaml
xpack.securitySolution.enableExperimental:
  - endpointManagementSpaceAwarenessEnabled

xpack.fleet.enableExperimental:
  - useSpaceAwareness
```

### Switch Fleet to Space aware

```http request
POST /internal/fleet/enable_space_awareness
Elastic-Api-Version: 1,
```

### Ensure that a `9.1.0-prerelease.x` endpoint package is installed

Space awareness needs to have the latest 9.1 package installed in fleet. Ensure that is the case prior to creating policies by going to the integrations page, enabling `Display beta integrations` and then clicking on Elastic Defend and installing the latest 9.1 pre-release package version.



### Add data

You should now be all setup to load data for testing. Remember that space data visibility is mostly driven by Fleet and how Policies are setup and shared between spaces - Agent Policies now have a Space ID field to manage this.

Our scripts that run live VMs for each type o9f EDR have been updated to support a `--spaceId` CLI argument and thus can be used to target specific spaces.






## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




