### PR TITLE
[APM] Metrics: add the missing otel_native-otel_other-go to the dashboard names

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/static_dashboard/dashboards/dashboard_catalog.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/static_dashboard/dashboards/dashboard_catalog.ts
@@ -19,6 +19,7 @@ export const existingDashboardFileNames = new Set([
   'otel_native-edot-python',
   'otel_native-edot-nodejs',
   'classic_apm-otel_other-go',
+  'otel_native-otel_other-go',
 ]);
 
 // The new dashboard files should be mapped here


### PR DESCRIPTION
Follow up  https://github.com/elastic/kibana/pull/220242

## Summary

This PR adds the missing `otel_native-otel_other-go` to the dashboard names. More info in  https://github.com/elastic/kibana/pull/220242




<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->