### PR TITLE
[8.19] [Security Solution] Remove index pattern field from Sourcerer (#190113) And other sourcerer clean ups

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
@@ -16,7 +16,7 @@ import { useKibana } from '../../../common/lib/kibana';
 
 export const TopValuesPopover = React.memo(() => {
   const { pathname } = useLocation();
-  const { browserFields, indexPattern } = useSourcererDataView(getScopeFromPath(pathname));
+  const { browserFields, sourcererDataView } = useSourcererDataView(getScopeFromPath(pathname));
   const {
     services: { topValuesPopover },
   } = useKibana();
@@ -43,7 +43,7 @@ export const TopValuesPopover = React.memo(() => {
         field={data.fieldName}
         scopeId={data.scopeId}
         toggleTopN={onClose}
-        indexPattern={indexPattern}
+        dataViewSpec={sourcererDataView}
         browserFields={browserFields}
       />
     </EuiWrappingPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -189,18 +189,18 @@ const AttackDiscoveryPageComponent: React.FC = () => {
 
   const pageTitle = useMemo(() => <PageTitle />, []);
 
-  const { indexPattern } = useSourcererDataView();
+  const { sourcererDataView } = useSourcererDataView();
 
   // filterQuery is the combined search bar query and filters in ES format:
   const [filterQuery, kqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec: sourcererDataView,
         queries: [query ?? getDefaultQuery()], // <-- search bar query
         filters: filters ?? [], // <-- search bar filters
       }),
-    [filters, indexPattern, query, uiSettings]
+    [filters, sourcererDataView, query, uiSettings]
   );
 
   // renders a toast if the filter query is invalid:

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
@@ -45,7 +45,7 @@ export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
     http,
   });
 
-  const { indexPattern } = useSourcererDataView();
+  const { sourcererDataView } = useSourcererDataView();
 
   const { mutateAsync: createAttackDiscoverySchedule, isLoading: isLoadingQuery } =
     useCreateAttackDiscoverySchedule();
@@ -62,7 +62,7 @@ export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
           scheduleData,
           alertsIndexPattern ?? '',
           connector,
-          indexPattern,
+          sourcererDataView,
           uiSettings
         );
         await createAttackDiscoverySchedule({ scheduleToCreate });
@@ -76,7 +76,7 @@ export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
       alertsIndexPattern,
       createAttackDiscoverySchedule,
       onClose,
-      indexPattern,
+      sourcererDataView,
       uiSettings,
     ]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
@@ -64,7 +64,7 @@ export const DetailsFlyout: React.FC<Props> = React.memo(({ scheduleId, onClose 
       id: scheduleId,
     });
 
-  const { indexPattern } = useSourcererDataView();
+  const { sourcererDataView } = useSourcererDataView();
 
   const [isEditing, setIsEditing] = useState(false);
 
@@ -83,7 +83,7 @@ export const DetailsFlyout: React.FC<Props> = React.memo(({ scheduleId, onClose 
           scheduleData,
           alertsIndexPattern ?? '',
           connector,
-          indexPattern,
+          sourcererDataView,
           uiSettings
         );
         await updateAttackDiscoverySchedule({ id: scheduleId, scheduleToUpdate });
@@ -95,7 +95,7 @@ export const DetailsFlyout: React.FC<Props> = React.memo(({ scheduleId, onClose 
     [
       aiConnectors,
       uiSettings,
-      indexPattern,
+      sourcererDataView,
       scheduleId,
       alertsIndexPattern,
       updateAttackDiscoverySchedule,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/utils/convert_form_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/utils/convert_form_data.test.ts
@@ -6,8 +6,8 @@
  */
 
 import type { IUiSettingsClient } from '@kbn/core/public';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
 import type { AIConnector } from '@kbn/elastic-assistant';
-import type { DataViewBase } from '@kbn/es-query';
 
 import { convertFormDataInBaseSchedule } from './convert_form_data';
 import { convertToBuildEsQuery } from '../../../../../common/lib/kuery';
@@ -47,7 +47,7 @@ describe('convertFormDataInBaseSchedule', () => {
       },
       '.alert-*',
       {} as AIConnector,
-      {} as DataViewBase,
+      {} as DataViewSpec,
       {
         get: jest.fn(),
       } as unknown as IUiSettingsClient

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/utils/convert_form_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/utils/convert_form_data.ts
@@ -6,9 +6,9 @@
  */
 
 import type { IUiSettingsClient } from '@kbn/core/public';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { AIConnector } from '@kbn/elastic-assistant';
-import type { DataViewBase } from '@kbn/es-query';
 
 import { convertToBuildEsQuery } from '../../../../../common/lib/kuery';
 import type { AttackDiscoveryScheduleSchema } from '../edit_form/types';
@@ -19,14 +19,14 @@ export const convertFormDataInBaseSchedule = (
   scheduleData: AttackDiscoveryScheduleSchema,
   alertsIndexPattern: string,
   connector: AIConnector,
-  indexPattern: DataViewBase,
+  dataViewSpec: DataViewSpec,
   uiSettings: IUiSettingsClient
 ) => {
   const alertsSelectionSettings = scheduleData.alertsSelectionSettings;
 
   const [filterQuery, kqlError] = convertToBuildEsQuery({
     config: getEsQueryConfig(uiSettings),
-    indexPattern,
+    dataViewSpec,
     queries: [alertsSelectionSettings.query],
     filters: alertsSelectionSettings.filters,
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -145,9 +145,8 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
   const {
     browserFields,
     dataViewId,
-    indexPattern,
-    sourcererDataView,
     selectedPatterns,
+    sourcererDataView,
     dataViewId: selectedDataViewId,
     loading: isLoadingIndexPattern,
   } = useSourcererDataView(sourcererScope);
@@ -234,12 +233,12 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
         dataProviders: [],
         filters: globalFilters,
         from: start,
-        indexPattern,
+        indexPattern: sourcererDataView,
         kqlMode: 'filter',
         kqlQuery: query,
         to: end,
       }),
-    [esQueryConfig, browserFields, globalFilters, start, indexPattern, query, end]
+    [esQueryConfig, browserFields, globalFilters, start, sourcererDataView, query, end]
   );
 
   const canQueryTimeline = useMemo(
@@ -281,7 +280,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
       id: tableId,
       indexNames: indexNames ?? selectedPatterns,
       limit: itemsPerPage,
-      runtimeMappings: sourcererDataView?.runtimeFieldMap as RunTimeMappings,
+      runtimeMappings: sourcererDataView.runtimeFieldMap as RunTimeMappings,
       skip: !canQueryTimeline,
       sort: sortField,
       startDate: start,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -233,7 +233,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
         dataProviders: [],
         filters: globalFilters,
         from: start,
-        indexPattern: sourcererDataView,
+        dataViewSpec: sourcererDataView,
         kqlMode: 'filter',
         kqlQuery: query,
         to: end,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
@@ -281,7 +281,7 @@ const InsightEditorComponent = ({
   onCancel,
 }: EuiMarkdownEditorUiPluginEditorProps<InsightComponentProps & { relativeTimerange: string }>) => {
   const isEditMode = node != null;
-  const { indexPattern } = useSourcererDataView(SourcererScopeName.default);
+  const { sourcererDataView } = useSourcererDataView(SourcererScopeName.default);
   const {
     unifiedSearch: {
       ui: { FiltersBuilderLazy },
@@ -400,7 +400,7 @@ const InsightEditorComponent = ({
     );
   }, [labelController.field.value, providers, dataView]);
   const filtersStub = useMemo(() => {
-    const index = indexPattern && indexPattern.getName ? indexPattern.getName() : '*';
+    const index = sourcererDataView.name ?? '*';
     return [
       {
         $state: {
@@ -414,7 +414,7 @@ const InsightEditorComponent = ({
         },
       },
     ];
-  }, [indexPattern]);
+  }, [sourcererDataView]);
   const isPlatinum = useLicense().isAtLeast('platinum');
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
@@ -41,7 +41,7 @@ export const useInsightQuery = ({
 }: UseInsightQuery): UseInsightQueryResult => {
   const { uiSettings } = useKibana().services;
   const esQueryConfig = useMemo(() => getEsQueryConfig(uiSettings), [uiSettings]);
-  const { browserFields, selectedPatterns, indexPattern, dataViewId } = useSourcererDataView(
+  const { browserFields, selectedPatterns, sourcererDataView, dataViewId } = useSourcererDataView(
     SourcererScopeName.timeline
   );
   const [hasError, setHasError] = useState(false);
@@ -51,7 +51,7 @@ export const useInsightQuery = ({
         const parsedCombinedQueries = combineQueries({
           config: esQueryConfig,
           dataProviders,
-          indexPattern,
+          indexPattern: sourcererDataView,
           browserFields,
           filters,
           kqlQuery: {
@@ -66,7 +66,7 @@ export const useInsightQuery = ({
       setHasError(true);
       return null;
     }
-  }, [browserFields, dataProviders, esQueryConfig, hasError, indexPattern, filters]);
+  }, [browserFields, dataProviders, esQueryConfig, hasError, sourcererDataView, filters]);
 
   const [dataLoadingState, { events, totalCount }] = useTimelineEvents({
     dataViewId,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
@@ -51,7 +51,7 @@ export const useInsightQuery = ({
         const parsedCombinedQueries = combineQueries({
           config: esQueryConfig,
           dataProviders,
-          indexPattern: sourcererDataView,
+          dataViewSpec: sourcererDataView,
           browserFields,
           filters,
           kqlQuery: {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.test.tsx
@@ -11,7 +11,7 @@ import { TableId } from '@kbn/securitysolution-data-table';
 
 import { TimelineId } from '../../../../common/types/timeline';
 import { mockBrowserFields } from '../../containers/source/mock';
-import { mockGlobalState, TestProviders, mockIndexPattern, createMockStore } from '../../mock';
+import { mockGlobalState, TestProviders, createMockStore, mockDataViewSpec } from '../../mock';
 import type { State } from '../../store';
 import { TopN } from './top_n';
 import { detectionAlertsTables } from './helpers';
@@ -153,7 +153,7 @@ const store = createMockStore(state);
 const testProps = {
   browserFields: mockBrowserFields,
   field,
-  indexPattern: mockIndexPattern,
+  indexPattern: mockDataViewSpec,
   scopeId: TableId.hostsPageEvents,
   toggleTopN: jest.fn(),
   onFilterAdded: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.tsx
@@ -96,7 +96,7 @@ const StatefulTopNComponent: React.FC<Props> = ({
   browserFields,
   dataProviders,
   field,
-  dataViewSpec: indexPattern,
+  dataViewSpec,
   globalFilters = EMPTY_FILTERS,
   globalQuery = EMPTY_QUERY,
   kqlMode,
@@ -119,7 +119,7 @@ const StatefulTopNComponent: React.FC<Props> = ({
             config: getEsQueryConfig(uiSettings),
             dataProviders,
             filters: activeTimelineFilters,
-            indexPattern,
+            dataViewSpec,
             kqlMode,
             kqlQuery: {
               language: 'kuery',
@@ -133,7 +133,7 @@ const StatefulTopNComponent: React.FC<Props> = ({
       uiSettings,
       dataProviders,
       activeTimelineFilters,
-      indexPattern,
+      dataViewSpec,
       kqlMode,
       activeTimelineKqlQueryExpression,
     ]
@@ -152,7 +152,7 @@ const StatefulTopNComponent: React.FC<Props> = ({
       field={field as AlertsStackByField}
       filters={isActiveTimeline(scopeId ?? '') ? EMPTY_FILTERS : globalFilters}
       from={isActiveTimeline(scopeId ?? '') ? activeTimelineFrom : from}
-      indexPattern={indexPattern}
+      dataViewSpec={dataViewSpec}
       options={options}
       paddingSize={paddingSize}
       query={isActiveTimeline(scopeId ?? '') ? EMPTY_QUERY : globalQuery}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/index.tsx
@@ -9,8 +9,8 @@ import React, { useMemo } from 'react';
 import type { ConnectedProps } from 'react-redux';
 import { connect } from 'react-redux';
 
-import type { DataViewBase, Filter, Query } from '@kbn/es-query';
-import { getEsQueryConfig } from '@kbn/data-plugin/common';
+import type { Filter, Query } from '@kbn/es-query';
+import { type DataViewSpec, getEsQueryConfig } from '@kbn/data-plugin/common';
 import { isActiveTimeline } from '../../../helpers';
 import { InputsModelId } from '../../store/inputs/constants';
 import { useGlobalTime } from '../../containers/use_global_time';
@@ -77,7 +77,7 @@ const connector = connect(makeMapStateToProps);
 export interface OwnProps {
   browserFields: BrowserFields;
   field: string;
-  indexPattern: DataViewBase;
+  dataViewSpec?: DataViewSpec;
   scopeId?: string;
   toggleTopN: () => void;
   onFilterAdded?: () => void;
@@ -96,7 +96,7 @@ const StatefulTopNComponent: React.FC<Props> = ({
   browserFields,
   dataProviders,
   field,
-  indexPattern,
+  dataViewSpec: indexPattern,
   globalFilters = EMPTY_FILTERS,
   globalQuery = EMPTY_QUERY,
   kqlMode,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 
-import { TestProviders, mockIndexPattern } from '../../mock';
+import { TestProviders, mockDataViewSpec } from '../../mock';
 
 import { allEvents, defaultOptions } from './helpers';
 import type { Props as TopNProps } from './top_n';
@@ -105,7 +105,7 @@ describe('TopN', () => {
     field,
     filters: [],
     from: '2020-04-14T00:31:47.695Z',
-    indexPattern: mockIndexPattern,
+    indexPattern: mockDataViewSpec,
     options: defaultOptions,
     query,
     setAbsoluteRangeDatePickerTarget: InputsModelId.global,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.test.tsx
@@ -105,7 +105,7 @@ describe('TopN', () => {
     field,
     filters: [],
     from: '2020-04-14T00:31:47.695Z',
-    indexPattern: mockDataViewSpec,
+    dataViewSpec: mockDataViewSpec,
     options: defaultOptions,
     query,
     setAbsoluteRangeDatePickerTarget: InputsModelId.global,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
@@ -9,7 +9,8 @@ import { EuiButtonIcon, EuiSuperSelect, useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 
-import type { DataViewBase, Filter, Query } from '@kbn/es-query';
+import type { Filter, Query } from '@kbn/es-query';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
 import type { GlobalTimeArgs } from '../../containers/use_global_time';
 import { EventsByDataset } from '../../../overview/components/events_by_dataset';
 import { SignalsByCategory } from '../../../overview/components/signals_by_category';
@@ -51,7 +52,7 @@ export interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery
   defaultView: TimelineEventsType;
   field: AlertsStackByField;
   filters: Filter[];
-  indexPattern: DataViewBase;
+  indexPattern?: DataViewSpec;
   options: TopNOption[];
   paddingSize?: 's' | 'm' | 'l' | 'none';
   query: Query;
@@ -122,7 +123,7 @@ const TopNComponent: React.FC<Props> = ({
             filters={applicableFilters}
             from={from}
             headerChildren={headerChildren}
-            indexPattern={indexPattern}
+            dataViewSpec={indexPattern}
             onlyField={field}
             paddingSize={paddingSize}
             query={query}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
@@ -52,7 +52,7 @@ export interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery
   defaultView: TimelineEventsType;
   field: AlertsStackByField;
   filters: Filter[];
-  indexPattern?: DataViewSpec;
+  dataViewSpec?: DataViewSpec;
   options: TopNOption[];
   paddingSize?: 's' | 'm' | 'l' | 'none';
   query: Query;
@@ -70,7 +70,7 @@ const TopNComponent: React.FC<Props> = ({
   filters,
   field,
   from,
-  indexPattern,
+  dataViewSpec,
   options,
   paddingSize,
   query,
@@ -123,7 +123,7 @@ const TopNComponent: React.FC<Props> = ({
             filters={applicableFilters}
             from={from}
             headerChildren={headerChildren}
-            dataViewSpec={indexPattern}
+            dataViewSpec={dataViewSpec}
             onlyField={field}
             paddingSize={paddingSize}
             query={query}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_by_status_donut.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_by_status_donut.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../../../../sourcerer/containers', () => ({
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
     selectedPatterns: ['signal-index'],
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../../../../sourcerer/containers', () => ({
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
     selectedPatterns: ['signal-index'],
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_table.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_table.test.ts
@@ -29,6 +29,7 @@ jest.mock('../../../../../../sourcerer/containers', () => ({
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
     selectedPatterns: ['signal-index'],
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/rule_preview.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/rule_preview.test.ts
@@ -24,6 +24,7 @@ jest.mock('../../../../../../sourcerer/containers', () => ({
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
     selectedPatterns: ['signal-index'],
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/authentication.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/authentication.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/event.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/event.test.ts
@@ -27,6 +27,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_area.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_metric.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_area.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_bar.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_bar.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_destination_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_destination_metric.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_source_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_unique_ips_source_metric.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_dns_queries.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_dns_queries.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_network_events.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_network_events.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_tls_handshakes.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_tls_handshakes.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_flow_ids.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_flow_ids.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_area.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_bar.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_bar.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_destination_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_destination_metric.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_source_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_source_metric.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_area.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_metric.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentication_metric_failure.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentication_metric_failure.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_bar.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_bar.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_metric_success.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_metric_success.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
@@ -43,6 +43,7 @@ describe('useLensAttributes', () => {
       dataViewId: 'security-solution-default',
       indicesExist: true,
       selectedPatterns: ['auditbeat-*'],
+      sourcererDataView: {},
     });
     (useRouteSpy as jest.Mock).mockReturnValue([
       {
@@ -245,6 +246,7 @@ describe('useLensAttributes', () => {
       dataViewId: 'security-solution-default',
       indicesExist: false,
       selectedPatterns: ['auditbeat-*'],
+      sourcererDataView: {},
     });
     const { result } = renderHook(
       () =>
@@ -263,6 +265,7 @@ describe('useLensAttributes', () => {
       dataViewId: 'security-solution-default',
       indicesExist: false,
       selectedPatterns: ['auditbeat-*'],
+      sourcererDataView: {},
     });
     const { result } = renderHook(
       () =>
@@ -281,6 +284,7 @@ describe('useLensAttributes', () => {
       dataViewId: 'security-solution-default',
       indicesExist: false,
       selectedPatterns: ['auditbeat-*'],
+      sourcererDataView: {},
     });
     const { result } = renderHook(
       () =>
@@ -302,6 +306,7 @@ describe('useLensAttributes', () => {
       dataViewId: 'security-solution-default',
       indicesExist: false,
       selectedPatterns: ['auditbeat-*'],
+      sourcererDataView: {},
     });
     const { result } = renderHook(
       () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.test.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import type { DataProvider } from '../../../../common/types/timeline';
 import { convertToBuildEsQuery, buildGlobalQuery } from '.';
-import { mockIndexPattern } from '../../mock';
+import { mockDataViewSpec } from '../../mock';
 
 describe('convertToBuildEsQuery', () => {
   /**
@@ -61,7 +61,7 @@ describe('convertToBuildEsQuery', () => {
     const [converted, _] = convertToBuildEsQuery({
       config,
       queries: queryWithNestedFields,
-      indexPattern: mockIndexPattern,
+      dataViewSpec: mockDataViewSpec,
       filters,
     });
 
@@ -176,7 +176,7 @@ describe('convertToBuildEsQuery', () => {
     const [converted, _] = convertToBuildEsQuery({
       config: configWithOverride,
       queries: queryWithNestedFields,
-      indexPattern: mockIndexPattern,
+      dataViewSpec: mockDataViewSpec,
       filters,
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts
@@ -30,7 +30,7 @@ export type PrimitiveOrArrayOfPrimitives =
 export interface CombineQueries {
   config: EsQueryConfig;
   dataProviders: DataProvider[];
-  indexPattern?: DataViewSpec;
+  dataViewSpec?: DataViewSpec;
   browserFields: BrowserFields;
   filters: Filter[];
   kqlQuery: Query;
@@ -245,7 +245,7 @@ export interface CombinedQuery {
 export const combineQueries = ({
   config,
   dataProviders = [],
-  indexPattern,
+  dataViewSpec,
   browserFields,
   filters = [],
   kqlQuery,
@@ -258,7 +258,7 @@ export const combineQueries = ({
     const [filterQuery, kqlError] = convertToBuildEsQuery({
       config,
       queries: [kuery],
-      dataViewSpec: indexPattern,
+      dataViewSpec,
       filters,
     });
 
@@ -286,7 +286,7 @@ export const combineQueries = ({
   const [filterQuery, kqlError] = convertToBuildEsQuery({
     config,
     queries: [kuery],
-    dataViewSpec: indexPattern,
+    dataViewSpec,
     filters,
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/index_pattern.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/index_pattern.ts
@@ -110,3 +110,8 @@ export const mockIndexPattern: SecuritySolutionDataViewBase = {
 };
 
 export const mockIndexNames = ['filebeat-*', 'auditbeat-*', 'packetbeat-*'];
+
+export const mockDataViewSpec = {
+  fields: Object.fromEntries(mockIndexPattern.fields.map((f) => [f.name, f])),
+  title: 'filebeat-*,auditbeat-*,packetbeat-*',
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.test.tsx
@@ -47,11 +47,11 @@ const coreStart = coreMock.createStart();
 
 const mockUseSourcererDataView = useSourcererDataView as jest.Mock;
 mockUseSourcererDataView.mockReturnValue({
-  indexPattern: { fields: [] },
   missingPatterns: {},
   selectedPatterns: {},
   scopeSelectedPatterns: {},
   loading: false,
+  sourcererDataView: {},
 });
 
 const mockUseRuleExecutionEvents = useExecutionResults as jest.Mock;

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
@@ -37,6 +37,7 @@ import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { ThemeServiceStart } from '@kbn/core-theme-browser';
 
+import { dataViewSpecToViewBase } from '../../../../../common/lib/kuery';
 import { InputsModelId } from '../../../../../common/store/inputs/constants';
 
 import {
@@ -160,7 +161,7 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
   } = useRuleDetailsContext();
 
   // Index for `add filter` action and toasts for errors
-  const { indexPattern } = useSourcererDataView(SourcererScopeName.detections);
+  const { sourcererDataView } = useSourcererDataView(SourcererScopeName.detections);
   const { addError, addSuccess, remove } = useAppToasts();
 
   // QueryString, Filters, and TimeRange state
@@ -233,9 +234,10 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
   const maxEvents = events?.total ?? 0;
 
   // Cache UUID field from data view as it can be expensive to iterate all data view fields
-  const uuidDataViewField = useMemo(() => {
-    return indexPattern.fields.find((f) => f.name === EXECUTION_UUID_FIELD_NAME);
-  }, [indexPattern]);
+  const uuidDataViewField = useMemo(
+    () => sourcererDataView.fields?.[EXECUTION_UUID_FIELD_NAME],
+    [sourcererDataView]
+  );
 
   // Callbacks
   const onTableChangeCallback = useCallback(
@@ -300,12 +302,18 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
 
   const onFilterByExecutionIdCallback = useCallback(
     (executionId: string, executionStart: string) => {
-      if (uuidDataViewField != null) {
+      const dataViewAsViewBase = dataViewSpecToViewBase(sourcererDataView);
+
+      if (
+        uuidDataViewField != null &&
+        typeof uuidDataViewField !== 'undefined' &&
+        dataViewAsViewBase
+      ) {
         // Update cached global query state with current state as a rollback point
         cachedGlobalQueryState.current = { filters, query, timerange };
         // Create filter & daterange constraints
         const filter = buildFilter(
-          indexPattern,
+          dataViewAsViewBase,
           uuidDataViewField,
           FILTERS.PHRASE,
           false,
@@ -351,18 +359,18 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
       }
     },
     [
-      addError,
-      addSuccess,
+      uuidDataViewField,
+      filters,
+      query,
+      timerange,
+      sourcererDataView,
       dispatch,
       filterManager,
-      filters,
-      indexPattern,
-      query,
-      resetGlobalQueryState,
       selectAlertsTab,
-      timerange,
-      uuidDataViewField,
+      addSuccess,
+      resetGlobalQueryState,
       startServices,
+      addError,
     ]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
@@ -217,7 +217,7 @@ export const Table = memo(({ dataView, groupingFilters, packages, ruleResponse }
     const combinedQuery = combineQueries({
       config: getEsQueryConfig(uiSettings),
       dataProviders: [],
-      indexPattern: dataView,
+      dataViewSpec,
       browserFields,
       filters,
       kqlQuery: globalQuery,
@@ -234,7 +234,7 @@ export const Table = memo(({ dataView, groupingFilters, packages, ruleResponse }
     } catch {
       return { bool: {} };
     }
-  }, [browserFields, dataView, filters, globalQuery, uiSettings]);
+  }, [browserFields, dataViewSpec, filters, globalQuery, uiSettings]);
 
   const renderAdditionalToolbarControls = useCallback(
     () => <AdditionalToolbarControls dataView={dataView} />,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.test.tsx
@@ -156,6 +156,7 @@ describe('ChartPanels', () => {
       indicesExist: true,
       indexPattern: {},
       browserFields: mockBrowserFields,
+      sourcererDataView: {},
     });
 
     (useAlertsLocalStorage as jest.Mock).mockReturnValue({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.test.tsx
@@ -73,6 +73,7 @@ describe('AdditionalToolbarControls', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       ...sourcererDataView,
       selectedPatterns: ['myFakebeat-*'],
+      sourcererDataView: {},
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
@@ -174,6 +174,7 @@ describe('GroupedAlertsTable', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       ...sourcererDataView,
       selectedPatterns: ['myFakebeat-*'],
+      sourcererDataView: {},
     });
     mockUseQueryAlerts.mockImplementation((i) => {
       if (i.skip) {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -106,7 +106,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
         return combineQueries({
           config: getEsQueryConfig(uiSettings),
           dataProviders: [],
-          indexPattern: sourcererDataView,
+          dataViewSpec: sourcererDataView,
           browserFields,
           filters: [
             ...defaultFilters,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -98,15 +98,15 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
   const {
     services: { uiSettings },
   } = useKibana();
-  const { browserFields, indexPattern } = useSourcererDataView(SourcererScopeName.detections);
+  const { browserFields, sourcererDataView } = useSourcererDataView(SourcererScopeName.detections);
 
   const getGlobalQuery = useCallback(
     (customFilters: Filter[]) => {
-      if (browserFields != null && indexPattern != null) {
+      if (browserFields != null && sourcererDataView) {
         return combineQueries({
           config: getEsQueryConfig(uiSettings),
           dataProviders: [],
-          indexPattern,
+          indexPattern: sourcererDataView,
           browserFields,
           filters: [
             ...defaultFilters,
@@ -127,10 +127,10 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
       from,
       globalFilters,
       globalQuery,
-      indexPattern,
       parentGroupingFilter,
       to,
       uiSettings,
+      sourcererDataView,
     ]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -223,7 +223,7 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
       return combineQueries({
         config: getEsQueryConfig(uiSettings),
         dataProviders: [],
-        indexPattern: indexPatterns,
+        dataViewSpec: sourcererDataView,
         browserFields,
         filters: [...allFilters],
         kqlQuery: globalQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -185,11 +185,7 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
     enableIpDetailsFlyout: true,
     onRuleChange,
   });
-  const {
-    browserFields,
-    indexPattern: indexPatterns,
-    sourcererDataView,
-  } = useSourcererDataView(sourcererScope);
+  const { browserFields, sourcererDataView } = useSourcererDataView(sourcererScope);
   const license = useLicense();
   const isEnterprisePlus = license.isEnterprise();
 
@@ -219,7 +215,7 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
   }, [inputFilters, globalFilters, timeRangeFilter]);
 
   const combinedQuery = useMemo(() => {
-    if (browserFields != null && indexPatterns != null) {
+    if (browserFields != null && sourcererDataView) {
       return combineQueries({
         config: getEsQueryConfig(uiSettings),
         dataProviders: [],
@@ -231,7 +227,7 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
       });
     }
     return null;
-  }, [browserFields, globalQuery, indexPatterns, uiSettings, allFilters]);
+  }, [browserFields, globalQuery, sourcererDataView, uiSettings, allFilters]);
 
   useInvalidFilterQuery({
     id: tableType,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -71,7 +71,6 @@ export const useAddBulkToTimelineAction = ({
   const {
     browserFields,
     dataViewId,
-    indexPattern,
     sourcererDataView,
     // important to get selectedPatterns from useSourcererDataView
     // in order to include the exclude filters in the search that are not stored in the timeline
@@ -104,13 +103,13 @@ export const useAddBulkToTimelineAction = ({
     return combineQueries({
       config: esQueryConfig,
       dataProviders: [],
-      indexPattern,
+      indexPattern: sourcererDataView,
       filters: combinedFilters,
       kqlQuery: { query: '', language: 'kuery' },
       browserFields,
       kqlMode: 'filter',
     });
-  }, [esQueryConfig, indexPattern, combinedFilters, browserFields]);
+  }, [esQueryConfig, sourcererDataView, combinedFilters, browserFields]);
 
   const filterQuery = useMemo(() => {
     if (!combinedQuery) return '';
@@ -128,7 +127,7 @@ export const useAddBulkToTimelineAction = ({
     sort: timelineQuerySortField,
     indexNames: selectedPatterns,
     filterQuery,
-    runtimeMappings: sourcererDataView?.runtimeFieldMap as RunTimeMappings,
+    runtimeMappings: sourcererDataView.runtimeFieldMap as RunTimeMappings,
     limit: Math.min(BULK_ADD_TO_TIMELINE_LIMIT, totalCount),
     timerangeKind: 'absolute',
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -103,7 +103,7 @@ export const useAddBulkToTimelineAction = ({
     return combineQueries({
       config: esQueryConfig,
       dataProviders: [],
-      indexPattern: sourcererDataView,
+      dataViewSpec: sourcererDataView,
       filters: combinedFilters,
       kqlQuery: { query: '', language: 'kuery' },
       browserFields,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/detection_engine_filters/detection_engine_filters.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/detection_engine_filters/detection_engine_filters.test.tsx
@@ -72,9 +72,9 @@ describe('DetectionEngineFilters', () => {
     },
     timeRange: { from: 'now-15m', to: 'now' },
     onInit: jest.fn(),
-    indexPattern: {
+    dataViewSpec: {
       title: 'mock-title',
-      fields: [],
+      fields: {},
     },
   };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/detection_engine_filters/detection_engine_filters.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/detection_engine_filters/detection_engine_filters.tsx
@@ -13,21 +13,24 @@ import type { AlertFilterControlsProps } from '@kbn/alerts-ui-shared/src/alert_f
 import { AlertFilterControls } from '@kbn/alerts-ui-shared/src/alert_filter_controls';
 import { useHistory } from 'react-router-dom';
 import { SECURITY_SOLUTION_RULE_TYPE_IDS } from '@kbn/securitysolution-rules';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
 import { useKibana } from '../../../common/lib/kibana';
 import { DEFAULT_DETECTION_PAGE_FILTERS } from '../../../../common/constants';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
-import type { SecuritySolutionDataViewBase } from '../../../common/types';
 import { SECURITY_ALERT_DATA_VIEW } from '../../constants';
 
 export type DetectionEngineFiltersProps = Pick<
   AlertFilterControlsProps,
   'filters' | 'onFiltersChange' | 'query' | 'timeRange' | 'onInit'
 > & {
-  indexPattern?: SecuritySolutionDataViewBase;
+  dataViewSpec?: DataViewSpec;
 };
 
-export const DetectionEngineFilters = ({ indexPattern, ...props }: DetectionEngineFiltersProps) => {
+export const DetectionEngineFilters = ({
+  dataViewSpec: indexPattern,
+  ...props
+}: DetectionEngineFiltersProps) => {
   const { http, notifications, dataViews } = useKibana().services;
   const spaceId = useSpaceId();
   const history = useHistory();

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
@@ -28,6 +28,7 @@ jest.mock('../../../sourcerer/containers', () => ({
     defaultIndex: 'defaultIndex',
     loading: false,
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 jest.mock('../../../common/components/guided_onboarding_tour/tour_step');

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.test.ts
@@ -112,6 +112,7 @@ describe('useRuleFromTimeline', () => {
         ...mockSourcererScope,
         dataViewId: 'custom-data-view-id',
         selectedPatterns: ['awesome-*'],
+        sourcererDataView: {},
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.test.tsx
@@ -196,7 +196,6 @@ describe('DetectionEnginePageComponent', () => {
     ]);
     (useSourcererDataView as jest.Mock).mockReturnValue({
       indicesExist: true,
-      indexPattern: {},
       browserFields: mockBrowserFields,
       sourcererDataView: {
         fields: {},

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
@@ -161,7 +161,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
   const sourcererDataView = useSourcererDataView(SourcererScopeName.detections);
   const sourcererDataViewSpec: DataViewSpec = sourcererDataView.sourcererDataView as DataViewSpec;
   const isLoadingIndexPattern = sourcererDataView.loading;
-  const indexPattern = sourcererDataView.indexPattern;
 
   const { formatUrl } = useFormatUrl(SecurityPageName.rules);
 
@@ -427,7 +426,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
                 query={query}
                 timeRange={pageFiltersTimerange}
                 onInit={setDetectionPageFilterHandler}
-                indexPattern={indexPattern}
+                dataViewSpec={sourcererDataViewSpec}
               />
               <EuiSpacer size="l" />
               <ChartPanels

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_preview_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_preview_section.tsx
@@ -148,6 +148,8 @@ const RiskEnginePreview: React.FC<{ includeClosedAlerts: boolean; from: string; 
     bool: { must: [], filter: [], should: [], must_not: [] },
   });
 
+  const [dataViewsArray, setDataViewsArray] = useState<DataView[]>([]);
+
   const { sourcererDataView } = useSourcererDataView(SourcererScopeName.detections);
 
   const { data, isLoading, refetch, isError } = useRiskScorePreview({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_preview_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_preview_section.tsx
@@ -148,8 +148,6 @@ const RiskEnginePreview: React.FC<{ includeClosedAlerts: boolean; from: string; 
     bool: { must: [], filter: [], should: [], must_not: [] },
   });
 
-  const [dataViewsArray, setDataViewsArray] = useState<DataView[]>([]);
-
   const { sourcererDataView } = useSourcererDataView(SourcererScopeName.detections);
 
   const { data, isLoading, refetch, isError } = useRiskScorePreview({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_donut.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_donut.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_over_time_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_over_time_area.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.test.ts
@@ -19,6 +19,7 @@ jest.mock('../../sourcerer/containers', () => ({
     selectedPatterns: ['auditbeat-mytest-*'],
     dataViewId: 'security-solution-my-test',
     indicesExist: true,
+    sourcererDataView: {},
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/details_tabs.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/details_tabs.test.tsx
@@ -12,6 +12,7 @@ import useResizeObserver from 'use-resize-observer/polyfilled';
 
 import {
   createMockStore,
+  mockDataViewSpec,
   mockGlobalState,
   mockIndexPattern,
   TestProviders,
@@ -162,7 +163,7 @@ describe('body', () => {
               setQuery={jest.fn()}
               hostDetailsPagePath={hostDetailsPagePath}
               indexNames={[]}
-              indexPattern={mockIndexPattern}
+              dataViewSpec={mockDataViewSpec}
               type={HostsType.details}
               hostDetailsFilter={mockHostDetailsPageFilters}
               filterQuery={filterQuery}
@@ -181,34 +182,32 @@ describe('body', () => {
         startDate: '2020-07-07T08:20:18.966Z',
         type: 'details',
         indexPattern: {
-          fields: [
-            { name: '@timestamp', searchable: true, type: 'date', aggregatable: true },
-            { name: '@version', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.ephemeral_id', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.hostname', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.id', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test1', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test2', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test3', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test4', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test5', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test6', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test7', searchable: true, type: 'string', aggregatable: true },
-            { name: 'agent.test8', searchable: true, type: 'string', aggregatable: true },
-            { name: 'host.name', searchable: true, type: 'string', aggregatable: true },
-            {
+          fields: {
+            '@timestamp': { searchable: true, type: 'date', aggregatable: true },
+            '@version': { searchable: true, type: 'string', aggregatable: true },
+            'agent.ephemeral_id': { searchable: true, type: 'string', aggregatable: true },
+            'agent.hostname': { searchable: true, type: 'string', aggregatable: true },
+            'agent.id': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test1': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test2': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test3': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test4': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test5': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test6': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test7': { searchable: true, type: 'string', aggregatable: true },
+            'agent.test8': { searchable: true, type: 'string', aggregatable: true },
+            'host.name': { searchable: true, type: 'string', aggregatable: true },
+            'nestedField.firstAttributes': {
               aggregatable: false,
-              name: 'nestedField.firstAttributes',
               searchable: true,
               type: 'string',
             },
-            {
+            'nestedField.secondAttributes': {
               aggregatable: false,
-              name: 'nestedField.secondAttributes',
               searchable: true,
               type: 'string',
             },
-          ],
+          },
           title: 'filebeat-*,auditbeat-*,packetbeat-*',
         },
         hostName: 'host-1',

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/details_tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/details_tabs.tsx
@@ -29,7 +29,7 @@ export const HostDetailsTabs = React.memo<HostDetailsTabsProps>(
     detailName,
     filterQuery,
     indexNames,
-    indexPattern,
+    dataViewSpec: indexPattern,
     hostDetailsPagePath,
     hostDetailsFilter,
   }) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
@@ -21,6 +21,7 @@ import { buildEsQuery } from '@kbn/es-query';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { dataTableSelectors, tableDefaults, TableId } from '@kbn/securitysolution-data-table';
 import type { NarrowDateRange } from '../../../../common/components/ml/types';
+import { dataViewSpecToViewBase } from '../../../../common/lib/kuery';
 import { useCalculateEntityRiskScore } from '../../../../entity_analytics/api/hooks/use_calculate_entity_risk_score';
 import {
   useAssetCriticalityData,
@@ -129,8 +130,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
     [dispatch]
   );
 
-  const { indexPattern, indicesExist, selectedPatterns, sourcererDataView } =
-    useSourcererDataView();
+  const { indicesExist, selectedPatterns, sourcererDataView } = useSourcererDataView();
   const [loading, { inspect, hostDetails: hostOverview, id, refetch }] = useHostDetails({
     endDate: to,
     startDate: from,
@@ -143,7 +143,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
     try {
       return [
         buildEsQuery(
-          indexPattern,
+          dataViewSpecToViewBase(sourcererDataView),
           [query],
           [...hostDetailsPageFilters, ...globalFilters],
           getEsQueryConfig(uiSettings)
@@ -152,7 +152,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
     } catch (e) {
       return [undefined, e];
     }
-  }, [globalFilters, indexPattern, query, uiSettings, hostDetailsPageFilters]);
+  }, [sourcererDataView, query, hostDetailsPageFilters, globalFilters, uiSettings]);
 
   const stringifiedAdditionalFilters = JSON.stringify(rawFilteredQuery);
   useInvalidFilterQuery({
@@ -318,7 +318,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
               setQuery={setQuery}
               filterQuery={stringifiedAdditionalFilters}
               hostDetailsPagePath={hostDetailsPagePath}
-              indexPattern={indexPattern}
+              dataViewSpec={sourcererDataView}
             />
           </SecuritySolutionPageWrapper>
         </>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/types.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { DataViewBase, Filter } from '@kbn/es-query';
+import type { Filter } from '@kbn/es-query';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
 import type { HostsTableType } from '../../store/model';
 import type { HostsQueryProps } from '../types';
 import type { NavTab } from '../../../../common/components/navigation/types';
@@ -40,6 +41,6 @@ export type HostDetailsTabsProps = HostBodyComponentDispatchProps &
     indexNames: string[];
     hostDetailsFilter: Filter[];
     filterQuery?: string;
-    indexPattern: DataViewBase;
+    dataViewSpec?: DataViewSpec;
     type: hostsModel.HostsType;
   };

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
@@ -105,27 +105,26 @@ const HostsComponent = () => {
     return globalFilters;
   }, [globalFilters, severitySelection, tabName]);
 
-  const { indicesExist, indexPattern, selectedPatterns, sourcererDataView } =
-    useSourcererDataView();
+  const { indicesExist, selectedPatterns, sourcererDataView } = useSourcererDataView();
   const [globalFilterQuery, kqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec: sourcererDataView,
         queries: [query],
         filters: globalFilters,
       }),
-    [globalFilters, indexPattern, uiSettings, query]
+    [globalFilters, sourcererDataView, uiSettings, query]
   );
   const [tabsFilterQuery] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec: sourcererDataView,
         queries: [query],
         filters: tabsFilters,
       }),
-    [indexPattern, query, tabsFilters, uiSettings]
+    [sourcererDataView, query, tabsFilters, uiSettings]
   );
 
   useInvalidFilterQuery({

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/columns.tsx
@@ -8,7 +8,6 @@
 import { get } from 'lodash/fp';
 import numeral from '@elastic/numeral';
 import React from 'react';
-import type { DataViewBase } from '@kbn/es-query';
 import {
   SecurityCellActions,
   CellActionsMode,
@@ -45,7 +44,6 @@ export type NetworkTopCountriesColumnsNetworkDetails = [
 ];
 
 export const getNetworkTopCountriesColumns = (
-  indexPattern: DataViewBase,
   flowTarget: FlowTargetSourceDest,
   type: networkModel.NetworkType,
   tableId: string
@@ -149,12 +147,11 @@ export const getNetworkTopCountriesColumns = (
 ];
 
 export const getCountriesColumnsCurated = (
-  indexPattern: DataViewBase,
   flowTarget: FlowTargetSourceDest,
   type: networkModel.NetworkType,
   tableId: string
 ): NetworkTopCountriesColumns | NetworkTopCountriesColumnsNetworkDetails => {
-  const columns = getNetworkTopCountriesColumns(indexPattern, flowTarget, type, tableId);
+  const columns = getNetworkTopCountriesColumns(flowTarget, type, tableId);
 
   // Columns to exclude from host details pages
   if (type === networkModel.NetworkType.details) {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/index.tsx
@@ -9,7 +9,6 @@ import { last } from 'lodash/fp';
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
-import type { DataViewBase } from '@kbn/es-query';
 
 import { networkActions, networkModel, networkSelectors } from '../../store';
 import type { NetworkTopCountriesEdges, SortField } from '../../../../../common/search_strategy';
@@ -31,7 +30,6 @@ interface NetworkTopCountriesTableProps {
   fakeTotalCount: number;
   flowTargeted: FlowTargetSourceDest;
   id: string;
-  indexPattern: DataViewBase;
   isInspect: boolean;
   loading: boolean;
   loadPage: (newActivePage: number) => void;
@@ -59,7 +57,6 @@ const NetworkTopCountriesTableComponent: React.FC<NetworkTopCountriesTableProps>
   fakeTotalCount,
   flowTargeted,
   id,
-  indexPattern,
   isInspect,
   loading,
   loadPage,
@@ -152,8 +149,8 @@ const NetworkTopCountriesTableComponent: React.FC<NetworkTopCountriesTableProps>
   );
 
   const columns = useMemo(
-    () => getCountriesColumnsCurated(indexPattern, flowTargeted, type, NetworkTopCountriesTableId),
-    [indexPattern, flowTargeted, type]
+    () => getCountriesColumnsCurated(flowTargeted, type, NetworkTopCountriesTableId),
+    [flowTargeted, type]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.test.tsx
@@ -125,6 +125,7 @@ describe('Network Details', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       indicesExist: false,
       indexPattern: {},
+      sourcererDataView: {},
     });
     global.fetch = jest.fn().mockImplementationOnce(() =>
       Promise.resolve({
@@ -145,6 +146,7 @@ describe('Network Details', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       indicesExist: true,
       indexPattern: {},
+      sourcererDataView: {},
     });
     (useParams as jest.Mock).mockReturnValue({
       detailName: ip,
@@ -165,6 +167,7 @@ describe('Network Details', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       indicesExist: true,
       indexPattern: {},
+      sourcererDataView: {},
     });
     (useParams as jest.Mock).mockReturnValue({
       detailName: ip,
@@ -187,6 +190,7 @@ describe('Network Details', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       indicesExist: false,
       indexPattern: {},
+      sourcererDataView: {},
     });
     (useParams as jest.Mock).mockReturnValue({
       detailName: ip,

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
@@ -13,6 +13,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiSpacer } from '@elasti
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 
 import { buildEsQuery } from '@kbn/es-query';
+import { dataViewSpecToViewBase } from '../../../../common/lib/kuery';
 import { AlertsByStatus } from '../../../../overview/components/detection_response/alerts_by_status';
 import { useSignalIndex } from '../../../../detections/containers/detection_engine/alerts/use_signal_index';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
@@ -105,8 +106,7 @@ const NetworkDetailsComponent: React.FC = () => {
     dispatch(setNetworkDetailsTablesActivePageToZero());
   }, [detailName, dispatch]);
 
-  const { indicesExist, indexPattern, selectedPatterns, sourcererDataView } =
-    useSourcererDataView();
+  const { indicesExist, selectedPatterns, sourcererDataView } = useSourcererDataView();
 
   const ip = decodeIpv6(detailName);
   const networkDetailsFilter = useMemo(() => getNetworkDetailsPageFilter(ip), [ip]);
@@ -115,7 +115,7 @@ const NetworkDetailsComponent: React.FC = () => {
     try {
       return [
         buildEsQuery(
-          indexPattern,
+          dataViewSpecToViewBase(sourcererDataView),
           [query],
           [...networkDetailsFilter, ...globalFilters],
           getEsQueryConfig(uiSettings)
@@ -124,7 +124,7 @@ const NetworkDetailsComponent: React.FC = () => {
     } catch (e) {
       return [undefined, e];
     }
-  }, [globalFilters, indexPattern, networkDetailsFilter, query, uiSettings]);
+  }, [globalFilters, networkDetailsFilter, query, sourcererDataView, uiSettings]);
 
   const additionalFilters = useMemo(
     () => (rawFilteredQuery ? [rawFilteredQuery] : []),
@@ -166,6 +166,10 @@ const NetworkDetailsComponent: React.FC = () => {
     }),
     [detailName, flowTarget]
   );
+
+  const indexPattern = useMemo(() => {
+    return dataViewSpecToViewBase(sourcererDataView);
+  }, [sourcererDataView]);
 
   return (
     <div data-test-subj="network-details-page">

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/countries_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/countries_query_tab_body.tsx
@@ -56,7 +56,6 @@ export const CountriesQueryTabBody = ({
       fakeTotalCount={getOr(50, 'fakeTotalCount', pageInfo)}
       flowTargeted={flowTarget}
       id={id}
-      indexPattern={indexPattern}
       inspect={inspect}
       isInspect={isInspected}
       loading={loading}

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/network_routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/network_routes.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Routes, Route } from '@kbn/shared-ux-router';
 
 import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { TableId } from '@kbn/securitysolution-data-table';
+import { dataViewSpecToViewBase } from '../../../../common/lib/kuery';
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy/security_solution/network';
 
 import {
@@ -30,7 +31,9 @@ import { NetworkRouteType } from './types';
 import { NETWORK_PATH } from '../../../../../common/constants';
 
 export const NetworkRoutes = React.memo<NetworkRoutesProps>(
-  ({ type, to, filterQuery, isInitializing, from, indexPattern, indexNames, setQuery }) => {
+  ({ type, to, filterQuery, isInitializing, from, dataViewSpec, indexNames, setQuery }) => {
+    const index = useMemo(() => dataViewSpecToViewBase(dataViewSpec), [dataViewSpec]);
+
     const networkAnomaliesFilterQuery = {
       bool: {
         should: [
@@ -61,7 +64,7 @@ export const NetworkRoutes = React.memo<NetworkRoutesProps>(
 
     const tabProps = {
       ...commonProps,
-      indexPattern,
+      indexPattern: index,
     };
 
     const anomaliesProps = {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/types.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import type { DataViewBase } from '@kbn/es-query';
 import type { Optional } from 'utility-types';
 
+import type { DataViewBase } from '@kbn/es-query';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
 import type { ESTermQuery } from '../../../../../common/typed_json';
 
 import type { NavTab } from '../../../../common/components/navigation/types';
@@ -45,7 +46,7 @@ export type HttpQueryTabBodyProps = QueryTabBodyProps;
 export type NetworkRoutesProps = GlobalTimeArgs & {
   type: networkModel.NetworkType;
   filterQuery?: string | ESTermQuery;
-  indexPattern: DataViewBase;
+  dataViewSpec: DataViewSpec;
   indexNames: string[];
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.test.tsx
@@ -227,6 +227,7 @@ describe('Network page - rendering', () => {
       selectedPatterns: [],
       indicesExist: true,
       indexPattern: { fields: [], title: 'title' },
+      sourcererDataView: {},
     });
     const myStore = createMockStore();
     render(

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
@@ -88,8 +88,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
       return globalFilters;
     }, [tabName, globalFilters]);
 
-    const { indicesExist, indexPattern, selectedPatterns, sourcererDataView } =
-      useSourcererDataView();
+    const { indicesExist, selectedPatterns, sourcererDataView } = useSourcererDataView();
 
     const onSkipFocusBeforeEventsTable = useCallback(() => {
       containerElement.current
@@ -117,14 +116,14 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
 
     const [filterQuery, kqlError] = convertToBuildEsQuery({
       config: getEsQueryConfig(kibana.services.uiSettings),
-      indexPattern,
+      dataViewSpec: sourcererDataView,
       queries: [query],
       filters: globalFilters,
     });
 
     const [tabsFilterQuery] = convertToBuildEsQuery({
       config: getEsQueryConfig(kibana.services.uiSettings),
-      indexPattern,
+      dataViewSpec: sourcererDataView,
       queries: [query],
       filters: tabsFilters,
     });
@@ -175,7 +174,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
                 <NetworkKpiComponent from={from} to={to} />
               </Display>
 
-              {capabilitiesFetched && !isInitializing ? (
+              {capabilitiesFetched && !isInitializing && sourcererDataView ? (
                 <>
                   <Display show={!globalFullScreen}>
                     <EuiSpacer />
@@ -187,7 +186,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
                     filterQuery={tabsFilterQuery}
                     from={from}
                     isInitializing={isInitializing}
-                    indexPattern={indexPattern}
+                    dataViewSpec={sourcererDataView}
                     indexNames={selectedPatterns}
                     setQuery={setQuery}
                     type={networkModel.NetworkType.page}

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
@@ -21,6 +21,7 @@ import type { Filter } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import { dataTableSelectors, TableId } from '@kbn/securitysolution-data-table';
 import { LastEventIndexKey } from '@kbn/timelines-plugin/common';
+import { dataViewSpecToViewBase } from '../../../../common/lib/kuery';
 import { useCalculateEntityRiskScore } from '../../../../entity_analytics/api/hooks/use_calculate_entity_risk_score';
 import {
   useAssetCriticalityData,
@@ -116,14 +117,13 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
     [detailName]
   );
 
-  const { indicesExist, indexPattern, selectedPatterns, sourcererDataView } =
-    useSourcererDataView();
+  const { indicesExist, selectedPatterns, sourcererDataView } = useSourcererDataView();
 
   const [rawFilteredQuery, kqlError] = useMemo(() => {
     try {
       return [
         buildEsQuery(
-          indexPattern,
+          dataViewSpecToViewBase(sourcererDataView),
           [query],
           [...usersDetailsPageFilters, ...globalFilters],
           getEsQueryConfig(uiSettings)
@@ -132,7 +132,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
     } catch (e) {
       return [undefined, e];
     }
-  }, [globalFilters, indexPattern, query, uiSettings, usersDetailsPageFilters]);
+  }, [globalFilters, sourcererDataView, query, uiSettings, usersDetailsPageFilters]);
 
   const stringifiedAdditionalFilters = JSON.stringify(rawFilteredQuery);
   useInvalidFilterQuery({
@@ -292,7 +292,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
               filterQuery={stringifiedAdditionalFilters}
               from={from}
               indexNames={selectedPatterns}
-              indexPattern={indexPattern}
+              dataViewSpec={sourcererDataView}
               isInitializing={isInitializing}
               userDetailFilter={usersDetailsPageFilters}
               setQuery={setQuery}

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/types.ts
@@ -7,7 +7,8 @@
 
 import type { ActionCreator } from 'typescript-fsa';
 
-import type { DataViewBase, Filter, Query } from '@kbn/es-query';
+import { type DataViewSpec } from '@kbn/data-plugin/common';
+import type { Filter, Query } from '@kbn/es-query';
 
 import type { UsersQueryProps } from '../types';
 import type { NavTab } from '../../../../common/components/navigation/types';
@@ -47,6 +48,6 @@ export type UsersDetailsTabsProps = UserBodyComponentDispatchProps &
     indexNames: string[];
     userDetailFilter: Filter[];
     filterQuery?: string;
-    indexPattern: DataViewBase;
+    dataViewSpec?: DataViewSpec;
     type: usersModel.UsersType;
   };

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
@@ -99,27 +99,26 @@ const UsersComponent = () => {
     return globalFilters;
   }, [severitySelection, tabName, globalFilters]);
 
-  const { indicesExist, indexPattern, selectedPatterns, sourcererDataView } =
-    useSourcererDataView();
+  const { indicesExist, selectedPatterns, sourcererDataView } = useSourcererDataView();
   const [globalFiltersQuery, kqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec: sourcererDataView,
         queries: [query],
         filters: globalFilters,
       }),
-    [globalFilters, indexPattern, uiSettings, query]
+    [globalFilters, sourcererDataView, uiSettings, query]
   );
   const [tabsFilterQuery] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec: sourcererDataView,
         queries: [query],
         filters: tabsFilters,
       }),
-    [indexPattern, query, tabsFilters, uiSettings]
+    [sourcererDataView, query, tabsFilters, uiSettings]
   );
 
   useInvalidFilterQuery({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/entities_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/entities_details.test.tsx
@@ -65,7 +65,9 @@ jest.mock('../../../../helper_hooks', () => ({
 }));
 
 jest.mock('../../../../sourcerer/containers', () => ({
-  useSourcererDataView: jest.fn().mockReturnValue({ selectedPatterns: ['index'] }),
+  useSourcererDataView: jest
+    .fn()
+    .mockReturnValue({ selectedPatterns: ['index'], sourcererDataView: {} }),
 }));
 
 jest.mock('../../../../common/components/ml/anomaly/anomaly_table_provider', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.test.tsx
@@ -84,7 +84,9 @@ jest.mock('../../../../helper_hooks', () => ({
 }));
 
 jest.mock('../../../../sourcerer/containers', () => ({
-  useSourcererDataView: jest.fn().mockReturnValue({ selectedPatterns: ['index'] }),
+  useSourcererDataView: jest
+    .fn()
+    .mockReturnValue({ selectedPatterns: ['index'], sourcererDataView: {} }),
 }));
 
 jest.mock('../../../../common/components/ml/anomaly/anomaly_table_provider', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.test.tsx
@@ -88,8 +88,7 @@ describe('<SessionView />', () => {
       loading: false,
       indicesExist: true,
       selectedPatterns: ['index'],
-      indexPattern: { fields: [], title: '' },
-      sourcererDataView: undefined,
+      sourcererDataView: {},
     });
   });
   it('renders session view correctly', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.test.tsx
@@ -76,7 +76,9 @@ jest.mock('../../../../common/components/ml/hooks/use_ml_capabilities');
 const mockUseMlUserPermissions = useMlCapabilities as jest.Mock;
 
 jest.mock('../../../../sourcerer/containers', () => ({
-  useSourcererDataView: jest.fn().mockReturnValue({ selectedPatterns: ['index'] }),
+  useSourcererDataView: jest
+    .fn()
+    .mockReturnValue({ selectedPatterns: ['index'], sourcererDataView: {} }),
 }));
 
 jest.mock('../../../../common/components/ml/anomaly/anomaly_table_provider', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.test.ts
@@ -50,8 +50,7 @@ describe('useThreatIntelligenceDetails', () => {
       loading: false,
       indicesExist: true,
       selectedPatterns: [],
-      indexPattern: { fields: [], title: '' },
-      sourcererDataView: undefined,
+      sourcererDataView: {},
     });
 
     jest

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.ts
@@ -71,7 +71,7 @@ export const useThreatIntelligenceDetails = (): ThreatIntelligenceDetailsResult 
   const [isEventDataLoading, eventData] = useTimelineEventsDetails({
     indexName,
     eventId,
-    runtimeMappings: sourcererDataView.sourcererDataView?.runtimeFieldMap as RunTimeMappings,
+    runtimeMappings: sourcererDataView.sourcererDataView.runtimeFieldMap as RunTimeMappings,
     skip: !eventId,
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
@@ -64,7 +64,6 @@ describe('useEventDetails', () => {
     expect(hookResult.result.current.dataAsNestedObject).toEqual({});
     expect(hookResult.result.current.dataFormattedForFieldBrowser).toEqual([]);
     expect(hookResult.result.current.getFieldsData('test')).toEqual('test');
-    expect('indexPattern' in hookResult.result.current).toEqual(true);
     expect(hookResult.result.current.loading).toEqual(false);
     expect(hookResult.result.current.refetchFlyoutData()).toEqual(undefined);
     expect(hookResult.result.current.searchHit).toEqual({});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
@@ -53,6 +53,7 @@ describe('useEventDetails', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       browserFields: {},
       indexPattern: {},
+      sourcererDataView: {},
     });
     (useTimelineEventsDetails as jest.Mock).mockReturnValue([false, [], {}, {}, jest.fn()]);
     jest.mocked(useGetFieldsData).mockReturnValue({ getFieldsData: (field: string) => field });
@@ -63,7 +64,7 @@ describe('useEventDetails', () => {
     expect(hookResult.result.current.dataAsNestedObject).toEqual({});
     expect(hookResult.result.current.dataFormattedForFieldBrowser).toEqual([]);
     expect(hookResult.result.current.getFieldsData('test')).toEqual('test');
-    expect(hookResult.result.current.indexPattern).toEqual({});
+    expect('indexPattern' in hookResult.result.current).toEqual(true);
     expect(hookResult.result.current.loading).toEqual(false);
     expect(hookResult.result.current.refetchFlyoutData()).toEqual(undefined);
     expect(hookResult.result.current.searchHit).toEqual({});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
@@ -8,7 +8,7 @@
 import type { BrowserFields, TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import type { DataViewBase } from '@kbn/es-query';
+import { type DataViewSpec } from '@kbn/data-plugin/common';
 import { DEFAULT_ALERTS_INDEX, DEFAULT_PREVIEW_INDEX } from '../../../../../common/constants';
 import type { RunTimeMappings } from '../../../../../common/api/search_strategy';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';
@@ -66,7 +66,7 @@ export interface UseEventDetailsResult {
   /**
    * Index pattern for rule details
    */
-  indexPattern: DataViewBase;
+  indexPattern?: DataViewSpec;
   /**
    * Whether the data is loading
    */
@@ -102,7 +102,7 @@ export const useEventDetails = ({
     useTimelineEventsDetails({
       indexName: eventIndex,
       eventId: eventId ?? '',
-      runtimeMappings: sourcererDataView?.sourcererDataView?.runtimeFieldMap as RunTimeMappings,
+      runtimeMappings: sourcererDataView.sourcererDataView.runtimeFieldMap as RunTimeMappings,
       skip: !eventId,
     });
   const { getFieldsData } = useGetFieldsData({ fieldsData: searchHit?.fields });
@@ -112,7 +112,7 @@ export const useEventDetails = ({
     dataAsNestedObject,
     dataFormattedForFieldBrowser,
     getFieldsData,
-    indexPattern: sourcererDataView.indexPattern,
+    indexPattern: sourcererDataView.sourcererDataView,
     loading,
     refetchFlyoutData,
     searchHit,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
@@ -8,7 +8,6 @@
 import type { BrowserFields, TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import { type DataViewSpec } from '@kbn/data-plugin/common';
 import { DEFAULT_ALERTS_INDEX, DEFAULT_PREVIEW_INDEX } from '../../../../../common/constants';
 import type { RunTimeMappings } from '../../../../../common/api/search_strategy';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';
@@ -64,10 +63,6 @@ export interface UseEventDetailsResult {
    */
   getFieldsData: GetFieldsData;
   /**
-   * Index pattern for rule details
-   */
-  indexPattern?: DataViewSpec;
-  /**
    * Whether the data is loading
    */
   loading: boolean;
@@ -112,7 +107,6 @@ export const useEventDetails = ({
     dataAsNestedObject,
     dataFormattedForFieldBrowser,
     getFieldsData,
-    indexPattern: sourcererDataView.sourcererDataView,
     loading,
     refetchFlyoutData,
     searchHit,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/components/network_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/components/network_details.tsx
@@ -73,10 +73,10 @@ export const NetworkDetails = ({ ip, flowTarget }: NetworkDetailsProps) => {
     services: { uiSettings },
   } = useKibana();
 
-  const { indicesExist, indexPattern, selectedPatterns } = useSourcererDataView();
+  const { indicesExist, sourcererDataView, selectedPatterns } = useSourcererDataView();
   const [filterQuery, kqlError] = convertToBuildEsQuery({
     config: getEsQueryConfig(uiSettings),
-    indexPattern,
+    dataViewSpec: sourcererDataView,
     queries: [query],
     filters,
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/kubernetes/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/kubernetes/pages/index.tsx
@@ -25,12 +25,13 @@ import { convertToBuildEsQuery } from '../../common/lib/kuery';
 import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_query';
 import { SessionsView } from '../../common/components/sessions_viewer';
 import { kubernetesSessionsHeaders } from './constants';
+import { dataViewSpecToIndexPattern } from './utils/data_view_spec_to_index_pattern';
 
 export const KubernetesContainer = React.memo(() => {
   const { kubernetesSecurity, uiSettings } = useKibana().services;
 
   const { globalFullScreen } = useGlobalFullScreen();
-  const { indexPattern, sourcererDataView, dataViewId } = useSourcererDataView();
+  const { sourcererDataView, dataViewId } = useSourcererDataView();
   const { from, to } = useGlobalTime();
 
   const getGlobalFiltersQuerySelector = useMemo(
@@ -45,11 +46,11 @@ export const KubernetesContainer = React.memo(() => {
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec: sourcererDataView,
         queries: [query],
         filters,
       }),
-    [filters, indexPattern, uiSettings, query]
+    [filters, sourcererDataView, uiSettings, query]
   );
 
   useInvalidFilterQuery({
@@ -84,7 +85,7 @@ export const KubernetesContainer = React.memo(() => {
             <SiemSearchBar id={InputsModelId.global} sourcererDataView={sourcererDataView} />
           </FiltersGlobal>
         ),
-        indexPattern,
+        indexPattern: dataViewSpecToIndexPattern(sourcererDataView),
         globalFilter: {
           filterQuery,
           startDate: from,

--- a/x-pack/solutions/security/plugins/security_solution/public/kubernetes/pages/utils/data_view_spec_to_index_pattern.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/kubernetes/pages/utils/data_view_spec_to_index_pattern.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataViewSpec } from '@kbn/data-plugin/common';
+import type { IndexPattern } from '@kbn/kubernetes-security-plugin/public/types';
+
+export const dataViewSpecToIndexPattern = (
+  dataViewSpec?: DataViewSpec
+): IndexPattern | undefined => {
+  return dataViewSpec as IndexPattern | undefined;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/event_counts/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/event_counts/index.test.tsx
@@ -8,7 +8,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { mockIndexPattern, TestProviders } from '../../../common/mock';
+import { mockDataViewSpec, TestProviders } from '../../../common/mock';
 import { OverviewHost } from '../overview_host';
 import { OverviewNetwork } from '../overview_network';
 
@@ -35,7 +35,7 @@ describe('EventCounts', () => {
     filters: [],
     from,
     indexNames: [],
-    indexPattern: mockIndexPattern,
+    dataViewSpec: mockDataViewSpec,
     setQuery: jest.fn(),
     to,
     query: {

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/event_counts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/event_counts/index.tsx
@@ -8,8 +8,8 @@
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
 
-import type { DataViewBase, Filter, Query } from '@kbn/es-query';
-import { getEsQueryConfig } from '@kbn/data-plugin/common';
+import type { Filter, Query } from '@kbn/es-query';
+import { type DataViewSpec, getEsQueryConfig } from '@kbn/data-plugin/common';
 import { ID as OverviewHostQueryId } from '../../containers/overview_host';
 import { OverviewHost } from '../overview_host';
 import { OverviewNetwork } from '../overview_network';
@@ -26,7 +26,7 @@ import { SecurityPageName } from '../../../../common/constants';
 interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'setQuery'> {
   filters: Filter[];
   indexNames: string[];
-  indexPattern: DataViewBase;
+  dataViewSpec?: DataViewSpec;
   query: Query;
 }
 
@@ -34,7 +34,7 @@ const EventCountsComponent: React.FC<Props> = ({
   filters,
   from,
   indexNames,
-  indexPattern,
+  dataViewSpec,
   query,
   setQuery,
   to,
@@ -45,22 +45,22 @@ const EventCountsComponent: React.FC<Props> = ({
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec,
         queries: [query],
         filters: [...filters, ...fieldNameExistsFilter(SecurityPageName.hosts)],
       }),
-    [filters, indexPattern, query, uiSettings]
+    [dataViewSpec, filters, query, uiSettings]
   );
 
   const [networkFilterQuery] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        indexPattern,
+        dataViewSpec,
         queries: [query],
         filters: [...filters, ...sourceOrDestinationIpExistsFilter],
       }),
-    [filters, indexPattern, uiSettings, query]
+    [uiSettings, dataViewSpec, query, filters]
   );
 
   useInvalidFilterQuery({

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useMemo, useCallback } from 'react';
 import type { DataViewBase, Filter, Query } from '@kbn/es-query';
 import styled from '@emotion/styled';
 import { EuiButton } from '@elastic/eui';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { DEFAULT_NUMBER_FORMAT, APP_UI_ID } from '../../../../common/constants';
 import { SHOWING, UNIT } from '../../../common/components/events_viewer/translations';
@@ -46,7 +47,7 @@ interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery'> {
   filterQuery?: string;
   filters: Filter[];
   headerChildren?: React.ReactNode;
-  indexPattern: DataViewBase;
+  dataViewSpec?: DataViewSpec;
   onlyField?: string;
   paddingSize?: 's' | 'm' | 'l' | 'none';
   query: Query;
@@ -76,7 +77,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
   filters,
   from,
   headerChildren,
-  indexPattern,
+  dataViewSpec,
   onlyField,
   paddingSize,
   query,
@@ -129,13 +130,13 @@ const EventsByDatasetComponent: React.FC<Props> = ({
     if (filterQueryFromProps == null) {
       return convertToBuildEsQuery({
         config: getEsQueryConfig(kibana.services.uiSettings),
-        indexPattern,
+        dataViewSpec,
         queries: [query],
         filters,
       });
     }
     return [filterQueryFromProps];
-  }, [filterQueryFromProps, kibana, indexPattern, query, filters]);
+  }, [filterQueryFromProps, kibana.services.uiSettings, dataViewSpec, query, filters]);
 
   useInvalidFilterQuery({
     id: uniqueQueryId,

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -9,7 +9,7 @@ import { Position } from '@elastic/charts';
 import numeral from '@elastic/numeral';
 import React, { useEffect, useMemo, useCallback } from 'react';
 
-import type { DataViewBase, Filter, Query } from '@kbn/es-query';
+import type { Filter, Query } from '@kbn/es-query';
 import styled from '@emotion/styled';
 import { EuiButton } from '@elastic/eui';
 import type { DataViewSpec } from '@kbn/data-plugin/common';

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
@@ -50,8 +50,7 @@ const OverviewComponent = () => {
   const filters = useDeepEqualSelector(getGlobalFiltersQuerySelector);
 
   const { from, deleteQuery, setQuery, to } = useGlobalTime();
-  const { indicesExist, sourcererDataView, indexPattern, selectedPatterns } =
-    useSourcererDataView();
+  const { indicesExist, sourcererDataView, selectedPatterns } = useSourcererDataView();
 
   const endpointMetadataIndex = useMemo<string[]>(() => {
     return [ENDPOINT_METADATA_INDEX];
@@ -114,7 +113,7 @@ const OverviewComponent = () => {
                       deleteQuery={deleteQuery}
                       filters={filters}
                       from={from}
-                      indexPattern={indexPattern}
+                      dataViewSpec={sourcererDataView}
                       query={query}
                       queryType="overview"
                       to={to}
@@ -126,7 +125,7 @@ const OverviewComponent = () => {
                       filters={filters}
                       from={from}
                       indexNames={selectedPatterns}
-                      indexPattern={indexPattern}
+                      dataViewSpec={sourcererDataView}
                       query={query}
                       setQuery={setQuery}
                       to={to}

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/alerts_sourcerer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/alerts_sourcerer.test.tsx
@@ -72,6 +72,7 @@ describe('sourcerer on alerts page or rules details page', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       ...sourcererDataView,
       indicesExist: true,
+      sourcererDataView: {},
     });
 
     render(

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
@@ -152,8 +152,8 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
   const { indicesExist, loading, sourcererDataView } = useSourcererDataView(scopeId);
 
   const activePatterns = useMemo(
-    () => (sourcererDataView?.title || '')?.split(',').filter(Boolean) as string[],
-    [sourcererDataView?.title]
+    () => (sourcererDataView.title || '')?.split(',').filter(Boolean) as string[],
+    [sourcererDataView.title]
   );
 
   const [missingPatterns, setMissingPatterns] = useState<string[]>(

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/sourcerer_integration.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/sourcerer_integration.test.tsx
@@ -72,6 +72,7 @@ const patternListNoSignals = sortWithExcludesAtEnd(
 const sourcererDataView = {
   indicesExist: true,
   loading: false,
+  sourcererDataView: {},
 };
 
 describe('Sourcerer integration tests', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/timeline_sourcerer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/timeline_sourcerer.test.tsx
@@ -56,6 +56,7 @@ const { id } = mockGlobalState.sourcerer.defaultDataView;
 const sourcererDataView = {
   indicesExist: true,
   loading: false,
+  sourcererDataView: {},
 };
 
 describe('timeline sourcerer', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.test.ts
@@ -37,7 +37,7 @@ describe('useGetScopedSourcererDataView', () => {
   it('should return undefined when no spec is provided', () => {
     mockGetSourcererDataView.mockReturnValueOnce({
       ...mockSourcererScope,
-      sourcererDataView: undefined,
+      sourcererDataView: {},
     });
     const { result } = renderHookCustom({ sourcererScope: SourcererScopeName.timeline });
     expect(result.current).toBeUndefined();
@@ -45,7 +45,7 @@ describe('useGetScopedSourcererDataView', () => {
   it('should return undefined when no spec is provided and should update the return when spec is updated to correct value', () => {
     mockGetSourcererDataView.mockReturnValueOnce({
       ...mockSourcererScope,
-      sourcererDataView: undefined,
+      sourcererDataView: {},
     });
     const { rerender, result } = renderHookCustom({ sourcererScope: SourcererScopeName.timeline });
     expect(result.current).toBeUndefined();

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.tsx
@@ -30,7 +30,7 @@ export const useGetScopedSourcererDataView = ({
   const { sourcererDataView } = useSourcererDataView(sourcererScope);
 
   const dataView = useMemo(() => {
-    if (sourcererDataView) {
+    if (Object.keys(sourcererDataView).length) {
       return new DataView({ spec: sourcererDataView, fieldFormats });
     } else {
       return undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
@@ -649,7 +649,6 @@ describe('Sourcerer Hooks', () => {
           '-filebeat-*',
           '-packetbeat-*',
         ]);
-        expect(result.current.indexPattern).toHaveProperty('getName');
       });
     });
 
@@ -658,7 +657,7 @@ describe('Sourcerer Hooks', () => {
         wrapper: StoreProvider,
       });
 
-      expect(result.current.sourcererDataView?.title).toBe(
+      expect(result.current.sourcererDataView.title).toBe(
         'apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-*'
       );
 
@@ -675,8 +674,8 @@ describe('Sourcerer Hooks', () => {
 
       rerender();
 
-      expect(result.current.sourcererDataView?.title).toBe(testPatterns.join(','));
-      expect(result.current.sourcererDataView?.name).toBe(testPatterns.join(','));
+      expect(result.current.sourcererDataView.title).toBe(testPatterns.join(','));
+      expect(result.current.sourcererDataView.name).toBe(testPatterns.join(','));
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import type { FieldSpec } from '@kbn/data-plugin/common';
 import { sourcererSelectors } from '../store';
 import type { SelectedDataView, SourcererDataView, RunTimeMappings } from '../store/model';
 import { SourcererScopeName } from '../store/model';
@@ -56,8 +57,7 @@ export const useSourcererDataView = (
       id: fetchIndexReturn.dataView?.id ?? null,
       loading: indexPatternsLoading,
       patternList: fetchIndexReturn.indexes,
-      indexFields: fetchIndexReturn.indexPatterns
-        .fields as SelectedDataView['indexPattern']['fields'],
+      indexFields: fetchIndexReturn.indexPatterns.fields as FieldSpec[],
       fields: fetchIndexReturn.dataView?.fields,
     }),
     [fetchIndexReturn, indexPatternsLoading]

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
@@ -120,28 +120,12 @@ export const useSourcererDataView = (
     () => ({
       browserFields: browserFields(),
       dataViewId: sourcererDataView.id,
-      indexPattern: {
-        fields: Object.values(sourcererDataView.fields || {}),
-        title: selectedPatterns.join(','),
-        getName: () => selectedPatterns.join(','),
-      },
       indicesExist,
       loading: loading || sourcererDataView.loading,
-      // all active & inactive patterns in DATA_VIEW
-      patternList: sourcererDataView.title.split(','),
       // selected patterns in DATA_VIEW including filter
       selectedPatterns,
-      // if we have to do an update to data view, tell us which patterns are active
-      ...(legacyPatterns.length > 0 ? { activePatterns: sourcererDataView.patternList } : {}),
       sourcererDataView: sourcererDataView.dataView,
     }),
-    [
-      browserFields,
-      sourcererDataView,
-      selectedPatterns,
-      indicesExist,
-      loading,
-      legacyPatterns.length,
-    ]
+    [browserFields, sourcererDataView, selectedPatterns, indicesExist, loading]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/mocks.ts
@@ -38,19 +38,6 @@ export const mockSourcererScope: SelectedDataView = {
       },
     },
   },
-  indexPattern: {
-    fields: [
-      {
-        aggregatable: false,
-        esTypes: undefined,
-        name: '_id',
-        searchable: true,
-        subType: undefined,
-        type: 'string',
-      },
-    ],
-    title: mockPatterns.join(),
-  },
   sourcererDataView: mockGlobalState.sourcerer.defaultDataView,
   selectedPatterns: mockPatterns,
   indicesExist: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
@@ -9,7 +9,6 @@ import type { BrowserFields } from '@kbn/timelines-plugin/common';
 import { EMPTY_BROWSER_FIELDS } from '@kbn/timelines-plugin/common';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { RuntimeFieldSpec, RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
-import type { SecuritySolutionDataViewBase } from '../../common/types';
 
 /** Uniquely identifies a Sourcerer Scope */
 export enum SourcererScopeName {
@@ -88,11 +87,6 @@ export interface SelectedDataView {
    */
   browserFields: BrowserFields;
   dataViewId: string | null; // null if legacy pre-8.0 timeline
-  /**
-   * @deprecated use sourcererDataView
-   * DataViewBase with enhanced index fields used in timelines
-   */
-  indexPattern: SecuritySolutionDataViewBase;
   /** do the selected indices exist  */
   indicesExist: boolean;
   /** is an update being made to the data view */
@@ -103,7 +97,7 @@ export interface SelectedDataView {
    * Easier to add this additional data rather than
    * try to extend the SelectedDataView type from DataView.
    */
-  sourcererDataView: DataViewSpec | undefined;
+  sourcererDataView: DataViewSpec;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
@@ -63,7 +63,11 @@ describe('OpenTimelineButton', () => {
   it('should open the modal after clicking on the button', async () => {
     (useParams as jest.Mock).mockReturnValue({ tabName: TimelineTypeEnum.template });
     (useStartTransaction as jest.Mock).mockReturnValue({ startTransaction: jest.fn() });
-    (useSourcererDataView as jest.Mock).mockReturnValue({ dataViewId: '', selectedPatterns: [] });
+    (useSourcererDataView as jest.Mock).mockReturnValue({
+      dataViewId: '',
+      selectedPatterns: [],
+      sourcererDataView: {},
+    });
     (useTimelineStatus as jest.Mock).mockReturnValue({
       timelineStatus: 'active',
       templateTimelineFilter: null,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.test.tsx
@@ -59,6 +59,7 @@ describe('TimelineModalHeader', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       browserFields: {},
       indexPattern: { fields: [], title: '' },
+      sourcererDataView: {},
     });
 
     const { getByTestId, getByText } = renderTimelineModalHeader();
@@ -78,6 +79,7 @@ describe('TimelineModalHeader', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       browserFields: {},
       indexPattern: { fields: [], title: '' },
+      sourcererDataView: {},
     });
     (useKibana as jest.Mock).mockReturnValue({
       services: {
@@ -107,6 +109,7 @@ describe('TimelineModalHeader', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       browserFields: {},
       indexPattern: { fields: [], title: '' },
+      sourcererDataView: {},
     });
 
     const spy = jest.spyOn(timelineActions, 'showTimeline');

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -88,7 +88,7 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
         combineQueries({
           config: esQueryConfig,
           dataProviders,
-          indexPattern: sourcererDataView,
+          dataViewSpec: dataView,
           browserFields,
           filters: filters ? filters : [],
           kqlQuery: kqlQueryObj,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -70,7 +70,7 @@ interface FlyoutHeaderPanelProps {
 export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
   ({ timelineId, openToggleRef }) => {
     const dispatch = useDispatch();
-    const { browserFields, indexPattern } = useSourcererDataView(SourcererScopeName.timeline);
+    const { browserFields, sourcererDataView } = useSourcererDataView(SourcererScopeName.timeline);
     const { cases, uiSettings } = useKibana().services;
     const esQueryConfig = useMemo(() => getEsQueryConfig(uiSettings), [uiSettings]);
     const userCasesPermissions = useMemo(() => cases.helpers.canUseCases([APP_ID]), [cases]);
@@ -88,13 +88,21 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
         combineQueries({
           config: esQueryConfig,
           dataProviders,
-          indexPattern,
+          indexPattern: sourcererDataView,
           browserFields,
           filters: filters ? filters : [],
           kqlQuery: kqlQueryObj,
           kqlMode,
         }),
-      [browserFields, dataProviders, esQueryConfig, filters, indexPattern, kqlMode, kqlQueryObj]
+      [
+        browserFields,
+        dataProviders,
+        esQueryConfig,
+        filters,
+        kqlMode,
+        kqlQueryObj,
+        sourcererDataView,
+      ]
     );
     const isInspectDisabled = !isDataInTimeline || combinedQueries?.filterQuery === undefined;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -88,7 +88,7 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
         combineQueries({
           config: esQueryConfig,
           dataProviders,
-          dataViewSpec: dataView,
+          dataViewSpec: sourcererDataView,
           browserFields,
           filters: filters ? filters : [],
           kqlQuery: kqlQueryObj,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
@@ -32,7 +32,7 @@ interface KpiExpandedProps {
 }
 
 export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
-  const { browserFields, indexPattern, selectedPatterns } = useSourcererDataView(
+  const { browserFields, sourcererDataView, selectedPatterns } = useSourcererDataView(
     SourcererScopeName.timeline
   );
 
@@ -82,13 +82,13 @@ export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
       combineQueries({
         config: esQueryConfig,
         dataProviders,
-        indexPattern,
+        indexPattern: sourcererDataView,
         browserFields,
         filters: filters ? filters : [],
         kqlQuery,
         kqlMode,
       }),
-    [browserFields, dataProviders, esQueryConfig, filters, indexPattern, kqlMode, kqlQuery]
+    [browserFields, dataProviders, esQueryConfig, filters, sourcererDataView, kqlMode, kqlQuery]
   );
 
   const isBlankTimeline: boolean = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
@@ -82,7 +82,7 @@ export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
       combineQueries({
         config: esQueryConfig,
         dataProviders,
-        indexPattern: sourcererDataView,
+        dataViewSpec: sourcererDataView,
         browserFields,
         filters: filters ? filters : [],
         kqlQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
@@ -17,7 +17,10 @@ import { InputsModelId } from '../../../../common/store/inputs/constants';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
-import { convertKueryToElasticSearchQuery } from '../../../../common/lib/kuery';
+import {
+  convertKueryToElasticSearchQuery,
+  dataViewSpecToViewBase,
+} from '../../../../common/lib/kuery';
 import type { KqlMode } from '../../../store/model';
 import { useSavedQueryServices } from '../../../../common/utils/saved_query_services';
 import type { DispatchUpdateReduxTime } from '../../../../common/components/super_date_picker';
@@ -107,13 +110,18 @@ export const QueryBarTimeline = memo<QueryBarTimelineComponentProps>(
     const [dateRangeTo, setDateRangTo] = useState<string>(
       toStr != null ? toStr : new Date(to).toISOString()
     );
-    const { browserFields, indexPattern } = useSourcererDataView(SourcererScopeName.timeline);
+    const { browserFields, sourcererDataView } = useSourcererDataView(SourcererScopeName.timeline);
     const [savedQuery, setSavedQuery] = useState<SavedQuery | undefined>(undefined);
     const [filterQueryConverted, setFilterQueryConverted] = useState<Query>({
       query: filterQuery != null ? filterQuery.expression : '',
       language: filterQuery != null ? filterQuery.kind : 'kuery',
     });
     const queryBarFilters = useMemo(() => getNonDropAreaFilters(filters), [filters]);
+
+    const indexPattern = useMemo(
+      () => dataViewSpecToViewBase(sourcererDataView),
+      [sourcererDataView]
+    );
 
     const [dataProvidersDsl, setDataProvidersDsl] = useState<string>(
       convertKueryToElasticSearchQuery(buildGlobalQuery(dataProviders, browserFields), indexPattern)
@@ -258,6 +266,10 @@ export const QueryBarTimeline = memo<QueryBarTimelineComponentProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [dataProvidersDsl, savedQueryId, savedQueryServices]
     );
+
+    if (!indexPattern) {
+      return null;
+    }
 
     return (
       <SearchBarContainer className="search_bar_container">

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
@@ -73,7 +73,7 @@ const StatefulSearchOrFilterComponent = React.memo<Props>(
       services: { data },
     } = useKibana();
 
-    const { indexPattern } = useSourcererDataView(SourcererScopeName.timeline);
+    const { sourcererDataView } = useSourcererDataView(SourcererScopeName.timeline);
 
     const getIsDataProviderVisible = useMemo(
       () => timelineSelectors.dataProviderVisibilitySelector(),
@@ -86,25 +86,22 @@ const StatefulSearchOrFilterComponent = React.memo<Props>(
 
     useEffect(() => {
       let dv: DataView;
-      if (isDataView(indexPattern)) {
-        setDataView(indexPattern);
-      } else if (!filterQuery) {
-        const createDataView = async () => {
-          try {
-            dv = await data.dataViews.create({ title: indexPattern.title });
-            setDataView(dv);
-          } catch (error) {
-            addError(error, { title: i18n.ERROR_PROCESSING_INDEX_PATTERNS });
-          }
-        };
-        createDataView();
-      }
+      const createDataView = async () => {
+        try {
+          dv = await data.dataViews.create(sourcererDataView);
+          setDataView(dv);
+        } catch (error) {
+          addError(error, { title: i18n.ERROR_PROCESSING_INDEX_PATTERNS });
+        }
+      };
+      createDataView();
+
       return () => {
         if (dv?.id) {
           data.dataViews.clearInstanceCache(dv?.id);
         }
       };
-    }, [data.dataViews, indexPattern, filterQuery, addError]);
+    }, [data.dataViews, filterQuery, addError, sourcererDataView]);
 
     const arrDataView = useMemo(() => (dataView != null ? [dataView] : []), [dataView]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -148,7 +148,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
       fields: timelineQueryFields,
       limit: itemsPerPage,
       filterQuery,
-      runtimeMappings: sourcererDataView?.runtimeFieldMap as RunTimeMappings,
+      runtimeMappings: sourcererDataView.runtimeFieldMap as RunTimeMappings,
       skip: filterQuery === '',
       startDate: '',
       sort: timelineQuerySortField,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
@@ -90,7 +90,6 @@ export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string
     browserFields,
     dataViewId,
     loading: loadingSourcerer,
-    indexPattern,
     // important to get selectedPatterns from useSourcererDataView
     // in order to include the exclude filters in the search that are not stored in the timeline
     selectedPatterns,
@@ -123,7 +122,7 @@ export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string
       kqlQuery,
       kqlMode,
     });
-  }, [esQueryConfig, dataProviders, indexPattern, browserFields, filters, kqlQuery, kqlMode]);
+  }, [esQueryConfig, dataProviders, sourcererDataView, browserFields, filters, kqlQuery, kqlMode]);
 
   useInvalidFilterQuery({
     id: timelineId,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
@@ -117,7 +117,7 @@ export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string
     return combineQueries({
       config: esQueryConfig,
       dataProviders,
-      indexPattern,
+      dataViewSpec: sourcererDataView,
       browserFields,
       filters,
       kqlQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -126,7 +126,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     return combineQueries({
       config: esQueryConfig,
       dataProviders,
-      indexPattern: sourcererDataView,
+      dataViewSpec: sourcererDataView,
       browserFields,
       filters,
       kqlQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -87,7 +87,6 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     browserFields,
     dataViewId,
     loading: loadingSourcerer,
-    indexPattern,
     // important to get selectedPatterns from useSourcererDataView
     // in order to include the exclude filters in the search that are not stored in the timeline
     selectedPatterns,
@@ -127,13 +126,13 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     return combineQueries({
       config: esQueryConfig,
       dataProviders,
-      indexPattern,
+      indexPattern: sourcererDataView,
       browserFields,
       filters,
       kqlQuery,
       kqlMode,
     });
-  }, [esQueryConfig, dataProviders, indexPattern, browserFields, filters, kqlQuery, kqlMode]);
+  }, [esQueryConfig, dataProviders, sourcererDataView, browserFields, filters, kqlQuery, kqlMode]);
 
   useInvalidFilterQuery({
     id: timelineId,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.test.tsx
@@ -32,6 +32,7 @@ describe('TimelinesPage', () => {
   it('should render landing page if no indicesExist', () => {
     (useSourcererDataView as unknown as jest.Mock).mockReturnValue({
       indicesExist: false,
+      sourcererDataView: {},
     });
     (useUserPrivileges as jest.Mock).mockReturnValue({
       timelinePrivileges: {
@@ -49,6 +50,7 @@ describe('TimelinesPage', () => {
   it('should show the correct elements if user has crud', () => {
     (useSourcererDataView as unknown as jest.Mock).mockReturnValue({
       indicesExist: true,
+      sourcererDataView: {},
     });
     (useUserPrivileges as jest.Mock).mockReturnValue({
       timelinePrivileges: {

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/containers/field_types_provider.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/containers/field_types_provider.tsx
@@ -16,16 +16,18 @@ export const FieldTypesContext = createContext<FieldTypesContextValue | undefine
  * Exposes mapped field types for threat intel shared use
  */
 export const FieldTypesProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const { indexPattern } = useSourcererDataView();
+  const {
+    sourcererDataView: { fields = {} },
+  } = useSourcererDataView();
 
   // field name to field type map to allow the cell_renderer to format dates
   const fieldTypes: FieldTypesContextValue = useMemo(
     () =>
-      indexPattern.fields.reduce((acc, field) => {
+      Object.values(fields).reduce((acc, field) => {
         acc[field.name] = field.type;
         return acc;
       }, {} as FieldTypesContextValue),
-    [indexPattern.fields]
+    [fields]
   );
 
   return <FieldTypesContext.Provider value={fieldTypes}>{children}</FieldTypesContext.Provider>;

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector.stories.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector.stories.tsx
@@ -7,23 +7,9 @@
 
 import React from 'react';
 import type { StoryFn } from '@storybook/react';
-import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { EuiComboBoxOptionOption } from '@elastic/eui';
 import { RawIndicatorFieldId } from '../../../../../common/types/indicator';
 import { IndicatorsFieldSelector } from './field_selector';
-
-const mockIndexPattern: DataView = {
-  fields: [
-    {
-      name: '@timestamp',
-      type: 'date',
-    } as DataViewField,
-    {
-      name: 'threat.feed.name',
-      type: 'string',
-    } as DataViewField,
-  ],
-} as DataView;
 
 export default {
   component: IndicatorsFieldSelector,
@@ -33,7 +19,6 @@ export default {
 export const Default: StoryFn = () => {
   return (
     <IndicatorsFieldSelector
-      indexPattern={mockIndexPattern}
       valueChange={({ label }: EuiComboBoxOptionOption<string>) =>
         window.alert(`${label} selected`)
       }
@@ -44,7 +29,6 @@ export const Default: StoryFn = () => {
 export const WithDefaultValue: StoryFn = () => {
   return (
     <IndicatorsFieldSelector
-      indexPattern={mockIndexPattern}
       valueChange={({ label }: EuiComboBoxOptionOption<string>) =>
         window.alert(`${label} selected`)
       }
@@ -54,5 +38,5 @@ export const WithDefaultValue: StoryFn = () => {
 };
 
 export const NoData: StoryFn = () => {
-  return <IndicatorsFieldSelector indexPattern={{ fields: [] } as any} valueChange={() => {}} />;
+  return <IndicatorsFieldSelector valueChange={() => {}} />;
 };

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector.test.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector.test.tsx
@@ -7,31 +7,16 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { TestProvidersComponent } from '../../../../mocks/test_providers';
 import { IndicatorsFieldSelector } from './field_selector';
 import { EuiComboBoxOptionOption } from '@elastic/eui';
 import { DROPDOWN_TEST_ID } from './test_ids';
-
-const mockIndexPattern: DataView = {
-  fields: [
-    {
-      name: '@timestamp',
-      type: 'date',
-    } as DataViewField,
-    {
-      name: 'threat.feed.name',
-      type: 'string',
-    } as DataViewField,
-  ],
-} as DataView;
 
 describe('<IndicatorsFieldSelector />', () => {
   it('should handle empty array of indexPatterns', () => {
     const { getByTestId } = render(
       <TestProvidersComponent>
         <IndicatorsFieldSelector
-          indexPattern={{ fields: [] } as any}
           // eslint-disable-next-line no-console
           valueChange={(value: EuiComboBoxOptionOption<string>) => console.log(value)}
         />
@@ -45,7 +30,6 @@ describe('<IndicatorsFieldSelector />', () => {
     const { getByTestId } = render(
       <TestProvidersComponent>
         <IndicatorsFieldSelector
-          indexPattern={mockIndexPattern}
           // eslint-disable-next-line no-console
           valueChange={(value: EuiComboBoxOptionOption<string>) => console.log(value)}
         />

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector.tsx
@@ -7,16 +7,15 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiComboBox } from '@elastic/eui';
-import { DataViewField } from '@kbn/data-views-plugin/common';
+import { FieldSpec } from '@kbn/data-views-plugin/common';
 import { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/types';
-import { SecuritySolutionDataViewBase } from '../../../../types';
 import { RawIndicatorFieldId } from '../../../../../common/types/indicator';
 import { useStyles } from './styles';
 import { DROPDOWN_TEST_ID } from './test_ids';
 import { COMBOBOX_PREPEND_LABEL } from './translations';
+import { useCurrentDataViewFields } from '../../hooks/use_current_data_view_fields';
 
 export interface IndicatorsFieldSelectorProps {
-  indexPattern: SecuritySolutionDataViewBase;
   valueChange: (value: EuiComboBoxOptionOption<string>) => void;
   defaultStackByValue?: RawIndicatorFieldId;
 }
@@ -25,10 +24,12 @@ const DEFAULT_STACK_BY_VALUE = RawIndicatorFieldId.Feed;
 const COMBOBOX_SINGLE_SELECTION = { asPlainText: true };
 
 export const IndicatorsFieldSelector = memo<IndicatorsFieldSelectorProps>(
-  ({ indexPattern, valueChange, defaultStackByValue = DEFAULT_STACK_BY_VALUE }) => {
+  ({ valueChange, defaultStackByValue = DEFAULT_STACK_BY_VALUE }) => {
+    const rawFields = useCurrentDataViewFields();
+
     const styles = useStyles();
-    const defaultStackByValueInfo = indexPattern.fields.find(
-      (f: DataViewField) => f.name === defaultStackByValue
+    const defaultStackByValueInfo = rawFields.find(
+      (f: FieldSpec) => f.name === defaultStackByValue
     );
     const [selectedField, setSelectedField] = useState<Array<EuiComboBoxOptionOption<string>>>([
       {
@@ -38,13 +39,11 @@ export const IndicatorsFieldSelector = memo<IndicatorsFieldSelectorProps>(
     ]);
     const fields: Array<EuiComboBoxOptionOption<string>> = useMemo(
       () =>
-        indexPattern
-          ? indexPattern.fields.map((f: DataViewField) => ({
-              label: f.name,
-              value: f.type,
-            }))
-          : [],
-      [indexPattern]
+        rawFields.map((f: FieldSpec) => ({
+          label: f.name,
+          value: f.type,
+        })),
+      [rawFields]
     );
 
     const selectedFieldChange = useCallback(

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/wrapper.stories.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/wrapper.stories.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { of } from 'rxjs';
 import type { StoryObj } from '@storybook/react';
-import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { TimeRange } from '@kbn/es-query';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { IUiSettingsClient } from '@kbn/core/public';
@@ -27,19 +26,6 @@ export default {
 };
 
 const mockTimeRange: TimeRange = { from: '', to: '' };
-
-const mockIndexPattern: DataView = {
-  fields: [
-    {
-      name: '@timestamp',
-      type: 'date',
-    } as DataViewField,
-    {
-      name: 'threat.feed.name',
-      type: 'string',
-    } as DataViewField,
-  ],
-} as DataView;
 
 const validDate: string = '1 Jan 2022 00:00:00 GMT';
 const numberOfDays: number = 1;
@@ -139,7 +125,6 @@ export const Default: StoryObj = {
           series={[]}
           field={mockField}
           onFieldChange={mockOnFieldChange}
-          indexPattern={mockIndexPattern}
         />
       </StoryProvidersComponent>
     );
@@ -167,7 +152,6 @@ export const InitialLoad: StoryObj = {
           isFetching={false}
           field={mockField}
           onFieldChange={mockOnFieldChange}
-          indexPattern={mockIndexPattern}
         />
       </StoryProvidersComponent>
     );
@@ -218,7 +202,6 @@ export const UpdatingData: StoryObj = {
           isFetching={true}
           field={mockField}
           onFieldChange={mockOnFieldChange}
-          indexPattern={mockIndexPattern}
         />
       </StoryProvidersComponent>
     );

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/wrapper.test.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { TimeRange } from '@kbn/es-query';
-import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { TestProvidersComponent } from '../../../../mocks/test_providers';
 import { IndicatorsBarChartWrapper } from './wrapper';
 import {
@@ -20,19 +19,6 @@ import moment from 'moment';
 import { DROPDOWN_TEST_ID } from './test_ids';
 
 jest.mock('../../../query_bar/hooks/use_filters');
-
-const mockIndexPattern: DataView = {
-  fields: [
-    {
-      name: '@timestamp',
-      type: 'date',
-    } as DataViewField,
-    {
-      name: 'threat.feed.name',
-      type: 'string',
-    } as DataViewField,
-  ],
-} as DataView;
 
 const mockTimeRange: TimeRange = { from: '', to: '' };
 const mockField = { label: 'host.name', value: 'string' };
@@ -47,7 +33,6 @@ describe('<IndicatorsBarChartWrapper />', () => {
             series={[]}
             field={mockField}
             onFieldChange={jest.fn()}
-            indexPattern={mockIndexPattern}
             timeRange={mockTimeRange}
             isFetching={false}
             isLoading={false}
@@ -70,7 +55,6 @@ describe('<IndicatorsBarChartWrapper />', () => {
             series={[]}
             field={mockField}
             onFieldChange={jest.fn()}
-            indexPattern={mockIndexPattern}
             timeRange={mockTimeRange}
             isFetching={false}
             isLoading={true}
@@ -92,7 +76,6 @@ describe('<IndicatorsBarChartWrapper />', () => {
             series={[]}
             field={mockField}
             onFieldChange={jest.fn()}
-            indexPattern={mockIndexPattern}
             timeRange={mockTimeRange}
             isFetching={true}
             isLoading={false}

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/barchart/wrapper.tsx
@@ -18,7 +18,6 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { TimeRange } from '@kbn/es-query';
 import { TimeRangeBounds } from '@kbn/data-plugin/common';
-import { SecuritySolutionDataViewBase } from '../../../../types';
 import { RawIndicatorFieldId } from '../../../../../common/types/indicator';
 import { IndicatorsFieldSelector } from './field_selector';
 import { IndicatorsBarChart } from './barchart';
@@ -36,10 +35,6 @@ export interface IndicatorsBarChartWrapperProps {
    * From and to values received from the KQL bar and passed down to the hook to query data.
    */
   timeRange?: TimeRange;
-  /**
-   * List of fields coming from the Security Solution sourcerer data view, passed down to the {@link IndicatorsFieldSelector} to populate the dropdown.
-   */
-  indexPattern: SecuritySolutionDataViewBase;
 
   series: ChartSeries[];
 
@@ -61,7 +56,7 @@ export interface IndicatorsBarChartWrapperProps {
  * and handles retrieving aggregated indicator data.
  */
 export const IndicatorsBarChartWrapper = memo<IndicatorsBarChartWrapperProps>(
-  ({ timeRange, indexPattern, isLoading, isFetching, series, dateRange, field, onFieldChange }) => {
+  ({ timeRange, isLoading, isFetching, series, dateRange, field, onFieldChange }) => {
     if (isLoading) {
       return (
         <EuiFlexGroup justifyContent="spaceAround">
@@ -89,7 +84,6 @@ export const IndicatorsBarChartWrapper = memo<IndicatorsBarChartWrapperProps>(
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <IndicatorsFieldSelector
-              indexPattern={indexPattern}
               defaultStackByValue={DEFAULT_FIELD}
               valueChange={onFieldChange}
             />

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/table.stories.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/table.stories.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { DataView } from '@kbn/data-views-plugin/common';
 import { mockIndicatorsFiltersContext } from '../../../../mocks/mock_indicators_filters_context';
 import { StoryProvidersComponent } from '../../../../mocks/story_providers';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
@@ -18,8 +17,6 @@ export default {
   component: IndicatorsTable,
   title: 'IndicatorsTable',
 };
-
-const mockIndexPattern: DataView = undefined as unknown as DataView;
 
 const stub = () => void 0;
 
@@ -54,7 +51,6 @@ export function IndicatorsFullyLoaded() {
           onChangePage={stub}
           onChangeItemsPerPage={stub}
           indicatorCount={indicatorsFixture.length * 2}
-          indexPattern={mockIndexPattern}
           columnSettings={columnSettings}
         />
       </IndicatorsFiltersContext.Provider>
@@ -77,7 +73,6 @@ export function FirstLoad() {
         onChangeItemsPerPage={stub}
         indicatorCount={0}
         isLoading={true}
-        indexPattern={mockIndexPattern}
         columnSettings={columnSettings}
       />
     </StoryProvidersComponent>
@@ -103,7 +98,6 @@ export function DataUpdateInProgress() {
           onChangePage={stub}
           onChangeItemsPerPage={stub}
           indicatorCount={indicatorsFixture.length * 2}
-          indexPattern={mockIndexPattern}
           columnSettings={columnSettings}
         />
       </IndicatorsFiltersContext.Provider>
@@ -126,7 +120,6 @@ export function WithNoIndicators() {
         onChangeItemsPerPage={stub}
         indicatorCount={0}
         isLoading={false}
-        indexPattern={mockIndexPattern}
         columnSettings={columnSettings}
       />
     </StoryProvidersComponent>

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/table.test.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/table.test.tsx
@@ -11,7 +11,6 @@ import { IndicatorsTable, IndicatorsTableProps } from './table';
 import { TestProvidersComponent } from '../../../../mocks/test_providers';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { BUTTON_TEST_ID, TABLE_UPDATE_PROGRESS_TEST_ID } from './test_ids';
-import { SecuritySolutionDataViewBase } from '../../../../types';
 import { INDICATORS_FLYOUT_TITLE_TEST_ID } from '../flyout/test_ids';
 
 const stub = () => {};
@@ -24,7 +23,6 @@ const tableProps: IndicatorsTableProps = {
   indicatorCount: 0,
   isLoading: false,
   browserFields: {},
-  indexPattern: { fields: [], title: '' } as SecuritySolutionDataViewBase,
   columnSettings: {
     columnVisibility: {
       visibleColumns: [],

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/table.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/table.tsx
@@ -25,7 +25,7 @@ import {
 import { CellActions } from './cell_actions';
 import { cellPopoverRendererFactory } from './cell_popover_renderer';
 import { cellRendererFactory } from './cell_renderer';
-import { BrowserFields, SecuritySolutionDataViewBase } from '../../../../types';
+import { BrowserFields } from '../../../../types';
 import { Indicator, RawIndicatorFieldId } from '../../../../../common/types/indicator';
 import { EmptyState } from '../../../../components/empty_state';
 import { IndicatorsTableContext, IndicatorsTableContextValue } from '../../hooks/use_table_context';
@@ -51,7 +51,6 @@ export interface IndicatorsTableProps {
    */
   isLoading?: boolean;
   isFetching?: boolean;
-  indexPattern: SecuritySolutionDataViewBase;
   browserFields: BrowserFields;
   columnSettings: ColumnSettingsValue;
 }

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_current_data_view_fields.test.ts
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_current_data_view_fields.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useCurrentDataViewFields } from './use_current_data_view_fields';
+import { useSourcererDataView } from './use_sourcerer_data_view';
+
+jest.mock('./use_sourcerer_data_view');
+
+describe('useFields', () => {
+  it('should return fields from sourcererDataView', () => {
+    const mockFields = { field1: {}, field2: {} };
+    (useSourcererDataView as jest.Mock).mockReturnValue({
+      sourcererDataView: { fields: mockFields },
+    });
+
+    const { result } = renderHook(() => useCurrentDataViewFields());
+
+    expect(result.current).toEqual(Object.values(mockFields));
+  });
+
+  it('should return an empty array if fields are undefined', () => {
+    (useSourcererDataView as jest.Mock).mockReturnValue({
+      sourcererDataView: { fields: undefined },
+    });
+
+    const { result } = renderHook(() => useCurrentDataViewFields());
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_current_data_view_fields.ts
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_current_data_view_fields.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { FieldSpec } from '@kbn/data-views-plugin/common';
+import { useSourcererDataView } from './use_sourcerer_data_view';
+
+/**
+ * Custom hook to retrieve fields from the sourcerer data view.
+ */
+export const useCurrentDataViewFields = (): FieldSpec[] => {
+  const { sourcererDataView } = useSourcererDataView();
+
+  return useMemo(() => Object.values(sourcererDataView.fields ?? {}), [sourcererDataView.fields]);
+};

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
@@ -7,7 +7,6 @@
 
 import { useMemo } from 'react';
 import { RawIndicatorFieldId } from '../../../../common/types/indicator';
-import { SecuritySolutionDataViewBase } from '../../../types';
 import { useSecurityContext } from '../../../hooks/use_security_context';
 import { DESCRIPTION } from './translations';
 
@@ -27,17 +26,6 @@ const indicatorNameField = {
 export const useSourcererDataView = () => {
   const { sourcererDataView } = useSecurityContext();
 
-  const updatedPattern = useMemo(() => {
-    const fields = [...sourcererDataView.indexPattern.fields, indicatorNameField];
-
-    return {
-      ...sourcererDataView.indexPattern,
-      fields,
-    } as SecuritySolutionDataViewBase;
-  }, [sourcererDataView.indexPattern]);
-
-  const indexPatterns = useMemo(() => [updatedPattern], [updatedPattern]);
-
   const browserFields = useMemo(() => {
     const { threat = { fields: {} } } = sourcererDataView.browserFields;
 
@@ -55,10 +43,9 @@ export const useSourcererDataView = () => {
   return useMemo(
     () => ({
       ...sourcererDataView,
-      indexPatterns,
-      indexPattern: updatedPattern,
       browserFields,
+      patternList: sourcererDataView.selectedPatterns,
     }),
-    [browserFields, indexPatterns, sourcererDataView, updatedPattern]
+    [browserFields, sourcererDataView]
   );
 };

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/pages/indicators.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/pages/indicators.tsx
@@ -37,7 +37,7 @@ const IndicatorsPageProviders: FC<PropsWithChildren<unknown>> = ({ children }) =
 const IndicatorsPageContent: VFC = () => {
   const { blockListIndicatorValue } = useBlockListContext();
 
-  const { browserFields, indexPattern, sourcererDataView } = useSourcererDataView();
+  const { sourcererDataView, browserFields } = useSourcererDataView();
 
   const columnSettings = useColumnSettings();
 
@@ -91,7 +91,6 @@ const IndicatorsPageContent: VFC = () => {
           dateRange={dateRange}
           series={series}
           timeRange={timeRange}
-          indexPattern={indexPattern}
           field={selectedField}
           onFieldChange={onFieldChange}
           isFetching={isFetchingAggregatedIndicators}
@@ -100,7 +99,6 @@ const IndicatorsPageContent: VFC = () => {
 
         <IndicatorsTable
           browserFields={browserFields}
-          indexPattern={indexPattern}
           columnSettings={columnSettings}
           pagination={pagination}
           indicatorCount={indicatorCount}

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.ts
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.ts
@@ -59,10 +59,10 @@ export const useFilterInOut = ({
       key,
       value,
       filterType,
-      sourcererDataView?.id
+      sourcererDataView.id
     );
     filterManager.setFilters(newFilters);
-  }, [filterManager, filterType, key, sourcererDataView?.id, value]);
+  }, [filterManager, filterType, key, sourcererDataView.id, value]);
 
   if (!fieldAndValueValid(key, value)) {
     return {} as unknown as UseFilterInValue;

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/types.ts
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/types.ts
@@ -65,7 +65,7 @@ export interface LicenseAware {
 export type BrowserFields = Readonly<Record<string, Partial<BrowserField>>>;
 
 export interface SelectedDataView {
-  sourcererDataView: DataViewSpec | undefined;
+  sourcererDataView: DataViewSpec;
   indexPattern: SecuritySolutionDataViewBase;
   browserFields: BrowserFields;
   selectedPatterns: string[];

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/types.ts
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/types.ts
@@ -8,16 +8,11 @@
 import { ComponentType, NamedExoticComponent, ReactElement, ReactNode, VFC } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import {
-  DataViewField,
-  type DataViewSpec,
-  DataViewsPublicPluginStart,
-  FieldSpec,
-} from '@kbn/data-views-plugin/public';
+import { type DataViewSpec, DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { TimelinesUIStart } from '@kbn/timelines-plugin/public';
 import type { TriggersAndActionsUIPublicPluginStart as TriggersActionsStart } from '@kbn/triggers-actions-ui-plugin/public';
-import { DataViewBase, Filter, Query, TimeRange } from '@kbn/es-query';
+import { Filter, Query, TimeRange } from '@kbn/es-query';
 import { BrowserField } from '@kbn/rule-registry-plugin/common';
 import { Store } from 'redux';
 import { DataProvider } from '@kbn/timelines-plugin/common';
@@ -25,10 +20,6 @@ import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import { CasesPublicSetup, CasesPublicStart } from '@kbn/cases-plugin/public/types';
 import { CreateExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { Policy } from './modules/block_list/hooks/use_policies';
-
-export interface SecuritySolutionDataViewBase extends DataViewBase {
-  fields: Array<FieldSpec & DataViewField>;
-}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ThreatIntelligencePluginSetup {}
@@ -66,7 +57,6 @@ export type BrowserFields = Readonly<Record<string, Partial<BrowserField>>>;
 
 export interface SelectedDataView {
   sourcererDataView: DataViewSpec;
-  indexPattern: SecuritySolutionDataViewBase;
   browserFields: BrowserFields;
   selectedPatterns: string[];
   loading: boolean;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Remove index pattern field from Sourcerer (#190113)](https://github.com/elastic/kibana/pull/190113)
 - [remove unused fields from the sourcerer hook result #206030](https://github.com/elastic/kibana/pull/206030) 
- [[Security Solution][Sourcerer] Rename index pattern props to data view #216542](https://github.com/elastic/kibana/pull/216542)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Luke Gmys","email":"11671118+lgestc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-28T11:11:00Z","message":"[Security Solution] Remove index pattern field from Sourcerer (#190113)\n\n## Summary\r\n\r\nThis PR removes index pattern field from the sourcerer model, replacing\r\nit with direct access to data view spec.\r\n\r\nThe end goal for the sourcerer is to just utilize platform wide Data\r\nView Types, instead of some custom abstractions / containers such as\r\nindexPattern field which is effectively a DataViewSpec, just packed up\r\ndifferently.","sha":"a8048ddf6b3f6623c87236c875a0ef1506a39fe2","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:Threat Hunting:Investigations","Team:Threat Hunting:Explore"],"title":"[Security Solution] Remove index pattern field from Sourcerer","number":190113,"url":"https://github.com/elastic/kibana/pull/190113","mergeCommit":{"message":"[Security Solution] Remove index pattern field from Sourcerer (#190113)\n\n## Summary\r\n\r\nThis PR removes index pattern field from the sourcerer model, replacing\r\nit with direct access to data view spec.\r\n\r\nThe end goal for the sourcerer is to just utilize platform wide Data\r\nView Types, instead of some custom abstractions / containers such as\r\nindexPattern field which is effectively a DataViewSpec, just packed up\r\ndifferently.","sha":"a8048ddf6b3f6623c87236c875a0ef1506a39fe2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/190113","number":190113,"mergeCommit":{"message":"[Security Solution] Remove index pattern field from Sourcerer (#190113)\n\n## Summary\r\n\r\nThis PR removes index pattern field from the sourcerer model, replacing\r\nit with direct access to data view spec.\r\n\r\nThe end goal for the sourcerer is to just utilize platform wide Data\r\nView Types, instead of some custom abstractions / containers such as\r\nindexPattern field which is effectively a DataViewSpec, just packed up\r\ndifferently.","sha":"a8048ddf6b3f6623c87236c875a0ef1506a39fe2"}}]}] BACKPORT-->