### PR TITLE
fix issue accessing repo owner name

### DIFF
--- a/.github/workflows/trigger-chromium-build.yml
+++ b/.github/workflows/trigger-chromium-build.yml
@@ -86,8 +86,7 @@ jobs:
               fi
           }
 
-          # attempt extracting puppeteer version bump config from the issue body, 
-          # single quote is very much intentional here so it's not escaped by bash
+          # attempt extracting puppeteer version bump config from the issue body
           echo "$ISSUE_BODY" | extract_code_blocks
       - name: Report multiple puppeteer_version properties
         if: ${{ steps.extract_version_bump_config.outputs.multiple_puppeteer_version_properties == 'true' }}
@@ -122,9 +121,9 @@ jobs:
           token: ${{ secrets.SHAREDUX_BUILDKITE_TOKEN }}
           pipeline: 'kibana-chromium-linux-build'
           env-vars: |
-            GITHUB_ISSUE_BASE_OWNER=${{ github.event.repository.owner.name }}
-            GITHUB_ISSUE_BASE_REPO=${{ github.event.repository.name }}/
+            GITHUB_ISSUE_BASE_OWNER=${{ github.event.repository.owner.login }}
+            GITHUB_ISSUE_BASE_REPO=${{ github.event.repository.name }}
             GITHUB_ISSUE_NUMBER=${{ github.event.issue.number }}
-            GITHUB_ISSUE_LABELS=${{ github.event.issue.labels }} | jq -r '. | map(.name) | join(",")'
+            GITHUB_ISSUE_LABELS=$(echo ${{ github.event.issue.labels }} | jq -r '. | map(.name) | join(",")')
             GITHUB_ISSUE_TRIGGER_USER=${{ github.event.issue.user.login }}
             PUPPETEER_VERSION=$(echo ${{ fromJSON(needs.matches_label.outputs.version_bump_config) }} | jq -r '.puppeteer_version')

--- a/.github/workflows/trigger-chromium-build.yml
+++ b/.github/workflows/trigger-chromium-build.yml
@@ -124,6 +124,5 @@ jobs:
             GITHUB_ISSUE_BASE_OWNER=${{ github.event.repository.owner.login }}
             GITHUB_ISSUE_BASE_REPO=${{ github.event.repository.name }}
             GITHUB_ISSUE_NUMBER=${{ github.event.issue.number }}
-            GITHUB_ISSUE_LABELS=$(echo ${{ github.event.issue.labels }} | jq -r '. | map(.name) | join(",")')
             GITHUB_ISSUE_TRIGGER_USER=${{ github.event.issue.user.login }}
             PUPPETEER_VERSION=$(echo ${{ fromJSON(needs.matches_label.outputs.version_bump_config) }} | jq -r '.puppeteer_version')


### PR DESCRIPTION
## Summary

Fix accessor for repo name on github event passed to github action causing [build failure](https://github.com/elastic/kibana/actions/runs/15295451939/job/43026027772), also remove unused env for github labels.


<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->
