### PR TITLE
[Synthetics] Fixed add monitor test

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/add_monitor.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/add_monitor.journey.ts
@@ -102,7 +102,10 @@ const configuration = {
     monitorEditDetails: [
       ['[data-test-subj=syntheticsMonitorConfigSchedule]', '10'],
       ['[data-test-subj=syntheticsMonitorConfigName]', browserName],
-      ['[data-test-subj=codeEditorContainer] textarea', 'step("test step", () => {})'],
+      [
+        'div[data-test-subj="codeEditorContainer"][aria-label="JavaScript code editor"] .view-line',
+        'step("test step", () => {})',
+      ],
       ['[data-test-subj=syntheticsMonitorConfigAPMServiceName]', apmServiceName],
     ],
   },
@@ -124,7 +127,10 @@ const configuration = {
     monitorEditDetails: [
       ['[data-test-subj=syntheticsMonitorConfigSchedule]', '10'],
       ['[data-test-subj=syntheticsMonitorConfigName]', browserRecorderName],
-      ['[data-test-subj=codeEditorContainer] textarea', 'step("test step", () => {})'],
+      [
+        'div[data-test-subj="codeEditorContainer"][aria-label="JavaScript code editor"] .view-line',
+        'step("test step", () => {})',
+      ],
       // name: httpName,
     ],
   },
@@ -187,10 +193,7 @@ const createMonitorJourney = ({
       step(`edit ${monitorName}`, async () => {
         await syntheticsApp.navigateToEditMonitor(monitorName);
         await syntheticsApp.findByText(monitorListDetails.location);
-        const hasFailure = await syntheticsApp.findEditMonitorConfiguration(
-          monitorEditDetails,
-          monitorType
-        );
+        const hasFailure = await syntheticsApp.findEditMonitorConfiguration(monitorEditDetails);
         expect(hasFailure).toBeFalsy();
         await page.waitForTimeout(1000);
         await page.getByTestId('syntheticsMonitorConfigSubmitButton').click();

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/page_objects/synthetics_app.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/page_objects/synthetics_app.tsx
@@ -221,16 +221,17 @@ export function syntheticsAppPageProvider({
       }
     },
 
-    async findEditMonitorConfiguration(
-      monitorConfig: Array<[string, string]>,
-      monitorType: FormMonitorType
-    ) {
+    async findEditMonitorConfiguration(monitorConfig: Array<[string, string]>) {
       await page.click('text="Advanced options"');
 
       for (let i = 0; i < monitorConfig.length; i++) {
         const [selector, expected] = monitorConfig[i];
-        const actual = await page.inputValue(selector);
-        expect(actual).toEqual(expected);
+        if (selector.includes('codeEditorContainer')) {
+          expect(page.locator(selector)).toHaveText(expected);
+        } else {
+          const actual = await page.inputValue(selector);
+          expect(actual).toEqual(expected);
+        }
       }
     },
 


### PR DESCRIPTION
PR to fix a test that broke after merging [this PR](https://github.com/elastic/kibana/pull/206176)

To run the tests:

`cd x-pack/solutions/observability/plugins/synthetics`
on one terminal run the server
`node scripts/e2e --server`
and on another one the runner
`node scripts/e2e --runner --grep "SyntheticsAddMonitor*"`

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->