### PR TITLE
[Infra][8.19] Skip same suites as in main for `node_details.ts`

### DIFF
--- a/x-pack/test/functional/apps/infra/node_details.ts
+++ b/x-pack/test/functional/apps/infra/node_details.ts
@@ -131,8 +131,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     await browser.refresh();
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/222073
-  describe.skip('Node Details', () => {
+  describe('Node Details', () => {
     let synthEsClient: InfraSynthtraceEsClient;
     before(async () => {
       synthEsClient = await getInfraSynthtraceEsClient(esClient);
@@ -256,6 +255,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           { metric: 'network', chartsCount: 1 },
         ].forEach(({ metric, chartsCount }) => {
           it(`should render ${chartsCount} ${metric} chart(s) in the Metrics section`, async () => {
+            await waitForChartsToLoad();
             const hosts = await pageObjects.assetDetails.getOverviewTabHostMetricCharts(metric);
             expect(hosts.length).to.equal(chartsCount);
           });
@@ -537,7 +537,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
-      describe('Logs Tab', () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/203656
+      describe.skip('Logs Tab', () => {
         before(async () => {
           await pageObjects.assetDetails.clickLogsTab();
           await pageObjects.timePicker.setAbsoluteRange(
@@ -565,7 +566,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
-      describe('Osquery Tab', () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/216514
+      // We should revisit this test and decide if it is usefull and worth to keep
+      describe.skip('Osquery Tab', () => {
         before(async () => {
           await browser.scrollTop();
           await pageObjects.assetDetails.clickOsqueryTab();
@@ -717,6 +720,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         ].forEach(({ metric, chartsCount }) => {
           it(`should render ${chartsCount} ${metric} chart`, async () => {
             await retry.tryForTime(5000, async () => {
+              await waitForChartsToLoad();
               const charts = await (metric === 'kubernetes'
                 ? pageObjects.assetDetails.getOverviewTabKubernetesMetricCharts()
                 : pageObjects.assetDetails.getOverviewTabHostMetricCharts(metric));


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/222073

This PR skips the same suites as those skipped in the `main` branch for `node_details.ts`

