### PR TITLE
[Security Solution] Fix banner title in event preview

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/preview/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/preview/index.tsx
@@ -17,15 +17,23 @@ import { PanelHeader } from '../right/header';
 import { PanelContent } from '../right/content';
 import { PreviewPanelFooter } from './footer';
 import type { RightPanelTabType } from '../right/tabs';
-import { ALERT_PREVIEW_BANNER } from './constants';
+import { ALERT_PREVIEW_BANNER, EVENT_PREVIEW_BANNER } from './constants';
+import { useBasicDataFromDetailsData } from '../shared/hooks/use_basic_data_from_details_data';
 
 /**
  * Panel to be displayed in the document details expandable flyout on top of right section
  */
 export const PreviewPanel: FC<Partial<DocumentDetailsProps>> = memo(({ path }) => {
   const { openPreviewPanel } = useExpandableFlyoutApi();
-  const { eventId, indexName, scopeId, getFieldsData, dataAsNestedObject } =
-    useDocumentDetailsContext();
+  const {
+    eventId,
+    indexName,
+    scopeId,
+    getFieldsData,
+    dataAsNestedObject,
+    dataFormattedForFieldBrowser,
+  } = useDocumentDetailsContext();
+  const { isAlert } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
   const flyoutIsExpandable = useFlyoutIsExpandable({ getFieldsData, dataAsNestedObject });
 
   const { tabsDisplayed, selectedTabId } = useTabs({ flyoutIsExpandable, path });
@@ -41,7 +49,7 @@ export const PreviewPanel: FC<Partial<DocumentDetailsProps>> = memo(({ path }) =
         indexName,
         scopeId,
         isPreviewMode: true,
-        banner: ALERT_PREVIEW_BANNER,
+        banner: isAlert ? ALERT_PREVIEW_BANNER : EVENT_PREVIEW_BANNER,
       },
     });
   };


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/222265

This PR fixes a bug in the event preview banner. Before the fix, upon navigating to a different tab, the banner text changes to `Preview alert details`. 

![image](https://github.com/user-attachments/assets/e3afc33a-703d-4ec3-92df-8157b3c102cd)


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->