### PR TITLE
[9.0] [Response Ops][Alerting] Fixing issue with setting `cancelAlertsOnRuleTimeout=false` in kibana config (#222263)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -284,6 +284,12 @@ export class AlertingPlugin {
 
     plugins.features.registerKibanaFeature(maintenanceWindowFeature);
 
+    if (this.config.cancelAlertsOnRuleTimeout === false) {
+      this.logger.warn(
+        `Setting xpack.alerting.cancelAlertsOnRuleTimeout=false can lead to unexpected behavior for certain rule types. This setting will be deprecated in a future version and will be ignored for rule types that do not support it.`
+      );
+    }
+
     this.isESOCanEncrypt = plugins.encryptedSavedObjects.canEncrypt;
 
     if (!this.isESOCanEncrypt) {
@@ -451,15 +457,38 @@ export class AlertingPlugin {
         if (!(ruleType.minimumLicenseRequired in LICENSE_TYPE)) {
           throw new Error(`"${ruleType.minimumLicenseRequired}" is not a valid license type`);
         }
+
+        // validate cancelAlertsOnTimeout if set explicitly on the rule type definition
+        if (
+          ruleType.cancelAlertsOnRuleTimeout === false &&
+          (ruleType.autoRecoverAlerts == null || ruleType.autoRecoverAlerts === true)
+        ) {
+          throw new Error(
+            `Rule type "${ruleType.id}" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true.`
+          );
+        }
+
         ruleType.ruleTaskTimeout = getRuleTaskTimeout({
           config: this.config.rules,
           ruleTaskTimeout: ruleType.ruleTaskTimeout,
           ruleTypeId: ruleType.id,
         });
-        ruleType.cancelAlertsOnRuleTimeout =
-          ruleType.cancelAlertsOnRuleTimeout ?? this.config.cancelAlertsOnRuleTimeout;
         ruleType.doesSetRecoveryContext = ruleType.doesSetRecoveryContext ?? false;
         ruleType.autoRecoverAlerts = ruleType.autoRecoverAlerts ?? true;
+
+        if (
+          ruleType.autoRecoverAlerts === true &&
+          this.config.cancelAlertsOnRuleTimeout === false
+        ) {
+          this.logger.debug(
+            `Setting xpack.alerting.cancelAlertsOnRuleTimeout=false is incompatible with rule type "${ruleType.id}" and will be ignored.`
+          );
+          ruleType.cancelAlertsOnRuleTimeout = true;
+        } else {
+          ruleType.cancelAlertsOnRuleTimeout =
+            ruleType.cancelAlertsOnRuleTimeout ?? this.config.cancelAlertsOnRuleTimeout;
+        }
+
         ruleTypeRegistry.register(ruleType);
       },
       getSecurityHealth: async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/plugin_cancel_alerts_on_rule_timeout.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin_cancel_alerts_on_rule_timeout.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AlertingServerSetup } from './plugin';
+import { AlertingPlugin } from './plugin';
+import {
+  type PluginInitializerContextMock,
+  coreMock,
+  statusServiceMock,
+} from '@kbn/core/server/mocks';
+import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { eventLogServiceMock } from '@kbn/event-log-plugin/server/event_log_service.mock';
+import { featuresPluginMock } from '@kbn/features-plugin/server/mocks';
+import type { AlertingConfig } from './config';
+import type { RuleType } from './types';
+import { actionsMock } from '@kbn/actions-plugin/server/mocks';
+import { dataPluginMock } from '@kbn/data-plugin/server/mocks';
+import { dataPluginMock as autocompletePluginMock } from '@kbn/unified-search-plugin/server/mocks';
+import { monitoringCollectionMock } from '@kbn/monitoring-collection-plugin/server/mocks';
+import type { PluginSetup as DataPluginSetup } from '@kbn/data-plugin/server';
+import { alertsServiceMock } from './alerts_service/alerts_service.mock';
+
+const mockAlertService = alertsServiceMock.create();
+jest.mock('./alerts_service/alerts_service', () => ({
+  AlertsService: jest.fn().mockImplementation(() => mockAlertService),
+}));
+import { generateAlertingConfig } from './test_utils';
+
+const sampleRuleType: RuleType<never, never, {}, never, never, 'default', 'recovered', {}> = {
+  id: 'test',
+  name: 'test',
+  minimumLicenseRequired: 'basic',
+  isExportable: true,
+  actionGroups: [],
+  defaultActionGroupId: 'default',
+  category: 'test',
+  producer: 'test',
+  solution: 'stack',
+  async executor() {
+    return { state: {} };
+  },
+  validate: {
+    params: { validate: (params) => params },
+  },
+};
+
+describe('Alerting Plugin - cancelAlertsOnRuleTimeout', () => {
+  describe('registerType()', () => {
+    const encryptedSavedObjectsSetup = encryptedSavedObjectsMock.createSetup({ canEncrypt: true });
+    const setupMocks = coreMock.createSetup();
+    const mockPlugins = {
+      licensing: licensingMock.createSetup(),
+      encryptedSavedObjects: encryptedSavedObjectsSetup,
+      taskManager: taskManagerMock.createSetup(),
+      eventLog: eventLogServiceMock.create(),
+      actions: actionsMock.createSetup(),
+      statusService: statusServiceMock.createSetupContract(),
+      monitoringCollection: monitoringCollectionMock.createSetup(),
+      data: dataPluginMock.createSetupContract() as unknown as DataPluginSetup,
+      features: featuresPluginMock.createSetup(),
+      unifiedSearch: autocompletePluginMock.createSetupContract(),
+    };
+
+    let context: PluginInitializerContextMock<AlertingConfig>;
+    let plugin: AlertingPlugin;
+    let setup: AlertingServerSetup;
+
+    async function setupHelper(configOverwrites = {}) {
+      context = coreMock.createPluginInitializerContext<AlertingConfig>(
+        generateAlertingConfig(configOverwrites)
+      );
+      plugin = new AlertingPlugin(context);
+      setup = plugin.setup(setupMocks, mockPlugins);
+      await waitForSetupComplete(setupMocks);
+    }
+
+    beforeEach(() => jest.clearAllMocks());
+
+    for (const cancelAlertsOnRuleTimeoutInConfig of [true, false]) {
+      describe(`xpack.alerting.cancelAlertsOnRuleTimeout=${cancelAlertsOnRuleTimeoutInConfig}`, () => {
+        beforeEach(async () => {
+          await setupHelper({ cancelAlertsOnRuleTimeout: cancelAlertsOnRuleTimeoutInConfig });
+        });
+        describe('should prioritize explicit settings on rule type definition', () => {
+          it('should register rule type when autoRecoverAlerts=true and cancelAlertsOnRuleTimeout=true', async () => {
+            setup.registerType({
+              ...sampleRuleType,
+              autoRecoverAlerts: true,
+              cancelAlertsOnRuleTimeout: true,
+            });
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').id).toBe('test');
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').autoRecoverAlerts).toBe(true);
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').cancelAlertsOnRuleTimeout).toBe(true);
+          });
+          it('should throw when autoRecoverAlerts=true and cancelAlertsOnRuleTimeout=false', async () => {
+            expect(() =>
+              setup.registerType({
+                ...sampleRuleType,
+                autoRecoverAlerts: true,
+                cancelAlertsOnRuleTimeout: false,
+              })
+            ).toThrowErrorMatchingInlineSnapshot(
+              `"Rule type \\"test\\" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true."`
+            );
+          });
+          it('should register rule type when autoRecoverAlerts=false and cancelAlertsOnRuleTimeout=true', async () => {
+            setup.registerType({
+              ...sampleRuleType,
+              autoRecoverAlerts: false,
+              cancelAlertsOnRuleTimeout: true,
+            });
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').id).toBe('test');
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').autoRecoverAlerts).toBe(false);
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').cancelAlertsOnRuleTimeout).toBe(true);
+          });
+          it('should register rule type when autoRecoverAlerts=false and cancelAlertsOnRuleTimeout=false', async () => {
+            setup.registerType({
+              ...sampleRuleType,
+              autoRecoverAlerts: false,
+              cancelAlertsOnRuleTimeout: false,
+            });
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').id).toBe('test');
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').autoRecoverAlerts).toBe(false);
+            // @ts-expect-error: private properties cannot be accessed
+            expect(plugin.ruleTypeRegistry.get('test').cancelAlertsOnRuleTimeout).toBe(false);
+          });
+        });
+
+        it('should log warning when config is set to false', async () => {
+          if (cancelAlertsOnRuleTimeoutInConfig === false) {
+            expect(context.logger.get().warn).toHaveBeenCalledWith(
+              `Setting xpack.alerting.cancelAlertsOnRuleTimeout=false can lead to unexpected behavior for certain rule types. This setting will be deprecated in a future version and will be ignored for rule types that do not support it.`
+            );
+          } else {
+            expect(context.logger.get().warn).not.toHaveBeenCalled();
+          }
+        });
+
+        it('should register lifecycle rule type', async () => {
+          setup.registerType({
+            ...sampleRuleType,
+            autoRecoverAlerts: true,
+          });
+          // @ts-expect-error: private properties cannot be accessed
+          expect(plugin.ruleTypeRegistry.get('test').id).toBe('test');
+          // @ts-expect-error: private properties cannot be accessed
+          expect(plugin.ruleTypeRegistry.get('test').autoRecoverAlerts).toBe(true);
+          // @ts-expect-error: private properties cannot be accessed
+
+          // this is registered as true even if config is set to false
+          expect(plugin.ruleTypeRegistry.get('test').cancelAlertsOnRuleTimeout).toBe(true);
+
+          if (cancelAlertsOnRuleTimeoutInConfig) {
+            expect(context.logger.get().debug).not.toHaveBeenCalled();
+          } else {
+            expect(context.logger.get().debug).toHaveBeenCalledWith(
+              `Setting xpack.alerting.cancelAlertsOnRuleTimeout=false is incompatible with rule type \"test\" and will be ignored.`
+            );
+          }
+        });
+
+        it('should register non-lifecycle rule type', async () => {
+          setup.registerType({
+            ...sampleRuleType,
+            autoRecoverAlerts: false,
+          });
+          // @ts-expect-error: private properties cannot be accessed
+          expect(plugin.ruleTypeRegistry.get('test').id).toBe('test');
+          // @ts-expect-error: private properties cannot be accessed
+          expect(plugin.ruleTypeRegistry.get('test').autoRecoverAlerts).toBe(false);
+          // @ts-expect-error: private properties cannot be accessed
+
+          // this should match the config value
+          expect(plugin.ruleTypeRegistry.get('test').cancelAlertsOnRuleTimeout).toBe(
+            cancelAlertsOnRuleTimeoutInConfig
+          );
+
+          expect(context.logger.get().debug).not.toHaveBeenCalled();
+        });
+      });
+    }
+  });
+});
+
+type CoreSetupMocks = ReturnType<typeof coreMock.createSetup>;
+
+const WaitForSetupAttempts = 10;
+const WaitForSetupDelay = 200;
+const WaitForSetupSeconds = (WaitForSetupAttempts * WaitForSetupDelay) / 1000;
+
+// wait for setup to *really* complete: waiting for calls to
+// setupMocks.status.set, which needs to wait for core.getStartServices()
+export async function waitForSetupComplete(setupMocks: CoreSetupMocks) {
+  let attempts = 0;
+  while (setupMocks.status.set.mock.calls.length < 1) {
+    attempts++;
+    await new Promise((resolve) => setTimeout(resolve, WaitForSetupDelay));
+    if (attempts > WaitForSetupAttempts) {
+      throw new Error(`setupMocks.status.set was not called within ${WaitForSetupSeconds} seconds`);
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting/server/plugin_cancel_alerts_on_rule_timeout.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin_cancel_alerts_on_rule_timeout.test.ts
@@ -41,7 +41,6 @@ const sampleRuleType: RuleType<never, never, {}, never, never, 'default', 'recov
   defaultActionGroupId: 'default',
   category: 'test',
   producer: 'test',
-  solution: 'stack',
   async executor() {
     return { state: {} };
   },

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
@@ -750,63 +750,6 @@ describe('Create Lifecycle', () => {
       expect(registry.get('test').producer).toEqual('alerts');
     });
 
-    test('should throw an error if cancelAlertsOnRuleTimeout: false and autoRecoverAlerts: true', () => {
-      const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
-      expect(() =>
-        registry.register({
-          id: 'test',
-          name: 'Test',
-          actionGroups: [
-            {
-              id: 'default',
-              name: 'Default',
-            },
-          ],
-          defaultActionGroupId: 'default',
-          minimumLicenseRequired: 'basic',
-          isExportable: true,
-          executor: jest.fn(),
-          category: 'test',
-          producer: 'alerts',
-          validate: {
-            params: { validate: (params) => params },
-          },
-          cancelAlertsOnRuleTimeout: false,
-          autoRecoverAlerts: true,
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Rule type \\"test\\" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true."`
-      );
-    });
-
-    test('should throw an error if cancelAlertsOnRuleTimeout: false and autoRecoverAlerts is not set (defaults to true)', () => {
-      const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
-      expect(() =>
-        registry.register({
-          id: 'test',
-          name: 'Test',
-          actionGroups: [
-            {
-              id: 'default',
-              name: 'Default',
-            },
-          ],
-          defaultActionGroupId: 'default',
-          minimumLicenseRequired: 'basic',
-          isExportable: true,
-          executor: jest.fn(),
-          category: 'test',
-          producer: 'alerts',
-          validate: {
-            params: { validate: (params) => params },
-          },
-          cancelAlertsOnRuleTimeout: false,
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Rule type \\"test\\" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true."`
-      );
-    });
-
     test('registers rule if cancelAlertsOnRuleTimeout: true and autoRecoverAlerts: true', () => {
       const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
       registry.register({

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
@@ -277,22 +277,6 @@ export class RuleTypeRegistry {
       }
     }
 
-    // validate cancelAlertsOnTimeout if set
-    if (
-      ruleType.cancelAlertsOnRuleTimeout === false &&
-      (ruleType.autoRecoverAlerts == null || ruleType.autoRecoverAlerts === true)
-    ) {
-      throw new Error(
-        i18n.translate('xpack.alerting.ruleTypeRegistry.register.cancelAlertsOnTimeoutError', {
-          defaultMessage:
-            'Rule type "{id}" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true.',
-          values: {
-            id: ruleType.id,
-          },
-        })
-      );
-    }
-
     const normalizedRuleType = augmentActionGroupsWithReserved<
       Params,
       ExtractedParams,

--- a/x-pack/platform/plugins/shared/alerting/server/test_utils/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/test_utils/index.ts
@@ -48,7 +48,7 @@ export function alertsWithAnyUUID(
   return newAlerts;
 }
 
-export function generateAlertingConfig(): AlertingConfig {
+export function generateAlertingConfig(overwrites = {}): AlertingConfig {
   return {
     healthCheck: {
       interval: '5m',
@@ -72,5 +72,6 @@ export function generateAlertingConfig(): AlertingConfig {
       },
     },
     rulesSettings: { cacheInterval: 60000 },
+    ...overwrites,
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Response Ops][Alerting] Fixing issue with setting `cancelAlertsOnRuleTimeout=false` in kibana config (#222263)](https://github.com/elastic/kibana/pull/222263)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-06-05T01:58:47Z","message":"[Response Ops][Alerting] Fixing issue with setting `cancelAlertsOnRuleTimeout=false` in kibana config (#222263)\n\nFixing https://github.com/elastic/kibana/issues/222127\n\n## Summary\n\nFixes issue that causes Kibana to bootloop when\n`xpack.alerting.cancelAlertsOnRuleTimeout` is set to `false` in the\nkibana config.\n\nMoves the check for incompatible `cancelAlertsOnRuleTimeout` and\n`autoRecoverAlerts` rule type config to the plugin setup code because we\nmutate some of these values before registering. So now the check\nactually checks the values set by the rule type in the code. Then we\nproceed with merging some of these values with the Kibana config.\nBecause there are issues with lifecycle rule types when\n`cancelAlertsOnRuleTimeout` is set to false, we log a warning when we\nsee this override in the config and ignore the setting for lifecycle\nrule types. Persistent rule types (detection rules) will still respect\nthis config override if set.\n\nThere will be a followup issue to deprecate this config for 9.10 and\n8.19. This PR is to address the immediate bug.\n\n## To Verify\n1. Set `xpack.alerting.cancelAlertsOnRuleTimeout: false` in the Kibana\nconfig and start Kibana.\n2. Verify Kibana starts up correctly with no errors.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"69690c9bc58a1114ea7b56782dddae3c0b9caf46","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Alerting","Team:ResponseOps","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[Response Ops][Alerting] Fixing issue with setting `cancelAlertsOnRuleTimeout=false` in kibana config","number":222263,"url":"https://github.com/elastic/kibana/pull/222263","mergeCommit":{"message":"[Response Ops][Alerting] Fixing issue with setting `cancelAlertsOnRuleTimeout=false` in kibana config (#222263)\n\nFixing https://github.com/elastic/kibana/issues/222127\n\n## Summary\n\nFixes issue that causes Kibana to bootloop when\n`xpack.alerting.cancelAlertsOnRuleTimeout` is set to `false` in the\nkibana config.\n\nMoves the check for incompatible `cancelAlertsOnRuleTimeout` and\n`autoRecoverAlerts` rule type config to the plugin setup code because we\nmutate some of these values before registering. So now the check\nactually checks the values set by the rule type in the code. Then we\nproceed with merging some of these values with the Kibana config.\nBecause there are issues with lifecycle rule types when\n`cancelAlertsOnRuleTimeout` is set to false, we log a warning when we\nsee this override in the config and ignore the setting for lifecycle\nrule types. Persistent rule types (detection rules) will still respect\nthis config override if set.\n\nThere will be a followup issue to deprecate this config for 9.10 and\n8.19. This PR is to address the immediate bug.\n\n## To Verify\n1. Set `xpack.alerting.cancelAlertsOnRuleTimeout: false` in the Kibana\nconfig and start Kibana.\n2. Verify Kibana starts up correctly with no errors.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"69690c9bc58a1114ea7b56782dddae3c0b9caf46"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222263","number":222263,"mergeCommit":{"message":"[Response Ops][Alerting] Fixing issue with setting `cancelAlertsOnRuleTimeout=false` in kibana config (#222263)\n\nFixing https://github.com/elastic/kibana/issues/222127\n\n## Summary\n\nFixes issue that causes Kibana to bootloop when\n`xpack.alerting.cancelAlertsOnRuleTimeout` is set to `false` in the\nkibana config.\n\nMoves the check for incompatible `cancelAlertsOnRuleTimeout` and\n`autoRecoverAlerts` rule type config to the plugin setup code because we\nmutate some of these values before registering. So now the check\nactually checks the values set by the rule type in the code. Then we\nproceed with merging some of these values with the Kibana config.\nBecause there are issues with lifecycle rule types when\n`cancelAlertsOnRuleTimeout` is set to false, we log a warning when we\nsee this override in the config and ignore the setting for lifecycle\nrule types. Persistent rule types (detection rules) will still respect\nthis config override if set.\n\nThere will be a followup issue to deprecate this config for 9.10 and\n8.19. This PR is to address the immediate bug.\n\n## To Verify\n1. Set `xpack.alerting.cancelAlertsOnRuleTimeout: false` in the Kibana\nconfig and start Kibana.\n2. Verify Kibana starts up correctly with no errors.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"69690c9bc58a1114ea7b56782dddae3c0b9caf46"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/222729","number":222729,"state":"OPEN"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->