### PR TITLE
[8.19] [LensEmbeddable] Add "Open in lens" in the same tab (#217528)

### DIFF
--- a/src/platform/plugins/shared/ui_actions/public/actions/action.ts
+++ b/src/platform/plugins/shared/ui_actions/public/actions/action.ts
@@ -20,6 +20,10 @@ export interface ActionExecutionMeta {
    * Trigger that executed the action
    */
   trigger: Trigger;
+  /**
+   * The event that caused the action to execute (e.g., mouse click, keyboard event)
+   */
+  event?: React.MouseEvent;
 }
 
 /**

--- a/src/platform/plugins/shared/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
+++ b/src/platform/plugins/shared/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
@@ -9,7 +9,7 @@
 
 import { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { buildContextMenuForActions } from './build_eui_context_menu_panels';
-import { Action, createAction } from '../actions';
+import { Action, ActionExecutionContext, createAction } from '../actions';
 import { PresentableGrouping } from '@kbn/ui-actions-browser';
 
 const createTestAction = ({
@@ -18,19 +18,21 @@ const createTestAction = ({
   order,
   grouping = undefined,
   disabled,
+  execute = async () => {},
 }: {
   type?: string;
   displayName: string;
   order?: number;
   grouping?: PresentableGrouping;
   disabled?: boolean;
+  execute?: (context: ActionExecutionContext<object>) => Promise<void>;
 }) =>
   createAction({
     id: type as string,
     type,
     getDisplayName: () => displayName,
     order,
-    execute: async () => {},
+    execute,
     grouping,
     disabled,
   });
@@ -495,4 +497,65 @@ test('it creates disabled actions', async () => {
       },
     ]
   `);
+});
+
+test('it calls execute with the right context when the target is a link', async () => {
+  const mockExecute = jest.fn();
+  const mockMouseEvent = new MouseEvent('click') as unknown as React.MouseEvent;
+  // We need to make sure that the current target is a HTMLAnchorElement
+  Object.defineProperty(mockMouseEvent, 'currentTarget', {
+    value: document.createElement('a'),
+  });
+
+  const actions = [
+    createTestAction({
+      order: 1,
+      displayName: 'Foo',
+      execute: mockExecute,
+    }),
+  ];
+
+  const menu = await buildContextMenuForActions({
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
+  });
+
+  // Simulate clicking the first menu item
+  const firstMenuItem = menu[0].items![0];
+  if (firstMenuItem.onClick) {
+    firstMenuItem.onClick(mockMouseEvent as any);
+  }
+
+  expect(mockExecute).toHaveBeenCalledTimes(1);
+  expect(mockExecute).toHaveBeenCalledWith({
+    trigger: { id: 'TEST' },
+  });
+});
+
+test('it calls execute with the right context when the target is not a link', async () => {
+  const mockExecute = jest.fn();
+  const mockMouseEvent = new MouseEvent('click') as unknown as React.MouseEvent;
+
+  const actions = [
+    createTestAction({
+      order: 1,
+      displayName: 'Foo',
+      execute: mockExecute,
+    }),
+  ];
+
+  const menu = await buildContextMenuForActions({
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
+  });
+
+  // Simulate clicking the first menu item
+  const firstMenuItem = menu[0].items![0];
+  if (firstMenuItem.onClick) {
+    firstMenuItem.onClick(mockMouseEvent as any);
+  }
+
+  expect(mockExecute).toHaveBeenCalledTimes(1);
+  expect(mockExecute).toHaveBeenCalledWith({
+    trigger: { id: 'TEST' },
+    event: mockMouseEvent,
+  });
 });

--- a/src/platform/plugins/shared/ui_actions/public/context_menu/build_eui_context_menu_panels.tsx
+++ b/src/platform/plugins/shared/ui_actions/public/context_menu/build_eui_context_menu_panels.tsx
@@ -57,7 +57,7 @@ const onClick =
         event.preventDefault();
         action.execute(context);
       }
-    } else action.execute(context);
+    } else action.execute({ ...context, event });
     close();
   };
 

--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_lens_attributes.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_lens_attributes.ts
@@ -15,7 +15,13 @@ import {
   type LensConfig,
   LensConfigBuilder,
 } from '@kbn/lens-embeddable-utils/config_builder';
+
 import { useKibanaContextForPlugin } from './use_kibana';
+
+const isAppleDevice =
+  typeof window !== 'undefined' && /Mac|iPhone|iPad/.test(window.navigator.userAgent);
+const isMetaKey = ({ metaKey, ctrlKey }: { metaKey: boolean; ctrlKey: boolean }) =>
+  isAppleDevice ? metaKey : ctrlKey;
 
 export type UseLensAttributesParams = LensConfig;
 
@@ -72,7 +78,7 @@ export const useLensAttributes = (params: UseLensAttributesParams) => {
         query: Query | AggregateQuery;
         lastReloadRequestTime?: number;
       }) =>
-      () => {
+      (openInNewTab: boolean) => {
         const injectedAttributes = injectFilters({ filters, query });
         if (injectedAttributes) {
           navigateToPrefilledEditor(
@@ -83,7 +89,7 @@ export const useLensAttributes = (params: UseLensAttributesParams) => {
               lastReloadRequestTime,
             },
             {
-              openInNewTab: true,
+              openInNewTab,
             }
           );
         }
@@ -127,7 +133,7 @@ export const useLensAttributes = (params: UseLensAttributesParams) => {
   };
 };
 
-const getOpenInLensAction = (onExecute: () => void): Action => {
+const getOpenInLensAction = (onExecute: (openInNewTab: boolean) => void): Action => {
   return {
     id: 'openInLens',
     getDisplayName(_context: ActionExecutionContext): string {
@@ -142,8 +148,11 @@ const getOpenInLensAction = (onExecute: () => void): Action => {
     async isCompatible(_context: ActionExecutionContext): Promise<boolean> {
       return true;
     },
-    async execute(_context: ActionExecutionContext): Promise<void> {
-      onExecute();
+    async execute({ event }: ActionExecutionContext): Promise<void> {
+      const openInNewTab = event
+        ? isMetaKey({ metaKey: event.metaKey, ctrlKey: event.ctrlKey })
+        : false;
+      onExecute(openInNewTab);
     },
     order: 100,
   };

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -31,7 +31,7 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await datePickerInput.type(time);
 
       // dismiss the tooltip, which won't be hidden because blur doesn't happen reliably
-      await testSubjects.click('waffleDatePickerIntervalTooltip');
+      await this.dismissDatePickerTooltip();
 
       await this.waitForLoading();
     },

--- a/x-pack/test/functional/page_objects/infra_hosts_view.ts
+++ b/x-pack/test/functional/page_objects/infra_hosts_view.ts
@@ -133,9 +133,12 @@ export function InfraHostsViewProvider({ getService }: FtrProviderContext) {
     async clickAndValidateMetricChartActionOptions() {
       const element = await testSubjects.find('hostsView-metricChart-tx');
       await element.moveMouseTo();
+
       const button = await element.findByTestSubject('embeddablePanelToggleMenuIcon');
       await button.click();
-      await testSubjects.existOrFail('embeddablePanelAction-openInLens');
+      const menuElement = await testSubjects.find('presentationPanelContextMenuItems');
+      await menuElement.moveMouseTo();
+      return testSubjects.existOrFail('embeddablePanelAction-openInLens');
     },
 
     // KPIs


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[LensEmbeddable] Add "Open in lens" in the same tab (#217528)](https://github.com/elastic/kibana/pull/217528)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maria Iriarte","email":"106958839+mariairiartef@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-26T16:25:56Z","message":"[LensEmbeddable] Add \"Open in lens\" in the same tab (#217528)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/204155\n\nAdds support for the following behaviors:\n\n1. Clicking \"Open in Lens\" opens the Lens editor in the same tab.\n2. Using Command (or Ctrl if is not an apple device) + Click opens the\nLens editor in a new tab.\n\n> [!NOTE]\n> This is a temporary workaround until a more comprehensive solution,\nwhich requires additional effort, is implemented.\n\n### Details\n\nThe goal is that by clicking on the \"Open in Lens\" button, the Lens\neditor is opened in the current tab, and by Command + Clicking, the Lens\neditor is opened in a separate tab. Currently, the approach uses the\n`navigateToPrefilledEditor` method, exposed by the Lens plugin, which is\ncalled upon execution of the action.\n\nInitially, the idea was to use the shortUrl service to generate a share\nURL. This service generates an Elasticsearch object, which can be\nexcessive since the requirement doesn’t imply generating a URL that can\nbe shared.\n\nWith the current approach, the data is persisted because it is in the\nsession storage. That is why when we click on the button and it opens in\na new tab, you can see the data. However, if you copy the same URL to\nanother tab, nothing appears because there’s no data.\n\nIf we want to add an href by specifying the `getHref` method to the\naction (as suggested\n[here](https://github.com/elastic/kibana/issues/204155#issuecomment-2578218129),\nit won’t work as you cannot persist the data when you click on a link.\n\nTo maintain the requested behavior, we update the openInNewTab parameter\nthat is passed to the Lens `navigateToPrefilledEditor` method to be true\nwhen it is a modified event or false when it is not.\n\n## Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ca1d622ed0501b937490d56e16a7cf33c61cab09","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Visualizations","Feature:Lens","backport:version","v9.1.0","v8.19.0"],"title":"[LensEmbeddable] Add \"Open in lens\" in the same tab","number":217528,"url":"https://github.com/elastic/kibana/pull/217528","mergeCommit":{"message":"[LensEmbeddable] Add \"Open in lens\" in the same tab (#217528)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/204155\n\nAdds support for the following behaviors:\n\n1. Clicking \"Open in Lens\" opens the Lens editor in the same tab.\n2. Using Command (or Ctrl if is not an apple device) + Click opens the\nLens editor in a new tab.\n\n> [!NOTE]\n> This is a temporary workaround until a more comprehensive solution,\nwhich requires additional effort, is implemented.\n\n### Details\n\nThe goal is that by clicking on the \"Open in Lens\" button, the Lens\neditor is opened in the current tab, and by Command + Clicking, the Lens\neditor is opened in a separate tab. Currently, the approach uses the\n`navigateToPrefilledEditor` method, exposed by the Lens plugin, which is\ncalled upon execution of the action.\n\nInitially, the idea was to use the shortUrl service to generate a share\nURL. This service generates an Elasticsearch object, which can be\nexcessive since the requirement doesn’t imply generating a URL that can\nbe shared.\n\nWith the current approach, the data is persisted because it is in the\nsession storage. That is why when we click on the button and it opens in\na new tab, you can see the data. However, if you copy the same URL to\nanother tab, nothing appears because there’s no data.\n\nIf we want to add an href by specifying the `getHref` method to the\naction (as suggested\n[here](https://github.com/elastic/kibana/issues/204155#issuecomment-2578218129),\nit won’t work as you cannot persist the data when you click on a link.\n\nTo maintain the requested behavior, we update the openInNewTab parameter\nthat is passed to the Lens `navigateToPrefilledEditor` method to be true\nwhen it is a modified event or false when it is not.\n\n## Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ca1d622ed0501b937490d56e16a7cf33c61cab09"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217528","number":217528,"mergeCommit":{"message":"[LensEmbeddable] Add \"Open in lens\" in the same tab (#217528)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/204155\n\nAdds support for the following behaviors:\n\n1. Clicking \"Open in Lens\" opens the Lens editor in the same tab.\n2. Using Command (or Ctrl if is not an apple device) + Click opens the\nLens editor in a new tab.\n\n> [!NOTE]\n> This is a temporary workaround until a more comprehensive solution,\nwhich requires additional effort, is implemented.\n\n### Details\n\nThe goal is that by clicking on the \"Open in Lens\" button, the Lens\neditor is opened in the current tab, and by Command + Clicking, the Lens\neditor is opened in a separate tab. Currently, the approach uses the\n`navigateToPrefilledEditor` method, exposed by the Lens plugin, which is\ncalled upon execution of the action.\n\nInitially, the idea was to use the shortUrl service to generate a share\nURL. This service generates an Elasticsearch object, which can be\nexcessive since the requirement doesn’t imply generating a URL that can\nbe shared.\n\nWith the current approach, the data is persisted because it is in the\nsession storage. That is why when we click on the button and it opens in\na new tab, you can see the data. However, if you copy the same URL to\nanother tab, nothing appears because there’s no data.\n\nIf we want to add an href by specifying the `getHref` method to the\naction (as suggested\n[here](https://github.com/elastic/kibana/issues/204155#issuecomment-2578218129),\nit won’t work as you cannot persist the data when you click on a link.\n\nTo maintain the requested behavior, we update the openInNewTab parameter\nthat is passed to the Lens `navigateToPrefilledEditor` method to be true\nwhen it is a modified event or false when it is not.\n\n## Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ca1d622ed0501b937490d56e16a7cf33c61cab09"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->