### PR TITLE
[Detection Engine][Test Fix] Ensure that alerts are absent before loading our alerts archive

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/trial_license_complete_tier/document_level_security.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/trial_license_complete_tier/document_level_security.ts
@@ -9,6 +9,7 @@ import expect from '@kbn/expect';
 
 import { DETECTION_ENGINE_QUERY_SIGNALS_URL } from '@kbn/security-solution-plugin/common/constants';
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
+import { deleteAllAlerts } from '../../../../../../common/utils/security_solution';
 
 const roleToAccessSecuritySolution = {
   name: 'sec_all_spaces',
@@ -73,6 +74,10 @@ export default ({ getService }: FtrProviderContext) => {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const esArchiver = getService('esArchiver');
   const security = getService('security');
+  const supertest = getService('supertest');
+  const log = getService('log');
+  const es = getService('es');
+
   // Notes: Similar tests should be added for serverless once infrastructure
   // is in place to test roles in MKI enviornment.
   describe('@ess @skipInServerless find alert with/without doc level security', () => {
@@ -98,6 +103,7 @@ export default ({ getService }: FtrProviderContext) => {
         email: userAllSecWithDls.email,
       });
 
+      await deleteAllAlerts(supertest, log, es);
       await esArchiver.load(
         'x-pack/test/functional/es_archives/security_solution/alerts/8.8.0_multiple_docs',
         {


### PR DESCRIPTION
## Summary

This test has [failed a few times recently](https://github.com/elastic/kibana/issues/219112) with a
`version_conflict_engine_exception`, stating explicitly that the documents we're trying to load already exist in elasticsearch. In one case the reason was obvious (the suite was retried), but in another it was not clear why the data was there to cause this exception.

Regardless, adding this sanity check (deleting all the alerts) should ensure that this behavior does not recur.

Closes #219112.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed ([200x](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8329))
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["7.17","8.17","8.18","8.19","9.0"]} ONMERGE-->