### PR TITLE
[Docs][8.18.x] Add known issue about maintenance windows

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -182,7 +182,7 @@ Review the following information about the {kib} 8.18.0 release.
 [%collapsible]
 ====
 *Details* +
-Errors occur when rules execute during an active maintenance window that has filters and matching rule category. 
+Errors occur when rules execute during an active maintenance window that has filters and a matching rule category. 
 
 *Workaround* +
 Remove any filters added to the active maintenance window.

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -182,7 +182,7 @@ Review the following information about the {kib} 8.18.0 release.
 [%collapsible]
 ====
 *Details* +
-Errors occur when rules execute during an active maintenance window that has filters and a matching rule category. 
+Errors occur when rules run during an active maintenance window that has filters and a matching rule category. 
 
 *Workaround* +
 Remove any filters added to the active maintenance window.

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -178,7 +178,7 @@ Review the following information about the {kib} 8.18.0 release.
 === Known issues
 
 // tag::known-issue-320[]
-.Errors in rule executions occur when maintenance windows have filters
+.Errors in rule executions occur when maintenance windows have filters.
 [%collapsible]
 ====
 *Details* +

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -178,7 +178,7 @@ Review the following information about the {kib} 8.18.0 release.
 === Known issues
 
 // tag::known-issue-320[]
-.Observability AI assistant gets stuck in a loop when attempting to call the `execute_connector` function.
+.Errors in rule executions occur when maintenance windows have filters
 [%collapsible]
 ====
 *Details* +

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -134,6 +134,7 @@ The 8.18.1 release includes the following known issues, enhancements and fixes.
 [[known-issues-8.18.1]]
 === Known issues
 
+include::CHANGELOG.asciidoc[tag=known-issue-320]
 include::CHANGELOG.asciidoc[tag=known-issue-220339]
 include::CHANGELOG.asciidoc[tag=known-issue-1508]
 
@@ -175,6 +176,19 @@ Review the following information about the {kib} 8.18.0 release.
 [float]
 [[known-issues-8.18.0]]
 === Known issues
+
+// tag::known-issue-320[]
+.Observability AI assistant gets stuck in a loop when attempting to call the `execute_connector` function.
+[%collapsible]
+====
+*Details* +
+Errors occur when rules execute during an active maintenance window that has filters and matching rule category. 
+
+*Workaround* +
+Remove any filters added to the active maintenance window.
+
+====
+// end::known-issue-320[]
 
 // tag::known-issue-1508[]
 .Observability AI assistant gets stuck in a loop when attempting to call the `execute_connector` function.


### PR DESCRIPTION
## Summary

Contributes to https://github.com/elastic/response-ops-team/issues/320 by updating the Kibana 8.18.0 and 8.18.1 release notes to include a known issue about maintenance windows.

**Corresponding PRs**
- Kibana 9.x known issues: https://github.com/elastic/kibana/pull/222097

## Preview
- [8.18.0 known issues](https://kibana_bk_222096.docs-preview.app.elstc.co/guide/en/kibana/8.x/release-notes-8.18.0.html#known-issues-8.18.0)
- [8.18.1 known issues](https://kibana_bk_222096.docs-preview.app.elstc.co/guide/en/kibana/8.x/release-notes-8.18.1.html)



