### PR TITLE
[APM] Fix dev script

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/scripts/test/api.js
+++ b/x-pack/solutions/observability/plugins/apm/scripts/test/api.js
@@ -97,7 +97,7 @@ const cmd = [
   ...(grep ? [`--grep "${grep}"`] : []),
   ...(updateSnapshots ? [`--updateSnapshots`] : []),
   ...(bail ? [`--bail`] : []),
-  `--config ${REPO_ROOT}/x-pack/test/apm_api_integration/${license}/config.ts`,
+  `--config ${REPO_ROOT}/x-pack/solutions/observability/test/apm_api_integration/${license}/config.ts`,
 ].join(' ');
 
 console.log(`Running: "${cmd}"`);


### PR DESCRIPTION
## Summary

As the tests have been relocated to `x-pack/solutions/observability/test/...`, this PR updates the dev script to run them.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->