### PR TITLE
[8.19] [Lens] Keep suggestions up to date with the main workspace (#221901)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
@@ -1345,6 +1345,7 @@ export const stackingTypes = [
       defaultMessage: 'Stacked',
     }),
     subtypes: ['bar_stacked', 'area_stacked', 'bar_horizontal_stacked'],
+    dataTestSubj: 'lnsStackingOptionsButtonStacked',
   },
   {
     type: 'unstacked',
@@ -1352,6 +1353,7 @@ export const stackingTypes = [
       defaultMessage: 'Unstacked',
     }),
     subtypes: ['bar', 'area', 'bar_horizontal'],
+    dataTestSubj: 'lnsStackingOptionsButtonUnstacked',
   },
   {
     type: 'percentage',
@@ -1363,6 +1365,7 @@ export const stackingTypes = [
       'area_percentage_stacked',
       'bar_horizontal_percentage_stacked',
     ],
+    dataTestSubj: 'lnsStackingOptionsButtonPercentage',
   },
 ];
 
@@ -1380,10 +1383,11 @@ const SubtypeSwitch = ({
     return null;
   }
   const subTypeIndex = stackingType.subtypes.indexOf(layer.seriesType);
-  const options = stackingTypes.map(({ label, subtypes }) => ({
+  const options = stackingTypes.map(({ label, subtypes, dataTestSubj }) => ({
     label,
     value: subtypes[subTypeIndex],
     checked: subtypes[subTypeIndex] === layer.seriesType ? ('on' as const) : undefined,
+    'data-test-subj': dataTestSubj,
   }));
 
   return (
@@ -1400,6 +1404,7 @@ const SubtypeSwitch = ({
             fullWidth
             size="s"
             label={stackingType.label}
+            data-test-subj="lnsStackingOptionsButton"
           />
         }
         isOpen={flyoutOpen}

--- a/x-pack/test/functional/apps/lens/group1/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/group1/smokescreen.ts
@@ -829,5 +829,39 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await lens.waitForVisualization('xyVisChart');
       expect(await lens.getWorkspaceErrorCount()).to.eql(0);
     });
+
+    it('should keep suggestions up to date with the current configuration', async () => {
+      await visualize.navigateToNewVisualization();
+      await visualize.clickVisType('lens');
+      await lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+      await lens.configureDimension({
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
+        operation: 'average',
+        field: 'bytes',
+      });
+      // duplicate the layer
+      await lens.duplicateLayer();
+
+      // now make the first layer bar percentage to lead it in an broken rendering state
+      await lens.switchToVisualizationSubtype('Percentage');
+
+      // now check that both the main visualization and the current visualization suggestion are in error state
+      expect(await lens.getWorkspaceErrorCount()).to.eql(1);
+      await testSubjects.existOrFail(
+        'lnsSuggestion-currentVisualization > lnsSuggestionPanel__error'
+      );
+
+      // revert the subtype to stacked and everything should be fine again
+      await lens.switchToVisualizationSubtype('Stacked');
+
+      expect(await lens.getWorkspaceErrorCount()).to.eql(0);
+      await testSubjects.missingOrFail(
+        'lnsSuggestion-currentVisualization > lnsSuggestionPanel__error'
+      );
+    });
   });
 }

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -925,6 +925,19 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       });
     },
 
+    async switchToVisualizationSubtype(subType: string, layerIndex: number = 0) {
+      if (!(await testSubjects.exists(`lns-layerPanel-${layerIndex} > lnsStackingOptionsButton`))) {
+        throw new Error('No subtype available for the current visualization');
+      }
+      await testSubjects.click(`lns-layerPanel-${layerIndex} > lnsStackingOptionsButton`);
+      await testSubjects.click(`lnsStackingOptionsButton${subType}`);
+    },
+
+    async getChartTypeFromChartSwitcher() {
+      const chartSwitcher = await testSubjects.find('lnsChartSwitchPopover');
+      return await chartSwitcher.getVisibleText();
+    },
+
     async openChartSwitchPopover(layerIndex = 0) {
       if (await testSubjects.exists('lnsChartSwitchList', { timeout: 50 })) {
         return;
@@ -1102,6 +1115,15 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           }
         }
       }
+    },
+
+    async duplicateLayer(index: number = 0) {
+      await retry.try(async () => {
+        if (await testSubjects.exists(`lnsLayerSplitButton--${index}`)) {
+          await testSubjects.click(`lnsLayerSplitButton--${index}`);
+        }
+        await testSubjects.click(`lnsLayerClone--${index}`);
+      });
     },
 
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Lens] Keep suggestions up to date with the main workspace (#221901)](https://github.com/elastic/kibana/pull/221901)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Liberati","email":"dej611@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-30T14:14:32Z","message":"[Lens] Keep suggestions up to date with the main workspace (#221901)\n\n## Summary\n\nFixes #178571 \n\nThis PR reverts #221248 adding the missing part on it to make the bug\nfound in #178571 disappear.\nIn fact there was just a single line missing who was meant to keep the\nsuggestion frame version up to date with the latest workspace state.\n\n\n![lens_suggestion_bug_fix](https://github.com/user-attachments/assets/ff59e4d6-cfac-4801-857a-a79b1c98762d)\n\nI've tried to add a unit test but it was so hard to actually follow the\ncode underneath, so I settled to add a FTR, which led to few more\nextras:\n\n* subtype selector now has test ids\n* Lens page now has few more utility helpers for layer cloning and sub\ntype selector\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"0bcd7ffcddb706da6407337ad3e3e85e0713fb13","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport missing","backport:version","v9.1.0","v8.19.0"],"title":"[Lens] Keep suggestions up to date with the main workspace","number":221901,"url":"https://github.com/elastic/kibana/pull/221901","mergeCommit":{"message":"[Lens] Keep suggestions up to date with the main workspace (#221901)\n\n## Summary\n\nFixes #178571 \n\nThis PR reverts #221248 adding the missing part on it to make the bug\nfound in #178571 disappear.\nIn fact there was just a single line missing who was meant to keep the\nsuggestion frame version up to date with the latest workspace state.\n\n\n![lens_suggestion_bug_fix](https://github.com/user-attachments/assets/ff59e4d6-cfac-4801-857a-a79b1c98762d)\n\nI've tried to add a unit test but it was so hard to actually follow the\ncode underneath, so I settled to add a FTR, which led to few more\nextras:\n\n* subtype selector now has test ids\n* Lens page now has few more utility helpers for layer cloning and sub\ntype selector\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"0bcd7ffcddb706da6407337ad3e3e85e0713fb13"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221901","number":221901,"mergeCommit":{"message":"[Lens] Keep suggestions up to date with the main workspace (#221901)\n\n## Summary\n\nFixes #178571 \n\nThis PR reverts #221248 adding the missing part on it to make the bug\nfound in #178571 disappear.\nIn fact there was just a single line missing who was meant to keep the\nsuggestion frame version up to date with the latest workspace state.\n\n\n![lens_suggestion_bug_fix](https://github.com/user-attachments/assets/ff59e4d6-cfac-4801-857a-a79b1c98762d)\n\nI've tried to add a unit test but it was so hard to actually follow the\ncode underneath, so I settled to add a FTR, which led to few more\nextras:\n\n* subtype selector now has test ids\n* Lens page now has few more utility helpers for layer cloning and sub\ntype selector\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"0bcd7ffcddb706da6407337ad3e3e85e0713fb13"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->