### PR TITLE
[Upgrade Assistant] Change resolution column icons to filled

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/resolution_table_cell.tsx
@@ -85,7 +85,7 @@ export const ClusterSettingsResolutionCell: React.FunctionComponent<Props> = ({ 
         data-test-subj="clusterSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="check" color="success" />
+          <EuiIcon type="checkInCircleFilled" color="success" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteCompleteText}</EuiText>
@@ -102,7 +102,7 @@ export const ClusterSettingsResolutionCell: React.FunctionComponent<Props> = ({ 
         data-test-subj="clusterSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warning" color="danger" />
+          <EuiIcon type="warningFilled" color="danger" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteFailedText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
@@ -176,7 +176,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="check" color="success" />
+            <EuiIcon type="checkInCircleFilled" color="success" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionCompleteText}</EuiText>
@@ -187,7 +187,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warning" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionFailedText}</EuiText>
@@ -198,7 +198,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warning" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionFetchFailedText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/resolution_table_cell.tsx
@@ -85,7 +85,7 @@ export const IndexSettingsResolutionCell: React.FunctionComponent<Props> = ({ st
         data-test-subj="indexSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="check" color="success" />
+          <EuiIcon type="checkInCircleFilled" color="success" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteCompleteText}</EuiText>
@@ -102,7 +102,7 @@ export const IndexSettingsResolutionCell: React.FunctionComponent<Props> = ({ st
         data-test-subj="indexSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warning" color="danger" />
+          <EuiIcon type="warningFilled" color="danger" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteFailedText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
@@ -152,7 +152,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="check" color="success" />
+            <EuiIcon type="checkInCircleFilled" color="success" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexCompleteText}</EuiText>
@@ -164,7 +164,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
         return (
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="warning" color="danger" />
+              <EuiIcon type="warningFilled" color="danger" />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiText size="s">{i18nTexts.reindexFailedText}</EuiText>
@@ -177,7 +177,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warning" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexFetchFailedText}</EuiText>
@@ -188,7 +188,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warning" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexPausedText}</EuiText>
@@ -202,7 +202,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="check" color="success" />
+            <EuiIcon type="checkInCircleFilled" color="success" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.updateCompleteText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/resolution_table_cell.tsx
@@ -95,7 +95,7 @@ export const MlSnapshotsResolutionCell: React.FunctionComponent = () => {
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="mlActionResolutionCell">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="check" color="success" />
+          <EuiIcon type="checkInCircleFilled" color="success" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">
@@ -112,7 +112,7 @@ export const MlSnapshotsResolutionCell: React.FunctionComponent = () => {
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="mlActionResolutionCell">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warning" color="danger" />
+          <EuiIcon type="warningFilled" color="danger" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/kibana_deprecations/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/kibana_deprecations/resolution_table_cell.tsx
@@ -136,7 +136,7 @@ export const ResolutionTableCell: React.FunctionComponent<Props> = ({
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="resolutionStatusCell">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="warning" color="danger" />
+                <EuiIcon type="warningFilled" color="danger" />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiText size="s">{resolutionI18nTexts.resolutionFailedCellLabel}</EuiText>
@@ -148,7 +148,7 @@ export const ResolutionTableCell: React.FunctionComponent<Props> = ({
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="resolutionStatusCell">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="check" color="success" />
+                <EuiIcon type="checkInCircleFilled" color="success" />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiText size="s">{resolutionI18nTexts.resolutionCompleteCellLabel}</EuiText>


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/222036

## Summary

Small PR to change the icons in the ES deprecations table resolution column to the filled version as required in the mocks. I've also updated the icons in the Kibana Deprecations table for consistency.

Before:
<img width="583" alt="Screenshot 2025-06-05 at 10 26 35" src="https://github.com/user-attachments/assets/f22449dd-6859-4459-ba1d-bdfdaf535fde" />
<img width="522" alt="Screenshot 2025-06-05 at 10 25 22" src="https://github.com/user-attachments/assets/acb96c78-14b7-49b1-903d-c7f36237b15b" />

After:
<img width="528" alt="Screenshot 2025-06-05 at 10 23 09" src="https://github.com/user-attachments/assets/6a7e888f-6fb7-44a7-a970-6b48d04f6f96" />

<img width="556" alt="Screenshot 2025-06-05 at 10 24 31" src="https://github.com/user-attachments/assets/fdb15ad7-825e-42d4-810f-869bf86dd36f" />


## How to test

* Follow the instructions in https://github.com/elastic/kibana-team/issues/1521. Use the any data folder.