### PR TITLE
[Dataset quality] unskipping stats api tests

### DIFF
--- a/x-pack/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
@@ -59,9 +59,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     ]);
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/211517
-  // Failing: See https://github.com/elastic/kibana/issues/213290
-  registry.when.skip('Api Key privileges check', { config: 'basic' }, () => {
+  registry.when('Api Key privileges check', { config: 'basic' }, () => {
     describe('index privileges', () => {
       it('returns user authorization as false for noAccessUser', async () => {
         const resp = await callApiAs('noAccessUser');
@@ -78,6 +76,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(resp.body.datasetUserPrivileges).to.eql({
           canRead: true,
           canMonitor: true,
+          canReadFailureStore: true,
           canViewIntegrations: true,
         });
       });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/211517 and https://github.com/elastic/kibana/issues/213290

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->