### PR TITLE
Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group3.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_flows·ts - Alerting maintenanceWindowFlows alerts triggered within a MW should fire actions if still active or recoveres after the MW expired

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_flows.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_flows.ts
@@ -26,8 +26,7 @@ export default function maintenanceWindowFlowsTests({ getService }: FtrProviderC
   const supertest = getService('supertest');
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/220281
-  describe.skip('maintenanceWindowFlows', () => {
+  describe('maintenanceWindowFlows', () => {
     const objectRemover = new ObjectRemover(supertestWithoutAuth);
 
     afterEach(async () => {
@@ -216,83 +215,38 @@ export default function maintenanceWindowFlowsTests({ getService }: FtrProviderC
       });
     });
 
-    it('alerts triggered within a MW should fire actions if still active or recoveres after the MW expired', async () => {
+    it('alerts triggered within a MW should fire actions if still active or recovers after the MW expired', async () => {
       const pattern = {
         instance: [true, true, false, true],
       };
 
       // Create active maintenance window
-      const maintenanceWindow = await createMaintenanceWindow({
-        supertest,
-        objectRemover,
-      });
-      const activeMaintenanceWindows = await getActiveMaintenanceWindows({
-        supertest,
-      });
+      const maintenanceWindow = await createMaintenanceWindow({ supertest, objectRemover });
+      const activeMaintenanceWindows = await getActiveMaintenanceWindows({ supertest });
       expect(activeMaintenanceWindows[0].id).eql(maintenanceWindow.id);
 
       // Create action and rule
-      const action = await createAction({
-        supertest,
-        objectRemover,
-      });
-      const rule = await createRule({
-        actionId: action.id,
-        pattern,
-        supertest,
-        objectRemover,
-      });
+      const action = await createAction({ supertest, objectRemover });
+      const rule = await createRule({ actionId: action.id, pattern, supertest, objectRemover });
 
       // Run the first time - active
-      await getRuleEvents({
-        id: rule.id,
-        activeInstance: 1,
-        retry,
-        getService,
-      });
+      await getRuleEvents({ id: rule.id, activeInstance: 1, retry, getService });
 
-      await expectNoActionsFired({
-        id: rule.id,
-        supertest,
-        retry,
-      });
+      await expectNoActionsFired({ id: rule.id, supertest, retry });
 
       // End the maintenance window
-      await finishMaintenanceWindow({
-        id: maintenanceWindow.id,
-        supertest,
-      });
-      const empty = await getActiveMaintenanceWindows({
-        supertest,
-      });
-      expect(empty).eql([]);
+      await finishMaintenanceWindow({ id: maintenanceWindow.id, supertest });
+      const maintenanceWindows = await getActiveMaintenanceWindows({ supertest });
+      expect(maintenanceWindows).eql([]);
 
       // Run again - active
-      await runSoon({
-        id: rule.id,
-        supertest,
-        retry,
-      });
-      await getRuleEvents({
-        id: rule.id,
-        activeInstance: 2,
-        retry,
-        getService,
-      });
+      await runSoon({ id: rule.id, supertest, retry });
+      await getRuleEvents({ id: rule.id, activeInstance: 2, retry, getService });
 
-      await expectActionsFired({
-        id: rule.id,
-        supertest,
-        retry,
-        expectedNumberOfActions: 1,
-      });
+      await expectActionsFired({ id: rule.id, supertest, retry, expectedNumberOfActions: 1 });
 
       // Run again - recovered
-      await runSoon({
-        id: rule.id,
-        supertest,
-        retry,
-      });
+      await runSoon({ id: rule.id, supertest, retry });
       await getRuleEvents({
         id: rule.id,
         activeInstance: 2,
@@ -301,19 +255,10 @@ export default function maintenanceWindowFlowsTests({ getService }: FtrProviderC
         getService,
       });
 
-      await expectActionsFired({
-        id: rule.id,
-        supertest,
-        retry,
-        expectedNumberOfActions: 2,
-      });
+      await expectActionsFired({ id: rule.id, supertest, retry, expectedNumberOfActions: 2 });
 
       // Run again - active again, this time fire the action since its a new alert instance
-      await runSoon({
-        id: rule.id,
-        supertest,
-        retry,
-      });
+      await runSoon({ id: rule.id, supertest, retry });
       await getRuleEvents({
         id: rule.id,
         action: 3,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
@@ -225,7 +225,7 @@ export const expectActionsFired = async ({
   retry: RetryService;
   expectedNumberOfActions: number;
 }) => {
-  const events = await retry.try(async () => {
+  await retry.try(async () => {
     const { body: result } = await supertest
       .get(`${getUrlPrefix(Spaces.space1.id)}/_test/event_log/alert/${id}/_find?per_page=5000`)
       .expect(200);
@@ -233,14 +233,13 @@ export const expectActionsFired = async ({
     if (!result.total) {
       throw new Error('no events found yet');
     }
-    return result.data as IValidatedEvent[];
-  });
 
-  const actionEvents = events.filter((event) => {
-    return event?.event?.action === 'execute-action';
-  });
+    const actionEvents = result.data.filter((event: IValidatedEvent) => {
+      return event?.event?.action === 'execute-action';
+    });
 
-  expect(actionEvents.length).eql(expectedNumberOfActions);
+    expect(actionEvents.length).eql(expectedNumberOfActions);
+  });
 };
 
 export const runSoon = async ({


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/220281

## Summary

Updates the retry logic to retry retrieving action event log docs.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->