### PR TITLE
[8.19] Update aria label for the discuss forum link (#221936)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/footer/footer.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/footer/footer.tsx
@@ -63,7 +63,7 @@ export const Footer: FunctionComponent = () => {
       ),
       linkARIALabel: i18n.translate(
         'xpack.observability_onboarding.experimentalOnboardingFlow.exploreForumFlexItemLinkARIALabel',
-        { defaultMessage: 'Open Elastic Discuss forum' }
+        { defaultMessage: 'Discuss forum. Open Elastic forum' }
       ),
       link: URL_FORUM,
       testSubject: 'observabilityOnboardingFooterDiscussForumLink',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update aria label for the discuss forum link (#221936)](https://github.com/elastic/kibana/pull/221936)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Giorgos Bamparopoulos","email":"georgios.bamparopoulos@elastic.co"},"sourceCommit":{"committedDate":"2025-05-29T15:34:33Z","message":"Update aria label for the discuss forum link (#221936)\n\n### Summary\n- Updates aria label for the discuss forum link in onboarding so the\nstart of the link text is announced the same in the reader\n- Tested with VoiceOver in Mac\n\n### VoiceOver text announcement:\n**Before**\n<img width=\"620\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c1de61db-c17a-4915-8f67-734aeff07beb\"\n/>\n\n**After**\n<img width=\"634\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/677a620d-949b-49a0-9b5c-4fca9528c41f\"\n/>\n\n\nCloses https://github.com/elastic/kibana/issues/220812","sha":"6c47a74e9bb48c0d0ca886faf5ef6d64cbf5e609","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.1.0","v8.19.0"],"title":"Update aria label for the discuss forum link","number":221936,"url":"https://github.com/elastic/kibana/pull/221936","mergeCommit":{"message":"Update aria label for the discuss forum link (#221936)\n\n### Summary\n- Updates aria label for the discuss forum link in onboarding so the\nstart of the link text is announced the same in the reader\n- Tested with VoiceOver in Mac\n\n### VoiceOver text announcement:\n**Before**\n<img width=\"620\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c1de61db-c17a-4915-8f67-734aeff07beb\"\n/>\n\n**After**\n<img width=\"634\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/677a620d-949b-49a0-9b5c-4fca9528c41f\"\n/>\n\n\nCloses https://github.com/elastic/kibana/issues/220812","sha":"6c47a74e9bb48c0d0ca886faf5ef6d64cbf5e609"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221936","number":221936,"mergeCommit":{"message":"Update aria label for the discuss forum link (#221936)\n\n### Summary\n- Updates aria label for the discuss forum link in onboarding so the\nstart of the link text is announced the same in the reader\n- Tested with VoiceOver in Mac\n\n### VoiceOver text announcement:\n**Before**\n<img width=\"620\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c1de61db-c17a-4915-8f67-734aeff07beb\"\n/>\n\n**After**\n<img width=\"634\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/677a620d-949b-49a0-9b5c-4fca9528c41f\"\n/>\n\n\nCloses https://github.com/elastic/kibana/issues/220812","sha":"6c47a74e9bb48c0d0ca886faf5ef6d64cbf5e609"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->