### PR TITLE
[8.19] [Security Solution] extract dataView from GroupedAlertsTable (#220681)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -38,7 +38,7 @@ import {
   tableDefaults,
   TableId,
 } from '@kbn/securitysolution-data-table';
-import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { useGroupTakeActionsItems } from '../../../../detections/hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupStatsAggregations,
@@ -261,9 +261,9 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
   const { loading: listsConfigLoading, needsConfiguration: needsListsConfiguration } =
     useListsConfig();
 
-  const { sourcererDataView, loading: isLoadingIndexPattern } = useSourcererDataView(
-    SourcererScopeName.detections
-  );
+  const sourcererDataView = useSourcererDataView(SourcererScopeName.detections);
+  const sourcererDataViewSpec: DataViewSpec = sourcererDataView.sourcererDataView as DataViewSpec;
+  const isLoadingIndexPattern = sourcererDataView.loading;
 
   const loading = userInfoLoading || listsConfigLoading;
   const { detailName: ruleId } = useParams<{
@@ -632,7 +632,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
           <SiemSearchBar
             id={InputsModelId.global}
             pollForSignalIndex={pollForSignalIndex}
-            sourcererDataView={sourcererDataView}
+            sourcererDataView={sourcererDataViewSpec}
           />
         </FiltersGlobal>
         <RuleDetailsContextProvider>
@@ -802,6 +802,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
                       <GroupedAlertsTable
                         accordionButtonContent={defaultGroupTitleRenderers}
                         accordionExtraActionGroupStats={accordionExtraActionGroupStats}
+                        dataViewSpec={sourcererDataViewSpec}
                         defaultFilters={alertMergedFilters}
                         defaultGroupingOptions={defaultGroupingOptions}
                         from={from}
@@ -810,8 +811,6 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
                         groupTakeActionItems={groupTakeActionItems}
                         loading={loading}
                         renderChildComponent={renderGroupedAlertTable}
-                        runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}
-                        signalIndexName={signalIndexName}
                         tableId={TableId.alertsOnRuleDetailsPage}
                         to={to}
                       />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
@@ -27,6 +27,8 @@ import {
   defaultGroupStatsRenderer,
   defaultGroupTitleRenderers,
 } from './grouping_settings';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
 jest.mock('../../containers/detection_engine/alerts/use_query');
 jest.mock('../../../sourcerer/containers');
@@ -117,6 +119,9 @@ const sourcererDataView = {
 };
 const renderChildComponent = (groupingFilters: Filter[]) => <p data-test-subj="alerts-table" />;
 
+const dataViewSpec: DataViewSpec = { title: 'test' };
+const dataView: DataView = createStubDataView({ spec: dataViewSpec });
+
 const testProps: AlertsTableComponentProps = {
   ...mockDate,
   accordionButtonContent: defaultGroupTitleRenderers,
@@ -124,6 +129,7 @@ const testProps: AlertsTableComponentProps = {
     aggregations: defaultGroupStatsAggregations,
     renderer: defaultGroupStatsRenderer,
   },
+  dataViewSpec: dataView.toSpec(),
   defaultFilters: [],
   defaultGroupingOptions,
   globalFilters: [],
@@ -133,8 +139,6 @@ const testProps: AlertsTableComponentProps = {
   },
   loading: false,
   renderChildComponent,
-  runtimeMappings: {},
-  signalIndexName: 'test',
   tableId: TableId.test,
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import type { Filter, Query } from '@kbn/es-query';
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import {
   type GroupOption,
   type GroupStatsItem,
@@ -26,9 +27,7 @@ import { groupIdSelector } from '../../../common/store/grouping/selectors';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { updateGroups } from '../../../common/store/grouping/actions';
 import { defaultUnit } from '../../../common/components/toolbar/unit';
-import { useSourcererDataView } from '../../../sourcerer/containers';
 import type { RunTimeMappings } from '../../../sourcerer/store/model';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useKibana } from '../../../common/lib/kibana';
 import { GroupedSubLevel } from './alerts_sub_grouping';
 import { AlertsEventTypes, track } from '../../../common/lib/telemetry';
@@ -56,6 +55,10 @@ export interface AlertsTableComponentProps {
      */
     renderer: GetGroupStats<AlertsGroupingAggregation>;
   };
+  /**
+   * DataViewSpec object to use internally to fetch the data
+   */
+  dataViewSpec: DataViewSpec;
   defaultFilters?: Filter[];
   /**
    * Default values to display in the group selection dropdown.
@@ -72,8 +75,6 @@ export interface AlertsTableComponentProps {
   groupTakeActionItems?: GroupTakeActionItems;
   loading: boolean;
   renderChildComponent: (groupingFilters: Filter[]) => React.ReactElement;
-  runtimeMappings: RunTimeMappings;
-  signalIndexName: string | null;
   tableId: TableIdLiteral;
   to: string;
 }
@@ -135,8 +136,6 @@ const useStorage = (storage: Storage, tableId: string) =>
 const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props) => {
   const dispatch = useDispatch();
 
-  const { indexPattern, selectedPatterns } = useSourcererDataView(SourcererScopeName.detections);
-
   const {
     services: { storage, telemetry },
   } = useKibana();
@@ -174,7 +173,10 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
     [dispatch, props.tableId]
   );
 
-  const fields = useMemo(() => Object.values(indexPattern.fields || {}), [indexPattern]);
+  const fields = useMemo(
+    () => Object.values(props.dataViewSpec.fields || {}),
+    [props.dataViewSpec]
+  );
 
   const groupingOptions = useMemo(
     () => props.defaultGroupingOptions || DEFAULT_GROUPING_OPTIONS,
@@ -334,16 +336,18 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
           pageSize={pageSize[level] ?? DEFAULT_PAGE_SIZE}
           parentGroupingFilter={parentGroupingFilter}
           renderChildComponent={rcc}
+          runtimeMappings={props.dataViewSpec.runtimeFieldMap as RunTimeMappings}
           selectedGroup={selectedGroup}
           setPageIndex={(newIndex: number) => setPageVar(newIndex, level, 'index')}
           setPageSize={(newSize: number) => setPageVar(newSize, level, 'size')}
+          signalIndexName={props.dataViewSpec.title}
         />
       );
     },
     [getGrouping, groupStatusAggregations, pageIndex, pageSize, props, selectedGroups, setPageVar]
   );
 
-  if (isEmpty(selectedPatterns)) {
+  if (isEmpty(props.dataViewSpec.title)) {
     return null;
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -65,7 +65,7 @@ interface OwnProps {
   selectedGroup: string;
   setPageIndex: (newIndex: number) => void;
   setPageSize: (newSize: number) => void;
-  signalIndexName: string | null;
+  signalIndexName: string | undefined;
   tableId: TableIdLiteral;
   to: string;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.test.tsx
@@ -198,6 +198,10 @@ describe('DetectionEnginePageComponent', () => {
       indicesExist: true,
       indexPattern: {},
       browserFields: mockBrowserFields,
+      sourcererDataView: {
+        fields: {},
+        title: '',
+      },
     });
     jest
       .spyOn(alertFilterControlsPackage, 'AlertFilterControls')

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
@@ -34,6 +34,7 @@ import {
 import { isEqual } from 'lodash';
 import type { FilterGroupHandler } from '@kbn/alerts-ui-shared';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { useGroupTakeActionsItems } from '../../hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupingOptions,
@@ -157,11 +158,10 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
     FilterGroupHandler | undefined
   >();
 
-  const {
-    sourcererDataView,
-    loading: isLoadingIndexPattern,
-    indexPattern,
-  } = useSourcererDataView(SourcererScopeName.detections);
+  const sourcererDataView = useSourcererDataView(SourcererScopeName.detections);
+  const sourcererDataViewSpec: DataViewSpec = sourcererDataView.sourcererDataView as DataViewSpec;
+  const isLoadingIndexPattern = sourcererDataView.loading;
+  const indexPattern = sourcererDataView.indexPattern;
 
   const { formatUrl } = useFormatUrl(SecurityPageName.rules);
 
@@ -391,7 +391,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
             <SiemSearchBar
               id={InputsModelId.global}
               pollForSignalIndex={pollForSignalIndex}
-              sourcererDataView={sourcererDataView}
+              sourcererDataView={sourcererDataViewSpec}
             />
           </FiltersGlobal>
           <SecuritySolutionPageWrapper
@@ -435,7 +435,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
                 alertsDefaultFilters={alertsDefaultFilters}
                 isLoadingIndexPattern={isChartPanelLoading}
                 query={query}
-                runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}
+                runtimeMappings={sourcererDataViewSpec.runtimeFieldMap as RunTimeMappings}
                 signalIndexName={signalIndexName}
                 updateDateRangeCallback={updateDateRangeCallback}
               />
@@ -444,6 +444,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
             <GroupedAlertsTable
               accordionButtonContent={defaultGroupTitleRenderers}
               accordionExtraActionGroupStats={accordionExtraActionGroupStats}
+              dataViewSpec={sourcererDataViewSpec}
               defaultFilters={alertsTableDefaultFilters}
               defaultGroupingOptions={defaultGroupingOptions}
               from={from}
@@ -452,8 +453,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
               groupTakeActionItems={groupTakeActionItems}
               loading={isAlertTableLoading}
               renderChildComponent={renderAlertTable}
-              runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}
-              signalIndexName={signalIndexName}
               tableId={TableId.alertsOnAlertsPage}
               to={to}
             />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
-import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { useGroupTakeActionsItems } from '../../../detections/hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupingOptions,
@@ -52,9 +52,9 @@ export const TopRiskScoreContributorsAlerts = <T extends EntityType>({
   loading,
 }: TopRiskScoreContributorsAlertsProps<T>) => {
   const { to, from } = useGlobalTime();
-  const [{ loading: userInfoLoading, signalIndexName, hasIndexWrite, hasIndexMaintenance }] =
-    useUserData();
-  const { sourcererDataView } = useSourcererDataView(SourcererScopeName.detections);
+  const [{ loading: userInfoLoading, hasIndexWrite, hasIndexMaintenance }] = useUserData();
+  const sourcererDataView = useSourcererDataView(SourcererScopeName.detections);
+  const sourcererDataViewSpec: DataViewSpec = sourcererDataView.sourcererDataView as DataViewSpec;
   const getGlobalFiltersQuerySelector = useMemo(
     () => inputsSelectors.globalFiltersQuerySelector(),
     []
@@ -138,6 +138,7 @@ export const TopRiskScoreContributorsAlerts = <T extends EntityType>({
             <GroupedAlertsTable
               accordionButtonContent={defaultGroupTitleRenderers}
               accordionExtraActionGroupStats={accordionExtraActionGroupStats}
+              dataViewSpec={sourcererDataViewSpec}
               defaultFilters={defaultFilters}
               defaultGroupingOptions={defaultGroupingOptions}
               from={from}
@@ -146,8 +147,6 @@ export const TopRiskScoreContributorsAlerts = <T extends EntityType>({
               groupTakeActionItems={groupTakeActionItems}
               loading={userInfoLoading || loading}
               renderChildComponent={renderGroupedAlertTable}
-              runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}
-              signalIndexName={signalIndexName}
               tableId={TableId.alertsRiskInputs}
               to={to}
             />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] extract dataView from GroupedAlertsTable (#220681)](https://github.com/elastic/kibana/pull/220681)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-05-23T17:03:49Z","message":"[Security Solution] extract dataView from GroupedAlertsTable (#220681)\n\n## Summary\n\nSimilar to the following previous PRs([this\none](https://github.com/elastic/kibana/pull/216572) and [that\none](https://github.com/elastic/kibana/pull/219878)), this PR aims at\nremoving some logic built-in to the `GroupedAlertsTable` and pass the\ninformation via props. It makes this reusable component a lot easier to\nuse in different scenarios.\n\nIn this current case, we're removing the retrieval of the dataView\nwithin the `GroupedAlertsTable`. We now rely on the `DataViewSpec`\nobject passed via prop instead. This allows us to get rid of the\nfollowing props:\n- `signalIndexName`, which we now retrieve from the DataViewSpec object\ndirectly\n- `runtimeMappings`, which we also now retrieve from the DataViewSpec\nobject directly\n\nThis solves one issue, which was related to the fact that the\n`GroupedAlertsTable` was retrieving the `detections` dataView\ninternally, so there was a high chance that the `signalIndexName` and\n`runtimeMappins` passed via props would not match the hardcoded\n`detections` dataView retrieved internally... which is very confusing!\nWe are having this problem in the AI4DSOC Alert summary page, which\ncreates a adhoc dataView just for alerts...\n\n**_No UI or behavior change are introduced in this PR!_**\n\nAlerts page\n\n\nhttps://github.com/user-attachments/assets/a4e0c1a6-fa91-4b1e-881c-56d95667e84b\n\nRule details page\n\n\nhttps://github.com/user-attachments/assets/6d93e7d0-0446-4ecb-aa37-4ab266b62686\n\nAI4DSOC Alert summary page\n\n\nhttps://github.com/user-attachments/assets/7354bad2-64d1-4722-94c3-ae2d9b72fcab\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"8ca90573d6266dbad79db14839c5363b23a084d3","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Threat Hunting:Investigations","v9.1.0"],"title":"[Security Solution] extract dataView from GroupedAlertsTable","number":220681,"url":"https://github.com/elastic/kibana/pull/220681","mergeCommit":{"message":"[Security Solution] extract dataView from GroupedAlertsTable (#220681)\n\n## Summary\n\nSimilar to the following previous PRs([this\none](https://github.com/elastic/kibana/pull/216572) and [that\none](https://github.com/elastic/kibana/pull/219878)), this PR aims at\nremoving some logic built-in to the `GroupedAlertsTable` and pass the\ninformation via props. It makes this reusable component a lot easier to\nuse in different scenarios.\n\nIn this current case, we're removing the retrieval of the dataView\nwithin the `GroupedAlertsTable`. We now rely on the `DataViewSpec`\nobject passed via prop instead. This allows us to get rid of the\nfollowing props:\n- `signalIndexName`, which we now retrieve from the DataViewSpec object\ndirectly\n- `runtimeMappings`, which we also now retrieve from the DataViewSpec\nobject directly\n\nThis solves one issue, which was related to the fact that the\n`GroupedAlertsTable` was retrieving the `detections` dataView\ninternally, so there was a high chance that the `signalIndexName` and\n`runtimeMappins` passed via props would not match the hardcoded\n`detections` dataView retrieved internally... which is very confusing!\nWe are having this problem in the AI4DSOC Alert summary page, which\ncreates a adhoc dataView just for alerts...\n\n**_No UI or behavior change are introduced in this PR!_**\n\nAlerts page\n\n\nhttps://github.com/user-attachments/assets/a4e0c1a6-fa91-4b1e-881c-56d95667e84b\n\nRule details page\n\n\nhttps://github.com/user-attachments/assets/6d93e7d0-0446-4ecb-aa37-4ab266b62686\n\nAI4DSOC Alert summary page\n\n\nhttps://github.com/user-attachments/assets/7354bad2-64d1-4722-94c3-ae2d9b72fcab\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"8ca90573d6266dbad79db14839c5363b23a084d3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220681","number":220681,"mergeCommit":{"message":"[Security Solution] extract dataView from GroupedAlertsTable (#220681)\n\n## Summary\n\nSimilar to the following previous PRs([this\none](https://github.com/elastic/kibana/pull/216572) and [that\none](https://github.com/elastic/kibana/pull/219878)), this PR aims at\nremoving some logic built-in to the `GroupedAlertsTable` and pass the\ninformation via props. It makes this reusable component a lot easier to\nuse in different scenarios.\n\nIn this current case, we're removing the retrieval of the dataView\nwithin the `GroupedAlertsTable`. We now rely on the `DataViewSpec`\nobject passed via prop instead. This allows us to get rid of the\nfollowing props:\n- `signalIndexName`, which we now retrieve from the DataViewSpec object\ndirectly\n- `runtimeMappings`, which we also now retrieve from the DataViewSpec\nobject directly\n\nThis solves one issue, which was related to the fact that the\n`GroupedAlertsTable` was retrieving the `detections` dataView\ninternally, so there was a high chance that the `signalIndexName` and\n`runtimeMappins` passed via props would not match the hardcoded\n`detections` dataView retrieved internally... which is very confusing!\nWe are having this problem in the AI4DSOC Alert summary page, which\ncreates a adhoc dataView just for alerts...\n\n**_No UI or behavior change are introduced in this PR!_**\n\nAlerts page\n\n\nhttps://github.com/user-attachments/assets/a4e0c1a6-fa91-4b1e-881c-56d95667e84b\n\nRule details page\n\n\nhttps://github.com/user-attachments/assets/6d93e7d0-0446-4ecb-aa37-4ab266b62686\n\nAI4DSOC Alert summary page\n\n\nhttps://github.com/user-attachments/assets/7354bad2-64d1-4722-94c3-ae2d9b72fcab\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"8ca90573d6266dbad79db14839c5363b23a084d3"}}]}] BACKPORT-->