### PR TITLE
[Discover] Show ES|QL request URL in Inpector flyout

### DIFF
--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -511,6 +511,7 @@ export class SearchInterceptor {
               rawResponse: esqlResponse,
               isPartial: esqlResponse.is_partial,
               isRunning: esqlResponse.is_running,
+              requestParams,
               warning,
             };
           default:

--- a/src/platform/test/functional/apps/discover/esql/_esql_view.ts
+++ b/src/platform/test/functional/apps/discover/esql/_esql_view.ts
@@ -402,6 +402,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const requestNames = await inspector.getRequestNames();
           expect(requestNames).to.contain('Table');
           expect(requestNames).to.contain('Visualization');
+          const request = await inspector.getRequest(1);
+          expect(request.command).to.be('POST /_query/async?drop_null_columns');
         });
       });
 

--- a/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
@@ -377,6 +377,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const requestNames = await inspector.getRequestNames();
           expect(requestNames).to.contain('Table');
           expect(requestNames).to.contain('Visualization');
+          const request = await inspector.getRequest(1);
+          expect(request.command).to.be('POST /_query/async?drop_null_columns');
         });
       });
     });


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/221581

## Summary

This PR adds the missing `requestParams` to the search interceptor code. This makes the request URL appear again in Inpector flyout (Request tab).

<img width="1072" alt="Screenshot 2025-05-28 at 17 55 09" src="https://github.com/user-attachments/assets/1c11c7d7-1e49-4265-a014-88f369dad2a7" />



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->