### PR TITLE
[8.19] [ES|QL] support more subqueries in `FORK` (#218176)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
@@ -44,6 +44,7 @@ import {
 } from './factories';
 import { createChangePointCommand } from './factories/change_point';
 import { createDissectCommand } from './factories/dissect';
+import { createEvalCommand } from './factories/eval';
 import { createForkCommand } from './factories/fork';
 import { createFromCommand } from './factories/from';
 import { createGrokCommand } from './factories/grok';
@@ -57,7 +58,6 @@ import { getPosition } from './helpers';
 import {
   collectAllAggFields,
   collectAllColumnIdentifiers,
-  collectAllFields,
   getEnrichClauses,
   getMatchField,
   getPolicyName,
@@ -156,9 +156,10 @@ export class ESQLAstBuilderListener implements ESQLParserListener {
    * @param ctx the parse tree
    */
   exitEvalCommand(ctx: EvalCommandContext) {
-    const commandAst = createCommand('eval', ctx);
-    this.ast.push(commandAst);
-    commandAst.args.push(...collectAllFields(ctx.fields()));
+    if (this.inFork) {
+      return;
+    }
+    this.ast.push(createEvalCommand(ctx));
   }
 
   /**
@@ -166,7 +167,11 @@ export class ESQLAstBuilderListener implements ESQLParserListener {
    * @param ctx the parse tree
    */
   exitStatsCommand(ctx: StatsCommandContext) {
-    const command = createStatsCommand(ctx, this.src);
+    if (this.inFork) {
+      return;
+    }
+
+    const command = createStatsCommand(ctx);
 
     this.ast.push(command);
   }
@@ -251,9 +256,10 @@ export class ESQLAstBuilderListener implements ESQLParserListener {
    * @param ctx the parse tree
    */
   exitDissectCommand(ctx: DissectCommandContext) {
-    const command = createDissectCommand(ctx);
-
-    this.ast.push(command);
+    if (this.inFork) {
+      return;
+    }
+    this.ast.push(createDissectCommand(ctx));
   }
 
   /**

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/eval.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/eval.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EvalCommandContext } from '../../antlr/esql_parser';
+import { ESQLCommand } from '../../types';
+import { createCommand } from '../factories';
+import { collectAllFields } from '../walkers';
+
+export const createEvalCommand = (ctx: EvalCommandContext): ESQLCommand<'eval'> => {
+  const command = createCommand('eval', ctx);
+  const fields = collectAllFields(ctx.fields());
+
+  command.args.push(...fields);
+
+  return command;
+};

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/fork.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/fork.ts
@@ -17,8 +17,11 @@ import {
 import { Builder } from '../../builder';
 import { ESQLCommand } from '../../types';
 import { createCommand, createParserFields } from '../factories';
+import { createDissectCommand } from './dissect';
+import { createEvalCommand } from './eval';
 import { createLimitCommand } from './limit';
 import { createSortCommand } from './sort';
+import { createStatsCommand } from './stats';
 import { createWhereCommand } from './where';
 
 export const createForkCommand = (ctx: ForkCommandContext): ESQLCommand<'fork'> => {
@@ -76,5 +79,20 @@ function visitForkSubQueryProcessingCommandContext(ctx: ForkSubQueryProcessingCo
   const limitCtx = ctx.limitCommand();
   if (limitCtx) {
     return createLimitCommand(limitCtx);
+  }
+
+  const dissectCtx = ctx.dissectCommand();
+  if (dissectCtx) {
+    return createDissectCommand(dissectCtx);
+  }
+
+  const evalCtx = ctx.evalCommand();
+  if (evalCtx) {
+    return createEvalCommand(evalCtx);
+  }
+
+  const statsCtx = ctx.statsCommand();
+  if (statsCtx) {
+    return createStatsCommand(statsCtx);
   }
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/stats.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/stats.ts
@@ -41,7 +41,7 @@ const createAggField = (ctx: AggFieldContext) => {
   return aggField;
 };
 
-export const createStatsCommand = (ctx: StatsCommandContext, src: string): ESQLCommand<'stats'> => {
+export const createStatsCommand = (ctx: StatsCommandContext): ESQLCommand<'stats'> => {
   const command = createCommand('stats', ctx);
 
   if (ctx._stats) {

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
@@ -195,11 +195,6 @@ export class CommandVisitorContext<
     return this.node.name.toUpperCase();
   }
 
-  public visitSubQuery(queryNode: ESQLAstQueryExpression) {
-    this.ctx.assertMethodExists('visitQuery');
-    return this.ctx.visitQuery(this, queryNode, undefined as any);
-  }
-
   public *options(): Iterable<ESQLCommandOption> {
     for (const arg of this.node.args) {
       if (!arg || Array.isArray(arg)) {
@@ -284,6 +279,25 @@ export class CommandVisitorContext<
         const sourceContext = new SourceExpressionVisitorContext(this.ctx, arg, this);
         const result = this.ctx.methods.visitSourceExpression!(sourceContext, input);
 
+        yield result;
+      }
+    }
+  }
+
+  public visitSubQuery(queryNode: ESQLAstQueryExpression) {
+    this.ctx.assertMethodExists('visitQuery');
+    return this.ctx.visitQuery(this, queryNode, undefined as any);
+  }
+
+  public *visitSubQueries() {
+    this.ctx.assertMethodExists('visitQuery');
+    for (const arg of this.node.args) {
+      if (!arg || Array.isArray(arg)) {
+        continue;
+      }
+
+      if (arg.type === 'query') {
+        const result = this.visitSubQuery(arg);
         yield result;
       }
     }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.fork.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.fork.test.ts
@@ -7,12 +7,21 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Location } from '../../definitions/types';
+import { ESQL_STRING_TYPES } from '../../shared/esql_types';
 import { EXPECTED_FIELD_AND_FUNCTION_SUGGESTIONS } from './autocomplete.command.sort.test';
+import { AVG_TYPES, EXPECTED_FOR_EMPTY_EXPRESSION } from './autocomplete.command.stats.test';
 import {
   EMPTY_WHERE_SUGGESTIONS,
   EXPECTED_COMPARISON_WITH_TEXT_FIELD_SUGGESTIONS,
 } from './autocomplete.command.where.test';
-import { AssertSuggestionsFn, SuggestFn, setup } from './helpers';
+import {
+  AssertSuggestionsFn,
+  SuggestFn,
+  getFieldNamesByType,
+  getFunctionSignaturesByReturnType,
+  setup,
+} from './helpers';
 
 describe.skip('autocomplete.suggest', () => {
   describe('FORK (COMMAND ... [| COMMAND ...]) [(COMMAND ... [| COMMAND ...])]', () => {
@@ -39,7 +48,7 @@ describe.skip('autocomplete.suggest', () => {
       });
 
       describe('(COMMAND ... | COMMAND ...)', () => {
-        const FORK_SUBCOMMANDS = ['WHERE ', 'SORT ', 'LIMIT '];
+        const FORK_SUBCOMMANDS = ['WHERE ', 'SORT ', 'LIMIT ', 'DISSECT ', 'STATS ', 'EVAL '];
 
         it('suggests FORK sub commands in an open branch', async () => {
           await assertSuggestions('FROM a | FORK (/)', FORK_SUBCOMMANDS);
@@ -78,6 +87,93 @@ describe.skip('autocomplete.suggest', () => {
               'NULLS LAST',
             ]);
           });
+
+          test('dissect', async () => {
+            await assertSuggestions(
+              'FROM a | FORK (DISSECT /)',
+              getFieldNamesByType(ESQL_STRING_TYPES).map((name) => `${name} `)
+            );
+            await assertSuggestions('FROM a | FORK (DISSECT keywordField /)', ['"%{firstWord}" ']);
+            await assertSuggestions('FROM a | FORK (DISSECT keywordField "" /)', [
+              'APPEND_SEPARATOR = ',
+              '| ',
+            ]);
+          });
+
+          describe('stats', () => {
+            it('suggests for empty expression', async () => {
+              await assertSuggestions('FROM a | FORK (STATS /)', EXPECTED_FOR_EMPTY_EXPRESSION);
+              await assertSuggestions(
+                'FROM a | FORK (STATS AVG(integerField), /)',
+                EXPECTED_FOR_EMPTY_EXPRESSION
+              );
+            });
+
+            it('suggest within a function', async () => {
+              await assertSuggestions('FROM a | FORK (STATS AVG(/))', [
+                ...getFieldNamesByType(AVG_TYPES),
+                ...getFunctionSignaturesByReturnType(Location.STATS, AVG_TYPES, { scalar: true }),
+              ]);
+              await assertSuggestions('FROM a | FORK (STATS AVG(integerField) BY ACOS(/))', [
+                ...getFieldNamesByType([...AVG_TYPES, 'unsigned_long']),
+                ...getFunctionSignaturesByReturnType(
+                  Location.STATS,
+                  [...AVG_TYPES, 'unsigned_long'],
+                  {
+                    scalar: true,
+                    // grouping functions are a bug: https://github.com/elastic/kibana/issues/218319
+                    grouping: true,
+                  },
+                  undefined,
+                  ['acos']
+                ),
+              ]);
+            });
+
+            it('supports STATS ... WHERE', async () => {
+              await assertSuggestions(
+                'FROM a | FORK (STATS AVG(integerField) WHERE integerField /)',
+                [
+                  ...getFunctionSignaturesByReturnType(
+                    Location.STATS_WHERE,
+                    'any',
+                    { operators: true },
+                    ['integer']
+                  ),
+                ]
+              );
+            });
+          });
+
+          describe('eval', () => {
+            it('suggests for empty expression', async () => {
+              const emptyExpressionSuggestions = [
+                'col0 = ',
+                ...getFieldNamesByType('any').map((name) => `${name} `),
+                ...getFunctionSignaturesByReturnType(Location.EVAL, 'any', { scalar: true }),
+              ];
+              await assertSuggestions('FROM a | FORK (EVAL /)', emptyExpressionSuggestions);
+              await assertSuggestions(
+                'FROM a | FORK (EVAL ACOS(integerField), /)',
+                emptyExpressionSuggestions
+              );
+            });
+
+            it('suggests within a function', async () => {
+              await assertSuggestions('FROM a | FORK (EVAL ACOS(/))', [
+                ...getFieldNamesByType(['integer', 'long', 'unsigned_long', 'double']),
+                ...getFunctionSignaturesByReturnType(
+                  Location.STATS,
+                  ['integer', 'long', 'unsigned_long', 'double'],
+                  {
+                    scalar: true,
+                  },
+                  undefined,
+                  ['acos']
+                ),
+              ]);
+            });
+          });
         });
 
         it('suggests pipe after complete subcommands', async () => {
@@ -89,6 +185,9 @@ describe.skip('autocomplete.suggest', () => {
           await assertSuggestsPipe('FROM a | FORK (WHERE keywordField IS NOT NULL /)');
           await assertSuggestsPipe('FROM a | FORK (LIMIT 1234 /)');
           await assertSuggestsPipe('FROM a | FORK (SORT keywordField ASC /)');
+          await assertSuggestsPipe(
+            'FROM a | FORK (DISSECT keywordField "%{firstWord}" APPEND_SEPARATOR=":" /)'
+          );
         });
 
         it('suggests FORK subcommands after in-branch pipe', async () => {
@@ -101,6 +200,29 @@ describe.skip('autocomplete.suggest', () => {
             'FROM a | FORK (SORT longField ASC NULLS LAST) (WHERE keywordField IS NULL | LIMIT 1234 | /)',
             FORK_SUBCOMMANDS
           );
+        });
+
+        describe('user-defined columns', () => {
+          it('suggests user-defined columns from earlier in this branch', async () => {
+            const suggestions = await suggest(
+              'FROM a | FORK (EVAL foo = 1 | EVAL bar = 2 | WHERE /)'
+            );
+            expect(suggestions.map(({ label }) => label)).toContain('foo');
+            expect(suggestions.map(({ label }) => label)).toContain('bar');
+          });
+
+          it('does NOT suggest user-defined columns from another branch', async () => {
+            const suggestions = await suggest('FROM a | FORK (EVAL foo = 1) (WHERE /)');
+            expect(suggestions.map(({ label }) => label)).not.toContain('foo');
+          });
+
+          it('suggests user-defined columns from all branches after FORK', async () => {
+            const suggestions = await suggest(
+              'FROM a | FORK (EVAL foo = 1) (EVAL bar = 2) | WHERE /'
+            );
+            expect(suggestions.map(({ label }) => label)).not.toContain('foo');
+            expect(suggestions.map(({ label }) => label)).not.toContain('bar');
+          });
         });
       });
     });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
@@ -49,7 +49,14 @@ const allGroupingFunctions = getFunctionSignaturesByReturnType(
 );
 
 // types accepted by the AVG function
-const avgTypes: Array<FieldType & FunctionReturnType> = ['double', 'integer', 'long'];
+export const AVG_TYPES: Array<FieldType & FunctionReturnType> = ['double', 'integer', 'long'];
+
+export const EXPECTED_FOR_EMPTY_EXPRESSION = [
+  'col0 = ',
+  ...allAggFunctions,
+  ...allGroupingFunctions,
+  ...allEvaFunctions,
+];
 
 describe('autocomplete.suggest', () => {
   describe('STATS <aggregates> [ BY <grouping> ]', () => {
@@ -63,12 +70,7 @@ describe('autocomplete.suggest', () => {
 
     describe('... <aggregates> ...', () => {
       test('suggestions for a fresh expression', async () => {
-        const expected = [
-          'col0 = ',
-          ...allAggFunctions,
-          ...allGroupingFunctions,
-          ...allEvaFunctions,
-        ];
+        const expected = EXPECTED_FOR_EMPTY_EXPRESSION;
 
         await assertSuggestions('from a | stats /', expected);
         await assertSuggestions('FROM a | STATS /', expected);
@@ -139,16 +141,16 @@ describe('autocomplete.suggest', () => {
           ),
         ]);
         await assertSuggestions('from a | stats avg(/', [
-          ...getFieldNamesByType(avgTypes),
-          ...getFunctionSignaturesByReturnType(Location.EVAL, avgTypes, {
+          ...getFieldNamesByType(AVG_TYPES),
+          ...getFunctionSignaturesByReturnType(Location.EVAL, AVG_TYPES, {
             scalar: true,
           }),
         ]);
         await assertSuggestions('from a | stats round(avg(/', [
-          ...getFieldNamesByType(avgTypes),
+          ...getFieldNamesByType(AVG_TYPES),
           ...getFunctionSignaturesByReturnType(
             Location.EVAL,
-            avgTypes,
+            AVG_TYPES,
             { scalar: true },
             undefined,
             ['round']
@@ -193,8 +195,8 @@ describe('autocomplete.suggest', () => {
 
       test('inside function argument list', async () => {
         await assertSuggestions('from a | stats avg(b/) by stringField', [
-          ...getFieldNamesByType(avgTypes),
-          ...getFunctionSignaturesByReturnType(Location.EVAL, avgTypes, {
+          ...getFieldNamesByType(AVG_TYPES),
+          ...getFunctionSignaturesByReturnType(Location.EVAL, AVG_TYPES, {
             scalar: true,
           }),
         ]);

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/suggest.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/suggest.ts
@@ -42,7 +42,9 @@ export async function suggest(
 
   // within a branch
   if (activeBranch?.commands.length === 0 || pipePrecedesCurrentWord(params.innerText)) {
-    return getCommandAutocompleteDefinitions(getCommandsByName(['limit', 'sort', 'where']));
+    return getCommandAutocompleteDefinitions(
+      getCommandsByName(['limit', 'sort', 'where', 'dissect', 'stats', 'eval'])
+    );
   }
 
   const subCommand = activeBranch?.commands[activeBranch.commands.length - 1];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/util.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/util.ts
@@ -66,8 +66,7 @@ export const getPosition = (innerText: string, command: ESQLCommand): CaretPosit
     return 'expression_after_assignment';
   }
 
-  const previousWord = findPreviousWord(innerText);
-  if (getLastNonWhitespaceChar(innerText) === ',' || noCaseCompare(previousWord, 'stats')) {
+  if (getLastNonWhitespaceChar(innerText) === ',' || /stats\s+\S*$/i.test(innerText)) {
     return 'expression_without_assignment';
   }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.test.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { buildPartialMatcher, getOverlapRange } from './helper';
+import { parse } from '@kbn/esql-ast';
+import { buildPartialMatcher, getOverlapRange, getQueryForFields } from './helper';
 
 describe('getOverlapRange', () => {
   it('should return the overlap range', () => {
@@ -36,5 +37,37 @@ describe('buildPartialMatcher', () => {
     expect(matcher.test('not')).toEqual(false);
     expect(matcher.test('is null')).toEqual(false);
     expect(matcher.test('is not nullz')).toEqual(false);
+  });
+});
+
+describe('getQueryForFields', () => {
+  const assert = (query: string, expected: string) => {
+    const { root } = parse(query);
+
+    const result = getQueryForFields(query, root);
+
+    expect(result).toEqual(expected);
+  };
+
+  it('should return everything up till the last command', () => {
+    const query = 'FROM index | EVAL foo = 1 | STATS field1 | KEEP esql_editor_marker';
+    assert(query, 'FROM index | EVAL foo = 1 | STATS field1');
+  });
+
+  it('should convert FORK branches into vanilla queries', () => {
+    const query = `FROM index
+    | EVAL foo = 1
+    | FORK (STATS field1 | EVAL esql_editor_marker)`;
+    assert(query, 'FROM index | EVAL foo = 1 | STATS field1');
+
+    const query2 = `FROM index 
+    | EVAL foo = 1
+    | FORK (STATS field1) (LIMIT 10) (WHERE field1 == 1 | EVAL esql_editor_marker)`;
+    assert(query2, 'FROM index | EVAL foo = 1 | WHERE field1 == 1');
+  });
+
+  it('should return empty string if non-FROM source command', () => {
+    assert('ROW field1 = 1', '');
+    assert('SHOW INFO', '');
   });
 });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.ts
@@ -16,6 +16,8 @@ import {
   type ESQLFunction,
   type ESQLLiteral,
   type ESQLSource,
+  ESQLAstQueryExpression,
+  BasicPrettyPrinter,
 } from '@kbn/esql-ast';
 import { ESQLVariableType } from '@kbn/esql-types';
 import { uniqBy } from 'lodash';
@@ -107,10 +109,46 @@ export function strictlyGetParamAtPosition(
   return params[position] ? params[position] : null;
 }
 
-export function getQueryForFields(queryString: string, commands: ESQLCommand[]) {
+/**
+ * This function is used to build the query that will be used to compute the
+ * available fields for the current cursor location.
+ *
+ * Generally, this is the user's query up to the end of the previous command.
+ *
+ * @param queryString The original query string
+ * @param commands
+ * @returns
+ */
+export function getQueryForFields(queryString: string, root: ESQLAstQueryExpression): string {
+  const commands = root.commands;
+  const lastCommand = commands[commands.length - 1];
+  if (lastCommand && lastCommand.name === 'fork' && lastCommand.args.length > 0) {
+    /**
+     * This translates the current fork command branch into a simpler but equivalent
+     * query that is compatible with the existing field computation/caching strategy.
+     *
+     * The intuition here is that if the cursor is within a fork branch, the
+     * previous context is equivalent to a query without the FORK command.:
+     *
+     * Original query: FROM lolz | EVAL foo = 1 | FORK (EVAL bar = 2) (EVAL baz = 3 | WHERE /)
+     * Simplified: FROM lolz | EVAL foo = 1 | EVAL baz = 3 | WHERE /
+     */
+    const currentBranch = lastCommand.args[lastCommand.args.length - 1] as ESQLAstQueryExpression;
+    const newCommands = commands.slice(0, -1).concat(currentBranch.commands.slice(0, -1));
+    return BasicPrettyPrinter.print({ ...root, commands: newCommands });
+  }
+
   // If there is only one source command and it does not require fields, do not
   // fetch fields, hence return an empty string.
-  return commands.length === 1 && ['row', 'show'].includes(commands[0].name) ? '' : queryString;
+  return commands.length === 1 && ['row', 'show'].includes(commands[0].name)
+    ? ''
+    : buildQueryUntilPreviousCommand(queryString, commands);
+}
+
+// TODO consider replacing this with a pretty printer-based solution
+function buildQueryUntilPreviousCommand(queryString: string, commands: ESQLCommand[]) {
+  const prevCommand = commands[Math.max(commands.length - 2, 0)];
+  return prevCommand ? queryString.substring(0, prevCommand.location.max + 1) : queryString;
 }
 
 export function getSourcesFromCommands(commands: ESQLCommand[], sourceType: 'index' | 'policy') {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/context.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/context.ts
@@ -8,15 +8,15 @@
  */
 
 import {
-  type ESQLAstItem,
-  type ESQLSingleAstItem,
-  type ESQLAst,
-  type ESQLFunction,
-  type ESQLCommand,
+  ESQLCommandMode,
+  ESQLCommandOption,
   Walker,
   isIdentifier,
-  ESQLCommandOption,
-  ESQLCommandMode,
+  type ESQLAst,
+  type ESQLAstItem,
+  type ESQLCommand,
+  type ESQLFunction,
+  type ESQLSingleAstItem,
 } from '@kbn/esql-ast';
 import { FunctionDefinitionTypes } from '../definitions/types';
 import { EDITOR_MARKER } from './constants';
@@ -29,36 +29,14 @@ import {
   within,
 } from './helpers';
 
-function findNode(nodes: ESQLAstItem[], offset: number): ESQLSingleAstItem | undefined {
-  for (const node of nodes) {
-    if (Array.isArray(node)) {
-      const ret = findNode(node, offset);
-      if (ret) {
-        return ret;
-      }
-    } else {
-      if (node && node.location && node.location.min <= offset && node.location.max >= offset) {
-        if ('args' in node) {
-          const ret = findNode(node.args, offset);
-          // if the found node is the marker, then return its parent
-          if (ret?.text === EDITOR_MARKER) {
-            return node;
-          }
-          if (ret) {
-            return ret;
-          }
-        }
-        return node;
-      }
-    }
-  }
-}
-
 function findCommand(ast: ESQLAst, offset: number) {
   const commandIndex = ast.findIndex(
     ({ location }) => location.min <= offset && location.max >= offset
   );
-  return ast[commandIndex] || ast[ast.length - 1];
+
+  const command = ast[commandIndex] || ast[ast.length - 1];
+
+  return command;
 }
 
 function findOption(nodes: ESQLAstItem[], offset: number): ESQLCommandOption | undefined {
@@ -127,17 +105,30 @@ function findAstPosition(ast: ESQLAst, offset: number) {
     return { command: undefined, node: undefined };
   }
 
-  const containingFunction = Walker.findAll(
-    command,
-    (node) =>
-      node.type === 'function' && node.subtype === 'variadic-call' && within(offset, node.location)
-  ).pop() as ESQLFunction | undefined;
+  let containingFunction: ESQLFunction | undefined;
+  let node: ESQLSingleAstItem | undefined;
+
+  Walker.walk(command, {
+    visitAny: (_node) => {
+      if (
+        _node.type === 'function' &&
+        _node.subtype === 'variadic-call' &&
+        _node.location?.max >= offset
+      ) {
+        containingFunction = _node;
+      }
+
+      if (_node.location.max >= offset && _node.text !== EDITOR_MARKER) {
+        node = _node as ESQLSingleAstItem;
+      }
+    },
+  });
 
   return {
     command: removeMarkerArgFromArgsList(command)!,
     containingFunction: removeMarkerArgFromArgsList(containingFunction),
     option: removeMarkerArgFromArgsList(findOption(command.args, offset)),
-    node: removeMarkerArgFromArgsList(cleanMarkerNode(findNode(command.args, offset))),
+    node: removeMarkerArgFromArgsList(cleanMarkerNode(node)),
   };
 }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -989,7 +989,7 @@ export async function getCurrentQueryAvailableFields(
   previousPipeFields: ESQLFieldWithMetadata[]
 ) {
   const cacheCopy = new Map<string, ESQLFieldWithMetadata>();
-  previousPipeFields?.forEach((field) => cacheCopy.set(field.name, field));
+  previousPipeFields.forEach((field) => cacheCopy.set(field.name, field));
   const lastCommand = commands[commands.length - 1];
   const commandDef = getCommandDefinition(lastCommand.name);
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/query_string_utils.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/query_string_utils.ts
@@ -49,12 +49,3 @@ export function toSingleLine(inputString: string): string {
     .filter((line) => line !== '')
     .join(' | ');
 }
-
-export function getFirstPipeValue(inputString: string): string {
-  const queryNoComments = removeComments(inputString);
-  const parts = queryNoComments.split('|');
-  if (parts.length > 1) {
-    return parts[0].trim();
-  }
-  return queryNoComments.trim();
-}

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.ts
@@ -6,23 +6,14 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { type ESQLAst, parse } from '@kbn/esql-ast';
+
+import { parse } from '@kbn/esql-ast';
 import type { ESQLCallbacks } from './types';
 import type { ESQLFieldWithMetadata } from '../validation/types';
 import { getFieldsFromES, getCurrentQueryAvailableFields } from './helpers';
-import {
-  removeLastPipe,
-  processPipes,
-  toSingleLine,
-  getFirstPipeValue,
-} from './query_string_utils';
+import { removeLastPipe, processPipes, toSingleLine } from './query_string_utils';
 
 export const NOT_SUGGESTED_TYPES = ['unsupported'];
-
-export function buildQueryUntilPreviousCommand(ast: ESQLAst, queryString: string) {
-  const prevCommand = ast[Math.max(ast.length - 2, 0)];
-  return prevCommand ? queryString.substring(0, prevCommand.location.max + 1) : queryString;
-}
 
 const cache = new Map<string, ESQLFieldWithMetadata[]>();
 
@@ -46,7 +37,12 @@ function getValueInsensitive(keyToCheck: string) {
   return undefined;
 }
 
-async function setFieldsToCache(queryText: string) {
+/**
+ * Given a query, this function will compute the available fields and cache them
+ * for the next time the same query is used.
+ * @param queryText
+ */
+async function cacheFieldsForQuery(queryText: string) {
   const existsInCache = checkCacheInsensitive(queryText);
   if (existsInCache) {
     // this is already in the cache
@@ -54,13 +50,13 @@ async function setFieldsToCache(queryText: string) {
   }
   const queryTextWithoutLastPipe = removeLastPipe(queryText);
   // retrieve the user defined fields from the query without an extra call
-  const previousPipeFields = getValueInsensitive(queryTextWithoutLastPipe);
-  if (previousPipeFields && previousPipeFields?.length) {
+  const fieldsAvailableAfterPreviousCommand = getValueInsensitive(queryTextWithoutLastPipe);
+  if (fieldsAvailableAfterPreviousCommand && fieldsAvailableAfterPreviousCommand?.length) {
     const { root } = parse(queryText);
     const availableFields = await getCurrentQueryAvailableFields(
       queryText,
       root.commands,
-      previousPipeFields
+      fieldsAvailableAfterPreviousCommand
     );
     cache.set(queryText, availableFields);
   }
@@ -72,23 +68,19 @@ export function getFieldsByTypeHelper(queryText: string, resourceRetriever?: ESQ
     if (!queryText) {
       return;
     }
-    // We will use the from clause to get the fields from the ES
-    const queryForIndexFields = getFirstPipeValue(queryText);
 
-    const output = processPipes(queryText);
-    for (const line of output) {
-      if (line === queryForIndexFields) {
-        const existsInCache = getValueInsensitive(line);
-        // retrieve the index fields from ES ONLY if the FROM clause is not in the cache
-        if (!existsInCache) {
-          const fieldsWithMetadata = await getFieldsFromES(line, resourceRetriever);
-          cache.set(line, fieldsWithMetadata);
-        }
-      } else {
-        // retrieve the fields by parsing the query
-        // and set them to the cache, no extra call to ES
-        await setFieldsToCache(line);
-      }
+    const [sourceCommand, ...partialQueries] = processPipes(queryText);
+
+    // retrieve the index fields from ES ONLY if the source command is not in the cache
+    const existsInCache = getValueInsensitive(sourceCommand);
+    if (!existsInCache) {
+      const fieldsWithMetadata = await getFieldsFromES(sourceCommand, resourceRetriever);
+      cache.set(sourceCommand, fieldsWithMetadata);
+    }
+
+    // build fields cache for every partial query
+    for (const query of partialQueries) {
+      await cacheFieldsForQuery(query);
     }
   };
 
@@ -106,7 +98,8 @@ export function getFieldsByTypeHelper(queryText: string, resourceRetriever?: ESQ
           const ts = Array.isArray(type) ? type : [type];
           return (
             !ignored.includes(name) &&
-            ts.some((t) => types[0] === 'any' || types.includes(t)) &&
+            (types[0] === 'any' || // if the type is 'any' we don't need to check the type
+              ts.some((t) => types.includes(t))) &&
             !NOT_SUGGESTED_TYPES.includes(type)
           );
         }) || []

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/user_defined_columns.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/user_defined_columns.ts
@@ -161,6 +161,9 @@ export function collectUserDefinedColumns(
         // BY and WITH can contain userDefinedColumns
         ret.push(...ctx.visitOptions());
       }
+      if (ctx.node.name === 'fork') {
+        ret.push(...ctx.visitSubQueries());
+      }
       return ret;
     })
     .on('visitQuery', (ctx) => [...ctx.visitCommands()]);

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.fork.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.fork.ts
@@ -120,6 +120,57 @@ export const validationForkCommandTestSuite = (setup: helpers.Setup) => {
               ]
             );
           });
+
+          describe('user-defined columns', () => {
+            it('allows columns to be defined within sub-commands', async () => {
+              const { expectErrors } = await setup();
+
+              await expectErrors(
+                `FROM index 
+  | FORK
+      (EVAL foo = TO_UPPER(keywordField) | LIMIT 100)
+      (EVAL bar = 1)`,
+                []
+              );
+            });
+
+            it('recognizes user-defined columns within branches', async () => {
+              const { expectErrors } = await setup();
+
+              await expectErrors(
+                `FROM index
+  | FORK
+      (EVAL foo = TO_UPPER(keywordField) | WHERE foo | LIMIT 100)
+      (LIMIT 1)`,
+                []
+              );
+            });
+
+            it.skip('does not recognize user-defined columns between branches', async () => {
+              const { expectErrors } = await setup();
+
+              await expectErrors(
+                `FROM index 
+  | FORK
+      (EVAL foo = TO_UPPER(keywordField) | LIMIT 100)
+      (EVAL TO_LOWER(foo))`,
+                ['Unknown column [foo]']
+              );
+            });
+
+            it('recognizes user-defined columns from all branches after FORK', async () => {
+              const { expectErrors } = await setup();
+
+              await expectErrors(
+                `FROM index
+  | FORK
+      (EVAL foo = 1)
+      (EVAL bar = 1)
+  | KEEP foo, bar`,
+                []
+              );
+            });
+          });
         });
       });
     });

--- a/src/platform/packages/shared/kbn-monaco/src/esql/lib/hover/hover.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/esql/lib/hover/hover.ts
@@ -20,7 +20,6 @@ import {
   getFunctionDefinition,
   getFunctionSignatures,
   type ESQLCallbacks,
-  getPolicyHelper,
 } from '@kbn/esql-validation-autocomplete';
 import { getFieldsByTypeRetriever } from '@kbn/esql-validation-autocomplete/src/autocomplete/autocomplete';
 import {
@@ -32,10 +31,10 @@ import {
   getValidSignaturesAndTypesToSuggestNext,
 } from '@kbn/esql-validation-autocomplete/src/autocomplete/helper';
 import { ENRICH_MODES } from '@kbn/esql-validation-autocomplete/src/definitions/commands_helpers';
-import { modeDescription } from '@kbn/esql-validation-autocomplete/src/autocomplete/commands/enrich/util';
-import { i18n } from '@kbn/i18n';
-import { buildQueryUntilPreviousCommand } from '@kbn/esql-validation-autocomplete/src/shared/resources_helpers';
 import { within } from '@kbn/esql-validation-autocomplete/src/shared/helpers';
+import { getPolicyHelper } from '@kbn/esql-validation-autocomplete/src/shared/resources_helpers';
+import { i18n } from '@kbn/i18n';
+import { modeDescription } from '@kbn/esql-validation-autocomplete/src/autocomplete/commands/enrich/util';
 import { monacoPositionToOffset } from '../shared/utils';
 import { monaco } from '../../../monaco_imports';
 import { getVariablesHoverContent } from './helpers';
@@ -166,10 +165,7 @@ async function getHintForFunctionArg(
   offset: number,
   resourceRetriever?: ESQLCallbacks
 ) {
-  const queryForFields = getQueryForFields(
-    buildQueryUntilPreviousCommand(root.commands, query),
-    root.commands
-  );
+  const queryForFields = getQueryForFields(query, root);
   const { getFieldsMap } = getFieldsByTypeRetriever(queryForFields, resourceRetriever);
 
   const fnDefinition = getFunctionDefinition(fnNode.name);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES|QL] support more subqueries in `FORK` (#218176)](https://github.com/elastic/kibana/pull/218176)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2025-05-06T15:19:13Z","message":"[ES|QL] support more subqueries in `FORK` (#218176)\n\n## Summary\n\nClose https://github.com/elastic/kibana/issues/218051\n\nAlso fixes a bug with suggestions within functions within `WHERE` within\n`FORK` 😄\n\n```\n... | FORK (WHERE COS(/))\n```\n\nwas giving wrong suggestions.\n\n\n### TODO\n- [x] validation needs to work for user-defined columns in branches\n\n<img width=\"440\" alt=\"Screenshot 2025-04-16 at 2 49 26 PM\"\nsrc=\"https://github.com/user-attachments/assets/7bdd6c09-161d-42bf-aa6e-954c5ecefb4e\"\n/>\n\n- [x] column suggestions need to take previous subquery commands into\naccount\n\n<img width=\"719\" alt=\"Screenshot 2025-04-16 at 2 45 37 PM\"\nsrc=\"https://github.com/user-attachments/assets/881c8319-1d53-472b-abfa-f97d823a628a\"\n/>\n\n- [x] suggest all user-defined fields from within branches after the\n`FORK` command\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"81385f6c53153aa1adc0a64cc0663798574e889e","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[ES|QL] support more subqueries in `FORK`","number":218176,"url":"https://github.com/elastic/kibana/pull/218176","mergeCommit":{"message":"[ES|QL] support more subqueries in `FORK` (#218176)\n\n## Summary\n\nClose https://github.com/elastic/kibana/issues/218051\n\nAlso fixes a bug with suggestions within functions within `WHERE` within\n`FORK` 😄\n\n```\n... | FORK (WHERE COS(/))\n```\n\nwas giving wrong suggestions.\n\n\n### TODO\n- [x] validation needs to work for user-defined columns in branches\n\n<img width=\"440\" alt=\"Screenshot 2025-04-16 at 2 49 26 PM\"\nsrc=\"https://github.com/user-attachments/assets/7bdd6c09-161d-42bf-aa6e-954c5ecefb4e\"\n/>\n\n- [x] column suggestions need to take previous subquery commands into\naccount\n\n<img width=\"719\" alt=\"Screenshot 2025-04-16 at 2 45 37 PM\"\nsrc=\"https://github.com/user-attachments/assets/881c8319-1d53-472b-abfa-f97d823a628a\"\n/>\n\n- [x] suggest all user-defined fields from within branches after the\n`FORK` command\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"81385f6c53153aa1adc0a64cc0663798574e889e"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218176","number":218176,"mergeCommit":{"message":"[ES|QL] support more subqueries in `FORK` (#218176)\n\n## Summary\n\nClose https://github.com/elastic/kibana/issues/218051\n\nAlso fixes a bug with suggestions within functions within `WHERE` within\n`FORK` 😄\n\n```\n... | FORK (WHERE COS(/))\n```\n\nwas giving wrong suggestions.\n\n\n### TODO\n- [x] validation needs to work for user-defined columns in branches\n\n<img width=\"440\" alt=\"Screenshot 2025-04-16 at 2 49 26 PM\"\nsrc=\"https://github.com/user-attachments/assets/7bdd6c09-161d-42bf-aa6e-954c5ecefb4e\"\n/>\n\n- [x] column suggestions need to take previous subquery commands into\naccount\n\n<img width=\"719\" alt=\"Screenshot 2025-04-16 at 2 45 37 PM\"\nsrc=\"https://github.com/user-attachments/assets/881c8319-1d53-472b-abfa-f97d823a628a\"\n/>\n\n- [x] suggest all user-defined fields from within branches after the\n`FORK` command\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"81385f6c53153aa1adc0a64cc0663798574e889e"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->