### PR TITLE
[OAS] Pass down env to router processors and remove `added in...` from serverless OAS

### DIFF
--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -5431,7 +5431,7 @@
         "tags": [
           "alerting"
         ],
-        "x-state": "Generally available; added in 8.19.0"
+        "x-state": "Generally available"
       }
     },
     "/api/alerting/rule/{ruleId}/snooze_schedule/{scheduleId}": {
@@ -5485,7 +5485,7 @@
         "tags": [
           "alerting"
         ],
-        "x-state": "Generally available; added in 8.19.0"
+        "x-state": "Generally available"
       }
     },
     "/api/alerting/rule/{rule_id}/alert/{alert_id}/_mute": {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -4218,7 +4218,7 @@ paths:
       summary: Schedule a snooze for the rule
       tags:
         - alerting
-      x-state: Generally available; added in 8.19.0
+      x-state: Generally available
   /api/alerting/rule/{rule_id}/alert/{alert_id}/_mute:
     post:
       operationId: post-alerting-rule-rule-id-alert-alert-id-mute
@@ -4324,7 +4324,7 @@ paths:
       summary: Delete a snooze schedule for a rule
       tags:
         - alerting
-      x-state: Generally available; added in 8.19.0
+      x-state: Generally available
   /api/alerting/rules/_find:
     get:
       operationId: get-alerting-rules-find

--- a/src/core/packages/http/server-internal/src/http_service.ts
+++ b/src/core/packages/http/server-internal/src/http_service.ts
@@ -311,6 +311,7 @@ export class HttpService
                     title: 'Kibana HTTP APIs',
                     version: '0.0.0', // TODO get a better version here
                     filters,
+                    env: { serverless: this.env.packageInfo.buildFlavor === 'serverless' },
                   }
                 );
                 return h.response(result);

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
@@ -45,6 +45,10 @@ interface RecursiveType {
   self: undefined | RecursiveType;
 }
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('generateOpenApiDocument', () => {
   describe('@kbn/config-schema', () => {
     it('generates the expected OpenAPI document for the shared schema', async () => {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
@@ -571,6 +571,7 @@ describe('generateOpenApiDocument', () => {
             title: 'test',
             baseUrl: 'https://test.oas',
             version: '99.99.99',
+            env: { serverless: false },
           }
         );
 

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
@@ -7,9 +7,27 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+jest.mock('./process_router', () => {
+  const module = jest.requireActual('./process_router');
+  return {
+    ...module,
+    processRouter: jest.fn(module.processRouter),
+  };
+});
+
+jest.mock('./process_versioned_router', () => {
+  const module = jest.requireActual('./process_versioned_router');
+  return {
+    ...module,
+    processVersionedRouter: jest.fn(module.processVersionedRouter),
+  };
+});
+
 import { schema, Type } from '@kbn/config-schema';
 import { get } from 'lodash';
 import { generateOpenApiDocument } from './generate_oas';
+import { processRouter } from './process_router';
+import { processVersionedRouter } from './process_versioned_router';
 import {
   createTestRouters,
   createRouter,
@@ -562,6 +580,7 @@ describe('generateOpenApiDocument', () => {
       '$name: $expectedState',
       async ({ routerConfig, expectedPath, expectedState }) => {
         const [routers, versionedRouters] = createTestRouters(routerConfig);
+        const env = { serverless: false, dummy: true };
         const result = await generateOpenApiDocument(
           {
             routers,
@@ -571,9 +590,22 @@ describe('generateOpenApiDocument', () => {
             title: 'test',
             baseUrl: 'https://test.oas',
             version: '99.99.99',
-            env: { serverless: false },
+            env,
           }
         );
+
+        // Assert that the env has been passed down as expected
+        if ((processRouter as jest.Mock).mock.calls.length) {
+          (processRouter as jest.Mock).mock.calls.forEach(([{ env: routerEnv }]) =>
+            expect(routerEnv).toEqual({ serverless: false, dummy: true })
+          );
+        }
+        if ((processVersionedRouter as jest.Mock).mock.calls.length) {
+          (processVersionedRouter as jest.Mock).mock.calls.forEach(
+            ([{ env: versionedRouterEnv }]) =>
+              expect(versionedRouterEnv).toEqual({ serverless: false, dummy: true })
+          );
+        }
 
         if (expectedState) {
           expect(result.paths[expectedPath]!.get).toMatchObject({

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/process_router.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/process_router.ts
@@ -25,17 +25,26 @@ import {
   setXState,
   GetOpId,
 } from './util';
-import type { GenerateOpenApiDocumentOptionsFilters } from './generate_oas';
+import type { Env, GenerateOpenApiDocumentOptionsFilters } from './generate_oas';
 import type { CustomOperationObject, InternalRouterRoute } from './type';
 import { extractAuthzDescription } from './extract_authz_description';
 import { mergeOperation } from './merge_operation';
 
-export const processRouter = async (
-  appRouter: Router,
-  converter: OasConverter,
-  getOpId: GetOpId,
-  filters: GenerateOpenApiDocumentOptionsFilters
-) => {
+export interface ProcessRouterOptions {
+  appRouter: Router;
+  converter: OasConverter;
+  getOpId: GetOpId;
+  filters: GenerateOpenApiDocumentOptionsFilters;
+  env?: Env;
+}
+
+export const processRouter = async ({
+  appRouter,
+  converter,
+  getOpId,
+  filters,
+  env = { serverless: false },
+}: ProcessRouterOptions) => {
   const paths: OpenAPIV3.PathsObject = {};
   if (filters?.version && filters.version !== SERVERLESS_VERSION_2023_10_31) return { paths };
   const routes = prepareRoutes(appRouter.getRoutes({ excludeVersionedRoutes: true }), filters);
@@ -98,7 +107,7 @@ export const processRouter = async (
         operationId: getOpId({ path: route.path, method: route.method }),
       };
 
-      setXState(route.options.availability, operation);
+      setXState(route.options.availability, operation, env);
 
       if (route.options.oasOperationObject) {
         await mergeOperation(route.options.oasOperationObject(), operation);

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.test.ts
@@ -122,35 +122,35 @@ describe('extractVersionedResponses', () => {
 
 describe('processVersionedRouter', () => {
   it('correctly extracts the version based on the version filter', async () => {
-    const baseCase = await processVersionedRouter(
-      { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
-      new OasConverter(),
-      createOpIdGenerator(),
-      { access: 'public', version: '2023-10-31' }
-    );
+    const baseCase = await processVersionedRouter({
+      appRouter: { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
+      converter: new OasConverter(),
+      getOpId: createOpIdGenerator(),
+      filters: { access: 'public', version: '2023-10-31' },
+    });
 
     expect(Object.keys(get(baseCase, 'paths["/foo"].get.responses.200.content')!)).toEqual([
       'application/test+json',
     ]);
 
-    const filteredCase = await processVersionedRouter(
-      { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
-      new OasConverter(),
-      createOpIdGenerator(),
-      { version: '2024-12-31', access: 'public' }
-    );
+    const filteredCase = await processVersionedRouter({
+      appRouter: { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
+      converter: new OasConverter(),
+      getOpId: createOpIdGenerator(),
+      filters: { version: '2024-12-31', access: 'public' },
+    });
     expect(Object.keys(get(filteredCase, 'paths["/foo"].get.responses.200.content')!)).toEqual([
       'application/test+json',
     ]);
   });
 
   it('correctly updates the authz description for routes that require privileges', async () => {
-    const results = await processVersionedRouter(
-      { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
-      new OasConverter(),
-      createOpIdGenerator(),
-      { version: '2023-10-31', access: 'public' }
-    );
+    const results = await processVersionedRouter({
+      appRouter: { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
+      converter: new OasConverter(),
+      getOpId: createOpIdGenerator(),
+      filters: { version: '2023-10-31', access: 'public' },
+    });
     expect(results.paths['/foo']).toBeDefined();
 
     expect(results.paths['/foo']!.get).toBeDefined();

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.ts
@@ -15,7 +15,7 @@ import {
 import type { RouteMethod, VersionedRouterRoute } from '@kbn/core-http-server';
 import type { OpenAPIV3 } from 'openapi-types';
 import { extractAuthzDescription } from './extract_authz_description';
-import type { GenerateOpenApiDocumentOptionsFilters } from './generate_oas';
+import type { Env, GenerateOpenApiDocumentOptionsFilters } from './generate_oas';
 import type { OasConverter } from './oas_converter';
 import {
   prepareRoutes,
@@ -33,12 +33,21 @@ import {
 import { isReferenceObject } from './oas_converter/common';
 import { mergeOperation } from './merge_operation';
 
-export const processVersionedRouter = async (
-  appRouter: CoreVersionedRouter,
-  converter: OasConverter,
-  getOpId: GetOpId,
-  filters: GenerateOpenApiDocumentOptionsFilters
-) => {
+export interface ProcessVersionedRouterOptions {
+  appRouter: CoreVersionedRouter;
+  converter: OasConverter;
+  getOpId: GetOpId;
+  filters: GenerateOpenApiDocumentOptionsFilters;
+  env?: Env;
+}
+
+export const processVersionedRouter = async ({
+  appRouter,
+  converter,
+  getOpId,
+  filters,
+  env = { serverless: false },
+}: ProcessVersionedRouterOptions) => {
   const routes = prepareRoutes(appRouter.getRoutes(), filters);
   const paths: OpenAPIV3.PathsObject = {};
   for (const route of routes) {
@@ -129,7 +138,7 @@ export const processVersionedRouter = async (
         operationId: getOpId({ path: route.path, method: route.method }),
       };
 
-      setXState(route.options.options?.availability, operation);
+      setXState(route.options.options?.availability, operation, env);
 
       if (handler.options.options?.oasOperationObject) {
         await mergeOperation(handler.options.options.oasOperationObject(), operation);

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/util.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/util.test.ts
@@ -351,57 +351,115 @@ describe('createOpIdGenerator', () => {
 });
 
 describe('setXState', () => {
-  test.each([
-    {
-      name: 'stable with since',
-      availability: { stability: 'stable' as const, since: '8.0.0' },
-      expected: 'Generally available; added in 8.0.0',
-    },
-    {
-      name: 'stable without since',
-      availability: { stability: 'stable' as const },
-      expected: 'Generally available',
-    },
-    {
-      name: 'experimental with since',
-      availability: { stability: 'experimental' as const, since: '8.0.0' },
-      expected: 'Technical Preview; added in 8.0.0',
-    },
-    {
-      name: 'experimental without since',
-      availability: { stability: 'experimental' as const },
-      expected: 'Technical Preview',
-    },
-    {
-      name: 'beta with since',
-      availability: { stability: 'beta' as const, since: '8.0.0' },
-      expected: 'Beta; added in 8.0.0',
-    },
-    {
-      name: 'beta without since',
-      availability: { stability: 'beta' as const },
-      expected: 'Beta',
-    },
-    {
-      name: 'no availability',
-      availability: undefined,
-      expected: undefined,
-    },
-    {
-      name: 'only since',
-      availability: { since: '8.0.0' },
-      expected: 'Added in 8.0.0',
-    },
-  ])('$name', ({ availability, expected }) => {
-    // Create a minimal valid CustomOperationObject with required responses property
-    const operation: CustomOperationObject = {
-      responses: {
-        '200': {
-          description: 'OK',
-        },
+  describe('with serverless=false (default)', () => {
+    test.each([
+      {
+        name: 'stable with since',
+        availability: { stability: 'stable' as const, since: '8.0.0' },
+        expected: 'Generally available; added in 8.0.0',
       },
-    };
-    setXState(availability, operation);
-    expect(operation['x-state']).toBe(expected);
+      {
+        name: 'stable without since',
+        availability: { stability: 'stable' as const },
+        expected: 'Generally available',
+      },
+      {
+        name: 'experimental with since',
+        availability: { stability: 'experimental' as const, since: '8.0.0' },
+        expected: 'Technical Preview; added in 8.0.0',
+      },
+      {
+        name: 'experimental without since',
+        availability: { stability: 'experimental' as const },
+        expected: 'Technical Preview',
+      },
+      {
+        name: 'beta with since',
+        availability: { stability: 'beta' as const, since: '8.0.0' },
+        expected: 'Beta; added in 8.0.0',
+      },
+      {
+        name: 'beta without since',
+        availability: { stability: 'beta' as const },
+        expected: 'Beta',
+      },
+      {
+        name: 'no availability',
+        availability: undefined,
+        expected: undefined,
+      },
+      {
+        name: 'only since',
+        availability: { since: '8.0.0' },
+        expected: 'Added in 8.0.0',
+      },
+    ])('$name', ({ availability, expected }) => {
+      // Create a minimal valid CustomOperationObject with required responses property
+      const operation: CustomOperationObject = {
+        responses: {
+          '200': {
+            description: 'OK',
+          },
+        },
+      };
+      setXState(availability, operation, { serverless: false });
+      expect(operation['x-state']).toBe(expected);
+    });
+  });
+
+  describe('with serverless=true', () => {
+    test.each([
+      {
+        name: 'stable with since',
+        availability: { stability: 'stable' as const, since: '8.0.0' },
+        expected: 'Generally available',
+      },
+      {
+        name: 'stable without since',
+        availability: { stability: 'stable' as const },
+        expected: 'Generally available',
+      },
+      {
+        name: 'experimental with since',
+        availability: { stability: 'experimental' as const, since: '8.0.0' },
+        expected: 'Technical Preview',
+      },
+      {
+        name: 'experimental without since',
+        availability: { stability: 'experimental' as const },
+        expected: 'Technical Preview',
+      },
+      {
+        name: 'beta with since',
+        availability: { stability: 'beta' as const, since: '8.0.0' },
+        expected: 'Beta',
+      },
+      {
+        name: 'beta without since',
+        availability: { stability: 'beta' as const },
+        expected: 'Beta',
+      },
+      {
+        name: 'no availability',
+        availability: undefined,
+        expected: undefined,
+      },
+      {
+        name: 'only since',
+        availability: { since: '8.0.0' },
+        expected: '',
+      },
+    ])('$name', ({ availability, expected }) => {
+      // Create a minimal valid CustomOperationObject with required responses property
+      const operation: CustomOperationObject = {
+        responses: {
+          '200': {
+            description: 'OK',
+          },
+        },
+      };
+      setXState(availability, operation, { serverless: true });
+      expect(operation['x-state']).toBe(expected);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/util.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/util.ts
@@ -19,6 +19,7 @@ import {
 } from '@kbn/core-http-server';
 import { CustomOperationObject, KnownParameters } from './type';
 import type { GenerateOpenApiDocumentOptionsFilters } from './generate_oas';
+import { Env } from './generate_oas';
 
 const tagPrefix = 'oas-tag:';
 const extractTag = (tag: string) => {
@@ -183,7 +184,8 @@ export const getXsrfHeaderForMethod = (
 
 export const setXState = (
   availability: RouteConfigOptions<RouteMethod>['availability'],
-  operation: CustomOperationObject
+  operation: CustomOperationObject,
+  env: Env
 ): void => {
   if (availability) {
     let state = '';
@@ -194,7 +196,7 @@ export const setXState = (
     } else if (availability.stability === 'beta') {
       state = 'Beta';
     }
-    if (availability.since) {
+    if (!env.serverless && availability.since) {
       state = state ? `${state}; added in ${availability.since}` : `Added in ${availability.since}`;
     }
     operation['x-state'] = state;


### PR DESCRIPTION
## Summary

* Addresses this comment https://github.com/elastic/kibana/issues/221056#issuecomment-2917522252, essentially avoid stating `added in...` if we are generating OAS for a serverless Kibana
* Refactors `processRouter` and `processVersionedRouter` to take in object (for easier refactoring)
* Adds test coverage


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios