### PR TITLE
[8.19] Balance serverless test groups

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -21,6 +21,8 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group4.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group5.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group7.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group8.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group10.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts

--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -15,6 +15,8 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group4.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group5.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group6.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group7.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group8.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group10.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts

--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -35,6 +35,8 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group4.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group7.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group8.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts

--- a/x-pack/test_serverless/functional/test_suites/common/visualizations/group5/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/visualizations/group5/index.ts
@@ -17,7 +17,7 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
   const config = getService('config');
   let remoteEsArchiver;
 
-  describe('lens serverless - group 1 - subgroup 1', function () {
+  describe('lens serverless - group 1 - subgroup 5', function () {
     this.tags(['esGate']);
 
     const esArchive = 'x-pack/test/functional/es_archives/logstash_functional';
@@ -73,7 +73,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.savedObjects.cleanStandardList();
     });
 
-    loadTestFile(require.resolve('./smokescreen.ts')); // 14m 25s
-    loadTestFile(require.resolve('./vega_chart.ts')); // 3m
+    loadTestFile(require.resolve('./tsdb.ts')); // 14m 25s
   });
 };

--- a/x-pack/test_serverless/functional/test_suites/common/visualizations/group5/tsdb.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/visualizations/group5/tsdb.ts
@@ -17,7 +17,7 @@ import {
   getDocsGenerator,
   setupScenarioRunner,
   sumFirstNValues,
-} from './tsdb_logsdb_helpers';
+} from '../tsdb_logsdb_helpers';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const { common, lens, dashboard, svlCommonPage } = getPageObjects([

--- a/x-pack/test_serverless/functional/test_suites/common/visualizations/group6/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/visualizations/group6/index.ts
@@ -17,7 +17,7 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
   const config = getService('config');
   let remoteEsArchiver;
 
-  describe('lens serverless - group 1 - subgroup 1', function () {
+  describe('lens serverless - group 1 - subgroup 6', function () {
     this.tags(['esGate']);
 
     const esArchive = 'x-pack/test/functional/es_archives/logstash_functional';
@@ -73,7 +73,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.savedObjects.cleanStandardList();
     });
 
-    loadTestFile(require.resolve('./smokescreen.ts')); // 14m 25s
-    loadTestFile(require.resolve('./vega_chart.ts')); // 3m
+    loadTestFile(require.resolve('./logsdb.ts')); // 28m
   });
 };

--- a/x-pack/test_serverless/functional/test_suites/common/visualizations/group6/logsdb.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/visualizations/group6/logsdb.ts
@@ -14,14 +14,15 @@ import {
   getDocsGenerator,
   setupScenarioRunner,
   TIME_PICKER_FORMAT,
-} from './tsdb_logsdb_helpers';
+} from '../tsdb_logsdb_helpers';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const { common, lens, discover, header } = getPageObjects([
+  const { common, lens, discover, header, svlCommonPage } = getPageObjects([
     'common',
     'lens',
     'discover',
     'header',
+    'svlCommonPage',
   ]);
   const testSubjects = getService('testSubjects');
   const find = getService('find');
@@ -45,6 +46,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     const toTime = 'Jun 16, 2023 @ 00:00:00.000';
 
     before(async () => {
+      await svlCommonPage.loginAsAdmin();
       log.info(`loading ${logsdbIndex} index...`);
       await esArchiver.loadIfNeeded(logsdbEsArchive);
       log.info(`creating a data view for "${logsdbDataView}"...`);

--- a/x-pack/test_serverless/functional/test_suites/common/visualizations/tsdb_logsdb_helpers.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/visualizations/tsdb_logsdb_helpers.ts
@@ -9,7 +9,7 @@ import { Client } from '@elastic/elasticsearch';
 import { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
 import { ToolingLog } from '@kbn/tooling-log';
 import moment from 'moment';
-import { FtrProviderContext } from '../../../../ftr_provider_context';
+import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export const TEST_DOC_COUNT = 100;
 export const TIME_PICKER_FORMAT = 'MMM D, YYYY [@] HH:mm:ss.SSS';

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group7.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group7.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseTestConfig = await readConfigFile(require.resolve('../config.ts'));
+
+  return {
+    ...baseTestConfig.getAll(),
+    testFiles: [require.resolve('../../common/visualizations/group5')],
+    junit: {
+      reportName: 'Serverless Observability Functional Tests - Common Group 7',
+    },
+  };
+}

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group8.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group8.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseTestConfig = await readConfigFile(require.resolve('../config.ts'));
+
+  return {
+    ...baseTestConfig.getAll(),
+    testFiles: [require.resolve('../../common/visualizations/group6')],
+    junit: {
+      reportName: 'Serverless Observability Functional Tests - Common Group 8',
+    },
+  };
+}

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group7.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group7.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseTestConfig = await readConfigFile(require.resolve('../config.ts'));
+
+  return {
+    ...baseTestConfig.getAll(),
+    testFiles: [require.resolve('../../common/visualizations/group5')],
+    junit: {
+      reportName: 'Serverless Search Functional Tests - Common Group 7',
+    },
+  };
+}

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group8.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group8.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseTestConfig = await readConfigFile(require.resolve('../config.ts'));
+
+  return {
+    ...baseTestConfig.getAll(),
+    testFiles: [require.resolve('../../common/visualizations/group6')],
+    junit: {
+      reportName: 'Serverless Search Functional Tests - Common Group 8',
+    },
+  };
+}

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group7.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group7.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseTestConfig = await readConfigFile(require.resolve('../config.ts'));
+
+  return {
+    ...baseTestConfig.getAll(),
+    testFiles: [require.resolve('../../common/visualizations/group5')],
+    junit: {
+      reportName: 'Serverless Security Functional Tests - Common Group 7',
+    },
+  };
+}

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group8.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group8.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseTestConfig = await readConfigFile(require.resolve('../config.ts'));
+
+  return {
+    ...baseTestConfig.getAll(),
+    testFiles: [require.resolve('../../common/visualizations/group6')],
+    junit: {
+      reportName: 'Serverless Security Functional Tests - Common Group 8',
+    },
+  };
+}


### PR DESCRIPTION
# Backport

I was backporting #218415 to `8.19` and noticed this PR was missing as well.

This will backport the following commits from `main` to `8.19`:
 - [Balance serverless test groups](https://github.com/elastic/kibana/pull/200896)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charis Kalpakis","email":"39087493+fake-haris@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-11-27T15:00:05Z","message":"Balance serverless test groups","sha":"68ca81e9a9c3ca9305d0fb996a1e3e1d6346cbe8","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:version","v9.1.0","v8.19.0"],"title":"Balance serverless test groups","number":200896,"url":"https://github.com/elastic/kibana/pull/200896","mergeCommit":{"message":"Balance serverless test groups","sha":"68ca81e9a9c3ca9305d0fb996a1e3e1d6346cbe8"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200896","number":200896,"mergeCommit":{"message":"Balance serverless test groups","sha":"68ca81e9a9c3ca9305d0fb996a1e3e1d6346cbe8"}},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->