### PR TITLE
[8.19] [Fleet] skipping agent setup steps when agentless by default  (#218676)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -137,7 +137,7 @@ export function Detail() {
   const { getHref, getPath } = useLink();
   const history = useHistory();
   const { pathname, search, hash } = useLocation();
-  const { isAgentlessIntegration } = useAgentless();
+  const { isAgentlessIntegration, isAgentlessDefault } = useAgentless();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
   const integration = useMemo(() => queryParams.get('integration'), [queryParams]);
   const prerelease = useMemo(() => Boolean(queryParams.get('prerelease')), [queryParams]);
@@ -419,6 +419,7 @@ export function Detail() {
         isGuidedOnboardingActive,
         pkgkey,
         isAgentlessIntegration: isAgentlessIntegration(packageInfo || undefined),
+        isAgentlessDefault,
       });
 
       /** Users from Security and Observability Solution onboarding pages will have returnAppId and returnPath
@@ -448,6 +449,7 @@ export function Detail() {
       history,
       integration,
       isAgentlessIntegration,
+      isAgentlessDefault,
       isCloud,
       isExperimentalAddIntegrationPageEnabled,
       isFirstTimeAgentUser,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.test.ts
@@ -74,6 +74,7 @@ describe('getInstallPkgRouteOptions', () => {
 
     expect(getInstallPkgRouteOptions(opts)).toEqual(['fleet', expectedOptions]);
   });
+
   it('should navigate to steps app if isCloud and page enabled and first time agent user', () => {
     const opts = {
       currentPath: 'currentPath',
@@ -102,6 +103,7 @@ describe('getInstallPkgRouteOptions', () => {
 
     expect(getInstallPkgRouteOptions(opts)).toEqual(['fleet', expectedOptions]);
   });
+
   it('should not navigate to steps app for apm', () => {
     const opts = {
       currentPath: 'currentPath',
@@ -135,6 +137,7 @@ describe('getInstallPkgRouteOptions', () => {
 
     expect(getInstallPkgRouteOptions(opts)).toEqual(['fleet', expectedOptions]);
   });
+
   it('should navigate to steps app for endpoint', () => {
     const opts = {
       currentPath: 'currentPath',
@@ -167,5 +170,103 @@ describe('getInstallPkgRouteOptions', () => {
     };
 
     expect(getInstallPkgRouteOptions(opts)).toEqual(['fleet', expectedOptions]);
+  });
+
+  describe('useMultiPageLayout logic', () => {
+    it('should use multi-page layout if isCloud, first time agent user, and package is not exempt', () => {
+      const opts = {
+        currentPath: 'currentPath',
+        integration: 'myintegration',
+        pkgkey: 'myintegration-1.0.0',
+        isFirstTimeAgentUser: true,
+        isGuidedOnboardingActive: false,
+        isCloud: true,
+        isExperimentalAddIntegrationPageEnabled: true,
+      };
+
+      const expectedOptions = {
+        path: '/integrations/myintegration-1.0.0/add-integration/myintegration?useMultiPageLayout',
+        state: expect.any(Object),
+      };
+
+      expect(getInstallPkgRouteOptions(opts)[1]).toMatchObject(expectedOptions);
+    });
+
+    it('should not use multi-page layout if package is exempt', () => {
+      const opts = {
+        currentPath: 'currentPath',
+        integration: 'myintegration',
+        pkgkey: 'apm-1.0.0',
+        isFirstTimeAgentUser: true,
+        isGuidedOnboardingActive: false,
+        isCloud: true,
+        isExperimentalAddIntegrationPageEnabled: true,
+      };
+
+      const expectedOptions = {
+        path: '/integrations/apm-1.0.0/add-integration/myintegration',
+        state: expect.any(Object),
+      };
+
+      expect(getInstallPkgRouteOptions(opts)[1]).toMatchObject(expectedOptions);
+    });
+
+    it('should not use multi-page layout if isCloud is false', () => {
+      const opts = {
+        currentPath: 'currentPath',
+        integration: 'myintegration',
+        pkgkey: 'myintegration-1.0.0',
+        isFirstTimeAgentUser: true,
+        isGuidedOnboardingActive: false,
+        isCloud: false,
+        isExperimentalAddIntegrationPageEnabled: true,
+      };
+
+      const expectedOptions = {
+        path: '/integrations/myintegration-1.0.0/add-integration/myintegration',
+        state: expect.any(Object),
+      };
+
+      expect(getInstallPkgRouteOptions(opts)[1]).toMatchObject(expectedOptions);
+    });
+
+    it('should not use multi-page layout if isFirstTimeAgentUser and isGuidedOnboardingActive are false', () => {
+      const opts = {
+        currentPath: 'currentPath',
+        integration: 'myintegration',
+        pkgkey: 'myintegration-1.0.0',
+        isFirstTimeAgentUser: false,
+        isGuidedOnboardingActive: false,
+        isCloud: true,
+        isExperimentalAddIntegrationPageEnabled: true,
+      };
+
+      const expectedOptions = {
+        path: '/integrations/myintegration-1.0.0/add-integration/myintegration',
+        state: expect.any(Object),
+      };
+
+      expect(getInstallPkgRouteOptions(opts)[1]).toMatchObject(expectedOptions);
+    });
+
+    it('should not use multi-page layout if isAgentlessDefault is true', () => {
+      const opts = {
+        currentPath: 'currentPath',
+        integration: 'myintegration',
+        pkgkey: 'myintegration-1.0.0',
+        isFirstTimeAgentUser: true,
+        isGuidedOnboardingActive: false,
+        isCloud: true,
+        isExperimentalAddIntegrationPageEnabled: true,
+        isAgentlessDefault: true,
+      };
+
+      const expectedOptions = {
+        path: '/integrations/myintegration-1.0.0/add-integration/myintegration',
+        state: expect.any(Object),
+      };
+
+      expect(getInstallPkgRouteOptions(opts)[1]).toMatchObject(expectedOptions);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
@@ -31,6 +31,7 @@ interface GetInstallPkgRouteOptionsParams {
   isFirstTimeAgentUser: boolean;
   isGuidedOnboardingActive: boolean;
   isAgentlessIntegration?: boolean;
+  isAgentlessDefault?: boolean;
 }
 
 export type InstallPkgRouteOptions = [
@@ -54,6 +55,7 @@ export const getInstallPkgRouteOptions = ({
   isExperimentalAddIntegrationPageEnabled,
   isGuidedOnboardingActive,
   isAgentlessIntegration,
+  isAgentlessDefault,
 }: GetInstallPkgRouteOptionsParams): InstallPkgRouteOptions => {
   const integrationOpts: { integration?: string } = integration ? { integration } : {};
   const packageExemptFromStepsLayout = isPackageExemptFromStepsLayout(pkgkey);
@@ -61,7 +63,8 @@ export const getInstallPkgRouteOptions = ({
     isExperimentalAddIntegrationPageEnabled &&
     isCloud &&
     (isFirstTimeAgentUser || isGuidedOnboardingActive) &&
-    !packageExemptFromStepsLayout;
+    !packageExemptFromStepsLayout &&
+    !isAgentlessDefault;
   const path = pagePathGetters.add_integration_to_policy({
     pkgkey,
     useMultiPageLayout,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] skipping agent setup steps when agentless by default  (#218676)](https://github.com/elastic/kibana/pull/218676)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kylie Meli","email":"kylie.geller@elastic.co"},"sourceCommit":{"committedDate":"2025-04-22T11:58:45Z","message":"[Fleet] skipping agent setup steps when agentless by default  (#218676)\n\n## Summary\n\nUpdating the flow so that users do _not_ see the multi-page setup (setup\nan agent splash screen and instructions) if\n`xpack.fleet.agentless.isDefault: true` for the AI4DSOC project.\n\n<img width=\"500\" alt=\"Screenshot 2025-04-18 at 4 12 50 PM\"\nsrc=\"https://github.com/user-attachments/assets/559235e4-f0a7-4bec-9f84-000b04ac0606\"\n/>\n\n## Note\n\nThis is a short term solution for AI4DSOC until we have something more\npermanent in https://github.com/elastic/security-team/issues/11628\n\n## Screen recordings\n\n[AI4DSOC]\n\n\nhttps://github.com/user-attachments/assets/d62be4a2-d2c7-4c99-9bcf-6dc05a822da0\n\n[Otherwise]\n\n\nhttps://github.com/user-attachments/assets/1bf87305-bf6d-4707-92a7-32a6d52c9d23\n\n___ \nRelates \n- https://github.com/elastic/security-team/issues/11789\n- https://github.com/elastic/security-team/issues/11628\n- https://github.com/elastic/kibana/pull/216535","sha":"9ddc1569d002a5f76d0d400932933d4d0eb1b369","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.1.0","v8.19.0"],"title":"[Fleet] skipping agent setup steps when agentless by default ","number":218676,"url":"https://github.com/elastic/kibana/pull/218676","mergeCommit":{"message":"[Fleet] skipping agent setup steps when agentless by default  (#218676)\n\n## Summary\n\nUpdating the flow so that users do _not_ see the multi-page setup (setup\nan agent splash screen and instructions) if\n`xpack.fleet.agentless.isDefault: true` for the AI4DSOC project.\n\n<img width=\"500\" alt=\"Screenshot 2025-04-18 at 4 12 50 PM\"\nsrc=\"https://github.com/user-attachments/assets/559235e4-f0a7-4bec-9f84-000b04ac0606\"\n/>\n\n## Note\n\nThis is a short term solution for AI4DSOC until we have something more\npermanent in https://github.com/elastic/security-team/issues/11628\n\n## Screen recordings\n\n[AI4DSOC]\n\n\nhttps://github.com/user-attachments/assets/d62be4a2-d2c7-4c99-9bcf-6dc05a822da0\n\n[Otherwise]\n\n\nhttps://github.com/user-attachments/assets/1bf87305-bf6d-4707-92a7-32a6d52c9d23\n\n___ \nRelates \n- https://github.com/elastic/security-team/issues/11789\n- https://github.com/elastic/security-team/issues/11628\n- https://github.com/elastic/kibana/pull/216535","sha":"9ddc1569d002a5f76d0d400932933d4d0eb1b369"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218676","number":218676,"mergeCommit":{"message":"[Fleet] skipping agent setup steps when agentless by default  (#218676)\n\n## Summary\n\nUpdating the flow so that users do _not_ see the multi-page setup (setup\nan agent splash screen and instructions) if\n`xpack.fleet.agentless.isDefault: true` for the AI4DSOC project.\n\n<img width=\"500\" alt=\"Screenshot 2025-04-18 at 4 12 50 PM\"\nsrc=\"https://github.com/user-attachments/assets/559235e4-f0a7-4bec-9f84-000b04ac0606\"\n/>\n\n## Note\n\nThis is a short term solution for AI4DSOC until we have something more\npermanent in https://github.com/elastic/security-team/issues/11628\n\n## Screen recordings\n\n[AI4DSOC]\n\n\nhttps://github.com/user-attachments/assets/d62be4a2-d2c7-4c99-9bcf-6dc05a822da0\n\n[Otherwise]\n\n\nhttps://github.com/user-attachments/assets/1bf87305-bf6d-4707-92a7-32a6d52c9d23\n\n___ \nRelates \n- https://github.com/elastic/security-team/issues/11789\n- https://github.com/elastic/security-team/issues/11628\n- https://github.com/elastic/kibana/pull/216535","sha":"9ddc1569d002a5f76d0d400932933d4d0eb1b369"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->