### PR TITLE
Fix registry for prismjs 1.27.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26461,7 +26461,7 @@ prismjs@^1.29.0:
 
 prismjs@~1.27.0:
   version "1.27.0"
-  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:


### PR DESCRIPTION
## Summary

Inadvertently changed from yarn to npm in https://github.com/elastic/kibana/pull/222019, and backported to 9.0 & 8.19.

<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->