### PR TITLE
[Dataset quality] unskipping tests

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
@@ -39,7 +39,6 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
   const failedDatasetName = datasetNames[1];
 
-  // Failing: See https://github.com/elastic/kibana/issues/213289
   describe('Dataset quality table', () => {
     before(async () => {
       // Install Integration and ingest logs for it


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/213289.

The test were already unskipped when merging failure store, we just missed removing the comment

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->