### PR TITLE
[8.19] [ES|QL] `COMPLETION` command parsing support (#221609)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/completion.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/completion.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EsqlQuery } from '../../query';
+import { ESQLCommandOption } from '../../types';
+
+describe('COMPLETION command', () => {
+  describe('correctly formatted', () => {
+    describe('COMPLETION <prompt> WITH <inferenceId> ...', () => {
+      it('parses the COMPLETION command', () => {
+        const text = `FROM index | COMPLETION prompt WITH inferenceId`;
+        const query = EsqlQuery.fromSrc(text);
+
+        expect(query.ast.commands[1]).toMatchObject({
+          type: 'command',
+          name: 'completion',
+          incomplete: false,
+        });
+      });
+
+      it('parses prompt primary expression as the first argument', () => {
+        const text = `FROM index | COMPLETION prompt WITH inferenceId`;
+        const query = EsqlQuery.fromSrc(text);
+
+        expect(query.ast.commands[1].args[0]).toMatchObject({
+          type: 'column',
+          name: 'prompt',
+        });
+      });
+
+      it('parses prompt when it is a param', () => {
+        const text = `FROM index | COMPLETION ? WITH inferenceId`;
+        const query = EsqlQuery.fromSrc(text);
+
+        expect(query.ast.commands[1].args[0]).toMatchObject([
+          {
+            type: 'literal',
+            literalType: 'param',
+            paramType: 'unnamed',
+          },
+        ]);
+      });
+
+      it('parses the WITH command option as the second argument', () => {
+        const text = `FROM index | COMPLETION prompt WITH inferenceId`;
+        const query = EsqlQuery.fromSrc(text);
+
+        expect(query.ast.commands[1].args[1]).toMatchObject({
+          type: 'option',
+          name: 'with',
+        });
+      });
+
+      it('parses inferenceId as the argument of the WITH option', () => {
+        const text = `FROM index | COMPLETION prompt WITH inferenceId`;
+        const query = EsqlQuery.fromSrc(text);
+
+        const withOption = query.ast.commands[1].args[1] as ESQLCommandOption;
+
+        expect(withOption).toMatchObject({
+          args: [
+            {
+              type: 'identifier',
+              name: 'inferenceId',
+            },
+          ],
+        });
+      });
+
+      it('parses backtick inferenceId', () => {
+        const text = `FROM index | COMPLETION prompt WITH \`inferenceId\``;
+        const query = EsqlQuery.fromSrc(text);
+
+        const withOption = query.ast.commands[1].args[1] as ESQLCommandOption;
+
+        expect(query.errors.length).toBe(0);
+        expect(withOption).toMatchObject({
+          args: [
+            {
+              type: 'identifier',
+              name: 'inferenceId',
+            },
+          ],
+        });
+      });
+
+      it('parses inferenceId when it is param', () => {
+        const text = `FROM index | COMPLETION prompt WITH ?`;
+        const query = EsqlQuery.fromSrc(text);
+
+        const withOption = query.ast.commands[1].args[1] as ESQLCommandOption;
+
+        expect(query.errors.length).toBe(0);
+        expect(withOption).toMatchObject({
+          args: [
+            {
+              type: 'literal',
+              literalType: 'param',
+              paramType: 'unnamed',
+            },
+          ],
+        });
+      });
+    });
+
+    describe('... AS <targetField>', () => {
+      it('parses the AS command option as the third argument', () => {
+        const text = `FROM index | COMPLETION prompt WITH inferenceId AS targetField`;
+        const query = EsqlQuery.fromSrc(text);
+
+        expect(query.ast.commands[1].args[2]).toMatchObject({
+          type: 'option',
+          name: 'as',
+        });
+      });
+
+      it('parses targetField as AS option argument', () => {
+        const text = `FROM index | COMPLETION prompt WITH inferenceId AS targetField`;
+        const query = EsqlQuery.fromSrc(text);
+
+        const asOption = query.ast.commands[1].args[2] as ESQLCommandOption;
+
+        expect(asOption).toMatchObject({
+          args: [
+            {
+              type: 'column',
+              name: 'targetField',
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  describe('incorrectly formatted', () => {
+    it('throws on missing prompt', () => {
+      const text = `FROM index | COMPLETION`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+
+    it('throws on missing prompt with options', () => {
+      const text = `FROM index | COMPLETION WITH inferenceId`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('throws on missing WITH option', () => {
+      const text = `FROM index | COMPLETION prompt`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+
+    it('throws on missing WITH argument', () => {
+      const text = `FROM index | COMPLETION prompt WITH`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+
+    it('sets incomplete flag on WITH argument if not inferenceId provided', () => {
+      const text = `FROM index | COMPLETION prompt WITH `;
+      const { ast } = EsqlQuery.fromSrc(text);
+
+      expect(ast.commands[1].args[1]).toMatchObject({
+        type: 'option',
+        name: 'with',
+        incomplete: true,
+      });
+    });
+
+    it('throws on inferenceId wrapped in double quotes', () => {
+      const text = `FROM index | COMPLETION prompt WITH "inferenceId"`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+
+    it('throws on missing WITH argument with AS argument', () => {
+      const text = `FROM index | COMPLETION prompt WITH AS targetField`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+
+    it('throws on missing AS argument', () => {
+      const text = `FROM index | COMPLETION prompt WITH inferenceId AS`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+
+    it('throws on extra unsupported argument', () => {
+      const text = `FROM index | COMPLETION prompt WITH inferenceId AS target WHEN`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+
+    it('throws on unsupported argument after prompt', () => {
+      const text = `FROM index | COMPLETION prompt AS target`;
+      const { errors } = EsqlQuery.fromSrc(text);
+
+      expect(errors.length).toBe(1);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ErrorNode, ParserRuleContext, TerminalNode } from 'antlr4';
+import { createCompletionCommand } from './factories/completion';
 import {
   InlinestatsCommandContext,
   JoinCommandContext,
@@ -32,6 +33,7 @@ import {
   type TimeSeriesCommandContext,
   type WhereCommandContext,
   RerankCommandContext,
+  CompletionCommandContext,
   RrfCommandContext,
   SampleCommandContext,
 } from '../antlr/esql_parser';
@@ -350,6 +352,20 @@ export class ESQLAstBuilderListener implements ESQLParserListener {
   exitRerankCommand(ctx: RerankCommandContext): void {
     const command = createRerankCommand(ctx);
 
+    this.ast.push(command);
+  }
+
+  /**
+   * Exit a parse tree produced by `esql_parser.completionCommand`.
+   *
+   * Parse the COMPLETION command:
+   *
+   * COMPLETION <prompt> WITH <inferenceId> [ AS <targetField> ]
+   *
+   * @param ctx the parse tree
+   */
+  exitCompletionCommand(ctx: CompletionCommandContext): void {
+    const command = createCompletionCommand(ctx);
     this.ast.push(command);
   }
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/completion.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/completion.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Builder, ESQLCommand } from '../../..';
+import { visitPrimaryExpression } from '../walkers';
+import { CompletionCommandContext } from '../../antlr/esql_parser';
+import { createColumn, createCommand, createIdentifierOrParam } from '../factories';
+import { getPosition } from '../helpers';
+
+export const createCompletionCommand = (
+  ctx: CompletionCommandContext
+): ESQLCommand<'completion'> => {
+  const command = createCommand<'completion'>('completion', ctx);
+
+  const prompt = visitPrimaryExpression(ctx._prompt);
+  command.args.push(prompt);
+
+  const inferenceIdCtx = ctx._inferenceId;
+  const maybeInferenceId = inferenceIdCtx ? createIdentifierOrParam(inferenceIdCtx) : undefined;
+  const inferenceId = maybeInferenceId ?? Builder.identifier('', { incomplete: true });
+
+  const withCtx = ctx.WITH();
+  const optionWith = Builder.option(
+    {
+      name: 'with',
+      args: [inferenceId],
+    },
+    withCtx && inferenceIdCtx
+      ? {
+          location: getPosition(withCtx.symbol, inferenceIdCtx.stop),
+        }
+      : undefined
+  );
+
+  if (inferenceId.incomplete || !withCtx) {
+    optionWith.incomplete = true;
+  }
+
+  command.args.push(optionWith);
+
+  if (ctx._targetField && ctx._targetField.getText()) {
+    const targetField = createColumn(ctx._targetField);
+    const option = Builder.option(
+      {
+        name: 'as',
+        args: [targetField],
+      },
+      {
+        location: getPosition(ctx.AS().symbol, ctx._targetField.stop),
+      }
+    );
+
+    command.args.push(option);
+  }
+
+  return command;
+};

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/__tests__/commands.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/__tests__/commands.test.ts
@@ -164,3 +164,26 @@ test('can visit RERANK command', () => {
 
   expect(list).toEqual(['RERANK']);
 });
+
+test('can visit COMPLETION command', () => {
+  const { ast } = EsqlQuery.fromSrc(`
+    FROM index
+      | COMPLETION "test" WITH inferenceId
+  `);
+  const visitor = new Visitor()
+    .on('visitExpression', (ctx) => {
+      return null;
+    })
+    .on('visitCompletionCommand', (ctx) => {
+      return 'COMPLETION';
+    })
+    .on('visitCommand', (ctx) => {
+      return null;
+    })
+    .on('visitQuery', (ctx) => {
+      return [...ctx.visitCommands()].flat();
+    });
+  const list = visitor.visitQuery(ast).flat().filter(Boolean);
+
+  expect(list).toEqual(['COMPLETION']);
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
@@ -520,6 +520,12 @@ export class ForkCommandVisitorContext<
   Data extends SharedData = SharedData
 > extends CommandVisitorContext<Methods, Data, ESQLAstCommand> {}
 
+// COMPLETION
+export class CompletionCommandVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData
+> extends CommandVisitorContext<Methods, Data, ESQLAstCommand> {}
+
 // SAMPLE <probability> [SEED <seed>]
 export class SampleCommandVisitorContext<
   Methods extends VisitorMethods = VisitorMethods,

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
@@ -197,6 +197,10 @@ export class GlobalVisitorContext<
         if (!this.methods.visitForkCommand) break;
         return this.visitForkCommand(parent, commandNode, input as any);
       }
+      case 'completion': {
+        if (!this.methods.visitCompletionCommand) break;
+        return this.visitCompletionCommand(parent, commandNode, input as any);
+      }
       case 'sample': {
         if (!this.methods.visitSampleCommand) break;
         return this.visitSampleCommand(parent, commandNode, input as any);
@@ -423,6 +427,15 @@ export class GlobalVisitorContext<
   ): types.VisitorOutput<Methods, 'visitForkCommand'> {
     const context = new contexts.ForkCommandVisitorContext(this, node, parent);
     return this.visitWithSpecificContext('visitForkCommand', context, input);
+  }
+
+  public visitCompletionCommand(
+    parent: contexts.VisitorContext | null,
+    node: ESQLAstCommand,
+    input: types.VisitorInput<Methods, 'visitCompletionCommand'>
+  ): types.VisitorOutput<Methods, 'visitCompletionCommand'> {
+    const context = new contexts.CompletionCommandVisitorContext(this, node, parent);
+    return this.visitWithSpecificContext('visitCompletionCommand', context, input);
   }
 
   public visitSampleCommand(

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
@@ -144,7 +144,8 @@ export type CommandVisitorOutput<Methods extends VisitorMethods> =
   | VisitorOutput<Methods, 'visitMvExpandCommand'>
   | VisitorOutput<Methods, 'visitJoinCommand'>
   | VisitorOutput<Methods, 'visitRerankCommand'>
-  | VisitorOutput<Methods, 'visitChangePointCommand'>;
+  | VisitorOutput<Methods, 'visitChangePointCommand'>
+  | VisitorOutput<Methods, 'visitCompletionCommand'>;
 
 export interface VisitorMethods<
   Visitors extends VisitorMethods = any,
@@ -188,6 +189,11 @@ export interface VisitorMethods<
     any
   >;
   visitForkCommand?: Visitor<contexts.ForkCommandVisitorContext<Visitors, Data>, any, any>;
+  visitCompletionCommand?: Visitor<
+    contexts.CompletionCommandVisitorContext<Visitors, Data>,
+    any,
+    any
+  >;
   visitSampleCommand?: Visitor<contexts.SampleCommandVisitorContext<Visitors, Data>, any, any>;
   visitCommandOption?: Visitor<contexts.CommandOptionVisitorContext<Visitors, Data>, any, any>;
   visitRrfCommand?: Visitor<contexts.RrfCommandVisitorContext<Visitors, Data>, any, any>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES|QL] `COMPLETION` command parsing support (#221609)](https://github.com/elastic/kibana/pull/221609)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastian Delle Donne","email":"sebastian.delledonne@elastic.co"},"sourceCommit":{"committedDate":"2025-06-02T15:30:35Z","message":"[ES|QL] `COMPLETION` command parsing support (#221609)\n\nPartially addresses https://github.com/elastic/kibana/issues/218052\n\nAdds parsing support for `COMPLETION` command.\nAdd support for completion API.\n\nChecklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"db763477d988080c44cb2f5ab087eaf3a2c433dd","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[ES|QL] `COMPLETION` command parsing support","number":221609,"url":"https://github.com/elastic/kibana/pull/221609","mergeCommit":{"message":"[ES|QL] `COMPLETION` command parsing support (#221609)\n\nPartially addresses https://github.com/elastic/kibana/issues/218052\n\nAdds parsing support for `COMPLETION` command.\nAdd support for completion API.\n\nChecklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"db763477d988080c44cb2f5ab087eaf3a2c433dd"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221609","number":221609,"mergeCommit":{"message":"[ES|QL] `COMPLETION` command parsing support (#221609)\n\nPartially addresses https://github.com/elastic/kibana/issues/218052\n\nAdds parsing support for `COMPLETION` command.\nAdd support for completion API.\n\nChecklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"db763477d988080c44cb2f5ab087eaf3a2c433dd"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->