### PR TITLE
chore: update @elastic/eslint-plugin-eui to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1393,7 +1393,7 @@
     "@cypress/debugging-proxy": "2.0.1",
     "@cypress/grep": "^4.0.1",
     "@cypress/webpack-preprocessor": "^6.0.2",
-    "@elastic/eslint-plugin-eui": "0.2.0",
+    "@elastic/eslint-plugin-eui": "1.0.0",
     "@elastic/makelogs": "^6.1.1",
     "@elastic/synthetics": "^1.18.0",
     "@emotion/babel-preset-css-prop": "^11.11.0",

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_bar_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_bar_chart.tsx
@@ -73,7 +73,7 @@ export const AssetInventoryBarChart = ({
   const baseTheme = useElasticChartsTheme();
   return (
     <div css={getChartStyles(euiTheme, xsFontSize)}>
-      {/* eslint-disable-next-line @elastic/eui/prefer-css-attributes-for-eui-components */}
+      {/* eslint-disable-next-line @elastic/eui/prefer-css-prop-for-static-styles */}
       <EuiProgress size="xs" color="accent" style={getProgressStyle(isFetching)} />
       {isLoading ? (
         <EuiFlexGroup

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,10 +2164,10 @@
     semver "^7.6.3"
     topojson-client "^3.1.0"
 
-"@elastic/eslint-plugin-eui@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.2.0.tgz#0f32724e394f3bfa35d18ef8fa2e79da47191779"
-  integrity sha512-EDp5FP8nbzGXwAMWM2xo6SL2LdsUwEVrt6idE8AoW45KybuJZ9Dr8IB8z6+wCr7Jxrg+nwdst039LpaslDur+g==
+"@elastic/eslint-plugin-eui@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-1.0.0.tgz#2db728692ab1f13e08826a65c2adb180c3962195"
+  integrity sha512-2CZ8w5+vJgruqWm5XEA1KENX+ZYAjMfkRyJtXafq4/jXIFLYCWqqAAWmVgrbY+DufLr405Zf8718L7Rp39TMEg==
 
 "@elastic/eui-amsterdam@npm:@elastic/eui@102.2.0-amsterdam.0":
   version "102.2.0-amsterdam.0"


### PR DESCRIPTION
`@elastic/eslint-plugin-eui`: `0.2.0` ⏩ `1.0.0`

[Questions? Please see our Kibana upgrade FAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)

## Changes

This PR updates the `@elastic/eslint-plugin-eui` version to latest: [v1.0.0](https://www.npmjs.com/package/@elastic/eslint-plugin-eui/v/1.0.0).

## Package updates

### `@elastic/eslint-plugin-eui`

- Changed the `prefer-css-prop-for-static-styles` rule message (formerly `prefer-css-attribute-for-eui-components`) ([#8722](https://github.com/elastic/eui/pull/8722))

**Breaking changes**

- Renamed the rule from `prefer-css-attribute-for-eui-components` to `prefer-css-prop-for-static-styles` to align with Emotion's best practice guidelines ([#8722](https://github.com/elastic/eui/pull/8722))

**Dependency updates**

- Updated `typescript` to v5.8.3 ([#8669](https://github.com/elastic/eui/pull/8669))
- Updated `@typescript-eslint/eslint-plugin` to v8.31.1 ([#8669](https://github.com/elastic/eui/pull/8669))
- Updated `@typescript-eslint/parser` to v8.31.1 ([#8669](https://github.com/elastic/eui/pull/8669))
- Updated `@typescript-eslint/rule-tester` to v8.31.1 ([#8669](https://github.com/elastic/eui/pull/8669))
- Updated `@typescript-eslint/typescript-estree` to v8.31.1 ([#8669](https://github.com/elastic/eui/pull/8669))
- Updated `@typescript-eslint/utils` to v8.31.1 ([#8669](https://github.com/elastic/eui/pull/8669))