### PR TITLE
[Watcher] Fetch all watches with pagination

### DIFF
--- a/x-pack/platform/plugins/private/watcher/__jest__/client_integration/watch_list_page.test.ts
+++ b/x-pack/platform/plugins/private/watcher/__jest__/client_integration/watch_list_page.test.ts
@@ -76,17 +76,48 @@ describe('<WatchListPage />', () => {
           testBed.component.update();
         });
 
-        test('should retain the search query', async () => {
-          const { actions, find } = testBed;
+        test('should show error callout if search is invalid', async () => {
+          const { exists, actions } = testBed;
 
-          await actions.searchWatches('query text');
+          await actions.searchWatches('or');
+
+          expect(exists('watcherListSearchError')).toBe(true);
+        });
+
+        test('should retain the search query', async () => {
+          const { table, actions } = testBed;
+
+          await actions.searchWatches(watch1.name);
+
+          const { tableCellsValues } = table.getMetaData('watchesTable');
+
+          // Expect "watch1" is only visible in the table
+          expect(tableCellsValues.length).toEqual(1);
+          const row = tableCellsValues[0];
+          const { name, id } = watch1;
+
+          const expectedRow = [
+            '', // checkbox
+            id,
+            name,
+            '', // state
+            '', // lastMetCondition
+            '', // lastChecked
+            '', // comment
+            '', // row actions
+          ];
+
+          expect(row).toEqual(expectedRow);
 
           await actions.advanceTimeToTableRefresh();
 
-          const searchInput = find('watchesTableContainer').find('input.euiFieldSearch');
-          // Verify the query text is still in the search bar
-          // @ts-ignore
-          expect(searchInput.instance().value).toEqual('query text');
+          const { tableCellsValues: updatedTableCellsValues } = table.getMetaData('watchesTable');
+
+          // Verify "watch1" is still the only watch visible in the table
+          expect(updatedTableCellsValues.length).toEqual(1);
+          const updatedRow = updatedTableCellsValues[0];
+
+          expect(updatedRow).toEqual(expectedRow);
         });
 
         test('should set the correct app title', () => {

--- a/x-pack/platform/plugins/private/watcher/common/constants/index.ts
+++ b/x-pack/platform/plugins/private/watcher/common/constants/index.ts
@@ -11,6 +11,7 @@ export { ACTION_TYPES } from './action_types';
 export { AGG_TYPES } from './agg_types';
 export { COMPARATORS } from './comparators';
 export { ES_SCROLL_SETTINGS } from './es_scroll_settings';
+export { QUERY_WATCHES_PAGINATION } from './query_watches_pagination';
 export { INDEX_NAMES } from './index_names';
 export { LISTS } from './lists';
 export { PAGINATION } from './pagination';

--- a/x-pack/platform/plugins/private/watcher/common/constants/query_watches_pagination.ts
+++ b/x-pack/platform/plugins/private/watcher/common/constants/query_watches_pagination.ts
@@ -7,7 +7,12 @@
 
 export const QUERY_WATCHES_PAGINATION: {
   PAGE_SIZE: number;
+  MAX_RESULT_WINDOW: number;
 } = {
   // How many watches to return per response
+  // Page size of 500 balances performance and safety, allowing up to 20 pages before hitting the 10,000 limit
   PAGE_SIZE: 500,
+  // The Query Watch API doesn't allow the sum of `form` and `size` params to exceed 10000.
+  // Therefore, the maximum number of watches that we can fetch is 10000
+  MAX_RESULT_WINDOW: 10000,
 };

--- a/x-pack/platform/plugins/private/watcher/common/constants/query_watches_pagination.ts
+++ b/x-pack/platform/plugins/private/watcher/common/constants/query_watches_pagination.ts
@@ -5,11 +5,9 @@
  * 2.0.
  */
 
-export type {
-  ActionStatusModelEs,
-  ServerActionStatusModel,
-  ClientActionStatusModel,
-  WatchStatusModelEs,
-  ServerWatchStatusModel,
-  ClientWatchStatusModel,
-} from './status_types';
+export const QUERY_WATCHES_PAGINATION: {
+  PAGE_SIZE: number;
+} = {
+  // How many watches to return per response
+  PAGE_SIZE: 500,
+};

--- a/x-pack/platform/plugins/private/watcher/public/application/lib/api.ts
+++ b/x-pack/platform/plugins/private/watcher/public/application/lib/api.ts
@@ -29,33 +29,16 @@ export const getHttpClient = () => {
 
 const basePath = ROUTES.API_ROOT;
 
-const loadWatchesDeserializer = ({
-  watches = [],
-  watchCount,
-}: {
-  watches: any[];
-  watchCount: number;
-}) => {
-  return {
-    watches: watches.map((watch: any) => Watch.fromUpstreamJson(watch)),
-    watchCount,
-  };
+const loadWatchesDeserializer = ({ watches = [] }: { watches: any[] }) => {
+  return watches.map((watch: any) => Watch.fromUpstreamJson(watch));
 };
 
-export const useLoadWatches = (
-  pollIntervalMs: number,
-  pageSize: number,
-  pageIndex: number,
-  sortField?: string,
-  sortDirection?: string,
-  query?: string
-) => {
+export const useLoadWatches = (pollIntervalMs: number) => {
   return useRequest({
     path: `${basePath}/watches`,
     method: 'get',
     pollIntervalMs,
     deserializer: loadWatchesDeserializer,
-    query: { pageSize, pageIndex, sortField, sortDirection, query },
   });
 };
 

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_list_page/watch_list_page.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_list_page/watch_list_page.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import React, { useState, useMemo, useEffect, Fragment, useCallback } from 'react';
+import React, { useState, useMemo, useEffect, Fragment } from 'react';
 
 import {
+  CriteriaWithPagination,
   EuiButton,
   EuiButtonEmpty,
-  EuiSearchBar,
+  EuiCallOut,
   EuiInMemoryTable,
   EuiIcon,
   EuiLink,
@@ -24,7 +25,6 @@ import {
   EuiPageHeader,
   EuiPageTemplate,
   EuiSearchBarOnChangeArgs,
-  EuiTablePagination,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -32,11 +32,7 @@ import { Moment } from 'moment';
 
 import { reactRouterNavigate } from '@kbn/kibana-react-plugin/public';
 
-import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
-import { debounce } from 'lodash';
-import { PropertySort } from '@elastic/eui/src/services/sort/property_sort';
 import { REFRESH_INTERVALS, PAGINATION, WATCH_TYPES } from '../../../../common/constants';
-import { BaseWatch } from '../../../../common/types';
 import { listBreadcrumb } from '../../lib/breadcrumbs';
 import {
   getPageErrorCode,
@@ -133,46 +129,34 @@ export const WatchListPage = () => {
     links: { watcherGettingStartedUrl },
   } = useAppContext();
   const [query, setQuery] = useState('');
+  const [queryError, setQueryError] = useState<string | null>(null);
 
   const [selection, setSelection] = useState([]);
   const [watchesToDelete, setWatchesToDelete] = useState<string[]>([]);
   // Filter out deleted watches on the client, because the API will return 200 even though some watches
   // may not really be deleted until after they're done firing and this could take some time.
   const [deletedWatches, setDeletedWatches] = useState<string[]>([]);
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: PAGINATION.initialPageSize,
+  });
 
   useEffect(() => {
     setBreadcrumbs([listBreadcrumb]);
   }, [setBreadcrumbs]);
 
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(PAGINATION.initialPageSize);
-
-  const [sort, setSort] = useState<Criteria<BaseWatch>['sort']>({
-    field: 'name', // Currently we can only sort by name
-    direction: 'asc',
-  });
-
   const {
     isLoading: isWatchesLoading,
-    data,
+    data: watches,
     error,
-  } = useLoadWatches(
-    REFRESH_INTERVALS.WATCH_LIST,
-    pageSize,
-    pageIndex,
-    sort?.field,
-    sort?.direction,
-    query
-  );
+  } = useLoadWatches(REFRESH_INTERVALS.WATCH_LIST);
 
   const [isPopoverOpen, setIsPopOverOpen] = useState<boolean>(false);
 
   const availableWatches = useMemo(
     () =>
-      data?.watches
-        ? data.watches.filter((watch: any) => !deletedWatches.includes(watch.id))
-        : undefined,
-    [data?.watches, deletedWatches]
+      watches ? watches.filter((watch: any) => !deletedWatches.includes(watch.id)) : undefined,
+    [watches, deletedWatches]
   );
 
   const watcherDescriptionText = (
@@ -265,15 +249,6 @@ export const WatchListPage = () => {
     </EuiPopover>
   );
 
-  const updateQuery = useCallback(({ queryText }: EuiSearchBarOnChangeArgs) => {
-    setQuery(queryText);
-  }, []);
-
-  const debouncedUpdateQuery = useMemo(() => {
-    // Trigger update 500 ms after the user stopped typing to reduce fetch requests to the server
-    return debounce(updateQuery, 500);
-  }, [updateQuery]);
-
   if (isWatchesLoading) {
     return (
       <EuiPageTemplate.EmptyPrompt>
@@ -304,7 +279,7 @@ export const WatchListPage = () => {
     );
   }
 
-  if (availableWatches && availableWatches.length === 0 && !query) {
+  if (availableWatches && availableWatches.length === 0) {
     const emptyPromptBody = (
       <EuiText color="subdued">
         <p>
@@ -346,6 +321,7 @@ export const WatchListPage = () => {
         name: i18n.translate('xpack.watcher.sections.watchList.watchTable.idHeader', {
           defaultMessage: 'ID',
         }),
+        sortable: true,
         truncateText: false,
         render: (id: string) => {
           return (
@@ -372,12 +348,14 @@ export const WatchListPage = () => {
       {
         field: 'watchStatus.state',
         name: stateColumnHeader,
+        sortable: true,
         width: '130px',
         render: (state: string) => <WatchStateBadge state={state} />,
       },
       {
         field: 'watchStatus.lastMetCondition',
         name: conditionLastMetHeader,
+        sortable: true,
         truncateText: true,
         width: '160px',
         render: (lastMetCondition: Moment) => {
@@ -387,6 +365,7 @@ export const WatchListPage = () => {
       {
         field: 'watchStatus.lastChecked',
         name: lastCheckedHeader,
+        sortable: true,
         truncateText: true,
         width: '160px',
         render: (lastChecked: Moment) => {
@@ -396,6 +375,7 @@ export const WatchListPage = () => {
       {
         field: 'watchStatus.comment',
         name: commentHeader,
+        sortable: true,
         truncateText: true,
       },
       {
@@ -463,8 +443,8 @@ export const WatchListPage = () => {
     ];
 
     const selectionConfig = {
-      onSelectionChange: setSelection as (selection: BaseWatch[]) => void,
-      selectable: (watch: BaseWatch) => !watch.isSystemWatch,
+      onSelectionChange: setSelection,
+      selectable: (watch: any) => !watch.isSystemWatch,
       selectableMessage: (selectable: boolean) =>
         !selectable
           ? i18n.translate('xpack.watcher.sections.watchList.watchTable.disabledWatchTooltipText', {
@@ -473,60 +453,87 @@ export const WatchListPage = () => {
           : '',
     };
 
+    const handleOnChange = ({ queryText, error: searchError }: EuiSearchBarOnChangeArgs) => {
+      if (!searchError) {
+        setQuery(queryText);
+        setQueryError(null);
+      } else {
+        setQueryError(searchError.message);
+      }
+    };
+
+    const searchConfig = {
+      onChange: handleOnChange,
+      query,
+      box: {
+        incremental: true,
+      },
+      toolsLeft:
+        selection.length > 0 ? (
+          <EuiButton
+            data-test-subj="btnDeleteWatches"
+            onClick={() => {
+              setWatchesToDelete(selection.map((selected: any) => selected.id));
+            }}
+            color="danger"
+          >
+            {selection.length > 1 ? (
+              <FormattedMessage
+                id="xpack.watcher.sections.watchList.deleteMultipleWatchesButtonLabel"
+                defaultMessage="Delete watches"
+              />
+            ) : (
+              <FormattedMessage
+                id="xpack.watcher.sections.watchList.deleteSingleWatchButtonLabel"
+                defaultMessage="Delete watch"
+              />
+            )}
+          </EuiButton>
+        ) : undefined,
+      toolsRight: createWatchContextMenu,
+    };
+
     content = (
       <div data-test-subj="watchesTableContainer">
-        <EuiSearchBar
-          query={query}
-          box={{
-            placeholder: i18n.translate(
-              'xpack.watcher.sections.watchList.watchTable.searchBar.placeholder',
-              {
-                defaultMessage: 'Search by name or ID',
-              }
-            ),
-            incremental: true,
-          }}
-          onChange={debouncedUpdateQuery}
-          toolsLeft={
-            selection.length > 0 ? (
-              <EuiButton
-                data-test-subj="btnDeleteWatches"
-                onClick={() => {
-                  setWatchesToDelete(selection.map((selected: any) => selected.id));
-                }}
-                color="danger"
-              >
-                {selection.length > 1 ? (
-                  <FormattedMessage
-                    id="xpack.watcher.sections.watchList.deleteMultipleWatchesButtonLabel"
-                    defaultMessage="Delete watches"
-                  />
-                ) : (
-                  <FormattedMessage
-                    id="xpack.watcher.sections.watchList.deleteSingleWatchButtonLabel"
-                    defaultMessage="Delete watch"
-                  />
-                )}
-              </EuiButton>
-            ) : undefined
-          }
-          toolsRight={createWatchContextMenu}
-        />
-
-        <EuiSpacer size="l" />
-
         <EuiInMemoryTable
-          onTableChange={({ sort: newSort }: Criteria<BaseWatch>) => {
-            if (newSort) {
-              setSort(newSort);
-            }
-          }}
+          onTableChange={({ page: { index, size } }: CriteriaWithPagination<never>) =>
+            setPagination({ pageIndex: index, pageSize: size })
+          }
           items={availableWatches}
           itemId="id"
           columns={columns}
-          pagination={false}
-          sorting={{ sort: sort as PropertySort }}
+          search={searchConfig}
+          pagination={{
+            ...PAGINATION,
+            pageIndex: pagination.pageIndex,
+            pageSize: pagination.pageSize,
+          }}
+          sorting={{
+            sort: {
+              field: 'name',
+              direction: 'asc',
+            },
+          }}
           selection={selectionConfig}
+          childrenBetween={
+            queryError && (
+              <>
+                <EuiCallOut
+                  data-test-subj="watcherListSearchError"
+                  iconType="warning"
+                  color="danger"
+                  title={
+                    <FormattedMessage
+                      id="xpack.watcher.sections.watchList.watchTable.errorOnSearch"
+                      defaultMessage="Invalid search: {queryError}"
+                      values={{ queryError }}
+                    />
+                  }
+                />
+                <EuiSpacer />
+              </>
+            )
+          }
           message={
             <FormattedMessage
               id="xpack.watcher.sections.watchList.watchTable.noWatchesMessage"
@@ -540,18 +547,6 @@ export const WatchListPage = () => {
             'data-test-subj': 'cell',
           })}
           data-test-subj="watchesTable"
-        />
-
-        <EuiSpacer size="l" />
-
-        <EuiTablePagination
-          aria-label="Table pagination example"
-          pageCount={data?.watchCount ? Math.ceil(data?.watchCount / pageSize) : 0}
-          activePage={pageIndex}
-          onChangePage={setPageIndex}
-          itemsPerPage={pageSize}
-          onChangeItemsPerPage={setPageSize}
-          itemsPerPageOptions={PAGINATION.pageSizeOptions}
         />
       </div>
     );

--- a/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.test.ts
+++ b/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fetchWatchesWithPagination } from './fetch_watches_with_pagination';
+import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+import { WatcherQueryWatch } from '@elastic/elasticsearch/lib/api/types';
+
+describe('fetchWatchesWithPagination (iterative version with pageSize)', () => {
+  const mockQueryWatches = jest.fn();
+  const mockScopedClusterClient: IScopedClusterClient = {
+    asCurrentUser: {
+      watcher: {
+        queryWatches: mockQueryWatches,
+      },
+    },
+    asInternalUser: {} as any,
+  } as IScopedClusterClient;
+
+  const sampleWatches = [{ _id: 1 }, { _id: 2 }, { _id: 3 }] as WatcherQueryWatch[];
+  const pageSize = 3;
+
+  beforeEach(() => {
+    mockQueryWatches.mockClear();
+  });
+
+  describe('when there are no watches', () => {
+    it('should return an empty array if queryWatches returns nothing', async () => {
+      mockQueryWatches.mockResolvedValueOnce({ count: 0, watches: [] });
+
+      const watches = await fetchWatchesWithPagination(mockScopedClusterClient, pageSize);
+      expect(watches).toEqual([]);
+      expect(mockQueryWatches).toHaveBeenCalledTimes(1);
+      expect(mockQueryWatches).toHaveBeenCalledWith({
+        from: 0,
+        size: pageSize,
+      });
+    });
+  });
+
+  describe('when there are fewer watches than a full page', () => {
+    it('should return all the watches from the first page', async () => {
+      mockQueryWatches.mockResolvedValueOnce({
+        count: 3,
+        watches: sampleWatches,
+      });
+
+      const watches = await fetchWatchesWithPagination(mockScopedClusterClient, pageSize);
+      expect(watches).toEqual(sampleWatches);
+      expect(mockQueryWatches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when watches span multiple pages', () => {
+    it('should accumulate all watches across multiple pages', async () => {
+      const additionalWatches = [{ _id: 4 }, { _id: 5 }, { _id: 6 }] as WatcherQueryWatch[];
+      const totalCount = sampleWatches.length + additionalWatches.length;
+
+      mockQueryWatches
+        .mockResolvedValueOnce({ count: totalCount, watches: sampleWatches }) // from: 0
+        .mockResolvedValueOnce({ count: totalCount, watches: additionalWatches }); // from: 3
+
+      const watches = await fetchWatchesWithPagination(mockScopedClusterClient, pageSize);
+      expect(watches).toEqual([...sampleWatches, ...additionalWatches]);
+      expect(mockQueryWatches).toHaveBeenCalledTimes(2);
+      expect(mockQueryWatches).toHaveBeenNthCalledWith(1, {
+        from: 0,
+        size: pageSize,
+      });
+      expect(mockQueryWatches).toHaveBeenNthCalledWith(2, {
+        from: pageSize,
+        size: pageSize,
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.test.ts
+++ b/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.test.ts
@@ -19,10 +19,14 @@ describe('fetchWatchesWithPagination (iterative version with pageSize)', () => {
       },
     },
     asInternalUser: {} as any,
-  } as IScopedClusterClient;
+  } as unknown as IScopedClusterClient;
 
-  const sampleWatches = [{ _id: 1 }, { _id: 2 }, { _id: 3 }] as WatcherQueryWatch[];
-  const pageSize = 3;
+  const sampleWatches = [
+    { _id: 'watch1' },
+    { _id: 'watch2' },
+    { _id: 'watch3' },
+  ] as WatcherQueryWatch[];
+  let pageSize = 3;
 
   beforeEach(() => {
     mockQueryWatches.mockClear();
@@ -57,7 +61,11 @@ describe('fetchWatchesWithPagination (iterative version with pageSize)', () => {
 
   describe('when watches span multiple pages', () => {
     it('should accumulate all watches across multiple pages', async () => {
-      const additionalWatches = [{ _id: 4 }, { _id: 5 }, { _id: 6 }] as WatcherQueryWatch[];
+      const additionalWatches = [
+        { _id: 'watch4' },
+        { _id: 'watch5' },
+        { _id: 'watch6' },
+      ] as WatcherQueryWatch[];
       const totalCount = sampleWatches.length + additionalWatches.length;
 
       mockQueryWatches
@@ -79,17 +87,7 @@ describe('fetchWatchesWithPagination (iterative version with pageSize)', () => {
   });
 
   it('should not exceed the Elasticsearch max result window (from + size <= 10000)', async () => {
-    const mockQueryWatches = jest.fn();
-    const mockScopedClusterClient: IScopedClusterClient = {
-      asCurrentUser: {
-        watcher: {
-          queryWatches: mockQueryWatches,
-        },
-      },
-      asInternalUser: {} as any,
-    } as IScopedClusterClient;
-
-    const pageSize = 1000;
+    pageSize = 1000;
     const totalWatches = 11000; // simulate more than allowed
 
     // Mock 10 pages of 1000 watches

--- a/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.ts
+++ b/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.ts
@@ -7,6 +7,7 @@
 
 import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import { WatcherQueryWatch } from '@elastic/elasticsearch/lib/api/types';
+import { QUERY_WATCHES_PAGINATION } from "@kbn/watcher-plugin/common/constants";
 
 /**
  * Fetches all watches using the Query Watches API.
@@ -22,7 +23,7 @@ export const fetchWatchesWithPagination = async (
 
   let total = Infinity;
 
-  while (allWatches.length < total) {
+  while (allWatches.length < total && from + pageSize <= QUERY_WATCHES_PAGINATION.MAX_RESULT_WINDOW) {
     const response = await dataClient.asCurrentUser.watcher.queryWatches({
       from,
       size: pageSize,

--- a/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.ts
+++ b/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.ts
@@ -7,7 +7,7 @@
 
 import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import { WatcherQueryWatch } from '@elastic/elasticsearch/lib/api/types';
-import { QUERY_WATCHES_PAGINATION } from "@kbn/watcher-plugin/common/constants";
+import { QUERY_WATCHES_PAGINATION } from '../../../common/constants';
 
 /**
  * Fetches all watches using the Query Watches API.
@@ -23,7 +23,10 @@ export const fetchWatchesWithPagination = async (
 
   let total = Infinity;
 
-  while (allWatches.length < total && from + pageSize <= QUERY_WATCHES_PAGINATION.MAX_RESULT_WINDOW) {
+  while (
+    allWatches.length < total &&
+    from + pageSize <= QUERY_WATCHES_PAGINATION.MAX_RESULT_WINDOW
+  ) {
     const response = await dataClient.asCurrentUser.watcher.queryWatches({
       from,
       size: pageSize,

--- a/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.ts
+++ b/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/fetch_watches_with_pagination.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+import { WatcherQueryWatch } from '@elastic/elasticsearch/lib/api/types';
+
+/**
+ * Fetches all watches using the Query Watches API.
+ * It uses pagination via the `from` and `size` parameters to retrieve all available watches,
+ * accumulating them across multiple requests.
+ */
+export const fetchWatchesWithPagination = async (
+  dataClient: IScopedClusterClient,
+  pageSize: number
+): Promise<WatcherQueryWatch[]> => {
+  let from = 0;
+  const allWatches: WatcherQueryWatch[] = [];
+
+  let total = Infinity;
+
+  while (allWatches.length < total) {
+    const response = await dataClient.asCurrentUser.watcher.queryWatches({
+      from,
+      size: pageSize,
+    });
+
+    const watches = response?.watches ?? [];
+    allWatches.push(...watches);
+
+    // Update total in case new watches have been created in the meantime
+    total = response?.count ?? 0;
+
+    from += pageSize;
+
+    // Early break in case something went wrong with count logic to avoid an infinite loop
+    if (watches.length === 0) break;
+  }
+
+  return allWatches;
+};

--- a/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/index.ts
+++ b/x-pack/platform/plugins/private/watcher/server/lib/fetch_watches_with_pagination/index.ts
@@ -5,11 +5,4 @@
  * 2.0.
  */
 
-export type {
-  ActionStatusModelEs,
-  ServerActionStatusModel,
-  ClientActionStatusModel,
-  WatchStatusModelEs,
-  ServerWatchStatusModel,
-  ClientWatchStatusModel,
-} from './status_types';
+export { fetchWatchesWithPagination } from './fetch_watches_with_pagination';

--- a/x-pack/platform/plugins/private/watcher/tsconfig.json
+++ b/x-pack/platform/plugins/private/watcher/tsconfig.json
@@ -39,7 +39,6 @@
     "@kbn/code-editor",
     "@kbn/react-kibana-context-render",
     "@kbn/core-elasticsearch-server",
-    "@kbn/watcher-plugin",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/platform/plugins/private/watcher/tsconfig.json
+++ b/x-pack/platform/plugins/private/watcher/tsconfig.json
@@ -38,6 +38,7 @@
     "@kbn/core-ui-settings-browser-mocks",
     "@kbn/code-editor",
     "@kbn/react-kibana-context-render",
+    "@kbn/core-elasticsearch-server",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/platform/plugins/private/watcher/tsconfig.json
+++ b/x-pack/platform/plugins/private/watcher/tsconfig.json
@@ -39,6 +39,7 @@
     "@kbn/code-editor",
     "@kbn/react-kibana-context-render",
     "@kbn/core-elasticsearch-server",
+    "@kbn/watcher-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/221820
Fixes https://github.com/elastic/kibana/issues/220879

## Summary

This PR reverts changes in https://github.com/elastic/kibana/pull/204296 and https://github.com/elastic/kibana/pull/218853, and uses and alternative approach for using the Query Watch API: fetch all watches through pagination with `form` and `size` params, and perform filtering/sorting on client side. This will resolve the following issues that were introduced in these two PRs:
- Page is broken if none of the watches has a name
- Sorting only by name
- Searching only by whole id, but not partial id
- Search bar losing focus on key strokes
- Search bar is case-sensitive

**Limitations**:
Due to a limitation in the Es Query Watch API, we can only fetch up to 10,000 watches, as Es throws an error if `from + size > 10000`.

