### PR TITLE
[8.17] Upgrade prismjs 1.29.0 → 1.30.0 (#222019)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27181,13 +27181,13 @@ printj@~1.1.0:
   integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 prismjs@^1.22.0, prismjs@^1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
-  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
+  integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
 prismjs@~1.27.0:
   version "1.27.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
@@ -30634,7 +30634,7 @@ string-replace-loader@^3.1.0:
 
 "string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27187,7 +27187,7 @@ prismjs@^1.22.0, prismjs@^1.29.0:
 
 prismjs@~1.27.0:
   version "1.27.0"
-  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
@@ -30634,7 +30634,7 @@ string-replace-loader@^3.1.0:
 
 "string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Upgrade prismjs 1.29.0 → 1.30.0 (#222019)](https://github.com/elastic/kibana/pull/222019)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2025-05-30T14:50:56Z","message":"Upgrade prismjs 1.29.0 → 1.30.0 (#222019)\n\n## Summary\n\nUpgrades the `prismjs` dependency to version 1.30.0 where possible.","sha":"69682401bbe227679f6fde06ebd38f6770f310e6","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.1.0","v8.19.0","v9.0.2"],"title":"Upgrade prismjs 1.29.0 → 1.30.0","number":222019,"url":"https://github.com/elastic/kibana/pull/222019","mergeCommit":{"message":"Upgrade prismjs 1.29.0 → 1.30.0 (#222019)\n\n## Summary\n\nUpgrades the `prismjs` dependency to version 1.30.0 where possible.","sha":"69682401bbe227679f6fde06ebd38f6770f310e6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222019","number":222019,"mergeCommit":{"message":"Upgrade prismjs 1.29.0 → 1.30.0 (#222019)\n\n## Summary\n\nUpgrades the `prismjs` dependency to version 1.30.0 where possible.","sha":"69682401bbe227679f6fde06ebd38f6770f310e6"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/222071","number":222071,"state":"MERGED","mergeCommit":{"sha":"f33c16f66e2da0f731c01511d8c734b7bdd2031e","message":"[8.19] Upgrade prismjs 1.29.0 → 1.30.0 (#222019) (#222071)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [Upgrade prismjs 1.29.0 → 1.30.0\n(#222019)](https://github.com/elastic/kibana/pull/222019)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/222072","number":222072,"state":"MERGED","mergeCommit":{"sha":"8da7114436d8569b8ce8e548d937455e8554d8d9","message":"[9.0] Upgrade prismjs 1.29.0 → 1.30.0 (#222019) (#222072)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [Upgrade prismjs 1.29.0 → 1.30.0\n(#222019)](https://github.com/elastic/kibana/pull/222019)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}}]}] BACKPORT-->