### PR TITLE
[DOCS] Fix formatting in alerting settings YAML

### DIFF
--- a/docs/settings-gen/readme.md
+++ b/docs/settings-gen/readme.md
@@ -1,19 +1,15 @@
 # YAML-based settings documentation
 
-We're aiming to update the Kibana configuration settings pages to be based off of YAML-formatted source files. The approach has the advantages that:
- - The YAML format makes it easier to add new settings and update existing ones. The setting data is separate from almost all formatting, whether Asciidoc or (future) Markdown.
- - The HTML files will have a more consistent and user-friendly appearance.
- - The YAML format makes it easier for teams to identify missing settings or settings that are lacking details that should be made available in the docs.
+Kibana configuration settings documentation is planned to be sourced from YAML files. This is intended to improve consistency in these docs and also allow for easier contribution and maintenance.
 
-The YAML settings files in the `settings-gen/source` folder are converted to Asciidoc source, located in the same directory, by means of the `parse-settings.pl` Perl script. Please do not update the generated Asciidoc files directly as your changes will be overwritten. Please make any required docs changes in the `<name>-settings.yml` files.
-
-Following is a schema for all available properties in a YAML settings file.
+Following is a schema for all available properties in the docs settings source file.
 
 ## Schema
 
 ```
 product: REQUIRED e.g. Elasticsearch, Kibana, Enterprise Search
 collection: REQUIRED e.g. Alerting and action settings in Kibana
+id: REQUIRED The ID used for for other docs to link to this page, e.g., general-alert-action-settings
 page_description: |
   OPTIONAL
   Multiline string. Can include tables, lists, code examples, etc.

--- a/docs/settings-gen/readme.md
+++ b/docs/settings-gen/readme.md
@@ -9,7 +9,7 @@ Following is a schema for all available properties in the docs settings source f
 ```
 product: REQUIRED e.g. Elasticsearch, Kibana, Enterprise Search
 collection: REQUIRED e.g. Alerting and action settings in Kibana
-id: REQUIRED The ID used for for other docs to link to this page, e.g., general-alert-action-settings
+id: REQUIRED The ID used for links to this page, e.g., general-alert-action-settings
 page_description: |
   OPTIONAL
   Multiline string. Can include tables, lists, code examples, etc.

--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -35,7 +35,7 @@ groups:
         # tip: ""
         # warning: ""
         # important: ""
-        datatype: "string"
+        datatype: string
         # default:
         # options:
         #   - option:

--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -3,6 +3,7 @@
 
 product: Kibana
 collection: Alerting and action settings in Kibana
+id: alert-action-settings-kb
 page_description: |
   Alerting and actions are enabled by default in {{kib}}, but require you to configure the following:
 

--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -16,8 +16,7 @@ groups:
   - group: General settings
     id: general-alert-action-settings
     # description: |
-    #  - ""
-    # example: example-group-name.asciidoc
+    # example: |
     settings:
 
       - setting: xpack.encryptedSavedObjects.encryptionKey
@@ -50,8 +49,8 @@ groups:
   - group: Action settings
     id: action-settings
     # description: |
-    #  - ""
-    # example: example-group-name.asciidoc
+    # description: |
+    # example: |
     settings:
 
       - setting: xpack.actions.allowedHosts

--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -49,7 +49,6 @@ groups:
   - group: Action settings
     id: action-settings
     # description: |
-    # description: |
     # example: |
     settings:
 


### PR DESCRIPTION
## Summary

This fixes a few super small issues with the config settings files:
 - Fixes an outdated Asciidoc remnant in our "Alert and Actions settings" PoC file
 - Adds a page-level ID in the sample file and the readme
 - Fixes up the readme
 - Removes unneeded quotation marks from one value in the PoC file.