### PR TITLE
[Lens] Keep suggestions up to date with the main workspace

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { camelCase } from 'lodash';
+import { camelCase, pick } from 'lodash';
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
@@ -46,6 +46,7 @@ import {
   DatasourceMap,
   VisualizationMap,
   UserMessagesGetter,
+  DatasourceLayers,
 } from '../../types';
 import { getSuggestions, switchToSuggestion } from './suggestion_helpers';
 import { getDatasourceExpressionsByLayers } from './expression_helpers';
@@ -707,6 +708,30 @@ function getPreviewExpression(
     datasourceLayers: { ...frame.datasourceLayers },
   };
   try {
+    // use current frame api and patch apis for changed datasource layers
+    if (
+      visualizableState.keptLayerIds &&
+      visualizableState.datasourceId &&
+      visualizableState.datasourceState
+    ) {
+      const datasource = datasources[visualizableState.datasourceId];
+      const datasourceState = visualizableState.datasourceState;
+      const updatedLayerApis: DatasourceLayers = pick(
+        frame.datasourceLayers,
+        visualizableState.keptLayerIds
+      );
+      const changedLayers = datasource.getLayers(visualizableState.datasourceState);
+      changedLayers.forEach((layerId) => {
+        if (updatedLayerApis[layerId]) {
+          updatedLayerApis[layerId] = datasource.getPublicAPI({
+            layerId,
+            state: datasourceState,
+            indexPatterns: frame.dataViews.indexPatterns,
+          });
+        }
+        suggestionFrameApi.datasourceLayers[layerId] = updatedLayerApis[layerId];
+      });
+    }
     const datasourceExpressionsByLayers = getDatasourceExpressionsByLayers(
       datasources,
       datasourceStates,

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -131,7 +131,7 @@ const PreviewRenderer = ({
   const euiThemeContext = useEuiTheme();
   const { euiTheme } = euiThemeContext;
   const onErrorMessage = (
-    <div css={suggestionStyles.icon(euiThemeContext)}>
+    <div css={suggestionStyles.icon(euiThemeContext)} data-test-subj="lnsSuggestionPanel__error">
       <EuiIconTip
         size="xl"
         color="danger"

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
@@ -1357,6 +1357,7 @@ export const stackingTypes = [
       defaultMessage: 'Stacked',
     }),
     subtypes: ['bar_stacked', 'area_stacked', 'bar_horizontal_stacked'],
+    dataTestSubj: 'lnsStackingOptionsButtonStacked',
   },
   {
     type: 'unstacked',
@@ -1364,6 +1365,7 @@ export const stackingTypes = [
       defaultMessage: 'Unstacked',
     }),
     subtypes: ['bar', 'area', 'bar_horizontal'],
+    dataTestSubj: 'lnsStackingOptionsButtonUnstacked',
   },
   {
     type: 'percentage',
@@ -1375,6 +1377,7 @@ export const stackingTypes = [
       'area_percentage_stacked',
       'bar_horizontal_percentage_stacked',
     ],
+    dataTestSubj: 'lnsStackingOptionsButtonPercentage',
   },
 ];
 
@@ -1392,10 +1395,11 @@ const SubtypeSwitch = ({
     return null;
   }
   const subTypeIndex = stackingType.subtypes.indexOf(layer.seriesType);
-  const options = stackingTypes.map(({ label, subtypes }) => ({
+  const options = stackingTypes.map(({ label, subtypes, dataTestSubj }) => ({
     label,
     value: subtypes[subTypeIndex],
     checked: subtypes[subTypeIndex] === layer.seriesType ? ('on' as const) : undefined,
+    'data-test-subj': dataTestSubj,
   }));
 
   return (
@@ -1412,6 +1416,7 @@ const SubtypeSwitch = ({
             fullWidth
             size="s"
             label={stackingType.label}
+            data-test-subj="lnsStackingOptionsButton"
           />
         }
         isOpen={flyoutOpen}

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -924,6 +924,15 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         }
       });
     },
+
+    async switchToVisualizationSubtype(subType: string, layerIndex: number = 0) {
+      if (!(await testSubjects.exists(`lns-layerPanel-${layerIndex} > lnsStackingOptionsButton`))) {
+        throw new Error('No subtype available for the current visualization');
+      }
+      await testSubjects.click(`lns-layerPanel-${layerIndex} > lnsStackingOptionsButton`);
+      await testSubjects.click(`lnsStackingOptionsButton${subType}`);
+    },
+
     async getChartTypeFromChartSwitcher() {
       const chartSwitcher = await testSubjects.find('lnsChartSwitchPopover');
       return await chartSwitcher.getVisibleText();
@@ -1106,6 +1115,15 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           }
         }
       }
+    },
+
+    async duplicateLayer(index: number = 0) {
+      await retry.try(async () => {
+        if (await testSubjects.exists(`lnsLayerSplitButton--${index}`)) {
+          await testSubjects.click(`lnsLayerSplitButton--${index}`);
+        }
+        await testSubjects.click(`lnsLayerClone--${index}`);
+      });
     },
 
     /**


### PR DESCRIPTION
## Summary

Fixes #178571 

This PR reverts #221248 adding the missing part on it to make the bug found in #178571 disappear.
In fact there was just a single line missing who was meant to keep the suggestion frame version up to date with the latest workspace state.

![lens_suggestion_bug_fix](https://github.com/user-attachments/assets/ff59e4d6-cfac-4801-857a-a79b1c98762d)

I've tried to add a unit test but it was so hard to actually follow the code underneath, so I settled to add a FTR, which led to few more extras:

* subtype selector now has test ids
* Lens page now has few more utility helpers for layer cloning and sub type selector

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->