### PR TITLE
[Fleet] Ensure postUpdate callback is call for package policy bulk update

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1499,24 +1499,19 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
 
     updatedPoliciesSuccess = (
       await pMap(
-        chunk(updatedPoliciesSuccess, 100),
+        chunk(updatedPoliciesSuccess, MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS),
         async (updatedPoliciesChunk) => {
           const updatedPoliciesComplete = await this.getByIDs(
             soClient,
             updatedPoliciesChunk.map((p) => p.id)
           );
-          return pMap(
-            updatedPoliciesComplete,
-            (packagePolicy) =>
-              packagePolicyService.runExternalCallbacks(
-                'packagePolicyPostUpdate',
-                packagePolicy,
-                soClient,
-                esClient
-              ),
-            {
-              concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS,
-            }
+          return pMap(updatedPoliciesComplete, (packagePolicy) =>
+            packagePolicyService.runExternalCallbacks(
+              'packagePolicyPostUpdate',
+              packagePolicy,
+              soClient,
+              esClient
+            )
           );
         },
         { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_10 }


### PR DESCRIPTION
## Description

Resolve https://github.com/elastic/kibana/issues/221781


Fleet provide callbacks to call other plugins on package policy operation 

the `postUpdate` callback was never implemented for `bulkUpdate` this is causing issue as upgrade rely on that method.

That PR attempt to fix it.

## Tests

Change is covered by unit tests

I manually tested performance here, as that code is know for having some performance issues:
I tried the upgrade with 500 aws agent policies and it seems the performance impact is correct adding ~5s to the total upgrade time (~25s)
