### PR TITLE
[Alerts] fix Duplicated filters are shown

### DIFF
--- a/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
@@ -10,6 +10,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { BehaviorSubject, Subject, map } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
+import { cloneDeep } from 'lodash';
 
 import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
 import type { Filter, Query, TimeRange } from '@kbn/es-query';
@@ -110,7 +111,7 @@ export const ControlGroupRenderer = ({
 
     let cancelled = false;
 
-    getCreationOptions({ ...defaultRuntimeState }, controlGroupStateBuilder)
+    getCreationOptions(cloneDeep(defaultRuntimeState), controlGroupStateBuilder)
       .then(({ initialState, editorConfig }) => {
         if (cancelled) return;
         const initialRuntimeState = {

--- a/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
@@ -110,7 +110,7 @@ export const ControlGroupRenderer = ({
 
     let cancelled = false;
 
-    getCreationOptions(defaultRuntimeState, controlGroupStateBuilder)
+    getCreationOptions({ ...defaultRuntimeState }, controlGroupStateBuilder)
       .then(({ initialState, editorConfig }) => {
         if (cancelled) return;
         const initialRuntimeState = {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/221545

### Background
https://github.com/elastic/kibana/pull/215947 refactored [ControlGroupRenderer](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx)

The regression is caused by this line changing `await getCreationOptions?.(getDefaultControlGroupRuntimeState(), controlGroupStateBuilder)` to `getCreationOptions(defaultRuntimeState, controlGroupStateBuilder)`. 

Opening the SLO view caused https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/quick_filters.tsx#L72 to mutate `defaultRuntimeState`, and populate `initialChildControlState` with `slo-status-filter` and `slo-tags-filter`. Then when returning to Alerts view, `defaultRuntimeState.initialChildControlState` contained the controls from SLO page.

### Fix
This PR resolves the issue by passing a new object to `getCreationOptions` so that `defaultRuntimeState` can not be polluted by consumers.

### Test steps
* Start kibana with `yarn start`
* Go license page and install 30 day trial license
* In seperate window, run
    ```
    node x-pack/scripts/data_forge.js \
	--events-per-cycle 100 \
	--lookback now-7d  \
	--dataset fake_stack \
	--install-kibana-assets \
	--kibana-url http://localhost:5601/<basePath>
    ```
* In SLO, create an SLO with the following ([more details](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/slo/dev_docs/slo.md))
    * Type: Custom Query
    * Index: Admin Console
    * Good (query): http.response.status_code < 500
    * Total (query): http.response.status_code : *
 * toggle between SLO and alerts page and verify controls in alerts page do not grow after each visit to SLO page

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->