### PR TITLE
[APM] Skip failing test

### DIFF
--- a/x-pack/solutions/observability/test/apm_api_integration/tests/settings/anomaly_detection/update_to_v3.spec.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/settings/anomaly_detection/update_to_v3.spec.ts
@@ -61,8 +61,8 @@ export default function apiTest({ getService }: FtrProviderContext) {
   function deleteJobs(jobIds: string[]) {
     return Promise.allSettled(jobIds.map((jobId) => ml.deleteAnomalyDetectionJobES(jobId)));
   }
-
-  registry.when('Updating ML jobs to v3', { config: 'trial', archives: [] }, () => {
+  // this will be fixed in https://github.com/elastic/kibana/issues/221458
+  registry.when.skip('Updating ML jobs to v3', { config: 'trial', archives: [] }, () => {
     before(async () => {
       const res = await getJobs();
       const jobIds = res.body.jobs.map((job: any) => job.jobId);


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/221458

This PR skips the test to avoid blocking the ES promotion.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->