### PR TITLE
Make option list with stats accessible with keyboard

### DIFF
--- a/x-pack/platform/packages/private/ml/field_stats_flyout/options_list_with_stats/option_list_with_stats.tsx
+++ b/x-pack/platform/packages/private/ml/field_stats_flyout/options_list_with_stats/option_list_with_stats.tsx
@@ -117,6 +117,13 @@ export const OptionListWithFieldStats: FC<OptionListWithFieldStatsProps> = ({
             onChange={() => {}}
             value={value}
             aria-labelledby={titleId}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === 'ArrowDown') {
+                e.preventDefault();
+                e.stopPropagation();
+                setPopoverOpen.bind(null, true)();
+              }
+            }}
           />
         </EuiFormControlLayout>
       }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/219516

## Summary
The Transform plugin has some text fields that are not keyboard accessible and those fields are using the `OptionListWithFieldStats` component. This PR adds the `onKeyDown` event for that component, fixing the problem for Transform plugin. 



https://github.com/user-attachments/assets/ec527750-b830-41e6-b3e5-c174a1c26311



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->