### PR TITLE
[Discover] Update aria-label in doc viewer table

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_filters.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_filters.tsx
@@ -24,10 +24,6 @@ import { FieldRow } from './field_row';
 export const LOCAL_STORAGE_KEY_SEARCH_TERM = 'discover:searchText';
 export const LOCAL_STORAGE_KEY_SELECTED_FIELD_TYPES = 'unifiedDocViewer:selectedFieldTypes';
 
-const searchPlaceholder = i18n.translate('unifiedDocViewer.docView.table.searchPlaceHolder', {
-  defaultMessage: 'Search field names or values',
-});
-
 export enum TermMatch {
   name = 'name',
   value = 'value',
@@ -67,8 +63,12 @@ export const TableFilters: React.FC<TableFiltersProps> = ({
   return (
     <EuiFieldSearch
       data-test-subj="unifiedDocViewerFieldsSearchInput"
-      aria-label={searchPlaceholder}
-      placeholder={searchPlaceholder}
+      aria-label={i18n.translate('unifiedDocViewer.docView.table.searchAriaLabel', {
+        defaultMessage: 'Field name or value',
+      })}
+      placeholder={i18n.translate('unifiedDocViewer.docView.table.searchPlaceHolder', {
+        defaultMessage: 'Search field names or values',
+      })}
       fullWidth
       compressed
       value={searchTerm}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/217558

The NVDA screen reader not only reads aria-labels but placeholders, this specific input had the same text for both of them so it seemed like it was reading the same twice, for that we are slightly changing the content of the aria-label.

| Before | After |
|--------|------|
| <img width="978" alt="image" src="https://github.com/user-attachments/assets/fd034f44-89f8-4b86-995e-48ea93c9eb2e" /> | <img width="968" alt="image (1)" src="https://github.com/user-attachments/assets/e59c98bf-edf6-4e87-8788-b28fbe77dde4" /> |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->