### PR TITLE
[ResponseOps] Cases analytics index synchronization

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.test.ts
@@ -187,7 +187,8 @@ describe('AnalyticsIndex', () => {
     expect(scheduleCAIBackfillTaskMock).toBeCalledTimes(0);
 
     expect(logger.debug).toBeCalledWith(
-      `[${indexName}] Mapping version is up to date. Skipping update.`
+      `[${indexName}] Mapping version is up to date. Skipping update.`,
+      { tags: ['cai-index-creation', `${indexName}`] }
     );
   });
 
@@ -204,7 +205,8 @@ describe('AnalyticsIndex', () => {
     expect(scheduleCAIBackfillTaskMock).toBeCalledTimes(0);
 
     expect(logger.debug).toBeCalledWith(
-      `[${indexName}] Mapping version is up to date. Skipping update.`
+      `[${indexName}] Mapping version is up to date. Skipping update.`,
+      { tags: ['cai-index-creation', `${indexName}`] }
     );
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.ts
@@ -122,10 +122,10 @@ export class AnalyticsIndex {
       const indexExists = await this.indexExists();
 
       if (!indexExists) {
-        this.handleDebug(`Index does not exist. Creating.`);
+        this.logDebug(`Index does not exist. Creating.`);
         await this.createIndexMapping();
       } else {
-        this.handleDebug(`Index exists. Updating mapping.`);
+        this.logDebug(`Index exists. Updating mapping.`);
         await this.updateIndexMapping();
       }
     } catch (error) {
@@ -140,7 +140,7 @@ export class AnalyticsIndex {
       if (shouldUpdateMapping) {
         await this.updateMapping();
       } else {
-        this.handleDebug(`Mapping version is up to date. Skipping update.`);
+        this.logDebug(`Mapping version is up to date. Skipping update.`);
       }
     } catch (error) {
       this.handleError('Failed to update the index mapping.', error);
@@ -154,24 +154,24 @@ export class AnalyticsIndex {
   }
 
   private async updateMapping() {
-    this.handleDebug(`Updating the painless script.`);
+    this.logDebug(`Updating the painless script.`);
     await this.putScript();
 
-    this.handleDebug(`Updating index mapping.`);
+    this.logDebug(`Updating index mapping.`);
     await this.esClient.indices.putMapping({
       index: this.indexName,
       ...this.mappings,
     });
 
-    this.handleDebug(`Scheduling the backfill task.`);
+    this.logDebug(`Scheduling the backfill task.`);
     await this.scheduleBackfillTask();
   }
 
   private async createIndexMapping() {
-    this.handleDebug(`Creating painless script.`);
+    this.logDebug(`Creating painless script.`);
     await this.putScript();
 
-    this.handleDebug(`Creating index.`);
+    this.logDebug(`Creating index.`);
     await this.esClient.indices.create({
       index: this.indexName,
       timeout: CAI_DEFAULT_TIMEOUT,
@@ -181,12 +181,12 @@ export class AnalyticsIndex {
       },
     });
 
-    this.handleDebug(`Scheduling the backfill task.`);
+    this.logDebug(`Scheduling the backfill task.`);
     await this.scheduleBackfillTask();
   }
 
   private async indexExists(): Promise<boolean> {
-    this.handleDebug(`Checking if index exists.`);
+    this.logDebug(`Checking if index exists.`);
     return this.esClient.indices.exists({
       index: this.indexName,
     });
@@ -211,7 +211,7 @@ export class AnalyticsIndex {
     indexVersion: number;
     painlessScriptId: string;
   }): MappingMeta {
-    this.handleDebug(
+    this.logDebug(
       `Construction mapping._meta. Index version: ${indexVersion}. Painless script: ${painlessScriptId}.`
     );
 
@@ -221,7 +221,7 @@ export class AnalyticsIndex {
     };
   }
 
-  public handleDebug(message: string) {
+  public logDebug(message: string) {
     this.logger.debug(`[${this.indexName}] ${message}`, {
       tags: ['cai-index-creation', this.indexName],
     });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
@@ -35,3 +35,48 @@ export const CAI_ATTACHMENTS_SOURCE_QUERY: QueryDslQueryContainer = {
 export const CAI_ATTACHMENTS_SOURCE_INDEX = ALERTING_CASES_SAVED_OBJECT_INDEX;
 
 export const CAI_ATTACHMENTS_BACKFILL_TASK_ID = 'cai_attachments_backfill_task';
+
+export const CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID = 'cai_cases_attachments_synchronization_task';
+
+export const getAttachmentsSynchronizationSourceQuery = (
+  lastSyncAt: Date
+): QueryDslQueryContainer => ({
+  bool: {
+    must: [
+      {
+        term: {
+          type: 'cases-comments',
+        },
+      },
+      {
+        bool: {
+          must_not: {
+            term: {
+              'cases-comments.type': 'user',
+            },
+          },
+        },
+      },
+      {
+        bool: {
+          should: [
+            {
+              range: {
+                'cases-comments.created_at': {
+                  gte: lastSyncAt.toISOString(),
+                },
+              },
+            },
+            {
+              range: {
+                'cases-comments.updated_at': {
+                  gte: lastSyncAt.toISOString(),
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
@@ -14,9 +14,11 @@ import {
   CAI_ATTACHMENTS_SOURCE_INDEX,
   CAI_ATTACHMENTS_SOURCE_QUERY,
   CAI_ATTACHMENTS_BACKFILL_TASK_ID,
+  CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID,
 } from './constants';
 import { CAI_ATTACHMENTS_INDEX_MAPPINGS } from './mappings';
 import { CAI_ATTACHMENTS_INDEX_SCRIPT, CAI_ATTACHMENTS_INDEX_SCRIPT_ID } from './painless_scripts';
+import { scheduleCAISynchronizationTask } from '../tasks/synchronization_task';
 
 export const createAttachmentsAnalyticsIndex = ({
   esClient,
@@ -43,3 +45,25 @@ export const createAttachmentsAnalyticsIndex = ({
     sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
     sourceQuery: CAI_ATTACHMENTS_SOURCE_QUERY,
   });
+
+export const scheduleAttachmentsAnalyticsSyncTask = ({
+  taskManager,
+  logger,
+}: {
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+}) => {
+  try {
+    scheduleCAISynchronizationTask({
+      taskId: CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID,
+      sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
+      destIndex: CAI_ATTACHMENTS_INDEX_NAME,
+      taskManager,
+      logger,
+    });
+  } catch (e) {
+    logger.error(
+      `Error scheduling ${CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID} task, received ${e.message}`
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
@@ -53,17 +53,15 @@ export const scheduleAttachmentsAnalyticsSyncTask = ({
   taskManager: TaskManagerStartContract;
   logger: Logger;
 }) => {
-  try {
-    scheduleCAISynchronizationTask({
-      taskId: CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID,
-      sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
-      destIndex: CAI_ATTACHMENTS_INDEX_NAME,
-      taskManager,
-      logger,
-    });
-  } catch (e) {
+  scheduleCAISynchronizationTask({
+    taskId: CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID,
+    sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
+    destIndex: CAI_ATTACHMENTS_INDEX_NAME,
+    taskManager,
+    logger,
+  }).catch((e) => {
     logger.error(
       `Error scheduling ${CAI_ATTACHMENTS_SYNCHRONIZATION_TASK_ID} task, received ${e.message}`
     );
-  }
+  });
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
@@ -22,3 +22,37 @@ export const CAI_CASES_SOURCE_QUERY: QueryDslQueryContainer = {
 export const CAI_CASES_SOURCE_INDEX = ALERTING_CASES_SAVED_OBJECT_INDEX;
 
 export const CAI_CASES_BACKFILL_TASK_ID = 'cai_cases_backfill_task';
+
+export const CAI_CASES_SYNCHRONIZATION_TASK_ID = 'cai_cases_synchronization_task';
+
+export const getCasesSynchronizationSourceQuery = (lastSyncAt: Date): QueryDslQueryContainer => ({
+  bool: {
+    must: [
+      {
+        term: {
+          type: 'cases',
+        },
+      },
+      {
+        bool: {
+          should: [
+            {
+              range: {
+                'cases.created_at': {
+                  gte: lastSyncAt.toISOString(),
+                },
+              },
+            },
+            {
+              range: {
+                'cases.updated_at': {
+                  gte: lastSyncAt.toISOString(),
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
@@ -53,17 +53,15 @@ export const scheduleCasesAnalyticsSyncTask = ({
   taskManager: TaskManagerStartContract;
   logger: Logger;
 }) => {
-  try {
-    scheduleCAISynchronizationTask({
-      taskId: CAI_CASES_SYNCHRONIZATION_TASK_ID,
-      sourceIndex: CAI_CASES_SOURCE_INDEX,
-      destIndex: CAI_CASES_INDEX_NAME,
-      taskManager,
-      logger,
-    });
-  } catch (e) {
+  scheduleCAISynchronizationTask({
+    taskId: CAI_CASES_SYNCHRONIZATION_TASK_ID,
+    sourceIndex: CAI_CASES_SOURCE_INDEX,
+    destIndex: CAI_CASES_INDEX_NAME,
+    taskManager,
+    logger,
+  }).catch((e) => {
     logger.error(
       `Error scheduling ${CAI_CASES_SYNCHRONIZATION_TASK_ID} task, received ${e.message}`
     );
-  }
+  });
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
@@ -14,9 +14,11 @@ import {
   CAI_CASES_SOURCE_INDEX,
   CAI_CASES_SOURCE_QUERY,
   CAI_CASES_BACKFILL_TASK_ID,
+  CAI_CASES_SYNCHRONIZATION_TASK_ID,
 } from './constants';
 import { CAI_CASES_INDEX_MAPPINGS } from './mappings';
 import { CAI_CASES_INDEX_SCRIPT_ID, CAI_CASES_INDEX_SCRIPT } from './painless_scripts';
+import { scheduleCAISynchronizationTask } from '../tasks/synchronization_task';
 
 export const createCasesAnalyticsIndex = ({
   esClient,
@@ -43,3 +45,25 @@ export const createCasesAnalyticsIndex = ({
     sourceIndex: CAI_CASES_SOURCE_INDEX,
     sourceQuery: CAI_CASES_SOURCE_QUERY,
   });
+
+export const scheduleCasesAnalyticsSyncTask = ({
+  taskManager,
+  logger,
+}: {
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+}) => {
+  try {
+    scheduleCAISynchronizationTask({
+      taskId: CAI_CASES_SYNCHRONIZATION_TASK_ID,
+      sourceIndex: CAI_CASES_SOURCE_INDEX,
+      destIndex: CAI_CASES_INDEX_NAME,
+      taskManager,
+      logger,
+    });
+  } catch (e) {
+    logger.error(
+      `Error scheduling ${CAI_CASES_SYNCHRONIZATION_TASK_ID} task, received ${e.message}`
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
@@ -33,3 +33,44 @@ export const CAI_COMMENTS_SOURCE_QUERY: QueryDslQueryContainer = {
 export const CAI_COMMENTS_SOURCE_INDEX = ALERTING_CASES_SAVED_OBJECT_INDEX;
 
 export const CAI_COMMENTS_BACKFILL_TASK_ID = 'cai_comments_backfill_task';
+
+export const CAI_COMMENTS_SYNCHRONIZATION_TASK_ID = 'cai_cases_comments_synchronization_task';
+
+export const getCommentsSynchronizationSourceQuery = (
+  lastSyncAt: Date
+): QueryDslQueryContainer => ({
+  bool: {
+    must: [
+      {
+        term: {
+          'cases-comments.type': 'user',
+        },
+      },
+      {
+        term: {
+          type: 'cases-comments',
+        },
+      },
+      {
+        bool: {
+          should: [
+            {
+              range: {
+                'cases-comments.created_at': {
+                  gte: lastSyncAt.toISOString(),
+                },
+              },
+            },
+            {
+              range: {
+                'cases-comments.updated_at': {
+                  gte: lastSyncAt.toISOString(),
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
@@ -53,17 +53,15 @@ export const scheduleCommentsAnalyticsSyncTask = ({
   taskManager: TaskManagerStartContract;
   logger: Logger;
 }) => {
-  try {
-    scheduleCAISynchronizationTask({
-      taskId: CAI_COMMENTS_SYNCHRONIZATION_TASK_ID,
-      sourceIndex: CAI_COMMENTS_SOURCE_INDEX,
-      destIndex: CAI_COMMENTS_INDEX_NAME,
-      taskManager,
-      logger,
-    });
-  } catch (e) {
+  scheduleCAISynchronizationTask({
+    taskId: CAI_COMMENTS_SYNCHRONIZATION_TASK_ID,
+    sourceIndex: CAI_COMMENTS_SOURCE_INDEX,
+    destIndex: CAI_COMMENTS_INDEX_NAME,
+    taskManager,
+    logger,
+  }).catch((e) => {
     logger.error(
       `Error scheduling ${CAI_COMMENTS_SYNCHRONIZATION_TASK_ID} task, received ${e.message}`
     );
-  }
+  });
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
@@ -14,9 +14,11 @@ import {
   CAI_COMMENTS_SOURCE_INDEX,
   CAI_COMMENTS_SOURCE_QUERY,
   CAI_COMMENTS_BACKFILL_TASK_ID,
+  CAI_COMMENTS_SYNCHRONIZATION_TASK_ID,
 } from './constants';
 import { CAI_COMMENTS_INDEX_MAPPINGS } from './mappings';
 import { CAI_COMMENTS_INDEX_SCRIPT, CAI_COMMENTS_INDEX_SCRIPT_ID } from './painless_scripts';
+import { scheduleCAISynchronizationTask } from '../tasks/synchronization_task';
 
 export const createCommentsAnalyticsIndex = ({
   esClient,
@@ -43,3 +45,25 @@ export const createCommentsAnalyticsIndex = ({
     sourceIndex: CAI_COMMENTS_SOURCE_INDEX,
     sourceQuery: CAI_COMMENTS_SOURCE_QUERY,
   });
+
+export const scheduleCommentsAnalyticsSyncTask = ({
+  taskManager,
+  logger,
+}: {
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+}) => {
+  try {
+    scheduleCAISynchronizationTask({
+      taskId: CAI_COMMENTS_SYNCHRONIZATION_TASK_ID,
+      sourceIndex: CAI_COMMENTS_SOURCE_INDEX,
+      destIndex: CAI_COMMENTS_INDEX_NAME,
+      taskManager,
+      logger,
+    });
+  } catch (e) {
+    logger.error(
+      `Error scheduling ${CAI_COMMENTS_SYNCHRONIZATION_TASK_ID} task, received ${e.message}`
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/constants.ts
@@ -5,6 +5,18 @@
  * 2.0.
  */
 
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+
+import {
+  CAI_ATTACHMENTS_INDEX_NAME,
+  getAttachmentsSynchronizationSourceQuery,
+} from './attachments_index/constants';
+import { CAI_CASES_INDEX_NAME, getCasesSynchronizationSourceQuery } from './cases_index/constants';
+import {
+  CAI_COMMENTS_INDEX_NAME,
+  getCommentsSynchronizationSourceQuery,
+} from './comments_index/constants';
+
 export const CAI_NUMBER_OF_SHARDS = 1;
 /** Allocate 1 replica if there are enough data nodes, otherwise continue with 0 */
 export const CAI_AUTO_EXPAND_REPLICAS = '0-1';
@@ -21,3 +33,12 @@ export const CAI_INDEX_MODE = 'lookup';
  * request or response sent over the socket it will be dropped after 60s.
  */
 export const CAI_DEFAULT_TIMEOUT = '300s';
+
+export const SYNCHRONIZATION_QUERIES_DICTIONARY: Record<
+  string,
+  (lastSyncAt: Date) => QueryDslQueryContainer
+> = {
+  [CAI_CASES_INDEX_NAME]: getCasesSynchronizationSourceQuery,
+  [CAI_COMMENTS_INDEX_NAME]: getCommentsSynchronizationSourceQuery,
+  [CAI_ATTACHMENTS_INDEX_NAME]: getAttachmentsSynchronizationSourceQuery,
+};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
@@ -12,9 +12,13 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { CasesServerStartDependencies } from '../types';
 import { registerCAIBackfillTask } from './tasks/backfill_task';
-import { createCasesAnalyticsIndex } from './cases_index';
-import { createCommentsAnalyticsIndex } from './comments_index';
-import { createAttachmentsAnalyticsIndex } from './attachments_index';
+import { registerCAISynchronizationTask } from './tasks/synchronization_task';
+import {
+  createAttachmentsAnalyticsIndex,
+  scheduleAttachmentsAnalyticsSyncTask,
+} from './attachments_index';
+import { createCasesAnalyticsIndex, scheduleCasesAnalyticsSyncTask } from './cases_index';
+import { createCommentsAnalyticsIndex, scheduleCommentsAnalyticsSyncTask } from './comments_index';
 
 export const createCasesAnalyticsIndexes = ({
   esClient,
@@ -53,7 +57,7 @@ export const createCasesAnalyticsIndexes = ({
   ]);
 };
 
-export const registerCasesAnalyticsIndicesTasks = ({
+export const registerCasesAnalyticsIndexesTasks = ({
   taskManager,
   logger,
   core,
@@ -63,4 +67,17 @@ export const registerCasesAnalyticsIndicesTasks = ({
   core: CoreSetup<CasesServerStartDependencies>;
 }) => {
   registerCAIBackfillTask({ taskManager, logger, core });
+  registerCAISynchronizationTask({ taskManager, logger, core });
+};
+
+export const scheduleCasesAnalyticsSyncTasks = ({
+  taskManager,
+  logger,
+}: {
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+}) => {
+  scheduleCasesAnalyticsSyncTask({ taskManager, logger });
+  scheduleCommentsAnalyticsSyncTask({ taskManager, logger });
+  scheduleAttachmentsAnalyticsSyncTask({ taskManager, logger });
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.test.ts
@@ -39,7 +39,7 @@ describe('BackfillTaskRunner', () => {
       source: 'ctx._source.remove("foobar");',
     };
 
-    esClient.indices.getMapping.mockResolvedValueOnce({
+    esClient.indices.getMapping.mockResolvedValue({
       [destIndex]: {
         mappings: {
           _meta: {
@@ -79,7 +79,9 @@ describe('BackfillTaskRunner', () => {
         query: sourceQuery,
       },
       dest: { index: destIndex },
-      script: painlessScript,
+      script: {
+        id: painlessScriptId,
+      },
       refresh: true,
     });
     expect(result).toEqual({ state: {} });
@@ -114,8 +116,8 @@ describe('BackfillTaskRunner', () => {
       });
 
       expect(logger.error).toBeCalledWith(
-        'Backfill reindex of .dest-index failed. Error: My retryable error',
-        { tags: ['backfill-run-failed', 'framework-error'] }
+        '[.dest-index] Backfill reindex failed. Error: My retryable error',
+        { tags: ['cai-backfill', 'cai-backfill-error', '.dest-index'] }
       );
     });
 
@@ -138,8 +140,8 @@ describe('BackfillTaskRunner', () => {
       }
 
       expect(logger.error).toBeCalledWith(
-        'Backfill reindex of .dest-index failed. Error: My unrecoverable error',
-        { tags: ['backfill-run-failed', 'framework-error'] }
+        '[.dest-index] Backfill reindex failed. Error: My unrecoverable error',
+        { tags: ['cai-backfill', 'cai-backfill-error', '.dest-index'] }
       );
     });
   });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.ts
@@ -75,7 +75,7 @@ export class BackfillTaskRunner implements CancellableTask {
     const painlessScript = await this.getPainlessScript(esClient);
 
     if (painlessScript.found) {
-      this.handleDebug(`Reindexing from ${this.sourceIndex} to ${this.destIndex}.`);
+      this.logDebug(`Reindexing from ${this.sourceIndex} to ${this.destIndex}.`);
       const painlessScriptId = await this.getPainlessScriptId(esClient);
 
       await esClient.reindex({
@@ -101,7 +101,7 @@ export class BackfillTaskRunner implements CancellableTask {
   private async getPainlessScript(esClient: ElasticsearchClient) {
     const painlessScriptId = await this.getPainlessScriptId(esClient);
 
-    this.handleDebug(`Getting painless script with id ${painlessScriptId}.`);
+    this.logDebug(`Getting painless script with id ${painlessScriptId}.`);
     return esClient.getScript({
       id: painlessScriptId,
     });
@@ -124,14 +124,14 @@ export class BackfillTaskRunner implements CancellableTask {
   private async getCurrentMapping(
     esClient: ElasticsearchClient
   ): Promise<IndicesGetMappingResponse> {
-    this.handleDebug('Getting index mapping.');
+    this.logDebug('Getting index mapping.');
     return esClient.indices.getMapping({
       index: this.destIndex,
     });
   }
 
   private async waitForDestIndex(esClient: ElasticsearchClient) {
-    this.handleDebug('Checking index availability.');
+    this.logDebug('Checking index availability.');
     return esClient.cluster.health({
       index: this.destIndex,
       wait_for_status: 'green',
@@ -140,7 +140,7 @@ export class BackfillTaskRunner implements CancellableTask {
     });
   }
 
-  public handleDebug(message: string) {
+  public logDebug(message: string) {
     this.logger.debug(`[${this.destIndex}] ${message}`, {
       tags: ['cai-backfill', this.destIndex],
     });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type {
+  IntervalSchedule,
+  RunContext,
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
+import type { CasesServerStartDependencies } from '../../../types';
+import { AnalyticsIndexSynchronizationTaskFactory } from './synchronization_task_factory';
+
+const TASK_TYPE = 'cai:cases_analytics_index_synchronization';
+const SCHEDULE: IntervalSchedule = { interval: '1m' };
+
+export function registerCAISynchronizationTask({
+  taskManager,
+  logger,
+  core,
+}: {
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+  core: CoreSetup<CasesServerStartDependencies>;
+}) {
+  const getESClient = async (): Promise<ElasticsearchClient> => {
+    const [{ elasticsearch }] = await core.getStartServices();
+    return elasticsearch.client.asInternalUser;
+  };
+
+  taskManager.registerTaskDefinitions({
+    [TASK_TYPE]: {
+      title: 'Synchronization for the cases analytics index',
+      createTaskRunner: (context: RunContext) => {
+        return new AnalyticsIndexSynchronizationTaskFactory({ getESClient, logger }).create(
+          context
+        );
+      },
+    },
+  });
+}
+
+export async function scheduleCAISynchronizationTask({
+  taskId,
+  sourceIndex,
+  destIndex,
+  taskManager,
+  logger,
+}: {
+  taskId: string;
+  sourceIndex: string;
+  destIndex: string;
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+}) {
+  try {
+    await taskManager.ensureScheduled({
+      id: taskId,
+      taskType: TASK_TYPE,
+      params: { sourceIndex, destIndex },
+      schedule: SCHEDULE, // every 5 minutes
+      state: {},
+    });
+  } catch (e) {
+    logger.error(`Error scheduling ${taskId} task, received ${e.message}`);
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
@@ -17,7 +17,7 @@ import type { CasesServerStartDependencies } from '../../../types';
 import { AnalyticsIndexSynchronizationTaskFactory } from './synchronization_task_factory';
 
 const TASK_TYPE = 'cai:cases_analytics_index_synchronization';
-const SCHEDULE: IntervalSchedule = { interval: '1m' };
+const SCHEDULE: IntervalSchedule = { interval: '5m' };
 
 export function registerCAISynchronizationTask({
   taskManager,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
@@ -45,6 +45,9 @@ export function registerCAISynchronizationTask({
   });
 }
 
+/**
+ * @param {destIndex} string Should be a key of SYNCHRONIZATION_QUERIES_DICTIONARY
+ */
 export async function scheduleCAISynchronizationTask({
   taskId,
   sourceIndex,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_factory.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { Logger } from '@kbn/logging';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { RunContext } from '@kbn/task-manager-plugin/server';
+import { SynchronizationTaskRunner } from './synchronization_task_runner';
+
+interface AnalyticsIndexSynchronizationTaskFactoryParams {
+  logger: Logger;
+  getESClient: () => Promise<ElasticsearchClient>;
+}
+
+export class AnalyticsIndexSynchronizationTaskFactory {
+  private readonly logger: Logger;
+  private readonly getESClient: () => Promise<ElasticsearchClient>;
+
+  constructor({ logger, getESClient }: AnalyticsIndexSynchronizationTaskFactoryParams) {
+    this.logger = logger;
+    this.getESClient = getESClient;
+  }
+
+  public create(context: RunContext) {
+    return new SynchronizationTaskRunner({
+      taskInstance: context.taskInstance,
+      logger: this.logger,
+      getESClient: this.getESClient,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { errors as esErrors } from '@elastic/elasticsearch';
+
+import { SynchronizationTaskRunner } from './synchronization_task_runner';
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import { isRetryableError } from '@kbn/task-manager-plugin/server/task_running';
+
+describe('SynchronizationTaskRunner', () => {
+  const logger = loggingSystemMock.createLogger();
+  const sourceIndex = '.source-index';
+  const destIndex = '.dest-index';
+  const sourceQuery = 'source-query';
+  const taskInstance = {
+    params: {
+      sourceIndex,
+      destIndex,
+      sourceQuery,
+    },
+  } as unknown as ConcreteTaskInstance;
+
+  let taskRunner: SynchronizationTaskRunner;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reindexes as expected', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    const painlessScriptId = 'painlessScriptId';
+    const painlessScript = {
+      lang: 'painless',
+      source: 'ctx._source.remove("foobar");',
+    };
+
+    esClient.indices.getMapping.mockResolvedValueOnce({
+      [destIndex]: {
+        mappings: {
+          _meta: {
+            painless_script_id: painlessScriptId,
+          },
+        },
+      },
+    });
+
+    esClient.getScript.mockResolvedValueOnce({
+      found: true,
+      _id: painlessScriptId,
+      script: painlessScript,
+    });
+
+    const getESClient = async () => esClient;
+
+    taskRunner = new SynchronizationTaskRunner({
+      logger,
+      getESClient,
+      taskInstance,
+    });
+
+    const result = await taskRunner.run();
+
+    expect(esClient.cluster.health).toBeCalledWith({
+      index: destIndex,
+      wait_for_status: 'green',
+      timeout: '300ms',
+      wait_for_active_shards: 'all',
+    });
+    expect(esClient.indices.getMapping).toBeCalledWith({ index: destIndex });
+    expect(esClient.getScript).toBeCalledWith({ id: painlessScriptId });
+    expect(esClient.reindex).toBeCalledWith({
+      source: {
+        index: sourceIndex,
+        query: sourceQuery,
+      },
+      dest: { index: destIndex },
+      script: painlessScript,
+      refresh: true,
+    });
+    expect(result).toEqual({ state: {} });
+  });
+
+  describe('Error handling', () => {
+    it('calls throwRetryableError if the esClient throws a retryable error', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.cluster.health.mockRejectedValueOnce(
+        new esErrors.ConnectionError('My retryable error')
+      );
+
+      const getESClient = async () => esClient;
+
+      taskRunner = new SynchronizationTaskRunner({
+        logger,
+        getESClient,
+        taskInstance,
+      });
+
+      try {
+        await taskRunner.run();
+      } catch (e) {
+        expect(isRetryableError(e)).toBe(true);
+      }
+
+      expect(esClient.cluster.health).toBeCalledWith({
+        index: destIndex,
+        wait_for_status: 'green',
+        timeout: '300ms',
+        wait_for_active_shards: 'all',
+      });
+
+      expect(logger.error).toBeCalledWith(
+        'Synchronization reindex of .dest-index failed. Error: My retryable error',
+        { tags: ['synchronization-run-failed', 'framework-error'] }
+      );
+    });
+
+    it('calls throwUnrecoverableError if execution throws a non-retryable error', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.cluster.health.mockRejectedValueOnce(new Error('My unrecoverable error'));
+
+      const getESClient = async () => esClient;
+
+      taskRunner = new SynchronizationTaskRunner({
+        logger,
+        getESClient,
+        taskInstance,
+      });
+
+      try {
+        await taskRunner.run();
+      } catch (e) {
+        expect(isRetryableError(e)).toBe(null);
+      }
+
+      expect(logger.error).toBeCalledWith(
+        'Synchronization reindex of .dest-index failed. Error: My unrecoverable error',
+        { tags: ['synchronization-run-failed', 'framework-error'] }
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
@@ -146,6 +146,7 @@ describe('SynchronizationTaskRunner', () => {
         id: painlessScriptId,
       },
       refresh: true,
+      wait_for_completion: false,
     });
 
     expect(result).toEqual({
@@ -225,6 +226,7 @@ describe('SynchronizationTaskRunner', () => {
         id: painlessScriptId,
       },
       refresh: true,
+      wait_for_completion: false,
     });
 
     expect(result).toEqual({
@@ -321,6 +323,7 @@ describe('SynchronizationTaskRunner', () => {
         id: painlessScriptId,
       },
       refresh: true,
+      wait_for_completion: false,
     });
 
     expect(result).toEqual({

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
@@ -31,7 +31,7 @@ describe('SynchronizationTaskRunner', () => {
   const lastSyncAttempt = new Date('2025-06-10T09:30:00.000Z');
   const newAttemptTime = new Date('2025-06-10T09:40:00.000Z');
 
-  const syncTaskId = 'foobar';
+  const esReindexTaskId = 'foobar';
 
   const taskInstance = {
     params: {
@@ -41,7 +41,7 @@ describe('SynchronizationTaskRunner', () => {
     state: {
       lastSyncSuccess,
       lastSyncAttempt,
-      syncTaskId,
+      esReindexTaskId,
     },
   } as unknown as ConcreteTaskInstance;
 
@@ -67,7 +67,7 @@ describe('SynchronizationTaskRunner', () => {
     });
 
     esClient.reindex.mockResolvedValue({
-      task: syncTaskId,
+      task: esReindexTaskId,
     });
   });
 
@@ -91,7 +91,7 @@ describe('SynchronizationTaskRunner', () => {
 
     const result = await taskRunner.run();
 
-    expect(esClient.tasks.get).toBeCalledWith({ task_id: syncTaskId });
+    expect(esClient.tasks.get).toBeCalledWith({ task_id: esReindexTaskId });
     expect(esClient.cluster.health).toBeCalledWith({
       index: destIndex,
       wait_for_status: 'green',
@@ -155,7 +155,7 @@ describe('SynchronizationTaskRunner', () => {
         lastSyncSuccess: lastSyncAttempt,
         // we set a new value for lastSyncAttempt
         lastSyncAttempt: newAttemptTime,
-        syncTaskId,
+        esReindexTaskId,
       },
     });
   });
@@ -233,7 +233,7 @@ describe('SynchronizationTaskRunner', () => {
       state: {
         lastSyncSuccess: undefined,
         lastSyncAttempt: newAttemptTime,
-        syncTaskId,
+        esReindexTaskId,
       },
     });
   });
@@ -332,7 +332,7 @@ describe('SynchronizationTaskRunner', () => {
         lastSyncSuccess,
         // we set a new value for lastSyncAttempt
         lastSyncAttempt: newAttemptTime,
-        syncTaskId,
+        esReindexTaskId,
       },
     });
   });
@@ -347,7 +347,7 @@ describe('SynchronizationTaskRunner', () => {
         taskInstance: {
           ...taskInstance,
           state: {
-            // A missing syncTaskId should have missing sync times
+            // A missing esReindexTaskId should have missing sync times
             lastSyncAttempt: 'some-time',
           },
         },

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.ts
@@ -37,7 +37,7 @@ enum ReindexStatus {
   MISSING_TASK_ID = 'missing_task_id',
 }
 
-const LOOKBACK_WINDOW = 5 * 60 * 1000;
+const LOOKBACK_WINDOW = 5 * 20 * 1000;
 
 export class SynchronizationTaskRunner implements CancellableTask {
   private readonly sourceIndex: string;
@@ -171,6 +171,8 @@ export class SynchronizationTaskRunner implements CancellableTask {
         },
         /** If `true`, the request refreshes affected shards to make this operation visible to search. */
         refresh: true,
+        /** Makes sure the task id is */
+        wait_for_completion: false,
       });
 
       this.handleDebug(JSON.stringify(reindexResponse));

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import {
+  createTaskRunError,
+  TaskErrorSource,
+  throwRetryableError,
+  throwUnrecoverableError,
+  type ConcreteTaskInstance,
+} from '@kbn/task-manager-plugin/server';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { CancellableTask } from '@kbn/task-manager-plugin/server/task';
+import type {
+  IndicesGetMappingResponse,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+import { isRetryableEsClientError } from '../../utils';
+import { SYNCHRONIZATION_QUERIES_DICTIONARY } from '../../constants';
+
+interface SynchronizationTaskRunnerFactoryConstructorParams {
+  taskInstance: ConcreteTaskInstance;
+  getESClient: () => Promise<ElasticsearchClient>;
+  logger: Logger;
+}
+
+type SynchronizationTaskState = Record<string, unknown>;
+
+enum ReindexStatus {
+  RUNNING = 0,
+  COMPLETED = 1,
+  FAILED = 2,
+  MISSING_TASK_ID = 3,
+}
+
+const LOOKBACK_WINDOW = 5 * 60 * 1000;
+
+export class SynchronizationTaskRunner implements CancellableTask {
+  private readonly sourceIndex: string;
+  private readonly destIndex: string;
+  private readonly sourceQuery: QueryDslQueryContainer;
+  private readonly getESClient: () => Promise<ElasticsearchClient>;
+  private readonly logger: Logger;
+  private readonly errorSource = TaskErrorSource.FRAMEWORK;
+  private readonly lastSyncedAt: Date | undefined;
+  private readonly syncTaskId: TaskId | undefined;
+
+  constructor({
+    taskInstance,
+    getESClient,
+    logger,
+  }: SynchronizationTaskRunnerFactoryConstructorParams) {
+    this.lastSyncedAt = taskInstance.state.lastSyncedAt;
+    this.syncTaskId = taskInstance.state.syncTaskId;
+    this.sourceIndex = taskInstance.params.sourceIndex;
+    this.destIndex = taskInstance.params.destIndex;
+
+    /**
+     * Ideally the different getSourceQuery functions would be part of the
+     * task instance parameters. This is not possible since the task instance
+     * is stored in ES and the function gets converted into string.
+     */
+    this.sourceQuery = SYNCHRONIZATION_QUERIES_DICTIONARY[this.destIndex](
+      new Date(this.lastSyncedAt ? this.lastSyncedAt : Date.now() - LOOKBACK_WINDOW) // TODO
+    );
+
+    this.getESClient = getESClient;
+    this.logger = logger;
+  }
+
+  public async run() {
+    const esClient = await this.getESClient();
+    let state: SynchronizationTaskState = {};
+
+    try {
+      const previousReindexStatus = await this.getPreviousReindexStatus(esClient);
+      this.logger.debug(`Previous synchronization task status ${previousReindexStatus}.`, {
+        tags: ['cai-synchronization', this.destIndex],
+      });
+
+      if (previousReindexStatus === ReindexStatus.RUNNING) {
+        state = this.getPreviousState();
+      } else if (
+        previousReindexStatus === ReindexStatus.COMPLETED ||
+        previousReindexStatus === ReindexStatus.MISSING_TASK_ID // probably the first task execution
+      ) {
+        if (await this.isIndexAvailable(esClient)) {
+          state = await this.synchronizeIndex(esClient);
+        } else {
+          state = this.getPreviousState();
+        }
+      } else {
+        // ReindexStatus.FAILED
+        // What to do?
+      }
+
+      return {
+        state,
+      };
+    } catch (e) {
+      this.logger.error(
+        `Synchronization reindex of ${this.destIndex} failed. Error: ${e.message}`,
+        {
+          tags: ['cai-synchronization', this.destIndex, `${this.errorSource}-error`],
+        }
+      );
+
+      if (isRetryableEsClientError(e)) {
+        throwRetryableError(
+          createTaskRunError(
+            new Error(`Synchronization reindex of ${this.destIndex} failed. Error: ${e.message}`),
+            this.errorSource
+          ),
+          true
+        );
+      }
+
+      throwUnrecoverableError(createTaskRunError(e, this.errorSource));
+    }
+  }
+
+  private async synchronizeIndex(esClient: ElasticsearchClient): Promise<SynchronizationTaskState> {
+    const painlessScript = await this.getPainlessScript(esClient);
+
+    if (painlessScript.found) {
+      this.logger.debug(`Reindexing from ${this.sourceIndex} to ${this.destIndex}.`);
+
+      const painlessScriptId = await this.getPainlessScriptId(esClient);
+      const lastSyncedAt = Date.now();
+
+      this.logger.debug(`Synchronizing ${this.destIndex} with ${this.sourceIndex}.`, {
+        tags: ['cai-synchronization', this.destIndex],
+      });
+
+      const reindexResponse = await esClient.reindex({
+        source: {
+          index: this.sourceIndex,
+          query: this.sourceQuery,
+        },
+        dest: { index: this.destIndex },
+        script: {
+          id: painlessScriptId,
+        },
+        /** If `true`, the request refreshes affected shards to make this operation visible to search. */
+        refresh: true,
+      });
+
+      return {
+        lastSyncedAt,
+        syncTaskId: reindexResponse.task,
+      };
+    } else {
+      throw createTaskRunError(
+        new Error(
+          `Synchronization reindex of ${this.destIndex} failed. Error: Painless script not found.`
+        ),
+        this.errorSource
+      );
+    }
+  }
+
+  private async getPainlessScript(esClient: ElasticsearchClient) {
+    const painlessScriptId = await this.getPainlessScriptId(esClient);
+
+    this.logger.debug(`Getting painless script with id ${painlessScriptId}.`, {
+      tags: ['cai-synchronization', this.destIndex],
+    });
+
+    return esClient.getScript({
+      id: painlessScriptId,
+    });
+  }
+
+  private getPreviousState(): SynchronizationTaskState {
+    return {
+      lastSyncedAt: this.lastSyncedAt,
+      syncTaskId: this.syncTaskId,
+    };
+  }
+
+  private async getPainlessScriptId(esClient: ElasticsearchClient): Promise<string> {
+    const mapping = await this.getMapping(esClient);
+    const painlessScriptId = mapping[this.destIndex].mappings._meta?.painless_script_id;
+
+    if (!painlessScriptId) {
+      throw createTaskRunError(
+        new Error(
+          `Synchronization reindex of ${this.destIndex} failed. Error: Painless script id missing from mapping.`
+        ),
+        this.errorSource
+      );
+    }
+
+    return painlessScriptId;
+  }
+
+  private async getMapping(esClient: ElasticsearchClient): Promise<IndicesGetMappingResponse> {
+    this.logger.debug(`Getting mapping of index ${this.destIndex}.`, {
+      tags: ['cai-synchronization', this.destIndex],
+    });
+
+    return esClient.indices.getMapping({
+      index: this.destIndex,
+    });
+  }
+
+  private async isIndexAvailable(esClient: ElasticsearchClient) {
+    this.logger.debug(`Checking ${this.destIndex} index availability.`, {
+      tags: ['cai-synchronization', this.destIndex],
+    });
+
+    return esClient.cluster.health({
+      index: this.destIndex,
+      wait_for_status: 'green',
+      timeout: '300ms', // this is probably too much
+      wait_for_active_shards: 'all',
+    });
+  }
+
+  private async getPreviousReindexStatus(esClient: ElasticsearchClient): Promise<ReindexStatus> {
+    this.logger.debug(
+      `Checking previous synchronization task status for index ${this.destIndex}.`,
+      {
+        tags: ['cai-synchronization', this.destIndex],
+      }
+    );
+
+    if (this.syncTaskId) {
+      const taskResponse = await esClient.tasks.get({ task_id: this.syncTaskId.toString() });
+
+      if (!taskResponse.completed) {
+        return ReindexStatus.RUNNING;
+      } else {
+        if (taskResponse.response?.failures?.length) {
+          return ReindexStatus.FAILED;
+        }
+        return ReindexStatus.COMPLETED;
+      }
+    }
+
+    return ReindexStatus.MISSING_TASK_ID;
+  }
+
+  public async cancel() {}
+}

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -47,7 +47,11 @@ import { registerCaseFileKinds } from './files';
 import type { ConfigType } from './config';
 import { registerConnectorTypes } from './connectors';
 import { registerSavedObjects } from './saved_object_types';
-import { createCasesAnalyticsIndexes, registerCasesAnalyticsIndicesTasks } from './cases_analytics';
+import {
+  createCasesAnalyticsIndexes,
+  registerCasesAnalyticsIndexesTasks,
+  scheduleCasesAnalyticsSyncTasks,
+} from './cases_analytics';
 
 export class CasePlugin
   implements
@@ -96,7 +100,7 @@ export class CasePlugin
     );
 
     registerCaseFileKinds(this.caseConfig.files, plugins.files, core.security.fips.isEnabled());
-    registerCasesAnalyticsIndicesTasks({
+    registerCasesAnalyticsIndexesTasks({
       taskManager: plugins.taskManager,
       logger: this.logger,
       core,
@@ -199,6 +203,7 @@ export class CasePlugin
 
     if (plugins.taskManager) {
       scheduleCasesTelemetryTask(plugins.taskManager, this.logger);
+      scheduleCasesAnalyticsSyncTasks({ taskManager: plugins.taskManager, logger: this.logger });
     }
 
     createCasesAnalyticsIndexes({

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -206,7 +206,7 @@ export class CasePlugin
       scheduleCasesAnalyticsSyncTasks({ taskManager: plugins.taskManager, logger: this.logger });
     }
 
-    createCasesAnalyticsIndexes({
+    void createCasesAnalyticsIndexes({
       esClient: core.elasticsearch.client.asInternalUser,
       logger: this.logger,
       isServerless: this.isServerless,

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -206,12 +206,12 @@ export class CasePlugin
       scheduleCasesAnalyticsSyncTasks({ taskManager: plugins.taskManager, logger: this.logger });
     }
 
-    void createCasesAnalyticsIndexes({
+    createCasesAnalyticsIndexes({
       esClient: core.elasticsearch.client.asInternalUser,
       logger: this.logger,
       isServerless: this.isServerless,
       taskManager: plugins.taskManager,
-    });
+    }).catch(() => {}); // it shouldn't reject, but just in case
 
     this.userProfileService.initialize({
       spaces: plugins.spaces,

--- a/x-pack/platform/plugins/shared/task_manager/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/mocks.ts
@@ -29,7 +29,7 @@ const createStartMock = () => {
     bulkRemove: jest.fn(),
     schedule: jest.fn(),
     runSoon: jest.fn(),
-    ensureScheduled: jest.fn(),
+    ensureScheduled: jest.fn().mockResolvedValue(Promise.resolve()), // it's a promise and there are some places where it's followed by `.catch()`
     removeIfExists: jest.fn().mockResolvedValue(Promise.resolve()), // it's a promise and there are some places where it's followed by `.catch()`
     bulkUpdateSchedules: jest.fn(),
     bulkSchedule: jest.fn(),

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -142,6 +142,8 @@ export default function ({ getService }: FtrProviderContext) {
         'apm-source-map-migration-task',
         'apm-telemetry-task',
         'cases-telemetry-task',
+        'cases:analytics_index_backfill',
+        'cases:analytics_index_synchronization',
         'cloud_security_posture-stats_task',
         'dashboard_telemetry',
         'endpoint:complete-external-response-actions',


### PR DESCRIPTION
Closes [#221232](https://github.com/elastic/kibana/issues/221232)

**Merging into a feature branch**

## Summary

This PR adds:
- Synchronization task registration.
- Synchronization task scheduling.
- Testing

## How to test

A few things are needed.

1. Create a role that has index creation permission. Below is what works for me; it might be overkill.
<img width="1030" alt="Screenshot 2025-04-25 at 11 30 45" src="https://github.com/user-attachments/assets/cbb7b384-e438-43ec-bbca-a18e62243523" />

2. Create a user with the role created in step 1. Let's call the user `index_creator`. **The password should be** `changeme`.
<img width="842" alt="Screenshot 2025-04-25 at 11 31 27" src="https://github.com/user-attachments/assets/a9547c96-086e-43b4-a442-a18f558dcb96" />

6. Start Kibana with this user as the Elasticsearch user - `yarn start` with the option `--elasticsearch.username=index_creator`.

7.  You can check the content of these indexes in the Dev Tools.
```
GET /.internal.cases/_search
GET /.internal.cases-comments/_search
GET /.internal.cases-attachments/_search
```

8. Create Cases, Comments, and Attachments.
9. After about 5 minutes, check again the content of the indexes using the instructions in step 7.
10. Confirm the Cases, Comments, and Attachments created in step 8 can be seen in the analytics indexes.

