### PR TITLE
[Obs AI Assistant] Change `re-deploy model` to `redeploy model` and attempt to fix flaky test

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -81,7 +81,7 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
       return i18n.translate(
         'xpack.observabilityAiAssistantManagement.knowledgeBase.redeployModelLabel',
         {
-          defaultMessage: 'Re-deploy model',
+          defaultMessage: 'Redeploy model',
         }
       );
     }

--- a/x-pack/test/observability_ai_assistant_functional/tests/settings/change_knowledge_base_model.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/settings/change_knowledge_base_model.spec.ts
@@ -98,14 +98,14 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(isButtonDisabled).to.be(null);
     });
 
-    it('should show a button to re-deploy the model if the model has been stopped', async () => {
+    it('should show a button to redeploy the model if the model has been stopped', async () => {
       await stopTinyElserModel(getService);
       await browser.refresh();
 
       const buttonText = await testSubjects.getVisibleText(
         'observabilityAiAssistantKnowledgeBaseUpdateModelButton'
       );
-      expect(buttonText).to.be('Re-deploy model');
+      expect(buttonText).to.be('Redeploy model');
 
       const statusBadgeText = await testSubjects.getVisibleText(
         'observabilityAiAssistantKnowledgeBaseStatus'

--- a/x-pack/test/observability_ai_assistant_functional/tests/settings/change_knowledge_base_model.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/settings/change_knowledge_base_model.spec.ts
@@ -100,12 +100,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     it('should show a button to redeploy the model if the model has been stopped', async () => {
       await stopTinyElserModel(getService);
-      await browser.refresh();
 
-      const buttonText = await testSubjects.getVisibleText(
-        'observabilityAiAssistantKnowledgeBaseUpdateModelButton'
-      );
-      expect(buttonText).to.be('Redeploy model');
+      await retry.try(async () => {
+        await browser.refresh();
+
+        const buttonText = await testSubjects.getVisibleText(
+          'observabilityAiAssistantKnowledgeBaseUpdateModelButton'
+        );
+        expect(buttonText).to.be('Redeploy model');
+      });
 
       const statusBadgeText = await testSubjects.getVisibleText(
         'observabilityAiAssistantKnowledgeBaseStatus'


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/221802
Relates to https://github.com/elastic/kibana/pull/221626

## Summary

Changes `re-deploy` to `redeploy` as this was changed in the setup phase via the PR linked above.

There is 1 flaky test. This happens because we install tiny ELSER in tests and not ELSER v2, and we don't provide tiny ELSER in the model options, which can lead to some flakiness when determining which model is selected as the current model. I'm adding a re-try and kicking off the flaky test runner. If it seems to be too flaky, I'll remove this test as this is already tested in the `setup` phase

Update: flaky test runner passed successfully for 200 test runs. 

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->