### PR TITLE
[Discover] Add info icon to doc viewer table (#214366)

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/get_pin_control.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/get_pin_control.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import {
   EuiButtonIcon,
   EuiDataGridControlColumn,
-  EuiScreenReaderOnly,
+  EuiIconTip,
   EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
@@ -71,17 +71,15 @@ export const getPinColumnControl = ({
   rows: FieldRow[];
   onTogglePinned: (fieldName: string) => void;
 }): EuiDataGridControlColumn => {
+  const pinColumnHeader = i18n.translate('unifiedDocViewer.fieldsTable.pinControlColumnHeader', {
+    defaultMessage: 'Pin field column',
+  });
+
   return {
     id: 'pin_field',
     width: 32,
     headerCellRender: () => (
-      <EuiScreenReaderOnly>
-        <span>
-          {i18n.translate('unifiedDocViewer.fieldsTable.pinControlColumnHeader', {
-            defaultMessage: 'Pin field column',
-          })}
-        </span>
-      </EuiScreenReaderOnly>
+      <EuiIconTip aria-label={pinColumnHeader} type="iInCircle" content={pinColumnHeader} />
     ),
     rowCellRender: ({ rowIndex }) => {
       const row = rows[rowIndex];


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/214366

| Before | After |
|--------|------|
| <img width="387" alt="image" src="https://github.com/user-attachments/assets/b0e011b9-5563-4b63-9632-cfed9d3eea1c" /> | <img width="389" alt="image" src="https://github.com/user-attachments/assets/b26696ab-ee6a-4433-8dd4-877e2d2e7d90" /> |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->