### PR TITLE
[Security Solution] Fix data view picker privilege

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
@@ -62,6 +62,11 @@ jest.mock('@kbn/unified-search-plugin/public', () => ({
           {'Add Field'}
         </button>
       )}
+      {props.onEditDataView && (
+        <button type="button" onClick={() => props.onEditDataView()} data-test-subj="editDataView">
+          {'Edit Data View'}
+        </button>
+      )}
       <div data-test-subj="currentDataViewId">{props.currentDataViewId}</div>
       <div data-test-subj="trigger">{props.trigger.label}</div>
     </div>
@@ -89,7 +94,10 @@ describe('DataViewPicker', () => {
     jest.mocked(useKibana).mockReturnValue({
       services: {
         dataViewFieldEditor: { openEditor: jest.fn() },
-        dataViewEditor: { openEditor: jest.fn() },
+        dataViewEditor: {
+          openEditor: jest.fn(),
+          userPermissions: { editDataView: jest.fn().mockReturnValue(true) },
+        },
         data: { dataViews: { get: jest.fn() } },
       },
     } as unknown as ReturnType<typeof useKibana>);
@@ -192,6 +200,36 @@ describe('DataViewPicker', () => {
         'security-solution-default'
       );
       expect(jest.mocked(useKibana().services.dataViewFieldEditor.openEditor)).toHaveBeenCalled();
+    });
+  });
+
+  describe('when user does not have editDataView permission', () => {
+    it('does not render edit data view button', () => {
+      jest
+        .mocked(useKibana().services.dataViewEditor.userPermissions.editDataView)
+        .mockReturnValue(false);
+
+      render(
+        <TestProviders>
+          <DataViewPicker scope={DataViewManagerScopeName.default} />
+        </TestProviders>
+      );
+
+      expect(screen.queryByTestId('editDataView')).not.toBeInTheDocument();
+    });
+
+    it('does not render add field button', () => {
+      jest
+        .mocked(useKibana().services.dataViewEditor.userPermissions.editDataView)
+        .mockReturnValue(false);
+
+      render(
+        <TestProviders>
+          <DataViewPicker scope={DataViewManagerScopeName.default} />
+        </TestProviders>
+      );
+
+      expect(screen.queryByTestId('addField')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/sourcerer_selection.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/sourcerer_selection.test.tsx
@@ -55,7 +55,10 @@ describe('SourcererButton', () => {
     jest.mocked(useKibana).mockReturnValue({
       services: {
         dataViewFieldEditor: { openEditor: jest.fn() },
-        dataViewEditor: { openEditor: jest.fn() },
+        dataViewEditor: {
+          openEditor: jest.fn(),
+          userPermissions: { editDataView: jest.fn().mockReturnValue(true) },
+        },
         data: { dataViews: { get: jest.fn() } },
       },
     } as unknown as ReturnType<typeof useKibana>);


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/220587

This PR limits user's ability to add fields and edit data views based on their access. The behavior of data view picker now matches the one in discover.

To test this PR, enable feature flag `newDataViewPickerEnabled`.

### 1. Have access to indices and write access to solutions

- Add field and Manage data view are displayed
- When creating a data view, can save and use without saving

| Discover | Security |
|--------|-----------------|
|![image](https://github.com/user-attachments/assets/d1c54b06-8b65-4f90-b8a1-0bbc2ac5f18d) | ![image](https://github.com/user-attachments/assets/c823f28b-5922-4d77-9f4f-7c96654ae86c)| 
|![image](https://github.com/user-attachments/assets/dd2100b8-bdb4-4854-90d1-762cf8fe96ca) | ![image](https://github.com/user-attachments/assets/f921ec24-e36b-4195-b740-30c3654fa52b) |


### 2. Haves access to indices and read access to solutions

- Add field and Manage data view are not displayed
- Can only create ad hoc data views


| Discover | Security |
|--------|-----------------|
|![image](https://github.com/user-attachments/assets/008f95bd-5307-440e-843d-61d7a2bdd933) | ![image](https://github.com/user-attachments/assets/d6aae373-8572-4adf-bc1c-4cce670d8625)|
|![image](https://github.com/user-attachments/assets/8986db3f-08a7-4b88-8edc-420b3c4fcdcf) | ![image](https://github.com/user-attachments/assets/c3806d72-657d-489e-a201-b4695496ac09)|


### 3. No access to indices and read access to solutions

- Page content do not show up
- Cannot create data views (because user has no access to any indices)

| Discover | Security |
|--------|-----------------|
|![image](https://github.com/user-attachments/assets/fb8a4be6-2ff0-4d9a-9414-fec99997a193) | ![image](https://github.com/user-attachments/assets/504ae1f5-0695-4499-99c8-197a11acc613) |



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

