### PR TITLE
[8.19] [Fleet] Add and setup new config `xpack.fleet.integrationsHomeOverride` for AI4DSOC (#216716)

### DIFF
--- a/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -266,6 +266,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.fleet.internal.fleetServerStandalone (boolean?)',
         'xpack.fleet.internal.onlyAllowAgentUpgradeToKnownVersions (boolean?)',
         'xpack.fleet.developer.maxAgentPoliciesWithInactivityTimeout (number?)',
+        'xpack.fleet.integrationsHomeOverride (string?)',
         'xpack.global_search.search_timeout (duration?)',
         'xpack.global_search_bar.input_max_limit (number?)',
         'xpack.graph.canEditDrillDownUrls (boolean?)',

--- a/x-pack/platform/plugins/shared/fleet/common/types/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/index.ts
@@ -87,6 +87,7 @@ export interface FleetConfigType {
   autoUpgrades?: {
     retryDelays?: string[];
   };
+  integrationsHomeOverride?: string;
 }
 
 // Calling Object.entries(PackagesGroupedByStatus) gave `status: string`

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -13,9 +13,6 @@ import { installationStatuses } from '../../../../../../../common/constants';
 
 import { INTEGRATIONS_ROUTING_PATHS, INTEGRATIONS_SEARCH_QUERYPARAM } from '../../../../constants';
 import { DefaultLayout } from '../../../../layouts';
-import { isPackageUpdatable } from '../../../../services';
-
-import { useAuthz, useGetPackagesQuery, useGetSettingsQuery } from '../../../../hooks';
 
 import type { CategoryFacet, ExtendedIntegrationCategory } from './category_facets';
 
@@ -42,6 +39,12 @@ export const categoryExists = (category: string, categories: CategoryFacet[]) =>
 };
 
 export const EPMHomePage: React.FC = () => {
+  const config = useConfig();
+  const { application } = useStartServices();
+  if (config.integrationsHomeOverride) {
+    application.navigateToUrl(config.integrationsHomeOverride);
+  }
+
   const authz = useAuthz();
   const isAuthorizedToFetchSettings = authz.fleet.readSettings;
   const { data: settings, isFetchedAfterMount: isSettingsFetched } = useGetSettingsQuery({

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -13,7 +13,15 @@ import { installationStatuses } from '../../../../../../../common/constants';
 
 import { INTEGRATIONS_ROUTING_PATHS, INTEGRATIONS_SEARCH_QUERYPARAM } from '../../../../constants';
 import { DefaultLayout } from '../../../../layouts';
+import { isPackageUpdatable } from '../../../../services';
 
+import {
+  useAuthz,
+  useConfig,
+  useGetPackagesQuery,
+  useGetSettingsQuery,
+  useStartServices,
+} from '../../../../hooks';
 import type { CategoryFacet, ExtendedIntegrationCategory } from './category_facets';
 
 import { InstalledPackages } from './installed_packages';

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -47,6 +47,7 @@ export const config: PluginConfigDescriptor = {
       activeAgentsSoftLimit: true,
       onlyAllowAgentUpgradeToKnownVersions: true,
     },
+    integrationsHomeOverride: true,
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
     // Unused settings before Fleet server exists
@@ -290,6 +291,7 @@ export const config: PluginConfigDescriptor = {
           retryDelays: schema.maybe(schema.arrayOf(schema.string())),
         })
       ),
+      integrationsHomeOverride: schema.maybe(schema.string()),
     },
     {
       validate: (configToValidate) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Add and setup new config `xpack.fleet.integrationsHomeOverride` for AI4DSOC (#216716)](https://github.com/elastic/kibana/pull/216716)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kylie Meli","email":"kylie.geller@elastic.co"},"sourceCommit":{"committedDate":"2025-04-03T19:24:59Z","message":"[Fleet] Add and setup new config `xpack.fleet.integrationsHomeOverride` for AI4DSOC (#216716)\n\n## Summary\n\nIntroduces a new fleet config variable to redirect from the integrations\nhome page to a specified URL.\n\nThe search_ai_lake serverless security product type will have its own\npage (`/app/security/configurations/integrations`) for browsing\nintegrations and viewing installed integrations, so this ensures those\nusers will only be able to see that dedicated page.\n\n## Screen recordings\n\nAI4DSOC:\n\n\nhttps://github.com/user-attachments/assets/9fc203ed-f9c0-45bb-a4a9-2d07688b5ecd\n\nOtherwise:\n\n\nhttps://github.com/user-attachments/assets/50071467-b813-4f13-895f-435fd746adcc\n\nRelates: https://github.com/elastic/security-team/issues/11789","sha":"1384ce13e92b1ce585b5a45003d877004cbfd3ca","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.1.0","v8.19.0"],"title":"[Fleet] Add and setup new config `xpack.fleet.integrationsHomeOverride` for AI4DSOC","number":216716,"url":"https://github.com/elastic/kibana/pull/216716","mergeCommit":{"message":"[Fleet] Add and setup new config `xpack.fleet.integrationsHomeOverride` for AI4DSOC (#216716)\n\n## Summary\n\nIntroduces a new fleet config variable to redirect from the integrations\nhome page to a specified URL.\n\nThe search_ai_lake serverless security product type will have its own\npage (`/app/security/configurations/integrations`) for browsing\nintegrations and viewing installed integrations, so this ensures those\nusers will only be able to see that dedicated page.\n\n## Screen recordings\n\nAI4DSOC:\n\n\nhttps://github.com/user-attachments/assets/9fc203ed-f9c0-45bb-a4a9-2d07688b5ecd\n\nOtherwise:\n\n\nhttps://github.com/user-attachments/assets/50071467-b813-4f13-895f-435fd746adcc\n\nRelates: https://github.com/elastic/security-team/issues/11789","sha":"1384ce13e92b1ce585b5a45003d877004cbfd3ca"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216716","number":216716,"mergeCommit":{"message":"[Fleet] Add and setup new config `xpack.fleet.integrationsHomeOverride` for AI4DSOC (#216716)\n\n## Summary\n\nIntroduces a new fleet config variable to redirect from the integrations\nhome page to a specified URL.\n\nThe search_ai_lake serverless security product type will have its own\npage (`/app/security/configurations/integrations`) for browsing\nintegrations and viewing installed integrations, so this ensures those\nusers will only be able to see that dedicated page.\n\n## Screen recordings\n\nAI4DSOC:\n\n\nhttps://github.com/user-attachments/assets/9fc203ed-f9c0-45bb-a4a9-2d07688b5ecd\n\nOtherwise:\n\n\nhttps://github.com/user-attachments/assets/50071467-b813-4f13-895f-435fd746adcc\n\nRelates: https://github.com/elastic/security-team/issues/11789","sha":"1384ce13e92b1ce585b5a45003d877004cbfd3ca"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->