### PR TITLE
[Security Solution] Skip a failing ES|QL validation Cypress test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/esql_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/esql_rule.cy.ts
@@ -170,7 +170,8 @@ describe(
         cy.get(ESQL_QUERY_BAR).contains('Error validating ES|QL');
       });
 
-      it('shows syntax error when query is syntactically invalid - prioritizing it over missing metadata operator error', function () {
+      // Skipped: https://github.com/elastic/kibana/issues/222182
+      it.skip('shows syntax error when query is syntactically invalid - prioritizing it over missing metadata operator error', function () {
         const invalidNonAggregatingQuery = 'from auditbeat* | limit 5 test';
         selectEsqlRuleType();
         fillEsqlQueryBar(invalidNonAggregatingQuery);


### PR DESCRIPTION
Skipping due to a failing test. Ticket to unskip: https://github.com/elastic/kibana/issues/222182

Might be related to: https://github.com/elastic/elasticsearch/pull/128464