### PR TITLE
[onechat] factorize chat agent execution to `runChatAgent` function

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-server/agents/provider.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/agents/provider.ts
@@ -54,7 +54,7 @@ export interface AgentHandlerContext {
    */
   modelProvider: ModelProvider;
   /**
-   * Tool provider that should be used to list of execute tools.
+   * Tool provider that can be used to list or execute tools.
    */
   toolProvider: ToolProvider;
   /**

--- a/x-pack/platform/packages/shared/onechat/onechat-server/src/tools.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/src/tools.ts
@@ -101,6 +101,10 @@ export interface ToolHandlerContext {
    */
   modelProvider: ModelProvider;
   /**
+   * Tool provider that can be used to list or execute tools.
+   */
+  toolProvider: ToolProvider;
+  /**
    * Onechat runner scoped to the current execution.
    * Can be used to run other workchat primitive as part of the tool execution.
    */

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { createDefaultAgentProvider } from './provider';
+export { runChatAgent } from './run_chat_agent';

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/run_chat_agent.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Observable, from, filter, shareReplay, firstValueFrom, map } from 'rxjs';
+import type { Logger } from '@kbn/logging';
+import { StreamEvent } from '@langchain/core/tracers/log_stream';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import {
+  RoundInput,
+  ConversationRound,
+  ChatAgentEvent,
+  isRoundCompleteEvent,
+} from '@kbn/onechat-common';
+import type {
+  ModelProvider,
+  ScopedRunner,
+  ExecutableTool,
+  ToolProvider,
+} from '@kbn/onechat-server';
+import { providerToLangchainTools, toLangchainTool, conversationLangchainMessages } from './utils';
+import { createAgentGraph } from './graph';
+import { convertGraphEvents, addRoundCompleteEvent } from './convert_graph_events';
+
+export interface RunChatAgentContext {
+  logger: Logger;
+  request: KibanaRequest;
+  modelProvider: ModelProvider;
+  runner: ScopedRunner;
+}
+
+export interface RunChatAgentParams {
+  /**
+   * The next message in this conversation that the agent should respond to.
+   */
+  nextInput: RoundInput;
+  /**
+   * Previous rounds of conversation.
+   */
+  conversation?: ConversationRound[];
+  /**
+   * Optional system prompt to override the default one.
+   */
+  systemPrompt?: string;
+  /**
+   * List of tools that will be exposed to the agent.
+   * Either a list of tools or a tool provider.
+   */
+  tools?: ToolProvider | ExecutableTool[];
+  /**
+   * In case of nested calls (e.g calling from a tool), allows to define the runId.
+   */
+  runId?: string;
+  /**
+   * Handler to react to the agent's events.
+   */
+  onEvent?: (event: ChatAgentEvent) => void;
+  /**
+   * Can be used to override the graph's name. Used for tracing.
+   */
+  agentGraphName?: string;
+}
+
+export type RunChatAgentFn = (
+  params: RunChatAgentParams,
+  context: RunChatAgentContext
+) => Promise<ConversationRound>;
+
+const defaultAgentGraphName = 'default-onechat-agent';
+
+const noopOnEvent = () => {};
+
+/**
+ * Create the handler function for the default onechat agent.
+ */
+export const runChatAgent: RunChatAgentFn = async (
+  {
+    nextInput,
+    conversation = [],
+    tools = [],
+    onEvent = noopOnEvent,
+    runId = uuidv4(),
+    systemPrompt,
+    agentGraphName = defaultAgentGraphName,
+  },
+  { logger, request, modelProvider }
+) => {
+  const model = await modelProvider.getDefaultModel();
+  const langchainTools = Array.isArray(tools)
+    ? tools.map((tool) => toLangchainTool({ tool, logger }))
+    : await providerToLangchainTools({ request, toolProvider: tools, logger });
+  const initialMessages = conversationLangchainMessages({
+    nextInput,
+    previousRounds: conversation,
+  });
+  const agentGraph = await createAgentGraph({
+    logger,
+    chatModel: model.chatModel,
+    tools: langchainTools,
+    systemPrompt,
+  });
+
+  const eventStream = agentGraph.streamEvents(
+    { initialMessages },
+    {
+      version: 'v2',
+      runName: agentGraphName,
+      metadata: {
+        graphName: agentGraphName,
+        runId,
+      },
+      recursionLimit: 10,
+      callbacks: [],
+    }
+  );
+
+  const events$ = from(eventStream).pipe(
+    filter(isStreamEvent),
+    convertGraphEvents({ graphName: agentGraphName, runName: agentGraphName }),
+    addRoundCompleteEvent({ userInput: nextInput }),
+    shareReplay()
+  );
+
+  events$.subscribe(onEvent);
+
+  return await extractRound(events$);
+};
+
+export const extractRound = async (events$: Observable<ChatAgentEvent>) => {
+  return await firstValueFrom(
+    events$.pipe(
+      filter(isRoundCompleteEvent),
+      map((event) => event.data.round)
+    )
+  );
+};
+
+const isStreamEvent = (input: any): input is StreamEvent => {
+  return 'event' in input;
+};

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/system_prompt.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/system_prompt.ts
@@ -7,17 +7,25 @@
 
 import { BaseMessage, BaseMessageLike } from '@langchain/core/messages';
 
-const getSystemPrompt = () => {
-  return `You are a helpful chat assistant from the Elasticsearch company.
+export const defaultSystemPrompt =
+  'You are a helpful chat assistant from the Elasticsearch company.';
 
-  You have tools at your disposal that you can use to answer the user's question.
+const getFullSystemPrompt = (systemPrompt: string) => {
+  return `${systemPrompt}
 
   ### Additional info
+  - You have tools at your disposal that you can use
   - The current date is: ${new Date().toISOString()}
   - You can use markdown format to structure your response
   `;
 };
 
-export const withSystemPrompt = ({ messages }: { messages: BaseMessage[] }): BaseMessageLike[] => {
-  return [['system', getSystemPrompt()], ...messages];
+export const withSystemPrompt = ({
+  systemPrompt,
+  messages,
+}: {
+  systemPrompt: string;
+  messages: BaseMessage[];
+}): BaseMessageLike[] => {
+  return [['system', getFullSystemPrompt(systemPrompt)], ...messages];
 };

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/utils/tool_provider_to_langchain_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/conversational/utils/tool_provider_to_langchain_tools.ts
@@ -9,23 +9,21 @@ import { StructuredTool, tool as toTool } from '@langchain/core/tools';
 import { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import { toolDescriptorToIdentifier, toSerializedToolIdentifier } from '@kbn/onechat-common';
-import type { ToolProvider, ExecutableTool, ScopedRunner } from '@kbn/onechat-server';
+import type { ToolProvider, ExecutableTool } from '@kbn/onechat-server';
 
 export const providerToLangchainTools = async ({
   request,
   toolProvider,
   logger,
-  runner,
 }: {
   request: KibanaRequest;
   toolProvider: ToolProvider;
   logger: Logger;
-  runner: ScopedRunner;
 }): Promise<StructuredTool[]> => {
   const allTools = await toolProvider.list({ request });
   return Promise.all(
     allTools.map((tool) => {
-      return toLangchainTool({ tool, logger, runner });
+      return toLangchainTool({ tool, logger });
     })
   );
 };
@@ -33,20 +31,15 @@ export const providerToLangchainTools = async ({
 export const toLangchainTool = ({
   tool,
   logger,
-  runner,
 }: {
   tool: ExecutableTool;
-  runner: ScopedRunner;
   logger: Logger;
 }): StructuredTool => {
   const toolId = toolDescriptorToIdentifier(tool);
   return toTool(
     async (input) => {
       try {
-        const toolReturn = await runner.runTool({
-          toolId,
-          toolParams: input,
-        });
+        const toolReturn = await tool.execute({ toolParams: input });
         return JSON.stringify(toolReturn.result);
       } catch (e) {
         logger.warn(`error calling tool ${tool.name}: ${e.message}`);

--- a/x-pack/platform/plugins/shared/onechat/server/services/runner/run_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/runner/run_agent.ts
@@ -11,6 +11,7 @@ import type {
   ConversationalAgentParams,
   RunAgentReturn,
 } from '@kbn/onechat-server';
+import { internalProviderToPublic } from '../tools/utils';
 import { createAgentEventEmitter, forkContextForAgentRun } from './utils';
 import type { RunnerManager } from './runner';
 
@@ -29,7 +30,10 @@ export const createAgentHandlerContext = <TParams = Record<string, unknown>>({
     esClient: elasticsearch.client.asScoped(request),
     modelProvider: modelProviderFactory({ request, defaultConnectorId }),
     runner: manager.getRunner(),
-    toolProvider: toolsService.registry.asPublicRegistry(),
+    toolProvider: internalProviderToPublic({
+      provider: toolsService.registry,
+      getRunner: manager.getRunner,
+    }),
     events: createAgentEventEmitter({ eventHandler: onEvent, context: manager.context }),
   };
 };

--- a/x-pack/platform/plugins/shared/onechat/server/services/runner/run_tool.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/runner/run_tool.ts
@@ -10,6 +10,7 @@ import type {
   ScopedRunnerRunToolsParams,
   RunToolReturn,
 } from '@kbn/onechat-server';
+import { internalProviderToPublic } from '../tools/utils';
 import { forkContextForToolRun } from './utils/run_context';
 import { createToolEventEmitter } from './utils/events';
 import type { RunnerManager } from './runner';
@@ -46,12 +47,17 @@ export const createToolHandlerContext = <TParams = Record<string, unknown>>({
   manager: RunnerManager;
 }): ToolHandlerContext => {
   const { onEvent } = toolExecutionParams;
-  const { request, defaultConnectorId, elasticsearch, modelProviderFactory } = manager.deps;
+  const { request, defaultConnectorId, elasticsearch, modelProviderFactory, toolsService } =
+    manager.deps;
   return {
     request,
     esClient: elasticsearch.client.asScoped(request),
     modelProvider: modelProviderFactory({ request, defaultConnectorId }),
     runner: manager.getRunner(),
+    toolProvider: internalProviderToPublic({
+      provider: toolsService.registry,
+      getRunner: manager.getRunner,
+    }),
     events: createToolEventEmitter({ eventHandler: onEvent, context: manager.context }),
   };
 };

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/utils/index.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/utils/index.ts
@@ -7,4 +7,4 @@
 
 export { combineToolProviders } from './combine_tool_providers';
 export { toolToDescriptor, toExecutableTool, addBuiltinSystemMeta } from './tool_conversion';
-export { createInternalRegistry } from './create_internal_registry';
+export { createInternalRegistry, internalProviderToPublic } from './create_internal_registry';


### PR DESCRIPTION
## Summary

Introduce a static `runChatAgent` function to allow re-using the agent's workflow from anywhere


### Example

```ts
    const completedRound = await runChatAgent(
      {
        nextInput,
        conversation,
        agentGraphName: defaultAgentGraphName,
        runId,
        onEvent: (event) => {
          events.emit(event);
        },
        tools: toolProvider,
      },
      {
        logger,
        runner,
        request,
        modelProvider,
      }
    );
```




