### PR TITLE
[8.19] [AI4DSOC] fix styling to address cutoff when screen is narrow (#219306)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -78,6 +78,7 @@ export function PackageCard({
   titleLineClamp,
   descriptionLineClamp,
   maxCardHeight,
+  minCardHeight,
   showDescription = true,
   showReleaseBadge = true,
 }: PackageCardProps) {
@@ -227,6 +228,8 @@ export function PackageCard({
             [class*='euiCard__titleButton'] {
               ${getLineClampStyles(titleLineClamp)}
             }
+
+            min-height: ${minCardHeight ? `${minCardHeight}px` : '127px'};
           `}
           data-test-subj={testid}
           isquickstart={isQuickstart}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx
@@ -55,6 +55,7 @@ export interface IntegrationCardItem {
   isUnverified?: boolean;
   isUpdateAvailable?: boolean;
   maxCardHeight?: number;
+  minCardHeight?: number;
   name: string;
   onCardClick?: () => void;
   release?: IntegrationCardReleaseLabel;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.test.tsx
@@ -72,10 +72,10 @@ describe('applyCategoryBadgeAndStyling', () => {
     expect(result.showReleaseBadge).toBe(false);
   });
 
-  it('should set maxCardHeight to 88', () => {
+  it('should set minCardHeight to 88', () => {
     const result = applyCategoryBadgeAndStyling(mockInt, IntegrationsFacets.available);
 
-    expect(result.maxCardHeight).toBe(88);
+    expect(result.minCardHeight).toBe(88);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
@@ -26,7 +26,7 @@ const FEATURED_INTEGRATION_SORT_ORDER = [
   'epr:sentinel_one',
   'epr:crowdstrike',
 ];
-const INTEGRATION_CARD_MAX_HEIGHT_PX = 88;
+const INTEGRATION_CARD_MIN_HEIGHT_PX = 88;
 
 const addPathParamToUrl = (url: string, path: string) => {
   const encodedPath = encodeURIComponent(path);
@@ -67,7 +67,7 @@ export const applyCategoryBadgeAndStyling = (
           </EuiFlexItem>,
         ] as React.ReactNode[])
       : [],
-    maxCardHeight: INTEGRATION_CARD_MAX_HEIGHT_PX,
+    minCardHeight: INTEGRATION_CARD_MIN_HEIGHT_PX,
   };
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[AI4DSOC] fix styling to address cutoff when screen is narrow (#219306)](https://github.com/elastic/kibana/pull/219306)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kylie Meli","email":"kylie.geller@elastic.co"},"sourceCommit":{"committedDate":"2025-05-01T20:43:51Z","message":"[AI4DSOC] fix styling to address cutoff when screen is narrow (#219306)\n\n## Summary\n\nFixing the css settings for the AI4DSOC integrations cards so the cards\nresize when the screen is narrow, instead of getting cut off.\n\n## Screenshots\n\n### Before\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 42 33 PM\"\nsrc=\"https://github.com/user-attachments/assets/2cb1033f-8998-4fd7-90ee-e7b6ce12c8ef\"\n/>\n\n### After\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 39 25 PM\"\nsrc=\"https://github.com/user-attachments/assets/dbee50c9-2c90-455c-8dc7-f7cf102d299b\"\n/>\n\n### Outside of AI4DSOC not impacted\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 33 25 PM\"\nsrc=\"https://github.com/user-attachments/assets/3b3961d5-4276-4da1-b046-3c8b0ac99bbe\"\n/>\n\n### AI4DSOC when not narrow screen\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 50 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/ff41c130-1691-4fae-baba-8b24e3641337\"\n/>\n\nRelates \n- https://github.com/elastic/security-team/issues/11789\n- https://github.com/elastic/kibana/pull/217905","sha":"6516cff1f873bbc5bbce7595e4335f2bac8aebbb","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Fleet","Team: SecuritySolution","backport:version","v9.1.0","v8.19.0"],"title":"[AI4DSOC] fix styling to address cutoff when screen is narrow","number":219306,"url":"https://github.com/elastic/kibana/pull/219306","mergeCommit":{"message":"[AI4DSOC] fix styling to address cutoff when screen is narrow (#219306)\n\n## Summary\n\nFixing the css settings for the AI4DSOC integrations cards so the cards\nresize when the screen is narrow, instead of getting cut off.\n\n## Screenshots\n\n### Before\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 42 33 PM\"\nsrc=\"https://github.com/user-attachments/assets/2cb1033f-8998-4fd7-90ee-e7b6ce12c8ef\"\n/>\n\n### After\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 39 25 PM\"\nsrc=\"https://github.com/user-attachments/assets/dbee50c9-2c90-455c-8dc7-f7cf102d299b\"\n/>\n\n### Outside of AI4DSOC not impacted\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 33 25 PM\"\nsrc=\"https://github.com/user-attachments/assets/3b3961d5-4276-4da1-b046-3c8b0ac99bbe\"\n/>\n\n### AI4DSOC when not narrow screen\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 50 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/ff41c130-1691-4fae-baba-8b24e3641337\"\n/>\n\nRelates \n- https://github.com/elastic/security-team/issues/11789\n- https://github.com/elastic/kibana/pull/217905","sha":"6516cff1f873bbc5bbce7595e4335f2bac8aebbb"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219306","number":219306,"mergeCommit":{"message":"[AI4DSOC] fix styling to address cutoff when screen is narrow (#219306)\n\n## Summary\n\nFixing the css settings for the AI4DSOC integrations cards so the cards\nresize when the screen is narrow, instead of getting cut off.\n\n## Screenshots\n\n### Before\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 42 33 PM\"\nsrc=\"https://github.com/user-attachments/assets/2cb1033f-8998-4fd7-90ee-e7b6ce12c8ef\"\n/>\n\n### After\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 39 25 PM\"\nsrc=\"https://github.com/user-attachments/assets/dbee50c9-2c90-455c-8dc7-f7cf102d299b\"\n/>\n\n### Outside of AI4DSOC not impacted\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 33 25 PM\"\nsrc=\"https://github.com/user-attachments/assets/3b3961d5-4276-4da1-b046-3c8b0ac99bbe\"\n/>\n\n### AI4DSOC when not narrow screen\n<img width=\"750\" alt=\"Screenshot 2025-04-25 at 2 50 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/ff41c130-1691-4fae-baba-8b24e3641337\"\n/>\n\nRelates \n- https://github.com/elastic/security-team/issues/11789\n- https://github.com/elastic/kibana/pull/217905","sha":"6516cff1f873bbc5bbce7595e4335f2bac8aebbb"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->