### PR TITLE
[8.19] [Synthetics] Skipping synthetics alerting tests on cloud (#222058)

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/custom_status_rule.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/custom_status_rule.ts
@@ -31,7 +31,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const samlAuth = getService('samlAuth');
 
   // Failing: See https://github.com/elastic/kibana/issues/202337
-  describe.skip('SyntheticsCustomStatusRule', () => {
+  describe.skip('SyntheticsCustomStatusRule', function () {
+    // Test failing on MKI and ECH
+    this.tags(['skipCloud']);
+
     const SYNTHETICS_RULE_ALERT_INDEX = '.alerts-observability.uptime.alerts-default';
 
     before(async () => {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/synthetics_default_rule.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/synthetics_default_rule.ts
@@ -26,7 +26,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     'my-slack1',
   ];
 
-  describe('SyntheticsDefaultRules', () => {
+  describe('SyntheticsDefaultRules', function () {
+    // Test failing on MKI and ECH
+    this.tags(['skipCloud']);
+
     before(async () => {
       supertestEditorWithApiKey = await roleScopedSupertest.getSupertestWithRoleScope('editor', {
         withInternalHeaders: true,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Skipping synthetics alerting tests on cloud (#222058)](https://github.com/elastic/kibana/pull/222058)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-05-30T15:50:23Z","message":"[Synthetics] Skipping synthetics alerting tests on cloud (#222058)","sha":"c03bcbcaa27d61f139655748845f3b1acac14906","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0","author:obs-ux-management"],"title":"[Synthetics] Skipping synthetics alerting tests on cloud","number":222058,"url":"https://github.com/elastic/kibana/pull/222058","mergeCommit":{"message":"[Synthetics] Skipping synthetics alerting tests on cloud (#222058)","sha":"c03bcbcaa27d61f139655748845f3b1acac14906"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222058","number":222058,"mergeCommit":{"message":"[Synthetics] Skipping synthetics alerting tests on cloud (#222058)","sha":"c03bcbcaa27d61f139655748845f3b1acac14906"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->