### PR TITLE
[9.0] [Build] Parallel artifact builds (#217929)

### DIFF
--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -9,7 +9,7 @@
 
 import { ToolingLog } from '@kbn/tooling-log';
 
-import { Config, createRunner, Task, GlobalTask } from './lib';
+import { Config, createRunner } from './lib';
 import * as Tasks from './tasks';
 
 export interface BuildOptions {
@@ -48,23 +48,22 @@ export interface BuildOptions {
 export async function buildDistributables(log: ToolingLog, options: BuildOptions): Promise<void> {
   log.verbose('building distributables with options:', options);
 
-  const config = await Config.create(options);
+  log.write('--- Running global Kibana build tasks');
 
-  const run: (task: Task | GlobalTask) => Promise<void> = createRunner({
-    config,
-    log,
-  });
+  const config = await Config.create(options);
+  const globalRun = createRunner({ config, log });
+  const artifactTasks = [];
 
   /**
    * verify, reset, and initialize the build environment
    */
   if (options.initialize) {
-    await run(Tasks.VerifyEnv);
-    await run(Tasks.Clean);
-    await run(
+    await globalRun(Tasks.VerifyEnv);
+    await globalRun(Tasks.Clean);
+    await globalRun(
       options.downloadFreshNode ? Tasks.DownloadNodeBuilds : Tasks.VerifyExistingNodeBuilds
     );
-    await run(Tasks.ExtractNodeBuilds);
+    await globalRun(Tasks.ExtractNodeBuilds);
   }
 
   /**
@@ -73,33 +72,33 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
   if (options.createGenericFolders) {
     // Build before copying source files
     if (options.buildCanvasShareableRuntime) {
-      await run(Tasks.BuildCanvasShareableRuntime);
+      await globalRun(Tasks.BuildCanvasShareableRuntime);
     }
 
-    await run(Tasks.CopyLegacySource);
+    await globalRun(Tasks.CopyLegacySource);
 
-    await run(Tasks.CreateEmptyDirsAndFiles);
-    await run(Tasks.CreateReadme);
-    await run(Tasks.BuildPackages);
-    await run(Tasks.ReplaceFavicon);
-    await run(Tasks.BuildKibanaPlatformPlugins);
-    await run(Tasks.CreatePackageJson);
-    await run(Tasks.InstallDependencies);
-    await run(Tasks.GeneratePackagesOptimizedAssets);
+    await globalRun(Tasks.CreateEmptyDirsAndFiles);
+    await globalRun(Tasks.CreateReadme);
+    await globalRun(Tasks.BuildPackages);
+    await globalRun(Tasks.ReplaceFavicon);
+    await globalRun(Tasks.BuildKibanaPlatformPlugins);
+    await globalRun(Tasks.CreatePackageJson);
+    await globalRun(Tasks.InstallDependencies);
+    await globalRun(Tasks.GeneratePackagesOptimizedAssets);
 
     // Run on all source files
     // **/packages need to be read
     // before DeletePackagesFromBuildRoot
-    await run(Tasks.CreateNoticeFile);
-    await run(Tasks.CreateXPackNoticeFile);
+    await globalRun(Tasks.CreateNoticeFile);
+    await globalRun(Tasks.CreateXPackNoticeFile);
 
-    await run(Tasks.DeletePackagesFromBuildRoot);
-    await run(Tasks.UpdateLicenseFile);
-    await run(Tasks.RemovePackageJsonDeps);
-    await run(Tasks.CleanPackageManagerRelatedFiles);
-    await run(Tasks.CleanExtraFilesFromModules);
-    await run(Tasks.CleanEmptyFolders);
-    await run(Tasks.FetchAgentVersionsList);
+    await globalRun(Tasks.DeletePackagesFromBuildRoot);
+    await globalRun(Tasks.UpdateLicenseFile);
+    await globalRun(Tasks.RemovePackageJsonDeps);
+    await globalRun(Tasks.CleanPackageManagerRelatedFiles);
+    await globalRun(Tasks.CleanExtraFilesFromModules);
+    await globalRun(Tasks.CleanEmptyFolders);
+    await globalRun(Tasks.FetchAgentVersionsList);
   }
 
   /**
@@ -107,18 +106,18 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
    * directories and perform platform/architecture-specific steps
    */
   if (options.createPlatformFolders) {
-    await run(Tasks.CreateArchivesSources);
-    await run(Tasks.InstallChromium);
-    await run(Tasks.CopyBinScripts);
-    await run(Tasks.CleanNodeBuilds);
+    await globalRun(Tasks.CreateArchivesSources);
+    await globalRun(Tasks.InstallChromium);
+    await globalRun(Tasks.CopyBinScripts);
+    await globalRun(Tasks.CleanNodeBuilds);
 
-    await run(Tasks.AssertFileTime);
-    await run(Tasks.AssertPathLength);
-    await run(Tasks.AssertNoUUID);
+    await globalRun(Tasks.AssertFileTime);
+    await globalRun(Tasks.AssertPathLength);
+    await globalRun(Tasks.AssertNoUUID);
   }
   // control w/ --skip-cdn-assets
   if (options.createCdnAssets) {
-    await run(Tasks.CreateCdnAssets);
+    await globalRun(Tasks.CreateCdnAssets);
   }
 
   /**
@@ -127,61 +126,74 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
    */
   if (options.createArchives) {
     // control w/ --skip-archives
-    await run(Tasks.CreateArchives);
+    await globalRun(Tasks.CreateArchives);
+  }
+
+  if (
+    options.downloadCloudDependencies &&
+    (options.createDockerCloud || options.createDockerCloudFIPS)
+  ) {
+    // control w/ --skip-cloud-dependencies-download
+    await globalRun(Tasks.DownloadCloudDependencies);
   }
 
   if (options.createDebPackage || options.createRpmPackage) {
-    await run(Tasks.CreatePackageConfig);
+    await globalRun(Tasks.CreatePackageConfig);
+
+    if (options.createDebPackage) {
+      // control w/ --deb or --skip-os-packages
+      artifactTasks.push(Tasks.CreateDebPackage);
+    }
+    if (options.createRpmPackage) {
+      // control w/ --rpm or --skip-os-packages
+      artifactTasks.push(Tasks.CreateRpmPackage);
+    }
   }
-  if (options.createDebPackage) {
-    // control w/ --deb or --skip-os-packages
-    await run(Tasks.CreateDebPackage);
-  }
-  if (options.createRpmPackage) {
-    // control w/ --rpm or --skip-os-packages
-    await run(Tasks.CreateRpmPackage);
-  }
+
   if (options.createDockerUBI) {
     // control w/ --docker-images or --skip-docker-ubi or --skip-os-packages
-    await run(Tasks.CreateDockerUBI);
+    artifactTasks.push(Tasks.CreateDockerUBI);
   }
 
   if (options.createDockerWolfi) {
     // control w/ --docker-images or --skip-docker-wolfi or --skip-os-packages
-    await run(Tasks.CreateDockerWolfi);
+    artifactTasks.push(Tasks.CreateDockerWolfi);
   }
+
   if (options.createDockerCloud) {
     // control w/ --docker-images and --skip-docker-cloud
-    if (options.downloadCloudDependencies) {
-      // control w/ --skip-cloud-dependencies-download
-      await run(Tasks.DownloadCloudDependencies);
-    }
-    await run(Tasks.CreateDockerCloud);
+    artifactTasks.push(Tasks.CreateDockerCloud);
   }
 
   if (options.createDockerServerless) {
     // control w/ --docker-images and --skip-docker-serverless
-    await run(Tasks.CreateDockerServerless);
+    artifactTasks.push(Tasks.CreateDockerServerless);
   }
 
   if (options.createDockerFIPS) {
     // control w/ --docker-images or --skip-docker-fips or --skip-os-packages
-    await run(Tasks.CreateDockerFIPS);
+    artifactTasks.push(Tasks.CreateDockerFIPS);
   }
 
   if (options.createDockerCloudFIPS) {
     // control w/ --docker-images and --skip-docker-cloud-fips
     // v9.0 does not have a Cloud FIPS release, this is a NOOP
-    await run(Tasks.CreateDockerCloudFIPS);
+    artifactTasks.push(Tasks.CreateDockerCloudFIPS);
   }
 
   if (options.createDockerContexts) {
     // control w/ --skip-docker-contexts
-    await run(Tasks.CreateDockerContexts);
+    artifactTasks.push(Tasks.CreateDockerContexts);
   }
+
+  await Promise.allSettled(
+    // createRunner for each task to ensure each task gets its own Build instance
+    artifactTasks.map(async (task) => await createRunner({ config, log, bufferLogs: true })(task))
+  );
 
   /**
    * finalize artifacts by writing sha1sums of each into the target directory
    */
-  await run(Tasks.WriteShaSums);
+  log.write('--- Finalizing Kibana artifacts');
+  await globalRun(Tasks.WriteShaSums);
 }

--- a/src/dev/build/lib/build.ts
+++ b/src/dev/build/lib/build.ts
@@ -13,10 +13,12 @@ import { Config } from './config';
 import { Platform } from './platform';
 
 export class Build {
+  private buildDesc: string = '';
+  private buildArch: string = '';
   private name = 'kibana';
   private logTag = chalk`{cyan [  kibana  ]}`;
 
-  constructor(private config: Config) {}
+  constructor(private config: Config, private bufferLogs = false) {}
 
   resolvePath(...args: string[]) {
     return this.config.resolveFromRepo('build', this.name, ...args);
@@ -51,5 +53,25 @@ export class Build {
 
   getLogTag() {
     return this.logTag;
+  }
+
+  getBufferLogs() {
+    return this.bufferLogs;
+  }
+
+  setBuildDesc(desc: string) {
+    this.buildDesc = desc;
+  }
+
+  getBuildDesc() {
+    return this.buildDesc;
+  }
+
+  setBuildArch(arch: string) {
+    this.buildArch = arch;
+  }
+
+  getBuildArch() {
+    return this.buildArch;
   }
 }

--- a/src/dev/build/lib/exec.ts
+++ b/src/dev/build/lib/exec.ts
@@ -9,24 +9,27 @@
 
 import execa from 'execa';
 import chalk from 'chalk';
+import { fromEvent, merge, map, toArray, takeUntil } from 'rxjs';
 import { ToolingLog, LogLevel } from '@kbn/tooling-log';
 
 import { watchStdioForLine } from './watch_stdio_for_line';
+import { Build } from './build';
 
 interface Options {
   level?: Exclude<LogLevel, 'silent' | 'error'>;
   cwd?: string;
   env?: Record<string, string>;
   exitAfter?: RegExp;
+  build?: Build;
 }
 
 export async function exec(
   log: ToolingLog,
   cmd: string,
   args: string[],
-  { level = 'debug', cwd, env, exitAfter }: Options = {}
+  { level = 'debug', cwd, env, exitAfter, build }: Options = {}
 ) {
-  log[level](chalk.dim('$'), cmd, ...args);
+  const bufferLogs = build && build?.getBufferLogs();
 
   const proc = execa(cmd, args, {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -35,5 +38,28 @@ export async function exec(
     preferLocal: true,
   });
 
-  await watchStdioForLine(proc, (line) => log[level](line), exitAfter);
+  if (bufferLogs) {
+    const stdout$ = fromEvent<Buffer>(proc.stdout!, 'data').pipe(map((chunk) => chunk.toString()));
+    const stderr$ = fromEvent<Buffer>(proc.stderr!, 'data').pipe(map((chunk) => chunk.toString()));
+    const close$ = fromEvent(proc, 'close');
+
+    await merge(stdout$, stderr$)
+      .pipe(takeUntil(close$), toArray())
+      .toPromise()
+      .then((logs) => {
+        log.write(`--- ${build.getBuildDesc()} [${build.getBuildArch()}]`);
+
+        log.indent(4, () => {
+          log[level](chalk.dim('$'), cmd, ...args);
+
+          if (logs?.length) {
+            logs.forEach((line: string) => log[level](line.trim()));
+          }
+        });
+      });
+  } else {
+    log[level](chalk.dim('$'), cmd, ...args);
+
+    await watchStdioForLine(proc, (line: string) => log[level](line), exitAfter);
+  }
 }

--- a/src/dev/build/lib/runner.test.ts
+++ b/src/dev/build/lib/runner.test.ts
@@ -80,7 +80,7 @@ describe('default dist', () => {
     });
 
     expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenLastCalledWith(config, log, [expect.any(Build)]);
+    expect(mock).toHaveBeenLastCalledWith(config, log);
   });
 
   it('calls local tasks once, passing the default build', async () => {

--- a/src/dev/build/tasks/create_archives_task.ts
+++ b/src/dev/build/tasks/create_archives_task.ts
@@ -15,65 +15,72 @@ import { CiStatsMetric } from '@kbn/ci-stats-reporter';
 
 import { mkdirp, compressTar, compressZip, Task } from '../lib';
 
+interface Archive {
+  format: string;
+  path: string;
+  fileCount: number;
+}
+
 const asyncStat = promisify(Fs.stat);
 
 export const CreateArchives: Task = {
   description: 'Creating the archives for each platform',
 
   async run(config, log, build) {
-    const archives = [];
+    const archives: Archive[] = [];
 
-    // archive one at a time, parallel causes OOM sometimes
-    for (const platform of config.getTargetPlatforms()) {
-      const source = build.resolvePathForPlatform(platform, '.');
-      const destination = build.getPlatformArchivePath(platform);
+    await Promise.allSettled(
+      config.getTargetPlatforms().map(async (platform) => {
+        const source = build.resolvePathForPlatform(platform, '.');
+        const destination = build.getPlatformArchivePath(platform);
 
-      log.info('archiving', source, 'to', destination);
+        log.info('archiving', source, 'to', destination);
 
-      await mkdirp(Path.dirname(destination));
+        await mkdirp(Path.dirname(destination));
 
-      switch (Path.extname(destination)) {
-        case '.zip':
-          archives.push({
-            format: 'zip',
-            path: destination,
-            fileCount: await compressZip({
-              source,
-              destination,
-              archiverOptions: {
-                zlib: {
-                  level: 9,
+        switch (Path.extname(destination)) {
+          case '.zip':
+            archives.push({
+              format: 'zip',
+              path: destination,
+              fileCount: await compressZip({
+                source,
+                destination,
+                archiverOptions: {
+                  zlib: {
+                    level: 9,
+                  },
                 },
-              },
-              createRootDirectory: true,
-              rootDirectoryName: build.getRootDirectory(),
-            }),
-          });
-          break;
+                createRootDirectory: true,
+                rootDirectoryName: build.getRootDirectory(),
+              }),
+            });
+            break;
 
-        case '.gz':
-          archives.push({
-            format: 'tar',
-            path: destination,
-            fileCount: await compressTar({
-              source,
-              destination,
-              archiverOptions: {
-                gzip: true,
-                gzipOptions: {
-                  level: 9,
+          case '.gz':
+            archives.push({
+              format: 'tar',
+              path: destination,
+              fileCount: await compressTar({
+                source,
+                destination,
+                archiverOptions: {
+                  gzip: true,
+                  gzipOptions: {
+                    level: 9,
+                  },
                 },
-              },
-              createRootDirectory: true,
-              rootDirectoryName: build.getRootDirectory(),
-            }),
-          });
-          break;
+                createRootDirectory: true,
+                rootDirectoryName: build.getRootDirectory(),
+              }),
+            });
+            break;
 
-        default:
-          throw new Error(`Unexpected extension for archive destination: ${destination}`);
-      }
-    }
+          default:
+            throw new Error(`Unexpected extension for archive destination: ${destination}`);
+        }
+      })
+    );
 
     const metrics: CiStatsMetric[] = [];
     for (const { format, path, fileCount } of archives) {

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
@@ -77,7 +77,7 @@ async function setup({ failOnUrl }: { failOnUrl?: string } = {}) {
 it('downloads node builds for each platform', async () => {
   const { config } = await setup();
 
-  await DownloadNodeBuilds.run(config, log, []);
+  await DownloadNodeBuilds.run(config, log);
 
   expect(downloadToDisk.mock.calls).toMatchInlineSnapshot(`
     Array [
@@ -119,7 +119,7 @@ it('downloads node builds for each platform', async () => {
 it('rejects if any download fails', async () => {
   const { config } = await setup({ failOnUrl: 'linux:url' });
 
-  await expect(DownloadNodeBuilds.run(config, log, [])).rejects.toMatchInlineSnapshot(
+  await expect(DownloadNodeBuilds.run(config, log)).rejects.toMatchInlineSnapshot(
     `[Error: Download failed for reasons]`
   );
   expect(testWriter.messages).toMatchInlineSnapshot(`Array []`);

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
@@ -73,7 +73,7 @@ beforeEach(() => {
 it('runs expected fs operations', async () => {
   const { config } = await setup();
 
-  await ExtractNodeBuilds.run(config, log, []);
+  await ExtractNodeBuilds.run(config, log);
 
   const usedMethods = Object.fromEntries(
     Object.entries(Fs)

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
@@ -102,7 +102,7 @@ beforeEach(() => {
 it('checks shasums for each downloaded node build', async () => {
   const { config } = await setup();
 
-  await VerifyExistingNodeBuilds.run(config, log, []);
+  await VerifyExistingNodeBuilds.run(config, log);
 
   expect(getNodeShasums).toMatchInlineSnapshot(`
     [MockFunction] {
@@ -488,7 +488,7 @@ it('rejects if any download has an incorrect sha256', async () => {
   });
 
   await expect(
-    VerifyExistingNodeBuilds.run(config, log, [])
+    VerifyExistingNodeBuilds.run(config, log)
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"Download at linux:default:linux-arm64:downloadPath does not match expected checksum invalid shasum"`
   );

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -74,6 +74,7 @@ export async function runDockerGenerator(
   const imageTag = `docker.elastic.co/${imageNamespace}/kibana`;
   const version = config.getBuildVersion();
   const artifactArchitecture = flags.architecture === 'aarch64' ? 'aarch64' : 'x86_64';
+  build.setBuildArch(artifactArchitecture);
   let artifactVariant = '';
   if (flags.serverless) artifactVariant = '-serverless';
   const artifactPrefix = `kibana${artifactVariant}-${version}-linux`;
@@ -204,6 +205,7 @@ export async function runDockerGenerator(
     await exec(log, `./build_docker.sh`, [], {
       cwd: dockerBuildDir,
       level: 'info',
+      build,
     });
   }
 

--- a/src/dev/build/tasks/os_packages/run_fpm.ts
+++ b/src/dev/build/tasks/os_packages/run_fpm.ts
@@ -23,6 +23,7 @@ export async function runFpm(
 ) {
   const linux = config.getPlatform('linux', architecture);
   const version = config.getBuildVersion();
+  build.setBuildArch(architecture);
 
   const resolveWithTrailingSlash = (...paths: string[]) => `${resolve(...paths)}/`;
 
@@ -150,5 +151,6 @@ export async function runFpm(
   await exec(log, 'fpm', args, {
     cwd: config.resolveFromRepo('.'),
     level: 'info',
+    build,
   });
 }


### PR DESCRIPTION

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/6326

# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Build] Parallel artifact builds (#217929)](https://github.com/elastic/kibana/pull/217929)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-03T00:49:02Z","message":"[Build] Parallel artifact builds (#217929)\n\n## Summary\n\nCloses #218143\nReverts #39292\n\nThis PR parallelizes the artifact outputs and archive creation tasks to\nreduce build runtime by about 49% (104min down to 53min). It required\nbuffering the logs as they were all interweaved from each task and were\nnot easily parsed by a human. So, the PR also cleans up the logging a\nlittle bit by utilizing the dropdowns available in Buildkite.\n\n\n### Testing\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/6253\n\nI also tried bumping the machine to `c2-standard-30` which increases\nvCPU from 16 to 30 and Memory from 64GB to 120GB:\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/6254\n\nThis results in a 13% reduction in run time for the parallel builds but\nis about twice the cost, which isn't worth it.","sha":"d0fd87e6c59c3f001acc6891c3db42fe70fea128","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v9.1.0"],"title":"[Build] Parallel artifact builds","number":217929,"url":"https://github.com/elastic/kibana/pull/217929","mergeCommit":{"message":"[Build] Parallel artifact builds (#217929)\n\n## Summary\n\nCloses #218143\nReverts #39292\n\nThis PR parallelizes the artifact outputs and archive creation tasks to\nreduce build runtime by about 49% (104min down to 53min). It required\nbuffering the logs as they were all interweaved from each task and were\nnot easily parsed by a human. So, the PR also cleans up the logging a\nlittle bit by utilizing the dropdowns available in Buildkite.\n\n\n### Testing\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/6253\n\nI also tried bumping the machine to `c2-standard-30` which increases\nvCPU from 16 to 30 and Memory from 64GB to 120GB:\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/6254\n\nThis results in a 13% reduction in run time for the parallel builds but\nis about twice the cost, which isn't worth it.","sha":"d0fd87e6c59c3f001acc6891c3db42fe70fea128"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217929","number":217929,"mergeCommit":{"message":"[Build] Parallel artifact builds (#217929)\n\n## Summary\n\nCloses #218143\nReverts #39292\n\nThis PR parallelizes the artifact outputs and archive creation tasks to\nreduce build runtime by about 49% (104min down to 53min). It required\nbuffering the logs as they were all interweaved from each task and were\nnot easily parsed by a human. So, the PR also cleans up the logging a\nlittle bit by utilizing the dropdowns available in Buildkite.\n\n\n### Testing\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/6253\n\nI also tried bumping the machine to `c2-standard-30` which increases\nvCPU from 16 to 30 and Memory from 64GB to 120GB:\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/6254\n\nThis results in a 13% reduction in run time for the parallel builds but\nis about twice the cost, which isn't worth it.","sha":"d0fd87e6c59c3f001acc6891c3db42fe70fea128"}},{"url":"https://github.com/elastic/kibana/pull/222289","number":222289,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->