### PR TITLE
[Synthetics] Remove run soon for sync private location task !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -116,7 +116,7 @@ export class Plugin implements PluginType {
       this.server.isElasticsearchServerless = coreStart.elasticsearch.getCapabilities().serverless;
     }
     this.syncPrivateLocationMonitorsTask?.start().catch((e) => {
-      this.logger.error('Failed to start sync private location monitors task',  { error: e });
+      this.logger.error('Failed to start sync private location monitors task', { error: e });
     });
 
     this.syntheticsService?.start(pluginsStart.taskManager);

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -115,8 +115,8 @@ export class Plugin implements PluginType {
       this.server.spaces = pluginsStart.spaces;
       this.server.isElasticsearchServerless = coreStart.elasticsearch.getCapabilities().serverless;
     }
-    this.syncPrivateLocationMonitorsTask?.start().catch(() => {
-      this.logger.error('Failed to start sync private location monitors task');
+    this.syncPrivateLocationMonitorsTask?.start().catch((e) => {
+      this.logger.error('Failed to start sync private location monitors task', , { error: e });
     });
 
     this.syntheticsService?.start(pluginsStart.taskManager);

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -116,7 +116,7 @@ export class Plugin implements PluginType {
       this.server.isElasticsearchServerless = coreStart.elasticsearch.getCapabilities().serverless;
     }
     this.syncPrivateLocationMonitorsTask?.start().catch((e) => {
-      this.logger.error('Failed to start sync private location monitors task', , { error: e });
+      this.logger.error('Failed to start sync private location monitors task',  { error: e });
     });
 
     this.syntheticsService?.start(pluginsStart.taskManager);

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -139,7 +139,6 @@ export class SyncPrivateLocationMonitorsTask {
       taskType: TASK_TYPE,
       params: {},
     });
-    await taskManager.runSoon(TASK_ID);
     logger.debug(`Sync private location monitors task scheduled successfully`);
   };
 


### PR DESCRIPTION
## Summary

Remove run soon for sync private location task !!

It's not needed since it's a scheduled task running every 10 minutes .


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->