### PR TITLE
[Discover] Support setting columns in Discover session embeddable

### DIFF
--- a/src/platform/packages/shared/kbn-saved-search-component/src/components/saved_search.tsx
+++ b/src/platform/packages/shared/kbn-saved-search-component/src/components/saved_search.tsx
@@ -16,6 +16,7 @@ import type {
 } from '@kbn/discover-plugin/public';
 import { SerializedPanelState } from '@kbn/presentation-publishing';
 import { css } from '@emotion/react';
+import { SavedSearchAttributes } from '@kbn/saved-search-plugin/common';
 import { SavedSearchComponentProps } from '../types';
 import { SavedSearchComponentErrorContent } from './error';
 
@@ -66,16 +67,16 @@ export const SavedSearchComponent: React.FC<SavedSearchComponentProps> = (props)
           searchSource.setField('filter', filters);
           const { searchSourceJSON, references } = searchSource.serialize();
           // By-value saved object structure
-          const attributes = {
+          const attributes: Partial<SavedSearchAttributes> = {
             kibanaSavedObjectMeta: {
               searchSourceJSON,
             },
+            columns,
           };
           setInitialSerializedState({
             rawState: {
               attributes: { ...attributes, references },
               timeRange,
-              columns,
               nonPersistedDisplayOptions: {
                 solutionNavIdOverride,
                 enableDocumentViewer: documentViewerEnabled,

--- a/src/platform/packages/shared/kbn-saved-search-component/src/components/saved_search.tsx
+++ b/src/platform/packages/shared/kbn-saved-search-component/src/components/saved_search.tsx
@@ -36,6 +36,7 @@ export const SavedSearchComponent: React.FC<SavedSearchComponentProps> = (props)
     filters,
     index,
     timestampField,
+    columns,
     height,
   } = props;
 
@@ -74,6 +75,7 @@ export const SavedSearchComponent: React.FC<SavedSearchComponentProps> = (props)
             rawState: {
               attributes: { ...attributes, references },
               timeRange,
+              columns,
               nonPersistedDisplayOptions: {
                 solutionNavIdOverride,
                 enableDocumentViewer: documentViewerEnabled,
@@ -94,6 +96,7 @@ export const SavedSearchComponent: React.FC<SavedSearchComponentProps> = (props)
       abortController.abort();
     };
   }, [
+    columns,
     dataViews,
     documentViewerEnabled,
     filters,
@@ -137,6 +140,7 @@ const SavedSearchComponentTable: React.FC<
     timeRange,
     timestampField,
     index,
+    columns,
   } = props;
   const embeddableApi = useRef<SearchEmbeddableApi | undefined>(undefined);
 
@@ -196,6 +200,14 @@ const SavedSearchComponentTable: React.FC<
       embeddableApi.current.setTimeRange(timeRange);
     },
     [timeRange]
+  );
+
+  useEffect(
+    function syncColumns() {
+      if (!embeddableApi.current) return;
+      embeddableApi.current.setColumns(columns);
+    },
+    [columns]
   );
 
   return (

--- a/src/platform/packages/shared/kbn-saved-search-component/src/types.ts
+++ b/src/platform/packages/shared/kbn-saved-search-component/src/types.ts
@@ -26,6 +26,7 @@ export interface SavedSearchComponentProps {
   query?: Query;
   filters?: Filter[];
   timestampField?: string;
+  columns?: string[];
   height?: CSSProperties['height'];
   displayOptions?: NonPersistedDisplayOptions;
 }

--- a/src/platform/packages/shared/kbn-saved-search-component/tsconfig.json
+++ b/src/platform/packages/shared/kbn-saved-search-component/tsconfig.json
@@ -25,5 +25,6 @@
     "@kbn/discover-plugin",
     "@kbn/i18n",
     "@kbn/presentation-publishing",
+    "@kbn/saved-search-plugin",
   ]
 }

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -29,7 +29,7 @@ import type { DiscoverServices } from '../build_services';
 import { EDITABLE_SAVED_SEARCH_KEYS } from './constants';
 import { getSearchEmbeddableDefaults } from './get_search_embeddable_defaults';
 import type {
-  PublishesSavedSearch,
+  PublishesWritableSavedSearch,
   SearchEmbeddableRuntimeState,
   SearchEmbeddableSerializedAttributes,
   SearchEmbeddableSerializedState,
@@ -73,7 +73,9 @@ export const initializeSearchEmbeddableApi = async (
     discoverServices: DiscoverServices;
   }
 ): Promise<{
-  api: PublishesSavedSearch & PublishesWritableDataViews & Partial<PublishesWritableUnifiedSearch>;
+  api: PublishesWritableSavedSearch &
+    PublishesWritableDataViews &
+    Partial<PublishesWritableUnifiedSearch>;
   stateManager: SearchEmbeddableStateManager;
   anyStateChange$: Observable<void>;
   comparators: StateComparators<SearchEmbeddableSerializedAttributes>;

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -170,6 +170,10 @@ export const initializeSearchEmbeddableApi = async (
     searchSource$.next(searchSource);
   };
 
+  const setColumns = (columns: string[] | undefined) => {
+    stateManager.columns.next(columns);
+  };
+
   /** Keep the saved search in sync with any state changes */
   const syncSavedSearch = combineLatest([onAnyStateChange, searchSource$])
     .pipe(
@@ -197,6 +201,7 @@ export const initializeSearchEmbeddableApi = async (
       query$,
       setQuery,
       canEditUnifiedSearch,
+      setColumns,
     },
     stateManager,
     anyStateChange$: onAnyStateChange.pipe(map(() => undefined)),

--- a/src/platform/plugins/shared/discover/public/embeddable/types.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/types.ts
@@ -117,6 +117,7 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<SearchEmbeddableSerialize
 
 export interface PublishesSavedSearch {
   savedSearch$: PublishingSubject<SavedSearch>;
+  setColumns: (columns: string[] | undefined) => void;
 }
 
 export const apiPublishesSavedSearch = (

--- a/src/platform/plugins/shared/discover/public/embeddable/types.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/types.ts
@@ -105,7 +105,7 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<SearchEmbeddableSerialize
   PublishesBlockingError &
   Required<PublishesWritableTitle> &
   Required<PublishesDescription> &
-  PublishesSavedSearch &
+  PublishesWritableSavedSearch &
   PublishesWritableDataViews &
   PublishesWritableUnifiedSearch &
   HasLibraryTransforms &
@@ -117,6 +117,9 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<SearchEmbeddableSerialize
 
 export interface PublishesSavedSearch {
   savedSearch$: PublishingSubject<SavedSearch>;
+}
+
+export interface PublishesWritableSavedSearch extends PublishesSavedSearch {
   setColumns: (columns: string[] | undefined) => void;
 }
 

--- a/src/platform/plugins/shared/discover/public/index.ts
+++ b/src/platform/plugins/shared/discover/public/index.ts
@@ -33,6 +33,7 @@ export {
   SEARCH_EMBEDDABLE_CELL_ACTIONS_TRIGGER_ID,
   apiPublishesSavedSearch,
   type PublishesSavedSearch,
+  type PublishesWritableSavedSearch,
   type HasTimeRange,
   type SearchEmbeddableSerializedState,
   type SearchEmbeddableRuntimeState,


### PR DESCRIPTION
## Summary

This PR adds support for consumers to set columns in the Discover session embeddable, and updates `SavedSearchComponent` to make use of it. This is a requirement for some usages of the embedded logs component where specific columns are needed.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->