### PR TITLE
[Fleet] Fix styled component theme lookup issue

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/app.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/app.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { memo, useEffect, useState } from 'react';
+import useObservable from 'react-use/lib/useObservable';
 import type { AppMountParameters } from '@kbn/core/public';
 import { EuiPortal, useEuiTheme } from '@elastic/eui';
 import type { History } from 'history';
@@ -21,8 +22,6 @@ import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
-
-import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 
 import type { FleetConfigType, FleetStartServices } from '../../plugin';
 
@@ -201,7 +200,10 @@ export const FleetAppContext: React.FC<{
     fleetStatus,
   }) => {
     const XXL_BREAKPOINT = 1600;
-    const isDarkMode = useKibanaIsDarkMode();
+    const isDarkMode = useObservable(
+      startServices.theme.theme$,
+      startServices.theme.getTheme()
+    ).darkMode;
 
     return (
       <KibanaRenderContextProvider

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/app.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/app.tsx
@@ -79,7 +79,10 @@ export const IntegrationsAppContext: React.FC<{
     fleetStatus,
   }) => {
     const XXL_BREAKPOINT = 1600;
-    const isDarkMode = useObservable(startServices.theme.theme$)?.darkMode;
+    const isDarkMode = useObservable(
+      startServices.theme.theme$,
+      startServices.theme.getTheme()
+    ).darkMode;
     const CloudContext = startServices.cloud?.CloudContextProvider || EmptyContext;
 
     return (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/app.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/app.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { memo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
 import type { AppMountParameters } from '@kbn/core/public';
 import { EuiPortal } from '@elastic/eui';
 import type { History } from 'history';
@@ -17,8 +18,6 @@ import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
-
-import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 
 import type { FleetConfigType, FleetStartServices } from '../../plugin';
 
@@ -80,8 +79,7 @@ export const IntegrationsAppContext: React.FC<{
     fleetStatus,
   }) => {
     const XXL_BREAKPOINT = 1600;
-    const isDarkMode = useKibanaIsDarkMode();
-
+    const isDarkMode = useObservable(startServices.theme.theme$)?.darkMode;
     const CloudContext = startServices.cloud?.CloudContextProvider || EmptyContext;
 
     return (
@@ -102,7 +100,7 @@ export const IntegrationsAppContext: React.FC<{
           <KibanaContextProvider services={{ ...startServices }}>
             <ConfigContext.Provider value={config}>
               <KibanaVersionContext.Provider value={kibanaVersion}>
-                {/* This should be removed since theme is passed to `KibanaRenderContextProvider`,
+                {/* TODO: This should be removed since theme is passed to `KibanaRenderContextProvider`,
                 however, removing this breaks usages of `props.theme.eui` in styled components */}
                 <EuiThemeProvider darkMode={isDarkMode}>
                   <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary

This fixes an issue caused by changes in #220141, specifically [here](https://github.com/elastic/kibana/pull/220141/files#diff-90215c9231256571f4b7369e58505a234b7f7b4082cf7c9fda47692787b52222L80-L83), which prevented the style components from receiving the correct `colorMode`.

### Before

![Screenshot 2025-05-29 at 21 36 06](https://github.com/user-attachments/assets/04bf27b4-8720-4104-8694-44ed6cb46e5c)


### After

![Screenshot 2025-05-29 at 21 00 00](https://github.com/user-attachments/assets/24919fd3-6fe0-4459-af78-7a6ffe3341db)


This is likely due to how we still use the deprecated `EuiThemeProvider` which needs to be passed the current `colorMode`. See code here...

https://github.com/elastic/kibana/blob/088e80ac27542fb39e6f660640213d34a831d2d2/x-pack/platform/plugins/shared/fleet/public/applications/integrations/app.tsx#L105-L107

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->