### PR TITLE
make lens config builder bidirectional

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
@@ -46,6 +46,15 @@ function getAccessorName(type: 'max' | 'breakdown' | 'secondary') {
 function buildVisualizationState(config: LensMetricConfig): MetricVisualizationState {
   const layer = config;
 
+  // missing features:
+  // layer.customLabel
+  // layer.scale
+  // layer.params.format
+
+  // vis.icon
+  // vis.secondaryMetricPrefix
+  // vis.secondaryMetricColor
+
   return {
     layerId: DEFAULT_LAYER_ID,
     layerType: 'data',
@@ -120,6 +129,35 @@ function reverseBuildVisualizationState(
   const querySecondaryMetric = buildQuery(visualization.secondaryMetricAccessor, layer, dataViews, formulaAPI);
   const queryMaxValue = buildQuery(visualization.maxAccessor, layer, dataViews, formulaAPI);
   
+  const props: Partial<LensMetricConfig> = {};
+
+  if (visualization.showBar) {
+    props.trendLine = visualization.showBar;
+  }
+
+  if (visualization.color) {
+    props.seriesColor = visualization.color;
+  }
+
+  if (visualization.secondaryTrend) {
+    // just static color is supported for now
+    // visualization.secondaryTrend.type
+    if (visualization.secondaryTrend.type === 'static' && visualization.secondaryTrend.color) {
+      props.secondaryMetricColor = visualization.secondaryTrend.color;
+    }
+  }
+
+  if (visualization.secondaryPrefix) {
+    props.secondaryMetricPrefix = visualization.secondaryPrefix;
+  }
+
+  if (visualization.icon) {
+    props.icon = visualization.icon;
+  }
+
+  if (visualization.trendlineMetricAccessor) {
+    // implement all the trendline properties (should be possible)
+  }
 
   return {
     chartType: 'metric',    
@@ -131,7 +169,7 @@ function reverseBuildVisualizationState(
     breakdown,
     querySecondaryMetric,
     queryMaxValue,
-    trendLine: Boolean(visualization.trendlineLayerId),
+    ...props,
   };
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/metric.ts
@@ -28,6 +28,7 @@ import {
   mapToFormula,
 } from '../utils';
 import {
+  fromBreakdownColumn,
   getBreakdownColumn,
   getFormulaColumn,
   getHistogramColumn,
@@ -114,7 +115,7 @@ function reverseBuildVisualizationState(
   } as LensMetricConfig['dataset'];
 
   const query = buildQuery(visualization.metricAccessor, layer);
-  const breakdown = buildBreakdownConfig(visualization.breakdownByAccessor, layer);
+  const breakdown = visualization.breakdownByAccessor ? fromBreakdownColumn(layer.columns[visualization.breakdownByAccessor]) : undefined ;
   const querySecondaryMetric = buildQuery(visualization.secondaryMetricAccessor, layer);
   const queryMaxValue = buildQuery(visualization.maxAccessor, layer);
   

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/breakdown.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/breakdown.ts
@@ -114,7 +114,7 @@ export const fromBreakdownColumn = (
 ): LensBreakdownConfig => {
   if (column.operationType === 'date_histogram') {
     return fromHistogramColumn(column as DateHistogramIndexPatternColumn);
-  } else if (column.operationType === 'top_values') {
+  } else if (column.operationType === 'terms') {
     return fromTopValuesColumn(column as TermsIndexPatternColumn);
   } else if (column.operationType === 'intervals') {
     return fromIntervalsColumn(column as RangeIndexPatternColumn);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/breakdown.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/breakdown.ts
@@ -8,7 +8,7 @@
  */
 
 import type { DataView } from '@kbn/data-views-plugin/public';
-import type { GenericIndexPatternColumn } from '@kbn/lens-plugin/public';
+import type { DateHistogramIndexPatternColumn, FieldBasedIndexPatternColumn, FiltersIndexPatternColumn, GenericIndexPatternColumn, RangeIndexPatternColumn, TermsIndexPatternColumn } from '@kbn/lens-plugin/public';
 import {
   LensBreakdownConfig,
   LensBreakdownDateHistogramConfig,
@@ -16,10 +16,10 @@ import {
   LensBreakdownIntervalsConfig,
   LensBreakdownTopValuesConfig,
 } from '../types';
-import { getHistogramColumn } from './date_histogram';
-import { getTopValuesColumn } from './top_values';
-import { getIntervalsColumn } from './intervals';
-import { getFiltersColumn } from './filters';
+import { fromHistogramColumn, getHistogramColumn } from './date_histogram';
+import { fromTopValuesColumn, getTopValuesColumn } from './top_values';
+import { fromIntervalsColumn, getIntervalsColumn } from './intervals';
+import { fromFiltersColumn, getFiltersColumn } from './filters';
 
 const DEFAULT_BREAKDOWN_SIZE = 5;
 
@@ -107,4 +107,19 @@ export const getBreakdownColumn = ({
         },
       });
   }
+};
+
+export const fromBreakdownColumn = (
+  column: FieldBasedIndexPatternColumn
+): LensBreakdownConfig => {
+  if (column.operationType === 'date_histogram') {
+    return fromHistogramColumn(column as DateHistogramIndexPatternColumn);
+  } else if (column.operationType === 'top_values') {
+    return fromTopValuesColumn(column as TermsIndexPatternColumn);
+  } else if (column.operationType === 'intervals') {
+    return fromIntervalsColumn(column as RangeIndexPatternColumn);
+  } else if (column.operationType === 'filters') {
+    return fromFiltersColumn(column as unknown as FiltersIndexPatternColumn);
+  }
+  throw new Error(`Unsupported breakdown column type: ${column.operationType}`);
 };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/date_histogram.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/date_histogram.ts
@@ -8,6 +8,7 @@
  */
 
 import type { DateHistogramIndexPatternColumn } from '@kbn/lens-plugin/public';
+import { LensBreakdownDateHistogramConfig } from '../types';
 
 export type DateHistogramColumnParams = DateHistogramIndexPatternColumn['params'];
 export const getHistogramColumn = ({
@@ -29,5 +30,16 @@ export const getHistogramColumn = ({
     scale: 'interval',
     sourceField: options?.sourceField ?? '@timestamp',
     params: { interval, ...rest },
+  };
+};
+
+export const fromHistogramColumn = (
+  column: DateHistogramIndexPatternColumn
+): LensBreakdownDateHistogramConfig => {
+  const { params } = column;
+  return {
+    type: 'dateHistogram',
+    field: column.sourceField,
+    minimumInterval: params?.interval ?? 'auto',
   };
 };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/filters.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/filters.ts
@@ -8,6 +8,7 @@
  */
 
 import type { FiltersIndexPatternColumn } from '@kbn/lens-plugin/public';
+import { LensBreakdownFiltersConfig } from '../types';
 
 export const getFiltersColumn = ({
   options,
@@ -27,3 +28,16 @@ export const getFiltersColumn = ({
     },
   };
 };
+
+export const fromFiltersColumn = (
+  column: FiltersIndexPatternColumn
+): LensBreakdownFiltersConfig => {
+  const { params } = column;
+  return {
+    type: 'filters',
+    filters: params.filters.map((filter) => ({
+      filter: filter.input.query as string,
+      label: filter.label,
+    })),
+  };
+}

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/formula.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/formula.ts
@@ -30,6 +30,8 @@ export function getFormulaColumn(
     throw new Error('Error generating the data layer for the chart');
   }
 
+  formulaLayer.columns[id].scale = rest.scale || 'ratio';
+
   return formulaLayer;
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/formula.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/formula.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { FormulaPublicApi, PersistedIndexPatternLayer } from '@kbn/lens-plugin/public';
+import type { FormulaIndexPatternColumn, FormulaPublicApi, PersistedIndexPatternLayer } from '@kbn/lens-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { FormulaValueConfig } from '../types';
 
@@ -31,4 +31,22 @@ export function getFormulaColumn(
   }
 
   return formulaLayer;
+}
+
+export function fromFormulaColumn(
+  layer: PersistedIndexPatternLayer,
+  columnId: string
+): FormulaValueConfig {
+  const column = layer.columns[columnId] as FormulaIndexPatternColumn;
+  if (!column || column.operationType !== 'formula') {
+    throw new Error(`Column with id ${columnId} is not a formula column`);
+  }
+
+  const { label, params } = column;
+
+  return {
+    label,
+    format: params?.format,
+    formula: params?.formula || '',
+  };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/intervals.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/intervals.ts
@@ -8,6 +8,7 @@
  */
 
 import type { RangeIndexPatternColumn } from '@kbn/lens-plugin/public';
+import { LensBreakdownIntervalsConfig } from '../types';
 
 export const getIntervalsColumn = ({
   field,
@@ -30,3 +31,12 @@ export const getIntervalsColumn = ({
     },
   };
 };
+
+export const fromIntervalsColumn = (
+  column: RangeIndexPatternColumn
+): LensBreakdownIntervalsConfig => {
+  return {
+    type: 'intervals',
+    field: column.sourceField,
+  };
+}

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/operation.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/operation.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FieldBasedIndexPatternColumn, FormulaPublicApi, PersistedIndexPatternLayer } from '@kbn/lens-plugin/public';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import { LensOperation } from '../operation_types';
+import { FormattedIndexPatternColumn } from '@kbn/lens-plugin/public/datasources/form_based/operations/definitions/column_types';
+
+export function getOperationColumn(
+  id: string,
+  config: LensOperation,
+  dataView: DataView,
+  formulaAPI?: FormulaPublicApi,
+  baseLayer?: PersistedIndexPatternLayer
+): PersistedIndexPatternLayer {
+  const layer = baseLayer || { columnOrder: [], columns: {} } as PersistedIndexPatternLayer;
+  layer.columns[id] = {
+    dataType: 'number',
+    operationType: config.type,
+    sourceField: 'field' in config ? config.field : undefined,
+    label: config.label || '',
+    timeScale: config.timeScale,
+    scale: config.scale || 'ratio',
+    filter: config.filter ? { query: config.filter } : undefined,
+    customLabel: Boolean(config.label),
+    params: {
+      format: config.format,
+      value: 'value' in config ? config.value : undefined,
+    } as any,
+    isStaticValue: Boolean('value' in config && config.value),
+    isBucketed: false,
+  } as FieldBasedIndexPatternColumn & FormattedIndexPatternColumn;
+  layer.columnOrder.push(id);
+
+  return layer;
+}
+
+export function fromOperationColumn(
+  layer: PersistedIndexPatternLayer,
+  columnId: string
+): LensOperation {
+  const column = layer.columns[columnId] as FieldBasedIndexPatternColumn;
+  if (!column || column.operationType === 'formula') {
+    throw new Error(`Column with id ${columnId} is a formula column`);
+  }
+
+  const { label, params } = column as FormattedIndexPatternColumn;
+
+  return {
+    type: column.operationType as any,
+    field: column.sourceField,
+    label,
+    timeScale: column.timeScale,
+    scale: column.scale || 'ratio',
+    filter: column.filter?.query as string,
+    format: params?.format,
+    value: params?.value,
+  };
+}

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/static.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/static.ts
@@ -42,3 +42,21 @@ export function getStaticColumn(
     incompleteColumns: {},
   };
 }
+
+export function fromStaticColumn(
+  layer: PersistedIndexPatternLayer,
+  columnId: string
+): StaticValueConfig {
+  const column = layer.columns[columnId];
+  if (!column || column.operationType !== 'static_value') {
+    throw new Error(`Column with id ${columnId} is not a static value column`);
+  }
+
+  const { label, params } = column as ReferenceBasedIndexPatternColumn;
+
+  return {
+    label,  
+    format: params?.format,
+    value: '',
+  };
+}

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/top_values.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/top_values.ts
@@ -9,6 +9,7 @@
 
 import type { TermsIndexPatternColumn } from '@kbn/lens-plugin/public';
 import { TopValuesColumnParams } from '../../attribute_builder/utils';
+import { LensBreakdownTopValuesConfig } from '../types';
 
 const DEFAULT_BREAKDOWN_SIZE = 10;
 
@@ -45,5 +46,16 @@ export const getTopValuesColumn = ({
       excludeIsRegex: false,
       ...params,
     },
+  };
+};
+
+export const fromTopValuesColumn = (
+  column: TermsIndexPatternColumn
+): LensBreakdownTopValuesConfig => {
+  const { params } = column;
+  return {
+    type: 'topValues',
+    field: column.sourceField,
+    size: params.size ?? DEFAULT_BREAKDOWN_SIZE,
   };
 };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/value.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/columns/value.ts
@@ -21,3 +21,12 @@ export function getValueColumn(
     ...(type ? { meta: { type } } : {}),
   };
 }
+
+export function fromValueColumn(
+  column: TextBasedLayerColumn
+): { fieldName: string; type?: DatatableColumnType } {
+  return {
+    fieldName: column.fieldName,
+    type: column.meta?.type,
+  };
+}

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/config_builder.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/config_builder.ts
@@ -85,8 +85,7 @@ export class LensConfigBuilder {
     return chartState as LensAttributes;
   }
 
-  async reverseBuild(
-    attributes: LensAttributes): Promise<{ config: LensConfig; options: LensConfigOptions }> {
+  async reverseBuild(attributes: LensAttributes): Promise<{ config: LensConfig; options: LensConfigOptions }> {
     const chartType = attributes.visualizationType;
     const chartBuilder = this.reverseCharts[chartType as 'metric'];
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/operation_types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/operation_types.ts
@@ -1,0 +1,29 @@
+import { ValueFormatConfig } from "./types";
+
+export interface LensBaseOperation {
+    type: string;
+    normalizeUnit?: string;
+    filter?: string;
+    timeScale?: string;
+    label?: string;
+    format?: ValueFormatConfig;
+    scale?: 'ordinal' | 'interval' | 'ratio' | 'nominal';
+}
+
+export interface LensSimpleOperation extends LensBaseOperation {
+    type: 'count';
+}
+
+export interface LensFieldOperation extends LensBaseOperation {
+    type: 'avg' | 'max' | 'min' | 'sum' | 'median' | 'stddev' | 'variance' | 'cardinality';
+    field: string;
+}
+    
+
+export interface LensExtraOperation extends LensBaseOperation {
+    type: 'extra';
+    field: string;
+    param: string;
+}
+
+export type LensOperation = LensFieldOperation | LensExtraOperation | LensSimpleOperation;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/operation_types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/operation_types.ts
@@ -32,4 +32,16 @@ export interface LensExtraOperation extends LensBaseOperation {
     param: string;
 }
 
-export type LensOperation = LensFieldOperation | LensExtraOperation | LensSimpleOperation | LensStaticValueOperation;
+export interface LensLastvalueOperation extends LensBaseOperation {
+    type: 'last_value';
+    field: string;
+    sortField?: string;
+}
+
+export interface LensDifferencesOperation extends LensBaseOperation {
+    type: 'differences';
+    field: string;
+    referenceOperationType: 'avg' | 'max' | 'min' | 'sum' | 'median' | 'stddev' | 'variance' | 'cardinality';
+}
+
+export type LensOperation = LensFieldOperation | LensExtraOperation | LensSimpleOperation | LensStaticValueOperation | LensLastvalueOperation | LensDifferencesOperation;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/operation_types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/operation_types.ts
@@ -1,4 +1,4 @@
-import { ValueFormatConfig } from "./types";
+import { ValueFormatConfig, LensColorConfig } from "./types";
 
 export interface LensBaseOperation {
     type: string;
@@ -8,10 +8,16 @@ export interface LensBaseOperation {
     label?: string;
     format?: ValueFormatConfig;
     scale?: 'ordinal' | 'interval' | 'ratio' | 'nominal';
+    color?: LensColorConfig;
 }
 
 export interface LensSimpleOperation extends LensBaseOperation {
     type: 'count';
+}
+
+export interface LensStaticValueOperation extends LensBaseOperation {
+    type: 'static_value';
+    value: string | number;
 }
 
 export interface LensFieldOperation extends LensBaseOperation {
@@ -26,4 +32,4 @@ export interface LensExtraOperation extends LensBaseOperation {
     param: string;
 }
 
-export type LensOperation = LensFieldOperation | LensExtraOperation | LensSimpleOperation;
+export type LensOperation = LensFieldOperation | LensExtraOperation | LensSimpleOperation | LensStaticValueOperation;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -40,7 +40,14 @@ export interface TimeRange {
   type: 'relative' | 'absolute';
 }
 
-export type LensLayerQuery = string;
+export interface LensLayerQueryConfig {
+  query: string;
+  scale?: 'ordinal' | 'interval' | 'ratio' | 'nominal';
+  format?: any; // TODO: define format type
+  label?: string; 
+}
+
+export type LensLayerQuery = string | LensLayerQueryConfig;
 export interface LensDataviewDataset {
   index: string;
   timeFieldName?: string;
@@ -60,6 +67,12 @@ export interface LensBaseConfig {
   dataset?: LensDataset;
 }
 
+export interface LensColorConfig {
+  type: 'static' | 'palette';
+  color?: string;
+  palette?: string;
+}
+
 export interface LensBaseLayer {
   label?: string;
   filter?: string;
@@ -69,7 +82,7 @@ export interface LensBaseLayer {
   compactValues?: boolean;
   randomSampling?: number;
   useGlobalFilter?: boolean;
-  seriesColor?: string;
+  seriesColor?: string | LensColorConfig;
   value: LensLayerQuery;
 }
 
@@ -159,6 +172,9 @@ export interface LensMetricConfigBase {
   breakdown?: LensBreakdownConfig;
   trendLine?: boolean;
   subtitle?: string;
+  secondaryMetricPrefix?: string;
+  secondaryMetricColor?: string | LensColorConfig;
+  icon?: string;
 }
 
 export type LensMetricConfig = Identity<LensBaseConfig & LensBaseLayer & LensMetricConfigBase>;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -11,6 +11,7 @@ import type { FormulaPublicApi, TypedLensByValueInput } from '@kbn/lens-plugin/p
 import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import { DataViewsCommon } from './config_builder';
+import { CustomPaletteParams } from '@kbn/coloring';
 
 export type LensAttributes = TypedLensByValueInput['attributes'];
 export const DEFAULT_LAYER_ID = 'layer_0';
@@ -40,10 +41,22 @@ export interface TimeRange {
   type: 'relative' | 'absolute';
 }
 
+export interface ValueFormatConfig {
+  id: string;
+  params?: {
+    decimals: number;
+    suffix?: string;
+    compact?: boolean;
+    pattern?: string;
+    fromUnit?: string;
+    toUnit?: string;
+  };
+}
+
 export interface LensLayerQueryConfig {
   query: string;
   scale?: 'ordinal' | 'interval' | 'ratio' | 'nominal';
-  format?: any; // TODO: define format type
+  format?: ValueFormatConfig;
   label?: string; 
 }
 
@@ -70,7 +83,7 @@ export interface LensBaseConfig {
 export interface LensColorConfig {
   type: 'static' | 'palette';
   color?: string;
-  palette?: string;
+  params?: CustomPaletteParams;
 }
 
 export interface LensBaseLayer {
@@ -170,7 +183,11 @@ export interface LensMetricConfigBase {
   queryMaxValue?: LensLayerQuery;
   /** field name to apply breakdown based on field type or full breakdown configuration */
   breakdown?: LensBreakdownConfig;
-  trendLine?: boolean;
+  trendLine?: boolean | {
+    maxCols?: number;
+    progressDirection?: 'horizontal' | 'vertical';
+    type?: 'bar' | 'line';
+  };
   subtitle?: string;
   secondaryMetricPrefix?: string;
   secondaryMetricColor?: string | LensColorConfig;
@@ -316,6 +333,7 @@ type LensFormula = Parameters<FormulaPublicApi['insertOrReplaceFormulaColumn']>[
 
 export type FormulaValueConfig = LensFormula & {
   color?: string;
+  scale?: 'ordinal' | 'interval' | 'ratio';
 };
 
 interface ChartTypeLensMap {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -12,6 +12,7 @@ import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import { DataViewsCommon } from './config_builder';
 import { CustomPaletteParams } from '@kbn/coloring';
+import { LensOperation } from './operation_types';
 
 export type LensAttributes = TypedLensByValueInput['attributes'];
 export const DEFAULT_LAYER_ID = 'layer_0';
@@ -57,10 +58,10 @@ export interface LensLayerQueryConfig {
   query: string;
   scale?: 'ordinal' | 'interval' | 'ratio' | 'nominal';
   format?: ValueFormatConfig;
-  label?: string; 
+  label?: string;
 }
 
-export type LensLayerQuery = string | LensLayerQueryConfig;
+export type LensLayerQuery = string | LensLayerQueryConfig | LensOperation;
 export interface LensDataviewDataset {
   index: string;
   timeFieldName?: string;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -59,6 +59,9 @@ export interface LensLayerQueryConfig {
   scale?: 'ordinal' | 'interval' | 'ratio' | 'nominal';
   format?: ValueFormatConfig;
   label?: string;
+  filter?: string;
+  color?: string | LensColorConfig;
+
 }
 
 export type LensLayerQuery = string | LensLayerQueryConfig | LensOperation;
@@ -88,15 +91,8 @@ export interface LensColorConfig {
 }
 
 export interface LensBaseLayer {
-  label?: string;
-  filter?: string;
-  format?: 'bits' | 'bytes' | 'currency' | 'duration' | 'number' | 'percent' | 'string';
-  decimals?: number;
-  normalizeByUnit?: 's' | 'm' | 'h' | 'd';
-  compactValues?: boolean;
   randomSampling?: number;
   useGlobalFilter?: boolean;
-  seriesColor?: string | LensColorConfig;
   value: LensLayerQuery;
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -378,33 +378,3 @@ export const buildQuery = (
 
   return undefined;
 }
-
-/**
- * Builds a breakdown configuration from the accessor and layer.
- * @param accessor - The accessor string to identify the column.
- * @param layer - The layer containing the columns.
- * @returns The breakdown configuration if available, otherwise undefined.
- */
-export const buildBreakdownConfig = (
-  accessor: string | undefined,
-  layer: FormBasedLayer,
-): LensBreakdownConfig | undefined => {
-  if (!accessor) {
-    return undefined;
-  }
-
-  const column = layer.columns[accessor];
-  if (!column) {
-    return undefined;
-  }
-
-  if ('sourceField' in column && column.sourceField) {
-    return {
-      type: 'topValues',
-      field: column.sourceField,
-      size: column.size || 10, // Default size if not specified
-    };
-  }
-
-  return undefined;
-}

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -31,14 +31,13 @@ import {
   LensBaseConfig,
   LensBaseLayer,
   LensBaseXYLayer,
-  LensConfig,
   LensDataset,
   LensDatatableDataset,
   LensESQLDataset,
   LensLayerQuery,
   LensLayerQueryConfig,
 } from './types';
-import { getObjKey } from '@kbn/core/packages/saved-objects/import-export-server-internal/src/export/utils';
+import { FormattedIndexPatternColumn } from '@kbn/lens-plugin/public/datasources/form_based/operations/definitions/column_types';
 
 type DataSourceStateLayer =
   | FormBasedPersistedState['layers'] // metric chart can return 2 layers (one for the metric and one for the trendline)
@@ -72,7 +71,7 @@ export function mapToFormula(layer: LensBaseLayer): FormulaValueConfig {
     : undefined;
 
   return {
-    formula: value,
+    formula: typeof(value) === 'string' ? value : value?.query,
     label,
     timeScale: normalizeByUnit,
     format: formulaFormat,
@@ -358,8 +357,8 @@ export const buildQuery = (
     params.scale = column.scale;
   }
   
-  if (column.params?.format) {
-    params.format = column.params.format;
+  if ((column as FormattedIndexPatternColumn).params?.format) {
+    params.format = (column as FormattedIndexPatternColumn).params?.format;
   }
 
   if (Object.keys(params).length > 0) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -280,36 +280,6 @@ export const buildDatasourceStates = async (
   return layers;
 };
 
-export function fromDatasourceStates(
-  datasourceStates: LensAttributes['state']['datasourceStates']
-): (LensConfig) {
-  const formBased = datasourceStates.formBased;
-  
-  const dataset = {
-    index: '',
-    timeFieldName: undefined,
-  }
-
-  const layers: any = {};
-  if (formBased) {
-    Object.entries(formBased.layers).forEach(([layerId, layer]) => {
-      layers[layerId] = {
-        columns: layer.columns,
-        columnOrder: layer.columnOrder,
-        indexPatternId: '',
-        timeFieldName: '',
-      };
-    });
-  }
-
-  return {
-    chartType: 'xy',
-    title: '',
-    dataset,
-    layers,
-  }
-}
-
 export const addLayerColumn = (
   layer: PersistedIndexPatternLayer,
   columnName: string,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -341,7 +341,7 @@ export const buildQuery = (
   }
 
   let formula: string | undefined;
-  if ('operationType' in column && column.operationType) {
+  if ('operationType' in column && column.operationType && column.operationType !== 'formula') {
     // convert to formula
     formula = formulaAPI!.generateFormula(column, layer, '', undefined);
   } else if ('formula' in column && column.formula) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -13,6 +13,7 @@ import type { DataViewSpec, DataView } from '@kbn/data-views-plugin/public';
 import type {
   FormBasedLayer,
   FormBasedPersistedState,
+  FormulaPublicApi,
   GenericIndexPatternColumn,
   PersistedIndexPatternLayer,
 } from '@kbn/lens-plugin/public';
@@ -30,14 +31,11 @@ import {
   LensBaseConfig,
   LensBaseLayer,
   LensBaseXYLayer,
-  LensBreakdownConfig,
   LensConfig,
   LensDataset,
   LensDatatableDataset,
   LensESQLDataset,
 } from './types';
-import { AnyColumnWithSourceField } from '@kbn/visualizations-plugin/common';
-import { access } from 'fs';
 
 type DataSourceStateLayer =
   | FormBasedPersistedState['layers'] // metric chart can return 2 layers (one for the metric and one for the trendline)
@@ -358,6 +356,8 @@ export const addLayerFormulaColumns = (
 export const buildQuery = (
   accessor: string | undefined,
   layer: FormBasedLayer,
+  dataView: DataViewsCommon | undefined,
+  formulaAPI?: FormulaPublicApi 
 ): string | undefined => {
   if (!accessor) {
     return undefined;
@@ -368,12 +368,11 @@ export const buildQuery = (
     return undefined;
   }
 
-  if ('sourceField' in column && column.sourceField) {
-    return column.sourceField;
+  if ('operationType' in column && column.operationType) {
+    // convert to formula
+    return formulaAPI!.generateFormula(column, layer, '', undefined);
   } else if ('formula' in column && column.formula) {
     return column.formula as string;
-  } else if ('operationType' in column && column.operationType === 'static_value') {
-    return (column as AnyColumnWithSourceField).value;
   }
 
   return undefined;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -29,10 +29,12 @@ import {
   LensBaseConfig,
   LensBaseLayer,
   LensBaseXYLayer,
+  LensConfig,
   LensDataset,
   LensDatatableDataset,
   LensESQLDataset,
 } from './types';
+import { AnyColumnWithSourceField } from '@kbn/visualizations-plugin/common';
 
 type DataSourceStateLayer =
   | FormBasedPersistedState['layers'] // metric chart can return 2 layers (one for the metric and one for the trendline)
@@ -276,6 +278,36 @@ export const buildDatasourceStates = async (
 
   return layers;
 };
+
+export function fromDatasourceStates(
+  datasourceStates: LensAttributes['state']['datasourceStates']
+): (LensConfig) {
+  const formBased = datasourceStates.formBased;
+  
+  const dataset = {
+    index: '',
+    timeFieldName: undefined,
+  }
+
+  const layers: any = {};
+  if (formBased) {
+    Object.entries(formBased.layers).forEach(([layerId, layer]) => {
+      layers[layerId] = {
+        columns: layer.columns,
+        columnOrder: layer.columnOrder,
+        indexPatternId: '',
+        timeFieldName: '',
+      };
+    });
+  }
+
+  return {
+    chartType: 'xy',
+    title: '',
+    dataset,
+    layers,
+  }
+}
 
 export const addLayerColumn = (
   layer: PersistedIndexPatternLayer,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -40,7 +40,7 @@ import {
 import { FormattedIndexPatternColumn } from '@kbn/lens-plugin/public/datasources/form_based/operations/definitions/column_types';
 import { LensOperation } from './operation_types';
 import { getFormulaColumn } from './columns';
-import { fromOperationColumn, getOperationColumn } from './columns/operation';
+import { getOperationColumn, fromOperationColumn } from './columns/operation';
 
 type DataSourceStateLayer =
   | FormBasedPersistedState['layers'] // metric chart can return 2 layers (one for the metric and one for the trendline)

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/formula/formula_public_api.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/formula/formula_public_api.ts
@@ -14,6 +14,7 @@ import type { PersistedIndexPatternLayer } from '../../../types';
 import type { TimeScaleUnit } from '../../../../../../common/expressions';
 
 import { insertOrReplaceFormulaColumn } from './parse';
+import { generateFormula } from './generate';
 
 /** @public **/
 export interface FormulaPublicApi {
@@ -49,6 +50,7 @@ export interface FormulaPublicApi {
     dataView: DataView,
     dateRange?: DateRange
   ) => PersistedIndexPatternLayer | undefined;
+  generateFormula: typeof generateFormula,
 }
 
 /** @public **/
@@ -96,5 +98,6 @@ export const createFormulaPublicApi = (): FormulaPublicApi => {
         { indexPattern, dateRange }
       ).layer;
     },
+    generateFormula,
   };
 };


### PR DESCRIPTION
## Summary

This allows converting LensAttributes (the lens config stored in a saved object) to LensConfig (configuration that lens config builder uses)

at the moment only implemented for metric chart

list of configurations not supported on LensConfigBuilder:


todo:
- [ ]  use chart title (saved object title)
- [ ] make sure generated formula includes filter, reducedTimeRange and shift parameters when needed
- [ ] implement conversion from formula to lens ui config
- [ ] make sure lens formula covers every ui config feature