### PR TITLE
[ML] Anomaly Explorer: Respects selected overall swimlane bucket for view by `jobId`

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline_state_service.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline_state_service.ts
@@ -272,6 +272,7 @@ export class AnomalyTimelineStateService extends StateService {
         this.getSwimLaneBucketInterval$(),
         this._timeBounds$,
         this._refreshSubject$,
+        this._swimLaneSeverity$,
       ]) as Observable<
         [
           ExplorerJob[],
@@ -282,7 +283,8 @@ export class AnomalyTimelineStateService extends StateService {
           AppStateSelectedCells,
           TimeBucketsInterval,
           TimeRangeBounds,
-          Refresh
+          Refresh,
+          number
         ]
       >
     )
@@ -296,6 +298,9 @@ export class AnomalyTimelineStateService extends StateService {
             swimLaneCardinality,
             selectedCells,
             swimLaneBucketInterval,
+            timeBounds,
+            refresh,
+            swimlaneSeverity,
           ]) => {
             if (!selectedCells?.showTopFieldValues) {
               return of([]);
@@ -319,7 +324,8 @@ export class AnomalyTimelineStateService extends StateService {
                 swimLanePagination.viewByFromPage,
                 swimLaneBucketInterval,
                 selectionInfluencers,
-                influencersFilterQuery
+                influencersFilterQuery,
+                swimlaneSeverity
               )
             );
           }

--- a/x-pack/platform/plugins/shared/ml/public/application/services/anomaly_timeline_service.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/services/anomaly_timeline_service.ts
@@ -257,7 +257,8 @@ export class AnomalyTimelineService {
     fromPage: number,
     bucketInterval: TimeBucketsInterval,
     selectionInfluencers: MlEntityField[],
-    influencersFilterQuery: InfluencersFilterQuery
+    influencersFilterQuery: InfluencersFilterQuery,
+    swimlaneSeverity: number
   ) {
     const selectedJobIds = selectedJobs.map((d) => d.id);
 
@@ -296,7 +297,7 @@ export class AnomalyTimelineService {
         bucketInterval.asMilliseconds(),
         perPage,
         fromPage,
-        swimlaneLimit
+        swimlaneSeverity
       );
       return Object.keys(resp.results);
     }


### PR DESCRIPTION
Currently, we pass `SWIMLANE_HARD_LIMIT` (1000) to the `mlResultsService.getScoresByBucket` request, which causes `topFieldValues` to be empty. As a result, `_initViewBySwimLaneData` isn't called, and the viewBy swimlane isn't filtered accordingly.

![image](https://github.com/user-attachments/assets/87c18531-fbfa-4635-8127-d5b926cbc7d2)
![image](https://github.com/user-attachments/assets/108ea3d8-fd48-4cec-82b2-8d1da51583d7)


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->