### PR TITLE
[Renovate] Prevent immortal vega PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2210,6 +2210,7 @@
         "release_note:skip",
         "backport:prev-minor"
       ],
+      "recreateWhen": "never",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },


### PR DESCRIPTION
## Summary

Renovate will continue to recreate Vega PRs when closed (i.e. https://github.com/elastic/kibana/pull/220913 and https://github.com/elastic/kibana/pull/221582).

We want to prevent this for the time being.

See immortal PR [docs](https://renovate-docs.elastic.dev/key-concepts/pull-requests/#immortal-prs).