### PR TITLE
Add windsurf to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target
 /build
 .jruby
 .idea
+.windsurf
 *.iml
 *.log
 types.eslint.config.js


### PR DESCRIPTION
## Summary

This PR adds the `.windsurf` directory to the `.gitignore` file.

## Motivation

The `.windsurf` directory is used by the Windsurf AI coding assistant for storing configuration files, temporary data, and other metadata that are specific to the local development environment. These files are not relevant to the source code, build artifacts, or collaborative workflows, and should not be tracked in version control.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->