### PR TITLE
[Observability Alerting] Refetch alert detail rule data on edit flyout submit

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -127,6 +127,10 @@ export function AlertDetails() {
     await Promise.all([refetchRelatedDashboards(), refetch()]);
   }, [refetch, refetchRelatedDashboards]);
 
+  // used to trigger refetch when rule edit flyout closes
+  const onUpdate = useCallback(() => {
+    refetch();
+  }, [refetch]);
   const [alertStatus, setAlertStatus] = useState<AlertStatus>();
   const { euiTheme } = useEuiTheme();
   const [sources, setSources] = useState<AlertDetailsSource[]>();
@@ -399,6 +403,7 @@ export function AlertDetails() {
               alertIndex={alertDetail?.raw._index}
               alertStatus={alertStatus}
               onUntrackAlert={onUntrackAlert}
+              onUpdate={onUpdate}
             />
           </CasesContext>,
         ],

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
@@ -39,6 +39,7 @@ export interface HeaderActionsProps {
   alertIndex?: string;
   alertStatus?: AlertStatus;
   onUntrackAlert: () => void;
+  onUpdate?: () => void;
 }
 
 export function HeaderActions({
@@ -46,6 +47,7 @@ export function HeaderActions({
   alertIndex,
   alertStatus,
   onUntrackAlert,
+  onUpdate,
 }: HeaderActionsProps) {
   const { services } = useKibana();
   const {
@@ -232,6 +234,7 @@ export function HeaderActions({
           }}
           onSubmit={() => {
             setRuleConditionsFlyoutOpen(false);
+            onUpdate?.();
             refetch();
           }}
         />


### PR DESCRIPTION
## Summary

Resolves #221428.

We noticed recently when we added the Investigation Guide that, if the user edits the values in the guide using the edit flyout, the data on the main page will not refresh when they submit.

This patch would add an `onUpdate` handler prop to the Header Actions component that would enable it to trigger the refresh on the parent component when the user submits the form in the edit flyout.

Example:

![20250530164523](https://github.com/user-attachments/assets/bd796824-e0d6-464d-b10e-89537d9b590e)


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->