### PR TITLE
[Dashboard] Fix "optimize for printing" layout

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/_print_viewport.scss
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/_print_viewport.scss
@@ -29,7 +29,7 @@ is being formed. This can result in parts of the vis being cut out.
   .kbnGrid {
     display: block !important;
   }
-  .kbnGridSectionHeader {
+  .kbnGridSectionHeader, .kbnGridSectionFooter {
     display: none;
   }
   .kbnGridPanel {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/_print_viewport.scss
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/_print_viewport.scss
@@ -26,8 +26,11 @@ is being formed. This can result in parts of the vis being cut out.
 }
 
 .dshDashboardViewport--print {
-  .kbnGridRow {
+  .kbnGrid {
     display: block !important;
+  }
+  .kbnGridSectionHeader {
+    display: none;
   }
   .kbnGridPanel {
     height: 100% !important;

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+
+import { EuiThemeProvider } from '@elastic/eui';
+import { render, waitFor } from '@testing-library/react';
+
+import { DashboardState } from '../../../common';
+import { DashboardContext } from '../../dashboard_api/use_dashboard_api';
+import { DashboardInternalContext } from '../../dashboard_api/use_dashboard_internal_api';
+import { buildMockDashboardApi, getMockDashboardPanels } from '../../mocks';
+import { DashboardViewport } from './dashboard_viewport';
+
+const createAndMountDashboardViewport = async () => {
+  const panels = getMockDashboardPanels().panels;
+  const { api, internalApi } = buildMockDashboardApi({
+    overrides: {
+      panels,
+    },
+  });
+  const component = render(
+    <EuiThemeProvider>
+      <DashboardContext.Provider value={api}>
+        <DashboardInternalContext.Provider value={internalApi}>
+          <DashboardViewport />
+        </DashboardInternalContext.Provider>
+      </DashboardContext.Provider>
+    </EuiThemeProvider>
+  );
+
+  // wait for first render
+  await waitFor(() => {
+    expect(component.queryAllByTestId('dashboardPanel').length).toBe(Object.keys(panels).length);
+  });
+
+  return { dashboardApi: api, internalApi, component };
+};
+
+describe('DashboardViewport', () => {
+  test('renders', async () => {
+    await createAndMountDashboardViewport();
+  });
+
+  test('renders print mode styles', async () => {
+    const { component, dashboardApi } = await createAndMountDashboardViewport();
+    dashboardApi.setViewMode('print');
+
+    await waitFor(() => {
+      const viewport = component.getByTestId('dshDashboardViewport');
+      expect(viewport).toHaveClass('dshDashboardViewport--print');
+    });
+    /**
+     * TODO: Once Dashboard is converted to Emotion, we should be able to uncomment these lines in order
+     * to actually test the print mode functionality - currently, this is broken because our Sass styles
+     * are imported on the Dashboard renderer rather than the viewport
+     */
+    // const gridLayout = component.getByTestId('kbnGridLayout');
+    // expect(gridLayout).toHaveStyleRule('display', 'block !important');
+  });
+});

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.test.tsx
@@ -12,7 +12,6 @@ import React from 'react';
 import { EuiThemeProvider } from '@elastic/eui';
 import { render, waitFor } from '@testing-library/react';
 
-import { DashboardState } from '../../../common';
 import { DashboardContext } from '../../dashboard_api/use_dashboard_api';
 import { DashboardInternalContext } from '../../dashboard_api/use_dashboard_internal_api';
 import { buildMockDashboardApi, getMockDashboardPanels } from '../../mocks';

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/viewport/dashboard_viewport.tsx
@@ -139,6 +139,7 @@ export const DashboardViewport = ({
         data-title={dashboardTitle}
         data-description={description}
         data-shared-items-count={visiblePanelCount}
+        data-test-subj={'dshDashboardViewport'}
       >
         {panelCount === 0 && sectionCount === 0 ? (
           <DashboardEmptyScreen />

--- a/src/platform/plugins/shared/dashboard/public/mocks.tsx
+++ b/src/platform/plugins/shared/dashboard/public/mocks.tsx
@@ -75,6 +75,7 @@ export const mockControlGroupApi = {
   esqlVariables$: new BehaviorSubject(undefined),
   dataViews$: new BehaviorSubject(undefined),
   hasUnsavedChanges$: new BehaviorSubject(false),
+  children$: new BehaviorSubject([]),
 } as unknown as ControlGroupApi;
 
 export function buildMockDashboardApi({


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/222431

## Summary

In https://github.com/elastic/kibana/pull/218900, some class names were changed on the `kbn-grid-layout` that the Dashboard relied on for print mode and I forgot to update them. This PR fixes that by targeting the updated class names.

| **Before** ([PDF](https://github.com/user-attachments/files/20593397/Before.pdf)) | **After** ([PDF](https://github.com/user-attachments/files/20593482/After.pdf)) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4009b0b5-97f5-4a0f-b4c1-7c2b58ab7927) | ![image](https://github.com/user-attachments/assets/46bcd274-430d-41ef-a913-e183e4aeafcb) |


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->