### PR TITLE
[9.0] [Fleet] Fix UnenrollInactiveAgentsTask to only unenroll agents inactive for longer than unenroll_timeout (#222592)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.test.ts
@@ -236,4 +236,31 @@ describe('UnenrollInactiveAgentsTask', () => {
       );
     });
   });
+
+  describe('getAgentQuery', () => {
+    const policy1 = createAgentPolicyMock({ id: 'agent-policy-1', unenroll_timeout: 1000 });
+    const policy2 = createAgentPolicyMock({ id: 'agent-policy-2', unenroll_timeout: 300 });
+
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2025-06-01'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('Should get a query that only gets agents that have been inactive for longer than the unenroll_timeout', async () => {
+      const policies = [policy1];
+      expect(mockTask.getAgentsQuery(policies as any)).toEqual(
+        `(fleet-agents.policy_id:\"agent-policy-1\" and (fleet-agents.last_checkin < 1748735000000)) and fleet-agents.status: inactive`
+      );
+    });
+
+    it('Should get a query for multiple agent policies that only gets agents inactive for longer than the unenroll_timeout', async () => {
+      const policies = [policy1, policy2];
+      expect(mockTask.getAgentsQuery(policies as any)).toEqual(
+        `(fleet-agents.policy_id:\"agent-policy-1\" and (fleet-agents.last_checkin < 1748735000000) or \"agent-policy-2\" and (fleet-agents.last_checkin < 1748735700000)) and fleet-agents.status: inactive`
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.ts
@@ -30,12 +30,12 @@ import type { AgentPolicy } from '../types';
 
 export const TYPE = 'fleet:unenroll-inactive-agents-task';
 export const VERSION = '1.0.1';
+export const POLICIES_BATCHSIZE = 500;
 const TITLE = 'Fleet Unenroll Inactive Agent Task';
 const SCOPE = ['fleet'];
 const INTERVAL = '10m';
 const TIMEOUT = '1m';
 const UNENROLLMENT_BATCHSIZE = 1000;
-const POLICIES_BATCHSIZE = 500;
 
 interface UnenrollInactiveAgentsTaskSetupContract {
   core: CoreSetup;

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.ts
@@ -26,15 +26,16 @@ import { AGENTS_PREFIX, AGENT_POLICY_SAVED_OBJECT_TYPE } from '../constants';
 import { getAgentsByKuery } from '../services/agents';
 import { unenrollBatch } from '../services/agents/unenroll_action_runner';
 import { agentPolicyService, auditLoggingService } from '../services';
+import type { AgentPolicy } from '../types';
 
 export const TYPE = 'fleet:unenroll-inactive-agents-task';
-export const VERSION = '1.0.0';
-export const POLICIES_BATCHSIZE = 500;
+export const VERSION = '1.0.1';
 const TITLE = 'Fleet Unenroll Inactive Agent Task';
 const SCOPE = ['fleet'];
 const INTERVAL = '10m';
 const TIMEOUT = '1m';
 const UNENROLLMENT_BATCHSIZE = 1000;
+const POLICIES_BATCHSIZE = 500;
 
 interface UnenrollInactiveAgentsTaskSetupContract {
   core: CoreSetup;
@@ -106,6 +107,19 @@ export class UnenrollInactiveAgentsTask {
     return `${TYPE}:${VERSION}`;
   }
 
+  // function marked public to allow testing
+  // find inactive agents enrolled on selected policies
+  // check that the time since last checkin was longer than unenroll_timeout
+  public getAgentsQuery(agentPolicies: AgentPolicy[]): string {
+    return `(${AGENTS_PREFIX}.policy_id:${agentPolicies
+      .map((policy) => {
+        // @ts-ignore-next-line
+        const inactivityThreshold = Date.now() - policy.unenroll_timeout * 1000;
+        return `"${policy.id}" and (${AGENTS_PREFIX}.last_checkin < ${inactivityThreshold})`;
+      })
+      .join(' or ')}) and ${AGENTS_PREFIX}.status: inactive`;
+  }
+
   private endRun(msg: string = '') {
     this.logger.info(`[UnenrollInactiveAgentsTask] runTask ended${msg ? ': ' + msg : ''}`);
   }
@@ -136,12 +150,10 @@ export class UnenrollInactiveAgentsTask {
       }
 
       // find inactive agents enrolled on above policies
+      // check that the time since last checkin was longer than unenroll_timeout
       // limit batch size to UNENROLLMENT_BATCHSIZE to avoid scale issues
-      const kuery = `(${AGENTS_PREFIX}.policy_id:${agentPolicyPageResults
-        .map((policy) => `"${policy.id}"`)
-        .join(' or ')}) and ${AGENTS_PREFIX}.status: inactive`;
       const res = await getAgentsByKuery(esClient, soClient, {
-        kuery,
+        kuery: this.getAgentsQuery(agentPolicyPageResults),
         showInactive: true,
         page: 1,
         perPage: this.unenrollBatchSize,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Fleet] Fix UnenrollInactiveAgentsTask to only unenroll agents inactive for longer than unenroll_timeout (#222592)](https://github.com/elastic/kibana/pull/222592)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-06T07:32:57Z","message":"[Fleet] Fix UnenrollInactiveAgentsTask to only unenroll agents inactive for longer than unenroll_timeout (#222592)\n\nFixes https://github.com/elastic/kibana/issues/220660\n\n## Summary\n\nThis bug was found through an SDH. Fixes the query that fetches the\nagents so that actually includes only those agents that have been\ninactive for longer than `unenroll_timeout`.\n\n### Testing\n- Add some inactive agents with the script in\n`x-pack/platform/plugins/shared/fleet/scripts/create_agents`. The fake\nagents are enrolled with an inactive time alraedy set to 5m. The script\nalso creates a policy.\n- In the policy setting, set `unenroll_timeout` to a time that's long\nenough, for instance 10m (600s)\n<img width=\"1351\" alt=\"Screenshot 2025-06-04 at 16 59 38\"\nsrc=\"https://github.com/user-attachments/assets/983e46c2-8b29-4340-a3d8-426fda38d061\"\n/>\n\n- the task runs every 10m so in order to test it, change [the interval\n](https://github.com/elastic/kibana/blob/9cc9e20c95cc96d7df90c1fb3d4674ecf5254307/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.ts#L34)to\na shorter time (3 or 5m)\n- Check that those agents are not unenrolled until they have been\ninactive for at least 10m\n- Try enrolling some other inactive agents and verify that those\ninactive for less than 10m are not unenrolled\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"61bc2f88a6efc6ee537b2599894ce4176164e6ac","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-minor","backport:prev-major","v9.1.0"],"title":"[Fleet] Fix UnenrollInactiveAgentsTask to only unenroll agents inactive for longer than unenroll_timeout","number":222592,"url":"https://github.com/elastic/kibana/pull/222592","mergeCommit":{"message":"[Fleet] Fix UnenrollInactiveAgentsTask to only unenroll agents inactive for longer than unenroll_timeout (#222592)\n\nFixes https://github.com/elastic/kibana/issues/220660\n\n## Summary\n\nThis bug was found through an SDH. Fixes the query that fetches the\nagents so that actually includes only those agents that have been\ninactive for longer than `unenroll_timeout`.\n\n### Testing\n- Add some inactive agents with the script in\n`x-pack/platform/plugins/shared/fleet/scripts/create_agents`. The fake\nagents are enrolled with an inactive time alraedy set to 5m. The script\nalso creates a policy.\n- In the policy setting, set `unenroll_timeout` to a time that's long\nenough, for instance 10m (600s)\n<img width=\"1351\" alt=\"Screenshot 2025-06-04 at 16 59 38\"\nsrc=\"https://github.com/user-attachments/assets/983e46c2-8b29-4340-a3d8-426fda38d061\"\n/>\n\n- the task runs every 10m so in order to test it, change [the interval\n](https://github.com/elastic/kibana/blob/9cc9e20c95cc96d7df90c1fb3d4674ecf5254307/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.ts#L34)to\na shorter time (3 or 5m)\n- Check that those agents are not unenrolled until they have been\ninactive for at least 10m\n- Try enrolling some other inactive agents and verify that those\ninactive for less than 10m are not unenrolled\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"61bc2f88a6efc6ee537b2599894ce4176164e6ac"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222592","number":222592,"mergeCommit":{"message":"[Fleet] Fix UnenrollInactiveAgentsTask to only unenroll agents inactive for longer than unenroll_timeout (#222592)\n\nFixes https://github.com/elastic/kibana/issues/220660\n\n## Summary\n\nThis bug was found through an SDH. Fixes the query that fetches the\nagents so that actually includes only those agents that have been\ninactive for longer than `unenroll_timeout`.\n\n### Testing\n- Add some inactive agents with the script in\n`x-pack/platform/plugins/shared/fleet/scripts/create_agents`. The fake\nagents are enrolled with an inactive time alraedy set to 5m. The script\nalso creates a policy.\n- In the policy setting, set `unenroll_timeout` to a time that's long\nenough, for instance 10m (600s)\n<img width=\"1351\" alt=\"Screenshot 2025-06-04 at 16 59 38\"\nsrc=\"https://github.com/user-attachments/assets/983e46c2-8b29-4340-a3d8-426fda38d061\"\n/>\n\n- the task runs every 10m so in order to test it, change [the interval\n](https://github.com/elastic/kibana/blob/9cc9e20c95cc96d7df90c1fb3d4674ecf5254307/x-pack/platform/plugins/shared/fleet/server/tasks/unenroll_inactive_agents_task.ts#L34)to\na shorter time (3 or 5m)\n- Check that those agents are not unenrolled until they have been\ninactive for at least 10m\n- Try enrolling some other inactive agents and verify that those\ninactive for less than 10m are not unenrolled\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"61bc2f88a6efc6ee537b2599894ce4176164e6ac"}}]}] BACKPORT-->