### PR TITLE
[8.19] [Core] Update RenderingService with`addContext` public method (#212163)

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/handle_system_colormode_change.tsx
+++ b/src/core/packages/chrome/browser-internal/src/handle_system_colormode_change.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { toMountPoint } from '@kbn/react-kibana-mount';
+import { mountReactNode } from '@kbn/core-mount-utils-browser-internal';
 import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { NotificationsStart } from '@kbn/core-notifications-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
@@ -108,7 +108,7 @@ export async function handleSystemColorModeChange({
           title: i18n.translate('core.ui.chrome.appearanceChange.successNotificationTitle', {
             defaultMessage: 'System color mode updated',
           }),
-          text: toMountPoint(
+          text: mountReactNode(
             <>
               <p>
                 {i18n.translate('core.ui.chrome.appearanceChange.successNotificationText', {
@@ -131,8 +131,7 @@ export async function handleSystemColorModeChange({
                   </EuiButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
-            </>,
-            coreStart
+            </>
           ),
         },
         { toastLifeTimeMs: Infinity } // leave it on until discard or page reload

--- a/src/core/packages/chrome/browser-internal/tsconfig.json
+++ b/src/core/packages/chrome/browser-internal/tsconfig.json
@@ -62,7 +62,6 @@
     "@kbn/core-user-profile-browser",
     "@kbn/core-ui-settings-browser",
     "@kbn/core-user-profile-common",
-    "@kbn/react-kibana-mount",
     "@kbn/core-theme-browser-internal"
   ],
   "exclude": [

--- a/src/core/packages/lifecycle/browser-mocks/src/core_start.mock.ts
+++ b/src/core/packages/lifecycle/browser-mocks/src/core_start.mock.ts
@@ -24,6 +24,7 @@ import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
 import { customBrandingServiceMock } from '@kbn/core-custom-branding-browser-mocks';
 import { securityServiceMock } from '@kbn/core-security-browser-mocks';
 import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
+import { renderingServiceMock } from '@kbn/core-rendering-browser-mocks';
 import { coreFeatureFlagsMock } from '@kbn/core-feature-flags-browser-mocks';
 
 export function createCoreStartMock({ basePath = '' } = {}) {
@@ -47,6 +48,7 @@ export function createCoreStartMock({ basePath = '' } = {}) {
     fatalErrors: fatalErrorsServiceMock.createStartContract(),
     security: securityServiceMock.createStart(),
     userProfile: userProfileServiceMock.createStart(),
+    rendering: renderingServiceMock.create(),
     plugins: {
       onStart: jest.fn(),
     },

--- a/src/core/packages/lifecycle/browser-mocks/tsconfig.json
+++ b/src/core/packages/lifecycle/browser-mocks/tsconfig.json
@@ -29,7 +29,8 @@
     "@kbn/core-custom-branding-browser-mocks",
     "@kbn/core-security-browser-mocks",
     "@kbn/core-user-profile-browser-mocks",
-    "@kbn/core-feature-flags-browser-mocks"
+    "@kbn/core-feature-flags-browser-mocks",
+    "@kbn/core-rendering-browser-mocks"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/lifecycle/browser/src/core_start.ts
+++ b/src/core/packages/lifecycle/browser/src/core_start.ts
@@ -24,6 +24,7 @@ import type { ChromeStart } from '@kbn/core-chrome-browser';
 import type { CustomBrandingStart } from '@kbn/core-custom-branding-browser';
 import type { PluginsServiceStart } from '@kbn/core-plugins-contracts-browser';
 import type { SecurityServiceStart } from '@kbn/core-security-browser';
+import type { RenderingService } from '@kbn/core-rendering-browser';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-browser';
 
@@ -81,4 +82,6 @@ export interface CoreStart {
   security: SecurityServiceStart;
   /** {@link UserProfileServiceStart} */
   userProfile: UserProfileServiceStart;
+  /** {@link RenderingService} */
+  rendering: RenderingService;
 }

--- a/src/core/packages/lifecycle/browser/tsconfig.json
+++ b/src/core/packages/lifecycle/browser/tsconfig.json
@@ -30,7 +30,8 @@
     "@kbn/core-plugins-contracts-browser",
     "@kbn/core-security-browser",
     "@kbn/core-user-profile-browser",
-    "@kbn/core-feature-flags-browser"
+    "@kbn/core-feature-flags-browser",
+    "@kbn/core-rendering-browser"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/mount-utils/browser-internal/src/mount.tsx
+++ b/src/core/packages/mount-utils/browser-internal/src/mount.tsx
@@ -39,6 +39,7 @@ export const MountWrapper: MountWrapperComponent = ({ mount, className = default
 
 /**
  * Mount converter for react node.
+ * This should only be used in internal Core packages to prevent circular dependency issues
  *
  * @param node to get a mount for
  * @internal

--- a/src/core/packages/notifications/browser-internal/src/notifications_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/notifications_service.ts
@@ -11,13 +11,11 @@ import { i18n } from '@kbn/i18n';
 
 import { Subscription } from 'rxjs';
 import type { AnalyticsServiceStart, AnalyticsServiceSetup } from '@kbn/core-analytics-browser';
-import type { ThemeServiceStart } from '@kbn/core-theme-browser';
-import type { UserProfileService } from '@kbn/core-user-profile-browser';
-import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { OverlayStart } from '@kbn/core-overlays-browser';
 import type { NotificationsSetup, NotificationsStart } from '@kbn/core-notifications-browser';
 import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { RenderingService } from '@kbn/core-rendering-browser';
 import { showErrorDialog, ToastsService } from './toasts';
 import { EventReporter, eventTypes } from './toasts/telemetry';
 
@@ -27,10 +25,8 @@ export interface SetupDeps {
 }
 
 export interface StartDeps {
-  i18n: I18nStart;
   overlays: OverlayStart;
-  theme: ThemeServiceStart;
-  userProfile: UserProfileService;
+  rendering: RenderingService;
   analytics: AnalyticsServiceStart;
   targetDomElement: HTMLElement;
 }

--- a/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/error_toast.test.tsx.snap
+++ b/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/error_toast.test.tsx.snap
@@ -1,46 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders matching snapshot 1`] = `
-<KibanaRenderContextProvider
-  analytics={
-    Object {
-      "optIn": [MockFunction],
-      "reportEvent": [MockFunction],
-      "telemetryCounter$": Subject {
-        "closed": false,
-        "currentObservers": null,
-        "hasError": false,
-        "isStopped": false,
-        "observers": Array [],
-        "thrownError": null,
-      },
-    }
-  }
-  i18n={
-    Object {
-      "Context": [MockFunction],
-    }
-  }
-  theme={
-    Object {
-      "getTheme": [MockFunction],
-      "theme$": Observable {
-        "_subscribe": [Function],
-      },
-    }
-  }
-  userProfile={
-    Object {
-      "bulkGet": [MockFunction],
-      "getCurrent": [MockFunction],
-      "getEnabled$": [MockFunction],
-      "getUserProfile$": [MockFunction],
-      "partialUpdate": [MockFunction],
-      "suggest": [MockFunction],
-      "update": [MockFunction],
-    }
-  }
->
+<Fragment>
   <p
     data-test-subj="errorToastMessage"
   >
@@ -61,5 +22,5 @@ exports[`renders matching snapshot 1`] = `
       />
     </EuiButton>
   </div>
-</KibanaRenderContextProvider>
+</Fragment>
 `;

--- a/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/toasts_service.test.tsx.snap
+++ b/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/toasts_service.test.tsx.snap
@@ -3,12 +3,17 @@
 exports[`#start() renders the GlobalToastList into the targetDomElement param 1`] = `
 Array [
   Array [
-    <KibanaRenderContextProvider
-      analytics={
-        Object {
-          "optIn": [MockFunction],
+    <GlobalToastList
+      dismissToast={[Function]}
+      reportEvent={
+        EventReporter {
           "reportEvent": [MockFunction],
-          "telemetryCounter$": Subject {
+        }
+      }
+      toasts$={
+        Observable {
+          "source": BehaviorSubject {
+            "_value": Array [],
             "closed": false,
             "currentObservers": null,
             "hasError": false,
@@ -18,53 +23,7 @@ Array [
           },
         }
       }
-      i18n={
-        Object {
-          "Context": [Function],
-        }
-      }
-      theme={
-        Object {
-          "getTheme": [MockFunction],
-          "theme$": Observable {
-            "_subscribe": [Function],
-          },
-        }
-      }
-      userProfile={
-        Object {
-          "bulkGet": [MockFunction],
-          "getCurrent": [MockFunction],
-          "getEnabled$": [MockFunction],
-          "getUserProfile$": [MockFunction],
-          "partialUpdate": [MockFunction],
-          "suggest": [MockFunction],
-          "update": [MockFunction],
-        }
-      }
-    >
-      <GlobalToastList
-        dismissToast={[Function]}
-        reportEvent={
-          EventReporter {
-            "reportEvent": [MockFunction],
-          }
-        }
-        toasts$={
-          Observable {
-            "source": BehaviorSubject {
-              "_value": Array [],
-              "closed": false,
-              "currentObservers": null,
-              "hasError": false,
-              "isStopped": false,
-              "observers": Array [],
-              "thrownError": null,
-            },
-          }
-        }
-      />
-    </KibanaRenderContextProvider>,
+    />,
     <div
       test="target-dom-element"
     />,

--- a/src/core/packages/notifications/browser-internal/src/toasts/error_toast.test.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/error_toast.test.tsx
@@ -11,11 +11,8 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 
-import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
 import { ErrorToast } from './error_toast';
-import { themeServiceMock } from '@kbn/core-theme-browser-mocks';
-import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
-import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
+import { renderingServiceMock } from '@kbn/core-rendering-browser-mocks';
 
 interface ErrorToastProps {
   error?: Error;
@@ -24,10 +21,7 @@ interface ErrorToastProps {
 }
 
 let openModal: jest.Mock;
-const mockAnalytics = analyticsServiceMock.createAnalyticsServiceStart();
-const mockTheme = themeServiceMock.createStartContract();
-const mockUserProfile = userProfileServiceMock.createStart();
-const mockI18n = i18nServiceMock.createStartContract();
+const mockRendering = renderingServiceMock.create();
 
 beforeEach(() => (openModal = jest.fn()));
 
@@ -38,10 +32,7 @@ function render(props: ErrorToastProps = {}) {
       error={props.error || new Error('error message')}
       title={props.title || 'An error occured'}
       toastMessage={props.toastMessage || 'This is the toast message'}
-      analytics={mockAnalytics}
-      i18n={mockI18n}
-      theme={mockTheme}
-      userProfile={mockUserProfile}
+      rendering={mockRendering}
     />
   );
 }

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.test.ts
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.test.ts
@@ -13,10 +13,7 @@ import { ToastsApi } from './toasts_api';
 
 import { apm } from '@elastic/apm-rum';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
-import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
-import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
-import { themeServiceMock } from '@kbn/core-theme-browser-mocks';
-import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
+import { renderingServiceMock } from '@kbn/core-rendering-browser-mocks';
 
 jest.mock('@elastic/apm-rum', () => ({
   apm: {
@@ -54,10 +51,7 @@ function toastDeps() {
 function startDeps() {
   return {
     overlays: {} as any,
-    analytics: analyticsServiceMock.createAnalyticsServiceStart(),
-    i18n: i18nServiceMock.createStartContract(),
-    theme: themeServiceMock.createStartContract(),
-    userProfile: userProfileServiceMock.createStart(),
+    rendering: renderingServiceMock.create(),
   };
 }
 

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.tsx
@@ -12,8 +12,6 @@ import * as Rx from 'rxjs';
 import { omitBy, isUndefined } from 'lodash';
 
 import { apm } from '@elastic/apm-rum';
-import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
-import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { OverlayStart } from '@kbn/core-overlays-browser';
 import { mountReactNode } from '@kbn/core-mount-utils-browser-internal';
@@ -25,8 +23,7 @@ import type {
   ToastInputFields,
   ToastOptions,
 } from '@kbn/core-notifications-browser';
-import type { ThemeServiceStart } from '@kbn/core-theme-browser';
-import type { UserProfileService } from '@kbn/core-user-profile-browser';
+import type { RenderingService } from '@kbn/core-rendering-browser';
 import { ErrorToast } from './error_toast';
 
 const normalizeToast = (toastOrTitle: ToastInput): ToastInputFields => {
@@ -57,11 +54,8 @@ const getApmLabels = (errorType: 'ToastError' | 'ToastDanger') => {
 };
 
 interface StartDeps {
-  analytics: AnalyticsServiceStart;
   overlays: OverlayStart;
-  i18n: I18nStart;
-  theme: ThemeServiceStart;
-  userProfile: UserProfileService;
+  rendering: RenderingService;
 }
 
 /**
@@ -212,7 +206,7 @@ export class ToastsApi implements IToasts {
           error={error}
           title={options.title}
           toastMessage={message}
-          {...this.startDeps!}
+          rendering={this.startDeps!.rendering}
         />
       ),
       ...options,

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.test.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.test.tsx
@@ -12,22 +12,14 @@ import { mockReactDomRender, mockReactDomUnmount } from './toasts_service.test.m
 import { ToastsService } from './toasts_service';
 import { ToastsApi } from './toasts_api';
 import { overlayServiceMock } from '@kbn/core-overlays-browser-mocks';
-import { themeServiceMock } from '@kbn/core-theme-browser-mocks';
-import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
 import { EventReporter } from './telemetry';
-
-const mockI18n: any = {
-  Context: function I18nContext() {
-    return '';
-  },
-};
+import { renderingServiceMock } from '@kbn/core-rendering-browser-mocks';
 
 const mockOverlays = overlayServiceMock.createStartContract();
-const mockTheme = themeServiceMock.createStartContract();
-const mockUserProfile = userProfileServiceMock.createStart();
 const mockAnalytics = analyticsServiceMock.createAnalyticsServiceStart();
+const mockRendering = renderingServiceMock.create();
 
 const eventReporter = new EventReporter({ analytics: mockAnalytics });
 
@@ -50,10 +42,7 @@ describe('#start()', () => {
     expect(mockReactDomRender).not.toHaveBeenCalled();
     toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() });
     toasts.start({
-      analytics: mockAnalytics,
-      i18n: mockI18n,
-      theme: mockTheme,
-      userProfile: mockUserProfile,
+      rendering: mockRendering,
       targetDomElement,
       overlays: mockOverlays,
       eventReporter,
@@ -70,10 +59,7 @@ describe('#start()', () => {
     ).toBeInstanceOf(ToastsApi);
     expect(
       toasts.start({
-        analytics: mockAnalytics,
-        i18n: mockI18n,
-        theme: mockTheme,
-        userProfile: mockUserProfile,
+        rendering: mockRendering,
         targetDomElement,
         overlays: mockOverlays,
         eventReporter,
@@ -90,10 +76,7 @@ describe('#stop()', () => {
 
     toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() });
     toasts.start({
-      analytics: mockAnalytics,
-      i18n: mockI18n,
-      theme: mockTheme,
-      userProfile: mockUserProfile,
+      rendering: mockRendering,
       targetDomElement,
       overlays: mockOverlays,
       eventReporter,
@@ -117,10 +100,7 @@ describe('#stop()', () => {
 
     toasts.setup({ uiSettings: uiSettingsServiceMock.createSetupContract() });
     toasts.start({
-      analytics: mockAnalytics,
-      i18n: mockI18n,
-      theme: mockTheme,
-      userProfile: mockUserProfile,
+      rendering: mockRendering,
       targetDomElement,
       overlays: mockOverlays,
       eventReporter,

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_service.tsx
@@ -10,13 +10,9 @@
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
-import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
-import type { ThemeServiceStart } from '@kbn/core-theme-browser';
-import type { UserProfileService } from '@kbn/core-user-profile-browser';
-import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { OverlayStart } from '@kbn/core-overlays-browser';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import type { RenderingService } from '@kbn/core-rendering-browser';
 import { GlobalToastList } from './global_toast_list';
 import { ToastsApi } from './toasts_api';
 import { EventReporter } from './telemetry';
@@ -26,11 +22,8 @@ interface SetupDeps {
 }
 
 interface StartDeps {
-  analytics: AnalyticsServiceStart;
-  i18n: I18nStart;
   overlays: OverlayStart;
-  theme: ThemeServiceStart;
-  userProfile: UserProfileService;
+  rendering: RenderingService;
   eventReporter: EventReporter;
   targetDomElement: HTMLElement;
 }
@@ -44,18 +37,18 @@ export class ToastsService {
     return this.api!;
   }
 
-  public start({ eventReporter, overlays, targetDomElement, ...startDeps }: StartDeps) {
-    this.api!.start({ overlays, ...startDeps });
+  public start({ eventReporter, overlays, targetDomElement, rendering }: StartDeps) {
+    this.api!.start({ overlays, rendering });
     this.targetDomElement = targetDomElement;
 
     render(
-      <KibanaRenderContextProvider {...startDeps}>
+      rendering.addContext(
         <GlobalToastList
           dismissToast={(toastId: string) => this.api!.remove(toastId)}
           toasts$={this.api!.get$()}
           reportEvent={eventReporter}
         />
-      </KibanaRenderContextProvider>,
+      ),
       targetDomElement
     );
 

--- a/src/core/packages/notifications/browser-internal/tsconfig.json
+++ b/src/core/packages/notifications/browser-internal/tsconfig.json
@@ -16,25 +16,20 @@
     "@kbn/i18n-react",
     "@kbn/i18n",
     "@kbn/utility-types",
-    "@kbn/core-theme-browser",
-    "@kbn/core-i18n-browser",
     "@kbn/core-ui-settings-browser",
     "@kbn/core-overlays-browser",
     "@kbn/core-notifications-browser",
     "@kbn/core-mount-utils-browser-internal",
     "@kbn/core-ui-settings-browser-mocks",
-    "@kbn/core-i18n-browser-mocks",
     "@kbn/test-jest-helpers",
     "@kbn/core-overlays-browser-mocks",
-    "@kbn/core-theme-browser-mocks",
     "@kbn/core-mount-utils-browser",
-    "@kbn/react-kibana-context-render",
     "@kbn/core-analytics-browser",
     "@kbn/core-analytics-browser-mocks",
-    "@kbn/core-user-profile-browser",
-    "@kbn/core-user-profile-browser-mocks"
+    "@kbn/core-rendering-browser-mocks",
+    "@kbn/core-rendering-browser"
   ],
   "exclude": [
-    "target/**/*",
+    "target/**/*"
   ]
 }

--- a/src/core/packages/notifications/browser-mocks/src/notifications_service.mock.ts
+++ b/src/core/packages/notifications/browser-mocks/src/notifications_service.mock.ts
@@ -9,7 +9,6 @@
 
 import type { DeeplyMockedKeys, MockedKeys } from '@kbn/utility-types-jest';
 import type { NotificationsSetup, NotificationsStart } from '@kbn/core-notifications-browser';
-import type { NotificationsServiceContract } from '@kbn/core-notifications-browser-internal';
 import { toastsServiceMock } from './toasts_service.mock';
 
 const createSetupContractMock = () => {
@@ -28,6 +27,15 @@ const createStartContractMock = () => {
   };
   return startContract;
 };
+
+/**
+ * This is declared internally to avoid a circular dependency issue
+ */
+export interface NotificationsServiceContract {
+  setup: typeof createSetupContractMock;
+  start: ({ targetDomElement }: { targetDomElement: HTMLElement }) => void;
+  stop: () => void;
+}
 
 const createMock = () => {
   const mocked: jest.Mocked<NotificationsServiceContract> = {

--- a/src/core/packages/notifications/browser-mocks/tsconfig.json
+++ b/src/core/packages/notifications/browser-mocks/tsconfig.json
@@ -12,10 +12,9 @@
   ],
   "kbn_references": [
     "@kbn/utility-types-jest",
-    "@kbn/core-notifications-browser",
-    "@kbn/core-notifications-browser-internal"
+    "@kbn/core-notifications-browser"
   ],
   "exclude": [
-    "target/**/*",
+    "target/**/*"
   ]
 }

--- a/src/core/packages/plugins/browser-internal/src/plugin_context.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin_context.ts
@@ -174,5 +174,6 @@ export function createPluginStartContext<
     plugins: {
       onStart: (...dependencyNames) => runtimeResolver.onStart(plugin.name, dependencyNames),
     },
+    rendering: deps.rendering,
   };
 }

--- a/src/core/packages/rendering/browser-internal/src/rendering_service.test.tsx
+++ b/src/core/packages/rendering/browser-internal/src/rendering_service.test.tsx
@@ -8,10 +8,25 @@
  */
 
 import React from 'react';
+import { render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { BehaviorSubject } from 'rxjs';
 
+jest.mock('@kbn/react-kibana-context-render', () => ({
+  KibanaRenderContextProvider: jest.fn(({ children }) => (
+    <div data-test-subj="kibana-render-context">{children}</div>
+  )),
+}));
+jest.mock('@elastic/eui', () => {
+  const actualEui = jest.requireActual('@elastic/eui');
+  return {
+    ...actualEui,
+    EuiLoadingSpinner: jest.fn(() => <div>Loading...</div>),
+  };
+});
+
 import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
+import { executionContextServiceMock } from '@kbn/core-execution-context-browser-mocks';
 import { applicationServiceMock } from '@kbn/core-application-browser-mocks';
 import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
 import { overlayServiceMock } from '@kbn/core-overlays-browser-mocks';
@@ -20,10 +35,11 @@ import { themeServiceMock } from '@kbn/core-theme-browser-mocks';
 import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
 import { RenderingService } from './rendering_service';
 
-describe('RenderingService#start', () => {
+describe('RenderingService', () => {
   let analytics: ReturnType<typeof analyticsServiceMock.createAnalyticsServiceStart>;
   let application: ReturnType<typeof applicationServiceMock.createInternalStartContract>;
   let chrome: ReturnType<typeof chromeServiceMock.createStartContract>;
+  let executionContext: ReturnType<typeof executionContextServiceMock.createStartContract>;
   let overlays: ReturnType<typeof overlayServiceMock.createStartContract>;
   let i18n: ReturnType<typeof i18nServiceMock.createStartContract>;
   let theme: ReturnType<typeof themeServiceMock.createStartContract>;
@@ -43,80 +59,104 @@ describe('RenderingService#start', () => {
     overlays = overlayServiceMock.createStartContract();
     overlays.banners.getComponent.mockReturnValue(<div>I&apos;m a banner!</div>);
 
+    executionContext = executionContextServiceMock.createStartContract();
     userProfile = userProfileServiceMock.createStart();
     theme = themeServiceMock.createStartContract();
     i18n = i18nServiceMock.createStartContract();
 
     targetDomElement = document.createElement('div');
-
     rendering = new RenderingService();
   });
 
-  const startService = () => {
-    return rendering.start({
-      analytics,
-      application,
-      chrome,
-      overlays,
-      i18n,
-      theme,
-      userProfile,
-      targetDomElement,
-    });
-  };
+  describe('renderCore', () => {
+    const startService = () => {
+      return rendering.start({
+        analytics,
+        i18n,
+        executionContext,
+        theme,
+        userProfile,
+      });
+    };
 
-  it('renders application service into provided DOM element', () => {
-    startService();
-    expect(targetDomElement.querySelector('div.kbnAppWrapper')).toMatchInlineSnapshot(`
-      <div
-        class="kbnAppWrapper kbnAppWrapper--hiddenChrome"
-        data-test-subj="kbnAppWrapper hiddenChrome"
-      >
+    it('renders application service into provided DOM element', () => {
+      const service = startService();
+      service.renderCore({ chrome, application, overlays }, targetDomElement);
+      expect(targetDomElement.querySelector('div.kbnAppWrapper')).toMatchInlineSnapshot(`
         <div
-          id="app-fixed-viewport"
-        />
-        <div>
-          Hello application!
+          class="kbnAppWrapper kbnAppWrapper--hiddenChrome"
+          data-test-subj="kbnAppWrapper hiddenChrome"
+        >
+          <div
+            id="app-fixed-viewport"
+          />
+          <div>
+            Hello application!
+          </div>
         </div>
-      </div>
-    `);
-  });
+      `);
+    });
 
-  it('adds the `kbnAppWrapper--hiddenChrome` class to the AppWrapper when chrome is hidden', () => {
-    const isVisible$ = new BehaviorSubject(true);
-    chrome.getIsVisible$.mockReturnValue(isVisible$);
-    startService();
+    it('adds the `kbnAppWrapper--hiddenChrome` class to the AppWrapper when chrome is hidden', () => {
+      const isVisible$ = new BehaviorSubject(true);
+      chrome.getIsVisible$.mockReturnValue(isVisible$);
+      const service = startService();
+      service.renderCore({ chrome, application, overlays }, targetDomElement);
 
-    const appWrapper = targetDomElement.querySelector('div.kbnAppWrapper')!;
-    expect(appWrapper.className).toEqual('kbnAppWrapper');
+      const appWrapper = targetDomElement.querySelector('div.kbnAppWrapper')!;
+      expect(appWrapper.className).toEqual('kbnAppWrapper');
 
-    act(() => isVisible$.next(false));
-    expect(appWrapper.className).toEqual('kbnAppWrapper kbnAppWrapper--hiddenChrome');
+      act(() => isVisible$.next(false));
+      expect(appWrapper.className).toEqual('kbnAppWrapper kbnAppWrapper--hiddenChrome');
 
-    act(() => isVisible$.next(true));
-    expect(appWrapper.className).toEqual('kbnAppWrapper');
-  });
+      act(() => isVisible$.next(true));
+      expect(appWrapper.className).toEqual('kbnAppWrapper');
+    });
 
-  it('contains wrapper divs', () => {
-    startService();
-    expect(targetDomElement.querySelector('div.kbnAppWrapper')).toBeDefined();
-  });
+    it('contains wrapper divs', () => {
+      startService();
+      expect(targetDomElement.querySelector('div.kbnAppWrapper')).toBeDefined();
+    });
 
-  it('renders the banner UI', () => {
-    startService();
-    expect(targetDomElement.querySelector('#globalBannerList')).toMatchInlineSnapshot(`
-              <div
-                id="globalBannerList"
-              >
-                <div>
-                  I'm a banner!
+    it('renders the banner UI', () => {
+      const service = startService();
+      service.renderCore({ chrome, application, overlays }, targetDomElement);
+      expect(targetDomElement.querySelector('#globalBannerList')).toMatchInlineSnapshot(`
+                <div
+                  id="globalBannerList"
+                >
+                  <div>
+                    I'm a banner!
+                  </div>
                 </div>
-              </div>
-          `);
+            `);
+    });
+
+    it('adds global styles via `KibanaRootRenderingContext` `globalStyles` configuration', () => {
+      startService();
+      expect(document.querySelector(`style[data-emotion="eui-styles-global"]`)).toBeDefined();
+    });
   });
 
-  it('adds global styles via `KibanaRootRenderingContext` `globalStyles` configuration', () => {
-    startService();
-    expect(document.querySelector(`style[data-emotion="eui-styles-global"]`)).toBeDefined();
+  describe('addContext', () => {
+    it('renders loading spinner when dependencies are null', () => {
+      const TestComponent = rendering.addContext(<div>Test Element</div>);
+
+      render(TestComponent);
+
+      expect(screen.getByText('Loading...')).toBeTruthy();
+    });
+
+    it('renders the React element when dependencies are provided', () => {
+      const deps = { analytics, executionContext, i18n, theme, userProfile };
+      rendering.start(deps);
+
+      const TestComponent = rendering.addContext(<div>Test Element</div>);
+
+      render(TestComponent);
+
+      expect(screen.getByText('Test Element')).toBeInTheDocument();
+      expect(screen.getByTestId('kibana-render-context')).toBeInTheDocument();
+    });
   });
 });

--- a/src/core/packages/rendering/browser-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/browser-internal/src/rendering_service.tsx
@@ -9,31 +9,43 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { pairwise, startWith } from 'rxjs';
+import useObservable from 'react-use/lib/useObservable';
+import { BehaviorSubject, pairwise, startWith } from 'rxjs';
 
+import { EuiLoadingSpinner } from '@elastic/eui';
 import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { InternalApplicationStart } from '@kbn/core-application-browser-internal';
 import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal';
+import type { ExecutionContextStart } from '@kbn/core-execution-context-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { OverlayStart } from '@kbn/core-overlays-browser';
+import { APP_FIXED_VIEWPORT_ID } from '@kbn/core-rendering-browser';
 import type { ThemeServiceStart } from '@kbn/core-theme-browser';
 import type { UserProfileService } from '@kbn/core-user-profile-browser';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { KibanaRootContextProvider } from '@kbn/react-kibana-context-root';
-import { APP_FIXED_VIEWPORT_ID } from '@kbn/core-rendering-browser';
+import { RenderingService as IRenderingService } from '@kbn/core-rendering-browser';
 import { AppWrapper } from './app_containers';
 
-interface StartServices {
+export interface RenderingServiceContextDeps {
   analytics: AnalyticsServiceStart;
+  executionContext: ExecutionContextStart;
   i18n: I18nStart;
   theme: ThemeServiceStart;
   userProfile: UserProfileService;
 }
 
-export interface StartDeps extends StartServices {
+export interface RenderingServiceRenderCoreDeps {
   application: InternalApplicationStart;
   chrome: InternalChromeStart;
   overlays: OverlayStart;
-  targetDomElement: HTMLDivElement;
+}
+
+export interface RenderingServiceInternalStart extends IRenderingService {
+  renderCore: (
+    renderCoreDeps: RenderingServiceRenderCoreDeps,
+    targetDomElement: HTMLDivElement
+  ) => void;
 }
 
 /**
@@ -44,8 +56,31 @@ export interface StartDeps extends StartServices {
  *
  * @internal
  */
-export class RenderingService {
-  start({ application, chrome, overlays, targetDomElement, ...startServices }: StartDeps) {
+export class RenderingService implements IRenderingService {
+  private contextDeps = new BehaviorSubject<RenderingServiceContextDeps | null>(null);
+
+  /**
+   * @internal
+   */
+  public start(deps: RenderingServiceContextDeps): RenderingServiceInternalStart {
+    this.contextDeps.next(deps);
+
+    const contract = {
+      renderCore: this.renderCore.bind(this),
+      addContext: this.addContext.bind(this),
+    };
+    return contract;
+  }
+
+  /**
+   * @internal
+   */
+  public renderCore(
+    renderCoreDeps: RenderingServiceRenderCoreDeps,
+    targetDomElement: HTMLDivElement
+  ) {
+    const { chrome, application, overlays } = renderCoreDeps;
+    const startServices = this.contextDeps.getValue()!;
     const chromeHeader = chrome.getHeaderComponent();
     const appComponent = application.getComponent();
     const bannerComponent = overlays.banners.getComponent();
@@ -80,5 +115,38 @@ export class RenderingService {
       </KibanaRootContextProvider>,
       targetDomElement
     );
+  }
+
+  /**
+   * @public
+   */
+  public addContext(element: React.ReactNode): React.ReactElement<string> {
+    const Component: React.FC = () => {
+      /**
+       * The dependencies are captured using BehaviorSubject, because we assume that Kibana plugins' start
+       * methods could be called before the CoreStart services are completely settled internally. If this
+       * assumption is wrong, the available dependencies are given as the initial value to `useObservable`, and
+       * there is no unnecessary re-render.
+       */
+      const deps = useObservable(this.contextDeps, this.contextDeps.getValue());
+
+      if (!deps) {
+        return <EuiLoadingSpinner size="s" />;
+      }
+
+      return (
+        <KibanaRenderContextProvider
+          analytics={deps.analytics}
+          executionContext={deps.executionContext}
+          i18n={deps.i18n}
+          theme={deps.theme}
+          userProfile={deps.userProfile}
+        >
+          {element}
+        </KibanaRenderContextProvider>
+      );
+    };
+
+    return <Component />;
   }
 }

--- a/src/core/packages/rendering/browser-internal/tsconfig.json
+++ b/src/core/packages/rendering/browser-internal/tsconfig.json
@@ -5,12 +5,13 @@
     "types": [
       "jest",
       "node",
-      "react"
+      "react",
+      "@testing-library/jest-dom"
     ]
   },
   "include": [
     "**/*.ts",
-    "**/*.tsx",
+    "**/*.tsx"
   ],
   "kbn_references": [
     "@kbn/core-application-common",
@@ -29,9 +30,12 @@
     "@kbn/core-theme-browser",
     "@kbn/core-rendering-browser",
     "@kbn/core-user-profile-browser",
-    "@kbn/core-user-profile-browser-mocks"
+    "@kbn/core-user-profile-browser-mocks",
+    "@kbn/core-execution-context-browser-mocks",
+    "@kbn/core-execution-context-browser",
+    "@kbn/react-kibana-context-render"
   ],
   "exclude": [
-    "target/**/*",
+    "target/**/*"
   ]
 }

--- a/src/core/packages/rendering/browser-mocks/src/rendering_service.mock.ts
+++ b/src/core/packages/rendering/browser-mocks/src/rendering_service.mock.ts
@@ -7,18 +7,32 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { PublicMethodsOf } from '@kbn/utility-types';
-import type { RenderingService } from '@kbn/core-rendering-browser-internal';
+import type { RenderingService } from '@kbn/core-rendering-browser';
 
-type RenderingServiceContract = PublicMethodsOf<RenderingService>;
+/**
+ * This is declared internally to avoid a circular dependency issue
+ */
+export interface RenderingServiceInternal {
+  start: (deps: unknown) => RenderingService;
+  renderCore: (deps: unknown, targetDomElement: HTMLElement) => void;
+}
+
+const createMockInternal = () => {
+  const mocked: jest.Mocked<RenderingServiceInternal> = {
+    start: jest.fn().mockImplementation(createMock),
+    renderCore: jest.fn(),
+  };
+  return mocked;
+};
 
 const createMock = () => {
-  const mocked: jest.Mocked<RenderingServiceContract> = {
-    start: jest.fn(),
+  const mocked: jest.Mocked<RenderingService> = {
+    addContext: jest.fn().mockImplementation((element) => element),
   };
   return mocked;
 };
 
 export const renderingServiceMock = {
+  createInternal: createMockInternal,
   create: createMock,
 };

--- a/src/core/packages/rendering/browser-mocks/tsconfig.json
+++ b/src/core/packages/rendering/browser-mocks/tsconfig.json
@@ -9,13 +9,12 @@
   },
   "include": [
     "**/*.ts",
-    "**/*.tsx",
+    "**/*.tsx"
   ],
   "kbn_references": [
-    "@kbn/utility-types",
-    "@kbn/core-rendering-browser-internal"
+    "@kbn/core-rendering-browser"
   ],
   "exclude": [
-    "target/**/*",
+    "target/**/*"
   ]
 }

--- a/src/core/packages/rendering/browser/index.ts
+++ b/src/core/packages/rendering/browser/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { APP_FIXED_VIEWPORT_ID, useAppFixedViewport } from './src';
+export type { RenderingService } from './src';

--- a/src/core/packages/rendering/browser/src/rendering_service.ts
+++ b/src/core/packages/rendering/browser/src/rendering_service.ts
@@ -7,5 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { APP_FIXED_VIEWPORT_ID, useAppFixedViewport } from './use_app_fixed_viewport';
-export type { RenderingService } from './rendering_service';
+import React from 'react';
+
+export interface RenderingService {
+  addContext: (element: React.ReactNode) => React.ReactElement;
+}

--- a/src/core/packages/root/browser-internal/src/core_system.test.mocks.ts
+++ b/src/core/packages/root/browser-internal/src/core_system.test.mocks.ts
@@ -128,7 +128,7 @@ jest.doMock('@kbn/core-doc-links-browser-internal', () => ({
   DocLinksService: DocLinksServiceConstructor,
 }));
 
-export const MockRenderingService = renderingServiceMock.create();
+export const MockRenderingService = renderingServiceMock.createInternal();
 export const RenderingServiceConstructor = jest.fn().mockImplementation(() => MockRenderingService);
 jest.doMock('@kbn/core-rendering-browser-internal', () => ({
   RenderingService: RenderingServiceConstructor,

--- a/src/core/packages/root/browser-internal/src/core_system.test.ts
+++ b/src/core/packages/root/browser-internal/src/core_system.test.ts
@@ -466,12 +466,10 @@ describe('#start()', () => {
     await startCore();
     expect(MockNotificationsService.start).toHaveBeenCalledTimes(1);
     expect(MockNotificationsService.start).toHaveBeenCalledWith({
-      i18n: expect.any(Object),
       overlays: expect.any(Object),
-      theme: expect.any(Object),
-      userProfile: expect.any(Object),
       targetDomElement: expect.any(HTMLElement),
       analytics: expect.any(Object),
+      rendering: expect.any(Object),
     });
   });
 
@@ -485,19 +483,17 @@ describe('#start()', () => {
     expect(MockOverlayService.start).toHaveBeenCalledTimes(1);
   });
 
-  it('calls rendering#start()', async () => {
+  it('calls rendering#renderCore()', async () => {
     await startCore();
-    expect(MockRenderingService.start).toHaveBeenCalledTimes(1);
-    expect(MockRenderingService.start).toHaveBeenCalledWith({
-      analytics: expect.any(Object),
-      application: expect.any(Object),
-      chrome: expect.any(Object),
-      overlays: expect.any(Object),
-      i18n: expect.any(Object),
-      theme: expect.any(Object),
-      userProfile: expect.any(Object),
-      targetDomElement: expect.any(HTMLElement),
-    });
+    expect(MockRenderingService.renderCore).toHaveBeenCalledTimes(1);
+    expect(MockRenderingService.renderCore).toHaveBeenCalledWith(
+      {
+        application: expect.any(Object),
+        chrome: expect.any(Object),
+        overlays: expect.any(Object),
+      },
+      expect.any(HTMLElement)
+    );
   });
 
   it('calls integrations#start()', async () => {
@@ -599,7 +595,7 @@ describe('#stop()', () => {
     await coreSystem.setup();
     await coreSystem.start();
     expect(rootDomElement.innerHTML).not.toBe('');
-    await coreSystem.stop();
+    coreSystem.stop();
     expect(rootDomElement.innerHTML).toBe('');
   });
 });
@@ -611,15 +607,15 @@ describe('RenderingService targetDomElement', () => {
       rootDomElement,
     });
 
-    let targetDomElementParentInStart: HTMLElement | null;
-    MockRenderingService.start.mockImplementation(({ targetDomElement }) => {
-      targetDomElementParentInStart = targetDomElement.parentElement;
+    let targetDomElementParentInRenderCore: HTMLElement | null;
+    MockRenderingService.renderCore.mockImplementation((_deps, targetDomElement) => {
+      targetDomElementParentInRenderCore = targetDomElement.parentElement;
     });
 
     // Starting the core system should pass the targetDomElement as a child of the rootDomElement
     await core.setup();
     await core.start();
-    expect(targetDomElementParentInStart!).toBe(rootDomElement);
+    expect(targetDomElementParentInRenderCore!).toBe(rootDomElement);
   });
 });
 
@@ -631,7 +627,7 @@ describe('Notifications targetDomElement', () => {
     });
 
     let targetDomElementInStart: HTMLElement | null;
-    MockNotificationsService.start.mockImplementation(({ targetDomElement }): any => {
+    MockNotificationsService.start.mockImplementation(({ targetDomElement }): void => {
       targetDomElementInStart = targetDomElement;
     });
 

--- a/src/core/packages/root/browser-internal/src/core_system.ts
+++ b/src/core/packages/root/browser-internal/src/core_system.ts
@@ -262,7 +262,6 @@ export class CoreSystem {
       const settings = this.settings.setup({ http, injectedMetadata });
       const notifications = this.notifications.setup({ uiSettings, analytics });
       const customBranding = this.customBranding.setup({ injectedMetadata });
-
       const application = this.application.setup({ http, analytics });
       this.coreApp.setup({ application, http, injectedMetadata, notifications });
       const featureFlags = this.featureFlags.setup({ injectedMetadata });
@@ -333,14 +332,7 @@ export class CoreSystem {
         userProfile,
         targetDomElement: overlayTargetDomElement,
       });
-      const notifications = this.notifications.start({
-        analytics,
-        i18n,
-        overlays,
-        theme,
-        userProfile,
-        targetDomElement: notificationsTargetDomElement,
-      });
+
       const customBranding = this.customBranding.start();
       const application = await this.application.start({
         http,
@@ -349,9 +341,22 @@ export class CoreSystem {
         customBranding,
         analytics,
       });
-
       const executionContext = this.executionContext.start({
         curApp$: application.currentAppId$,
+      });
+      const rendering = this.rendering.start({
+        analytics,
+        executionContext,
+        i18n,
+        theme,
+        userProfile,
+      });
+
+      const notifications = this.notifications.start({
+        analytics,
+        overlays,
+        targetDomElement: notificationsTargetDomElement,
+        rendering,
       });
 
       const chrome = await this.chrome.start({
@@ -403,6 +408,7 @@ export class CoreSystem {
         customBranding,
         security,
         userProfile,
+        rendering,
       };
 
       await this.plugins.start(core);
@@ -414,16 +420,7 @@ export class CoreSystem {
       this.rootDomElement.appendChild(notificationsTargetDomElement);
       this.rootDomElement.appendChild(overlayTargetDomElement);
 
-      this.rendering.start({
-        application,
-        chrome,
-        analytics,
-        i18n,
-        overlays,
-        theme,
-        targetDomElement: coreUiTargetDomElement,
-        userProfile,
-      });
+      this.rendering.renderCore({ chrome, application, overlays }, coreUiTargetDomElement);
 
       performance.mark(KBN_LOAD_MARKS, {
         detail: LOAD_START_DONE,

--- a/src/platform/packages/shared/react/kibana_context/render/render_provider.tsx
+++ b/src/platform/packages/shared/react/kibana_context/render/render_provider.tsx
@@ -19,8 +19,9 @@ import { KibanaErrorBoundary, KibanaErrorBoundaryProvider } from '@kbn/shared-ux
 export type KibanaRenderContextProviderProps = Omit<KibanaRootContextProviderProps, 'globalStyles'>;
 
 /**
- * The `KibanaRenderContextProvider` provides the necessary context for an out-of-current
- * React render, such as using `ReactDOM.render()`.
+ * The `KibanaRenderContextProvider` provides the necessary context for an out-of-current React render, such as using `ReactDOM.render()`.
+ *
+ * @internal Use RenderingService.addContext from the CoreStart contract instead of consuming this directly.
  */
 export const KibanaRenderContextProvider: FC<
   PropsWithChildren<KibanaRenderContextProviderProps>

--- a/src/platform/packages/shared/react/kibana_mount/kibana.jsonc
+++ b/src/platform/packages/shared/react/kibana_mount/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-browser",
   "id": "@kbn/react-kibana-mount",
   "owner": [
     "@elastic/appex-sharedux"

--- a/src/platform/packages/shared/react/kibana_mount/to_mount_point.tsx
+++ b/src/platform/packages/shared/react/kibana_mount/to_mount_point.tsx
@@ -7,32 +7,56 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
-import ReactDOM from 'react-dom';
 import type { MountPoint } from '@kbn/core-mount-utils-browser';
+import type { RenderingService } from '@kbn/core-rendering-browser';
 import {
   KibanaRenderContextProvider,
   KibanaRenderContextProviderProps,
 } from '@kbn/react-kibana-context-render';
+import React from 'react';
+import ReactDOM from 'react-dom';
 
-export type ToMountPointParams = Pick<
+/**
+ * @deprecated Pass RenderingService as the second parameter to toMountPoint instead
+ */
+type ToMountPointParamsDeprecated = Pick<
   KibanaRenderContextProviderProps,
   'analytics' | 'i18n' | 'theme' | 'userProfile'
 >;
 
+export type ToMountPointParams = ToMountPointParamsDeprecated | RenderingService;
+
+function isParamsUsingPreferred(params?: ToMountPointParams): params is RenderingService {
+  return (
+    typeof params !== 'undefined' && typeof (params as RenderingService).addContext !== 'undefined'
+  );
+}
+
 /**
  * MountPoint converter for react nodes.
  *
- * @param node to get a mount point for
+ * @param node React node to get a mount point for
+ * @param params services needed for rendering fully-featured React nodes in Kibana
  */
 export const toMountPoint = (node: React.ReactNode, params: ToMountPointParams): MountPoint => {
-  const mount = (element: HTMLElement) => {
-    ReactDOM.render(
-      <KibanaRenderContextProvider {...params}>{node}</KibanaRenderContextProvider>,
-      element
-    );
-    return () => ReactDOM.unmountComponentAtNode(element);
+  let mount: ((element: HTMLElement) => () => boolean) & {
+    __reactMount__?: React.ReactNode;
   };
+
+  if (isParamsUsingPreferred(params)) {
+    mount = (element: HTMLElement) => {
+      ReactDOM.render(params.addContext(node), element);
+      return () => ReactDOM.unmountComponentAtNode(element);
+    };
+  } else {
+    mount = (element: HTMLElement) => {
+      ReactDOM.render(
+        <KibanaRenderContextProvider {...params}>{node}</KibanaRenderContextProvider>,
+        element
+      );
+      return () => ReactDOM.unmountComponentAtNode(element);
+    };
+  }
 
   // only used for tests and snapshots serialization
   if (process.env.NODE_ENV !== 'production') {

--- a/src/platform/packages/shared/react/kibana_mount/tsconfig.json
+++ b/src/platform/packages/shared/react/kibana_mount/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "**/*.ts",
-    "**/*.tsx",
+    "**/*.tsx"
   ],
   "exclude": [
     "target/**/*"
@@ -23,5 +23,6 @@
     "@kbn/core-user-profile-browser-mocks",
     "@kbn/core-mount-utils-browser",
     "@kbn/core-theme-browser",
+    "@kbn/core-rendering-browser"
   ]
 }

--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/index.tsx
@@ -43,6 +43,7 @@ import { getCloud } from './cloud';
 import { getShare } from './share';
 import { getExecutionContext } from './execution_context';
 import { getCustomBranding } from './custom_branding';
+import { getRendering } from './rendering';
 
 // TODO: clintandrewhall - this is not ideal, or complete.  The root context of Fleet applications
 // requires full start contracts of its dependencies.  As a result, we have to mock all of those contracts
@@ -85,6 +86,7 @@ export const StorybookContext: React.FC<{
         languageClientsUiComponents: {},
       },
       customBranding: getCustomBranding(),
+      rendering: getRendering(),
       dashboard: {} as unknown as DashboardStart,
       docLinks: getDocLinks(),
       http: getHttp(),

--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/rendering.tsx
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/rendering.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+export const getRendering = () => {
+  return {
+    addContext: (node: React.ReactNode) => <>{node}</>,
+  };
+};

--- a/x-pack/platform/plugins/shared/serverless/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/serverless/public/plugin.tsx
@@ -10,7 +10,6 @@ import { InternalChromeStart } from '@kbn/core-chrome-browser-internal';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { toMountPoint } from '@kbn/react-kibana-mount';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { ProjectSwitcher, ProjectSwitcherKibanaProvider } from '@kbn/serverless-project-switcher';
 import { ProjectType } from '@kbn/serverless-types';
 import React from 'react';
@@ -83,21 +82,19 @@ export class ServerlessPlugin
     core.chrome.navControls.registerRight({
       order: 1,
       mount: toMountPoint(
-        <KibanaRenderContextProvider {...core}>
-          <EuiButton
-            href="https://ela.st/serverless-feedback"
-            size={'s'}
-            color={'warning'}
-            iconType={'popout'}
-            iconSide={'right'}
-            target={'_blank'}
-          >
-            {i18n.translate('xpack.serverless.header.giveFeedbackBtn.label', {
-              defaultMessage: 'Give feedback',
-            })}
-          </EuiButton>
-        </KibanaRenderContextProvider>,
-        { ...core }
+        <EuiButton
+          href="https://ela.st/serverless-feedback"
+          size={'s'}
+          color={'warning'}
+          iconType={'popout'}
+          iconSide={'right'}
+          target={'_blank'}
+        >
+          {i18n.translate('xpack.serverless.header.giveFeedbackBtn.label', {
+            defaultMessage: 'Give feedback',
+          })}
+        </EuiButton>,
+        core.rendering
       ),
     });
 
@@ -136,11 +133,12 @@ export class ServerlessPlugin
     currentProjectType: ProjectType
   ) {
     ReactDOM.render(
-      <KibanaRenderContextProvider {...coreStart}>
+      coreStart.rendering.addContext(
         <ProjectSwitcherKibanaProvider {...{ coreStart, projectChangeAPIUrl }}>
           <ProjectSwitcher {...{ currentProjectType }} />
         </ProjectSwitcherKibanaProvider>
-      </KibanaRenderContextProvider>,
+      ),
+
       targetDomElement
     );
 

--- a/x-pack/platform/plugins/shared/serverless/tsconfig.json
+++ b/x-pack/platform/plugins/shared/serverless/tsconfig.json
@@ -27,6 +27,5 @@
     "@kbn/i18n",
     "@kbn/management-cards-navigation",
     "@kbn/react-kibana-mount",
-    "@kbn/react-kibana-context-render",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Core] Update RenderingService with`addContext` public method (#212163)](https://github.com/elastic/kibana/pull/212163)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-11T22:23:40Z","message":"[Core] Update RenderingService with`addContext` public method (#212163)\n\n## Summary\n\nEpic: https://github.com/elastic/kibana-team/issues/1435\nCloses https://github.com/elastic/kibana/issues/205413\nCloses https://github.com/elastic/kibana/issues/205411\n\nThis PR creates a new way to expose stateful service dependencies needed\nfor rendering React elements in Kibana. The concept of the changes is\nthat `KibanaRenderContextProvider` should not be a shared module, but\nshould be wrapped by a core service (the `RenderContextService` name is\nTBD). The next steps in this direction would be to coordinate teams to\nmigrate away from directly using `KibanaRenderContextProvider`.\n\n### Background\n\nToday, the dependencies for `KibanaRenderContextProvider` are declared\nas separate services which can be found in the `CoreStart` context. This\nhas created a situation where enhancing the module with more\ndependencies creates widespread changes needed for the UI codebase.\n\nThe @elastic/appex-sharedux team is looking to solve this situation by\ndefining a less impactful way to make future enhancements. The solution\nis one that can be gradually migrated towards, so the SharedUX team can\nask Kibana contributors to migrate towards in their own code. This PR\noffers a POC for that solution.\n\n### Details of this POC\n\nThe driving goal for this refactor is to lessen the impact across the\nKibana codebase whenever the `KibanaRenderContext` module needs to\nrequire additional services from the `CoreStart` context.\n\n#### Rendering a React Element with `ReactDOM.render`: Before\n```tsx\nconst renderApp = ({ core, targetDomElement }: { core: CoreStart; targetDomElement: HTMLElement; }) => {\n  // If `KibanaRenderContextProvider` needs to expand its scope, more services could be needed here,\n  // updating all the places throughout the code to pass those is a ton of work 👎🏻 \n  const { i18n, theme, analytics, userProfile, executionContext } = core;\n  ReactDOM.render(\n    <KibanaRenderContextProvider {...{ i18n, theme, analytics, userProfile, executionContext }}>\n      <MyApplication />\n    </KibanaRenderContextProvider>,\n    targetDomElement\n  );\n  return () => ReactDOM.unmountComponentAtNode(targetDomElement);\n};\n```\n\n#### Rendering a React Element with `ReactDOM.render`: After\n\n```tsx\nconst renderApp = ({ core, targetDomElement }: { core: CoreStart; targetDomElement: HTMLElement; }) => {\n  // So much less code, so much more future-proof 👍🏻 \n  ReactDOM.render(core.rendering.addContext(<MyApplication />), targetDomElement);\n  return () => ReactDOM.unmountComponentAtNode(targetDomElement);\n};\n```\n\n### Alternatives considered\n\nSee https://github.com/elastic/kibana/pull/209161\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### FAQ\n\n1. **Q**: This is React-centric. Does this give Kibana more commitment\ntowards React?\n**A:** For now, yes. But if we want to Kibana to remain\nframework-agnostic we may be able to add more extensions to the\nRenderContextService that support other frameworks.\n1. **Q:** Why not have a service that wraps `ReactDOM.render`?\n**A:** As we steer towards upgrading to React 18 in Kibana, staying\nagnostic of how React is rendered benefits us. React 18 has different\nergonomics based on whether you want to update an existing tree or mount\na new one.\n1. **Q:** Does the API have to be named `rendering.addContext`?\n**A:** No, it does not. Please suggest a better name if you have one in\nmind.\n1. **Q:** What are the next steps?\n**A:** Refer to the\n[Epic](https://github.com/elastic/kibana-team/issues/1435). This PR\nstarted as a POC but became ready for merge. After it is delivered to\nthe codebase, the next steps are to improve documentation and engage in\n\"sheparding.\" That is, socialize the new way of injecting dependencies\ninto the context, support teams in their migration, and track the\nprogress of migration.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [x] Care is needed to ensure this doesn't not negatively impact\nperformance with unnecessary re-renders.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"584875e66652e73739064d94e2d81cd5ef8f2b6c","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:skip","Team:SharedUX","v9.1.0"],"title":"[Core] Update RenderingService with`addContext` public method","number":212163,"url":"https://github.com/elastic/kibana/pull/212163","mergeCommit":{"message":"[Core] Update RenderingService with`addContext` public method (#212163)\n\n## Summary\n\nEpic: https://github.com/elastic/kibana-team/issues/1435\nCloses https://github.com/elastic/kibana/issues/205413\nCloses https://github.com/elastic/kibana/issues/205411\n\nThis PR creates a new way to expose stateful service dependencies needed\nfor rendering React elements in Kibana. The concept of the changes is\nthat `KibanaRenderContextProvider` should not be a shared module, but\nshould be wrapped by a core service (the `RenderContextService` name is\nTBD). The next steps in this direction would be to coordinate teams to\nmigrate away from directly using `KibanaRenderContextProvider`.\n\n### Background\n\nToday, the dependencies for `KibanaRenderContextProvider` are declared\nas separate services which can be found in the `CoreStart` context. This\nhas created a situation where enhancing the module with more\ndependencies creates widespread changes needed for the UI codebase.\n\nThe @elastic/appex-sharedux team is looking to solve this situation by\ndefining a less impactful way to make future enhancements. The solution\nis one that can be gradually migrated towards, so the SharedUX team can\nask Kibana contributors to migrate towards in their own code. This PR\noffers a POC for that solution.\n\n### Details of this POC\n\nThe driving goal for this refactor is to lessen the impact across the\nKibana codebase whenever the `KibanaRenderContext` module needs to\nrequire additional services from the `CoreStart` context.\n\n#### Rendering a React Element with `ReactDOM.render`: Before\n```tsx\nconst renderApp = ({ core, targetDomElement }: { core: CoreStart; targetDomElement: HTMLElement; }) => {\n  // If `KibanaRenderContextProvider` needs to expand its scope, more services could be needed here,\n  // updating all the places throughout the code to pass those is a ton of work 👎🏻 \n  const { i18n, theme, analytics, userProfile, executionContext } = core;\n  ReactDOM.render(\n    <KibanaRenderContextProvider {...{ i18n, theme, analytics, userProfile, executionContext }}>\n      <MyApplication />\n    </KibanaRenderContextProvider>,\n    targetDomElement\n  );\n  return () => ReactDOM.unmountComponentAtNode(targetDomElement);\n};\n```\n\n#### Rendering a React Element with `ReactDOM.render`: After\n\n```tsx\nconst renderApp = ({ core, targetDomElement }: { core: CoreStart; targetDomElement: HTMLElement; }) => {\n  // So much less code, so much more future-proof 👍🏻 \n  ReactDOM.render(core.rendering.addContext(<MyApplication />), targetDomElement);\n  return () => ReactDOM.unmountComponentAtNode(targetDomElement);\n};\n```\n\n### Alternatives considered\n\nSee https://github.com/elastic/kibana/pull/209161\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### FAQ\n\n1. **Q**: This is React-centric. Does this give Kibana more commitment\ntowards React?\n**A:** For now, yes. But if we want to Kibana to remain\nframework-agnostic we may be able to add more extensions to the\nRenderContextService that support other frameworks.\n1. **Q:** Why not have a service that wraps `ReactDOM.render`?\n**A:** As we steer towards upgrading to React 18 in Kibana, staying\nagnostic of how React is rendered benefits us. React 18 has different\nergonomics based on whether you want to update an existing tree or mount\na new one.\n1. **Q:** Does the API have to be named `rendering.addContext`?\n**A:** No, it does not. Please suggest a better name if you have one in\nmind.\n1. **Q:** What are the next steps?\n**A:** Refer to the\n[Epic](https://github.com/elastic/kibana-team/issues/1435). This PR\nstarted as a POC but became ready for merge. After it is delivered to\nthe codebase, the next steps are to improve documentation and engage in\n\"sheparding.\" That is, socialize the new way of injecting dependencies\ninto the context, support teams in their migration, and track the\nprogress of migration.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [x] Care is needed to ensure this doesn't not negatively impact\nperformance with unnecessary re-renders.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"584875e66652e73739064d94e2d81cd5ef8f2b6c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212163","number":212163,"mergeCommit":{"message":"[Core] Update RenderingService with`addContext` public method (#212163)\n\n## Summary\n\nEpic: https://github.com/elastic/kibana-team/issues/1435\nCloses https://github.com/elastic/kibana/issues/205413\nCloses https://github.com/elastic/kibana/issues/205411\n\nThis PR creates a new way to expose stateful service dependencies needed\nfor rendering React elements in Kibana. The concept of the changes is\nthat `KibanaRenderContextProvider` should not be a shared module, but\nshould be wrapped by a core service (the `RenderContextService` name is\nTBD). The next steps in this direction would be to coordinate teams to\nmigrate away from directly using `KibanaRenderContextProvider`.\n\n### Background\n\nToday, the dependencies for `KibanaRenderContextProvider` are declared\nas separate services which can be found in the `CoreStart` context. This\nhas created a situation where enhancing the module with more\ndependencies creates widespread changes needed for the UI codebase.\n\nThe @elastic/appex-sharedux team is looking to solve this situation by\ndefining a less impactful way to make future enhancements. The solution\nis one that can be gradually migrated towards, so the SharedUX team can\nask Kibana contributors to migrate towards in their own code. This PR\noffers a POC for that solution.\n\n### Details of this POC\n\nThe driving goal for this refactor is to lessen the impact across the\nKibana codebase whenever the `KibanaRenderContext` module needs to\nrequire additional services from the `CoreStart` context.\n\n#### Rendering a React Element with `ReactDOM.render`: Before\n```tsx\nconst renderApp = ({ core, targetDomElement }: { core: CoreStart; targetDomElement: HTMLElement; }) => {\n  // If `KibanaRenderContextProvider` needs to expand its scope, more services could be needed here,\n  // updating all the places throughout the code to pass those is a ton of work 👎🏻 \n  const { i18n, theme, analytics, userProfile, executionContext } = core;\n  ReactDOM.render(\n    <KibanaRenderContextProvider {...{ i18n, theme, analytics, userProfile, executionContext }}>\n      <MyApplication />\n    </KibanaRenderContextProvider>,\n    targetDomElement\n  );\n  return () => ReactDOM.unmountComponentAtNode(targetDomElement);\n};\n```\n\n#### Rendering a React Element with `ReactDOM.render`: After\n\n```tsx\nconst renderApp = ({ core, targetDomElement }: { core: CoreStart; targetDomElement: HTMLElement; }) => {\n  // So much less code, so much more future-proof 👍🏻 \n  ReactDOM.render(core.rendering.addContext(<MyApplication />), targetDomElement);\n  return () => ReactDOM.unmountComponentAtNode(targetDomElement);\n};\n```\n\n### Alternatives considered\n\nSee https://github.com/elastic/kibana/pull/209161\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### FAQ\n\n1. **Q**: This is React-centric. Does this give Kibana more commitment\ntowards React?\n**A:** For now, yes. But if we want to Kibana to remain\nframework-agnostic we may be able to add more extensions to the\nRenderContextService that support other frameworks.\n1. **Q:** Why not have a service that wraps `ReactDOM.render`?\n**A:** As we steer towards upgrading to React 18 in Kibana, staying\nagnostic of how React is rendered benefits us. React 18 has different\nergonomics based on whether you want to update an existing tree or mount\na new one.\n1. **Q:** Does the API have to be named `rendering.addContext`?\n**A:** No, it does not. Please suggest a better name if you have one in\nmind.\n1. **Q:** What are the next steps?\n**A:** Refer to the\n[Epic](https://github.com/elastic/kibana-team/issues/1435). This PR\nstarted as a POC but became ready for merge. After it is delivered to\nthe codebase, the next steps are to improve documentation and engage in\n\"sheparding.\" That is, socialize the new way of injecting dependencies\ninto the context, support teams in their migration, and track the\nprogress of migration.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [x] Care is needed to ensure this doesn't not negatively impact\nperformance with unnecessary re-renders.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"584875e66652e73739064d94e2d81cd5ef8f2b6c"}}]}] BACKPORT-->