### PR TITLE
[ES|QL] fix duplicated suggestions after change_point command

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/change_point/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/change_point/fields_suggestions_after.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { type ESQLAstCommand, type ESQLAstChangePointCommand, LeafPrinter } from '@kbn/esql-ast';
+import uniqBy from 'lodash/uniqBy';
 import type { ESQLFieldWithMetadata } from '../../../validation/types';
 
 export const fieldsSuggestionsAfter = (
@@ -15,15 +16,19 @@ export const fieldsSuggestionsAfter = (
   userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const { target } = command as ESQLAstChangePointCommand;
-  previousCommandFields.push(
-    {
-      name: target ? LeafPrinter.column(target.type) : 'type',
-      type: 'keyword' as const,
-    },
-    {
-      name: target ? LeafPrinter.column(target.pvalue) : 'pvalue',
-      type: 'double' as const,
-    }
+
+  return uniqBy(
+    [
+      ...previousCommandFields,
+      {
+        name: target ? LeafPrinter.column(target.type) : 'type',
+        type: 'keyword' as const,
+      },
+      {
+        name: target ? LeafPrinter.column(target.pvalue) : 'pvalue',
+        type: 'double' as const,
+      },
+    ],
+    'name'
   );
-  return previousCommandFields;
 };


### PR DESCRIPTION
## Summary

Change point was pushing previous command fields mutating the parameter, leading to duplicated field suggestions and suggesting fields that were no longer available.

![image](https://github.com/user-attachments/assets/47dd6992-ed54-4b29-97c6-6de522ae1117)


![image](https://github.com/user-attachments/assets/a3f80594-2e9a-4c50-8890-ba06ecbe3941)




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->