### PR TITLE
[8.17] [APM] Fix transactions test (#201755)

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/latency.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/latency.spec.ts
@@ -58,6 +58,14 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   }
 
   describe('Latency', () => {
+    let apmSynthtraceEsClient: ApmSynthtraceEsClient;
+
+    before(async () => {
+      apmSynthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
+    });
+
+    after(() => apmSynthtraceEsClient.clean());
+
     describe('when data is not loaded ', () => {
       it('handles the empty state', async () => {
         const response = await fetchLatencyCharts();
@@ -75,10 +83,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       const GO_DEV_RATE = 20;
       const GO_PROD_DURATION = 1000;
       const GO_DEV_DURATION = 500;
-      let apmSynthtraceEsClient: ApmSynthtraceEsClient;
 
       before(async () => {
-        apmSynthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
         const serviceGoProdInstance = apm
           .service({ name: serviceName, environment: 'production', agentName: 'go' })
           .instance('instance-a');
@@ -86,7 +92,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           .service({ name: serviceName, environment: 'development', agentName: 'go' })
           .instance('instance-b');
 
-        await apmSynthtraceEsClient.index([
+        return apmSynthtraceEsClient.index([
           timerange(start, end)
             .ratePerMinute(GO_PROD_RATE)
             .generator((timestamp) =>

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts
@@ -73,7 +73,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     return response.body as TransactionsGroupsMainStatistics;
   }
 
-  describe('Transaction groups alerts', () => {
+  describe('Transaction groups alerts', function () {
     describe('when data is loaded', () => {
       const transactions = [
         {
@@ -108,6 +108,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       before(async () => {
         roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
         apmSynthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
+        await apmSynthtraceEsClient.clean();
         const serviceGoProdInstance = apm
           .service({ name: serviceName, environment: 'production', agentName: 'go' })
           .instance('instance-a');
@@ -150,6 +151,13 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         let alerts: Alerts;
 
         before(async () => {
+          await alertingApi.cleanUpAlerts({
+            alertIndexName: APM_ALERTS_INDEX,
+            connectorIndexName: APM_ACTION_VARIABLE_INDEX,
+            consumer: 'apm',
+            roleAuthc,
+          });
+
           const createdRule = await alertingApi.createRule({
             name: `Latency threshold | ${serviceName}`,
             params: {

--- a/x-pack/test/api_integration/deployment_agnostic/services/alerting_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/alerting_api.ts
@@ -1147,7 +1147,7 @@ export function AlertingApiProvider({ getService }: DeploymentAgnosticFtrProvide
         .set(samlAuth.getInternalRequestHeader());
     },
 
-    async deleteRules({ roleAuthc, filter }: { roleAuthc: RoleCredentials; filter: string }) {
+    async deleteRules({ roleAuthc, filter = '' }: { roleAuthc: RoleCredentials; filter?: string }) {
       const response = await this.searchRules(roleAuthc, filter);
       return Promise.all(
         response.body.data.map((rule: any) => this.deleteRuleById({ roleAuthc, ruleId: rule.id }))
@@ -1192,14 +1192,14 @@ export function AlertingApiProvider({ getService }: DeploymentAgnosticFtrProvide
       connectorIndexName,
     }: {
       roleAuthc: RoleCredentials;
-      ruleId: string;
+      ruleId?: string;
       consumer?: string;
       alertIndexName?: string;
       connectorIndexName?: string;
     }) {
       return Promise.allSettled([
         // Delete the rule by ID
-        this.deleteRuleById({ roleAuthc, ruleId }),
+        ruleId ? this.deleteRuleById({ roleAuthc, ruleId }) : this.deleteRules({ roleAuthc }),
         // Delete all documents in the alert index if specified
         alertIndexName
           ? es.deleteByQuery({


### PR DESCRIPTION
Closes [#201850](https://github.com/elastic/kibana/issues/201850)

# Backport

This will backport the following commits from `main` to `8.17`:
 - [[APM] Fix transactions test (#201755)](https://github.com/elastic/kibana/pull/201755)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2024-11-27T15:51:23Z","message":"[APM] Fix transactions test (#201755)\n\n## Summary\n\nCloses #201531\n\nThis PR fixes the skipped test for MKI `Transaction groups alerts when\ndata is loaded with avg transaction duration alerts returns the correct\nnumber of alert counts` in\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts`","sha":"662052919c8663d76a93cce8fe0df687fff92a15","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","Team:obs-ux-infra_services","v8.18.0"],"title":"[APM] Fix transactions test","number":201755,"url":"https://github.com/elastic/kibana/pull/201755","mergeCommit":{"message":"[APM] Fix transactions test (#201755)\n\n## Summary\n\nCloses #201531\n\nThis PR fixes the skipped test for MKI `Transaction groups alerts when\ndata is loaded with avg transaction duration alerts returns the correct\nnumber of alert counts` in\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts`","sha":"662052919c8663d76a93cce8fe0df687fff92a15"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201755","number":201755,"mergeCommit":{"message":"[APM] Fix transactions test (#201755)\n\n## Summary\n\nCloses #201531\n\nThis PR fixes the skipped test for MKI `Transaction groups alerts when\ndata is loaded with avg transaction duration alerts returns the correct\nnumber of alert counts` in\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts`","sha":"662052919c8663d76a93cce8fe0df687fff92a15"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/202017","number":202017,"state":"MERGED","mergeCommit":{"sha":"1c2c65f03828281d308c9bbaa1f0f37fa92bde29","message":"[8.x] [APM] Fix transactions test (#201755) (#202017)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[APM] Fix transactions test\n(#201755)](https://github.com/elastic/kibana/pull/201755)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}}]}] BACKPORT-->