### PR TITLE
[8.19] [ES|QL] Add support for `RRF`  (#221349)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/rrf.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/rrf.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { parse } from '../parser';
+
+describe('RRF', () => {
+  describe('correctly formatted', () => {
+    it('can parse RRF command without modifiers', () => {
+      const text = `FROM search-movies METADATA _score, _id, _index
+                    | FORK
+                      ( WHERE semantic_title:"Shakespeare" | SORT _score)
+                      ( WHERE title:"Shakespeare" | SORT _score)
+                    | RRF
+                    | KEEP title, _score`;
+
+      const { root, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(root.commands[2]).toMatchObject({
+        type: 'command',
+        name: 'rrf',
+        args: [],
+      });
+    });
+  });
+
+  describe('when incorrectly formatted, return errors', () => {
+    it('when no pipe after', () => {
+      const text = `FROM search-movies METADATA _score, _id, _index
+                      | FORK
+                        ( WHERE semantic_title:"Shakespeare" | SORT _score)
+                        ( WHERE title:"Shakespeare" | SORT _score)
+                      | RRF KEEP title, _score`;
+
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when no pipe between FORK and RRF', () => {
+      const text = `FROM search-movies METADATA _score, _id, _index
+                    | FORK
+                      ( WHERE semantic_title:"Shakespeare" | SORT _score)
+                      ( WHERE title:"Shakespeare" | SORT _score) RRF`;
+
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when RRF is invoked with arguments', () => {
+      const text = `FROM search-movies METADATA _score, _id, _index
+                    | FORK ( WHERE semantic_title:"Shakespeare" | SORT _score)
+                              ( WHERE title:"Shakespeare" | SORT _score)
+                    | RRF text`;
+
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
@@ -32,6 +32,7 @@ import {
   type TimeSeriesCommandContext,
   type WhereCommandContext,
   RerankCommandContext,
+  RrfCommandContext,
 } from '../antlr/esql_parser';
 import { default as ESQLParserListener } from '../antlr/esql_parser_listener';
 import type { ESQLAst } from '../types';
@@ -348,6 +349,20 @@ export class ESQLAstBuilderListener implements ESQLParserListener {
   exitRerankCommand(ctx: RerankCommandContext): void {
     const command = createRerankCommand(ctx);
 
+    this.ast.push(command);
+  }
+
+  /**
+   * Exit a parse tree produced by `esql_parser.rrfCommand`.
+   *
+   * Parse the RRF (Reciprocal Rank Fusion) command:
+   *
+   * RRF
+   *
+   * @param ctx the parse tree
+   */
+  exitRrfCommand(ctx: RrfCommandContext): void {
+    const command = createCommand('rrf', ctx);
     this.ast.push(command);
   }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -235,6 +235,32 @@ describe('single line query', () => {
         );
       });
     });
+
+    describe('RRF', () => {
+      test('from single line', () => {
+        const { text } =
+          reprint(`FROM search-movies METADATA _score, _id, _index | FORK (WHERE semantic_title : "Shakespeare" | SORT _score) (WHERE title : "Shakespeare" | SORT _score) | RRF | KEEP title, _score
+        `);
+
+        expect(text).toBe(
+          'FROM search-movies METADATA _score, _id, _index | FORK (WHERE semantic_title : "Shakespeare" | SORT _score) (WHERE title : "Shakespeare" | SORT _score) | RRF | KEEP title, _score'
+        );
+      });
+
+      test('from multiline', () => {
+        const { text } = reprint(`FROM search-movies METADATA _score, _id, _index
+  | FORK
+    (WHERE semantic_title : "Shakespeare" | SORT _score)
+    (WHERE title : "Shakespeare" | SORT _score)
+  | RRF
+  | KEEP title, _score
+          `);
+
+        expect(text).toBe(
+          'FROM search-movies METADATA _score, _id, _index | FORK (WHERE semantic_title : "Shakespeare" | SORT _score) (WHERE title : "Shakespeare" | SORT _score) | RRF | KEEP title, _score'
+        );
+      });
+    });
   });
 
   describe('expressions', () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
@@ -520,6 +520,12 @@ export class ForkCommandVisitorContext<
   Data extends SharedData = SharedData
 > extends CommandVisitorContext<Methods, Data, ESQLAstCommand> {}
 
+// RRF
+export class RrfCommandVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData
+> extends CommandVisitorContext<Methods, Data, ESQLAstCommand> {}
+
 // Expressions -----------------------------------------------------------------
 
 export class ExpressionVisitorContext<

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
@@ -197,6 +197,10 @@ export class GlobalVisitorContext<
         if (!this.methods.visitForkCommand) break;
         return this.visitForkCommand(parent, commandNode, input as any);
       }
+      case 'rrf': {
+        if (!this.methods.visitRrfCommand) break;
+        return this.visitRrfCommand(parent, commandNode, input as any);
+      }
     }
     return this.visitCommandGeneric(parent, commandNode, input as any);
   }
@@ -415,6 +419,15 @@ export class GlobalVisitorContext<
   ): types.VisitorOutput<Methods, 'visitForkCommand'> {
     const context = new contexts.ForkCommandVisitorContext(this, node, parent);
     return this.visitWithSpecificContext('visitForkCommand', context, input);
+  }
+
+  public visitRrfCommand(
+    parent: contexts.VisitorContext | null,
+    node: ESQLAstCommand,
+    input: types.VisitorInput<Methods, 'visitRrfCommand'>
+  ): types.VisitorOutput<Methods, 'visitRrfCommand'> {
+    const context = new contexts.RrfCommandVisitorContext(this, node, parent);
+    return this.visitWithSpecificContext('visitRrfCommand', context, input);
   }
 
   // #endregion

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
@@ -189,6 +189,7 @@ export interface VisitorMethods<
   >;
   visitForkCommand?: Visitor<contexts.ForkCommandVisitorContext<Visitors, Data>, any, any>;
   visitCommandOption?: Visitor<contexts.CommandOptionVisitorContext<Visitors, Data>, any, any>;
+  visitRrfCommand?: Visitor<contexts.RrfCommandVisitorContext<Visitors, Data>, any, any>;
   visitExpression?: Visitor<contexts.ExpressionVisitorContext<Visitors, Data>, any, any>;
   visitSourceExpression?: Visitor<
     contexts.SourceExpressionVisitorContext<Visitors, Data>,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
@@ -12,6 +12,12 @@ import type { IndexAutocompleteItem } from '@kbn/esql-types';
 import { ESQLFieldWithMetadata } from '../validation/types';
 import { fieldTypes } from '../definitions/types';
 import { ESQLCallbacks } from '../shared/types';
+import { METADATA_FIELDS } from '../shared/constants';
+
+export const metadataFields: ESQLFieldWithMetadata[] = METADATA_FIELDS.map((field) => ({
+  name: field,
+  type: 'keyword',
+}));
 
 export const fields: ESQLFieldWithMetadata[] = [
   ...fieldTypes.map((type) => ({ name: `${camelCase(type)}Field`, type })),
@@ -106,6 +112,9 @@ export function getCallbackMocks(): ESQLCallbacks {
           hasConflict: true,
         };
         return [field];
+      }
+      if (/METADATA/i.test(query)) {
+        return [...fields, ...metadataFields];
       }
       return fields;
     }),

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.rff.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.rff.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { setup } from './helpers';
+
+jest.mock('../../definitions/commands', () => {
+  const actual = jest.requireActual('../../definitions/commands');
+  const modifiedDefinitions = actual.commandDefinitions.map((def: any) =>
+    def.name === 'rrf' ? { ...def, hidden: false } : def
+  );
+  return {
+    ...actual,
+    commandDefinitions: modifiedDefinitions,
+  };
+});
+
+describe('autocomplete.suggest', () => {
+  describe('RRF', () => {
+    it('does not suggest RRF in the general list of commands', async () => {
+      const { suggest } = await setup();
+      const suggestedCommands = (await suggest('FROM index | /')).map((s) => s.text);
+      expect(suggestedCommands).not.toContain('RRF ');
+    });
+
+    it('suggests RRF immediately after a FORK command', async () => {
+      const { suggest } = await setup();
+      const suggestedCommands = (await suggest('FROM a | FORK (LIMIT 1) (LIMIT 2) | /')).map(
+        (s) => s.text
+      );
+      expect(suggestedCommands).toContain('RRF ');
+    });
+
+    it('does not suggests RRF if FORK is not immediately before', async () => {
+      const { suggest } = await setup();
+      const suggestedCommands = (
+        await suggest('FROM a | FORK (LIMIT 1) (LIMIT 2) | LIMIT 1 | /')
+      ).map((s) => s.text);
+      expect(suggestedCommands).not.toContain('RRF ');
+      expect(suggestedCommands).toContain('LIMIT ');
+    });
+
+    it('suggests pipe after complete command', async () => {
+      const { assertSuggestions } = await setup();
+      await assertSuggestions('FROM a | FORK (LIMIT 1) (LIMIT 2) | RRF /', ['| ']);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -118,8 +118,9 @@ export async function suggest(
 
   if (astContext.type === 'newCommand') {
     // propose main commands here
+    // resolve particular commands suggestions after
     // filter source commands if already defined
-    const suggestions = getCommandAutocompleteDefinitions(getAllCommands());
+    let suggestions = getCommandAutocompleteDefinitions(getAllCommands());
     if (!ast.length) {
       // Display the recommended queries if there are no commands (empty state)
       const recommendedQueriesSuggestions: SuggestionRawDefinition[] = [];
@@ -142,6 +143,12 @@ export async function suggest(
       }
       const sourceCommandsSuggestions = suggestions.filter(isSourceCommand);
       return [...sourceCommandsSuggestions, ...recommendedQueriesSuggestions];
+    }
+
+    // If the last command is not a FORK, RRF should not be suggested.
+    const lastCommand = root.commands[root.commands.length - 1];
+    if (lastCommand.name !== 'fork') {
+      suggestions = suggestions.filter((def) => def.label !== 'RRF');
     }
 
     return suggestions.filter((def) => !isSourceCommand(def));

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rrf/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rrf/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SuggestionRawDefinition } from '../../types';
+import { pipeCompleteItem } from '../../complete_items';
+
+export function suggest(): SuggestionRawDefinition[] {
+  return [pipeCompleteItem];
+}

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -48,6 +48,10 @@ import {
 } from '../autocomplete/commands/drop';
 import { suggest as suggestForEnrich } from '../autocomplete/commands/enrich';
 import { suggest as suggestForEval } from '../autocomplete/commands/eval';
+import {
+  suggest as suggestForFork,
+  fieldsSuggestionsAfter as fieldsSuggestionsAfterFork,
+} from '../autocomplete/commands/fork';
 import { suggest as suggestForFrom } from '../autocomplete/commands/from';
 import { suggest as suggestForTimeseries } from '../autocomplete/commands/timeseries';
 import {
@@ -65,6 +69,8 @@ import {
   fieldsSuggestionsAfter as fieldsSuggestionsAfterRename,
   suggest as suggestForRename,
 } from '../autocomplete/commands/rename';
+import { suggest as suggestForRrf } from '../autocomplete/commands/rrf';
+import { validate as validateRrf } from '../validation/commands/rrf';
 import { suggest as suggestForRow } from '../autocomplete/commands/row';
 import { suggest as suggestForShow } from '../autocomplete/commands/show';
 import { suggest as suggestForSort } from '../autocomplete/commands/sort';
@@ -73,9 +79,13 @@ import {
   suggest as suggestForStats,
 } from '../autocomplete/commands/stats';
 import { suggest as suggestForWhere } from '../autocomplete/commands/where';
-
+import {
+  suggest as suggestForChangePoint,
+  fieldsSuggestionsAfter as fieldsSuggestionsAfterChangePoint,
+} from '../autocomplete/commands/change_point';
 import { METADATA_FIELDS } from '../shared/constants';
 import { getMessageFromId } from '../validation/errors';
+import { isNumericType } from '../shared/esql_types';
 
 const statsValidator = (command: ESQLCommand) => {
   const messages: ESQLMessage[] = [];
@@ -578,5 +588,136 @@ export const commandDefinitions: Array<CommandDefinition<any>> = [
       // '… | <LEFT | RIGHT | LOOKUP> JOIN index AS alias ON index.field = index2.field, index.field2 = index2.field2',
     ],
     suggest: suggestForJoin,
+  },
+  {
+    name: 'change_point',
+    preview: true,
+    description: i18n.translate(
+      'kbn-esql-validation-autocomplete.esql.definitions.changePointDoc',
+      {
+        defaultMessage: 'Detect change point in the query results',
+      }
+    ),
+    declaration: `CHANGE_POINT <value> ON <field_name> AS <type>, <pvalue>`,
+    examples: [
+      '… | CHANGE_POINT value',
+      '… | CHANGE_POINT value ON timestamp',
+      '… | CHANGE_POINT value ON timestamp AS type, pvalue',
+    ],
+    validate: (command: ESQLCommand, references) => {
+      const messages: ESQLMessage[] = [];
+
+      // validate change point value column
+      const valueArg = command.args[0];
+      if (isColumnItem(valueArg)) {
+        const columnName = valueArg.name;
+        // look up for columns in userDefinedColumns and existing fields
+        let valueColumnType: string | undefined;
+        const userDefinedColumnRef = references.userDefinedColumns.get(columnName);
+        if (userDefinedColumnRef) {
+          valueColumnType = userDefinedColumnRef.find((v) => v.name === columnName)?.type;
+        } else {
+          const fieldRef = references.fields.get(columnName);
+          valueColumnType = fieldRef?.type;
+        }
+
+        if (valueColumnType && !isNumericType(valueColumnType)) {
+          messages.push({
+            location: command.location,
+            text: i18n.translate(
+              'kbn-esql-validation-autocomplete.esql.validation.changePointUnsupportedFieldType',
+              {
+                defaultMessage:
+                  'CHANGE_POINT only supports numeric types values, found [{columnName}] of type [{valueColumnType}]',
+                values: { columnName, valueColumnType },
+              }
+            ),
+            type: 'error',
+            code: 'changePointUnsupportedFieldType',
+          });
+        }
+      }
+
+      // validate ON column
+      const defaultOnColumnName = '@timestamp';
+      const onColumn = command.args.find((arg) => isOptionItem(arg) && arg.name === 'on');
+      const hasDefaultOnColumn = references.fields.has(defaultOnColumnName);
+      if (!onColumn && !hasDefaultOnColumn) {
+        messages.push({
+          location: command.location,
+          text: i18n.translate(
+            'kbn-esql-validation-autocomplete.esql.validation.changePointOnFieldMissing',
+            {
+              defaultMessage: '[CHANGE_POINT] Default {defaultOnColumnName} column is missing',
+              values: { defaultOnColumnName },
+            }
+          ),
+          type: 'error',
+          code: 'changePointOnFieldMissing',
+        });
+      }
+
+      // validate AS
+      const asArg = command.args.find((arg) => isOptionItem(arg) && arg.name === 'as');
+      if (asArg && isOptionItem(asArg)) {
+        // populate userDefinedColumns references to prevent the common check from failing with unknown column
+        asArg.args.forEach((arg, index) => {
+          if (isColumnItem(arg)) {
+            references.userDefinedColumns.set(arg.name, [
+              { name: arg.name, location: arg.location, type: index === 0 ? 'keyword' : 'long' },
+            ]);
+          }
+        });
+      }
+
+      return messages;
+    },
+    suggest: suggestForChangePoint,
+    fieldsSuggestionsAfter: fieldsSuggestionsAfterChangePoint,
+  },
+  {
+    hidden: true,
+    name: 'fork',
+    preview: true,
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.forkDoc', {
+      defaultMessage: 'Forks the stream.',
+    }),
+    declaration: `TODO`,
+    examples: [],
+    suggest: suggestForFork,
+    validate: (command) => {
+      const messages: ESQLMessage[] = [];
+
+      if (command.args.length < 2) {
+        messages.push({
+          location: command.location,
+          text: i18n.translate(
+            'kbn-esql-validation-autocomplete.esql.validation.forkTooFewBranches',
+            {
+              defaultMessage: '[FORK] Must include at least two branches.',
+            }
+          ),
+          type: 'error',
+          code: 'forkTooFewBranches',
+        });
+      }
+
+      return messages;
+    },
+
+    fieldsSuggestionsAfter: fieldsSuggestionsAfterFork,
+  },
+  {
+    hidden: true,
+    preview: true,
+    name: 'rrf',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.rrfDoc', {
+      defaultMessage:
+        'Combines multiple result sets with different scoring functions into a single result set.',
+    }),
+    declaration: `RRF`,
+    examples: ['… FORK (LIMIT 1) (LIMIT 2) | RRF'],
+    suggest: suggestForRrf,
+    validate: validateRrf,
   },
 ];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
@@ -6,13 +6,14 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import type {
+import {
   ESQLAstItem,
   ESQLCommand,
   ESQLFunction,
   ESQLMessage,
   ESQLSource,
   ESQLAstCommand,
+  ESQLAst,
 } from '@kbn/esql-ast';
 import { ESQLControlVariable } from '@kbn/esql-types';
 import { GetColumnsByTypeFn, SuggestionRawDefinition } from '../autocomplete/types';
@@ -415,7 +416,11 @@ export interface CommandDefinition<CommandName extends string> {
    * prevent the default behavior. If you need a full override, we are currently
    * doing those directly in the validateCommand function in the validation module.
    */
-  validate?: (command: ESQLCommand<CommandName>, references: ReferenceMaps) => ESQLMessage[];
+  validate?: (
+    command: ESQLCommand<CommandName>,
+    references: ReferenceMaps,
+    ast: ESQLAst
+  ) => ESQLMessage[];
 
   /**
    * This method is called to load suggestions when the cursor is within this command.

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.rrf.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.rrf.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as helpers from '../helpers';
+
+export const validationRrfCommandTestSuite = (setup: helpers.Setup) => {
+  describe('validation', () => {
+    describe('command', () => {
+      describe('RRF', () => {
+        test('no errors for valid command', async () => {
+          const { expectErrors } = await setup();
+
+          await expectErrors(
+            `FROM index METADATA _id, _score, _index
+                    | FORK
+                      (WHERE keywordField != "" | LIMIT 100)
+                      (SORT doubleField ASC NULLS LAST)
+                    | RRF`,
+            []
+          );
+        });
+
+        test('requires to be preceded by a FORK command', async () => {
+          const { expectErrors } = await setup();
+
+          await expectErrors(`FROM index METADATA _id, _score, _index | RRF`, [
+            '[RRF] Must be immediately preceded by a FORK command.',
+          ]);
+        });
+
+        test('requires to be immediately preceded by a FORK command', async () => {
+          const { expectErrors } = await setup();
+
+          await expectErrors(
+            `FROM index METADATA _id, _score, _index
+                    | FORK
+                      (WHERE keywordField != "" | LIMIT 100)
+                      (SORT doubleField ASC NULLS LAST)
+                    | SORT _id
+                    | RRF`,
+            ['[RRF] Must be immediately preceded by a FORK command.']
+          );
+        });
+
+        test('requires _id, _index and _score metadata to be selected in the FROM command', async () => {
+          const { expectErrors } = await setup();
+
+          await expectErrors(
+            `FROM index
+                    | FORK
+                      (WHERE keywordField != "" | LIMIT 100)
+                      (SORT doubleField ASC NULLS LAST)
+                    | RRF`,
+            [
+              '[RRF] The FROM command is missing the _id METADATA field.',
+              '[RRF] The FROM command is missing the _index METADATA field.',
+              '[RRF] The FROM command is missing the _score METADATA field.',
+            ]
+          );
+        });
+      });
+    });
+  });
+};

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.command.rrf.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.command.rrf.test.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as helpers from './helpers';
+import { validationRrfCommandTestSuite } from './test_suites/validation.command.rrf';
+
+validationRrfCommandTestSuite(helpers.setup);

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/commands/rrf/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/commands/rrf/index.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ESQLAst, ESQLCommand, ESQLMessage } from '@kbn/esql-ast';
+import { i18n } from '@kbn/i18n';
+import { ReferenceMaps } from '../../types';
+
+export function validate(
+  command: ESQLCommand<'rrf'>,
+  references: ReferenceMaps,
+  ast: ESQLAst
+): ESQLMessage[] {
+  const messages: ESQLMessage[] = [];
+
+  if (!isRrfImmediatelyAfterFork(ast)) {
+    messages.push({
+      location: command.location,
+      text: i18n.translate(
+        'kbn-esql-validation-autocomplete.esql.validation.rrfMissingScoreMetadata',
+        {
+          defaultMessage: '[RRF] Must be immediately preceded by a FORK command.',
+        }
+      ),
+      type: 'error',
+      code: 'rrfNotImmediatelyAfterFork',
+    });
+  }
+
+  if (!references.fields.get('_id')) {
+    messages.push(buildMissingMetadataMessage(command, '_id'));
+  }
+
+  if (!references.fields.get('_index')) {
+    messages.push(buildMissingMetadataMessage(command, '_index'));
+  }
+
+  if (!references.fields.get('_score')) {
+    messages.push(buildMissingMetadataMessage(command, '_score'));
+  }
+
+  return messages;
+}
+
+function buildMissingMetadataMessage(
+  command: ESQLCommand<'rrf'>,
+  metadataField: string
+): ESQLMessage {
+  return {
+    location: command.location,
+    text: i18n.translate('kbn-esql-validation-autocomplete.esql.validation.rrfMissingMetadata', {
+      defaultMessage: `[RRF] The FROM command is missing the {metadataField} METADATA field.`,
+      values: { metadataField },
+    }),
+    type: 'error',
+    code: `rrfMissingMetadata`,
+  };
+}
+
+function isRrfImmediatelyAfterFork(ast: ESQLAst): boolean {
+  const forkIndex = ast.findIndex((cmd) => cmd.name === 'fork');
+  const rrfIndex = ast.findIndex((cmd) => cmd.name === 'rrf');
+
+  return forkIndex !== -1 && rrfIndex === forkIndex + 1;
+}

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -216,7 +216,7 @@ function validateCommand(
   }
 
   if (commandDef.validate) {
-    messages.push(...commandDef.validate(command, references));
+    messages.push(...commandDef.validate(command, references, ast));
   }
 
   switch (commandDef.name) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES|QL] Add support for `RRF`  (#221349)](https://github.com/elastic/kibana/pull/221349)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastian Delle Donne","email":"sebastian.delledonne@elastic.co"},"sourceCommit":{"committedDate":"2025-05-30T08:21:20Z","message":"[ES|QL] Add support for `RRF`  (#221349)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/215092\n\n## Considerations\n### `RRF` may change in the future\n@ioanatia has stated that the command may change in the future as it's\nnot fully implemented yet.\n\n### Licence check\nWill be addressed at https://github.com/elastic/kibana/issues/216791\n\n\n\nhttps://github.com/user-attachments/assets/759470a2-4afa-4d20-adbf-cb3001895e95\n\n\n## New command support checklist\n### AST support\n- [x] Make sure that the new command is in the local Kibana grammar\ndefinition. The ANTLR lexer and parser files are updated every Monday\nfrom the source definition of the language at Elasticsearch (via a\nmanually merged, automatically generated\n[PR](https://github.com/elastic/kibana/pull/213006)).\n- [x] Create a factory for generating the new node. The new node should\nsatisfy the `ESQLCommand<Name>` interface. If the syntax of your command\ncannot be decomposed only in parameters, you can hold extra information\nby extending the `ESQLCommand` interface. I.E., check the Rerank\ncommand.\n- [x] While ANTLR is parsing the text query, we create our own AST by\nusing `onExit` listeners at\n`kbn-esql-ast/src/parser/esql_ast_builder_listener.ts`. Implement the\n`onExit<COMMAND_NAME>` method based on the interface autogenerated by\nANTLR and push the new node into the AST.\n- [x] Create unit tests checking that the correct AST nodes are\ngenerated when parsing your command.\n- [x] Add a dedicated [visitor\ncallback](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-ast/src/visitor/README.md)\nfor the new command.\n- [x] Verify that the `Walker` API can visit the new node.\n- [x] Verify that the `Synth` API can construct the new node.\n\n### Validating that the command works well when prettifying the query\n- [x] Validate that the prettifier works correctly.\n- [ ] Adjust the basic pretty printer and the wrapping pretty printer if\nneeded.\n- [x] Add unit tests validating that the queries are correctly formatted\n(even if no adjustment has been done).\n\n\n### Creating the command definition\n- [x] Add the definition of the new command at\n`kbn-esql-validation-autocomplete/src/definitions/commands.ts`.\n\n### Adding the corresponding client-side validations\n- [x] Add a custom validation if needed.\n- [x] Add tests checking the behavior of the validation following this\n[guide](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-validation-autocomplete/README.md#the-new-way).\n\n\n### Adding the autocomplete suggestions\n- [x] Add the suggestions to be shown when **positioned at** the new\ncommand.\n- [x] Create a new folder at\n`kbn-esql-validation-autocomplete/src/autocomplete/commands` for your\ncommand.\n- [x] Export a `suggest` function that should return an array of\nsuggestions and set it up into the command definition.\n- [ ] Optionally, we must filter or incorporate fields suggestions after\na command is executed, this is supported by adding the\n`fieldsSuggestionsAfter` method to the command definition. Read this\ndocumentation to understand how it works.\n- [x] If the new command must be suggested only in particular\nsituations, modify the corresponding suggestions to make it possible.\n- [x] Add tests following this\n[guide](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-validation-autocomplete/README.md#automated-testing).\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Drew Tate <drewctate@gmail.com>","sha":"0794030590e7489d0bda81b25beddd4713457d25","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[ES|QL] Add support for `RRF` ","number":221349,"url":"https://github.com/elastic/kibana/pull/221349","mergeCommit":{"message":"[ES|QL] Add support for `RRF`  (#221349)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/215092\n\n## Considerations\n### `RRF` may change in the future\n@ioanatia has stated that the command may change in the future as it's\nnot fully implemented yet.\n\n### Licence check\nWill be addressed at https://github.com/elastic/kibana/issues/216791\n\n\n\nhttps://github.com/user-attachments/assets/759470a2-4afa-4d20-adbf-cb3001895e95\n\n\n## New command support checklist\n### AST support\n- [x] Make sure that the new command is in the local Kibana grammar\ndefinition. The ANTLR lexer and parser files are updated every Monday\nfrom the source definition of the language at Elasticsearch (via a\nmanually merged, automatically generated\n[PR](https://github.com/elastic/kibana/pull/213006)).\n- [x] Create a factory for generating the new node. The new node should\nsatisfy the `ESQLCommand<Name>` interface. If the syntax of your command\ncannot be decomposed only in parameters, you can hold extra information\nby extending the `ESQLCommand` interface. I.E., check the Rerank\ncommand.\n- [x] While ANTLR is parsing the text query, we create our own AST by\nusing `onExit` listeners at\n`kbn-esql-ast/src/parser/esql_ast_builder_listener.ts`. Implement the\n`onExit<COMMAND_NAME>` method based on the interface autogenerated by\nANTLR and push the new node into the AST.\n- [x] Create unit tests checking that the correct AST nodes are\ngenerated when parsing your command.\n- [x] Add a dedicated [visitor\ncallback](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-ast/src/visitor/README.md)\nfor the new command.\n- [x] Verify that the `Walker` API can visit the new node.\n- [x] Verify that the `Synth` API can construct the new node.\n\n### Validating that the command works well when prettifying the query\n- [x] Validate that the prettifier works correctly.\n- [ ] Adjust the basic pretty printer and the wrapping pretty printer if\nneeded.\n- [x] Add unit tests validating that the queries are correctly formatted\n(even if no adjustment has been done).\n\n\n### Creating the command definition\n- [x] Add the definition of the new command at\n`kbn-esql-validation-autocomplete/src/definitions/commands.ts`.\n\n### Adding the corresponding client-side validations\n- [x] Add a custom validation if needed.\n- [x] Add tests checking the behavior of the validation following this\n[guide](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-validation-autocomplete/README.md#the-new-way).\n\n\n### Adding the autocomplete suggestions\n- [x] Add the suggestions to be shown when **positioned at** the new\ncommand.\n- [x] Create a new folder at\n`kbn-esql-validation-autocomplete/src/autocomplete/commands` for your\ncommand.\n- [x] Export a `suggest` function that should return an array of\nsuggestions and set it up into the command definition.\n- [ ] Optionally, we must filter or incorporate fields suggestions after\na command is executed, this is supported by adding the\n`fieldsSuggestionsAfter` method to the command definition. Read this\ndocumentation to understand how it works.\n- [x] If the new command must be suggested only in particular\nsituations, modify the corresponding suggestions to make it possible.\n- [x] Add tests following this\n[guide](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-validation-autocomplete/README.md#automated-testing).\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Drew Tate <drewctate@gmail.com>","sha":"0794030590e7489d0bda81b25beddd4713457d25"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221349","number":221349,"mergeCommit":{"message":"[ES|QL] Add support for `RRF`  (#221349)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/215092\n\n## Considerations\n### `RRF` may change in the future\n@ioanatia has stated that the command may change in the future as it's\nnot fully implemented yet.\n\n### Licence check\nWill be addressed at https://github.com/elastic/kibana/issues/216791\n\n\n\nhttps://github.com/user-attachments/assets/759470a2-4afa-4d20-adbf-cb3001895e95\n\n\n## New command support checklist\n### AST support\n- [x] Make sure that the new command is in the local Kibana grammar\ndefinition. The ANTLR lexer and parser files are updated every Monday\nfrom the source definition of the language at Elasticsearch (via a\nmanually merged, automatically generated\n[PR](https://github.com/elastic/kibana/pull/213006)).\n- [x] Create a factory for generating the new node. The new node should\nsatisfy the `ESQLCommand<Name>` interface. If the syntax of your command\ncannot be decomposed only in parameters, you can hold extra information\nby extending the `ESQLCommand` interface. I.E., check the Rerank\ncommand.\n- [x] While ANTLR is parsing the text query, we create our own AST by\nusing `onExit` listeners at\n`kbn-esql-ast/src/parser/esql_ast_builder_listener.ts`. Implement the\n`onExit<COMMAND_NAME>` method based on the interface autogenerated by\nANTLR and push the new node into the AST.\n- [x] Create unit tests checking that the correct AST nodes are\ngenerated when parsing your command.\n- [x] Add a dedicated [visitor\ncallback](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-ast/src/visitor/README.md)\nfor the new command.\n- [x] Verify that the `Walker` API can visit the new node.\n- [x] Verify that the `Synth` API can construct the new node.\n\n### Validating that the command works well when prettifying the query\n- [x] Validate that the prettifier works correctly.\n- [ ] Adjust the basic pretty printer and the wrapping pretty printer if\nneeded.\n- [x] Add unit tests validating that the queries are correctly formatted\n(even if no adjustment has been done).\n\n\n### Creating the command definition\n- [x] Add the definition of the new command at\n`kbn-esql-validation-autocomplete/src/definitions/commands.ts`.\n\n### Adding the corresponding client-side validations\n- [x] Add a custom validation if needed.\n- [x] Add tests checking the behavior of the validation following this\n[guide](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-validation-autocomplete/README.md#the-new-way).\n\n\n### Adding the autocomplete suggestions\n- [x] Add the suggestions to be shown when **positioned at** the new\ncommand.\n- [x] Create a new folder at\n`kbn-esql-validation-autocomplete/src/autocomplete/commands` for your\ncommand.\n- [x] Export a `suggest` function that should return an array of\nsuggestions and set it up into the command definition.\n- [ ] Optionally, we must filter or incorporate fields suggestions after\na command is executed, this is supported by adding the\n`fieldsSuggestionsAfter` method to the command definition. Read this\ndocumentation to understand how it works.\n- [x] If the new command must be suggested only in particular\nsituations, modify the corresponding suggestions to make it possible.\n- [x] Add tests following this\n[guide](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-validation-autocomplete/README.md#automated-testing).\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Drew Tate <drewctate@gmail.com>","sha":"0794030590e7489d0bda81b25beddd4713457d25"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->