### PR TITLE
[ci] trigger artifact builds for 9.0 also

### DIFF
--- a/.buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.ts
+++ b/.buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.ts
@@ -184,14 +184,14 @@ export function getArtifactStagingPipelineTriggers() {
 /**
  * This pipeline checks if there are any changes in the incorporated $BEATS_MANIFEST_LATEST_URL (beats version)
  * and triggers a staging artifact build.
- * Should be triggered for all open branches with a fixed version excluding 7.17: not main, 7.17 and 8.x.
+ * Should be triggered for all open branches with a fixed version excluding 7.17: 8.*, 9.* without main.
  *
  * TODO: we could basically do the check logic of .buildkite/scripts/steps/artifacts/trigger.sh in here, and remove kibana-artifacts-trigger
  */
 export function getArtifactBuildTriggers() {
   const versions = getVersionsFile();
-  const targetVersions = versions.prevMajors.filter((version) =>
-    Boolean(version.branch.match(/[0-9]{1,2}\.[0-9]{1,2}/))
+  const targetVersions = versions.versions.filter(
+    (version) => version.branch !== '7.17' && version.branch !== 'main'
   );
 
   return targetVersions.map(


### PR DESCRIPTION
## Summary
These jobs should be triggered for 9.0 as well (now that main is on 9.1): https://buildkite.com/elastic/kibana-trigger-version-dependent-jobs/builds/5001

Since we no longer have a long-term 8.x branch, we may simplify the triggering logic, and trigger it for any non-main, non-7.17 branches.