### PR TITLE
[ES|QL] fix: hide rrf command

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -722,6 +722,7 @@ export const commandDefinitions: Array<CommandDefinition<any>> = [
     suggest: suggestForSample,
   },
   {
+    hidden: true,
     preview: true,
     name: 'rrf',
     description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.rrfDoc', {


### PR DESCRIPTION
## Summary
`RRF` command should be hidden for now.








<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->