### PR TITLE
[8.19] Default `EUI_AMSTERDAM` to true when unset

### DIFF
--- a/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
+++ b/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
@@ -55,7 +55,12 @@ export const command = {
     const validate = args.getBooleanValue('validate') ?? true;
     const quiet = args.getBooleanValue('quiet') ?? false;
     const reactVersion = process.env.REACT_18 ? '18' : '17';
-    const euiAmsterdam = process.env.EUI_AMSTERDAM === 'true';
+
+    // Default to true when EUI_AMSTERDAM is not set on 8.19
+    // TODO: Remove when Kibana 8.19 is EOL and Amsterdam backports aren't needed anymore
+    // https://github.com/elastic/kibana/issues/221593
+    const euiAmsterdam = !process.env.EUI_AMSTERDAM || process.env.EUI_AMSTERDAM === 'true';
+
     const vscodeConfig =
       args.getBooleanValue('vscode') ?? (process.env.KBN_BOOTSTRAP_NO_VSCODE ? false : true);
 

--- a/kbn_pm/src/commands/watch_command.mjs
+++ b/kbn_pm/src/commands/watch_command.mjs
@@ -28,7 +28,10 @@ export const command = {
     await Bazel.watch(log, {
       offline: args.getBooleanValue('offline') ?? true,
       reactVersion: process.env.REACT_18 ? '18' : '17',
-      euiAmsterdam: process.env.EUI_AMSTERDAM === 'true',
+      // Default to true when EUI_AMSTERDAM is not set on 8.19
+      // TODO: Remove when Kibana 8.19 is EOL and Amsterdam backports aren't needed anymore
+      // https://github.com/elastic/kibana/issues/221593
+      euiAmsterdam: !process.env.EUI_AMSTERDAM || process.env.EUI_AMSTERDAM === 'true',
     });
   },
 };


### PR DESCRIPTION
## Summary

As a follow-up to https://github.com/elastic/kibana/pull/219818 this PR makes Kibana 8.19 default to the Amsterdam variant of EUI when `EUI_AMSTERDAM` environment variable is unset. See the initial PR description for more information.

## QA

Ensure Kibana imports all EUI components from `@elastic/eui-amsterdam`.

https://github.com/user-attachments/assets/39dddf50-5997-4be6-ac00-1da02fa967dc