### PR TITLE
[7.17] [Chore] Upgrade tar-fs dependency (#222855)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25511,9 +25511,9 @@ tape@^5.9.0:
     string.prototype.trim "^1.2.9"
 
 tar-fs@^2.0.0, tar-fs@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.2.tgz#425f154f3404cb16cb8ff6e671d45ab2ed9596c5"
-  integrity sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.3.tgz#fb3b8843a26b6f13a08e606f7922875eb1fbbf92"
+  integrity sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -25521,9 +25521,9 @@ tar-fs@^2.0.0, tar-fs@^2.1.0:
     tar-stream "^2.1.4"
 
 tar-fs@^3.0.4, tar-fs@^3.0.6:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.8.tgz#8f62012537d5ff89252d01e48690dc4ebed33ab7"
-  integrity sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.9.tgz#d570793c6370d7078926c41fa422891566a0b617"
+  integrity sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Chore] Upgrade tar-fs dependency (#222855)](https://github.com/elastic/kibana/pull/222855)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sid","email":"siddharthmantri1@gmail.com"},"sourceCommit":{"committedDate":"2025-06-06T08:23:16Z","message":"[Chore] Upgrade tar-fs dependency (#222855)\n\n## Summary\n\nUpgrade `tar-fs` \n\n- `3.0.4`, `3.0.6`, `3.0.8` -> `3.0.9`\n- `2.1.2` -> `2.1.3`","sha":"1ccb7a6b43d9255cb7bdecc4a86d07d4af6996fe","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.1.0","v8.19.0","v9.0.3"],"title":"[Chore] Upgrade tar-fs dependency","number":222855,"url":"https://github.com/elastic/kibana/pull/222855","mergeCommit":{"message":"[Chore] Upgrade tar-fs dependency (#222855)\n\n## Summary\n\nUpgrade `tar-fs` \n\n- `3.0.4`, `3.0.6`, `3.0.8` -> `3.0.9`\n- `2.1.2` -> `2.1.3`","sha":"1ccb7a6b43d9255cb7bdecc4a86d07d4af6996fe"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222855","number":222855,"mergeCommit":{"message":"[Chore] Upgrade tar-fs dependency (#222855)\n\n## Summary\n\nUpgrade `tar-fs` \n\n- `3.0.4`, `3.0.6`, `3.0.8` -> `3.0.9`\n- `2.1.2` -> `2.1.3`","sha":"1ccb7a6b43d9255cb7bdecc4a86d07d4af6996fe"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/222936","number":222936,"state":"MERGED","mergeCommit":{"sha":"de1bc24f885d7b0bb375318a3027cdfeaafc53ff","message":"[8.19] [Chore] Upgrade tar-fs dependency (#222855) (#222936)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Chore] Upgrade tar-fs dependency\n(#222855)](https://github.com/elastic/kibana/pull/222855)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sid <siddharthmantri1@gmail.com>"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/222937","number":222937,"state":"MERGED","mergeCommit":{"sha":"4a32f8827c0fae3e006e61625501584bbc3b52af","message":"[9.0] [Chore] Upgrade tar-fs dependency (#222855) (#222937)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Chore] Upgrade tar-fs dependency\n(#222855)](https://github.com/elastic/kibana/pull/222855)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sid <siddharthmantri1@gmail.com>"}},{"url":"https://github.com/elastic/kibana/pull/222978","number":222978,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/222980","number":222980,"branch":"8.17","state":"OPEN"}]}] BACKPORT-->