### PR TITLE
[Security Solution] Fix race condition when Defend is installed before rules package

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/bootstrap_prebuilt_rules/bootstrap_prebuilt_rules_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/bootstrap_prebuilt_rules/bootstrap_prebuilt_rules_handler.ts
@@ -49,7 +49,7 @@ export const bootstrapPrebuiltRulesHandler = async (
     const packageResults: PackageInstallStatus[] = [];
 
     // Install packages sequentially to avoid high memory usage
-    const prebuiltRulesResult = await installPrebuiltRulesPackage(config, securityContext);
+    const prebuiltRulesResult = await installPrebuiltRulesPackage(securityContext);
     packageResults.push({
       name: prebuiltRulesResult.package.name,
       version: prebuiltRulesResult.package.version,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/legacy_create_prepackaged_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/legacy_create_prepackaged_rules.ts
@@ -37,7 +37,6 @@ export const legacyCreatePrepackagedRules = async (
   rulesClient: RulesClient,
   exceptionsClient?: ExceptionListClient
 ): Promise<InstallPrebuiltRulesAndTimelinesResponse> => {
-  const config = context.getConfig();
   const savedObjectsClient = context.core.savedObjects.client;
   const siemClient = context.getAppClient();
   const exceptionsListClient = context.getExceptionListClient() ?? exceptionsClient;
@@ -53,11 +52,7 @@ export const legacyCreatePrepackagedRules = async (
     await exceptionsListClient.createEndpointList();
   }
 
-  const latestPrebuiltRules = await ensureLatestRulesPackageInstalled(
-    ruleAssetsClient,
-    config,
-    context
-  );
+  const latestPrebuiltRules = await ensureLatestRulesPackageInstalled(ruleAssetsClient, context);
 
   const installedPrebuiltRules = rulesToMap(await getExistingPrepackagedRules({ rulesClient }));
   const rulesToInstall = getRulesToInstall(latestPrebuiltRules, installedPrebuiltRules);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
@@ -32,7 +32,6 @@ export const performRuleInstallationHandler = async (
 
   try {
     const ctx = await context.resolve(['core', 'alerting', 'securitySolution']);
-    const config = ctx.securitySolution.getConfig();
     const soClient = ctx.core.savedObjects.client;
     const rulesClient = await ctx.alerting.getRulesClient();
     const detectionRulesClient = ctx.securitySolution.getDetectionRulesClient();
@@ -47,7 +46,7 @@ export const performRuleInstallationHandler = async (
 
     // If this API is used directly without hitting any detection engine
     // pages first, the rules package might be missing.
-    await ensureLatestRulesPackageInstalled(ruleAssetsClient, config, ctx.securitySolution);
+    await ensureLatestRulesPackageInstalled(ruleAssetsClient, ctx.securitySolution);
 
     const allLatestVersions = await ruleAssetsClient.fetchLatestVersions();
     const currentRuleVersions = await ruleObjectsClient.fetchInstalledRuleVersions();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/ensure_latest_rules_package_installed.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/ensure_latest_rules_package_installed.ts
@@ -5,20 +5,18 @@
  * 2.0.
  */
 
-import type { ConfigType } from '../../../../../config';
 import type { SecuritySolutionApiRequestHandlerContext } from '../../../../../types';
 import type { IPrebuiltRuleAssetsClient } from '../rule_assets/prebuilt_rule_assets_client';
 import { installPrebuiltRulesPackage } from './install_prebuilt_rules_package';
 
 export async function ensureLatestRulesPackageInstalled(
   ruleAssetsClient: IPrebuiltRuleAssetsClient,
-  config: ConfigType,
   securityContext: SecuritySolutionApiRequestHandlerContext
 ) {
   let latestPrebuiltRules = await ruleAssetsClient.fetchLatestAssets();
   if (latestPrebuiltRules.length === 0) {
     // Seems no packages with prepackaged rules were installed, try to install the default rules package
-    await installPrebuiltRulesPackage(config, securityContext);
+    await installPrebuiltRulesPackage(securityContext);
 
     // Try to get the prepackaged rules again
     latestPrebuiltRules = await ruleAssetsClient.fetchLatestAssets();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule.ts
@@ -13,6 +13,7 @@ import { ELASTIC_SECURITY_RULE_ID } from '../../../../../../common';
 import { createPrebuiltRuleObjectsClient } from '../rule_objects/prebuilt_rule_objects_client';
 import { createPrebuiltRuleAssetsClient } from '../rule_assets/prebuilt_rule_assets_client';
 import { createPrebuiltRules } from '../rule_objects/create_prebuilt_rules';
+import { ensureLatestRulesPackageInstalled } from './ensure_latest_rules_package_installed';
 
 export interface InstallEndpointSecurityPrebuiltRuleProps {
   logger: Logger;
@@ -64,6 +65,11 @@ export const installEndpointSecurityPrebuiltRule = async ({
 
     // This will create the endpoint list if it does not exist yet
     await exceptionsListClient?.createEndpointList();
+
+    // Make sure the latest prebuilt rules package is installed (in case the
+    // user installs Elastic Defend integration without visiting Security
+    // Solution first)
+    await ensureLatestRulesPackageInstalled(ruleAssetsClient, context);
 
     const latestRuleVersion = await ruleAssetsClient.fetchLatestVersions([
       ELASTIC_SECURITY_RULE_ID,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_prebuilt_rules_package.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_prebuilt_rules_package.ts
@@ -7,7 +7,6 @@
 
 import type { SecuritySolutionApiRequestHandlerContext } from '../../../../../types';
 import { PREBUILT_RULES_PACKAGE_NAME } from '../../../../../../common/detection_engine/constants';
-import type { ConfigType } from '../../../../../config';
 import { findLatestPackageVersion } from './find_latest_package_version';
 
 /**
@@ -17,9 +16,9 @@ import { findLatestPackageVersion } from './find_latest_package_version';
  * @param context Request handler context
  */
 export async function installPrebuiltRulesPackage(
-  config: ConfigType,
   context: SecuritySolutionApiRequestHandlerContext
 ) {
+  const config = context.getConfig();
   let pkgVersion = config.prebuiltRulesPackageVersion;
 
   if (!pkgVersion) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -148,7 +148,6 @@ export const importRulesRoute = (router: SecuritySolutionPluginRouter, config: C
           );
 
           const ruleSourceImporter = createRuleSourceImporter({
-            config,
             context: ctx.securitySolution,
             prebuiltRuleAssetsClient: createPrebuiltRuleAssetsClient(savedObjectsClient),
             prebuiltRuleObjectsClient: createPrebuiltRuleObjectsClient(rulesClient),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/rule_source_importer/rule_source_importer.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/rule_source_importer/rule_source_importer.test.ts
@@ -11,21 +11,19 @@ import type {
 } from '../../../../../../../common/api/detection_engine';
 import { createPrebuiltRuleAssetsClient as createPrebuiltRuleAssetsClientMock } from '../../../../prebuilt_rules/logic/rule_assets/__mocks__/prebuilt_rule_assets_client';
 import { createPrebuiltRuleObjectsClient as createPrebuiltRuleObjectsClientMock } from '../../../../prebuilt_rules/logic/rule_objects/__mocks__/prebuilt_rule_objects_client';
-import { createMockConfig, requestContextMock } from '../../../../routes/__mocks__';
+import { requestContextMock } from '../../../../routes/__mocks__';
 import { getPrebuiltRuleMock } from '../../../../prebuilt_rules/mocks';
 import { createRuleSourceImporter } from './rule_source_importer';
 
 describe('ruleSourceImporter', () => {
   let ruleAssetsClientMock: ReturnType<typeof createPrebuiltRuleAssetsClientMock>;
   let ruleObjectsClientMock: ReturnType<typeof createPrebuiltRuleObjectsClientMock>;
-  let config: ReturnType<typeof createMockConfig>;
   let context: ReturnType<typeof requestContextMock.create>['securitySolution'];
   let ruleToImport: RuleToImport;
   let subject: ReturnType<typeof createRuleSourceImporter>;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    config = createMockConfig();
     context = requestContextMock.create().securitySolution;
     ruleAssetsClientMock = createPrebuiltRuleAssetsClientMock();
     ruleAssetsClientMock.fetchLatestAssets.mockResolvedValue([{}]);
@@ -37,7 +35,6 @@ describe('ruleSourceImporter', () => {
 
     subject = createRuleSourceImporter({
       context,
-      config,
       prebuiltRuleAssetsClient: ruleAssetsClientMock,
       prebuiltRuleObjectsClient: ruleObjectsClientMock,
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/rule_source_importer/rule_source_importer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/rule_source_importer/rule_source_importer.ts
@@ -13,7 +13,6 @@
  */
 
 import type { SecuritySolutionApiRequestHandlerContext } from '../../../../../../types';
-import type { ConfigType } from '../../../../../../config';
 import type {
   RuleResponse,
   RuleToImport,
@@ -95,7 +94,6 @@ const fetchMatchingAssets = async ({
  */
 export class RuleSourceImporter implements IRuleSourceImporter {
   private context: SecuritySolutionApiRequestHandlerContext;
-  private config: ConfigType;
   private ruleAssetsClient: IPrebuiltRuleAssetsClient;
   private ruleObjectsClient: IPrebuiltRuleObjectsClient;
   private latestPackagesInstalled: boolean = false;
@@ -105,17 +103,14 @@ export class RuleSourceImporter implements IRuleSourceImporter {
   private availableRuleAssetIds: Set<string> = new Set();
 
   constructor({
-    config,
     context,
     prebuiltRuleAssetsClient,
     prebuiltRuleObjectsClient,
   }: {
-    config: ConfigType;
     context: SecuritySolutionApiRequestHandlerContext;
     prebuiltRuleAssetsClient: IPrebuiltRuleAssetsClient;
     prebuiltRuleObjectsClient: IPrebuiltRuleObjectsClient;
   }) {
-    this.config = config;
     this.ruleAssetsClient = prebuiltRuleAssetsClient;
     this.ruleObjectsClient = prebuiltRuleObjectsClient;
     this.context = context;
@@ -128,7 +123,7 @@ export class RuleSourceImporter implements IRuleSourceImporter {
    */
   public async setup(rules: RuleToImport[]): Promise<void> {
     if (!this.latestPackagesInstalled) {
-      await ensureLatestRulesPackageInstalled(this.ruleAssetsClient, this.config, this.context);
+      await ensureLatestRulesPackageInstalled(this.ruleAssetsClient, this.context);
       this.latestPackagesInstalled = true;
     }
 
@@ -209,18 +204,15 @@ export class RuleSourceImporter implements IRuleSourceImporter {
 }
 
 export const createRuleSourceImporter = ({
-  config,
   context,
   prebuiltRuleAssetsClient,
   prebuiltRuleObjectsClient,
 }: {
-  config: ConfigType;
   context: SecuritySolutionApiRequestHandlerContext;
   prebuiltRuleAssetsClient: IPrebuiltRuleAssetsClient;
   prebuiltRuleObjectsClient: IPrebuiltRuleObjectsClient;
 }): RuleSourceImporter => {
   return new RuleSourceImporter({
-    config,
     context,
     prebuiltRuleAssetsClient,
     prebuiltRuleObjectsClient,


### PR DESCRIPTION
## Summary

Fixes a race condition where the Elastic Defend rule is installed before the rules package becomes available, resulting in the following error:

```
[2025-05-29T10:40:00.066-04:00][ERROR][plugins.securitySolution.endpointFleetExtension] Unable to find Elastic Defend rule in the prebuilt rule assets (rule_id: 9a1a2dae-0b5f-4c3d-8305-a268d404c306)
```

### Steps to Reproduce

1. Start with a clean Kibana instance with no rules package installed.  
2. Navigate directly to the Integrations page (without visiting any Security Solution pages, which would trigger rules package bootstrapping), and install the Elastic Defend integration.  
3. Observe the `Unable to find Elastic Defend rule in the prebuilt rule assets` error in the Kibana logs.

This race condition appears to have existed for some time but was surfaced more clearly due to the recently added warning when the Defend rule cannot be installed.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->