### PR TITLE
[Flaky test] adjustments to reporting page objects 

### DIFF
--- a/src/platform/test/functional/page_objects/export_page.ts
+++ b/src/platform/test/functional/page_objects/export_page.ts
@@ -54,9 +54,14 @@ export class ExportPageObject extends FtrService {
   }
 
   async closeExportFlyout() {
-    if (await this.isExportFlyoutOpen()) {
-      await this.testSubjects.click('exportFlyoutCloseButton');
-    }
+    await this.retry.waitFor('close export flyout', async () => {
+      let isExportFlyoutOpen;
+      if ((isExportFlyoutOpen = await this.isExportFlyoutOpen())) {
+        await this.testSubjects.click('exportFlyoutCloseButton');
+      }
+
+      return !isExportFlyoutOpen;
+    });
   }
 
   async getExportAssetTextButton() {

--- a/x-pack/test/functional/apps/discover/group1/reporting.ts
+++ b/x-pack/test/functional/apps/discover/group1/reporting.ts
@@ -125,8 +125,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     return clipboardValue;
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/222247
-  describe.skip('Discover CSV Export', () => {
+  describe('Discover CSV Export', () => {
     describe('Check Available', () => {
       before(async () => {
         await esArchiver.emptyKibanaIndex();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/222247

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->

