### PR TITLE
Fixes the zindex of the resizable flyout over the editor

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -366,7 +366,7 @@ export function LensEditConfigurationFlyout({
           direction="column"
           gutterSize="none"
         >
-          <div ref={editorContainer} />
+          <div ref={editorContainer} style={{ zIndex: 0 }} />
           <EuiFlexItem
             grow={isLayerAccordionOpen ? 1 : false}
             css={css`


### PR DESCRIPTION
## Summary

Fixes the flyout resize area above the editor.

Before
![image](https://github.com/user-attachments/assets/2702ec5f-ede6-4712-84cd-294c1522a156)

After
<img width="862" alt="image" src="https://github.com/user-attachments/assets/4c772127-6bcb-4776-a969-5014843ae720" />






<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->