### PR TITLE
[ES|QL] Add fetch inference endpoints API

### DIFF
--- a/src/platform/plugins/shared/esql/server/README.md
+++ b/src/platform/plugins/shared/esql/server/README.md
@@ -10,6 +10,7 @@ The ES|QL server exposes the following internal API routes:
 
 * **`/internal/esql/autocomplete/join/indices`**: Used by the ES|QL editor to retrieve a list of indices suitable for **`JOIN`** autocompletion.
 * **`/internal/esql/autocomplete/timeseries/indices`**: Provides index suggestions specifically for **time-series analysis** contexts within the ES|QL editor.
+* **`/internal/esql/autocomplete/inference_endpoints/{taskType}`**: This endpoint is used to fetch LLM inference endpoints by task type.
 * **`/internal/esql_registry/extensions/{query}`**: This is the primary endpoint for fetching **registered ES|QL extensions**, which enhance the editor's capabilities by providing contextual suggestions.
 
 ---

--- a/src/platform/plugins/shared/esql/server/routes/get_inference_endpoints.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_inference_endpoints.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
+
+import { schema } from '@kbn/config-schema';
+import { EsqlService } from '../services/esql_service';
+
+export const registerGetInferenceEndpointsRoute = (
+  router: IRouter,
+  { logger }: PluginInitializerContext
+) => {
+  router.get(
+    {
+      path: '/internal/esql/autocomplete/inference_endpoints/{taskType}',
+      validate: {
+        params: schema.object({
+          taskType: schema.oneOf([
+            schema.literal('completion'),
+            schema.literal('rerank'),
+            schema.literal('text_embedding'),
+            schema.literal('sparse_embedding'),
+            schema.literal('chat_completion'),
+          ]),
+        }),
+      },
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
+    },
+    async (requestHandlerContext, request, response) => {
+      try {
+        const core = await requestHandlerContext.core;
+        const service = new EsqlService({ client: core.elasticsearch.client.asCurrentUser });
+        const result = await service.getInferenceEndpoints(request.params.taskType);
+
+        return response.ok({
+          body: result,
+        });
+      } catch (error) {
+        logger.get().debug(error);
+        throw error;
+      }
+    }
+  );
+};

--- a/src/platform/plugins/shared/esql/server/routes/index.ts
+++ b/src/platform/plugins/shared/esql/server/routes/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CoreSetup, PluginInitializerContext } from '@kbn/core/server';
+import { registerGetInferenceEndpointsRoute } from './get_inference_endpoints';
 import type { ESQLExtensionsRegistry } from '../extensions_registry';
 
 import { registerGetJoinIndicesRoute } from './get_join_indices';
@@ -24,4 +25,5 @@ export const registerRoutes = (
   registerGetJoinIndicesRoute(router, initContext);
   registerGetTimeseriesIndicesRoute(router, initContext);
   registerESQLExtensionsRoute(router, extensionsRegistry, initContext);
+  registerGetInferenceEndpointsRoute(router, initContext);
 };

--- a/src/platform/plugins/shared/esql/server/services/esql_service.ts
+++ b/src/platform/plugins/shared/esql/server/services/esql_service.ts
@@ -9,6 +9,10 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { IndicesAutocompleteResult, IndexAutocompleteItem } from '@kbn/esql-types';
+import {
+  InferenceInferenceEndpointInfo,
+  InferenceTaskType,
+} from '@elastic/elasticsearch/lib/api/types';
 
 export interface EsqlServiceOptions {
   client: ElasticsearchClient;
@@ -83,5 +87,20 @@ export class EsqlService {
     };
 
     return result;
+  }
+
+  public async getInferenceEndpoints(
+    taskType: InferenceTaskType
+  ): Promise<{ inferenceEndpoints: InferenceInferenceEndpointInfo[] }> {
+    const { client } = this.options;
+
+    const { endpoints } = await client.inference.get({
+      inference_id: '_all',
+      task_type: taskType,
+    });
+
+    return {
+      inferenceEndpoints: endpoints,
+    };
   }
 }

--- a/src/platform/plugins/shared/esql/server/services/integration_tests/esql_service.test.ts
+++ b/src/platform/plugins/shared/esql/server/services/integration_tests/esql_service.test.ts
@@ -65,4 +65,16 @@ describe('EsqlService', () => {
       aliases: ['ts_index2_alias1', 'ts_index2_alias2'],
     });
   });
+
+  it('can load the inference endpoints by type', async () => {
+    const url = '/internal/esql/autocomplete/inference_endpoints/rerank';
+    const result = await testbed.GET(url).send().expect(200);
+
+    const rerankInferenceEndpoint = result.body.inferenceEndpoints[0];
+
+    expect(rerankInferenceEndpoint).toMatchObject({
+      inference_id: '.rerank-v1-elasticsearch',
+      task_type: 'rerank',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana/issues/218052

Both `COMPLETION` and `RERANK` commands needs to fetch the available inference endpoints for suggestions.

Added a new API to fetch them by type:
`/internal/esql/autocomplete/inference_endpoints/{taskType}`

`taskType`:  completion | rerank | text_embedding | sparse_embedding | chat_completion

#### Response
```json
{
  "inferenceEndpoints": [
    {
      "inference_id": ".rerank-v1-elasticsearch",
      "task_type": "rerank",
      "service": "elasticsearch",
      "service_settings": {
        "num_threads": 1,
        "model_id": ".rerank-v1",
        "adaptive_allocations": {
          "enabled": true,
          "min_number_of_allocations": 0,
          "max_number_of_allocations": 32
        }
      },
      "task_settings": {
        "return_documents": true
      }
    }
  ]
}
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->