### PR TITLE
[8.19] [Discover] Show ES|QL request URL in Inpector flyout (#221816)

### DIFF
--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -528,6 +528,7 @@ export class SearchInterceptor {
                 rawResponse: esqlResponse,
                 isPartial: esqlResponse.is_partial,
                 isRunning: esqlResponse.is_running,
+                requestParams,
                 warning,
               };
             default:

--- a/src/platform/test/functional/apps/discover/esql/_esql_view.ts
+++ b/src/platform/test/functional/apps/discover/esql/_esql_view.ts
@@ -401,6 +401,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const requestNames = await inspector.getRequestNames();
           expect(requestNames).to.contain('Table');
           expect(requestNames).to.contain('Visualization');
+          const request = await inspector.getRequest(1);
+          expect(request.command).to.be('POST /_query/async?drop_null_columns');
         });
       });
 

--- a/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
@@ -376,6 +376,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const requestNames = await inspector.getRequestNames();
           expect(requestNames).to.contain('Table');
           expect(requestNames).to.contain('Visualization');
+          const request = await inspector.getRequest(1);
+          expect(request.command).to.be('POST /_query/async?drop_null_columns');
         });
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover] Show ES|QL request URL in Inpector flyout (#221816)](https://github.com/elastic/kibana/pull/221816)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2025-05-29T08:30:13Z","message":"[Discover] Show ES|QL request URL in Inpector flyout (#221816)\n\n- Closes https://github.com/elastic/kibana/issues/221581\n\n## Summary\n\nThis PR adds the missing `requestParams` to the search interceptor code.\nThis makes the request URL appear again in Inpector flyout (Request\ntab).\n\n<img width=\"1072\" alt=\"Screenshot 2025-05-28 at 17 55 09\"\nsrc=\"https://github.com/user-attachments/assets/1c11c7d7-1e49-4265-a014-88f369dad2a7\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"7fae9c5d6e86a588f6657dabe6894519449a03ad","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:DataDiscovery","Feature:ES|QL","backport:version","v9.1.0","v8.19.0","v9.0.2"],"title":"[Discover] Show ES|QL request URL in Inpector flyout","number":221816,"url":"https://github.com/elastic/kibana/pull/221816","mergeCommit":{"message":"[Discover] Show ES|QL request URL in Inpector flyout (#221816)\n\n- Closes https://github.com/elastic/kibana/issues/221581\n\n## Summary\n\nThis PR adds the missing `requestParams` to the search interceptor code.\nThis makes the request URL appear again in Inpector flyout (Request\ntab).\n\n<img width=\"1072\" alt=\"Screenshot 2025-05-28 at 17 55 09\"\nsrc=\"https://github.com/user-attachments/assets/1c11c7d7-1e49-4265-a014-88f369dad2a7\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"7fae9c5d6e86a588f6657dabe6894519449a03ad"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/221893","number":221893,"state":"MERGED","mergeCommit":{"sha":"ea2ff4db67d05650312ce4974285c3d6cb7593c7","message":"[9.0] [Discover] Show ES|QL request URL in Inpector flyout (#221816) (#221893)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Discover] Show ES|QL request URL in Inpector flyout\n(#221816)](https://github.com/elastic/kibana/pull/221816)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Julia Rechkunova <julia.rechkunova@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221816","number":221816,"mergeCommit":{"message":"[Discover] Show ES|QL request URL in Inpector flyout (#221816)\n\n- Closes https://github.com/elastic/kibana/issues/221581\n\n## Summary\n\nThis PR adds the missing `requestParams` to the search interceptor code.\nThis makes the request URL appear again in Inpector flyout (Request\ntab).\n\n<img width=\"1072\" alt=\"Screenshot 2025-05-28 at 17 55 09\"\nsrc=\"https://github.com/user-attachments/assets/1c11c7d7-1e49-4265-a014-88f369dad2a7\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"7fae9c5d6e86a588f6657dabe6894519449a03ad"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->