### PR TITLE
[ES|QL] [Lens] Renders the datagrid only when accordion is open

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/esql_data_grid_accordion.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/esql_data_grid_accordion.tsx
@@ -86,19 +86,21 @@ export const ESQLDataGridAccordion = ({
           </EuiNotificationBadge>
         }
       >
-        <>
-          <ESQLDataGrid
-            rows={dataGridAttrs?.rows}
-            columns={dataGridAttrs?.columns}
-            dataView={dataGridAttrs?.dataView}
-            query={query}
-            flyoutType="overlay"
-            isTableView={isTableView}
-            initialRowHeight={0}
-            controlColumnIds={['openDetails']}
-          />
-          <EuiSpacer />
-        </>
+        {isAccordionOpen && (
+          <>
+            <ESQLDataGrid
+              rows={dataGridAttrs?.rows}
+              columns={dataGridAttrs?.columns}
+              dataView={dataGridAttrs?.dataView}
+              query={query}
+              flyoutType="overlay"
+              isTableView={isTableView}
+              initialRowHeight={0}
+              controlColumnIds={['openDetails']}
+            />
+            <EuiSpacer />
+          </>
+        )}
       </EuiAccordion>
     </EuiFlexItem>
   );


### PR DESCRIPTION
## Summary

From some investigations I had in a customer instance I realized that the datagrid can be expensive for long running queries. It doesnt need to render unless someone opens the accordion so I feel that this is a good optimization







<!--ONMERGE {"backportTargets":["8.18","8.19"]} ONMERGE-->