### PR TITLE
Update aria label for the discuss forum link

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_shared/public/components/external_resource_links/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/components/external_resource_links/index.tsx
@@ -63,7 +63,7 @@ export const ExternalResourceLinks: FunctionComponent = () => {
       ),
       linkARIALabel: i18n.translate(
         'xpack.observabilityShared.experimentalOnboardingFlow.exploreForumFlexItemLinkARIALabel',
-        { defaultMessage: 'Open Elastic Discuss forum' }
+        { defaultMessage: 'Discuss forum. Open Elastic forum' }
       ),
       link: URL_FORUM,
       testSubject: 'observabilityOnboardingFooterDiscussForumLink',


### PR DESCRIPTION
### Summary
- Updates aria label for the discuss forum link in onboarding so the start of the link text is announced the same in the reader
- Tested with VoiceOver in Mac

### VoiceOver text announcement:
**Before**
<img width="620" alt="image" src="https://github.com/user-attachments/assets/c1de61db-c17a-4915-8f67-734aeff07beb" />

**After**
<img width="634" alt="image" src="https://github.com/user-attachments/assets/677a620d-949b-49a0-9b5c-4fca9528c41f" />


Closes https://github.com/elastic/kibana/issues/220812

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->