### PR TITLE
[8.19] 🌊 Streams: Test migration properly and refactor migration on read (#221533)

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/README.md
+++ b/src/platform/packages/shared/kbn-storage-adapter/README.md
@@ -74,3 +74,8 @@ To use the storage index adapter, instantiate it with an authenticated Elasticse
   });
 
 ```
+
+
+# Development
+
+To run integration tests locally, run `node scripts/jest_integration.js --config src/platform/packages/shared/kbn-storage-adapter/jest.integration.config.js`

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -88,6 +88,15 @@ function wrapEsCall<T>(p: Promise<T>): Promise<T> {
   });
 }
 
+export interface StorageIndexAdapterOptions<TApplicationType> {
+  /**
+   * If this callback is provided, it will be called on every _source before returned to the caller of the search or get methods.
+   * This is useful for migrating documents from one version to another, or for transforming the document before returning it.
+   * This should be used as rarely as possible - in most cases, new properties should be added as optional.
+   */
+  migrateSource?: (document: Record<string, unknown>) => TApplicationType;
+}
+
 /**
  * Adapter for writing and reading documents to/from Elasticsearch,
  * using plain indices.
@@ -104,7 +113,8 @@ export class StorageIndexAdapter<
   constructor(
     private readonly esClient: ElasticsearchClient,
     logger: Logger,
-    private readonly storage: TStorageSettings
+    private readonly storage: TStorageSettings,
+    private readonly options: StorageIndexAdapterOptions<TApplicationType> = {}
   ) {
     this.logger = logger.get('storage').get(this.storage.name);
   }
@@ -328,6 +338,18 @@ export class StorageIndexAdapter<
           ...request,
           index: this.getSearchIndexPattern(),
           allow_no_indices: true,
+        })
+        .then((response) => {
+          return {
+            ...response,
+            hits: {
+              ...response.hits,
+              hits: response.hits.hits.map((hit) => ({
+                ...hit,
+                _source: this.maybeMigrateSource(hit._source),
+              })),
+            },
+          };
         })
         .catch((error): StorageClientSearchResponse<TApplicationType, any> => {
           if (isNotFoundError(error)) {
@@ -574,7 +596,7 @@ export class StorageIndexAdapter<
       _id: hit._id!,
       _index: hit._index,
       found: true,
-      _source: hit._source as TApplicationType,
+      _source: this.maybeMigrateSource(hit._source),
       _ignored: hit._ignored,
       _primary_term: hit._primary_term,
       _routing: hit._routing,
@@ -582,6 +604,17 @@ export class StorageIndexAdapter<
       _version: hit._version,
       fields: hit.fields,
     };
+  };
+
+  private maybeMigrateSource = (_source: unknown): TApplicationType => {
+    // check whether source is an object, if not fail
+    if (typeof _source !== 'object' || _source === null) {
+      throw new Error(`Source must be an object, got ${typeof _source}`);
+    }
+    if (this.options.migrateSource) {
+      return this.options.migrateSource(_source as Record<string, unknown>);
+    }
+    return _source as TApplicationType;
   };
 
   private existsIndex: StorageClientExistsIndex = () => {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -26,7 +26,6 @@ import { SecurityError } from './errors/security_error';
 import { State } from './state_management/state';
 import { StatusError } from './errors/status_error';
 import { ASSET_ID, ASSET_TYPE } from './assets/fields';
-import { migrateOnRead } from './helpers/migrate_on_read';
 
 interface AcknowledgeResponse<TResult extends Result> {
   acknowledged: true;
@@ -329,9 +328,7 @@ export class StreamsClient {
     if (!source) {
       throw new DefinitionNotFoundError(`Cannot find stream definition`);
     }
-    const migratedSource = migrateOnRead(source);
-    Streams.all.Definition.asserts(migratedSource);
-    return migratedSource;
+    return source;
   }
 
   /**

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/migrate_on_read.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/migrate_on_read.ts
@@ -6,13 +6,17 @@
  */
 
 import { Streams } from '@kbn/streams-schema';
+import { BaseStream } from '@kbn/streams-schema/src/models/base';
 
-export function migrateOnRead(definition: Streams.all.Definition): Streams.all.Definition {
+export function migrateOnRead(definition: Record<string, unknown>): Streams.all.Definition {
+  let migratedDefinition = definition;
   if (typeof definition.description !== 'string') {
-    return {
+    migratedDefinition = {
       ...definition,
       description: '',
     };
   }
-  return definition;
+  Streams.all.Definition.asserts(migratedDefinition as unknown as BaseStream.Definition);
+
+  return migratedDefinition as unknown as Streams.all.Definition;
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
@@ -11,6 +11,7 @@ import { Streams } from '@kbn/streams-schema';
 import type { StreamsPluginStartDependencies } from '../../types';
 import { StreamsClient } from './client';
 import { AssetClient } from './assets/asset_client';
+import { migrateOnRead } from './helpers/migrate_on_read';
 
 export const streamsStorageSettings = {
   name: '.kibana_streams',
@@ -49,10 +50,14 @@ export class StreamsService {
 
     const isServerless = coreStart.elasticsearch.getCapabilities().serverless;
 
-    const storageAdapter = new StorageIndexAdapter<
-      StreamsStorageSettings,
-      Streams.all.Definition & { _id: string }
-    >(scopedClusterClient.asInternalUser, logger, streamsStorageSettings);
+    const storageAdapter = new StorageIndexAdapter<StreamsStorageSettings, Streams.all.Definition>(
+      scopedClusterClient.asInternalUser,
+      logger,
+      streamsStorageSettings,
+      {
+        migrateSource: migrateOnRead,
+      }
+    );
 
     return new StreamsClient({
       assetClient,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_from_definition.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_from_definition.ts
@@ -11,14 +11,12 @@ import type { StreamActiveRecord } from './stream_active_record';
 import { UnwiredStream } from '../streams/unwired_stream';
 import { WiredStream } from '../streams/wired_stream';
 import { GroupStream } from '../streams/group_stream';
-import { migrateOnRead } from '../../helpers/migrate_on_read';
 
 // This should be the only thing that knows about the various stream types
 export function streamFromDefinition(
   definition: Streams.all.Definition,
   dependencies: StateDependencies
 ): StreamActiveRecord {
-  definition = migrateOnRead(definition);
   if (Streams.WiredStream.Definition.is(definition)) {
     return new WiredStream(definition, dependencies);
   } else if (Streams.UnwiredStream.Definition.is(definition)) {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/migration_on_read.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/migration_on_read.ts
@@ -13,8 +13,30 @@ import {
   StreamsSupertestRepositoryClient,
   createStreamsRepositoryAdminClient,
 } from './helpers/repository_client';
+import { loadDashboards } from './helpers/dashboards';
 
 const TEST_STREAM_NAME = 'logs-test-default';
+const TEST_DASHBOARD_ID = '9230e631-1f1a-476d-b613-4b074c6cfdd0';
+
+// Do not update these if tests are failing - this is testing whether they get migrated correctly - you should
+// always make sure that existing definitions and links keep working.
+
+const assetLinks = [
+  {
+    'asset.type': 'query',
+    'asset.id': '12345',
+    'asset.uuid': '761ea54139754abb6e486ec1e29ea5c7f4df1387',
+    'stream.name': TEST_STREAM_NAME,
+    'query.title': 'Test',
+    'query.kql.query': 'atest',
+  },
+  {
+    'asset.type': 'dashboard',
+    'asset.id': TEST_DASHBOARD_ID,
+    'asset.uuid': 'a9e60eb2bc5fa77d1f66a612db29d2764ff8cf4a',
+    'stream.name': TEST_STREAM_NAME,
+  },
+];
 
 const streamDefinition = {
   name: TEST_STREAM_NAME,
@@ -63,6 +85,26 @@ const expectedStreamsResponse: Streams.UnwiredStream.Definition = {
   },
 };
 
+const expectedDashboardsResponse = {
+  dashboards: [
+    {
+      id: TEST_DASHBOARD_ID,
+      title: 'dashboard-4-panels',
+      tags: [],
+    },
+  ],
+};
+
+const expectedQueriesResponse = {
+  queries: [
+    {
+      id: '12345',
+      title: 'Test',
+      kql: { query: 'atest' },
+    },
+  ],
+};
+
 function expectStreams(expectedStreams: string[], persistedStreams: Streams.all.Definition[]) {
   for (const name of expectedStreams) {
     expect(persistedStreams.some((stream) => stream.name === name)).to.eql(true);
@@ -73,21 +115,57 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const roleScopedSupertest = getService('roleScopedSupertest');
   let apiClient: StreamsSupertestRepositoryClient;
   const esClient = getService('es');
+  const kibanaServer = getService('kibanaServer');
+  const SPACE_ID = 'default';
+  const ARCHIVES = [
+    'src/platform/test/api_integration/fixtures/kbn_archiver/saved_objects/content_pack_four_panels.json',
+  ];
 
   // This test verifies that it's still possible to read an existing stream definition without
   // error. If it fails, it indicates that the migration logic is not working as expected.
-  describe('read existing stream definition format', () => {
+  describe('read existing stream definition and asset link format', function () {
+    // This test can't run on MKI because there is no way to create a stream definition document that doesn't match the
+    // currently valid format. The test is designed to verify that the migration logic is working correctly.
+    this.tags(['failsOnMKI']);
     before(async () => {
+      await loadDashboards(kibanaServer, ARCHIVES, SPACE_ID);
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
       await enableStreams(apiClient);
+      // link and unlink dashboard to make sure assets index is created
+      await apiClient.fetch('PUT /api/streams/{name}/dashboards/{dashboardId} 2023-10-31', {
+        params: {
+          path: {
+            name: 'logs',
+            dashboardId: TEST_DASHBOARD_ID,
+          },
+        },
+      });
+      await apiClient.fetch('DELETE /api/streams/{name}/dashboards/{dashboardId} 2023-10-31', {
+        params: {
+          path: {
+            name: 'logs',
+            dashboardId: TEST_DASHBOARD_ID,
+          },
+        },
+      });
       await esClient.index({
         index: '.kibana_streams-000001',
         id: TEST_STREAM_NAME,
         document: streamDefinition,
       });
+      await Promise.all(
+        assetLinks.map((link) =>
+          esClient.index({
+            index: '.kibana_streams_assets-000001',
+            id: link['asset.uuid'],
+            document: link,
+          })
+        )
+      );
 
       // Refresh the index to make the document searchable
       await esClient.indices.refresh({ index: '.kibana_streams-000001' });
+      await esClient.indices.refresh({ index: '.kibana_streams_assets-000001' });
     });
 
     after(async () => {
@@ -147,6 +225,26 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         }
       );
       expect(dashboardResponse.status).to.eql(200);
+    });
+
+    it('should read expected dashboards for classic stream', async () => {
+      const response = await apiClient.fetch('GET /api/streams/{name}/dashboards 2023-10-31', {
+        params: {
+          path: { name: TEST_STREAM_NAME },
+        },
+      });
+      expect(response.status).to.eql(200);
+      expect(response.body.dashboards).to.eql(expectedDashboardsResponse.dashboards);
+    });
+
+    it('should read expected queries for classic stream', async () => {
+      const response = await apiClient.fetch('GET /api/streams/{name}/queries 2023-10-31', {
+        params: {
+          path: { name: TEST_STREAM_NAME },
+        },
+      });
+      expect(response.status).to.eql(200);
+      expect(response.body.queries).to.eql(expectedQueriesResponse.queries);
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [🌊 Streams: Test migration properly and refactor migration on read (#221533)](https://github.com/elastic/kibana/pull/221533)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2025-06-02T22:12:26Z","message":"🌊 Streams: Test migration properly and refactor migration on read (#221533)\n\nThis PR moves the migration-on-read logic into the storage adapter so\nit's not possible to accidentally read unmigrated `_source` objects and\nadds tests for this for asset links (dashboards and queries). While\nthere is no migration on read currently ongoing for dashboards and\nqueries, this test will highlight problems in this area, avoiding an\nissue like the one we had with streams definitions themselves.","sha":"03f7112374e40277533461d7f24c310baf1d6d08","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-logs","backport:version","Feature:Streams","v9.1.0","v8.19.0"],"title":"🌊 Streams: Test migration properly and refactor migration on read","number":221533,"url":"https://github.com/elastic/kibana/pull/221533","mergeCommit":{"message":"🌊 Streams: Test migration properly and refactor migration on read (#221533)\n\nThis PR moves the migration-on-read logic into the storage adapter so\nit's not possible to accidentally read unmigrated `_source` objects and\nadds tests for this for asset links (dashboards and queries). While\nthere is no migration on read currently ongoing for dashboards and\nqueries, this test will highlight problems in this area, avoiding an\nissue like the one we had with streams definitions themselves.","sha":"03f7112374e40277533461d7f24c310baf1d6d08"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221533","number":221533,"mergeCommit":{"message":"🌊 Streams: Test migration properly and refactor migration on read (#221533)\n\nThis PR moves the migration-on-read logic into the storage adapter so\nit's not possible to accidentally read unmigrated `_source` objects and\nadds tests for this for asset links (dashboards and queries). While\nthere is no migration on read currently ongoing for dashboards and\nqueries, this test will highlight problems in this area, avoiding an\nissue like the one we had with streams definitions themselves.","sha":"03f7112374e40277533461d7f24c310baf1d6d08"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->