### PR TITLE
[8.18] [APM] Fix error count waterfall navigation reload issue (#221664)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiIcon, EuiText, EuiTitle, EuiToolTip } from '@elastic/eui';
+import { EuiBadge, EuiIcon, EuiText, EuiTitle, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ReactNode } from 'react';
 import React, { useRef, useEffect, useState } from 'react';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
-import { useTheme } from '../../../../../../hooks/use_theme';
+import { useApmPluginContext } from '../../../../../../context/apm_plugin/use_apm_plugin_context';
 import { isMobileAgentName, isRumAgentName } from '../../../../../../../common/agent_name';
 import { SPAN_ID, TRACE_ID, TRANSACTION_ID } from '../../../../../../../common/es_fields/apm';
 import { asDuration } from '../../../../../../../common/utils/formatters';
@@ -314,13 +314,18 @@ function RelatedErrors({
   errorCount: number;
 }) {
   const apmRouter = useApmRouter();
-  const theme = useTheme();
+  const { euiTheme } = useEuiTheme();
   const { query } = useAnyOfApmParams(
     '/services/{serviceName}/transactions/view',
     '/mobile-services/{serviceName}/transactions/view',
     '/traces/explorer',
     '/dependencies/operation'
   );
+  const {
+    core: {
+      application: { navigateToUrl },
+    },
+  } = useApmPluginContext();
 
   let kuery = `${TRACE_ID} : "${item.doc.trace.id}"`;
   const transactionId = item.doc.transaction?.id;
@@ -350,22 +355,29 @@ function RelatedErrors({
     },
   });
 
+  const viewRelatedErrorsLabel = i18n.translate('xpack.apm.waterfall.errorCount', {
+    defaultMessage: '{errorCount, plural, one {View related error} other {View # related errors}}',
+    values: { errorCount },
+  });
+
+  const onClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation();
+    navigateToUrl(isMobileAgentName(item.doc.agent.name) ? mobileHref : href);
+  };
+
   if (errorCount > 0) {
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-      <div onClick={(e: React.MouseEvent) => e.stopPropagation()}>
-        <EuiBadge
-          href={isMobileAgentName(item.doc.agent.name) ? mobileHref : href}
-          color={theme.eui.euiColorDanger}
-          iconType="arrowRight"
-        >
-          {i18n.translate('xpack.apm.waterfall.errorCount', {
-            defaultMessage:
-              '{errorCount, plural, one {View related error} other {View # related errors}}',
-            values: { errorCount },
-          })}
-        </EuiBadge>
-      </div>
+      <EuiBadge
+        color={euiTheme.colors.danger}
+        iconType="arrowRight"
+        onClick={onClick}
+        tabIndex={0}
+        role="button"
+        aria-label={viewRelatedErrorsLabel}
+        onClickAriaLabel={viewRelatedErrorsLabel}
+      >
+        {viewRelatedErrorsLabel}
+      </EuiBadge>
     );
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[APM] Fix error count waterfall navigation reload issue (#221664)](https://github.com/elastic/kibana/pull/221664)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-06-02T11:02:22Z","message":"[APM] Fix error count waterfall navigation reload issue (#221664)\n\nCloses #82154 \n\n## Summary\n\nThis PR fixes the error count navigation reload issue in the APM\nwaterfall. To fix that, it combines the prevent default action needed\nbecause of the flyout opening and the navigation using the\n`navigateToUrl` action to create a SPA-like experience:\n\n\nhttps://github.com/user-attachments/assets/43faf3b9-2038-40d0-89c9-62c37087386d\n\nTesting ⬆️ \n- The navigation to the errors tab should not cause a full page refresh\n- The flyout should open without issues on click \n\n+ Now the errors link supports keyboard navigation (fixed that part\nhere, it was skipped before)\n\n\nhttps://github.com/user-attachments/assets/82c2d0b7-caef-4c24-8af9-d6b1d7f75eef","sha":"8a40c53263de722d1ee7936e775e9d439e7db744","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.1.0"],"title":"[APM] Fix error count waterfall navigation reload issue","number":221664,"url":"https://github.com/elastic/kibana/pull/221664","mergeCommit":{"message":"[APM] Fix error count waterfall navigation reload issue (#221664)\n\nCloses #82154 \n\n## Summary\n\nThis PR fixes the error count navigation reload issue in the APM\nwaterfall. To fix that, it combines the prevent default action needed\nbecause of the flyout opening and the navigation using the\n`navigateToUrl` action to create a SPA-like experience:\n\n\nhttps://github.com/user-attachments/assets/43faf3b9-2038-40d0-89c9-62c37087386d\n\nTesting ⬆️ \n- The navigation to the errors tab should not cause a full page refresh\n- The flyout should open without issues on click \n\n+ Now the errors link supports keyboard navigation (fixed that part\nhere, it was skipped before)\n\n\nhttps://github.com/user-attachments/assets/82c2d0b7-caef-4c24-8af9-d6b1d7f75eef","sha":"8a40c53263de722d1ee7936e775e9d439e7db744"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221664","number":221664,"mergeCommit":{"message":"[APM] Fix error count waterfall navigation reload issue (#221664)\n\nCloses #82154 \n\n## Summary\n\nThis PR fixes the error count navigation reload issue in the APM\nwaterfall. To fix that, it combines the prevent default action needed\nbecause of the flyout opening and the navigation using the\n`navigateToUrl` action to create a SPA-like experience:\n\n\nhttps://github.com/user-attachments/assets/43faf3b9-2038-40d0-89c9-62c37087386d\n\nTesting ⬆️ \n- The navigation to the errors tab should not cause a full page refresh\n- The flyout should open without issues on click \n\n+ Now the errors link supports keyboard navigation (fixed that part\nhere, it was skipped before)\n\n\nhttps://github.com/user-attachments/assets/82c2d0b7-caef-4c24-8af9-d6b1d7f75eef","sha":"8a40c53263de722d1ee7936e775e9d439e7db744"}}]}] BACKPORT-->