### PR TITLE
[Inference] Redaction

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
@@ -59,6 +59,15 @@ export {
   isToolNotFoundError,
   type ChatCompleteMetadata,
   type ConnectorTelemetryMetadata,
+  type UnredactedMessage,
+  type RedactionConfiguration,
+  type UnredactionOutput,
+  type RedactionOutput,
+  type Redaction,
+  type RedactionEntity,
+  type Unredaction,
+  type NamedEntityRecognitionRule,
+  type RegExpRule,
 } from './src/chat_complete';
 export {
   OutputEventType,

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/bound_api.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/bound_api.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ChatCompleteOptions, ChatCompleteCompositeResponse } from './api';
+import { RedactionConfiguration } from './redaction/types';
 import type { ToolOptions } from './tools';
 
 /**
@@ -13,23 +14,32 @@ import type { ToolOptions } from './tools';
  */
 export type BoundChatCompleteOptions<
   TToolOptions extends ToolOptions = ToolOptions,
-  TStream extends boolean = false
-> = Pick<ChatCompleteOptions<TToolOptions, TStream>, 'connectorId' | 'functionCalling'>;
+  TStream extends boolean = false,
+  TRedactionConfiguration extends RedactionConfiguration | undefined = undefined
+> = Pick<
+  ChatCompleteOptions<TToolOptions, TStream, TRedactionConfiguration>,
+  'connectorId' | 'functionCalling'
+>;
 
 /**
  * Options used to call the {@link BoundChatCompleteAPI}
  */
 export type UnboundChatCompleteOptions<
   TToolOptions extends ToolOptions = ToolOptions,
-  TStream extends boolean = false
-> = Omit<ChatCompleteOptions<TToolOptions, TStream>, 'connectorId' | 'functionCalling'>;
+  TStream extends boolean = false,
+  TRedactionConfiguration extends RedactionConfiguration | undefined = undefined
+> = Omit<
+  ChatCompleteOptions<TToolOptions, TStream, TRedactionConfiguration>,
+  'connectorId' | 'functionCalling'
+>;
 
 /**
  * Version of {@link ChatCompleteAPI} that got pre-bound to a set of static parameters
  */
 export type BoundChatCompleteAPI = <
   TToolOptions extends ToolOptions = ToolOptions,
-  TStream extends boolean = false
+  TStream extends boolean = false,
+  TRedactionConfiguration extends RedactionConfiguration | undefined = undefined
 >(
-  options: UnboundChatCompleteOptions<TToolOptions, TStream>
-) => ChatCompleteCompositeResponse<TToolOptions, TStream>;
+  options: UnboundChatCompleteOptions<TToolOptions, TStream, TRedactionConfiguration>
+) => ChatCompleteCompositeResponse<TToolOptions, TStream, TRedactionConfiguration>;

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/events.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/events.ts
@@ -6,6 +6,7 @@
  */
 
 import type { InferenceTaskEventBase } from '../inference_task';
+import { RedactionConfiguration, UnredactionOutput } from './redaction/types';
 import type { ToolCallsOf, ToolOptions } from './tools';
 
 /**
@@ -15,6 +16,7 @@ export enum ChatCompletionEventType {
   ChatCompletionChunk = 'chatCompletionChunk',
   ChatCompletionTokenCount = 'chatCompletionTokenCount',
   ChatCompletionMessage = 'chatCompletionMessage',
+  ChatCompletionUnredactedMessage = 'chatCompletionUnredactedMessage',
 }
 
 /**
@@ -33,6 +35,22 @@ export type ChatCompletionMessageEvent<TToolOptions extends ToolOptions = ToolOp
        * The eventual tool calls performed by the LLM.
        */
       toolCalls: ToolCallsOf<TToolOptions>['toolCalls'];
+    }
+  >;
+
+export type ChatCompletionUnredactedMessageEvent<TToolOptions extends ToolOptions = ToolOptions> =
+  InferenceTaskEventBase<
+    ChatCompletionEventType.ChatCompletionUnredactedMessage,
+    {
+      /**
+       * The text content of the LLM response.
+       */
+      content: string;
+      /**
+       * The eventual tool calls performed by the LLM.
+       */
+      toolCalls: ToolCallsOf<TToolOptions>['toolCalls'];
+      unredaction: UnredactionOutput;
     }
   >;
 
@@ -127,7 +145,14 @@ export type ChatCompletionTokenCountEvent = InferenceTaskEventBase<
  * event will be emitted ex
  *
  */
-export type ChatCompletionEvent<TToolOptions extends ToolOptions = ToolOptions> =
-  | ChatCompletionChunkEvent
-  | ChatCompletionTokenCountEvent
-  | ChatCompletionMessageEvent<TToolOptions>;
+export type ChatCompletionEvent<
+  TToolOptions extends ToolOptions = ToolOptions,
+  TRedactionConfiguration extends RedactionConfiguration | undefined =
+    | RedactionConfiguration
+    | undefined
+> = TRedactionConfiguration extends RedactionConfiguration
+  ? ChatCompletionUnredactedMessageEvent<TToolOptions>
+  :
+      | ChatCompletionChunkEvent
+      | ChatCompletionTokenCountEvent
+      | ChatCompletionMessageEvent<TToolOptions>;

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
@@ -69,3 +69,15 @@ export {
   isTokenLimitReachedError,
   isToolNotFoundError,
 } from './errors';
+
+export type {
+  UnredactedMessage,
+  RedactionConfiguration,
+  RedactionOutput,
+  UnredactionOutput,
+  Redaction,
+  RedactionEntity,
+  Unredaction,
+  NamedEntityRecognitionRule,
+  RegExpRule,
+} from './redaction';

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/redaction/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/redaction/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type {
+  UnredactedMessage,
+  RedactionConfiguration,
+  RedactionOutput,
+  UnredactionOutput,
+  Redaction,
+  RedactionEntity,
+  Unredaction,
+  NamedEntityRecognitionRule,
+  RegExpRule,
+} from './types';

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/redaction/types.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/redaction/types.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Message } from '../messages';
+
+interface RedactionRuleBase {
+  type: string;
+  enabled: boolean;
+}
+
+enum RuleMaskType {
+  hash = 'hash',
+}
+
+export interface NamedEntityRecognitionRule extends RedactionRuleBase {
+  type: 'NER';
+}
+
+export interface RegExpRule extends RedactionRuleBase {
+  type: 'RegExp';
+  pattern: string;
+  class_name: string;
+  mask?: RuleMaskType;
+}
+
+export type RedactionRule = NamedEntityRecognitionRule | RegExpRule;
+
+export interface RedactionConfiguration {
+  enabled: boolean;
+  rules: RedactionRule[];
+}
+
+export interface RedactionEntity {
+  class_name: string;
+  value: string;
+  mask: string;
+}
+
+export interface Redaction {
+  rule: {
+    type: string;
+  };
+  entity: RedactionEntity;
+}
+
+export interface Unredaction {
+  start: number;
+  end: number;
+  entity: RedactionEntity;
+}
+
+export interface RedactionOutput {
+  messages: Message[];
+  redactions: Redaction[];
+}
+
+export interface UnredactionOutput {
+  messages: UnredactedMessage[];
+}
+
+export type UnredactedMessage = Message & { unredactions: Unredaction[] };

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/redaction/types.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/redaction/types.ts
@@ -18,6 +18,7 @@ enum RuleMaskType {
 
 export interface NamedEntityRecognitionRule extends RedactionRuleBase {
   type: 'NER';
+  model_id: string;
 }
 
 export interface RegExpRule extends RedactionRuleBase {

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/inference_chat_model.test.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/inference_chat_model.test.ts
@@ -26,6 +26,7 @@ import {
   InferenceConnector,
   InferenceConnectorType,
   MessageRole,
+  ToolOptions,
   createInferenceRequestError,
 } from '@kbn/inference-common';
 import { InferenceChatModel } from './inference_chat_model';
@@ -53,7 +54,7 @@ const createStreamResponse = (
   chunks: ChunkEventInput[],
   tokenCount?: ChatCompletionTokenCount
 ): ChatCompleteStreamResponse => {
-  const events: ChatCompletionEvent[] = chunks.map(createChunkEvent);
+  const events: Array<ChatCompletionEvent<ToolOptions, undefined>> = chunks.map(createChunkEvent);
   if (tokenCount) {
     events.push({
       type: ChatCompletionEventType.ChatCompletionTokenCount,

--- a/x-pack/platform/plugins/shared/inference/scripts/util/kibana_client.ts
+++ b/x-pack/platform/plugins/shared/inference/scripts/util/kibana_client.ts
@@ -26,6 +26,7 @@ import {
   type ToolOptions,
   ChatCompleteOptions,
   type InferenceConnector,
+  RedactionConfiguration,
 } from '@kbn/inference-common';
 import type { ChatCompleteRequestBody } from '../../common/http_apis';
 import { createOutputApi } from '../../common/output/create_output_api';
@@ -179,7 +180,8 @@ export class KibanaClient {
 
     const chatCompleteApi: ChatCompleteAPI = <
       TToolOptions extends ToolOptions = ToolOptions,
-      TStream extends boolean = false
+      TStream extends boolean = false,
+      TRedactionConfiguration extends RedactionConfiguration | undefined = undefined
     >({
       connectorId: chatCompleteConnectorId,
       messages,
@@ -188,7 +190,11 @@ export class KibanaClient {
       tools,
       functionCalling,
       stream,
-    }: ChatCompleteOptions<TToolOptions, TStream>) => {
+    }: ChatCompleteOptions<
+      TToolOptions,
+      TStream,
+      TRedactionConfiguration
+    >): ChatCompleteCompositeResponse<TToolOptions, TStream, TRedactionConfiguration> => {
       const body: ChatCompleteRequestBody = {
         connectorId: chatCompleteConnectorId,
         system,
@@ -207,7 +213,7 @@ export class KibanaClient {
             body,
             { responseType: 'stream', timeout: NaN }
           )
-        ) as ChatCompleteCompositeResponse<TToolOptions, TStream>;
+        ) as ChatCompleteCompositeResponse<TToolOptions, TStream, TRedactionConfiguration>;
       } else {
         return this.axios
           .post(
@@ -219,7 +225,7 @@ export class KibanaClient {
           )
           .then((response) => {
             return response.data;
-          }) as ChatCompleteCompositeResponse<TToolOptions, TStream>;
+          }) as ChatCompleteCompositeResponse<TToolOptions, TStream, TRedactionConfiguration>;
       }
     };
 

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/get_redactable_message_parts.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/get_redactable_message_parts.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Message, MessageRole } from '@kbn/inference-common';
+
+export function getRedactableMessageParts(message: Message) {
+  if (message.role === MessageRole.Tool) {
+    return {
+      response: message.response,
+    };
+  }
+
+  if (message.role === MessageRole.Assistant) {
+    return {
+      content: message.content,
+      toolCalls: message.toolCalls?.map((toolCall) => {
+        return {
+          function: toolCall.function,
+        };
+      }),
+    };
+  }
+
+  return {
+    content: message.content,
+  };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/redact_messages.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/redact_messages.ts
@@ -13,17 +13,50 @@ import {
   RedactionOutput,
 } from '@kbn/inference-common';
 import { Message } from '@kbn/inference-common';
-import { merge, partition } from 'lodash';
+import { chunk, merge, partition } from 'lodash';
 import objectHash from 'object-hash';
+import { ElasticsearchClient } from '@kbn/core/server';
+import pLimit from 'p-limit';
 import { getRedactableMessageParts } from './get_redactable_message_parts';
 
-async function redact(
-  input: string,
-  redactionConfiguration: RedactionConfiguration
-): Promise<{ output: string; redactions: Redaction[] }> {
+const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
+const DEFAULT_BATCH_SIZE = 1000;
+
+export interface InferenceChunk {
+  chunkText: string;
+  charStartOffset: number;
+}
+
+export function chunkText(text: string, maxChars = 1_000): InferenceChunk[] {
+  const chunks: InferenceChunk[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    chunks.push({
+      chunkText: text.slice(i, i + maxChars),
+      charStartOffset: i,
+    });
+  }
+  return chunks;
+}
+
+function getEntityMask(entity: { class_name: string; value: string }) {
+  return objectHash({
+    value: entity.value,
+    class_name: entity.class_name,
+  });
+}
+
+async function redact({
+  input,
+  redactionConfiguration,
+  esClient,
+}: {
+  input: string;
+  redactionConfiguration: RedactionConfiguration;
+  esClient: ElasticsearchClient;
+}): Promise<{ output: string; redactions: Redaction[] }> {
   const rules = redactionConfiguration.rules.filter((rule) => rule.enabled);
 
-  const [regexRules, _nerRules] = partition(
+  const [regexRules, nerRules] = partition(
     rules,
     (rule): rule is RegExpRule => rule.type === 'RegExp'
   );
@@ -39,7 +72,7 @@ async function redact(
     while ((match = regex.exec(output))) {
       const value = match[0];
 
-      const mask = objectHash({
+      const mask = getEntityMask({
         value,
         class_name: rule.class_name,
       });
@@ -71,6 +104,69 @@ async function redact(
     });
   });
 
+  if (!nerRules.length) {
+    return {
+      output,
+      redactions,
+    };
+  }
+
+  // Maximum number of concurrent requests to the ML model
+  const limiter = pLimit(DEFAULT_MAX_CONCURRENT_REQUESTS);
+
+  // Batch size - number of documents to send in each request
+
+  const chunks = chunkText(output);
+
+  // Create batches of chunks for the inference request
+  const batches = chunk(chunks, DEFAULT_BATCH_SIZE);
+
+  for (const nerRule of nerRules) {
+    let offset: number = 0;
+
+    const allInferenceResults = await Promise.all(
+      batches.map(async (batchChunks) => {
+        const response = await limiter(() =>
+          esClient.ml.inferTrainedModel({
+            model_id: nerRule.model_id,
+            docs: batchChunks.map((batchChunk) => ({ text_field: batchChunk.chunkText })),
+          })
+        );
+
+        const inferenceResults = response?.inference_results || [];
+
+        return inferenceResults;
+      })
+    );
+
+    allInferenceResults.flat().forEach((result) => {
+      result.entities?.forEach((entityMatch) => {
+        const from = entityMatch.start_pos + offset;
+        const to = entityMatch.end_pos + offset;
+
+        const before = output.slice(0, from);
+        const after = output.slice(to);
+
+        const entity = {
+          class_name: entityMatch.class_name,
+          value: entityMatch.entity,
+        };
+
+        const mask = getEntityMask(entity);
+
+        offset += to - from - mask.length;
+        redactions.push({
+          entity: {
+            ...entity,
+            mask,
+          },
+          rule: nerRule,
+        });
+        output = before + mask + after;
+      });
+    });
+  }
+
   return {
     output,
     redactions,
@@ -80,13 +176,19 @@ async function redact(
 export async function redactMessages({
   messages,
   redactionConfiguration,
+  esClient,
 }: {
   messages: Message[];
   redactionConfiguration: RedactionConfiguration;
+  esClient: ElasticsearchClient;
 }): Promise<RedactionOutput> {
   const toRedact = messages.map(getRedactableMessageParts);
 
-  const { output, redactions } = await redact(JSON.stringify(toRedact), redactionConfiguration);
+  const { output, redactions } = await redact({
+    input: JSON.stringify(toRedact),
+    redactionConfiguration,
+    esClient,
+  });
 
   const redacted = JSON.parse(output) as typeof toRedact;
 

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/redact_messages.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/redact_messages.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  RedactionConfiguration,
+  RegExpRule,
+  RedactionEntity,
+  Redaction,
+  RedactionOutput,
+} from '@kbn/inference-common';
+import { Message } from '@kbn/inference-common';
+import { merge, partition } from 'lodash';
+import objectHash from 'object-hash';
+import { getRedactableMessageParts } from './get_redactable_message_parts';
+
+async function redact(
+  input: string,
+  redactionConfiguration: RedactionConfiguration
+): Promise<{ output: string; redactions: Redaction[] }> {
+  const rules = redactionConfiguration.rules.filter((rule) => rule.enabled);
+
+  const [regexRules, _nerRules] = partition(
+    rules,
+    (rule): rule is RegExpRule => rule.type === 'RegExp'
+  );
+
+  const entities: Array<{ rule: RegExpRule; entity: RedactionEntity }> = [];
+
+  let output = input;
+
+  regexRules.forEach((rule) => {
+    const regex = new RegExp(rule.pattern);
+
+    let match: RegExpMatchArray | null = null;
+    while ((match = regex.exec(output))) {
+      const value = match[0];
+
+      const mask = objectHash({
+        value,
+        class_name: rule.class_name,
+      });
+
+      output = output.replace(match[0], mask);
+
+      entities.push({
+        entity: {
+          value,
+          class_name: rule.class_name,
+          mask,
+        },
+        rule,
+      });
+    }
+  });
+
+  let index = 0;
+
+  const redactions: Redaction[] = [];
+  entities.forEach(({ entity, rule }) => {
+    const start = output.indexOf(entity.mask, index);
+    index = start + entity.mask.length;
+    redactions.push({
+      entity,
+      rule: {
+        type: rule.type,
+      },
+    });
+  });
+
+  return {
+    output,
+    redactions,
+  };
+}
+
+export async function redactMessages({
+  messages,
+  redactionConfiguration,
+}: {
+  messages: Message[];
+  redactionConfiguration: RedactionConfiguration;
+}): Promise<RedactionOutput> {
+  const toRedact = messages.map(getRedactableMessageParts);
+
+  const { output, redactions } = await redact(JSON.stringify(toRedact), redactionConfiguration);
+
+  const redacted = JSON.parse(output) as typeof toRedact;
+
+  const redactedMessages = messages.map((message, index) => {
+    return merge({}, message, redacted[index]);
+  });
+
+  return {
+    messages: redactedMessages,
+    redactions,
+  };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/unredact.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/unredact.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Message, RedactionEntity, Unredaction } from '@kbn/inference-common';
+import { getRedactableMessageParts } from './get_redactable_message_parts';
+
+export function unredact<TMessage extends Message>(
+  message: TMessage,
+  masksLookup: Record<string, RedactionEntity>
+): { message: TMessage; unredactions: Unredaction[] } {
+  const masks = Object.keys(masksLookup);
+
+  function replace(content: string) {
+    const unredactions: Unredaction[] = [];
+    let next = '';
+
+    for (let i = 0; i < content.length; i++) {
+      const slice = content.slice(i);
+
+      const foundMask = masks.find((mask) => slice.startsWith(mask));
+
+      if (foundMask) {
+        const entity = masksLookup[foundMask];
+        const start = i;
+        const end = start + entity.value.length;
+        unredactions.push({
+          start,
+          end,
+          entity,
+        });
+        next += entity.value;
+        i = end;
+        continue;
+      }
+
+      next += content.slice(i, i + 1);
+    }
+
+    return {
+      unredactions,
+      output: next,
+    };
+  }
+
+  const redacted = getRedactableMessageParts(message);
+
+  const contentUnredaction =
+    'content' in redacted && redacted.content && typeof redacted.content === 'string'
+      ? replace(redacted.content)
+      : undefined;
+
+  const unredaction = replace(JSON.stringify(redacted));
+
+  return {
+    message: {
+      ...message,
+      ...(JSON.parse(unredaction.output) as typeof redacted),
+    },
+    unredactions: contentUnredaction ? contentUnredaction.unredactions : [],
+  };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/unredact_message.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/redaction/unredact_message.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  AssistantMessage,
+  ChatCompletionEvent,
+  MessageRole,
+  RedactionEntity,
+  RedactionOutput,
+  withoutChunkEvents,
+  withoutTokenCountEvents,
+} from '@kbn/inference-common';
+import {
+  ChatCompletionEventType,
+  ChatCompletionUnredactedMessageEvent,
+} from '@kbn/inference-common/src/chat_complete/events';
+import { OperatorFunction, identity, map } from 'rxjs';
+import { unredact } from './unredact';
+
+export function unredactMessage<
+  T extends ChatCompletionEvent,
+  U extends RedactionOutput | undefined
+>({
+  redaction,
+}: {
+  redaction?: U;
+}): OperatorFunction<T, U extends RedactionOutput ? ChatCompletionUnredactedMessageEvent : T>;
+
+export function unredactMessage({
+  redaction,
+}: {
+  redaction?: RedactionOutput;
+}): OperatorFunction<ChatCompletionEvent, ChatCompletionEvent> {
+  if (!redaction) {
+    return identity;
+  }
+  const redactionEntityLookup: Record<string, RedactionEntity> = {};
+
+  redaction.redactions.forEach((item) => {
+    redactionEntityLookup[item.entity.mask] = item.entity;
+  });
+
+  return (source$) => {
+    return source$.pipe(
+      withoutChunkEvents(),
+      withoutTokenCountEvents(),
+      map((messageEvent): ChatCompletionUnredactedMessageEvent => {
+        const message = {
+          content: messageEvent.content,
+          toolCalls: messageEvent.toolCalls,
+          role: MessageRole.Assistant,
+        } satisfies AssistantMessage;
+
+        const {
+          message: { content, toolCalls },
+          unredactions,
+        } = unredact(message, redactionEntityLookup);
+
+        return {
+          content,
+          toolCalls,
+          type: ChatCompletionEventType.ChatCompletionUnredactedMessage,
+          unredaction: {
+            messages: redaction.messages
+              .map((msg) => {
+                const unredaction = unredact(msg, redactionEntityLookup);
+
+                return {
+                  ...unredaction.message,
+                  unredactions: unredaction.unredactions,
+                };
+              })
+              .concat({
+                ...message,
+                unredactions,
+              }),
+          },
+        };
+      })
+    );
+  };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.ts
@@ -12,13 +12,21 @@ import {
   createInferenceInternalError,
   isChatCompletionMessageEvent,
   isChatCompletionTokenCountEvent,
+  RedactionConfiguration,
   ToolOptions,
   withoutChunkEvents,
 } from '@kbn/inference-common';
 
-export const streamToResponse = <TToolOptions extends ToolOptions = ToolOptions>(
-  streamResponse$: ChatCompleteStreamResponse<TToolOptions>
-): Promise<ChatCompleteResponse<TToolOptions>> => {
+export function streamToResponse<
+  TToolOptions extends ToolOptions,
+  TRedactionConfiguration extends RedactionConfiguration | undefined
+>(
+  streamResponse$: ChatCompleteStreamResponse<ToolOptions, RedactionConfiguration | undefined>
+): Promise<ChatCompleteResponse<ToolOptions, RedactionConfiguration | undefined>>;
+
+export function streamToResponse(
+  streamResponse$: ChatCompleteStreamResponse<ToolOptions, RedactionConfiguration | undefined>
+): Promise<ChatCompleteResponse<ToolOptions, RedactionConfiguration | undefined>> {
   return firstValueFrom(
     streamResponse$.pipe(
       withoutChunkEvents(),
@@ -39,4 +47,4 @@ export const streamToResponse = <TToolOptions extends ToolOptions = ToolOptions>
       })
     )
   );
-};
+}

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/create_client.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/create_client.ts
@@ -9,6 +9,7 @@ import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { BoundChatCompleteOptions } from '@kbn/inference-common';
+import { ElasticsearchClient } from '@kbn/core/server';
 import type { BoundInferenceClient, InferenceClient } from './types';
 import { createInferenceClient } from './inference_client';
 import { bindClient } from './bind_client';
@@ -16,6 +17,7 @@ import { bindClient } from './bind_client';
 interface UnboundOptions {
   request: KibanaRequest;
   actions: ActionsPluginStart;
+  esClient: ElasticsearchClient;
   logger: Logger;
 }
 
@@ -28,8 +30,13 @@ export function createClient(options: BoundOptions): BoundInferenceClient;
 export function createClient(
   options: UnboundOptions | BoundOptions
 ): BoundInferenceClient | InferenceClient {
-  const { actions, request, logger } = options;
-  const client = createInferenceClient({ request, actions, logger: logger.get('client') });
+  const { actions, request, logger, esClient } = options;
+  const client = createInferenceClient({
+    request,
+    actions,
+    logger: logger.get('client'),
+    esClient,
+  });
   if ('bindTo' in options) {
     return bindClient(client, options.bindTo);
   } else {

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/inference_client.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/inference_client.ts
@@ -8,6 +8,7 @@
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import { ElasticsearchClient } from '@kbn/core/server';
 import type { InferenceClient } from './types';
 import { createChatCompleteApi } from '../chat_complete';
 import { createOutputApi } from '../../common/output/create_output_api';
@@ -17,12 +18,14 @@ export function createInferenceClient({
   request,
   actions,
   logger,
+  esClient,
 }: {
   request: KibanaRequest;
   logger: Logger;
   actions: ActionsPluginStart;
+  esClient: ElasticsearchClient;
 }): InferenceClient {
-  const chatComplete = createChatCompleteApi({ request, actions, logger });
+  const chatComplete = createChatCompleteApi({ request, actions, logger, esClient });
   return {
     chatComplete,
     output: createOutputApi(chatComplete),

--- a/x-pack/platform/plugins/shared/inference/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference/server/plugin.ts
@@ -77,10 +77,12 @@ export class InferencePlugin
   start(core: CoreStart, pluginsStart: InferenceStartDependencies): InferenceServerStart {
     return {
       getClient: <T extends InferenceClientCreateOptions>(options: T) => {
+        const esClient = core.elasticsearch.client.asScoped(options.request).asCurrentUser;
         return createInferenceClient({
           ...options,
           actions: pluginsStart.actions,
           logger: this.logger.get('client'),
+          esClient,
         }) as T extends InferenceBoundClientCreateOptions ? BoundInferenceClient : InferenceClient;
       },
 

--- a/x-pack/platform/plugins/shared/inference/server/tracing/with_chat_complete_span.ts
+++ b/x-pack/platform/plugins/shared/inference/server/tracing/with_chat_complete_span.ts
@@ -10,6 +10,7 @@ import {
   ChatCompleteCompositeResponse,
   Message,
   MessageRole,
+  RedactionConfiguration,
   ToolCall,
   ToolMessage,
   ToolOptions,
@@ -132,15 +133,16 @@ function mapAssistantResponse({
  * @param options
  * @param cb
  */
-export function withChatCompleteSpan<T extends ChatCompleteCompositeResponse<ToolOptions, boolean>>(
-  options: InferenceGenerationOptions,
-  cb: (span?: Span) => T
-): T;
+export function withChatCompleteSpan<
+  T extends ChatCompleteCompositeResponse<ToolOptions, boolean, RedactionConfiguration | undefined>
+>(options: InferenceGenerationOptions, cb: (span?: Span) => T): T;
 
 export function withChatCompleteSpan(
   options: InferenceGenerationOptions,
-  cb: (span?: Span) => ChatCompleteCompositeResponse<ToolOptions, boolean>
-): ChatCompleteCompositeResponse<ToolOptions, boolean> {
+  cb: (
+    span?: Span
+  ) => ChatCompleteCompositeResponse<ToolOptions, boolean, RedactionConfiguration | undefined>
+): ChatCompleteCompositeResponse<ToolOptions, boolean, RedactionConfiguration | undefined> {
   const { system, messages, model, provider, ...attributes } = options;
 
   const next = withInferenceSpan(


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



