### PR TITLE
[8.19] [Fleet] Keep the query params `returnAppId` and `returnPath` when switching tabs the integration details page (#216094)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -622,6 +622,12 @@ export function Detail() {
       return [];
     }
     const packageInfoKey = pkgKeyFromPackageInfo(packageInfo);
+    const pathValues = {
+      pkgkey: packageInfoKey,
+      ...(integration ? { integration } : {}),
+      ...(returnAppId ? { returnAppId } : {}),
+      ...(returnPath ? { returnPath } : {}),
+    };
 
     const tabs: WithHeaderLayoutProps['tabs'] = [
       {
@@ -634,10 +640,7 @@ export function Detail() {
         ),
         isSelected: panel === 'overview',
         'data-test-subj': `tab-overview`,
-        href: getHref('integration_details_overview', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-        }),
+        href: getHref('integration_details_overview', pathValues),
       },
     ];
 
@@ -652,10 +655,7 @@ export function Detail() {
         ),
         isSelected: panel === 'policies',
         'data-test-subj': `tab-policies`,
-        href: getHref('integration_details_policies', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-        }),
+        href: getHref('integration_details_policies', pathValues),
       });
     }
 
@@ -676,10 +676,7 @@ export function Detail() {
         ),
         isSelected: panel === 'assets',
         'data-test-subj': `tab-assets`,
-        href: getHref('integration_details_assets', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-        }),
+        href: getHref('integration_details_assets', pathValues),
       });
     }
 
@@ -694,10 +691,7 @@ export function Detail() {
         ),
         isSelected: panel === 'settings',
         'data-test-subj': `tab-settings`,
-        href: getHref('integration_details_settings', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-        }),
+        href: getHref('integration_details_settings', pathValues),
       });
     }
 
@@ -712,10 +706,7 @@ export function Detail() {
         ),
         isSelected: panel === 'configs',
         'data-test-subj': `tab-configs`,
-        href: getHref('integration_details_configs', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-        }),
+        href: getHref('integration_details_configs', pathValues),
       });
     }
 
@@ -730,10 +721,7 @@ export function Detail() {
         ),
         isSelected: panel === 'custom',
         'data-test-subj': `tab-custom`,
-        href: getHref('integration_details_custom', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-        }),
+        href: getHref('integration_details_custom', pathValues),
       });
     }
 
@@ -748,16 +736,15 @@ export function Detail() {
         ),
         isSelected: panel === 'api-reference',
         'data-test-subj': `tab-api-reference`,
-        href: getHref('integration_details_api_reference', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-        }),
+        href: getHref('integration_details_api_reference', pathValues),
       });
     }
 
     return tabs;
   }, [
     packageInfo,
+    returnAppId,
+    returnPath,
     panel,
     getHref,
     integration,

--- a/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
@@ -155,34 +155,40 @@ export const pagePathGetters: {
     return [INTEGRATIONS_BASE_PATH, `/installed/updates_available${categoryPath}${queryParams}`];
   },
   integration_create: () => [INTEGRATIONS_BASE_PATH, `/create`],
-  integration_details_overview: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/overview${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_policies: ({ pkgkey, integration, addAgentToPolicyId }) => {
-    const qs = stringify({ integration, addAgentToPolicyId });
+  integration_details_overview: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/overview${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_policies: ({
+    pkgkey,
+    integration,
+    addAgentToPolicyId,
+    returnAppId,
+    returnPath,
+  }) => {
+    const qs = stringify({ integration, addAgentToPolicyId, returnAppId, returnPath });
     return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/policies${qs ? `?${qs}` : ''}`];
   },
-  integration_details_assets: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/assets${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_settings: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/settings${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_configs: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/configs${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_custom: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/custom${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_api_reference: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/api-reference${integration ? `?integration=${integration}` : ''}`,
-  ],
+  integration_details_assets: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/assets${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_settings: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/settings${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_configs: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/configs${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_custom: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/custom${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_api_reference: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/api-reference${qs ? `?${qs}` : ''}`];
+  },
   integration_policy_edit: ({ packagePolicyId }) => [
     INTEGRATIONS_BASE_PATH,
     `/edit-integration/${packagePolicyId}`,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Keep the query params `returnAppId` and `returnPath` when switching tabs the integration details page (#216094)](https://github.com/elastic/kibana/pull/216094)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kylie Meli","email":"kylie.geller@elastic.co"},"sourceCommit":{"committedDate":"2025-03-27T15:26:53Z","message":"[Fleet] Keep the query params `returnAppId` and `returnPath` when switching tabs the integration details page (#216094)\n\n## Summary\n\nUpdates so that `returnAppId` and `returnPath` are maintained when the\nuser switches tabs on the Integrations details page.\n\n## Details\n\nWe currently have custom logic so that callers of the integrations cards\ncan customize the destinations of the back, cancel and save buttons.\nThis fixes that flow so that that customization is kept if the user\nswitches tabs.\n\nFollowup to https://github.com/elastic/kibana/pull/215561\n\n## Screen recordings\n\n\nhttps://github.com/user-attachments/assets/016ae86a-9d2f-434f-88cc-f34aeff9e14d\n\nRelates\n- https://github.com/elastic/security-team/issues/11789","sha":"e5b81ace3f83d8bc1a613eae241f41633de79337","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Fleet","v9.1.0"],"title":"[Fleet] Keep the query params `returnAppId` and `returnPath` when switching tabs the integration details page","number":216094,"url":"https://github.com/elastic/kibana/pull/216094","mergeCommit":{"message":"[Fleet] Keep the query params `returnAppId` and `returnPath` when switching tabs the integration details page (#216094)\n\n## Summary\n\nUpdates so that `returnAppId` and `returnPath` are maintained when the\nuser switches tabs on the Integrations details page.\n\n## Details\n\nWe currently have custom logic so that callers of the integrations cards\ncan customize the destinations of the back, cancel and save buttons.\nThis fixes that flow so that that customization is kept if the user\nswitches tabs.\n\nFollowup to https://github.com/elastic/kibana/pull/215561\n\n## Screen recordings\n\n\nhttps://github.com/user-attachments/assets/016ae86a-9d2f-434f-88cc-f34aeff9e14d\n\nRelates\n- https://github.com/elastic/security-team/issues/11789","sha":"e5b81ace3f83d8bc1a613eae241f41633de79337"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216094","number":216094,"mergeCommit":{"message":"[Fleet] Keep the query params `returnAppId` and `returnPath` when switching tabs the integration details page (#216094)\n\n## Summary\n\nUpdates so that `returnAppId` and `returnPath` are maintained when the\nuser switches tabs on the Integrations details page.\n\n## Details\n\nWe currently have custom logic so that callers of the integrations cards\ncan customize the destinations of the back, cancel and save buttons.\nThis fixes that flow so that that customization is kept if the user\nswitches tabs.\n\nFollowup to https://github.com/elastic/kibana/pull/215561\n\n## Screen recordings\n\n\nhttps://github.com/user-attachments/assets/016ae86a-9d2f-434f-88cc-f34aeff9e14d\n\nRelates\n- https://github.com/elastic/security-team/issues/11789","sha":"e5b81ace3f83d8bc1a613eae241f41633de79337"}}]}] BACKPORT-->