### PR TITLE
[8.19] [Ai4dSoc][Serverless] Hide `Security` feature sub-privileges in `search_ai_lake` tier (#217210)

### DIFF
--- a/x-pack/platform/plugins/shared/features/common/kibana_feature.ts
+++ b/x-pack/platform/plugins/shared/features/common/kibana_feature.ts
@@ -46,7 +46,7 @@ export interface KibanaFeatureConfig {
   /**
    * An optional description that will appear as subtext underneath the feature name
    */
-  description?: string;
+  description?: string | null;
 
   /**
    * The category for this feature.

--- a/x-pack/platform/plugins/shared/features/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/features/server/config.test.ts
@@ -39,7 +39,7 @@ describe('config schema', () => {
       ConfigSchema.validate(
         {
           overrides: {
-            featureA: { name: 'new name', hidden: true },
+            featureA: { name: 'new name', description: 'new description', hidden: true },
             featureB: {
               order: 100,
               category: 'management',
@@ -73,6 +73,7 @@ describe('config schema', () => {
       Object {
         "overrides": Object {
           "featureA": Object {
+            "description": "new description",
             "hidden": true,
             "name": "new name",
           },
@@ -108,6 +109,27 @@ describe('config schema', () => {
                 },
               },
             },
+          },
+        },
+      }
+    `);
+  });
+
+  it('can override `description` when it is `null`', () => {
+    expect(
+      ConfigSchema.validate(
+        {
+          overrides: {
+            featureA: { description: null },
+          },
+        },
+        { serverless: true }
+      )
+    ).toMatchInlineSnapshot(`
+      Object {
+        "overrides": Object {
+          "featureA": Object {
+            "description": null,
           },
         },
       }

--- a/x-pack/platform/plugins/shared/features/server/config.ts
+++ b/x-pack/platform/plugins/shared/features/server/config.ts
@@ -34,6 +34,7 @@ export const ConfigSchema = schema.object({
         schema.object({
           hidden: schema.maybe(schema.boolean()),
           name: schema.maybe(schema.string({ minLength: 1 })),
+          description: schema.maybe(schema.nullable(schema.string({ minLength: 1 }))),
           category: schema.maybe(
             schema.string({
               validate(categoryName) {

--- a/x-pack/platform/plugins/shared/features/server/feature_registry.ts
+++ b/x-pack/platform/plugins/shared/features/server/feature_registry.ts
@@ -123,6 +123,10 @@ export class FeatureRegistry {
         feature.name = featureOverride.name;
       }
 
+      if (typeof featureOverride.description !== 'undefined') {
+        feature.description = featureOverride.description;
+      }
+
       if (featureOverride.category) {
         feature.category = DEFAULT_APP_CATEGORIES[featureOverride.category];
       }

--- a/x-pack/solutions/security/packages/features/src/product_features_keys.ts
+++ b/x-pack/solutions/security/packages/features/src/product_features_keys.ts
@@ -27,6 +27,10 @@ export enum ProductFeatureSecurityKey {
    */
   endpointHostManagement = 'endpoint_host_management',
   /**
+   * Enables access to Endpoint host isolation and release actions
+   */
+  endpointHostIsolation = 'endpoint_host_isolation',
+  /**
    * Enables endpoint policy views that enables user to manage endpoint security policies
    */
   endpointPolicyManagement = 'endpoint_policy_management',

--- a/x-pack/solutions/security/packages/features/src/security/product_feature_config.ts
+++ b/x-pack/solutions/security/packages/features/src/security/product_feature_config.ts
@@ -90,6 +90,10 @@ export const securityDefaultProductFeaturesConfig: DefaultSecurityProductFeature
     },
   },
 
+  [ProductFeatureSecurityKey.endpointHostIsolation]: {
+    subFeatureIds: [SecuritySubFeatureId.hostIsolation],
+  },
+
   [ProductFeatureSecurityKey.endpointHostManagement]: {
     subFeatureIds: [SecuritySubFeatureId.endpointList],
   },

--- a/x-pack/solutions/security/packages/features/src/security/v1_features/kibana_sub_features.ts
+++ b/x-pack/solutions/security/packages/features/src/security/v1_features/kibana_sub_features.ts
@@ -689,7 +689,7 @@ const endpointExceptionsSubFeature = (): SubFeatureConfig => ({
  */
 export const getSecurityBaseKibanaSubFeatureIds = (
   { experimentalFeatures }: SecurityFeatureParams // currently un-used, but left here as a convenience for possible future use
-): SecuritySubFeatureId[] => [SecuritySubFeatureId.hostIsolation];
+): SecuritySubFeatureId[] => [];
 
 /**
  * Defines all the Security Assistant subFeatures available.

--- a/x-pack/solutions/security/packages/features/src/security/v2_features/kibana_sub_features.ts
+++ b/x-pack/solutions/security/packages/features/src/security/v2_features/kibana_sub_features.ts
@@ -703,7 +703,7 @@ const endpointExceptionsSubFeature = (): SubFeatureConfig => ({
  */
 export const getSecurityV2BaseKibanaSubFeatureIds = (
   { experimentalFeatures }: SecurityFeatureParams // currently un-used, but left here as a convenience for possible future use
-): SecuritySubFeatureId[] => [SecuritySubFeatureId.hostIsolation];
+): SecuritySubFeatureId[] => [];
 
 /**
  * Defines all the Security Assistant subFeatures available.

--- a/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts
@@ -22,18 +22,21 @@ export const PLI_PRODUCT_FEATURES: PliProductFeatures = {
       ProductFeatureKey.alertsSummary,
       ProductFeatureKey.configurations,
     ],
-    essentials: [ProductFeatureKey.attackDiscovery, ProductFeatureKey.assistant],
-    complete: [ProductFeatureKey.attackDiscovery, ProductFeatureKey.assistant],
+    // neither of these tiers are available in ai_soc product line
+    essentials: [],
+    complete: [],
   },
   [ProductLine.security]: {
     search_ai_lake: [],
     essentials: [
       ProductFeatureKey.endpointHostManagement,
       ProductFeatureKey.endpointPolicyManagement,
+      ProductFeatureKey.endpointHostIsolation,
     ],
     complete: [
       ProductFeatureKey.endpointHostManagement,
       ProductFeatureKey.endpointPolicyManagement,
+      ProductFeatureKey.endpointHostIsolation,
       ProductFeatureKey.advancedInsights,
       ProductFeatureKey.assistant,
       ProductFeatureKey.attackDiscovery,

--- a/x-pack/test/security_solution_cypress/cypress/e2e/ai4dsoc/privileges/security_privileges.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/ai4dsoc/privileges/security_privileges.cy.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ATTACK_DISCOVERY_FEATURE,
+  CASES_FEATURE,
+  ELASTIC_AI_ASSISTANT_FEATURE,
+  MACHINE_LEARNING_FEATURE,
+  NOTES_FEATURE,
+  SECURITY_FEATURE,
+  TIMELINE_FEATURE,
+} from '../../../screens/custom_roles/assign_to_space_flyout';
+import { login } from '../../../tasks/login';
+import { visit } from '../../../tasks/navigation';
+import { selectAllSpaces } from '../../../tasks/select_all_spaces';
+import { CUSTOM_ROLES_URL } from '../../../urls/navigation';
+
+describe('Custom role creation', { tags: '@serverless' }, () => {
+  beforeEach(() => {
+    login('admin');
+    visit(CUSTOM_ROLES_URL);
+  });
+
+  describe('Security privileges', () => {
+    it('should not show `Security` sub-privileges', () => {
+      selectAllSpaces();
+      // should not have Security sub-privileges
+      cy.get(SECURITY_FEATURE).should('exist');
+      cy.get(SECURITY_FEATURE).click();
+      cy.get(`${SECURITY_FEATURE} button.euiAccordion__arrow`).should('not.exist');
+    });
+
+    it('should not show `Timelines` and `Notes` features', () => {
+      selectAllSpaces();
+      // should not have Timeline/Notes sub-privileges
+      cy.get(TIMELINE_FEATURE).should('not.exist');
+      cy.get(NOTES_FEATURE).should('not.exist');
+    });
+
+    it('should show `Cases`, `Machine Learning`, `Elastic AI Assistant` and `Attack discovery` features', () => {
+      selectAllSpaces();
+      // should have Cases sub-privilege
+      cy.get(CASES_FEATURE).should('exist');
+      // should have Machine Learning sub-privilege
+      cy.get(MACHINE_LEARNING_FEATURE).should('exist');
+      // should have Elastic AI Assistant sub-privilege
+      cy.get(ELASTIC_AI_ASSISTANT_FEATURE).should('exist');
+      // should have Attack Discovery sub-privilege
+      cy.get(ATTACK_DISCOVERY_FEATURE).should('exist');
+    });
+  });
+});

--- a/x-pack/test/security_solution_cypress/cypress/screens/custom_roles/assign_to_space_flyout.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/custom_roles/assign_to_space_flyout.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const SPACE_SELECTOR_COMBO_BOX = '[data-test-subj="spaceSelectorComboBox"]';
+
+// Privileges
+export const SECURITY_CATEGORY = '[data-test-subj="featureCategory_securitySolution"]';
+
+// Sub-privileges
+export const SECURITY_FEATURE = '[data-test-subj="featureCategory_securitySolution_siemV2"]';
+
+export const CASES_FEATURE =
+  '[data-test-subj="featureCategory_securitySolution_securitySolutionCasesV3"]';
+export const MACHINE_LEARNING_FEATURE = '[data-test-subj="featureCategory_securitySolution_ml"]';
+export const ELASTIC_AI_ASSISTANT_FEATURE =
+  '[data-test-subj="featureCategory_securitySolution_securitySolutionAssistant"]';
+export const ATTACK_DISCOVERY_FEATURE =
+  '[data-test-subj="featureCategory_securitySolution_securitySolutionAttackDiscovery"]';
+export const TIMELINE_FEATURE =
+  '[data-test-subj="featureCategory_securitySolution_securitySolutionTimeline"]';
+export const NOTES_FEATURE =
+  '[data-test-subj="featureCategory_securitySolution_securitySolutionNotes"]';

--- a/x-pack/test/security_solution_cypress/cypress/tasks/select_all_spaces.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/select_all_spaces.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  SPACE_SELECTOR_COMBO_BOX,
+  SECURITY_CATEGORY,
+} from '../screens/custom_roles/assign_to_space_flyout';
+import { ASSIGN_TO_SPACE_BUTTON } from '../screens/custom_roles/custom_role_page';
+
+export const selectAllSpaces = (): void => {
+  cy.get(ASSIGN_TO_SPACE_BUTTON).click();
+
+  // select all spaces
+  cy.get(SPACE_SELECTOR_COMBO_BOX).click();
+  cy.get(SPACE_SELECTOR_COMBO_BOX).type('* All Spaces');
+  cy.get(SPACE_SELECTOR_COMBO_BOX).type('{enter}');
+
+  // expand security privileges
+  cy.get(SECURITY_CATEGORY).click();
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Ai4dSoc][Serverless] Hide `Security` feature sub-privileges in `search_ai_lake` tier (#217210)](https://github.com/elastic/kibana/pull/217210)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ash","email":"1849116+ashokaditya@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-16T21:40:09Z","message":"[Ai4dSoc][Serverless] Hide `Security` feature sub-privileges in `search_ai_lake` tier (#217210)\n\n## Summary\n\nHides security sub-privileges for ai4soc/search_ai_lake tier.\n![Screenshot 2025-04-11 at 10 22\n09](https://github.com/user-attachments/assets/6f3294bc-82de-404e-b9d3-22e717d54b65)\n\n### Reasoning for changes added to `x-pack/packages/security`:\n\nCurrently, the feature description of Security feature is tied to the\nfact that it has a list of sub-privileges. This is true on ESS and\n`essentials/complete` serverless tiers.\n\nWith the introduction of the lower `search_ai_lake` tier, security\nfeature would not have any sub-privileges available and thus it does not\nmake sense to show that description.\n\nThe ideal way to handle this would be to load feature privileges config\nsettings at the plugin level\n(security_solution/security_solution_serverless) and set `description`\nto `null | undefined` based on the tier, as currently the feature\nprivileges settings live in [kibana_features file\n(v2_features)](https://github.com/elastic/kibana/blob/795094d8c63dde1439220cfba1808fce50c781d1/x-pack/solutions/security/packages/features/src/security/v2_features/kibana_features.ts#L72)\n(also another set in v1_features) and the plugins only select a set of\nthose based on the [feature keys\navailable](https://github.com/elastic/kibana/blob/d4a33a2b61f05e85f99f8f5932b0266babb439f2/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts)\non each tier. The refactoring to pass in feature configs at the plugin\nlevel (instead of just feature keys) is not in the scope of the work cut\nout for RSA conf.\n\nThus the other simpler approach in this PR is to allow overriding the\ndescription field on the tier specific config file.\n\n## How to Test\n\n1. While on the Kibana root directory, run ES/Kibana on serverless mode\nwith:\n\n```bash\nyarn es serverless --kill --projectType security --kibanaUrl=http://0.0.0.0:5601\n```\nand on a new window\n```bash\nyarn serverless-security --no-base-path\n```\n\nEnable the AI for SOC tier, by adding the following to your\n`serverless.security.dev.yaml` file:\n\n```json5\nxpack.securitySolutionServerless.productTypes:\n  [\n    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },\n  ]\n```\n\n2. Once Kibana is up and running login in with the `admin` role using\nthe role dropdown.\n3. Navigate to `app/management/roles/edit`\n4. Click on `Assign to space` button and assign a space to that role on\nthe `Assign role to spaces` flyout.\n5. Expand the `Security` category and verify that `Security` feature is\nlisted in the list of features.\n6. Also verify that there is neither an accordion icon beside `Security`\nfeature nor a description text under it about sub-privileges.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"f6ad013220991ab0a572dea6128697e120d8fc54","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Defend Workflows","Team:Security Generative AI","backport:version","v9.1.0","v8.19.0"],"title":"[Ai4dSoc][Serverless] Hide `Security` feature sub-privileges in `search_ai_lake` tier","number":217210,"url":"https://github.com/elastic/kibana/pull/217210","mergeCommit":{"message":"[Ai4dSoc][Serverless] Hide `Security` feature sub-privileges in `search_ai_lake` tier (#217210)\n\n## Summary\n\nHides security sub-privileges for ai4soc/search_ai_lake tier.\n![Screenshot 2025-04-11 at 10 22\n09](https://github.com/user-attachments/assets/6f3294bc-82de-404e-b9d3-22e717d54b65)\n\n### Reasoning for changes added to `x-pack/packages/security`:\n\nCurrently, the feature description of Security feature is tied to the\nfact that it has a list of sub-privileges. This is true on ESS and\n`essentials/complete` serverless tiers.\n\nWith the introduction of the lower `search_ai_lake` tier, security\nfeature would not have any sub-privileges available and thus it does not\nmake sense to show that description.\n\nThe ideal way to handle this would be to load feature privileges config\nsettings at the plugin level\n(security_solution/security_solution_serverless) and set `description`\nto `null | undefined` based on the tier, as currently the feature\nprivileges settings live in [kibana_features file\n(v2_features)](https://github.com/elastic/kibana/blob/795094d8c63dde1439220cfba1808fce50c781d1/x-pack/solutions/security/packages/features/src/security/v2_features/kibana_features.ts#L72)\n(also another set in v1_features) and the plugins only select a set of\nthose based on the [feature keys\navailable](https://github.com/elastic/kibana/blob/d4a33a2b61f05e85f99f8f5932b0266babb439f2/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts)\non each tier. The refactoring to pass in feature configs at the plugin\nlevel (instead of just feature keys) is not in the scope of the work cut\nout for RSA conf.\n\nThus the other simpler approach in this PR is to allow overriding the\ndescription field on the tier specific config file.\n\n## How to Test\n\n1. While on the Kibana root directory, run ES/Kibana on serverless mode\nwith:\n\n```bash\nyarn es serverless --kill --projectType security --kibanaUrl=http://0.0.0.0:5601\n```\nand on a new window\n```bash\nyarn serverless-security --no-base-path\n```\n\nEnable the AI for SOC tier, by adding the following to your\n`serverless.security.dev.yaml` file:\n\n```json5\nxpack.securitySolutionServerless.productTypes:\n  [\n    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },\n  ]\n```\n\n2. Once Kibana is up and running login in with the `admin` role using\nthe role dropdown.\n3. Navigate to `app/management/roles/edit`\n4. Click on `Assign to space` button and assign a space to that role on\nthe `Assign role to spaces` flyout.\n5. Expand the `Security` category and verify that `Security` feature is\nlisted in the list of features.\n6. Also verify that there is neither an accordion icon beside `Security`\nfeature nor a description text under it about sub-privileges.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"f6ad013220991ab0a572dea6128697e120d8fc54"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217210","number":217210,"mergeCommit":{"message":"[Ai4dSoc][Serverless] Hide `Security` feature sub-privileges in `search_ai_lake` tier (#217210)\n\n## Summary\n\nHides security sub-privileges for ai4soc/search_ai_lake tier.\n![Screenshot 2025-04-11 at 10 22\n09](https://github.com/user-attachments/assets/6f3294bc-82de-404e-b9d3-22e717d54b65)\n\n### Reasoning for changes added to `x-pack/packages/security`:\n\nCurrently, the feature description of Security feature is tied to the\nfact that it has a list of sub-privileges. This is true on ESS and\n`essentials/complete` serverless tiers.\n\nWith the introduction of the lower `search_ai_lake` tier, security\nfeature would not have any sub-privileges available and thus it does not\nmake sense to show that description.\n\nThe ideal way to handle this would be to load feature privileges config\nsettings at the plugin level\n(security_solution/security_solution_serverless) and set `description`\nto `null | undefined` based on the tier, as currently the feature\nprivileges settings live in [kibana_features file\n(v2_features)](https://github.com/elastic/kibana/blob/795094d8c63dde1439220cfba1808fce50c781d1/x-pack/solutions/security/packages/features/src/security/v2_features/kibana_features.ts#L72)\n(also another set in v1_features) and the plugins only select a set of\nthose based on the [feature keys\navailable](https://github.com/elastic/kibana/blob/d4a33a2b61f05e85f99f8f5932b0266babb439f2/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts)\non each tier. The refactoring to pass in feature configs at the plugin\nlevel (instead of just feature keys) is not in the scope of the work cut\nout for RSA conf.\n\nThus the other simpler approach in this PR is to allow overriding the\ndescription field on the tier specific config file.\n\n## How to Test\n\n1. While on the Kibana root directory, run ES/Kibana on serverless mode\nwith:\n\n```bash\nyarn es serverless --kill --projectType security --kibanaUrl=http://0.0.0.0:5601\n```\nand on a new window\n```bash\nyarn serverless-security --no-base-path\n```\n\nEnable the AI for SOC tier, by adding the following to your\n`serverless.security.dev.yaml` file:\n\n```json5\nxpack.securitySolutionServerless.productTypes:\n  [\n    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },\n  ]\n```\n\n2. Once Kibana is up and running login in with the `admin` role using\nthe role dropdown.\n3. Navigate to `app/management/roles/edit`\n4. Click on `Assign to space` button and assign a space to that role on\nthe `Assign role to spaces` flyout.\n5. Expand the `Security` category and verify that `Security` feature is\nlisted in the list of features.\n6. Also verify that there is neither an accordion icon beside `Security`\nfeature nor a description text under it about sub-privileges.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"f6ad013220991ab0a572dea6128697e120d8fc54"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->