### PR TITLE
[Synthetics] Skipping synthetics alerting tests on cloud

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/custom_status_rule.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/custom_status_rule.ts
@@ -30,7 +30,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let adminRoleAuthc: RoleCredentials;
   const samlAuth = getService('samlAuth');
 
-  describe('SyntheticsCustomStatusRule', () => {
+  describe('SyntheticsCustomStatusRule', function () {
+    // Test failing on MKI and ECH
+    this.tags(['skipCloud']);
+
     const SYNTHETICS_RULE_ALERT_INDEX = '.alerts-observability.uptime.alerts-default';
 
     before(async () => {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/synthetics_default_rule.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/synthetics_default_rule.ts
@@ -26,7 +26,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     'my-slack1',
   ];
 
-  describe('SyntheticsDefaultRules', () => {
+  describe('SyntheticsDefaultRules', function () {
+    // Test failing on MKI and ECH
+    this.tags(['skipCloud']);
+
     before(async () => {
       supertestEditorWithApiKey = await roleScopedSupertest.getSupertestWithRoleScope('editor', {
         withInternalHeaders: true,


### PR DESCRIPTION
null

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->