### PR TITLE
[AI4DSOC] Removing addition of custom return path params from the configurations integrations all view

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.test.tsx
@@ -10,7 +10,6 @@ import {
   useEnhancedIntegrationCards,
   getCategoryBadgeIfAny,
 } from './use_enhanced_integration_cards';
-import { IntegrationsFacets } from '../../../../../configurations/constants';
 import type { IntegrationCardItem } from '@kbn/fleet-plugin/public';
 import { installationStatuses } from '@kbn/fleet-plugin/public';
 import { renderHook } from '@testing-library/react';
@@ -33,47 +32,51 @@ const mockCard = (name: string, categories?: string[]) =>
 describe('applyCategoryBadgeAndStyling', () => {
   const mockInt = mockCard('crowdstrike', ['edr_xdr']);
 
-  it('should add the correct return path to the URL', () => {
-    const callerView = IntegrationsFacets.available;
-    const result = applyCategoryBadgeAndStyling(mockInt, callerView);
+  it('should add the specified return path', () => {
+    const returnPath = `/my/custom/path`;
+    const result = applyCategoryBadgeAndStyling(mockInt, { returnPath });
 
     const urlParams = new URLSearchParams(result.url.split('?')[1]);
-    expect(urlParams.get('returnPath')).toBe(`/configurations/integrations/${callerView}`);
+    expect(urlParams.get('returnPath')).toBe(returnPath);
+  });
+
+  it('should add no return path details if not specified', () => {
+    const result = applyCategoryBadgeAndStyling(mockInt);
+
+    const urlParams = new URLSearchParams(result.url.split('?')[1]);
+    expect(urlParams.get('returnPath')).toBeNull();
   });
 
   it('should add the EDR/XDR badge if the category includes edr_xdr', () => {
     const cardWithEdrXdr = { ...mockInt, categories: ['edr_xdr'] };
-    const result = applyCategoryBadgeAndStyling(cardWithEdrXdr, IntegrationsFacets.available);
+    const result = applyCategoryBadgeAndStyling(cardWithEdrXdr);
 
     expect(result.extraLabelsBadges).toHaveLength(1);
   });
 
   it('should add the SIEM badge if the category includes siem', () => {
     const cardWithSiem = { ...mockInt, categories: ['siem'] };
-    const result = applyCategoryBadgeAndStyling(cardWithSiem, IntegrationsFacets.available);
+    const result = applyCategoryBadgeAndStyling(cardWithSiem);
 
     expect(result.extraLabelsBadges).toHaveLength(1);
   });
 
   it('should not add any badge if the category does not include edr_xdr or siem', () => {
     const cardWithOtherCategory = { ...mockInt, categories: ['other'] };
-    const result = applyCategoryBadgeAndStyling(
-      cardWithOtherCategory,
-      IntegrationsFacets.available
-    );
+    const result = applyCategoryBadgeAndStyling(cardWithOtherCategory);
 
     expect(result.extraLabelsBadges).toHaveLength(0);
   });
 
   it('should set showDescription and showReleaseBadge to false', () => {
-    const result = applyCategoryBadgeAndStyling(mockInt, IntegrationsFacets.available);
+    const result = applyCategoryBadgeAndStyling(mockInt);
 
     expect(result.showDescription).toBe(false);
     expect(result.showReleaseBadge).toBe(false);
   });
 
   it('should set minCardHeight to 88', () => {
-    const result = applyCategoryBadgeAndStyling(mockInt, IntegrationsFacets.available);
+    const result = applyCategoryBadgeAndStyling(mockInt);
 
     expect(result.minCardHeight).toBe(88);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
@@ -32,7 +32,7 @@ const INTEGRATION_CARD_MIN_HEIGHT_PX = 88;
 
 const addPathParamToUrl = (url: string, path: string | undefined) => {
   if (!path) {
-    return undefined;
+    return url;
   }
   const encodedPath = encodeURIComponent(path);
   const paramsString = `${RETURN_APP_ID}=${SECURITY_UI_APP_ID}&${RETURN_PATH}=${encodedPath}`;
@@ -51,11 +51,11 @@ export const applyCategoryBadgeAndStyling = (
   card: IntegrationCardItem,
   options?: EnhancedCardOptions
 ): IntegrationCardItem => {
-  const url = addPathParamToUrl(card.url, options?.returnPath ?? undefined);
+  const url = addPathParamToUrl(card.url, options?.returnPath);
   const categoryBadge = getCategoryBadgeIfAny(card.categories);
   return {
     ...card,
-    url: url ?? card.url,
+    url,
     showInstallationStatus: options?.showInstallationStatus,
     showCompressedInstallationStatus: options?.showCompressedInstallationStatus,
     showDescription: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
@@ -30,7 +30,10 @@ export const FEATURED_INTEGRATION_SORT_ORDER = [
 ];
 const INTEGRATION_CARD_MIN_HEIGHT_PX = 88;
 
-const addPathParamToUrl = (url: string, path: string) => {
+const addPathParamToUrl = (url: string, path: string | undefined) => {
+  if (!path) {
+    return undefined;
+  }
   const encodedPath = encodeURIComponent(path);
   const paramsString = `${RETURN_APP_ID}=${SECURITY_UI_APP_ID}&${RETURN_PATH}=${encodedPath}`;
 
@@ -46,15 +49,13 @@ export const getCategoryBadgeIfAny = (categories: string[]): string | null => {
 
 export const applyCategoryBadgeAndStyling = (
   card: IntegrationCardItem,
-  callerView: IntegrationsFacets,
   options?: EnhancedCardOptions
 ): IntegrationCardItem => {
-  const returnPath = options?.returnPath ?? `${CONFIGURATIONS_PATH}/integrations/${callerView}`;
-  const url = addPathParamToUrl(card.url, returnPath);
+  const url = addPathParamToUrl(card.url, options?.returnPath ?? undefined);
   const categoryBadge = getCategoryBadgeIfAny(card.categories);
   return {
     ...card,
-    url,
+    url: url ?? card.url,
     showInstallationStatus: options?.showInstallationStatus,
     showCompressedInstallationStatus: options?.showCompressedInstallationStatus,
     showDescription: false,
@@ -94,7 +95,7 @@ export const useEnhancedIntegrationCards = (
   const available = useMemo(
     () =>
       sorted.map((card) =>
-        applyCategoryBadgeAndStyling(card, IntegrationsFacets.available, {
+        applyCategoryBadgeAndStyling(card, {
           ...options,
           hasDataStreams: activeIntegrations.some(({ name }) => name === card.name),
         })
@@ -105,13 +106,18 @@ export const useEnhancedIntegrationCards = (
   const installed = useMemo(
     () =>
       sorted
-        .map((card) => applyCategoryBadgeAndStyling(card, IntegrationsFacets.installed))
+        .map((card) =>
+          applyCategoryBadgeAndStyling(card, {
+            ...options,
+            returnPath: `${CONFIGURATIONS_PATH}/integrations/${IntegrationsFacets.installed}`,
+          })
+        )
         .filter(
           (card) =>
             card.installStatus === installationStatuses.Installed ||
             card.installStatus === installationStatuses.InstallFailed
         ),
-    [sorted]
+    [sorted, options]
   );
 
   return { available, installed };


### PR DESCRIPTION
This updates the AI4DSOC Configurations Integrations page so that we no longer add the custom path params for return details from the browse all page. 

tweaking the logic so we don't add the return path params from the al……l integrations browse page

## Summary

This change is happening so that when a user navigates to the integration from that page, the back button shows 'Back to integrations' instead of 'Back to selection' to be more consistent with the regular page. This works because in the ai4soc project we have a setting that automatically redirects from the main integrations page to the project specific one. 

## Related

Relates https://github.com/elastic/kibana/issues/220748

## Screenshots/ screen recordings 

Before

<img width="876" alt="Screenshot 2025-06-03 at 4 35 56 PM" src="https://github.com/user-attachments/assets/843c969b-3b7d-4bc4-bb83-c47135ad8fbc" />

After

<img width="1726" alt="Screenshot 2025-06-03 at 4 35 37 PM" src="https://github.com/user-attachments/assets/dc0aabc1-0161-45b2-807b-cd5908045782" />



From the onboarding hub -- still utilizing the return path and showing back to selection 

https://github.com/user-attachments/assets/cffb490e-e007-4137-b0c9-af9153bef6f5

From the configurations integrations page -- browse all now showing back to integrations, but installed view still showing the back to selection

https://github.com/user-attachments/assets/f2a478a9-e388-4ed5-b343-258e3cc9748f


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->