### PR TITLE
[Dataset quality] unskipping  summary tests

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_summary.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_summary.ts
@@ -47,8 +47,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
     ]);
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/211516
-  describe.skip('Dataset quality summary', () => {
+  describe('Dataset quality summary', () => {
     afterEach(async () => {
       await synthtrace.clean();
     });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/211516

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->