### PR TITLE
[Synthetics] Avoid re-render when Run test finishes

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
@@ -30,7 +30,7 @@ export const StepDetailsLinkIcon = ({
   target?: '_self' | '_blank';
 }) => {
   const { basePath } = useSyntheticsSettingsContext();
-  const selectedLocation = useSelectedLocation();
+  const selectedLocation = useSelectedLocation(true, { refetchMonitorEnabled: false });
 
   const stepDetailsLink = `${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroup}/step/${stepIndex}?locationId=${selectedLocation?.id}`;
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
@@ -30,7 +30,7 @@ export const StepDetailsLinkIcon = ({
   target?: '_self' | '_blank';
 }) => {
   const { basePath } = useSyntheticsSettingsContext();
-  const selectedLocation = useSelectedLocation(true, { refetchMonitorEnabled: false });
+  const selectedLocation = useSelectedLocation({ refetchMonitorEnabled: false });
 
   const stepDetailsLink = `${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroup}/step/${stepIndex}?locationId=${selectedLocation?.id}`;
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -37,7 +37,7 @@ export const MonitorDetailsLinkPortal = ({ name, configId, locationId, updateUrl
 };
 
 const MonitorDetailsLinkWithLocation = ({ name, configId, locationId, updateUrl }: Props) => {
-  const selectedLocation = useSelectedLocation(updateUrl);
+  const selectedLocation = useSelectedLocation({ updateUrl });
 
   let locId = locationId;
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
@@ -12,10 +12,13 @@ import { useSelectedMonitor } from './use_selected_monitor';
 import { selectSelectedLocationId, setMonitorDetailsLocationAction } from '../../../state';
 import { useUrlParams, useLocations } from '../../../hooks';
 
-export const useSelectedLocation = (updateUrl = true) => {
+export const useSelectedLocation = (
+  updateUrl = true,
+  { refetchMonitorEnabled }: { refetchMonitorEnabled: boolean } = { refetchMonitorEnabled: true }
+) => {
   const [getUrlParams, updateUrlParams] = useUrlParams();
   const { locations } = useLocations();
-  const { monitor } = useSelectedMonitor();
+  const { monitor } = useSelectedMonitor(undefined, { refetchMonitorEnabled });
   const selectedLocationId = useSelector(selectSelectedLocationId);
   const dispatch = useDispatch();
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
@@ -12,13 +12,18 @@ import { useSelectedMonitor } from './use_selected_monitor';
 import { selectSelectedLocationId, setMonitorDetailsLocationAction } from '../../../state';
 import { useUrlParams, useLocations } from '../../../hooks';
 
-export const useSelectedLocation = (
+interface UseSelectedLocationOptions {
+  updateUrl?: boolean;
+  refetchMonitorEnabled?: boolean;
+}
+
+export const useSelectedLocation = ({
   updateUrl = true,
-  { refetchMonitorEnabled }: { refetchMonitorEnabled: boolean } = { refetchMonitorEnabled: true }
-) => {
+  refetchMonitorEnabled = true,
+}: UseSelectedLocationOptions = {}) => {
   const [getUrlParams, updateUrlParams] = useUrlParams();
   const { locations } = useLocations();
-  const { monitor } = useSelectedMonitor(undefined, { refetchMonitorEnabled });
+  const { monitor } = useSelectedMonitor({ refetchMonitorEnabled });
   const selectedLocationId = useSelector(selectSelectedLocationId);
   const dispatch = useDispatch();
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
@@ -19,10 +19,15 @@ import {
 } from '../../../state';
 import { useGetUrlParams } from '../../../hooks';
 
-export const useSelectedMonitor = (
-  monId?: string,
-  { refetchMonitorEnabled }: { refetchMonitorEnabled: boolean } = { refetchMonitorEnabled: true }
-) => {
+interface UseSelectedMonitorOptions {
+  monId?: string;
+  refetchMonitorEnabled?: boolean;
+}
+
+export const useSelectedMonitor = ({
+  monId = undefined,
+  refetchMonitorEnabled = true,
+}: UseSelectedMonitorOptions = {}) => {
   let monitorId = monId;
   const { monitorId: urlMonitorId } = useParams<{ monitorId: string }>();
   const { space } = useKibanaSpace();

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
@@ -19,7 +19,10 @@ import {
 } from '../../../state';
 import { useGetUrlParams } from '../../../hooks';
 
-export const useSelectedMonitor = (monId?: string) => {
+export const useSelectedMonitor = (
+  monId?: string,
+  { refetchMonitorEnabled }: { refetchMonitorEnabled: boolean } = { refetchMonitorEnabled: true }
+) => {
   let monitorId = monId;
   const { monitorId: urlMonitorId } = useParams<{ monitorId: string }>();
   const { space } = useKibanaSpace();
@@ -81,7 +84,8 @@ export const useSelectedMonitor = (monId?: string) => {
       !syntheticsMonitorLoading &&
       !monitorListLoading &&
       syntheticsMonitorDispatchedAt > 0 &&
-      Date.now() - syntheticsMonitorDispatchedAt > refreshInterval * 1000
+      Date.now() - syntheticsMonitorDispatchedAt > refreshInterval * 1000 &&
+      refetchMonitorEnabled
     ) {
       dispatch(
         getMonitorAction.get({
@@ -100,6 +104,7 @@ export const useSelectedMonitor = (monId?: string) => {
     syntheticsMonitorDispatchedAt,
     spaceId,
     space?.id,
+    refetchMonitorEnabled,
   ]);
 
   return {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
@@ -20,21 +20,16 @@ import {
 import { useGetUrlParams } from '../../../hooks';
 
 interface UseSelectedMonitorOptions {
-  monId?: string;
   refetchMonitorEnabled?: boolean;
 }
 
 export const useSelectedMonitor = ({
-  monId = undefined,
   refetchMonitorEnabled = true,
 }: UseSelectedMonitorOptions = {}) => {
-  let monitorId = monId;
-  const { monitorId: urlMonitorId } = useParams<{ monitorId: string }>();
+  const { monitorId } = useParams<{ monitorId: string }>();
   const { space } = useKibanaSpace();
   const { spaceId } = useGetUrlParams();
-  if (!monitorId) {
-    monitorId = urlMonitorId;
-  }
+
   const monitorsList = useSelector(selectEncryptedSyntheticsSavedMonitors);
   const { loading: monitorListLoading } = useSelector(selectMonitorListState);
 


### PR DESCRIPTION
This PR closes #217482 

After manually running a test a re-render was causing loss of unsaved changes.

Before:

https://github.com/user-attachments/assets/117b9130-b6cd-4c11-90f9-54e63e9cfc36

After:

https://github.com/user-attachments/assets/c84fac4e-b348-4a5d-ada6-94529ebfc42f



<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->