### PR TITLE
[Lens] Keeps the datable config when the query slighly changes

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -81,7 +81,7 @@ export const getGridAttrs = async (
   let queryColumns = results.response.columns;
   // if the query columns are empty, we need to use the all_columns property
   // which has all columns regardless if they have data or not
-  if (queryColumns.length === 0 && results.response.all_columns) {
+  if (results.response.all_columns) {
     queryColumns = results.response.all_columns;
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
@@ -43,15 +43,15 @@ export function mergeSuggestionWithVisContext({
   }
   const datasourceState = Object.assign({}, visAttributes.state.datasourceStates[datasourceId]);
 
+  const visualizationId = visAttributes.visualizationType;
   // should be based on same columns
   if (
     !datasourceState?.layers ||
-    Object.values(datasourceState?.layers).some(
-      (layer) =>
-        layer.columns?.some(
-          (c: { fieldName: string }) =>
-            !context?.textBasedColumns?.find((col) => col.id === c.fieldName)
-        ) || layer.columns?.length !== context?.textBasedColumns?.length
+    Object.values(datasourceState?.layers).some((layer) =>
+      layer.columns?.some(
+        (c: { fieldName: string }) =>
+          !context?.textBasedColumns?.find((col) => col.id === c.fieldName)
+      )
     )
   ) {
     return suggestion;
@@ -60,7 +60,7 @@ export function mergeSuggestionWithVisContext({
   try {
     return {
       title: visAttributes.title,
-      visualizationId: visAttributes.visualizationType,
+      visualizationId,
       visualizationState: visAttributes.state.visualization,
       keptLayerIds: layerIds,
       datasourceState,

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
@@ -92,7 +92,15 @@ export const suggestionsApi = ({
     activeVisualization: visualizationMap[activeVisualization.visualizationId],
     visualizationState: activeVisualization.visualizationState,
     dataViews,
-  }).filter((sug) => !sug.hide && sug.visualizationId !== 'lnsLegacyMetric');
+  }).filter(
+    (sug) =>
+      // Datatables are always return as hidden suggestions
+      // if the user has requested for a datatable (preferredChartType), we want to return it
+      // although it is a hidden suggestion
+      (sug.hide && sug.visualizationId === 'lnsDatatable') ||
+      // Filter out suggestions that are hidden and legacy metrics
+      (!sug.hide && sug.visualizationId !== 'lnsLegacyMetric')
+  );
 
   // check if there is an XY chart suggested
   // if user has requested for a line or area, we want to sligthly change the state

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
@@ -12,6 +12,7 @@ import type { DatasourceMap, VisualizationMap, VisualizeEditorContext } from '..
 import type { DataViewsState } from '../state_management';
 import type { TypedLensByValueInput } from '../react_embeddable/types';
 import { mergeSuggestionWithVisContext } from './helpers';
+import { MAX_NUM_OF_COLUMNS } from '../datasources/form_based/esql_layer/utils';
 
 interface SuggestionsApiProps {
   context: VisualizeFieldContext | VisualizeEditorContext;
@@ -96,8 +97,11 @@ export const suggestionsApi = ({
     (sug) =>
       // Datatables are always return as hidden suggestions
       // if the user has requested for a datatable (preferredChartType), we want to return it
-      // although it is a hidden suggestion
-      (sug.hide && sug.visualizationId === 'lnsDatatable') ||
+      // although it is a hidden suggestion if the columns are greater than 5
+      (sug.hide &&
+        sug.visualizationId === 'lnsDatatable' &&
+        'textBasedColumns' in context &&
+        (context?.textBasedColumns?.length ?? 0) > MAX_NUM_OF_COLUMNS) ||
       // Filter out suggestions that are hidden and legacy metrics
       (!sug.hide && sug.visualizationId !== 'lnsLegacyMetric')
   );

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
@@ -12,7 +12,6 @@ import type { DatasourceMap, VisualizationMap, VisualizeEditorContext } from '..
 import type { DataViewsState } from '../state_management';
 import type { TypedLensByValueInput } from '../react_embeddable/types';
 import { mergeSuggestionWithVisContext } from './helpers';
-import { MAX_NUM_OF_COLUMNS } from '../datasources/form_based/esql_layer/utils';
 
 interface SuggestionsApiProps {
   context: VisualizeFieldContext | VisualizeEditorContext;
@@ -97,11 +96,8 @@ export const suggestionsApi = ({
     (sug) =>
       // Datatables are always return as hidden suggestions
       // if the user has requested for a datatable (preferredChartType), we want to return it
-      // although it is a hidden suggestion if the columns are greater than 5
-      (sug.hide &&
-        sug.visualizationId === 'lnsDatatable' &&
-        'textBasedColumns' in context &&
-        (context?.textBasedColumns?.length ?? 0) > MAX_NUM_OF_COLUMNS) ||
+      // although it is a hidden suggestion
+      (sug.hide && sug.visualizationId === 'lnsDatatable') ||
       // Filter out suggestions that are hidden and legacy metrics
       (!sug.hide && sug.visualizationId !== 'lnsLegacyMetric')
   );

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/lens_suggestions_api.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/lens_suggestions_api.test.ts
@@ -171,6 +171,62 @@ describe('suggestionsApi', () => {
     expect(suggestions?.length).toEqual(1);
   });
 
+  test('keeps a datatable suggestion although it is marked as hidden', async () => {
+    const dataView = { id: 'index1' } as unknown as DataView;
+    const visualizationMap = {
+      testVis: {
+        ...mockVis,
+        getSuggestions: () => [
+          {
+            score: 0.8,
+            title: 'Lens datatable',
+            state: {},
+            previewIcon: 'empty',
+            visualizationId: 'lnsDatatable',
+            hide: true,
+          },
+          {
+            score: 0.8,
+            title: 'Test2',
+            state: {},
+            previewIcon: 'empty',
+          },
+          {
+            score: 0.8,
+            title: 'Test2',
+            state: {},
+            previewIcon: 'empty',
+            incomplete: true,
+          },
+        ],
+      },
+    };
+    datasourceMap.textBased.getDatasourceSuggestionsForVisualizeField.mockReturnValue([
+      generateSuggestion(),
+    ]);
+    const context = {
+      dataViewSpec: {
+        id: 'index1',
+        title: 'index1',
+        name: 'DataView',
+      },
+      fieldName: '',
+      textBasedColumns: textBasedQueryColumns,
+      query: {
+        esql: 'FROM "index1" | keep field1, field2',
+      },
+    };
+    const suggestions = suggestionsApi({
+      context,
+      dataView,
+      datasourceMap,
+      visualizationMap,
+      preferredChartType: ChartType.Tagcloud,
+    });
+    expect(suggestions?.length).toEqual(1);
+    expect(suggestions?.[0].title).toEqual('Lens datatable');
+  });
+
   test('prioritizes the chart type of the user preference if any', async () => {
     const dataView = { id: 'index1' } as unknown as DataView;
     const visualizationMap = {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/220939

The problem was that the table suggestions was filtered out as it is marked as always [hidden](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/visualization.tsx#L274)

This PR ensures that the datable will not filtered out in order to be able to keep the desired viz config

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

