### PR TITLE
[8.19] [ftr] split svl common configs with 4 extra groups (#218415)

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -21,8 +21,11 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group4.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group5.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group10.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group12.ts
   - x-pack/test_serverless/functional/test_suites/observability/config.screenshots.ts
-  - x-pack/test_serverless/functional/test_suites/observability/config.telemetry.ts
   # serverless config files that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts

--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -26,6 +26,7 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group12.ts
   - x-pack/test_serverless/functional/test_suites/observability/config.screenshots.ts
+  - x-pack/test_serverless/functional/test_suites/observability/config.telemetry.ts
   # serverless config files that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts

--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -20,6 +20,7 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group12.ts
   # serverless config files that run deployment-agnostic tests
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/search.serverless.config.ts
 
 # Serverless tests only run on main
 defaultQueue: 'n2-4-spot'

--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -15,8 +15,11 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group4.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group5.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group6.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group10.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group12.ts
   # serverless config files that run deployment-agnostic tests
-  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/search.serverless.config.ts
 
 # Serverless tests only run on main
 defaultQueue: 'n2-4-spot'

--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -12,7 +12,6 @@ disabled:
   - x-pack/test/security_solution_cypress/serverless_config.ts
   - x-pack/test/security_solution_cypress/ai4dsoc_serverless_config.ts
 
-
   # Playwright
   - x-pack/test/security_solution_playwright/serverless_config.ts
 
@@ -36,6 +35,10 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group4.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/trial_license_complete_tier/configs/serverless.config.ts

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group10.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group10.ts
@@ -13,11 +13,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/context'),
+      require.resolve('../../common/discover/esql'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 6',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts
@@ -13,11 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group3'),
+      require.resolve('../../common/discover/group4'),
+      require.resolve('../../common/discover/group5'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 11',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group12.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group12.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover/group6')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 12',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group5.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group5.ts
@@ -15,10 +15,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [
       require.resolve('../../common/discover/group1'),
       require.resolve('../../common/discover/group2'),
-      require.resolve('../../common/discover/group3'),
-      require.resolve('../../common/discover/group4'),
-      require.resolve('../../common/discover/group5'),
-      require.resolve('../../common/discover/group6'),
     ],
     junit: {
       reportName: 'Serverless Observability Functional Tests - Common Group 5',

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
@@ -15,9 +15,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [
       require.resolve('../../common/discover/embeddable'),
       require.resolve('../../common/discover/x_pack'),
-      require.resolve('../../common/discover_ml_uptime/discover'),
-      require.resolve('../../common/context'),
-      require.resolve('../../common/discover/esql'),
     ],
     junit: {
       reportName: 'Serverless Observability Functional Tests - Common Group 6',

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover_ml_uptime/discover')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 6',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group10.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group10.ts
@@ -13,11 +13,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/context'),
+      require.resolve('../../common/discover/esql'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 10',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts
@@ -13,11 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group3'), // 4 min
+      require.resolve('../../common/discover/group4'), // 4 min
+      require.resolve('../../common/discover/group5'), // 2 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 11',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group12.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group12.ts
@@ -13,11 +13,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group6'), // 13 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 12',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover_ml_uptime/discover')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 9',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts
@@ -13,11 +13,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/context'), // 5 min
+      require.resolve('../../common/discover/esql'), // 7 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 10',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts
@@ -13,11 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group3'),
+      require.resolve('../../common/discover/group4'),
+      require.resolve('../../common/discover/group5'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 11',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover/group6')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 12',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts
@@ -15,10 +15,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [
       require.resolve('../../common/discover/group1'),
       require.resolve('../../common/discover/group2'),
-      require.resolve('../../common/discover/group3'),
-      require.resolve('../../common/discover/group4'),
-      require.resolve('../../common/discover/group5'),
-      require.resolve('../../common/discover/group6'),
     ],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 5',

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
@@ -13,11 +13,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/embeddable'),
-      require.resolve('../../common/discover/x_pack'),
-      require.resolve('../../common/discover_ml_uptime/discover'),
-      require.resolve('../../common/context'),
-      require.resolve('../../common/discover/esql'),
+      require.resolve('../../common/discover/embeddable'), // 6 min
+      require.resolve('../../common/discover/x_pack'), // 8 min
     ],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 6',

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
@@ -13,11 +13,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover_ml_uptime/discover'), // 8 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 9',
     },
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ftr] split svl common configs with 4 extra groups (#218415)](https://github.com/elastic/kibana/pull/218415)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-04-16T16:34:55Z","message":"[ftr] split svl common configs with 4 extra groups (#218415)\n\n## Summary\n\nThese 2 configs for all solutions take 35-39 minutes:\n\n```\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group5.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group6.ts\n```\n\nI added 4 additional groups under each solution and relocated some\nconfigs to split original runtime by ~3:\n\n```\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group9.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group10.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group11.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group12.ts\n```\n\nIt should help balancing configs better and retry failed ones faster.\n\nAfter this PR groups runtime\n|config path| runtime |\n| ------------- | ------------- |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts|\n16m 15s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts|\n18m 7s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts|\n12m 7s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts\n| 16m 13s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts|\n14m 3s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts|\n17m 47s |","sha":"dfed7627ac0610a2e61935393341ca7a25fb384d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","FTR","backport:version","v9.1.0","v8.19.0"],"title":"[ftr] split svl common configs with 4 extra groups","number":218415,"url":"https://github.com/elastic/kibana/pull/218415","mergeCommit":{"message":"[ftr] split svl common configs with 4 extra groups (#218415)\n\n## Summary\n\nThese 2 configs for all solutions take 35-39 minutes:\n\n```\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group5.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group6.ts\n```\n\nI added 4 additional groups under each solution and relocated some\nconfigs to split original runtime by ~3:\n\n```\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group9.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group10.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group11.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group12.ts\n```\n\nIt should help balancing configs better and retry failed ones faster.\n\nAfter this PR groups runtime\n|config path| runtime |\n| ------------- | ------------- |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts|\n16m 15s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts|\n18m 7s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts|\n12m 7s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts\n| 16m 13s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts|\n14m 3s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts|\n17m 47s |","sha":"dfed7627ac0610a2e61935393341ca7a25fb384d"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/221963","number":221963,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218415","number":218415,"mergeCommit":{"message":"[ftr] split svl common configs with 4 extra groups (#218415)\n\n## Summary\n\nThese 2 configs for all solutions take 35-39 minutes:\n\n```\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group5.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group6.ts\n```\n\nI added 4 additional groups under each solution and relocated some\nconfigs to split original runtime by ~3:\n\n```\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group9.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group10.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group11.ts\nx-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group12.ts\n```\n\nIt should help balancing configs better and retry failed ones faster.\n\nAfter this PR groups runtime\n|config path| runtime |\n| ------------- | ------------- |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts|\n16m 15s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts|\n18m 7s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts|\n12m 7s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts\n| 16m 13s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts|\n14m 3s |\n\n|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts|\n17m 47s |","sha":"dfed7627ac0610a2e61935393341ca7a25fb384d"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->