### PR TITLE
[Security Solution] Add GitHub Action to auto-complete team labels and assign 'needs-team' when ambiguous

### DIFF
--- a/.github/workflows/security-issue-label-checker.yml
+++ b/.github/workflows/security-issue-label-checker.yml
@@ -1,0 +1,82 @@
+name: Check and Complete Team Labels
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  ensure-team-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and add missing labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const currentLabels = context.payload.issue.labels.map(l => l.name);
+
+            const hasDetectionEngine = currentLabels.includes("Team:Detection Engine");
+            const hasRuleManagement = currentLabels.includes("Team:Detection Rule Management");
+
+            const detectionGroup = [
+              "Team:Detection Engine",
+              "Team:Detections and Resp",
+              "Team:Security Solution",
+              "triage_needed"
+            ];
+
+            const ruleManagementGroup = [
+              "Team:Detection Rule Management",
+              "Team:Detections and Resp",
+              "Team:Security Solution",
+              "triage_needed"
+            ];
+
+            const labelsToAdd = new Set();
+
+            // Add missing labels for Detection Engine group
+            if (hasDetectionEngine) {
+              for (const label of detectionGroup) {
+                if (!currentLabels.includes(label)) {
+                  labelsToAdd.add(label);
+                }
+              }
+            }
+
+            // Add missing labels for Rule Management group
+            if (hasRuleManagement) {
+              for (const label of ruleManagementGroup) {
+                if (!currentLabels.includes(label)) {
+                  labelsToAdd.add(label);
+                }
+              }
+            }
+
+            // Add 'needs-team' when only shared labels are present (ambiguous ownership)
+            const hasOnlyShared =
+              !hasDetectionEngine &&
+              !hasRuleManagement &&
+              (currentLabels.includes("Team:Security Solution") || currentLabels.includes("Team:Detections and Resp"));
+
+            if (hasOnlyShared) {
+              if (!currentLabels.includes("needs-team")) {
+                labelsToAdd.add("needs-team");
+              }
+              if (!currentLabels.includes("triage_needed")) {
+                labelsToAdd.add("triage_needed");
+              }
+            }
+
+            if (labelsToAdd.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: Array.from(labelsToAdd)
+              });
+              console.log(`Added missing labels: ${Array.from(labelsToAdd).join(", ")}`);
+            } else {
+              console.log("No labels to add.");
+            }

--- a/.github/workflows/security-issue-label-checker.yml
+++ b/.github/workflows/security-issue-label-checker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check and add missing labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const currentLabels = context.payload.issue.labels.map(l => l.name);

--- a/.github/workflows/security-issue-label-checker.yml
+++ b/.github/workflows/security-issue-label-checker.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           script: |
             const currentLabels = context.payload.issue.labels.map(l => l.name);
+            const currentLabelSet = new Set(currentLabels);
 
             const hasDetectionEngine = currentLabels.includes("Team:Detection Engine");
             const hasRuleManagement = currentLabels.includes("Team:Detection Rule Management");
@@ -36,22 +37,21 @@ jobs:
 
             const labelsToAdd = new Set();
 
+            // Utility: set difference
+            function difference(setA, setB) {
+              return new Set([...setA].filter(x => !setB.has(x)));
+            }
+
             // Add missing labels for Detection Engine group
             if (hasDetectionEngine) {
-              for (const label of detectionGroup) {
-                if (!currentLabels.includes(label)) {
-                  labelsToAdd.add(label);
-                }
-              }
+              const missing = difference(new Set(detectionGroup), currentLabelSet);
+              missing.forEach(label => labelsToAdd.add(label));
             }
 
             // Add missing labels for Rule Management group
             if (hasRuleManagement) {
-              for (const label of ruleManagementGroup) {
-                if (!currentLabels.includes(label)) {
-                  labelsToAdd.add(label);
-                }
-              }
+              const missing = difference(new Set(ruleManagementGroup), currentLabelSet);
+              missing.forEach(label => labelsToAdd.add(label));
             }
 
             // Add 'needs-team' when only shared labels are present (ambiguous ownership)
@@ -61,10 +61,10 @@ jobs:
               (currentLabels.includes("Team:Security Solution") || currentLabels.includes("Team:Detections and Resp"));
 
             if (hasOnlyShared) {
-              if (!currentLabels.includes("needs-team")) {
+              if (!currentLabelSet.has("needs-team")) {
                 labelsToAdd.add("needs-team");
               }
-              if (!currentLabels.includes("triage_needed")) {
+              if (!currentLabelSet.has("triage_needed")) {
                 labelsToAdd.add("triage_needed");
               }
             }
@@ -76,7 +76,7 @@ jobs:
                 issue_number: context.issue.number,
                 labels: Array.from(labelsToAdd)
               });
-              console.log(`Added missing labels: ${Array.from(labelsToAdd).join(", ")}`);
+              console.log(`Added missing labels to issue #${context.issue.number}: ${Array.from(labelsToAdd).join(", ")}`);
             } else {
-              console.log("No labels to add.");
+              console.log(`No labels to add for issue #${context.issue.number}.`);
             }


### PR DESCRIPTION
### Summary

This PR introduces a GitHub Action that helps ensure consistency in issue labeling for Security Solution teams. For now, the logic covers Detection Engine and Rule Management only.

### Behavior

The workflow is triggered when an issue is opened, edited, or labeled. It performs the following checks:

#### 1. Detection Engine issues:
If the issue contains the label `Team:Detection Engine`, the action ensures that the following labels are present:
- `Team:Detections and Resp`
- `Team:Security Solution`

#### 2. Rule Management issues:
If the issue contains the label `Team:Detection Rule Management`, the action ensures that the following labels are present:
- `Team:Detections and Resp`
- `Team:Security Solution`

#### 3. Ensures `triage_needed` is present: 
  - For issues labeled with either "Team:Detection Engine" or "Team:Detection Rule Management", if the `triage_needed` label is missing, it will be added automatically.
  - For issues with only shared team labels (`Team:Security Solution` or `Team:Detections and Resp`), if `triage_needed` is not present, it will also be added.

#### 4. Ambiguous ownership (shared labels only):
If the issue contains only shared labels (either `Team:Detections and Resp` or `Team:Security Solution`) and **none of the team-specific labels**, the action automatically adds the label:
- `needs-team`

### Notes

- This logic currently supports Detection Engine and Rule Management only.
- The action runs on issue events: `opened`, `edited`, or `labeled`.
- It avoids adding labels that are already present.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

No.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



