### PR TITLE
[8.19] [Lens] [Data Table] Add settings for data grid density (#220252)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/expressions/datatable/datatable.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/datatable/datatable.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import type { ExecutionContext } from '@kbn/expressions-plugin/common';
+import type { DataGridDensity } from '@kbn/unified-data-table';
 import type { FormatFactory, RowHeightMode } from '../../types';
 import type { DatatableColumnResult } from './datatable_column';
 import type { DatatableExpressionFunction } from './types';
@@ -32,6 +33,7 @@ export interface DatatableArgs {
   headerRowHeight?: RowHeightMode;
   headerRowHeightLines?: number;
   pageSize?: PagingState['size'];
+  density?: DataGridDensity;
 }
 
 export const getDatatable = (
@@ -85,6 +87,10 @@ export const getDatatable = (
     },
     pageSize: {
       types: ['number'],
+      help: '',
+    },
+    density: {
+      types: ['string'],
       help: '',
     },
   },

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/density_settings.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/density_settings.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DataGridDensity } from '@kbn/unified-data-table';
+import { DensitySettings, type DensitySettingsProps } from './density_settings';
+
+describe('DensitySettings', () => {
+  const defaultProps: DensitySettingsProps = {
+    dataGridDensity: DataGridDensity.NORMAL,
+    onChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderDensitySettingsComponent = (propsOverrides: Partial<DensitySettingsProps> = {}) => {
+    const rtlRender = render(<DensitySettings {...defaultProps} {...propsOverrides} />);
+    return {
+      ...rtlRender,
+      rerender: (newProps: Partial<DensitySettingsProps>) =>
+        rtlRender.rerender(<DensitySettings {...defaultProps} {...newProps} />),
+    };
+  };
+
+  it('renders the density settings component with label', () => {
+    renderDensitySettingsComponent();
+
+    expect(screen.getByLabelText('Density')).toBeInTheDocument();
+    expect(screen.getByTestId('lnsDensitySettings')).toBeInTheDocument();
+  });
+
+  it('displays all three density options and selects the provided option', () => {
+    renderDensitySettingsComponent();
+
+    expect(screen.getByRole('button', { name: 'Compact', pressed: false })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Normal', pressed: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Expanded', pressed: false })).toBeInTheDocument();
+  });
+
+  it('calls onChange with compact density when compact option is clicked', () => {
+    renderDensitySettingsComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Compact' }));
+
+    expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onChange).toHaveBeenCalledWith(DataGridDensity.COMPACT);
+  });
+
+  it('calls onChange with expanded density when expanded option is clicked', () => {
+    renderDensitySettingsComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expanded' }));
+
+    expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onChange).toHaveBeenCalledWith(DataGridDensity.EXPANDED);
+  });
+
+  it('falls back to NORMAL density when an invalid density is provided', () => {
+    renderDensitySettingsComponent({
+      dataGridDensity: 'invalid' as DataGridDensity,
+    });
+
+    // The component should still render without errors
+    expect(screen.getByLabelText('Density')).toBeInTheDocument();
+
+    // The Normal button should be pressed
+    expect(screen.getByRole('button', { name: 'Normal', pressed: true })).toBeInTheDocument();
+  });
+
+  it('updates selection when props change', () => {
+    const { rerender } = renderDensitySettingsComponent();
+
+    // Initial render should have Normal selected
+    expect(screen.getByRole('button', { name: 'Normal', pressed: true }));
+
+    // Update props to Compact
+    rerender({ dataGridDensity: DataGridDensity.COMPACT });
+
+    // Now Compact should be pressed
+    expect(screen.getByRole('button', { name: 'Compact', pressed: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Normal', pressed: false })).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/density_settings.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/density_settings.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { EuiButtonGroup, EuiFormRow } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { DataGridDensity } from '@kbn/unified-data-table';
+
+export interface DensitySettingsProps {
+  dataGridDensity: DataGridDensity;
+  onChange: (density: DataGridDensity) => void;
+}
+
+const densityValues = Object.values(DataGridDensity);
+
+const getValidDensity = (density: string) => {
+  const isValidDensity = densityValues.includes(density as DataGridDensity);
+  return isValidDensity ? (density as DataGridDensity) : DataGridDensity.NORMAL;
+};
+
+const densityLabel = i18n.translate('xpack.lens.table.densityLabel', {
+  defaultMessage: 'Density',
+});
+
+const densityOptions = [
+  {
+    id: DataGridDensity.COMPACT,
+    label: i18n.translate('xpack.lens.table.labelCompact', {
+      defaultMessage: 'Compact',
+    }),
+  },
+  {
+    id: DataGridDensity.NORMAL,
+    label: i18n.translate('xpack.lens.table.labelNormal', {
+      defaultMessage: 'Normal',
+    }),
+  },
+  {
+    id: DataGridDensity.EXPANDED,
+    label: i18n.translate('xpack.lens.table.labelExpanded', {
+      defaultMessage: 'Expanded',
+    }),
+  },
+];
+
+export const DensitySettings: React.FC<DensitySettingsProps> = ({ dataGridDensity, onChange }) => {
+  // Falls back to NORMAL density when an invalid density is provided
+  const validDensity = getValidDensity(dataGridDensity);
+
+  const setDensity = useCallback(
+    (density: string) => {
+      onChange(getValidDensity(density));
+    },
+    [onChange]
+  );
+
+  return (
+    <EuiFormRow
+      aria-label={densityLabel}
+      display="columnCompressed"
+      data-test-subj="lnsDensitySettings"
+    >
+      <EuiButtonGroup
+        legend={densityLabel}
+        buttonSize="compressed"
+        isFullWidth
+        options={densityOptions}
+        onChange={setDensity}
+        idSelected={validDensity}
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.test.tsx
@@ -23,6 +23,7 @@ import { PaletteOutput } from '@kbn/coloring';
 import { getTransposeId } from '@kbn/transpose-utils';
 import { CustomPaletteState } from '@kbn/charts-plugin/common';
 import { getCellColorFn } from '../../../shared_components/coloring/get_cell_color_fn';
+import { DataGridDensity } from '@kbn/unified-data-table';
 
 jest.mock('../../../shared_components/coloring/get_cell_color_fn', () => {
   const mod = jest.requireActual('../../../shared_components/coloring/get_cell_color_fn');
@@ -760,6 +761,61 @@ describe('DatatableComponent', () => {
           ['3', 'red'],
         ]);
       });
+    });
+  });
+
+  describe('gridStyle', () => {
+    it('should apply default grid style when density is not provided', () => {
+      renderDatatableComponent();
+      const table = screen.getByTestId('lnsDataTable');
+      expect(table).toHaveClass(/cellPadding-m-fontSize-m/);
+    });
+    it('should apply normal grid style when density is normal', () => {
+      renderDatatableComponent({
+        args: {
+          ...args,
+          density: DataGridDensity.NORMAL,
+        },
+      });
+      const table = screen.getByTestId('lnsDataTable');
+      expect(table).toHaveClass(/cellPadding-m-fontSize-m/);
+    });
+    it('should apply compact grid style when density is compact', () => {
+      renderDatatableComponent({
+        args: {
+          ...args,
+          density: DataGridDensity.COMPACT,
+        },
+      });
+      const table = screen.getByTestId('lnsDataTable');
+      expect(table).toHaveClass(/cellPadding-s-fontSize-s/);
+    });
+    it('should apply expanded grid style when density is expanded', () => {
+      renderDatatableComponent({
+        args: {
+          ...args,
+          density: DataGridDensity.EXPANDED,
+        },
+      });
+      const table = screen.getByTestId('lnsDataTable');
+      expect(table).toHaveClass(/cellPadding-l-fontSize-l/);
+    });
+    it('should update grid style when density changes', () => {
+      const { rerender } = renderDatatableComponent({
+        args: {
+          ...args,
+          density: DataGridDensity.NORMAL,
+        },
+      });
+      const table = screen.getByTestId('lnsDataTable');
+      expect(table).toHaveClass(/cellPadding-m-fontSize-m/);
+      rerender({
+        args: {
+          ...args,
+          density: DataGridDensity.COMPACT,
+        },
+      });
+      expect(table).toHaveClass(/cellPadding-s-fontSize-s/);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -34,6 +34,8 @@ import { getColorCategories } from '@kbn/chart-expressions-common';
 import { getOriginalId } from '@kbn/transpose-utils';
 import { css } from '@emotion/react';
 import { CoreTheme } from '@kbn/core/public';
+import { DATA_GRID_DENSITY_STYLE_MAP } from '@kbn/unified-data-table/src/hooks/use_data_grid_density';
+import { DATA_GRID_STYLE_NORMAL } from '@kbn/unified-data-table/src/constants';
 import { getKbnPalettes } from '@kbn/palettes';
 import type { LensTableRowContextMenuEvent } from '../../../types';
 import type { FormatFactory } from '../../../../common/types';
@@ -69,7 +71,7 @@ import { getColumnAlignment } from '../utils';
 
 export const DataContext = React.createContext<DataContextType>({});
 
-const gridStyle: EuiDataGridStyle = {
+const DATA_GRID_STYLE_DEFAULT: EuiDataGridStyle = {
   border: 'horizontal',
   header: 'shade',
   footer: 'shade',
@@ -500,6 +502,16 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
       };
     }
   }, [columnConfig.columns, alignments, props.data, columns]);
+
+  const gridStyle = useMemo<EuiDataGridStyle>(
+    () => ({
+      ...DATA_GRID_STYLE_DEFAULT,
+      ...(props.args.density
+        ? DATA_GRID_DENSITY_STYLE_MAP[props.args.density]
+        : DATA_GRID_STYLE_NORMAL),
+    }),
+    [props.args.density]
+  );
 
   if (isEmpty) {
     return (

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/toolbar.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/toolbar.test.tsx
@@ -13,6 +13,7 @@ import { FramePublicAPI, VisualizationToolbarProps } from '../../../types';
 import { PagingState } from '../../../../common/expressions';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { DataGridDensity } from '@kbn/unified-data-table';
 
 // mocking random id generator function
 jest.mock('@elastic/eui', () => {
@@ -45,6 +46,7 @@ describe('datatable toolbar', () => {
   const renderAndOpenToolbar = async (overrides = {}) => {
     const ROW_HEIGHT_SETTINGS_TEST_ID = 'lnsRowHeightSettings';
     const HEADER_HEIGHT_SETTINGS_TEST_ID = 'lnsHeaderHeightSettings';
+    const DENSITY_SETTINGS_TEST_ID = 'lnsDensitySettings';
 
     const rtlRender = render(<DataTableToolbar {...defaultProps} {...overrides} />);
 
@@ -78,6 +80,9 @@ describe('datatable toolbar', () => {
       selectHeaderHeightOption: selectOptionFromButtonGroup(HEADER_HEIGHT_SETTINGS_TEST_ID),
       getPaginationSwitch,
       clickPaginationSwitch,
+      // Density
+      getDensityValue: getSelectedButtonInGroup(DENSITY_SETTINGS_TEST_ID),
+      selectDensityOption: selectOptionFromButtonGroup(DENSITY_SETTINGS_TEST_ID),
     };
   };
 
@@ -87,12 +92,14 @@ describe('datatable toolbar', () => {
       getRowHeightValue,
       getHeaderHeightValue,
       getPaginationSwitch,
+      getDensityValue,
     } = await renderAndOpenToolbar();
 
     expect(getRowHeightValue()).toHaveTextContent(/custom/i);
     expect(getHeaderHeightValue()).toHaveTextContent(/custom/i);
     expect(getHeaderHeightCustomValue()).toHaveValue(3);
     expect(getPaginationSwitch()).not.toBeChecked();
+    expect(getDensityValue()).toHaveTextContent(/normal/i);
   });
 
   it('should reflect passed state in the UI', async () => {
@@ -102,6 +109,7 @@ describe('datatable toolbar', () => {
       getPaginationSwitch,
       getHeaderHeightCustomValue,
       getRowHeightCustomValue,
+      getDensityValue,
     } = await renderAndOpenToolbar({
       state: {
         ...defaultProps.state,
@@ -110,6 +118,7 @@ describe('datatable toolbar', () => {
         headerRowHeight: 'custom',
         headerRowHeightLines: 4,
         paging: { size: 10, enabled: true },
+        density: DataGridDensity.COMPACT,
       },
     });
 
@@ -118,6 +127,7 @@ describe('datatable toolbar', () => {
     expect(getHeaderHeightValue()).toHaveTextContent(/custom/i);
     expect(getHeaderHeightCustomValue()).toHaveValue(4);
     expect(getPaginationSwitch()).toBeChecked();
+    expect(getDensityValue()).toHaveTextContent(/compact/i);
   });
 
   it('should change row height to "Auto" mode when selected', async () => {
@@ -188,6 +198,24 @@ describe('datatable toolbar', () => {
     expect(defaultProps.setState).toHaveBeenCalledTimes(1);
     expect(defaultProps.setState).toHaveBeenCalledWith({
       paging: { ...defaultPagingState, enabled: false },
+    });
+  });
+
+  it('should change density to "Compact" when selected', async () => {
+    const { selectDensityOption } = await renderAndOpenToolbar();
+    selectDensityOption(/compact/i);
+    expect(defaultProps.setState).toHaveBeenCalledTimes(1);
+    expect(defaultProps.setState).toHaveBeenCalledWith({
+      density: DataGridDensity.COMPACT,
+    });
+  });
+
+  it('should change density to "Expanded" when selected', async () => {
+    const { selectDensityOption } = await renderAndOpenToolbar();
+    selectDensityOption(/expanded/i);
+    expect(defaultProps.setState).toHaveBeenCalledTimes(1);
+    expect(defaultProps.setState).toHaveBeenCalledWith({
+      density: DataGridDensity.EXPANDED,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/toolbar.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/toolbar.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFormRow, EuiSwitch, EuiToolTip } from '@elastic/eui';
-import { RowHeightSettings, ROWS_HEIGHT_OPTIONS } from '@kbn/unified-data-table';
+import { DataGridDensity, RowHeightSettings, ROWS_HEIGHT_OPTIONS } from '@kbn/unified-data-table';
 import { ToolbarPopover } from '../../../shared_components';
 import type { VisualizationToolbarProps } from '../../../types';
 import type { DatatableVisualizationState } from '../visualization';
@@ -21,6 +21,7 @@ import {
   DEFAULT_ROW_HEIGHT_LINES,
   ROW_HEIGHT_LINES_KEYS,
 } from './constants';
+import { DensitySettings } from './density_settings';
 
 type LineCounts = {
   [key in keyof typeof ROW_HEIGHT_LINES_KEYS]: number;
@@ -86,6 +87,16 @@ export function DataTableToolbar(props: VisualizationToolbarProps<DatatableVisua
     });
   }, [setState, state]);
 
+  const onChangeDensity = useCallback(
+    (density: DataGridDensity) => {
+      setState({
+        ...state,
+        density,
+      });
+    },
+    [setState, state]
+  );
+
   return (
     <EuiFlexGroup alignItems="center" gutterSize="none" responsive={false}>
       <ToolbarPopover
@@ -97,6 +108,10 @@ export function DataTableToolbar(props: VisualizationToolbarProps<DatatableVisua
         buttonDataTestSubj="lnsVisualOptionsButton"
         data-test-subj="lnsVisualOptionsPopover"
       >
+        <DensitySettings
+          dataGridDensity={state.density ?? DataGridDensity.NORMAL}
+          onChange={onChangeDensity}
+        />
         <RowHeightSettings
           rowHeight={state.headerRowHeight ?? DEFAULT_HEADER_ROW_HEIGHT}
           label={i18n.translate('xpack.lens.table.visualOptionsHeaderRowHeightLabel', {

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/visualization.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/visualization.test.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../common/expressions';
 import { getPaletteDisplayColors } from '../../shared_components/coloring';
 import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
+import { DataGridDensity } from '@kbn/unified-data-table';
 
 jest.mock('../../shared_components/coloring', () => {
   return {
@@ -923,6 +924,25 @@ describe('Datatable Visualization', () => {
           alignment: [],
         })
       );
+    });
+
+    it('sets density based on state', () => {
+      expect(getDatatableExpressionArgs({ ...defaultExpressionTableState }).density).toEqual([
+        DataGridDensity.NORMAL,
+      ]);
+
+      for (const DENSITY of [
+        DataGridDensity.COMPACT,
+        DataGridDensity.NORMAL,
+        DataGridDensity.EXPANDED,
+      ]) {
+        expect(
+          getDatatableExpressionArgs({
+            ...defaultExpressionTableState,
+            density: DENSITY,
+          }).density
+        ).toEqual([DENSITY]);
+      }
     });
 
     describe('palette/colorMapping/colorMode', () => {

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/visualization.tsx
@@ -24,6 +24,7 @@ import { LayerTypes } from '@kbn/expression-xy-plugin/public';
 import { buildExpression, buildExpressionFunction } from '@kbn/expressions-plugin/common';
 import useObservable from 'react-use/lib/useObservable';
 import { getSortingCriteria } from '@kbn/sort-predicates';
+import { DataGridDensity } from '@kbn/unified-data-table';
 import { getKbnPalettes } from '@kbn/palettes';
 import type { FormBasedPersistedState } from '../../datasources/form_based/types';
 import type {
@@ -71,6 +72,7 @@ export interface DatatableVisualizationState {
   rowHeightLines?: number;
   headerRowHeightLines?: number;
   paging?: PagingState;
+  density?: DataGridDensity;
 }
 
 const visualizationLabel = i18n.translate('xpack.lens.datatable.label', {
@@ -643,6 +645,7 @@ export const getDatatableVisualization = ({
       rowHeightLines: state.rowHeightLines ?? DEFAULT_ROW_HEIGHT_LINES,
       headerRowHeightLines: state.headerRowHeightLines ?? DEFAULT_HEADER_ROW_HEIGHT_LINES,
       pageSize: state.paging?.enabled ? state.paging.size : undefined,
+      density: state.density ?? DataGridDensity.NORMAL,
     }).toAst();
 
     return {

--- a/x-pack/test/functional/apps/lens/group2/table.ts
+++ b/x-pack/test/functional/apps/lens/group2/table.ts
@@ -42,6 +42,23 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
+    it('should apply compact density correctly', async () => {
+      await lens.openVisualOptions();
+
+      await lens.setDataTableDensity('compact');
+      expect(await lens.checkDataTableDensity('s')).to.be(true);
+    });
+
+    it('should apply expanded density correctly', async () => {
+      await lens.setDataTableDensity('expanded');
+      expect(await lens.checkDataTableDensity('l')).to.be(true);
+    });
+
+    it('should apply normal density correctly', async () => {
+      await lens.setDataTableDensity('normal');
+      expect(await lens.checkDataTableDensity('m')).to.be(true);
+    });
+
     it('should able to sort a last_value column correctly in a table', async () => {
       // configure last_value with a keyword field
       await lens.configureDimension({

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -2059,5 +2059,17 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     async toggleDebug(enable: boolean = true) {
       await browser.execute(`window.ELASTIC_LENS_LOGGER = arguments[0];`, enable);
     },
+
+    async setDataTableDensity(value: string) {
+      const settings = await testSubjects.find('lnsDensitySettings');
+      const option = await settings.findByTestSubject(value);
+      await option.click();
+    },
+
+    async checkDataTableDensity(size: 'l' | 'm' | 's') {
+      return find.existsByCssSelector(
+        `[data-test-subj="lnsDataTable"][class*="cellPadding-${size}-fontSize-${size}"]`
+      );
+    },
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Lens] [Data Table] Add settings for data grid density (#220252)](https://github.com/elastic/kibana/pull/220252)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maria Iriarte","email":"106958839+mariairiartef@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-26T12:13:37Z","message":"[Lens] [Data Table] Add settings for data grid density (#220252)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/216095?reload=1?reload=1\n\nIntroduces a new `Density` setting for the Lens Data Table, ensuring\nconsistency with the density options available in Discover. This\nenhancement allows users to customize the table's appearance by\nselecting from `Compact`, `Normal`, and `Expanded` density modes.\n\n<img width=\"444\" alt=\"Screenshot 2025-05-08 at 11 13 26\"\nsrc=\"https://github.com/user-attachments/assets/c5a3bfb6-d2c7-4e14-ae58-c197165ddddc\"\n/>\n\n### Details\n\nThere is an existing DensityControl component in EUI that cannot be\naccessed directly, only by the use of the\n[toolbarVisibility](https://eui.elastic.co/docs/components/tabular-content/data-grid/toolbar/#toolbar-visibility)\nprop in the `EuiDataGrid` component. Since we aren't using this prop for\nthe settings display because we are using a separate `Toolbar`\ncomponent, we have copied and adapted the component found\n[here](https://github.com/elastic/eui/blob/1e78b3f8b435c59379582612aa9b9cfed39ad864/packages/eui/src/components/datagrid/controls/display_selector.tsx#L77).\n\n## Screen recording\n\n\nhttps://github.com/user-attachments/assets/4e281b58-7bd4-4cd3-bf8f-d4c2fd553ae8\n\n\n\n## Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"75681dff3b9f9ae56e0807d3f3fef1e8c9c6e95c","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Visualizations","Feature:Lens","backport missing","backport:version","v9.1.0","v8.19.0"],"title":"[Lens] [Data Table] Add settings for data grid density","number":220252,"url":"https://github.com/elastic/kibana/pull/220252","mergeCommit":{"message":"[Lens] [Data Table] Add settings for data grid density (#220252)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/216095?reload=1?reload=1\n\nIntroduces a new `Density` setting for the Lens Data Table, ensuring\nconsistency with the density options available in Discover. This\nenhancement allows users to customize the table's appearance by\nselecting from `Compact`, `Normal`, and `Expanded` density modes.\n\n<img width=\"444\" alt=\"Screenshot 2025-05-08 at 11 13 26\"\nsrc=\"https://github.com/user-attachments/assets/c5a3bfb6-d2c7-4e14-ae58-c197165ddddc\"\n/>\n\n### Details\n\nThere is an existing DensityControl component in EUI that cannot be\naccessed directly, only by the use of the\n[toolbarVisibility](https://eui.elastic.co/docs/components/tabular-content/data-grid/toolbar/#toolbar-visibility)\nprop in the `EuiDataGrid` component. Since we aren't using this prop for\nthe settings display because we are using a separate `Toolbar`\ncomponent, we have copied and adapted the component found\n[here](https://github.com/elastic/eui/blob/1e78b3f8b435c59379582612aa9b9cfed39ad864/packages/eui/src/components/datagrid/controls/display_selector.tsx#L77).\n\n## Screen recording\n\n\nhttps://github.com/user-attachments/assets/4e281b58-7bd4-4cd3-bf8f-d4c2fd553ae8\n\n\n\n## Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"75681dff3b9f9ae56e0807d3f3fef1e8c9c6e95c"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220252","number":220252,"mergeCommit":{"message":"[Lens] [Data Table] Add settings for data grid density (#220252)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/216095?reload=1?reload=1\n\nIntroduces a new `Density` setting for the Lens Data Table, ensuring\nconsistency with the density options available in Discover. This\nenhancement allows users to customize the table's appearance by\nselecting from `Compact`, `Normal`, and `Expanded` density modes.\n\n<img width=\"444\" alt=\"Screenshot 2025-05-08 at 11 13 26\"\nsrc=\"https://github.com/user-attachments/assets/c5a3bfb6-d2c7-4e14-ae58-c197165ddddc\"\n/>\n\n### Details\n\nThere is an existing DensityControl component in EUI that cannot be\naccessed directly, only by the use of the\n[toolbarVisibility](https://eui.elastic.co/docs/components/tabular-content/data-grid/toolbar/#toolbar-visibility)\nprop in the `EuiDataGrid` component. Since we aren't using this prop for\nthe settings display because we are using a separate `Toolbar`\ncomponent, we have copied and adapted the component found\n[here](https://github.com/elastic/eui/blob/1e78b3f8b435c59379582612aa9b9cfed39ad864/packages/eui/src/components/datagrid/controls/display_selector.tsx#L77).\n\n## Screen recording\n\n\nhttps://github.com/user-attachments/assets/4e281b58-7bd4-4cd3-bf8f-d4c2fd553ae8\n\n\n\n## Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"75681dff3b9f9ae56e0807d3f3fef1e8c9c6e95c"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->