### PR TITLE
[8.19] [Obs AI Assistant] Delete user instruction if text is empty (#221560)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
@@ -164,7 +164,7 @@ const saveKnowledgeBaseUserInstruction = createObservabilityAIAssistantServerRou
   params: t.type({
     body: t.type({
       id: t.string,
-      text: t.string,
+      text: nonEmptyStringRt,
       public: toBooleanRt,
     }),
   }),

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/hooks/use_delete_knowledge_base_entry.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/hooks/use_delete_knowledge_base_entry.ts
@@ -22,7 +22,7 @@ export function useDeleteKnowledgeBaseEntry() {
   const queryClient = useQueryClient();
   const observabilityAIAssistantApi = observabilityAIAssistant.service.callApi;
 
-  return useMutation<unknown, ServerError, { id: string }>(
+  return useMutation<unknown, ServerError, { id: string; isUserInstruction?: boolean }>(
     [REACT_QUERY_KEYS.CREATE_KB_ENTRIES],
     ({ id: entryId }) => {
       return observabilityAIAssistantApi(
@@ -38,21 +38,32 @@ export function useDeleteKnowledgeBaseEntry() {
       );
     },
     {
-      onSuccess: (_data, { id }) => {
-        toasts.addSuccess(
-          i18n.translate(
-            'xpack.observabilityAiAssistantManagement.kb.deleteManualEntry.successNotification',
-            {
-              defaultMessage: 'Successfully deleted {id}',
-              values: { id },
-            }
-          )
-        );
+      onSuccess: (_data, { id, isUserInstruction }) => {
+        if (isUserInstruction) {
+          toasts.addSuccess(
+            i18n.translate(
+              'xpack.observabilityAiAssistantManagement.kb.deleteUserInstruction.successNotification',
+              {
+                defaultMessage: 'Successfully deleted user instruction',
+              }
+            )
+          );
+        } else {
+          toasts.addSuccess(
+            i18n.translate(
+              'xpack.observabilityAiAssistantManagement.kb.deleteManualEntry.successNotification',
+              {
+                defaultMessage: 'Successfully deleted {id}',
+                values: { id },
+              }
+            )
+          );
 
-        queryClient.invalidateQueries({
-          queryKey: [REACT_QUERY_KEYS.GET_KB_ENTRIES],
-          refetchType: 'all',
-        });
+          queryClient.invalidateQueries({
+            queryKey: [REACT_QUERY_KEYS.GET_KB_ENTRIES],
+            refetchType: 'all',
+          });
+        }
       },
       onError: (error, { id }) => {
         toasts.addError(new Error(error.body?.message ?? error.message), {

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_user_instruction_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_user_instruction_flyout.test.tsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { KnowledgeBaseEditUserInstructionFlyout } from './knowledge_base_edit_user_instruction_flyout';
+import { useGetUserInstructions } from '../../hooks/use_get_user_instructions';
+import { useCreateKnowledgeBaseUserInstruction } from '../../hooks/use_create_knowledge_base_user_instruction';
+import { useDeleteKnowledgeBaseEntry } from '../../hooks/use_delete_knowledge_base_entry';
+jest.mock('../../hooks/use_get_user_instructions');
+jest.mock('../../hooks/use_create_knowledge_base_user_instruction');
+jest.mock('../../hooks/use_delete_knowledge_base_entry');
+
+const useGetUserInstructionsMock = useGetUserInstructions as jest.Mock;
+const useCreateKnowledgeBaseUserInstructionMock =
+  useCreateKnowledgeBaseUserInstruction as jest.Mock;
+const useDeleteKnowledgeBaseEntryMock = useDeleteKnowledgeBaseEntry as jest.Mock;
+
+const getUserInstructionsMock = jest.fn(() => Promise.resolve([]));
+const createOrUpdateMock = jest.fn(() => Promise.resolve());
+const deleteMock = jest.fn(() => Promise.resolve());
+const mockOnClose = jest.fn();
+
+const getBaseMutationResult = () => ({
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  isIdle: true,
+  status: 'idle',
+  data: undefined,
+  error: null,
+});
+
+describe('KnowledgeBaseEditUserInstructionFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useGetUserInstructionsMock.mockReturnValue({
+      userInstructions: [],
+      isLoading: false,
+      isRefetching: false,
+      isSuccess: true,
+      isError: false,
+      refetch: getUserInstructionsMock,
+    });
+
+    useCreateKnowledgeBaseUserInstructionMock.mockReturnValue({
+      mutateAsync: createOrUpdateMock,
+      ...getBaseMutationResult(),
+    });
+
+    useDeleteKnowledgeBaseEntryMock.mockReturnValue({
+      mutate: deleteMock,
+      mutateAsync: deleteMock,
+      ...getBaseMutationResult(),
+    });
+  });
+
+  it('should delete entry when submitting with empty text', async () => {
+    // Set up initial state with an existing instruction
+    const existingId = 'test-id';
+    useGetUserInstructionsMock.mockReturnValue({
+      userInstructions: [
+        {
+          id: existingId,
+          text: 'Original instruction',
+          public: false,
+        },
+      ],
+      isLoading: false,
+      isRefetching: false,
+      isSuccess: true,
+      isError: false,
+      refetch: getUserInstructionsMock,
+    });
+
+    const wrapper = mountWithIntl(<KnowledgeBaseEditUserInstructionFlyout onClose={mockOnClose} />);
+
+    // Wait for the component to load and initialize with the existing instruction
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      wrapper.update();
+    });
+
+    // Clear the instruction
+    await act(async () => {
+      const textarea = wrapper.find('textarea').first();
+      textarea.simulate('change', { target: { value: '' } });
+    });
+
+    await act(async () => {
+      const saveButton = wrapper.find(
+        'button[data-test-subj="knowledgeBaseEditManualEntryFlyoutSaveButton"]'
+      );
+      saveButton.simulate('click');
+    });
+
+    expect(deleteMock).toHaveBeenCalledWith({
+      id: existingId,
+      isUserInstruction: true,
+    });
+
+    expect(createOrUpdateMock).not.toHaveBeenCalled();
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should not delete entry when submitting with non-empty text', async () => {
+    // Set up initial state with an existing instruction
+    const existingId = 'test-id';
+    useGetUserInstructionsMock.mockReturnValue({
+      userInstructions: [
+        {
+          id: existingId,
+          text: 'Original instruction',
+          public: false,
+        },
+      ],
+      isLoading: false,
+      isRefetching: false,
+      isSuccess: true,
+      isError: false,
+      refetch: getUserInstructionsMock,
+    });
+
+    const wrapper = mountWithIntl(<KnowledgeBaseEditUserInstructionFlyout onClose={mockOnClose} />);
+
+    // Wait for the component to load
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      wrapper.update();
+    });
+
+    // Update the text
+    await act(async () => {
+      const textarea = wrapper.find('textarea').first();
+      textarea.simulate('change', { target: { value: 'Updated instruction' } });
+    });
+
+    // Submit the form
+    await act(async () => {
+      const saveButton = wrapper.find(
+        'button[data-test-subj="knowledgeBaseEditManualEntryFlyoutSaveButton"]'
+      );
+      saveButton.simulate('click');
+    });
+
+    // Verify deletion was not called
+    expect(deleteMock).not.toHaveBeenCalled();
+
+    // Verify create/update was called with correct params
+    expect(createOrUpdateMock).toHaveBeenCalledWith({
+      entry: {
+        id: existingId,
+        text: 'Updated instruction',
+        public: false,
+      },
+    });
+
+    // Verify flyout was closed
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should update existing instruction with new text', async () => {
+    // Set up initial state with an existing instruction
+    const existingId = 'test-id';
+    const originalText = 'Original instruction';
+    const updatedText = 'This is the updated instruction text';
+
+    useGetUserInstructionsMock.mockReturnValue({
+      userInstructions: [
+        {
+          id: existingId,
+          text: originalText,
+          public: false,
+        },
+      ],
+      isLoading: false,
+      isRefetching: false,
+      isSuccess: true,
+      isError: false,
+      refetch: getUserInstructionsMock,
+    });
+
+    const wrapper = mountWithIntl(<KnowledgeBaseEditUserInstructionFlyout onClose={mockOnClose} />);
+
+    // Wait for the component to load and initialize with the existing instruction
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      wrapper.update();
+    });
+
+    // Verify the textarea is initialized with the original text
+    const initialTextarea = wrapper.find('textarea').first();
+    expect(initialTextarea.prop('value')).toBe(originalText);
+
+    // Update the instruction text
+    await act(async () => {
+      const textarea = wrapper.find('textarea').first();
+      textarea.simulate('change', { target: { value: updatedText } });
+    });
+
+    // Submit the form
+    await act(async () => {
+      const saveButton = wrapper.find(
+        'button[data-test-subj="knowledgeBaseEditManualEntryFlyoutSaveButton"]'
+      );
+      saveButton.simulate('click');
+    });
+
+    // Verify the update was called with the correct parameters
+    expect(createOrUpdateMock).toHaveBeenCalledWith({
+      entry: {
+        id: existingId,
+        text: updatedText,
+        public: false,
+      },
+    });
+
+    // Verify that delete was not called
+    expect(deleteMock).not.toHaveBeenCalled();
+
+    // Verify the flyout was closed
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_user_instruction_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_user_instruction_flyout.tsx
@@ -25,12 +25,16 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { useGetUserInstructions } from '../../hooks/use_get_user_instructions';
 import { useCreateKnowledgeBaseUserInstruction } from '../../hooks/use_create_knowledge_base_user_instruction';
+import { useDeleteKnowledgeBaseEntry } from '../../hooks/use_delete_knowledge_base_entry';
 
 export function KnowledgeBaseEditUserInstructionFlyout({ onClose }: { onClose: () => void }) {
-  const { userInstructions, isLoading: isFetching } = useGetUserInstructions();
-  const { mutateAsync: createEntry, isLoading: isSaving } = useCreateKnowledgeBaseUserInstruction();
   const [newEntryText, setNewEntryText] = useState('');
   const [newEntryId, setNewEntryId] = useState<string>();
+
+  const { userInstructions, isLoading: isFetching } = useGetUserInstructions();
+  const { mutateAsync: createOrUpdateEntry, isLoading: isSaving } =
+    useCreateKnowledgeBaseUserInstruction();
+  const { mutate: deleteEntry } = useDeleteKnowledgeBaseEntry();
 
   useEffect(() => {
     const userInstruction = userInstructions?.find((entry) => !entry.public);
@@ -39,13 +43,17 @@ export function KnowledgeBaseEditUserInstructionFlyout({ onClose }: { onClose: (
   }, [userInstructions]);
 
   const handleSubmit = async () => {
-    await createEntry({
-      entry: {
-        id: newEntryId ?? uuidv4(),
-        text: newEntryText,
-        public: false, // limit user instructions to private (for now)
-      },
-    });
+    if (newEntryId && !newEntryText) {
+      deleteEntry({ id: newEntryId, isUserInstruction: true });
+    } else {
+      await createOrUpdateEntry({
+        entry: {
+          id: newEntryId ?? uuidv4(),
+          text: newEntryText,
+          public: false, // limit user instructions to private (for now)
+        },
+      });
+    }
 
     onClose();
   };

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/tsconfig.json
@@ -29,6 +29,10 @@
     "@kbn/core-plugins-server",
     "@kbn/product-doc-base-plugin",
     "@kbn/ml-plugin",
+    "@kbn/management-settings-field-definition",
+    "@kbn/management-settings-types",
+    "@kbn/management-settings-utilities",
+    "@kbn/test-jest-helpers"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/tsconfig.json
@@ -29,9 +29,6 @@
     "@kbn/core-plugins-server",
     "@kbn/product-doc-base-plugin",
     "@kbn/ml-plugin",
-    "@kbn/management-settings-field-definition",
-    "@kbn/management-settings-types",
-    "@kbn/management-settings-utilities",
     "@kbn/test-jest-helpers"
   ],
   "exclude": [

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_user_instructions.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_user_instructions.spec.ts
@@ -362,37 +362,6 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
     });
 
-    describe('Instructions can be saved and cleared again', () => {
-      async function updateInstruction(text: string) {
-        const { status } = await observabilityAIAssistantAPIClient.editor({
-          endpoint: 'PUT /internal/observability_ai_assistant/kb/user_instructions',
-          params: {
-            body: {
-              id: 'my-instruction-that-will-be-cleared',
-              text,
-              public: false,
-            },
-          },
-        });
-        expect(status).to.be(200);
-
-        const res = await observabilityAIAssistantAPIClient.editor({
-          endpoint: 'GET /internal/observability_ai_assistant/kb/user_instructions',
-        });
-        expect(res.status).to.be(200);
-
-        return res.body.userInstructions[0].text;
-      }
-
-      it('can clear the instruction', async () => {
-        const res1 = await updateInstruction('This is a user instruction that will be cleared');
-        expect(res1).to.be('This is a user instruction that will be cleared');
-
-        const res2 = await updateInstruction('');
-        expect(res2).to.be('');
-      });
-    });
-
     describe('Forwarding User Instructions via System Message to the LLM', () => {
       // Fails on MKI because the LLM Proxy does not yet work there: https://github.com/elastic/obs-ai-assistant-team/issues/199
       this.tags(['skipCloud']);

--- a/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
+++ b/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
@@ -31,6 +31,11 @@ const pages = {
     table: 'knowledgeBaseTable',
     tableTitleCell: 'knowledgeBaseTableTitleCell',
     tableAuthorCell: 'knowledgeBaseTableAuthorCell',
+    editUserInstructionButton:
+      'observabilityAiAssistantManagementKnowledgeBaseTabEditInstructionsButton',
+    entryMarkdownEditor: 'knowledgeBaseEditManualEntryFlyoutMarkdownEditor',
+    editEntryCancelButton: 'knowledgeBaseEditManualEntryFlyoutCancelButton',
+    saveEntryButton: 'knowledgeBaseEditManualEntryFlyoutSaveButton',
   },
   conversations: {
     setupGenAiConnectorsButtonSelector:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs AI Assistant] Delete user instruction if text is empty (#221560)](https://github.com/elastic/kibana/pull/221560)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-05-27T21:12:39Z","message":"[Obs AI Assistant] Delete user instruction if text is empty (#221560)\n\nCloses https://github.com/elastic/kibana/issues/220342\n\n## Summary\n\nAs of today, when the user clears the user instruction, the entry is not\ndeleted. Instead the text is cleared from the entry. This has caused\nproblems in the past.\n\nThis PR implements the change where, if a user clears the user\ninstruction, the entry will be deleted.\n\nNote: Entry deletion via functional tests appears to be flaky due to\nissues with clearing the instruction from the editor. Therefore, to\navoid introducing a flaky test, this was covered via a unit test. Added\nfunctional tests to cover scenarios such as creating an instruction,\nediting an instruction.\n\n### Screen recording\n\n\nhttps://github.com/user-attachments/assets/35a530ca-5a96-4a17-a4b8-d0e4002c1120\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6d5acfca0db486530e684d1036a67dc13f8a8b05","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0"],"title":"[Obs AI Assistant] Delete user instruction if text is empty","number":221560,"url":"https://github.com/elastic/kibana/pull/221560","mergeCommit":{"message":"[Obs AI Assistant] Delete user instruction if text is empty (#221560)\n\nCloses https://github.com/elastic/kibana/issues/220342\n\n## Summary\n\nAs of today, when the user clears the user instruction, the entry is not\ndeleted. Instead the text is cleared from the entry. This has caused\nproblems in the past.\n\nThis PR implements the change where, if a user clears the user\ninstruction, the entry will be deleted.\n\nNote: Entry deletion via functional tests appears to be flaky due to\nissues with clearing the instruction from the editor. Therefore, to\navoid introducing a flaky test, this was covered via a unit test. Added\nfunctional tests to cover scenarios such as creating an instruction,\nediting an instruction.\n\n### Screen recording\n\n\nhttps://github.com/user-attachments/assets/35a530ca-5a96-4a17-a4b8-d0e4002c1120\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6d5acfca0db486530e684d1036a67dc13f8a8b05"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221560","number":221560,"mergeCommit":{"message":"[Obs AI Assistant] Delete user instruction if text is empty (#221560)\n\nCloses https://github.com/elastic/kibana/issues/220342\n\n## Summary\n\nAs of today, when the user clears the user instruction, the entry is not\ndeleted. Instead the text is cleared from the entry. This has caused\nproblems in the past.\n\nThis PR implements the change where, if a user clears the user\ninstruction, the entry will be deleted.\n\nNote: Entry deletion via functional tests appears to be flaky due to\nissues with clearing the instruction from the editor. Therefore, to\navoid introducing a flaky test, this was covered via a unit test. Added\nfunctional tests to cover scenarios such as creating an instruction,\nediting an instruction.\n\n### Screen recording\n\n\nhttps://github.com/user-attachments/assets/35a530ca-5a96-4a17-a4b8-d0e4002c1120\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6d5acfca0db486530e684d1036a67dc13f8a8b05"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->