### PR TITLE
[9.0] [Performance][Security Solution][2/4] - Timeline Performance (#212478)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop/cell_actions_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop/cell_actions_wrapper.tsx
@@ -16,7 +16,7 @@ import {
   SecurityCellActionType,
 } from '../cell_actions';
 import { getSourcererScopeId } from '../../../helpers';
-import { TimelineContext } from '../../../timelines/components/timeline';
+import { TimelineContext } from '../../../timelines/components/timeline/context';
 
 import { TableContext } from '../events_viewer/shared';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IP Overview Component rendering it renders the default IP Overview 1`] = `
+.c1 > span.euiToolTipAnchor {
+  display: block;
+}
+
+.c1 > span.euiToolTipAnchor.eui-textTruncate {
+  display: inline-block;
+}
+
 .c0 {
   width: 100%;
   display: -webkit-box;
@@ -32,14 +40,6 @@ exports[`IP Overview Component rendering it renders the default IP Overview 1`] 
 .c0:hover .inspectButtonComponent {
   pointer-events: auto;
   opacity: 1;
-}
-
-.c1 > span.euiToolTipAnchor {
-  display: block;
-}
-
-.c1 > span.euiToolTipAnchor.eui-textTruncate {
-  display: inline-block;
 }
 
 <div
@@ -356,6 +356,14 @@ exports[`IP Overview Component rendering it renders the default IP Overview 1`] 
 `;
 
 exports[`IP Overview Component rendering it renders the side panel IP overview 1`] = `
+.c1 > span.euiToolTipAnchor {
+  display: block;
+}
+
+.c1 > span.euiToolTipAnchor.eui-textTruncate {
+  display: inline-block;
+}
+
 .c0 {
   width: 100%;
   display: -webkit-box;
@@ -387,14 +395,6 @@ exports[`IP Overview Component rendering it renders the side panel IP overview 1
 .c0:hover .inspectButtonComponent {
   pointer-events: auto;
   opacity: 1;
-}
-
-.c1 > span.euiToolTipAnchor {
-  display: block;
-}
-
-.c1 > span.euiToolTipAnchor.eui-textTruncate {
-  display: inline-block;
 }
 
 <div

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Host Summary Component it renders the default Host Summary 1`] = `
+.c1 > span.euiToolTipAnchor {
+  display: block;
+}
+
+.c1 > span.euiToolTipAnchor.eui-textTruncate {
+  display: inline-block;
+}
+
 .c0 {
   width: 100%;
   display: -webkit-box;
@@ -32,14 +40,6 @@ exports[`Host Summary Component it renders the default Host Summary 1`] = `
 .c0:hover .inspectButtonComponent {
   pointer-events: auto;
   opacity: 1;
-}
-
-.c1 > span.euiToolTipAnchor {
-  display: block;
-}
-
-.c1 > span.euiToolTipAnchor.eui-textTruncate {
-  display: inline-block;
 }
 
 <div
@@ -684,6 +684,14 @@ exports[`Host Summary Component it renders the default Host Summary 1`] = `
 `;
 
 exports[`Host Summary Component it renders the panel view Host Summary 1`] = `
+.c1 > span.euiToolTipAnchor {
+  display: block;
+}
+
+.c1 > span.euiToolTipAnchor.eui-textTruncate {
+  display: inline-block;
+}
+
 .c0 {
   width: 100%;
   display: -webkit-box;
@@ -715,14 +723,6 @@ exports[`Host Summary Component it renders the panel view Host Summary 1`] = `
 .c0:hover .inspectButtonComponent {
   pointer-events: auto;
   opacity: 1;
-}
-
-.c1 > span.euiToolTipAnchor {
-  display: block;
-}
-
-.c1 > span.euiToolTipAnchor.eui-textTruncate {
-  display: inline-block;
 }
 
 <div

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/user_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/user_overview/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`User Summary Component it renders the default User Summary 1`] = `
+.c1 > span.euiToolTipAnchor {
+  display: block;
+}
+
+.c1 > span.euiToolTipAnchor.eui-textTruncate {
+  display: inline-block;
+}
+
 .c0 {
   width: 100%;
   display: -webkit-box;
@@ -32,14 +40,6 @@ exports[`User Summary Component it renders the default User Summary 1`] = `
 .c0:hover .inspectButtonComponent {
   pointer-events: auto;
   opacity: 1;
-}
-
-.c1 > span.euiToolTipAnchor {
-  display: block;
-}
-
-.c1 > span.euiToolTipAnchor.eui-textTruncate {
-  display: inline-block;
 }
 
 <div
@@ -381,6 +381,14 @@ exports[`User Summary Component it renders the default User Summary 1`] = `
 `;
 
 exports[`User Summary Component it renders the panel view User Summary 1`] = `
+.c1 > span.euiToolTipAnchor {
+  display: block;
+}
+
+.c1 > span.euiToolTipAnchor.eui-textTruncate {
+  display: inline-block;
+}
+
 .c0 {
   width: 100%;
   display: -webkit-box;
@@ -412,14 +420,6 @@ exports[`User Summary Component it renders the panel view User Summary 1`] = `
 .c0:hover .inspectButtonComponent {
   pointer-events: auto;
   opacity: 1;
-}
-
-.c1 > span.euiToolTipAnchor {
-  display: block;
-}
-
-.c1 > span.euiToolTipAnchor.eui-textTruncate {
-  display: inline-block;
 }
 
 <div

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/bottom_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/bottom_bar/index.tsx
@@ -15,7 +15,7 @@ import { AddTimelineButton } from './add_timeline_button';
 import { timelineActions } from '../../store';
 import { TimelineSaveStatus } from '../save_status';
 import { AddToFavoritesButton } from '../add_to_favorites';
-import { TimelineEventsCountBadge } from '../../../common/hooks/use_timeline_events_count';
+import TimelineQueryTabEventsCount from '../timeline/tabs/query/events_count';
 
 interface TimelineBottomBarProps {
   /**
@@ -63,9 +63,9 @@ export const TimelineBottomBar = React.memo<TimelineBottomBarProps>(
               {title}
             </EuiLink>
           </EuiFlexItem>
-          {!show && ( // this is a hack because TimelineEventsCountBadge is using react-reverse-portal so the component which is used in multiple places cannot be visible in multiple places at the same time
+          {!show && ( // We only want to show this when the timeline modal is closed
             <EuiFlexItem grow={false} data-test-subj="timeline-event-count-badge">
-              <TimelineEventsCountBadge />
+              <TimelineQueryTabEventsCount timelineId={timelineId} />
             </EuiFlexItem>
           )}
           <EuiFlexItem grow={false}>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/more_container/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/more_container/index.tsx
@@ -9,7 +9,7 @@ import React, { useContext, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/css';
 import classNames from 'classnames';
-import { TimelineContext } from '../../timeline';
+import { TimelineContext } from '../../timeline/context';
 import { getSourcererScopeId } from '../../../../helpers';
 import { escapeDataProviderId } from '../../../../common/components/drag_and_drop/helpers';
 import { defaultToEmptyTag } from '../../../../common/components/empty_value';

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.test.tsx
@@ -14,12 +14,27 @@ import type { UnifiedTimelineBodyProps } from './unified_timeline_body';
 import { UnifiedTimelineBody } from './unified_timeline_body';
 import { render } from '@testing-library/react';
 import { defaultHeaders, mockTimelineData, TestProviders } from '../../../../common/mock';
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
+import { mockSourcererScope } from '../../../../sourcerer/containers/mocks';
+import { DataView } from '@kbn/data-views-plugin/common';
 
 jest.mock('../unified_components', () => {
   return {
     UnifiedTimeline: jest.fn(),
   };
 });
+
+const mockDataView = new DataView({
+  spec: mockSourcererScope.sourcererDataView,
+  fieldFormats: fieldFormatsMock,
+});
+
+// Not returning an actual dataView here, just an object as a non-null value;
+const mockUseGetScopedSourcererDataView = jest.fn().mockImplementation(() => mockDataView);
+
+jest.mock('../../../../sourcerer/components/use_get_sourcerer_data_view', () => ({
+  useGetScopedSourcererDataView: () => mockUseGetScopedSourcererDataView(),
+}));
 
 const mockEventsData = structuredClone(mockTimelineData);
 
@@ -76,5 +91,12 @@ describe('UnifiedTimelineBody', () => {
       }),
       {}
     );
+  });
+
+  it('should render the dataview error component when no dataView is provided', () => {
+    mockUseGetScopedSourcererDataView.mockImplementationOnce(() => undefined);
+    const { queryByTestId } = renderTestComponents();
+
+    expect(queryByTestId('dataViewErrorComponent')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
@@ -8,11 +8,15 @@
 import type { ComponentProps, ReactElement } from 'react';
 import React, { useMemo } from 'react';
 import { RootDragDropProvider } from '@kbn/dom-drag-drop';
+import { useGetScopedSourcererDataView } from '../../../../sourcerer/components/use_get_sourcerer_data_view';
+import { DataViewErrorComponent } from '../../../../common/components/with_data_view/data_view_error';
 import { StyledTableFlexGroup, StyledUnifiedTableFlexItem } from '../unified_components/styles';
 import { UnifiedTimeline } from '../unified_components';
 import { defaultUdtHeaders } from './column_headers/default_headers';
+import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
-export interface UnifiedTimelineBodyProps extends ComponentProps<typeof UnifiedTimeline> {
+export interface UnifiedTimelineBodyProps
+  extends Omit<ComponentProps<typeof UnifiedTimeline>, 'dataView'> {
   header: ReactElement;
 }
 
@@ -37,7 +41,9 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
     leadingControlColumns,
     onUpdatePageIndex,
   } = props;
-
+  const dataView = useGetScopedSourcererDataView({
+    sourcererScope: SourcererScopeName.timeline,
+  });
   const columnsHeader = useMemo(() => columns ?? defaultUdtHeaders, [columns]);
 
   return (
@@ -48,26 +54,31 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
         data-test-subj="unifiedTimelineBody"
       >
         <RootDragDropProvider>
-          <UnifiedTimeline
-            columns={columnsHeader}
-            rowRenderers={rowRenderers}
-            isSortEnabled={isSortEnabled}
-            timelineId={timelineId}
-            itemsPerPage={itemsPerPage}
-            itemsPerPageOptions={itemsPerPageOptions}
-            sort={sort}
-            events={events}
-            refetch={refetch}
-            dataLoadingState={dataLoadingState}
-            totalCount={totalCount}
-            onFetchMoreRecords={onFetchMoreRecords}
-            activeTab={activeTab}
-            updatedAt={updatedAt}
-            isTextBasedQuery={false}
-            trailingControlColumns={trailingControlColumns}
-            leadingControlColumns={leadingControlColumns}
-            onUpdatePageIndex={onUpdatePageIndex}
-          />
+          {dataView ? (
+            <UnifiedTimeline
+              columns={columnsHeader}
+              dataView={dataView}
+              rowRenderers={rowRenderers}
+              isSortEnabled={isSortEnabled}
+              timelineId={timelineId}
+              itemsPerPage={itemsPerPage}
+              itemsPerPageOptions={itemsPerPageOptions}
+              sort={sort}
+              events={events}
+              refetch={refetch}
+              dataLoadingState={dataLoadingState}
+              totalCount={totalCount}
+              onFetchMoreRecords={onFetchMoreRecords}
+              activeTab={activeTab}
+              updatedAt={updatedAt}
+              isTextBasedQuery={false}
+              trailingControlColumns={trailingControlColumns}
+              leadingControlColumns={leadingControlColumns}
+              onUpdatePageIndex={onUpdatePageIndex}
+            />
+          ) : (
+            <DataViewErrorComponent />
+          )}
         </RootDragDropProvider>
       </StyledUnifiedTableFlexItem>
     </StyledTableFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/context.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createContext } from 'react';
+
+export const TimelineContext = createContext<{
+  timelineId: string | null;
+}>({ timelineId: null });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -7,7 +7,7 @@
 
 import { pick } from 'lodash/fp';
 import { EuiPanel, EuiProgress, EuiText } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useRef, createContext } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
@@ -30,6 +30,7 @@ import { EXIT_FULL_SCREEN_CLASS_NAME } from '../../../common/components/exit_ful
 import { useResolveConflict } from '../../../common/hooks/use_resolve_conflict';
 import { sourcererSelectors } from '../../../common/store';
 import { defaultUdtHeaders } from './body/column_headers/default_headers';
+import { TimelineContext } from './context';
 
 const TimelineBody = styled.div`
   height: 100%;
@@ -37,7 +38,6 @@ const TimelineBody = styled.div`
   flex-direction: column;
 `;
 
-export const TimelineContext = createContext<{ timelineId: string | null }>({ timelineId: null });
 export interface Props {
   renderCellValue: (props: CellValueElementProps) => React.ReactNode;
   rowRenderers: RowRenderer[];

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.tsx
@@ -45,17 +45,7 @@ import { selectTimelineById, selectTimelineESQLSavedSearchId } from '../../../st
 import { fetchNotesBySavedObjectIds, selectSortedNotesBySavedObjectId } from '../../../../notes';
 import { ENABLE_VISUALIZATIONS_IN_FLYOUT_SETTING } from '../../../../../common/constants';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
-
-const HideShowContainer = styled.div.attrs<{ $isVisible: boolean; isOverflowYScroll: boolean }>(
-  ({ $isVisible = false, isOverflowYScroll = false }) => ({
-    style: {
-      display: $isVisible ? 'flex' : 'none',
-      overflow: isOverflowYScroll ? 'hidden scroll' : 'hidden',
-    },
-  })
-)<{ $isVisible: boolean; isOverflowYScroll?: boolean }>`
-  flex: 1;
-`;
+import { LazyTimelineTabRenderer, TimelineTabFallback } from './lazy_timeline_tab_renderer';
 
 /**
  * A HOC which supplies React.Suspense with a fallback component
@@ -76,13 +66,35 @@ const tabWithSuspense = <P extends {}, R = {}>(
   return Comp;
 };
 
-const QueryTab = tabWithSuspense(lazy(() => import('./query')));
-const EqlTab = tabWithSuspense(lazy(() => import('./eql')));
-const GraphTab = tabWithSuspense(lazy(() => import('./graph')));
-const NotesTab = tabWithSuspense(lazy(() => import('./notes')));
-const PinnedTab = tabWithSuspense(lazy(() => import('./pinned')));
-const SessionTab = tabWithSuspense(lazy(() => import('./session')));
-const EsqlTab = tabWithSuspense(lazy(() => import('./esql')));
+const QueryTab = tabWithSuspense(
+  lazy(() => import('./query')),
+  <TimelineTabFallback />
+);
+const EqlTab = tabWithSuspense(
+  lazy(() => import('./eql')),
+  <TimelineTabFallback />
+);
+const GraphTab = tabWithSuspense(
+  lazy(() => import('./graph')),
+  <TimelineTabFallback />
+);
+const NotesTab = tabWithSuspense(
+  lazy(() => import('./notes')),
+  <TimelineTabFallback />
+);
+const PinnedTab = tabWithSuspense(
+  lazy(() => import('./pinned')),
+  <TimelineTabFallback />
+);
+const SessionTab = tabWithSuspense(
+  lazy(() => import('./session')),
+  <TimelineTabFallback />
+);
+const EsqlTab = tabWithSuspense(
+  lazy(() => import('./esql')),
+  <TimelineTabFallback />
+);
+
 interface BasicTimelineTab {
   renderCellValue: (props: CellValueElementProps) => React.ReactNode;
   rowRenderers: RowRenderer[];
@@ -138,60 +150,60 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
       [activeTimelineTab]
     );
 
-    /* Future developer -> why are we doing that
-     * It is really expansive to re-render the QueryTab because the drag/drop
-     * Therefore, we are only hiding its dom when switching to another tab
-     * to avoid mounting/un-mounting === re-render
-     */
     return (
       <>
-        <HideShowContainer
-          $isVisible={TimelineTabs.query === activeTimelineTab}
-          data-test-subj={`timeline-tab-content-${TimelineTabs.query}`}
+        <LazyTimelineTabRenderer
+          timelineId={timelineId}
+          shouldShowTab={TimelineTabs.query === activeTimelineTab}
+          dataTestSubj={`timeline-tab-content-${TimelineTabs.query}`}
         >
           <QueryTab
             renderCellValue={renderCellValue}
             rowRenderers={rowRenderers}
             timelineId={timelineId}
           />
-        </HideShowContainer>
+        </LazyTimelineTabRenderer>
         {showTimeline && shouldShowESQLTab && activeTimelineTab === TimelineTabs.esql && (
-          <HideShowContainer
-            $isVisible={true}
-            data-test-subj={`timeline-tab-content-${TimelineTabs.esql}`}
+          <LazyTimelineTabRenderer
+            timelineId={timelineId}
+            shouldShowTab={true}
+            dataTestSubj={`timeline-tab-content-${TimelineTabs.esql}`}
           >
             <EsqlTab timelineId={timelineId} />
-          </HideShowContainer>
+          </LazyTimelineTabRenderer>
         )}
-        <HideShowContainer
-          $isVisible={TimelineTabs.pinned === activeTimelineTab}
-          data-test-subj={`timeline-tab-content-${TimelineTabs.pinned}`}
+        <LazyTimelineTabRenderer
+          timelineId={timelineId}
+          shouldShowTab={TimelineTabs.pinned === activeTimelineTab}
+          dataTestSubj={`timeline-tab-content-${TimelineTabs.pinned}`}
         >
           <PinnedTab
             renderCellValue={renderCellValue}
             rowRenderers={rowRenderers}
             timelineId={timelineId}
           />
-        </HideShowContainer>
+        </LazyTimelineTabRenderer>
         {timelineType === TimelineTypeEnum.default && (
-          <HideShowContainer
-            $isVisible={TimelineTabs.eql === activeTimelineTab}
-            data-test-subj={`timeline-tab-content-${TimelineTabs.eql}`}
+          <LazyTimelineTabRenderer
+            timelineId={timelineId}
+            shouldShowTab={TimelineTabs.eql === activeTimelineTab}
+            dataTestSubj={`timeline-tab-content-${TimelineTabs.eql}`}
           >
             <EqlTab
               renderCellValue={renderCellValue}
               rowRenderers={rowRenderers}
               timelineId={timelineId}
             />
-          </HideShowContainer>
+          </LazyTimelineTabRenderer>
         )}
-        <HideShowContainer
-          $isVisible={isGraphOrNotesTabs}
+        <LazyTimelineTabRenderer
+          timelineId={timelineId}
+          shouldShowTab={isGraphOrNotesTabs}
           isOverflowYScroll={activeTimelineTab === TimelineTabs.session}
-          data-test-subj={`timeline-tab-content-${TimelineTabs.graph}-${TimelineTabs.notes}`}
+          dataTestSubj={`timeline-tab-content-${TimelineTabs.graph}-${TimelineTabs.notes}`}
         >
-          {isGraphOrNotesTabs && getTab(activeTimelineTab)}
-        </HideShowContainer>
+          {isGraphOrNotesTabs ? getTab(activeTimelineTab) : null}
+        </LazyTimelineTabRenderer>
       </>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/lazy_timeline_tab_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/lazy_timeline_tab_renderer.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+import { render } from '@testing-library/react';
+import type { LazyTimelineTabRendererProps } from './lazy_timeline_tab_renderer';
+import { LazyTimelineTabRenderer } from './lazy_timeline_tab_renderer';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { TimelineId } from '../../../../../common/types';
+
+jest.mock('../../../../common/hooks/use_selector');
+
+describe('LazyTimelineTabRenderer', () => {
+  const mockUseDeepEqualSelector = useDeepEqualSelector as jest.Mock;
+  const defaultProps = {
+    dataTestSubj: 'test',
+    shouldShowTab: true,
+    isOverflowYScroll: false,
+    timelineId: TimelineId.test,
+  };
+
+  const TestComponent = ({ children, ...restProps }: Partial<LazyTimelineTabRendererProps>) => (
+    <LazyTimelineTabRenderer {...defaultProps} {...restProps}>
+      <div>{children ?? 'test component'}</div>
+    </LazyTimelineTabRenderer>
+  );
+  const renderTestComponents = (props?: Partial<LazyTimelineTabRendererProps>) => {
+    const { children, ...restProps } = props ?? {};
+    return render(<TestComponent {...restProps}>{children}</TestComponent>);
+  };
+
+  beforeEach(() => {
+    mockUseDeepEqualSelector.mockClear();
+  });
+
+  describe('timeline visibility', () => {
+    it('should NOT render children when the timeline show status is false', () => {
+      mockUseDeepEqualSelector.mockReturnValue({ show: false });
+      const { queryByText } = renderTestComponents();
+      expect(queryByText('test component')).not.toBeInTheDocument();
+    });
+
+    it('should render children when the timeline show status is true', () => {
+      mockUseDeepEqualSelector.mockReturnValue({ show: true });
+
+      const { getByText } = renderTestComponents();
+
+      expect(getByText('test component')).toBeInTheDocument();
+    });
+  });
+
+  describe('tab visibility', () => {
+    it('should not render children when show tab is false', () => {
+      const { queryByText } = renderTestComponents({ shouldShowTab: false });
+
+      expect(queryByText('test component')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('re-rendering', () => {
+    const testChildString = 'new content';
+    const mockFnShouldThatShouldOnlyRunOnce = jest.fn();
+
+    const TestChild = () => {
+      useEffect(() => {
+        mockFnShouldThatShouldOnlyRunOnce();
+      }, []);
+      return <div>{testChildString}</div>;
+    };
+
+    const RerenderTestComponent = (props?: Partial<LazyTimelineTabRendererProps>) => (
+      <TestComponent {...props}>
+        <TestChild />
+      </TestComponent>
+    );
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      mockUseDeepEqualSelector.mockReturnValue({ show: true });
+    });
+
+    it('should NOT re-render children after the first render', () => {
+      const { queryByText } = render(<RerenderTestComponent />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT re-render children even if timeline show status changes', () => {
+      const { rerender, queryByText } = render(<RerenderTestComponent />);
+      mockUseDeepEqualSelector.mockReturnValue({ show: false });
+      rerender(<RerenderTestComponent />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT re-render children even if tab visibility status changes', () => {
+      const { rerender, queryByText } = render(<RerenderTestComponent />);
+      rerender(<RerenderTestComponent shouldShowTab={false} />);
+      rerender(<RerenderTestComponent shouldShowTab={true} />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-render if the component is unmounted and remounted', () => {
+      const { rerender, queryByText, unmount } = render(<RerenderTestComponent />);
+      unmount();
+      rerender(<RerenderTestComponent shouldShowTab={true} />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/lazy_timeline_tab_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/lazy_timeline_tab_renderer.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState, useEffect } from 'react';
+import { css } from '@emotion/react';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingElastic } from '@elastic/eui';
+import type { TimelineId } from '../../../../../common/types';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { getTimelineShowStatusByIdSelector } from '../../../store/selectors';
+
+export interface LazyTimelineTabRendererProps {
+  children: React.ReactElement | null;
+  dataTestSubj: string;
+  isOverflowYScroll?: boolean;
+  shouldShowTab: boolean;
+  timelineId: TimelineId;
+}
+
+/**
+ * We check for the timeline open status to request the fields for the fields browser. The fields request
+ * is often a much longer running request for customers with a significant number of indices and fields in those indices.
+ * This request should only be made after the user has decided to interact with a specific tab in the timeline to prevent any performance impacts
+ * to the underlying security solution views, as this query will always run when the timeline exists on the page.
+ *
+ * `hasTimelineTabBeenOpenedOnce` - We want to keep timeline loading times as fast as possible after the user
+ * has chosen to interact with timeline at least once, so we use this flag to prevent re-requesting of this fields data
+ * every time timeline is closed and re-opened after the first interaction.
+ */
+export const LazyTimelineTabRenderer = React.memo(
+  ({
+    children,
+    dataTestSubj,
+    shouldShowTab,
+    isOverflowYScroll,
+    timelineId,
+  }: LazyTimelineTabRendererProps) => {
+    const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
+    const { show } = useDeepEqualSelector((state) => getTimelineShowStatus(state, timelineId));
+
+    const [hasTimelineTabBeenOpenedOnce, setHasTimelineTabBeenOpenedOnce] = useState(false);
+
+    useEffect(() => {
+      if (!hasTimelineTabBeenOpenedOnce && show && shouldShowTab) {
+        setHasTimelineTabBeenOpenedOnce(true);
+      }
+    }, [hasTimelineTabBeenOpenedOnce, shouldShowTab, show]);
+
+    return (
+      <div
+        // The shouldShowTab check here is necessary for the flex container to accurately size to the modal window when it's opened
+        css={css`
+          display: ${shouldShowTab ? 'flex' : 'none'};
+          overflow: ${isOverflowYScroll ? 'hidden scroll' : 'hidden'};
+          flex: 1;
+        `}
+        data-test-subj={dataTestSubj}
+      >
+        {hasTimelineTabBeenOpenedOnce ? children : <TimelineTabFallback />}
+      </div>
+    );
+  }
+);
+
+LazyTimelineTabRenderer.displayName = 'LazyTimelineTabRenderer';
+
+export const TimelineTabFallback = () => (
+  <EuiFlexGroup direction="row" justifyContent="spaceAround">
+    <EuiFlexItem
+      grow={false}
+      css={css`
+        justify-content: center;
+      `}
+    >
+      <EuiLoadingElastic size="xxl" />
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isEmpty } from 'lodash/fp';
+import React, { useEffect, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import { getEsQueryConfig } from '@kbn/data-plugin/common';
+import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { EuiLoadingSpinner } from '@elastic/eui';
+import { DataLoadingState } from '@kbn/unified-data-table';
+import { useDeepEqualSelector } from '../../../../../common/hooks/use_selector';
+import { useTimelineDataFilters } from '../../../../containers/use_timeline_data_filters';
+import { useInvalidFilterQuery } from '../../../../../common/hooks/use_invalid_filter_query';
+import { timelineActions, timelineSelectors } from '../../../../store';
+import type { Direction } from '../../../../../../common/search_strategy';
+import { useTimelineEvents } from '../../../../containers';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { combineQueries } from '../../../../../common/lib/kuery';
+import type {
+  KueryFilterQuery,
+  KueryFilterQueryKind,
+} from '../../../../../../common/types/timeline';
+import type { inputsModel } from '../../../../../common/store';
+import { inputsSelectors } from '../../../../../common/store';
+import { SourcererScopeName } from '../../../../../sourcerer/store/model';
+import { timelineDefaults } from '../../../../store/defaults';
+import { useSourcererDataView } from '../../../../../sourcerer/containers';
+import { isActiveTimeline } from '../../../../../helpers';
+import type { TimelineModel } from '../../../../store/model';
+import { useTimelineColumns } from '../shared/use_timeline_columns';
+import { EventsCountBadge } from '../shared/layout';
+
+/**
+ * TODO: This component is a pared down duplicate of the logic used in timeline/tabs/query/index.tsx
+ * This is only done to support the events count badge that shows in the bottom bar of the application,
+ * without needing to render the entire query tab, which is expensive to render at a significant enough fields count.
+ * The long term solution is a centralized query either via RTK or useQuery, that both can read from, but that is out of scope
+ * at this current time.
+ */
+
+const emptyFieldsList: string[] = [];
+export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string }> = ({
+  timelineId,
+}) => {
+  const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
+  const getKqlQueryTimeline = useMemo(() => timelineSelectors.getKqlFilterKuerySelector(), []);
+  const getInputsTimeline = useMemo(() => inputsSelectors.getTimelineSelector(), []);
+
+  const timeline: TimelineModel = useDeepEqualSelector(
+    (state) => getTimeline(state, timelineId) ?? timelineDefaults
+  );
+  const input: inputsModel.InputsRange = useDeepEqualSelector((state) => getInputsTimeline(state));
+  const { timerange: { to: end, from: start, kind: timerangeKind } = {} } = input;
+  const {
+    columns,
+    dataProviders,
+    filters: currentTimelineFilters,
+    kqlMode,
+    sort,
+    timelineType,
+  } = timeline;
+
+  const kqlQueryTimeline: KueryFilterQuery | null = useDeepEqualSelector((state) =>
+    getKqlQueryTimeline(state, timelineId)
+  );
+  const filters = useMemo(
+    () => (kqlMode === 'filter' ? currentTimelineFilters || [] : []),
+    [currentTimelineFilters, kqlMode]
+  );
+
+  // return events on empty search
+  const kqlQueryExpression =
+    isEmpty(dataProviders) &&
+    isEmpty(kqlQueryTimeline?.expression ?? '') &&
+    timelineType === 'template'
+      ? ' '
+      : kqlQueryTimeline?.expression ?? '';
+
+  const kqlQueryLanguage =
+    isEmpty(dataProviders) && timelineType === 'template'
+      ? 'kuery'
+      : kqlQueryTimeline?.kind ?? 'kuery';
+
+  const dispatch = useDispatch();
+  const {
+    browserFields,
+    dataViewId,
+    loading: loadingSourcerer,
+    // important to get selectedPatterns from useSourcererDataView
+    // in order to include the exclude filters in the search that are not stored in the timeline
+    selectedPatterns,
+    sourcererDataView,
+  } = useSourcererDataView(SourcererScopeName.timeline);
+  /*
+   * `pageIndex` needs to be maintained for each table in each tab independently
+   * and consequently it cannot be the part of common redux state
+   * of the timeline.
+   *
+   */
+
+  const { uiSettings, timelineDataService } = useKibana().services;
+  const esQueryConfig = useMemo(() => getEsQueryConfig(uiSettings), [uiSettings]);
+  const kqlQuery: {
+    query: string;
+    language: KueryFilterQueryKind;
+  } = useMemo(
+    () => ({ query: kqlQueryExpression.trim(), language: kqlQueryLanguage }),
+    [kqlQueryExpression, kqlQueryLanguage]
+  );
+
+  const combinedQueries = useMemo(() => {
+    return combineQueries({
+      config: esQueryConfig,
+      dataProviders,
+      indexPattern: sourcererDataView,
+      browserFields,
+      filters,
+      kqlQuery,
+      kqlMode,
+    });
+  }, [esQueryConfig, dataProviders, sourcererDataView, browserFields, filters, kqlQuery, kqlMode]);
+
+  useInvalidFilterQuery({
+    id: timelineId,
+    filterQuery: combinedQueries?.filterQuery,
+    kqlError: combinedQueries?.kqlError,
+    query: kqlQuery,
+    startDate: start,
+    endDate: end,
+  });
+
+  const isBlankTimeline: boolean =
+    isEmpty(dataProviders) &&
+    isEmpty(filters) &&
+    isEmpty(kqlQuery.query) &&
+    combinedQueries?.filterQuery === undefined;
+
+  const canQueryTimeline = useMemo(
+    () =>
+      combinedQueries != null &&
+      loadingSourcerer != null &&
+      !loadingSourcerer &&
+      !isEmpty(start) &&
+      !isEmpty(end) &&
+      combinedQueries?.filterQuery !== undefined,
+    [combinedQueries, end, loadingSourcerer, start]
+  );
+
+  const timelineQuerySortField = useMemo(() => {
+    return sort.map(({ columnId, columnType, esTypes, sortDirection }) => ({
+      field: columnId,
+      direction: sortDirection as Direction,
+      esTypes: esTypes ?? [],
+      type: columnType,
+    }));
+  }, [sort]);
+
+  const { defaultColumns } = useTimelineColumns(columns);
+
+  const [dataLoadingState, { totalCount }] = useTimelineEvents({
+    dataViewId,
+    endDate: end,
+    fields: emptyFieldsList,
+    filterQuery: combinedQueries?.filterQuery,
+    id: timelineId,
+    indexNames: selectedPatterns,
+    language: kqlQuery.language,
+    limit: 0, // We only care about the totalCount here
+    runtimeMappings: sourcererDataView.runtimeFieldMap as RunTimeMappings,
+    skip: !canQueryTimeline,
+    sort: timelineQuerySortField,
+    startDate: start,
+    timerangeKind,
+  });
+
+  useEffect(() => {
+    dispatch(
+      timelineActions.initializeTimelineSettings({
+        id: timelineId,
+        defaultColumns,
+      })
+    );
+  }, [dispatch, timelineId, defaultColumns]);
+
+  // NOTE: The timeline is blank after browser FORWARD navigation (after using back button to navigate to
+  // the previous page from the timeline), yet we still see total count. This is because the timeline
+  // is not getting refreshed when using browser navigation.
+  const showEventsCountBadge = !isBlankTimeline && totalCount >= 0;
+
+  // <Synchronisation of the timeline data service>
+  // Sync the timerange
+  const timelineFilters = useTimelineDataFilters(isActiveTimeline(timelineId));
+  useEffect(() => {
+    timelineDataService.query.timefilter.timefilter.setTime({
+      from: timelineFilters.from,
+      to: timelineFilters.to,
+    });
+  }, [timelineDataService.query.timefilter.timefilter, timelineFilters.from, timelineFilters.to]);
+
+  // Sync the base query
+  useEffect(() => {
+    timelineDataService.query.queryString.setQuery(
+      // We're using the base query of all combined queries here, to account for all
+      // of timeline's query dependencies (data providers, query etc.)
+      combinedQueries?.baseKqlQuery || { language: kqlQueryLanguage, query: '' }
+    );
+  }, [timelineDataService, combinedQueries, kqlQueryLanguage]);
+  // </Synchronisation of the timeline data service>
+
+  if (!showEventsCountBadge) return null;
+
+  return dataLoadingState === DataLoadingState.loading ||
+    dataLoadingState === DataLoadingState.loadingMore ? (
+    <EuiLoadingSpinner size="s" />
+  ) : (
+    <EventsCountBadge data-test-subj="query-events-count">{totalCount}</EventsCountBadge>
+  );
+};
+
+const TimelineQueryTabEventsCount = React.memo(TimelineQueryTabEventsCountComponent);
+
+// eslint-disable-next-line import/no-default-export
+export { TimelineQueryTabEventsCount as default };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -10,14 +10,16 @@ import React from 'react';
 import { TimelineDataTable } from '.';
 import { TimelineId, TimelineTabs } from '../../../../../../common/types';
 import { DataLoadingState } from '@kbn/unified-data-table';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { DataView } from '@kbn/data-views-plugin/common';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import type { ComponentProps } from 'react';
 import { getColumnHeaders } from '../../body/column_headers/helpers';
 import { mockSourcererScope } from '../../../../../sourcerer/containers/mocks';
 import * as timelineActions from '../../../../store/actions';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 
 jest.mock('../../../../../sourcerer/containers');
 
@@ -54,6 +56,11 @@ type TestComponentProps = Partial<ComponentProps<typeof TimelineDataTable>> & {
 // that is why we are setting it to 10s
 const SPECIAL_TEST_TIMEOUT = 50000;
 
+const mockDataView = new DataView({
+  spec: mockSourcererScope.sourcererDataView,
+  fieldFormats: fieldFormatsMock,
+});
+
 const TestComponent = (props: TestComponentProps) => {
   const { store = createMockStore(), ...restProps } = props;
   useSourcererDataView();
@@ -62,6 +69,7 @@ const TestComponent = (props: TestComponentProps) => {
       <TimelineDataTable
         columns={initialEnrichedColumns}
         columnIds={initialEnrichedColumnsIds}
+        dataView={mockDataView}
         activeTab={TimelineTabs.query}
         timelineId={TimelineId.test}
         itemsPerPage={50}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -27,7 +27,6 @@ import { DocumentDetailsRightPanelKey } from '../../../../../flyout/document_det
 import { selectTimelineById } from '../../../../store/selectors';
 import { RowRendererCount } from '../../../../../../common/api/timeline';
 import { EmptyComponent } from '../../../../../common/lib/cell_actions/helpers';
-import { withDataView } from '../../../../../common/components/with_data_view';
 import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
 import type { TimelineItem } from '../../../../../../common/search_strategy';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -443,7 +442,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
   }
 );
 
-export const TimelineDataTable = withDataView<DataTableProps>(TimelineDataTableComponent);
+export const TimelineDataTable = React.memo(TimelineDataTableComponent);
 
 // eslint-disable-next-line import/no-default-export
 export { TimelineDataTable as default };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
@@ -34,6 +34,8 @@ import { DataLoadingState } from '@kbn/unified-data-table';
 import { getColumnHeaders } from '../body/column_headers/helpers';
 import { defaultUdtHeaders } from '../body/column_headers/default_headers';
 import type { ColumnHeaderType } from '../../../../../common/types';
+import { DataView } from '@kbn/data-views-plugin/common';
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 
 jest.mock('../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -85,6 +87,11 @@ const SPECIAL_TEST_TIMEOUT = 50000;
 
 const localMockedTimelineData = structuredClone(mockTimelineData);
 
+const mockDataView = new DataView({
+  spec: mockSourcererScope.sourcererDataView,
+  fieldFormats: fieldFormatsMock,
+});
+
 const TestComponent = (
   props: Partial<ComponentProps<typeof UnifiedTimeline>> & { show?: boolean }
 ) => {
@@ -92,6 +99,7 @@ const TestComponent = (
   const testComponentDefaultProps: ComponentProps<typeof QueryTabContent> = {
     columns: getColumnHeaders(columnsToDisplay, mockSourcererScope.browserFields),
     activeTab: TimelineTabs.query,
+    dataView: mockDataView,
     rowRenderers: [],
     timelineId: TimelineId.test,
     itemsPerPage: 10,
@@ -513,50 +521,14 @@ describe('unified timeline', () => {
   });
 
   describe('unified field list', () => {
-    describe('render', () => {
-      let TestProviderWithNewStore: FC<PropsWithChildren<unknown>>;
-      beforeEach(() => {
-        const freshStore = createMockStore();
-        // eslint-disable-next-line react/display-name
-        TestProviderWithNewStore = ({ children }) => {
-          return <TestProviders store={freshStore}>{children}</TestProviders>;
-        };
-      });
-      it(
-        'should not render when timeline has never been opened',
-        async () => {
-          render(<TestComponent show={false} />, {
-            wrapper: TestProviderWithNewStore,
-          });
-          expect(await screen.queryByTestId('timeline-sidebar')).not.toBeInTheDocument();
-        },
-        SPECIAL_TEST_TIMEOUT
-      );
-
-      it(
-        'should render when timeline has been opened',
-        async () => {
-          render(<TestComponent />, {
-            wrapper: TestProviderWithNewStore,
-          });
-          expect(await screen.queryByTestId('timeline-sidebar')).toBeInTheDocument();
-        },
-        SPECIAL_TEST_TIMEOUT
-      );
-
-      it(
-        'should not re-render when timeline has been opened at least once',
-        async () => {
-          const { rerender } = render(<TestComponent />, {
-            wrapper: TestProviderWithNewStore,
-          });
-          rerender(<TestComponent show={false} />);
-          // Even after timeline is closed, it should still exist in the background
-          expect(await screen.queryByTestId('timeline-sidebar')).toBeInTheDocument();
-        },
-        SPECIAL_TEST_TIMEOUT
-      );
-    });
+    it(
+      'should render',
+      async () => {
+        renderTestComponents();
+        expect(await screen.queryByTestId('timeline-sidebar')).toBeInTheDocument();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
     it(
       'should be able to add filters',

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.tsx
@@ -6,7 +6,7 @@
  */
 import type { EuiDataGridProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiHideFor } from '@elastic/eui';
-import React, { useMemo, useCallback, useState, useRef, useEffect } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { generateFilters } from '@kbn/data-plugin/public';
@@ -26,8 +26,6 @@ import { UnifiedFieldListSidebarContainer } from '@kbn/unified-field-list';
 import type { EuiTheme } from '@kbn/react-kibana-context-styled';
 import type { CoreStart } from '@kbn/core-lifecycle-browser';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
-import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
-import { withDataView } from '../../../../common/components/with_data_view';
 import { EventDetailsWidthProvider } from '../../../../common/components/events_viewer/event_details_width_context';
 import type { TimelineItem } from '../../../../../common/search_strategy';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -47,7 +45,6 @@ import TimelineDataTable from './data_table';
 import { timelineActions } from '../../../store';
 import { getFieldsListCreationOptions } from './get_fields_list_creation_options';
 import { defaultUdtHeaders } from '../body/column_headers/default_headers';
-import { getTimelineShowStatusByIdSelector } from '../../../store/selectors';
 
 const TimelineBodyContainer = styled.div.attrs(({ className = '' }) => ({
   className: `${className}`,
@@ -345,31 +342,6 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
     onFieldEdited();
   }, [onFieldEdited]);
 
-  // PERFORMANCE ONLY CODE BLOCK
-  /**
-   * We check for the timeline open status to request the fields for the fields browser as the fields request
-   * is often a much longer running request for customers with a significant number of indices and fields in those indices.
-   * This request should only be made after the user has decided to interact with timeline to prevent any performance impacts
-   * to the underlying security solution views, as this query will always run when the timeline exists on the page.
-   *
-   * `hasTimelineBeenOpenedOnce` - We want to keep timeline loading times as fast as possible after the user
-   * has chosen to interact with timeline at least once, so we use this flag to prevent re-requesting of this fields data
-   * every time timeline is closed and re-opened after the first interaction.
-   */
-
-  const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
-  const { show } = useDeepEqualSelector((state) => getTimelineShowStatus(state, timelineId));
-
-  const [hasTimelineBeenOpenedOnce, setHasTimelineBeenOpenedOnce] = useState(false);
-
-  useEffect(() => {
-    if (!hasTimelineBeenOpenedOnce && show) {
-      setHasTimelineBeenOpenedOnce(true);
-    }
-  }, [hasTimelineBeenOpenedOnce, show]);
-
-  // END PERFORMANCE ONLY CODE BLOCK
-
   return (
     <TimelineBodyContainer className="timelineBodyContainer" ref={setSidebarContainer}>
       <TimelineResizableLayout
@@ -378,7 +350,7 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
         sidebarPanel={
           <SidebarPanelFlexGroup gutterSize="none">
             <EuiFlexItem className="sidebarContainer">
-              {dataView && hasTimelineBeenOpenedOnce ? (
+              {dataView && (
                 <UnifiedFieldListSidebarContainer
                   ref={unifiedFieldListContainerRef}
                   showFieldList
@@ -394,7 +366,7 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
                   onAddFilter={onAddFilter}
                   onFieldEdited={wrappedOnFieldEdited}
                 />
-              ) : null}
+              )}
             </EuiFlexItem>
             <EuiHideFor sizes={HIDE_FOR_SIZES}>
               <StyledSplitFlexItem grow={false} className="thinBorderSplit" />
@@ -423,6 +395,7 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
                     <DataGridMemoized
                       columns={columns}
                       columnIds={currentColumnIds}
+                      dataView={dataView}
                       rowRenderers={rowRenderers}
                       timelineId={timelineId}
                       isSortEnabled={isSortEnabled}
@@ -456,6 +429,6 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
   );
 };
 
-export const UnifiedTimeline = React.memo(withDataView<Props>(UnifiedTimelineComponent));
+export const UnifiedTimeline = React.memo(UnifiedTimelineComponent);
 // eslint-disable-next-line import/no-default-export
 export { UnifiedTimeline as default };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/inspect.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/inspect.ts
@@ -28,7 +28,7 @@ export const openTableInspectModal = (table: InspectTableMetadata) => {
   // wait for table to load
   cy.get(table.id).then(($table) => {
     if ($table.find(TABLE_LOADER).length > 0) {
-      cy.get(TABLE_LOADER).should('not.exist');
+      cy.get(TABLE_LOADER).should('not.be.visible');
     }
   });
 
@@ -44,7 +44,7 @@ export const openLensVisualizationsInspectModal = (
     .each(($el) => {
       // wait for visualization to load
       if ($el.find(LOADER_ARIA).length > 0) {
-        cy.get(LOADER_ARIA).should('not.exist');
+        cy.get(LOADER_ARIA).should('not.be.visible');
       }
 
       cy.wrap($el).realHover();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Performance][Security Solution][2/4] - Timeline Performance (#212478)](https://github.com/elastic/kibana/pull/212478)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michael Olorunnisola","email":"michael.olorunnisola@elastic.co"},"sourceCommit":{"committedDate":"2025-03-11T16:56:45Z","message":"[Performance][Security Solution][2/4] - Timeline Performance (#212478)\n\n## Summary\nPart 2 of https://github.com/elastic/kibana/pull/212173\n\n### Testing\nFor setup see testing section here:\nhttps://github.com/elastic/kibana/pull/212173#issue-2870522020\n\n**Areas/How to test:**\n- For the following pages, test there are no `fields` api requests in\nthe inspector network tab when visiting from another page. IF YOU\nREFRESH on any of these pages, you will see these requests as they are\ncalled by the Query Search Bar and the `useInitSourcerer` call\n  - Cases Page\n  - Dashboard Page\n  - Timelines Page\n- Timeline\n  - All Tabs\n    - Does it show the loading screen on first interaction?\n    - Does the `fields` api fire on first interaction with the tab\n    - When you navigate back to those tabs, do they not re-render?\n- All other pages hosting timeline\n - Do you feel like the performance is generally better?\n\n\n### Background\n\nWhen investigating the performance of the security solution application,\none of the issues that was observed was queries to the `fields` api on\npages that had no reason making that request (such as Cases, or the\nDashboards list view). This was due to the background background loaded\ntabs of timeline loading the relevant `dataView` necessary for their\nsearch functionality. When the fields request is significantly large\nthis can have a massive impact on the experience of users on pages that\nshould be relatively responsive.\n\nTo fix this a few changes were made. \n\n1. First the `withDataView` HOC was removed as it was only used in 2\ncomponents that shared a parent - child relationship, and the child\n`UnifiedTimeline` was only used in the parent. The hook that HOC calls\nwas not caching the dataView being created, so `dataView.create` was\nbeing called up to 6 times unnecessarily. Now it is only called once in\neach tab.\n\n2. A new wrapper `OnDemandRenderer` (open to different naming 😅) was\ncreated that will not render any of the nested tabs until they are\nopened. Once they are opened, they stay in memory, to avoid re-calling\nexpensive api's every time a user switches tabs.\n_Note_: There is currently a known issue where navigating between\nvarious routes in security solution causes the whole application to\nunmount and re-mount. Which means every page change will lead to\ntimeline needing to be re-loaded when the tab is opened. This is being\nresolved in a separate effort.\n\n3. Additional checks were added to the `useTimelineEvents` hook to limit\nadditional re-renders caused by unnecessary reference changes when the\nunderlying values never actually change\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n### Identify risks","sha":"2d8f3c1544aa6bff74623273a278f580df0d918d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","ci:cloud-deploy","ci:project-redeploy","backport:version","v9.1.0","v8.19.0","v8.17.5"],"title":"[Performance][Security Solution][2/4] - Timeline Performance","number":212478,"url":"https://github.com/elastic/kibana/pull/212478","mergeCommit":{"message":"[Performance][Security Solution][2/4] - Timeline Performance (#212478)\n\n## Summary\nPart 2 of https://github.com/elastic/kibana/pull/212173\n\n### Testing\nFor setup see testing section here:\nhttps://github.com/elastic/kibana/pull/212173#issue-2870522020\n\n**Areas/How to test:**\n- For the following pages, test there are no `fields` api requests in\nthe inspector network tab when visiting from another page. IF YOU\nREFRESH on any of these pages, you will see these requests as they are\ncalled by the Query Search Bar and the `useInitSourcerer` call\n  - Cases Page\n  - Dashboard Page\n  - Timelines Page\n- Timeline\n  - All Tabs\n    - Does it show the loading screen on first interaction?\n    - Does the `fields` api fire on first interaction with the tab\n    - When you navigate back to those tabs, do they not re-render?\n- All other pages hosting timeline\n - Do you feel like the performance is generally better?\n\n\n### Background\n\nWhen investigating the performance of the security solution application,\none of the issues that was observed was queries to the `fields` api on\npages that had no reason making that request (such as Cases, or the\nDashboards list view). This was due to the background background loaded\ntabs of timeline loading the relevant `dataView` necessary for their\nsearch functionality. When the fields request is significantly large\nthis can have a massive impact on the experience of users on pages that\nshould be relatively responsive.\n\nTo fix this a few changes were made. \n\n1. First the `withDataView` HOC was removed as it was only used in 2\ncomponents that shared a parent - child relationship, and the child\n`UnifiedTimeline` was only used in the parent. The hook that HOC calls\nwas not caching the dataView being created, so `dataView.create` was\nbeing called up to 6 times unnecessarily. Now it is only called once in\neach tab.\n\n2. A new wrapper `OnDemandRenderer` (open to different naming 😅) was\ncreated that will not render any of the nested tabs until they are\nopened. Once they are opened, they stay in memory, to avoid re-calling\nexpensive api's every time a user switches tabs.\n_Note_: There is currently a known issue where navigating between\nvarious routes in security solution causes the whole application to\nunmount and re-mount. Which means every page change will lead to\ntimeline needing to be re-loaded when the tab is opened. This is being\nresolved in a separate effort.\n\n3. Additional checks were added to the `useTimelineEvents` hook to limit\nadditional re-renders caused by unnecessary reference changes when the\nunderlying values never actually change\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n### Identify risks","sha":"2d8f3c1544aa6bff74623273a278f580df0d918d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212478","number":212478,"mergeCommit":{"message":"[Performance][Security Solution][2/4] - Timeline Performance (#212478)\n\n## Summary\nPart 2 of https://github.com/elastic/kibana/pull/212173\n\n### Testing\nFor setup see testing section here:\nhttps://github.com/elastic/kibana/pull/212173#issue-2870522020\n\n**Areas/How to test:**\n- For the following pages, test there are no `fields` api requests in\nthe inspector network tab when visiting from another page. IF YOU\nREFRESH on any of these pages, you will see these requests as they are\ncalled by the Query Search Bar and the `useInitSourcerer` call\n  - Cases Page\n  - Dashboard Page\n  - Timelines Page\n- Timeline\n  - All Tabs\n    - Does it show the loading screen on first interaction?\n    - Does the `fields` api fire on first interaction with the tab\n    - When you navigate back to those tabs, do they not re-render?\n- All other pages hosting timeline\n - Do you feel like the performance is generally better?\n\n\n### Background\n\nWhen investigating the performance of the security solution application,\none of the issues that was observed was queries to the `fields` api on\npages that had no reason making that request (such as Cases, or the\nDashboards list view). This was due to the background background loaded\ntabs of timeline loading the relevant `dataView` necessary for their\nsearch functionality. When the fields request is significantly large\nthis can have a massive impact on the experience of users on pages that\nshould be relatively responsive.\n\nTo fix this a few changes were made. \n\n1. First the `withDataView` HOC was removed as it was only used in 2\ncomponents that shared a parent - child relationship, and the child\n`UnifiedTimeline` was only used in the parent. The hook that HOC calls\nwas not caching the dataView being created, so `dataView.create` was\nbeing called up to 6 times unnecessarily. Now it is only called once in\neach tab.\n\n2. A new wrapper `OnDemandRenderer` (open to different naming 😅) was\ncreated that will not render any of the nested tabs until they are\nopened. Once they are opened, they stay in memory, to avoid re-calling\nexpensive api's every time a user switches tabs.\n_Note_: There is currently a known issue where navigating between\nvarious routes in security solution causes the whole application to\nunmount and re-mount. Which means every page change will lead to\ntimeline needing to be re-loaded when the tab is opened. This is being\nresolved in a separate effort.\n\n3. Additional checks were added to the `useTimelineEvents` hook to limit\nadditional re-renders caused by unnecessary reference changes when the\nunderlying values never actually change\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n### Identify risks","sha":"2d8f3c1544aa6bff74623273a278f580df0d918d"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215791","number":215791,"state":"MERGED","mergeCommit":{"sha":"45922ffa0196328ccb715fa2f2af1cc9d0fae139","message":"[8.x] [Performance][Security Solution][2/4] - Timeline Performance (#212478) (#215791)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Performance][Security Solution][2/4] - Timeline Performance\n(#212478)](https://github.com/elastic/kibana/pull/212478)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"8.17","label":"v8.17.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213988","number":213988,"state":"MERGED","mergeCommit":{"sha":"3febe25204eaf1c83970a7010ef63ac1d3fa8431","message":"[8.17] [Performance][Security Solution][2/4] - Timeline Performance (#212478) (#213988)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[Performance][Security Solution][2/4] - Timeline Performance\n(#212478)](https://github.com/elastic/kibana/pull/212478)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"url":"https://github.com/elastic/kibana/pull/222987","number":222987,"branch":"8.18","state":"OPEN"}]}] BACKPORT-->