### PR TITLE
[ftr] Increase timeout for loading package registry

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/config/serverless/serverless.base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/config/serverless/serverless.base.config.ts
@@ -62,7 +62,7 @@ export const defaultConfig: ScoutServerConfig = {
       port: dockerRegistryPort,
       args: dockerArgs,
       waitForLogLine: 'package manifests loaded',
-      waitForLogLineTimeoutMs: 60 * 2 * 1000, // 2 minutes
+      waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
     },
   }),
   esTestCluster: {

--- a/src/platform/packages/shared/kbn-scout/src/config/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/config/stateful/base.config.ts
@@ -67,7 +67,7 @@ export const defaultConfig: ScoutServerConfig = {
       port: dockerRegistryPort,
       args: dockerArgs,
       waitForLogLine: 'package manifests loaded',
-      waitForLogLineTimeoutMs: 60 * 2 * 1000, // 2 minutes
+      waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
     },
   }),
   esTestCluster: {

--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/serverless.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/serverless.config.base.ts
@@ -102,7 +102,7 @@ export function createServerlessTestConfig<T extends DeploymentAgnosticCommonSer
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 2 * 1000, // 2 minutes
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
         },
       }),
       esTestCluster: {

--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
@@ -96,7 +96,7 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 2 * 1000, // 2 minutes
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
         },
       }),
       testFiles: options.testFiles,

--- a/x-pack/test/common/services/security_solution/endpoint_registry_helpers.ts
+++ b/x-pack/test/common/services/security_solution/endpoint_registry_helpers.ts
@@ -70,7 +70,7 @@ export function SecuritySolutionEndpointRegistryHelpers() {
           port: dockerRegistryPort,
           args,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 2 * 10000, // 2 minutes,
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes,
         },
       });
     },

--- a/x-pack/test/dataset_quality_api_integration/common/config.ts
+++ b/x-pack/test/dataset_quality_api_integration/common/config.ts
@@ -129,7 +129,7 @@ export function createTestConfig(
           port: dockerRegistryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 2 * 10000, // 2 minutes
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
         },
       }),
       servicesRequiredForTestAnalysis: ['datasetQualityFtrConfig', 'registry'],

--- a/x-pack/test/fleet_api_integration/config.base.ts
+++ b/x-pack/test/fleet_api_integration/config.base.ts
@@ -49,7 +49,7 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
           port: registryPort,
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 2 * 10000, // 2 minutes
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
         },
       })
     : undefined;

--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -70,7 +70,7 @@ export default async () => {
         port: dockerRegistryPort,
         args: dockerArgs,
         waitForLogLine: 'package manifests loaded',
-        waitForLogLineTimeoutMs: 60 * 2 * 1000, // 2 minutes
+        waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
       },
     }),
     browser: {


### PR DESCRIPTION
We've been seeing intermittent timeouts over the last few weeks waiting for package manifests to load.

Successful runs are also near 2 minutes, which seems to indicate this isn't an issue with the service starting up.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->