### PR TITLE
chore: exclude new solution-specific test folders from CodeQL scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -126,6 +126,7 @@ paths-ignore:
   - x-pack/performance
   - x-pack/scripts
   - x-pack/solutions/observability/packages/kbn-genai-cli
+  - x-pack/solutions/*/test
   - x-pack/test
   - x-pack/test_serverless
 query-filters:


### PR DESCRIPTION
## Summary

Exclude new solution-specific test folders from CodeQL scans.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->