### PR TITLE
chore(NA): update versions after v8.18.3 bump

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -19,7 +19,7 @@
       "previousMajor": true
     },
     {
-      "version": "8.18.2",
+      "version": "8.18.3",
       "branch": "8.18",
       "previousMajor": true
     },


### PR DESCRIPTION
This PR is a simple update of our versions file after the recent bumps.