### PR TITLE
[8.19] fix type error from missed file backport

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.test.tsx
@@ -24,6 +24,9 @@ const packages: PackageListItem[] = [
     status: installationStatuses.NotInstalled,
     title: 'Splunk',
     version: '0.1.0',
+    download: '',
+    path: '',
+    description: 'description',
   },
 ];
 const ruleResponse = {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.test.tsx
@@ -7,22 +7,20 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 import { TestProviders } from '../../../../common/mock';
 import { GROUPED_TABLE_TEST_ID, TableSection } from './table_section';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import { installationStatuses } from '@kbn/fleet-plugin/common/constants';
 
-const dataView: DataView = createStubDataView({ spec: {} });
+const dataViewSpec: DataViewSpec = { title: '.alerts-security.alerts-default' };
+const dataView: DataView = createStubDataView({ spec: dataViewSpec });
 const packages: PackageListItem[] = [
   {
-    description: '',
-    download: '',
     id: 'splunk',
     icons: [{ src: 'icon.svg', path: 'mypath/icon.svg', type: 'image/svg+xml' }],
     name: 'splunk',
-    path: '',
     status: installationStatuses.NotInstalled,
     title: 'Splunk',
     version: '0.1.0',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.tsx
@@ -14,7 +14,6 @@ import { TableSectionContextProvider } from './table_section_context';
 import { groupStatsRenderer } from './group_stats_renderers';
 import { groupingOptions } from './grouping_options';
 import { groupTitleRenderers } from './group_title_renderers';
-import type { RunTimeMappings } from '../../../../sourcerer/store/model';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { Table } from './table';
 import { inputsSelectors } from '../../../../common/store';
@@ -24,8 +23,6 @@ import { groupStatsAggregations } from './group_stats_aggregations';
 import type { RuleResponse } from '../../../../../common/api/detection_engine';
 
 export const GROUPED_TABLE_TEST_ID = 'alert-summary-grouped-table';
-
-const runtimeMappings: RunTimeMappings = {};
 
 export interface TableSectionProps {
   /**
@@ -56,7 +53,7 @@ export interface TableSectionProps {
  * This component leverages the GroupedAlertsTable and the ResponseOps AlertsTable also used in the alerts page.
  */
 export const TableSection = memo(({ dataView, packages, ruleResponse }: TableSectionProps) => {
-  const indexNames = useMemo(() => dataView.getIndexPattern(), [dataView]);
+  const dataViewSpec = useMemo(() => dataView.toSpec(), [dataView]);
   const { to, from } = useGlobalTime();
 
   const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuerySelector(), []);
@@ -91,14 +88,13 @@ export const TableSection = memo(({ dataView, packages, ruleResponse }: TableSec
         <GroupedAlertsTable
           accordionButtonContent={groupTitleRenderers}
           accordionExtraActionGroupStats={accordionExtraActionGroupStats}
+          dataViewSpec={dataViewSpec}
           defaultGroupingOptions={groupingOptions}
           from={from}
           globalFilters={filters}
           globalQuery={globalQuery}
           loading={false}
           renderChildComponent={renderChildComponent}
-          runtimeMappings={runtimeMappings}
-          signalIndexName={indexNames}
           tableId={TableId.alertsOnAlertSummaryPage}
           to={to}
         />


### PR DESCRIPTION
## Summary
There's a type error on 8.19 coming from a backport that didn't apply on a file. Probably the file wasn't present at the time when the backport was issued.

As a solution I've copied the state of the file and it's unit test from main. (cc: @PhilippeOberti )

Original PR: https://github.com/elastic/kibana/pull/220681
Backport PR: https://github.com/elastic/kibana/pull/222475