### PR TITLE
[8.19] [Task Manager] Remove spaces plugin dependency in task manager plugin (#221596)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/task_manager/kibana.jsonc
@@ -17,7 +17,6 @@
     "optionalPlugins": [
       "cloud",
       "usageCollection",
-      "spaces"
     ]
   }
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/api_key_utils.test.ts
@@ -13,8 +13,6 @@ import {
 } from './api_key_utils';
 import { coreMock } from '@kbn/core/server/mocks';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
-import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
 import type { AuthenticatedUser } from '@kbn/core/server';
 
 const mockTask = {
@@ -156,13 +154,8 @@ describe('api_key_utils', () => {
 
   describe('getUserScope', () => {
     test('should return the users scope based on their request', async () => {
-      const request = httpServerMock.createKibanaRequest();
+      const request = httpServerMock.createKibanaRequest({ path: '/s/test-space' });
       const coreStart = coreMock.createStart();
-      const spacesStart: jest.Mocked<SpacesPluginStart> = spacesMock.createStart();
-
-      spacesStart.spacesService.getActiveSpace = jest.fn().mockResolvedValue({
-        id: 'testSpace',
-      });
 
       const mockUser = {
         authentication_type: 'basic',
@@ -178,18 +171,13 @@ describe('api_key_utils', () => {
         api_key: 'apiKey',
       });
 
-      const result = await getApiKeyAndUserScope(
-        [mockTask],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      const result = await getApiKeyAndUserScope([mockTask], request, coreStart.security);
 
       expect(result.get('task')).toEqual({
         apiKey: 'YXBpS2V5SWQ6YXBpS2V5',
         userScope: {
           apiKeyId: 'apiKeyId',
-          spaceId: 'testSpace',
+          spaceId: 'test-space',
           apiKeyCreatedByUser: false,
         },
       });
@@ -198,7 +186,6 @@ describe('api_key_utils', () => {
     test('should default space to default if space is not found', async () => {
       const request = httpServerMock.createKibanaRequest();
       const coreStart = coreMock.createStart();
-      const spacesStart: jest.Mocked<SpacesPluginStart> = spacesMock.createStart();
 
       const mockUser = {
         authentication_type: 'basic',
@@ -214,12 +201,7 @@ describe('api_key_utils', () => {
         api_key: 'apiKey',
       });
 
-      const result = await getApiKeyAndUserScope(
-        [mockTask],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      const result = await getApiKeyAndUserScope([mockTask], request, coreStart.security);
 
       expect(result.get('task')).toEqual({
         apiKey: 'YXBpS2V5SWQ6YXBpS2V5',
@@ -240,7 +222,6 @@ describe('api_key_utils', () => {
       });
 
       const coreStart = coreMock.createStart();
-      const spacesStart: jest.Mocked<SpacesPluginStart> = spacesMock.createStart();
       const mockUser = {
         authentication_type: 'api_key',
         username: 'testUser',
@@ -249,12 +230,7 @@ describe('api_key_utils', () => {
       coreStart.security.authc.apiKeys.areAPIKeysEnabled = jest.fn().mockReturnValueOnce(true);
       coreStart.security.authc.getCurrentUser = jest.fn().mockReturnValue(mockUser);
 
-      const result = await getApiKeyAndUserScope(
-        [mockTask],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      const result = await getApiKeyAndUserScope([mockTask], request, coreStart.security);
 
       expect(result.get('task')).toEqual({
         apiKey: 'YXBpS2V5SWQ6YXBpS2V5',

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -25,7 +25,6 @@ import type {
 import { ServiceStatusLevels } from '@kbn/core/server';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
 import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-shared';
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import {
   registerDeleteInactiveNodesTaskDefinition,
   scheduleDeleteInactiveNodesTaskDefinition,
@@ -99,7 +98,6 @@ export type TaskManagerStartContract = Pick<
 export interface TaskManagerPluginsStart {
   cloud?: CloudStart;
   usageCollection?: UsageCollectionStart;
-  spaces?: SpacesPluginStart;
 }
 
 export interface TaskManagerPluginsSetup {
@@ -292,7 +290,7 @@ export class TaskManagerPlugin
 
   public start(
     { http, savedObjects, elasticsearch, executionContext, security }: CoreStart,
-    { cloud, spaces }: TaskManagerPluginsStart
+    { cloud }: TaskManagerPluginsStart
   ): TaskManagerStartContract {
     const savedObjectsRepository = savedObjects.createInternalRepository([
       TASK_SO_NAME,
@@ -326,7 +324,6 @@ export class TaskManagerPlugin
       requestTimeouts: this.config.request_timeouts,
       security,
       canEncryptSavedObjects: this.canEncryptSavedObjects,
-      spaces,
     });
 
     const isServerless = this.initContext.env.packageInfo.buildFlavor === 'serverless';

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -25,7 +25,7 @@ import type {
 } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
-import { addSpaceIdToPath } from '@kbn/spaces-plugin/server';
+import { addSpaceIdToPath } from '@kbn/spaces-utils';
 import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
 import type { Middleware } from '../lib/middleware';
 import type { Result } from '../lib/result_type';

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -33,7 +33,6 @@ import { asErr, asOk } from './lib/result_type';
 import type { UpdateByQueryResponse } from '@elastic/elasticsearch/lib/api/types';
 import { MsearchError } from './lib/msearch_error';
 import { getApiKeyAndUserScope } from './lib/api_key_utils';
-import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
 import type {
   EncryptedSavedObjectsClient,
   EncryptedSavedObjectsClientOptions,
@@ -75,7 +74,6 @@ const adHocTaskCounter = new AdHocTaskCounter();
 const randomId = () => `id-${_.random(1, 20)}`;
 
 const coreStart = coreMock.createStart();
-const spacesStart = spacesMock.createStart();
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -146,7 +144,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -319,12 +316,7 @@ describe('TaskStore', () => {
         }
       );
 
-      expect(getApiKeyAndUserScope).toHaveBeenCalledWith(
-        [task],
-        request,
-        coreStart.security,
-        spacesStart
-      );
+      expect(getApiKeyAndUserScope).toHaveBeenCalledWith([task], request, coreStart.security);
 
       expect(savedObjectsClient.create).not.toHaveBeenCalled();
 
@@ -363,7 +355,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: false,
       });
 
@@ -1700,7 +1691,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -1821,7 +1811,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -2135,7 +2124,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: true,
       });
 
@@ -2342,8 +2330,7 @@ describe('TaskStore', () => {
       expect(getApiKeyAndUserScope).toHaveBeenCalledWith(
         [task1, task2],
         request,
-        coreStart.security,
-        spacesStart
+        coreStart.security
       );
 
       expect(savedObjectsClient.create).not.toHaveBeenCalled();
@@ -2404,7 +2391,6 @@ describe('TaskStore', () => {
         },
         savedObjectsService: coreStart.savedObjects,
         security: coreStart.security,
-        spaces: spacesStart,
         canEncryptSavedObjects: false,
       });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -31,7 +31,6 @@ import type {
 } from '@kbn/core/server';
 
 import { SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID } from '@kbn/core/server';
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 
 import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-shared';
 
@@ -80,7 +79,6 @@ export interface StoreOpts {
   security: SecurityServiceStart;
   canEncryptSavedObjects?: boolean;
   esoClient?: EncryptedSavedObjectsClient;
-  spaces?: SpacesPluginStart;
 }
 
 export interface SearchOpts {
@@ -150,7 +148,6 @@ export class TaskStore {
   private requestTimeouts: RequestTimeoutsConfig;
   private security: SecurityServiceStart;
   private canEncryptSavedObjects?: boolean;
-  private spaces?: SpacesPluginStart;
   private logger: Logger;
 
   /**
@@ -184,7 +181,6 @@ export class TaskStore {
     });
     this.requestTimeouts = opts.requestTimeouts;
     this.security = opts.security;
-    this.spaces = opts.spaces;
     this.canEncryptSavedObjects = opts.canEncryptSavedObjects;
     this.logger = opts.logger;
   }
@@ -225,12 +221,7 @@ export class TaskStore {
 
     let userScopeAndApiKey;
     try {
-      userScopeAndApiKey = await getApiKeyAndUserScope(
-        taskInstances,
-        request,
-        this.security,
-        this.spaces
-      );
+      userScopeAndApiKey = await getApiKeyAndUserScope(taskInstances, request, this.security);
     } catch (e) {
       this.errors$.next(e);
       throw e;

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -31,12 +31,12 @@
     "@kbn/core-elasticsearch-server",
     "@kbn/es-query",
     "@kbn/core-http-server-mocks",
-    "@kbn/spaces-plugin",
     "@kbn/encrypted-saved-objects-shared",
     "@kbn/core-saved-objects-api-server-mocks",
     "@kbn/core-http-server-utils",
     "@kbn/rrule",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/spaces-utils",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Task Manager] Remove spaces plugin dependency in task manager plugin (#221596)](https://github.com/elastic/kibana/pull/221596)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Krzysztof Kowalczyk","email":"krzysztof.kowalczyk@elastic.co"},"sourceCommit":{"committedDate":"2025-05-28T07:28:16Z","message":"[Task Manager] Remove spaces plugin dependency in task manager plugin (#221596)\n\n## Summary\n\nThis PR removes spaces plugin dependency from task manager plugin and\nreplaces `spacesService.getActiveSpace` with `getSpaceIdFromPath` from\n`@kbn/spaces-utils` package. This prevents a circular dependency from\nhappening in https://github.com/elastic/kibana/pull/220138\n\n> [!NOTE]  \n> I'm changing the test case to use `test-space` id instead of\n`testSpace` as this was an invalid space id and it shouldn't have been\nused in the mock.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"017c2e53f578d7da08616cca7cd4f9f920b5a571","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","Team:ResponseOps","backport:version","v9.1.0","v8.19.0"],"title":"[Task Manager] Remove spaces plugin dependency in task manager plugin","number":221596,"url":"https://github.com/elastic/kibana/pull/221596","mergeCommit":{"message":"[Task Manager] Remove spaces plugin dependency in task manager plugin (#221596)\n\n## Summary\n\nThis PR removes spaces plugin dependency from task manager plugin and\nreplaces `spacesService.getActiveSpace` with `getSpaceIdFromPath` from\n`@kbn/spaces-utils` package. This prevents a circular dependency from\nhappening in https://github.com/elastic/kibana/pull/220138\n\n> [!NOTE]  \n> I'm changing the test case to use `test-space` id instead of\n`testSpace` as this was an invalid space id and it shouldn't have been\nused in the mock.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"017c2e53f578d7da08616cca7cd4f9f920b5a571"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221596","number":221596,"mergeCommit":{"message":"[Task Manager] Remove spaces plugin dependency in task manager plugin (#221596)\n\n## Summary\n\nThis PR removes spaces plugin dependency from task manager plugin and\nreplaces `spacesService.getActiveSpace` with `getSpaceIdFromPath` from\n`@kbn/spaces-utils` package. This prevents a circular dependency from\nhappening in https://github.com/elastic/kibana/pull/220138\n\n> [!NOTE]  \n> I'm changing the test case to use `test-space` id instead of\n`testSpace` as this was an invalid space id and it shouldn't have been\nused in the mock.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"017c2e53f578d7da08616cca7cd4f9f920b5a571"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->