### PR TITLE
[Cloud Security] [Bug] Fix default credential not loading when changing policy templates in CSPM and Asset Discovery onboarding

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -159,6 +159,17 @@ export const updateAgentlessCloudConnectorConfig = (
       targetCsp = 'azure';
     }
 
+    if (targetCsp !== 'aws') {
+      setNewAgentPolicy({
+        ...newAgentPolicy,
+        agentless: {
+          ...newAgentPolicy.agentless,
+          cloud_connectors: undefined,
+        },
+      });
+      return;
+    }
+
     if (newAgentPolicy.agentless?.cloud_connectors?.enabled !== enabled) {
       setNewAgentPolicy({
         ...newAgentPolicy,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -773,15 +773,13 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
         const inputVars = getPostureInputHiddenVars(
           inputType,
           packageInfo,
-          inputType === CLOUDBEAT_AWS && isAgentlessAvailable
-            ? SetupTechnology.AGENTLESS
-            : SetupTechnology.AGENT_BASED,
+          setupTechnology,
           showCloudConnectors
         );
         const policy = getPosturePolicy(newPolicy, inputType, inputVars);
         updatePolicy(policy);
       },
-      [packageInfo, newPolicy, updatePolicy, isAgentlessAvailable, showCloudConnectors]
+      [packageInfo, newPolicy, setupTechnology, updatePolicy, showCloudConnectors]
     );
 
     // search for non null fields of the validation?.vars object

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_form.tsx
@@ -133,15 +133,13 @@ export const CloudAssetInventoryPolicyTemplateForm =
           const inputVars = getAssetInputHiddenVars(
             inputType,
             packageInfo,
-            inputType === CLOUDBEAT_AWS && isAgentlessAvailable
-              ? SetupTechnology.AGENTLESS
-              : SetupTechnology.AGENT_BASED,
+            setupTechnology,
             showCloudConnectors
           );
           const policy = getAssetPolicy(newPolicy, inputType, inputVars);
           updatePolicy(policy);
         },
-        [packageInfo, isAgentlessAvailable, showCloudConnectors, newPolicy, updatePolicy]
+        [packageInfo, setupTechnology, showCloudConnectors, newPolicy, updatePolicy]
       );
 
       // // search for non null fields of the validation?.vars object

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/agentless/security_posture.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/agentless/security_posture.ts
@@ -90,5 +90,24 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(hasSetupTechnologySelector).to.be(true);
       expect(hasAgentBased).to.be(false);
     });
+
+    it.only(`should show an invalid form state when agentless is default and switching between cloud providers`, async () => {
+      await cisIntegration.navigateToAddIntegrationWithVersionPage(
+        CLOUD_SECURITY_POSTURE_PACKAGE_VERSION
+      );
+      await pageObjects.header.waitUntilLoadingHasFinished();
+
+      await cisIntegration.clickAwsPolicyOption();
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      expect(await cisIntegration.isSaveButtonEnabled()).to.be(false);
+
+      await cisIntegration.clickGcpPolicyOption();
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      expect(await cisIntegration.isSaveButtonEnabled()).to.be(false);
+
+      await cisIntegration.clickAzurePolicyOption();
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      expect(await cisIntegration.isSaveButtonEnabled()).to.be(false);
+    });
   });
 }

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/agentless/security_posture.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/agentless/security_posture.ts
@@ -91,7 +91,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(hasAgentBased).to.be(false);
     });
 
-    it.only(`should show an invalid form state when agentless is default and switching between cloud providers`, async () => {
+    it(`should show an invalid form state when agentless is default and switching between cloud providers`, async () => {
       await cisIntegration.navigateToAddIntegrationWithVersionPage(
         CLOUD_SECURITY_POSTURE_PACKAGE_VERSION
       );

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
@@ -34,6 +34,9 @@ const TEST_IDS = {
   AGENTLESS_STATUS_BADGE: 'agentlessStatusBadge',
   CREATE_AGENT_POLICY_NAME_FIELD: 'createAgentPolicyNameField',
   CREDENTIALS_JSON_SECRET_PANEL: 'credentials_json_secret_panel_test_id',
+  GCP_POLICY_OPTION_TEST_ID: 'cisGcpTestId',
+  AWS_POLICY_OPTION_TEST_ID: 'cisAwsTestId',
+  AZURE_POLICY_OPTION_TEST_ID: 'cisAzureTestId',
 } as const;
 
 export function AddCisIntegrationFormPageProvider({
@@ -352,6 +355,27 @@ export function AddCisIntegrationFormPageProvider({
     await optionToBeClicked.click();
   };
 
+  const isSaveButtonEnabled = async () => {
+    const saveButton = await testSubjects.find(TEST_IDS.CREATE_PACKAGE_POLICY_SAVE_BUTTON);
+    const isEnabled = await saveButton.getAttribute('disabled');
+    return isEnabled === null; // If the button is enabled, it won't have a 'disabled' attribute
+  };
+
+  const clickAwsPolicyOption = async () => {
+    const awsPolicyOption = await findOptionInPage(TEST_IDS.AWS_POLICY_OPTION_TEST_ID);
+    await awsPolicyOption.click();
+  };
+
+  const clickGcpPolicyOption = async () => {
+    const gcpPolicyOption = await findOptionInPage(TEST_IDS.GCP_POLICY_OPTION_TEST_ID);
+    await gcpPolicyOption.click();
+  };
+
+  const clickAzurePolicyOption = async () => {
+    const azurePolicyOption = await findOptionInPage(TEST_IDS.AZURE_POLICY_OPTION_TEST_ID);
+    await azurePolicyOption.click();
+  };
+
   const clickSaveButton = async () => {
     const optionToBeClicked = await findOptionInPage(TEST_IDS.CREATE_PACKAGE_POLICY_SAVE_BUTTON);
     await optionToBeClicked.click();
@@ -654,5 +678,9 @@ export function AddCisIntegrationFormPageProvider({
     closeAllOpenTabs,
     waitUntilLaunchCloudFormationButtonAppears,
     showCredentialJsonSecretPanel,
+    isSaveButtonEnabled,
+    clickAwsPolicyOption,
+    clickGcpPolicyOption,
+    clickAzurePolicyOption,
   };
 }


### PR DESCRIPTION
## Summary
Fixes the Cloud Asset Discovery and Cloud Security Posture integration onboarding UI not loading the default agentless credentials when switching between AWS, GCP, and Azure.

Broken behaviour

https://github.com/user-attachments/assets/65aac8c5-3b63-4b4f-aa0f-e71300df6740


Fixed behaviour

https://github.com/user-attachments/assets/4d17c4e3-60e7-4d96-bb57-d3c267ee53ae




### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


