### PR TITLE
[8.19] Make option list with stats accessible with keyboard (#221729)

### DIFF
--- a/x-pack/platform/packages/private/ml/field_stats_flyout/options_list_with_stats/option_list_with_stats.tsx
+++ b/x-pack/platform/packages/private/ml/field_stats_flyout/options_list_with_stats/option_list_with_stats.tsx
@@ -120,6 +120,13 @@ export const OptionListWithFieldStats: FC<OptionListWithFieldStatsProps> = ({
             }
             onChange={() => {}}
             value={value}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === 'ArrowDown') {
+                e.preventDefault();
+                e.stopPropagation();
+                setPopoverOpen.bind(null, true)();
+              }
+            }}
           />
         </EuiFormControlLayout>
       }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Make option list with stats accessible with keyboard (#221729)](https://github.com/elastic/kibana/pull/221729)

Done manually due merge conflicts