### PR TITLE
[8.19] [Dataview] Fix flaky Dataviews field edit tests by using a single document  (#221088)

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/data_views/_edit_field.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/data_views/_edit_field.ts
@@ -5,26 +5,32 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const kibanaServer = getService('kibanaServer');
-  const retry = getService('retry');
   const PageObjects = getPageObjects(['settings', 'common']);
   const testSubjects = getService('testSubjects');
 
   describe('edit field', function () {
-    before(async function () {
-      await kibanaServer.importExport.load(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
+    before(async () => {
+      const es = getService('es');
+      await es.index({
+        index: 'data-view-edit-field',
+        id: '1',
+        document: {
+          extension: 'css',
+        },
+        refresh: true,
+      });
     });
 
-    after(async function afterAll() {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
+    after(async function () {
+      // Delete the index after tests
+      const es = getService('es');
+      await es.indices.delete({
+        index: 'data-view-edit-field',
+        ignore_unavailable: true,
+      });
     });
 
     describe('field preview', function fieldPreview() {
@@ -32,27 +38,30 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         // TODO: Navigation to Data View Management is different in Serverless
         await PageObjects.common.navigateToApp('management');
         await testSubjects.click('app-card-dataViews');
-        await PageObjects.settings.clickIndexPatternLogstash();
+        await PageObjects.settings.createIndexPattern('data-view-edit-field', null);
+      });
+      after(async function () {
+        // Delete the data view (index pattern) after the test
+        await PageObjects.common.navigateToApp('management');
+        await testSubjects.click('app-card-dataViews');
+        await PageObjects.settings.clickIndexPatternByName('data-view-edit-field');
+        await PageObjects.settings.removeIndexPattern();
       });
 
       it('should show preview for fields in _source', async function () {
-        await PageObjects.settings.filterField('extension');
-        await testSubjects.click('editFieldFormat');
-        await retry.tryForTime(5000, async () => {
-          const previewText = await testSubjects.getVisibleText('fieldPreviewItem > value');
-          expect(previewText).to.be('css');
+        await PageObjects.settings.changeAndValidateFieldFormat({
+          name: 'extension',
+          fieldType: 'text',
+          expectedPreviewText: 'css',
         });
-        await PageObjects.settings.closeIndexPatternFieldEditor();
       });
 
       it('should show preview for fields not in _source', async function () {
-        await PageObjects.settings.filterField('extension.raw');
-        await testSubjects.click('editFieldFormat');
-        await retry.tryForTime(5000, async () => {
-          const previewText = await testSubjects.getVisibleText('fieldPreviewItem > value');
-          expect(previewText).to.be('css');
+        await PageObjects.settings.changeAndValidateFieldFormat({
+          name: 'extension.keyword',
+          fieldType: 'keyword',
+          expectedPreviewText: 'css',
         });
-        await PageObjects.settings.closeIndexPatternFieldEditor();
       });
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Dataview] Fix flaky Dataviews field edit tests by using a single document  (#221088)](https://github.com/elastic/kibana/pull/221088)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Matthias Wilhelm","email":"matthias.wilhelm@elastic.co"},"sourceCommit":{"committedDate":"2025-05-26T13:30:29Z","message":"[Dataview] Fix flaky Dataviews field edit tests by using a single document  (#221088)\n\nUpdates functional tests to ingest only one document, avoiding flaky failures caused by inconsistent ordering. With only one document, ordering issues are no longer possible.","sha":"e13aa51e6e5c9dcf6c0142c961c9b75eb9b03cfa","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Data Views","release_note:skip","backport missing","Team:DataDiscovery","backport:prev-major","v9.1.0"],"title":"[Dataview] Fix flakiness in functional testing field edits ","number":221088,"url":"https://github.com/elastic/kibana/pull/221088","mergeCommit":{"message":"[Dataview] Fix flaky Dataviews field edit tests by using a single document  (#221088)\n\nUpdates functional tests to ingest only one document, avoiding flaky failures caused by inconsistent ordering. With only one document, ordering issues are no longer possible.","sha":"e13aa51e6e5c9dcf6c0142c961c9b75eb9b03cfa"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221088","number":221088,"mergeCommit":{"message":"[Dataview] Fix flaky Dataviews field edit tests by using a single document  (#221088)\n\nUpdates functional tests to ingest only one document, avoiding flaky failures caused by inconsistent ordering. With only one document, ordering issues are no longer possible.","sha":"e13aa51e6e5c9dcf6c0142c961c9b75eb9b03cfa"}}]}] BACKPORT-->