### PR TITLE
[8.19] [Alerting] Add snapshot telemetry for _ignored fields (#221480)

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -3050,6 +3050,109 @@
               "type": "long"
             }
           }
+        },
+        "count_ignored_fields_by_rule_type": {
+          "properties": {
+            "DYNAMIC_KEY": {
+              "type": "long"
+            },
+            "__index-threshold": {
+              "type": "long"
+            },
+            "__es-query": {
+              "type": "long"
+            },
+            "transform_health": {
+              "type": "long"
+            },
+            "apm__error_rate": {
+              "type": "long"
+            },
+            "apm__transaction_error_rate": {
+              "type": "long"
+            },
+            "apm__transaction_duration": {
+              "type": "long"
+            },
+            "apm__transaction_duration_anomaly": {
+              "type": "long"
+            },
+            "metrics__alert__threshold": {
+              "type": "long"
+            },
+            "metrics__alert__inventory__threshold": {
+              "type": "long"
+            },
+            "logs__alert__document__count": {
+              "type": "long"
+            },
+            "monitoring_alert_cluster_health": {
+              "type": "long"
+            },
+            "monitoring_alert_cpu_usage": {
+              "type": "long"
+            },
+            "monitoring_alert_disk_usage": {
+              "type": "long"
+            },
+            "monitoring_alert_elasticsearch_version_mismatch": {
+              "type": "long"
+            },
+            "monitoring_alert_kibana_version_mismatch": {
+              "type": "long"
+            },
+            "monitoring_alert_license_expiration": {
+              "type": "long"
+            },
+            "monitoring_alert_logstash_version_mismatch": {
+              "type": "long"
+            },
+            "monitoring_alert_nodes_changed": {
+              "type": "long"
+            },
+            "siem__signals": {
+              "type": "long"
+            },
+            "siem__notifications": {
+              "type": "long"
+            },
+            "siem__eqlRule": {
+              "type": "long"
+            },
+            "siem__indicatorRule": {
+              "type": "long"
+            },
+            "siem__mlRule": {
+              "type": "long"
+            },
+            "siem__queryRule": {
+              "type": "long"
+            },
+            "siem__savedQueryRule": {
+              "type": "long"
+            },
+            "siem__thresholdRule": {
+              "type": "long"
+            },
+            "xpack__uptime__alerts__monitorStatus": {
+              "type": "long"
+            },
+            "xpack__uptime__alerts__tls": {
+              "type": "long"
+            },
+            "xpack__uptime__alerts__durationAnomaly": {
+              "type": "long"
+            },
+            "__geo-containment": {
+              "type": "long"
+            },
+            "xpack__ml__anomaly_detection_alert": {
+              "type": "long"
+            },
+            "xpack__ml__anomaly_detection_jobs_health": {
+              "type": "long"
+            }
+          }
         }
       }
     },

--- a/x-pack/platform/plugins/shared/alerting/server/usage/alerting_usage_collector.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/alerting_usage_collector.ts
@@ -243,6 +243,7 @@ export function createAlertingUsageCollector(
           count_alerts_by_rule_type: {},
           count_rules_snoozed_by_type: {},
           count_rules_muted_by_type: {},
+          count_ignored_fields_by_rule_type: {},
         };
       }
     },
@@ -320,6 +321,7 @@ export function createAlertingUsageCollector(
       count_alerts_by_rule_type: byTypeSchema,
       count_rules_snoozed_by_type: byTypeSchema,
       count_rules_muted_by_type: byTypeSchema,
+      count_ignored_fields_by_rule_type: byTypeSchema,
     },
   });
 }

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.test.ts
@@ -32,9 +32,42 @@ describe('kibana index telemetry', () => {
           doc_count_error_upper_bound: 0,
           sum_other_doc_count: 0,
           buckets: [
-            { key: '.index-threshold', doc_count: 1 },
-            { key: 'logs.alert.document.count', doc_count: 2 },
-            { key: 'document.test.', doc_count: 3 },
+            {
+              key: '.index-threshold',
+              doc_count: 1,
+              ignored_field: {
+                doc_count_error_upper_bound: 0,
+                sum_other_doc_count: 0,
+                buckets: [],
+              },
+            },
+            {
+              key: 'logs.alert.document.count',
+              doc_count: 2,
+              ignored_field: {
+                doc_count_error_upper_bound: 0,
+                sum_other_doc_count: 0,
+                buckets: [
+                  {
+                    key: 'kibana.alert.grouping.container.id',
+                    doc_count: 2,
+                  },
+                  {
+                    key: 'kibana.alert.grouping.container.name',
+                    doc_count: 2,
+                  },
+                ],
+              },
+            },
+            {
+              key: 'document.test.',
+              doc_count: 3,
+              ignored_field: {
+                doc_count_error_upper_bound: 0,
+                sum_other_doc_count: 0,
+                buckets: [],
+              },
+            },
           ],
         },
       },
@@ -46,10 +79,10 @@ describe('kibana index telemetry', () => {
     const debugLogs = loggingSystemMock.collect(logger).debug;
     expect(debugLogs).toHaveLength(2);
     expect(debugLogs[0][0]).toEqual(
-      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}}}}}`
+      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}`
     );
     expect(debugLogs[1][0]).toEqual(
-      `results for getTotalAlertsCountAggregations query - {\"took\":4,\"timed_out\":false,\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":6,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[]},\"aggregations\":{\"by_rule_type_id\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\".index-threshold\",\"doc_count\":1},{\"key\":\"logs.alert.document.count\",\"doc_count\":2},{\"key\":\"document.test.\",\"doc_count\":3}]}}}`
+      `results for getTotalAlertsCountAggregations query - {\"took\":4,\"timed_out\":false,\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":6,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[]},\"aggregations\":{\"by_rule_type_id\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\".index-threshold\",\"doc_count\":1,\"ignored_field\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[]}},{\"key\":\"logs.alert.document.count\",\"doc_count\":2,\"ignored_field\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\"kibana.alert.grouping.container.id\",\"doc_count\":2},{\"key\":\"kibana.alert.grouping.container.name\",\"doc_count\":2}]}},{\"key\":\"document.test.\",\"doc_count\":3,\"ignored_field\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[]}}]}}}`
     );
 
     expect(telemetry).toEqual({
@@ -60,6 +93,12 @@ describe('kibana index telemetry', () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         logs__alert__document__count: 2,
         document__test__: 3,
+      },
+      count_ignored_fields_by_rule_type: {
+        '__index-threshold': 0,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        logs__alert__document__count: 2,
+        document__test__: 0,
       },
     });
   });
@@ -81,6 +120,7 @@ describe('kibana index telemetry', () => {
       hasErrors: false,
       count_alerts_total: 0,
       count_alerts_by_rule_type: {},
+      count_ignored_fields_by_rule_type: {},
     });
   });
 
@@ -94,7 +134,7 @@ describe('kibana index telemetry', () => {
     const loggerCalls = loggingSystemMock.collect(logger);
     expect(loggerCalls.debug).toHaveLength(1);
     expect(loggerCalls.debug[0][0]).toEqual(
-      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}}}}}`
+      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}`
     );
     expect(loggerCalls.warn).toHaveLength(1);
     expect(loggerCalls.warn[0][0]).toEqual(
@@ -109,6 +149,7 @@ describe('kibana index telemetry', () => {
       errorMessage: 'test',
       count_alerts_total: 0,
       count_alerts_by_rule_type: {},
+      count_ignored_fields_by_rule_type: {},
     });
   });
 
@@ -144,7 +185,7 @@ describe('kibana index telemetry', () => {
     const loggerCalls = loggingSystemMock.collect(logger);
     expect(loggerCalls.debug).toHaveLength(2);
     expect(loggerCalls.debug[0][0]).toEqual(
-      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}}}}}`
+      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}`
     );
     expect(loggerCalls.debug[1][0]).toMatchInlineSnapshot(`
       "Error executing alerting telemetry task: getTotalAlertsCountAggregations - ResponseError: search_phase_execution_exception
@@ -161,6 +202,7 @@ describe('kibana index telemetry', () => {
       errorMessage: `no_shard_available_action_exception`,
       count_alerts_total: 0,
       count_alerts_by_rule_type: {},
+      count_ignored_fields_by_rule_type: {},
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.test.ts
@@ -79,7 +79,7 @@ describe('kibana index telemetry', () => {
     const debugLogs = loggingSystemMock.collect(logger).debug;
     expect(debugLogs).toHaveLength(2);
     expect(debugLogs[0][0]).toEqual(
-      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}`
+      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}}`
     );
     expect(debugLogs[1][0]).toEqual(
       `results for getTotalAlertsCountAggregations query - {\"took\":4,\"timed_out\":false,\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":6,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[]},\"aggregations\":{\"by_rule_type_id\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\".index-threshold\",\"doc_count\":1,\"ignored_field\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[]}},{\"key\":\"logs.alert.document.count\",\"doc_count\":2,\"ignored_field\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[{\"key\":\"kibana.alert.grouping.container.id\",\"doc_count\":2},{\"key\":\"kibana.alert.grouping.container.name\",\"doc_count\":2}]}},{\"key\":\"document.test.\",\"doc_count\":3,\"ignored_field\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":[]}}]}}}`
@@ -134,7 +134,7 @@ describe('kibana index telemetry', () => {
     const loggerCalls = loggingSystemMock.collect(logger);
     expect(loggerCalls.debug).toHaveLength(1);
     expect(loggerCalls.debug[0][0]).toEqual(
-      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}`
+      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}}`
     );
     expect(loggerCalls.warn).toHaveLength(1);
     expect(loggerCalls.warn[0][0]).toEqual(
@@ -185,7 +185,7 @@ describe('kibana index telemetry', () => {
     const loggerCalls = loggingSystemMock.collect(logger);
     expect(loggerCalls.debug).toHaveLength(2);
     expect(loggerCalls.debug[0][0]).toEqual(
-      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33}},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}`
+      `query for getTotalAlertsCountAggregations - {\"index\":\".alerts-*\",\"size\":0,\"body\":{\"query\":{\"match_all\":{}},\"aggs\":{\"by_rule_type_id\":{\"terms\":{\"field\":\"kibana.alert.rule.rule_type_id\",\"size\":33},\"aggs\":{\"ignored_field\":{\"terms\":{\"field\":\"_ignored\",\"size\":33}}}}}}}`
     );
     expect(loggerCalls.debug[1][0]).toMatchInlineSnapshot(`
       "Error executing alerting telemetry task: getTotalAlertsCountAggregations - ResponseError: search_phase_execution_exception

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.ts
@@ -12,6 +12,7 @@ import type {
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 
 import { NUM_ALERTING_RULE_TYPES } from '../alerting_usage_collector';
+import { parseCountIgnoreRuleTypeBucket } from './parse_count_ignored_rule_type_bucket';
 import { parseSimpleRuleTypeBucket } from './parse_simple_rule_type_bucket';
 import type { AlertingUsage } from '../types';
 import { parseAndLogError } from './parse_and_log_error';
@@ -23,7 +24,7 @@ interface Opts {
 
 type GetTotaAlertsCountsResults = Pick<
   AlertingUsage,
-  'count_alerts_total' | 'count_alerts_by_rule_type'
+  'count_alerts_total' | 'count_alerts_by_rule_type' | 'count_ignored_fields_by_rule_type'
 > & {
   errorMessage?: string;
   hasErrors: boolean;
@@ -50,6 +51,14 @@ export async function getTotalAlertsCountAggregations({
               size: NUM_ALERTING_RULE_TYPES,
             },
           },
+          aggs: {
+            ignored_field: {
+              terms: {
+                field: '_ignored',
+                size: NUM_ALERTING_RULE_TYPES,
+              },
+            },
+          },
         },
       },
     };
@@ -71,6 +80,9 @@ export async function getTotalAlertsCountAggregations({
       hasErrors: false,
       count_alerts_total: totalAlertsCount ?? 0,
       count_alerts_by_rule_type: parseSimpleRuleTypeBucket(aggregations?.by_rule_type_id?.buckets),
+      count_ignored_fields_by_rule_type: parseCountIgnoreRuleTypeBucket(
+        aggregations?.by_rule_type_id?.buckets
+      ),
     };
   } catch (err) {
     const errorMessage = parseAndLogError(err, `getTotalAlertsCountAggregations`, logger);
@@ -80,6 +92,7 @@ export async function getTotalAlertsCountAggregations({
       errorMessage,
       count_alerts_total: 0,
       count_alerts_by_rule_type: {},
+      count_ignored_fields_by_rule_type: {},
     };
   }
 }

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.ts
@@ -50,12 +50,12 @@ export async function getTotalAlertsCountAggregations({
               field: 'kibana.alert.rule.rule_type_id',
               size: NUM_ALERTING_RULE_TYPES,
             },
-          },
-          aggs: {
-            ignored_field: {
-              terms: {
-                field: '_ignored',
-                size: NUM_ALERTING_RULE_TYPES,
+            aggs: {
+              ignored_field: {
+                terms: {
+                  field: '_ignored',
+                  size: NUM_ALERTING_RULE_TYPES,
+                },
               },
             },
           },

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/parse_count_ignored_rule_type_bucket.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/parse_count_ignored_rule_type_bucket.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AggregationsBuckets,
+  AggregationsStringTermsBucketKeys,
+} from '@elastic/elasticsearch/lib/api/types';
+import { replaceDotSymbols } from './replace_dots_with_underscores';
+
+type Bucket = AggregationsStringTermsBucketKeys & {
+  ignored_field: { buckets: Bucket[] };
+};
+
+export function parseCountIgnoreRuleTypeBucket(
+  ruleTypeBuckets: AggregationsBuckets<AggregationsStringTermsBucketKeys>
+) {
+  const buckets = ruleTypeBuckets as Bucket[];
+  return (buckets ?? []).reduce((acc, bucket: Bucket) => {
+    const ruleType: string = replaceDotSymbols(`${bucket.key}`);
+    acc[ruleType] = bucket.ignored_field.buckets?.length ?? 0;
+    return acc;
+  }, {} as Record<string, number>);
+}

--- a/x-pack/platform/plugins/shared/alerting/server/usage/task.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/task.ts
@@ -220,6 +220,8 @@ export function telemetryTaskRunner(
                 percentile_num_alerts_by_type_per_day: dailyExecutionCounts.alertsPercentilesByType,
                 count_alerts_total: totalAlertsCountAggregations.count_alerts_total,
                 count_alerts_by_rule_type: totalAlertsCountAggregations.count_alerts_by_rule_type,
+                count_ignored_fields_by_rule_type:
+                  totalAlertsCountAggregations.count_ignored_fields_by_rule_type,
               };
 
               return {

--- a/x-pack/platform/plugins/shared/alerting/server/usage/task_state.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/task_state.test.ts
@@ -714,4 +714,190 @@ describe('telemetry task state', () => {
       expect(result).not.toHaveProperty('foo');
     });
   });
+
+  describe('v5', () => {
+    const v5 = stateSchemaByVersion[5];
+    it('should work on empty object when running the up migration', () => {
+      const result = v5.up({});
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "avg_es_search_duration_by_type_per_day": Object {},
+          "avg_es_search_duration_per_day": 0,
+          "avg_execution_time_by_type_per_day": Object {},
+          "avg_execution_time_per_day": 0,
+          "avg_total_search_duration_by_type_per_day": Object {},
+          "avg_total_search_duration_per_day": 0,
+          "connectors_per_alert": Object {
+            "avg": 0,
+            "max": 0,
+            "min": 0,
+          },
+          "count_active_by_type": Object {},
+          "count_active_total": 0,
+          "count_alerts_by_rule_type": Object {},
+          "count_alerts_total": 0,
+          "count_by_type": Object {},
+          "count_connector_types_by_consumers": Object {},
+          "count_disabled_total": 0,
+          "count_failed_and_unrecognized_rule_tasks_by_status_by_type_per_day": Object {},
+          "count_failed_and_unrecognized_rule_tasks_by_status_per_day": Object {},
+          "count_failed_and_unrecognized_rule_tasks_per_day": 0,
+          "count_ignored_fields_by_rule_type": Object {},
+          "count_mw_total": 0,
+          "count_mw_with_filter_alert_toggle_on": 0,
+          "count_mw_with_repeat_toggle_on": 0,
+          "count_rules_by_execution_status": Object {
+            "error": 0,
+            "success": 0,
+            "warning": 0,
+          },
+          "count_rules_by_execution_status_per_day": Object {},
+          "count_rules_by_notify_when": Object {
+            "on_action_group_change": 0,
+            "on_active_alert": 0,
+            "on_throttle_interval": 0,
+          },
+          "count_rules_executions_by_type_per_day": Object {},
+          "count_rules_executions_failured_by_reason_by_type_per_day": Object {},
+          "count_rules_executions_failured_by_reason_per_day": Object {},
+          "count_rules_executions_failured_per_day": 0,
+          "count_rules_executions_per_day": 0,
+          "count_rules_executions_timeouts_by_type_per_day": Object {},
+          "count_rules_executions_timeouts_per_day": 0,
+          "count_rules_muted": 0,
+          "count_rules_muted_by_type": Object {},
+          "count_rules_namespaces": 0,
+          "count_rules_snoozed": 0,
+          "count_rules_snoozed_by_type": Object {},
+          "count_rules_with_investigation_guide": 0,
+          "count_rules_with_linked_dashboards": 0,
+          "count_rules_with_muted_alerts": 0,
+          "count_rules_with_tags": 0,
+          "count_total": 0,
+          "error_messages": undefined,
+          "has_errors": false,
+          "percentile_num_alerts_by_type_per_day": Object {},
+          "percentile_num_alerts_per_day": Object {},
+          "percentile_num_generated_actions_by_type_per_day": Object {},
+          "percentile_num_generated_actions_per_day": Object {},
+          "runs": 0,
+          "schedule_time": Object {
+            "avg": "0s",
+            "max": "0s",
+            "min": "0s",
+          },
+          "schedule_time_number_s": Object {
+            "avg": 0,
+            "max": 0,
+            "min": 0,
+          },
+          "throttle_time": Object {
+            "avg": "0s",
+            "max": "0s",
+            "min": "0s",
+          },
+          "throttle_time_number_s": Object {
+            "avg": 0,
+            "max": 0,
+            "min": 0,
+          },
+        }
+      `);
+    });
+
+    it(`shouldn't overwrite properties when running the up migration`, () => {
+      const state = {
+        avg_es_search_duration_by_type_per_day: { '.index-threshold': 1 },
+        avg_es_search_duration_per_day: 2,
+        avg_execution_time_by_type_per_day: { '.index-threshold': 3 },
+        avg_execution_time_per_day: 4,
+        avg_total_search_duration_by_type_per_day: { '.index-threshold': 5 },
+        avg_total_search_duration_per_day: 6,
+        connectors_per_alert: {
+          avg: 7,
+          max: 8,
+          min: 9,
+        },
+        count_active_by_type: { '.index-threshold': 10 },
+        count_active_total: 11,
+        count_alerts_by_rule_type: {},
+        count_alerts_total: 0,
+        count_by_type: { '.index-threshold': 12 },
+        count_connector_types_by_consumers: { '.index-threshold': 13 },
+        count_disabled_total: 14,
+        count_failed_and_unrecognized_rule_tasks_by_status_by_type_per_day: {
+          '.index-threshold': 15,
+        },
+        count_failed_and_unrecognized_rule_tasks_by_status_per_day: { '.index-threshold': 16 },
+        count_failed_and_unrecognized_rule_tasks_per_day: 17,
+        count_ignored_fields_by_rule_type: {},
+        count_mw_total: 0,
+        count_mw_with_filter_alert_toggle_on: 0,
+        count_mw_with_repeat_toggle_on: 0,
+        count_rules_by_execution_status: {
+          error: 18,
+          success: 19,
+          warning: 20,
+        },
+        count_rules_by_execution_status_per_day: { '.index-threshold': 21 },
+        count_rules_by_notify_when: {
+          on_action_group_change: 22,
+          on_active_alert: 23,
+          on_throttle_interval: 24,
+        },
+        count_rules_executions_by_type_per_day: { '.index-threshold': 25 },
+        count_rules_executions_failured_by_reason_by_type_per_day: { '.index-threshold': 26 },
+        count_rules_executions_failured_by_reason_per_day: { '.index-threshold': 27 },
+        count_rules_executions_failured_per_day: 28,
+        count_rules_executions_per_day: 29,
+        count_rules_executions_timeouts_by_type_per_day: { '.index-threshold': 30 },
+        count_rules_executions_timeouts_per_day: 31,
+        count_rules_muted: 32,
+        count_rules_muted_by_type: {},
+        count_rules_namespaces: 33,
+        count_rules_snoozed: 34,
+        count_rules_snoozed_by_type: {},
+        count_rules_with_muted_alerts: 35,
+        count_rules_with_tags: 36,
+        count_rules_with_linked_dashboards: 10,
+        count_rules_with_investigation_guide: 10,
+        count_total: 37,
+        error_messages: ['foo'],
+        has_errors: true,
+        percentile_num_alerts_by_type_per_day: { '.index-threshold': 38 },
+        percentile_num_alerts_per_day: { '.index-threshold': 39 },
+        percentile_num_generated_actions_by_type_per_day: { '.index-threshold': 40 },
+        percentile_num_generated_actions_per_day: { '.index-threshold': 41 },
+        runs: 42,
+        schedule_time: {
+          avg: '43s',
+          max: '44s',
+          min: '45s',
+        },
+        schedule_time_number_s: {
+          avg: 46,
+          max: 47,
+          min: 48,
+        },
+        throttle_time: {
+          avg: '49s',
+          max: '50s',
+          min: '51s',
+        },
+        throttle_time_number_s: {
+          avg: 52,
+          max: 53,
+          min: 54,
+        },
+      };
+      const result = v5.up(cloneDeep(state));
+      expect(result).toEqual(state);
+    });
+
+    it('should drop unknown properties when running the up migration', () => {
+      const state = { foo: true };
+      const result = v5.up(state);
+      expect(result).not.toHaveProperty('foo');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/usage/task_state.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/task_state.ts
@@ -131,6 +131,10 @@ const stateSchemaV4 = stateSchemaV3.extends({
   count_rules_muted_by_type: schema.recordOf(schema.string(), schema.number()),
 });
 
+const stateSchemaV5 = stateSchemaV4.extends({
+  count_ignored_fields_by_rule_type: schema.recordOf(schema.string(), schema.number()),
+});
+
 export const stateSchemaByVersion = {
   1: {
     // A task that was created < 8.10 will go through this "up" migration
@@ -245,9 +249,16 @@ export const stateSchemaByVersion = {
     }),
     schema: stateSchemaV4,
   },
+  5: {
+    up: (state: Record<string, unknown>) => ({
+      ...stateSchemaByVersion[4].up(state),
+      count_ignored_fields_by_rule_type: state.count_ignored_fields_by_rule_type || {},
+    }),
+    schema: stateSchemaV5,
+  },
 };
 
-const latestTaskStateSchema = stateSchemaByVersion[4].schema;
+const latestTaskStateSchema = stateSchemaByVersion[5].schema;
 export type LatestTaskStateSchema = TypeOf<typeof latestTaskStateSchema>;
 
 export const emptyState: LatestTaskStateSchema = {
@@ -328,6 +339,7 @@ export const emptyState: LatestTaskStateSchema = {
   percentile_num_alerts_by_type_per_day: {},
   count_alerts_total: 0,
   count_alerts_by_rule_type: {},
+  count_ignored_fields_by_rule_type: {},
   count_rules_with_linked_dashboards: 0,
   count_rules_with_investigation_guide: 0,
 };

--- a/x-pack/platform/plugins/shared/alerting/server/usage/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/types.ts
@@ -103,4 +103,5 @@ export interface AlertingUsage {
   count_alerts_by_rule_type: Record<string, number>;
   count_rules_snoozed_by_type: Record<string, number>;
   count_rules_muted_by_type: Record<string, number>;
+  count_ignored_fields_by_rule_type: Record<string, number>;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Alerting] Add snapshot telemetry for _ignored fields (#221480)](https://github.com/elastic/kibana/pull/221480)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2025-05-28T16:02:33Z","message":"[Alerting] Add snapshot telemetry for _ignored fields (#221480)\n\nCloses https://github.com/elastic/kibana/issues/220815\n\n## Summary\n\nThis PR adds telemetry for _ignored fields. The goal is to have an alert\nbased on this field and get notified in case a user hits the mapping\nlimit, but by default, we don't expect this to happen.\n\nThis PR adds `count_ignored_fields_by_rule_type` field that counts the\nnumber of _ignored fields per rule type.\n\nIn the future, we can extend the telemetry data to also include the\nactual number of mappings over the limit (there is a [feature\nrequest](https://github.com/elastic/elasticsearch/issues/68947) for\nadding field count information to index API)\n\n### How to test\n\n- Add a lot of dynamic fields as mentioned here:\nhttps://github.com/elastic/kibana/pull/216719\n- Create a rule with a custom threshold rule with multiple group by\nfields to generate an alert with _ignored field\n- Run the following API and check the value of\n`count_ignored_fields_by_rule_type`\n  ```\n  POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n  {\n    \"unencrypted\": true,\n    \"refreshCache\": true\n  }\n  ```\n\n<details>\n<summary> Here is what it looks like:</summary>\n\n\n![image](https://github.com/user-attachments/assets/bb71bde1-9002-4f96-9b84-3e4c7b6f0aed)\n\n\n![image](https://github.com/user-attachments/assets/725fda41-454b-4ed0-a2dc-40796729bc19)\n\n\n</details>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cde7a86287956467fffe4346a14a7fd24b99ff93","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.1.0","v8.19.0","author:obs-ux-management"],"title":"[Alerting] Add snapshot telemetry for _ignored fields","number":221480,"url":"https://github.com/elastic/kibana/pull/221480","mergeCommit":{"message":"[Alerting] Add snapshot telemetry for _ignored fields (#221480)\n\nCloses https://github.com/elastic/kibana/issues/220815\n\n## Summary\n\nThis PR adds telemetry for _ignored fields. The goal is to have an alert\nbased on this field and get notified in case a user hits the mapping\nlimit, but by default, we don't expect this to happen.\n\nThis PR adds `count_ignored_fields_by_rule_type` field that counts the\nnumber of _ignored fields per rule type.\n\nIn the future, we can extend the telemetry data to also include the\nactual number of mappings over the limit (there is a [feature\nrequest](https://github.com/elastic/elasticsearch/issues/68947) for\nadding field count information to index API)\n\n### How to test\n\n- Add a lot of dynamic fields as mentioned here:\nhttps://github.com/elastic/kibana/pull/216719\n- Create a rule with a custom threshold rule with multiple group by\nfields to generate an alert with _ignored field\n- Run the following API and check the value of\n`count_ignored_fields_by_rule_type`\n  ```\n  POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n  {\n    \"unencrypted\": true,\n    \"refreshCache\": true\n  }\n  ```\n\n<details>\n<summary> Here is what it looks like:</summary>\n\n\n![image](https://github.com/user-attachments/assets/bb71bde1-9002-4f96-9b84-3e4c7b6f0aed)\n\n\n![image](https://github.com/user-attachments/assets/725fda41-454b-4ed0-a2dc-40796729bc19)\n\n\n</details>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cde7a86287956467fffe4346a14a7fd24b99ff93"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221480","number":221480,"mergeCommit":{"message":"[Alerting] Add snapshot telemetry for _ignored fields (#221480)\n\nCloses https://github.com/elastic/kibana/issues/220815\n\n## Summary\n\nThis PR adds telemetry for _ignored fields. The goal is to have an alert\nbased on this field and get notified in case a user hits the mapping\nlimit, but by default, we don't expect this to happen.\n\nThis PR adds `count_ignored_fields_by_rule_type` field that counts the\nnumber of _ignored fields per rule type.\n\nIn the future, we can extend the telemetry data to also include the\nactual number of mappings over the limit (there is a [feature\nrequest](https://github.com/elastic/elasticsearch/issues/68947) for\nadding field count information to index API)\n\n### How to test\n\n- Add a lot of dynamic fields as mentioned here:\nhttps://github.com/elastic/kibana/pull/216719\n- Create a rule with a custom threshold rule with multiple group by\nfields to generate an alert with _ignored field\n- Run the following API and check the value of\n`count_ignored_fields_by_rule_type`\n  ```\n  POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n  {\n    \"unencrypted\": true,\n    \"refreshCache\": true\n  }\n  ```\n\n<details>\n<summary> Here is what it looks like:</summary>\n\n\n![image](https://github.com/user-attachments/assets/bb71bde1-9002-4f96-9b84-3e4c7b6f0aed)\n\n\n![image](https://github.com/user-attachments/assets/725fda41-454b-4ed0-a2dc-40796729bc19)\n\n\n</details>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cde7a86287956467fffe4346a14a7fd24b99ff93"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->