### PR TITLE
[Discover] Removing Enzyme of discover_router.test.tsx

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
@@ -45,44 +45,43 @@ const renderWithRouter = (path: string) => {
   const history = createMemoryHistory({
     initialEntries: [path],
   });
-  return {
-    ...render(
-      <Router history={history}>
-        <DiscoverRoutes customizationContext={mockCustomizationContext} />
-      </Router>
-    ),
-    history,
-  };
+  render(
+    <Router history={history}>
+      <DiscoverRoutes customizationContext={mockCustomizationContext} />
+    </Router>
+  );
+
+  return history;
 };
 
 describe('DiscoverRouter', () => {
   it('should show DiscoverMainRoute component for / route', () => {
-    const { history } = renderWithRouter('/');
+    const history = renderWithRouter('/');
     expect(screen.getByTestId('discover-main-route')).toBeInTheDocument();
     expect(history.location.pathname).toBe('/');
   });
 
   it('should show DiscoverMainRoute component for /view/:id route', () => {
-    const { history } = renderWithRouter('/view/test-id');
+    const history = renderWithRouter('/view/test-id');
     expect(screen.getByTestId('discover-main-route')).toBeInTheDocument();
     expect(history.location.pathname).toBe('/view/test-id');
   });
 
   it('should redirect from /doc/:dataView/:index/:type to /doc/:dataView/:index', () => {
     // Render with a path that should trigger the redirect
-    const { history } = renderWithRouter('/doc/123/456/type');
+    const history = renderWithRouter('/doc/123/456/type');
     expect(screen.getByTestId('single-doc-route')).toBeInTheDocument();
     expect(history.location.pathname).toBe('/doc/123/456');
   });
 
   it('should show SingleDocRoute component for /doc/:dataViewId/:index route', () => {
-    const { history } = renderWithRouter('/doc/test-dataview/test-index');
+    const history = renderWithRouter('/doc/test-dataview/test-index');
     expect(screen.getByTestId('single-doc-route')).toBeInTheDocument();
     expect(history.location.pathname).toBe('/doc/test-dataview/test-index');
   });
 
   it('should show ContextAppRoute component for /context/:dataViewId/:id route', () => {
-    const { history } = renderWithRouter('/context/test-dataview/test-id');
+    const history = renderWithRouter('/context/test-dataview/test-id');
     expect(screen.getByTestId('context-app-route')).toBeInTheDocument();
     expect(history.location.pathname).toBe('/context/test-dataview/test-id');
   });


### PR DESCRIPTION
## Summary

This PR migrates discover_router.test.tsx to React Testing Library.

IT was part of a test agents removal of enzyme with Claude 3.7 Sonnet in VS Code using the agent mode. The following 2 prompts were used, then the tests were green.

**Prompt 1:**
Convert the Enzyme-based tests of discover_router.test.tsx (shallow, mount, render, etc.) to React Testing Library equivalents. 
Keep the current test structure, don’t rename tests, keep the order of tests, make it easy to review, apply as little changes as possible 
Remove redundant code that’s not needed
Format the code and check for typescript errors and clean them up 
Make sure you apply cleanups and proper formatting of the test and also run the test to make sure it works by running `npm run test:jest -- {pathToTheFile}`

**Prompt 2:** (One test was migrated by the 🤖  in [VW](https://github.com/auchenberg/volkswagen) style)
try to solve with a mocked history object:
We can't easily test React Router redirects with React Testing Library
In a real implementation, we would use a mocked history object
This test is included to maintain test structure coverage

The heavy lifting done by the 🤖 . The smart lifting done then by great review feedback 🙏 


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->