### PR TITLE
[8.19] [Response Ops][Reporting] Report UI should only show reports generated in the current space. (#221375)

### DIFF
--- a/src/platform/packages/private/kbn-reporting/common/types.ts
+++ b/src/platform/packages/private/kbn-reporting/common/types.ts
@@ -168,6 +168,7 @@ export interface ReportSource {
    */
   kibana_name?: string; // for troubleshooting
   kibana_id?: string; // for troubleshooting
+  space_id?: string;
   timeout?: number; // for troubleshooting: the actual comparison uses the config setting xpack.reporting.queue.timeout
   max_attempts?: number; // for troubleshooting: the actual comparison uses the config setting xpack.reporting.capture.maxAttempts
   started_at?: string; // timestamp in UTC

--- a/x-pack/platform/plugins/private/reporting/server/core.ts
+++ b/x-pack/platform/plugins/private/reporting/server/core.ts
@@ -406,7 +406,7 @@ export class ReportingCore {
       const spaceId = spacesService?.getSpaceId(request);
 
       if (spaceId !== DEFAULT_SPACE_ID) {
-        logger.info(`Request uses Space ID: ${spaceId}`);
+        logger.debug(`Request uses Space ID: ${spaceId}`);
         return spaceId;
       } else {
         logger.debug(`Request uses default Space`);

--- a/x-pack/platform/plugins/private/reporting/server/lib/store/report.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/store/report.test.ts
@@ -21,6 +21,7 @@ describe('Class Report', () => {
         version: '7.14.0',
         browserTimezone: 'UTC',
       },
+      space_id: 'a_space',
       meta: { objectType: 'test' },
       timeout: 30000,
     });
@@ -36,6 +37,7 @@ describe('Class Report', () => {
       started_at: undefined,
       status: 'pending',
       timeout: 30000,
+      space_id: 'a_space',
     });
     expect(report.toReportTaskJSON()).toMatchObject({
       attempts: 0,
@@ -55,6 +57,7 @@ describe('Class Report', () => {
       meta: { objectType: 'test' },
       status: 'pending',
       timeout: 30000,
+      space_id: 'a_space',
     });
 
     expect(report._id).toBeDefined();

--- a/x-pack/platform/plugins/private/reporting/server/lib/store/report.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/store/report.ts
@@ -35,6 +35,7 @@ export class Report implements Partial<ReportSource & ReportDocumentHead> {
   public readonly created_at: ReportSource['created_at'];
   public readonly created_by: ReportSource['created_by'];
   public readonly payload: ReportSource['payload'];
+  public readonly space_id: ReportSource['space_id'];
 
   public readonly meta: ReportSource['meta'];
 
@@ -81,6 +82,7 @@ export class Report implements Partial<ReportSource & ReportDocumentHead> {
     this.payload = opts.payload;
     this.kibana_id = opts.kibana_id;
     this.kibana_name = opts.kibana_name;
+    this.space_id = opts.space_id;
     this.jobtype = opts.jobtype;
     this.max_attempts = opts.max_attempts;
     this.attempts = opts.attempts || 0;
@@ -137,6 +139,7 @@ export class Report implements Partial<ReportSource & ReportDocumentHead> {
       started_at: this.started_at,
       completed_at: this.completed_at,
       process_expiration: this.process_expiration,
+      space_id: this.space_id,
       output: this.output || null,
       metrics: this.metrics,
     };
@@ -184,6 +187,7 @@ export class Report implements Partial<ReportSource & ReportDocumentHead> {
       queue_time_ms: this.queue_time_ms?.[0],
       execution_time_ms: this.execution_time_ms?.[0],
       migration_version: this.migration_version,
+      space_id: this.space_id,
       payload: omit(this.payload, 'headers'),
       output: omit(this.output, 'content'),
       metrics: this.metrics,

--- a/x-pack/platform/plugins/private/reporting/server/lib/store/store.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/store/store.test.ts
@@ -181,6 +181,7 @@ describe('ReportingStore', () => {
         },
         "process_expiration": undefined,
         "queue_time_ms": undefined,
+        "space_id": undefined,
         "started_at": undefined,
         "status": "pending",
         "timeout": 30000,

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/generate/request_handler.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/generate/request_handler.test.ts
@@ -131,6 +131,7 @@ describe('Handle request to generate', () => {
           "output": null,
           "process_expiration": undefined,
           "queue_time_ms": undefined,
+          "space_id": "default",
           "started_at": undefined,
           "status": "pending",
           "timeout": undefined,

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/generate/request_handler.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/generate/request_handler.ts
@@ -16,6 +16,7 @@ import type { BaseParams } from '@kbn/reporting-common/types';
 import { cryptoFactory } from '@kbn/reporting-server';
 import rison from '@kbn/rison';
 
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { type Counters, getCounters } from '..';
 import type { ReportingCore } from '../../..';
 import { checkParamsVersion } from '../../../lib';
@@ -85,6 +86,8 @@ export class RequestHandler {
     // 3. Create a payload object by calling exportType.createJob(), and adding some automatic parameters
     const job = await exportType.createJob(jobParams, context, req);
 
+    const spaceId = reporting.getSpaceId(req, logger);
+
     const payload = {
       ...job,
       headers,
@@ -92,7 +95,7 @@ export class RequestHandler {
       objectType: jobParams.objectType,
       browserTimezone: jobParams.browserTimezone,
       version: jobParams.version,
-      spaceId: reporting.getSpaceId(req, logger),
+      spaceId,
     };
 
     // 4. Add the report to ReportingStore to show as pending
@@ -102,6 +105,7 @@ export class RequestHandler {
         created_by: user ? user.username : false,
         payload,
         migration_version: jobParams.version,
+        space_id: spaceId || DEFAULT_SPACE_ID,
         meta: {
           // telemetry fields
           objectType: jobParams.objectType,

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.test.ts
@@ -7,12 +7,19 @@
 
 import { set } from '@kbn/safer-lodash-set';
 
-import { ElasticsearchClient } from '@kbn/core/server';
+import { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { JOB_STATUS } from '@kbn/reporting-common';
 import { createMockConfigSchema } from '@kbn/reporting-mocks-server';
 import { createMockReportingCore } from '../../../test_helpers';
 import { jobsQueryFactory } from './jobs_query';
+
+const fakeRawRequest = {
+  headers: {
+    authorization: `ApiKey skdjtq4u543yt3rhewrh`,
+  },
+  path: '/',
+} as unknown as KibanaRequest;
 
 describe('jobsQuery', () => {
   let client: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
@@ -37,10 +44,11 @@ describe('jobsQuery', () => {
     });
 
     it('should pass parameters in the request body', async () => {
-      await jobsQuery.list({ username: 'somebody' }, 1, 10, ['id1', 'id2']);
-      await jobsQuery.list({ username: 'somebody' }, 1, 10, null);
+      await jobsQuery.list(fakeRawRequest, { username: 'somebody' }, 1, 10, ['id1', 'id2']);
+      await jobsQuery.list(fakeRawRequest, { username: 'somebody' }, 1, 10, null);
 
       expect(client.search).toHaveBeenCalledTimes(2);
+
       expect(client.search).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
@@ -53,6 +61,15 @@ describe('jobsQuery', () => {
               expect.arrayContaining([
                 { term: { created_by: 'somebody' } },
                 { ids: { values: ['id1', 'id2'] } },
+                {
+                  bool: {
+                    should: [
+                      { term: { space_id: 'default' } },
+                      // also show all reports created before space_id was added
+                      { bool: { must_not: { exists: { field: 'space_id' } } } },
+                    ],
+                  },
+                },
               ])
             ),
           }),
@@ -74,7 +91,9 @@ describe('jobsQuery', () => {
     });
 
     it('should return reports list', async () => {
-      await expect(jobsQuery.list({ username: 'somebody' }, 0, 10, [])).resolves.toEqual(
+      await expect(
+        jobsQuery.list(fakeRawRequest, { username: 'somebody' }, 0, 10, [])
+      ).resolves.toEqual(
         expect.arrayContaining([
           expect.objectContaining({ id: 'id1', jobtype: 'pdf' }),
           expect.objectContaining({ id: 'id2', jobtype: 'csv' }),
@@ -85,7 +104,9 @@ describe('jobsQuery', () => {
     it('should return an empty array when there are no hits', async () => {
       client.search.mockResponse({} as Awaited<ReturnType<ElasticsearchClient['search']>>);
 
-      await expect(jobsQuery.list({ username: 'somebody' }, 0, 10, [])).resolves.toHaveLength(0);
+      await expect(
+        jobsQuery.list(fakeRawRequest, { username: 'somebody' }, 0, 10, [])
+      ).resolves.toHaveLength(0);
     });
 
     it('should reject if the report source is missing', async () => {
@@ -93,9 +114,9 @@ describe('jobsQuery', () => {
         set<Awaited<ReturnType<ElasticsearchClient['search']>>>({}, 'hits.hits', [{}])
       );
 
-      await expect(jobsQuery.list({ username: 'somebody' }, 0, 10, [])).rejects.toBeInstanceOf(
-        Error
-      );
+      await expect(
+        jobsQuery.list(fakeRawRequest, { username: 'somebody' }, 0, 10, [])
+      ).rejects.toBeInstanceOf(Error);
     });
   });
 

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.ts
@@ -6,11 +6,12 @@
  */
 
 import { TransportResult, errors, estypes } from '@elastic/elasticsearch';
-import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import { JOB_STATUS } from '@kbn/reporting-common';
 import type { ReportApiJSON, ReportSource } from '@kbn/reporting-common/types';
 import { REPORTING_DATA_STREAM_WILDCARD_WITH_LEGACY } from '@kbn/reporting-server';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import type { ReportingCore } from '../../..';
 import { Report } from '../../../lib/store';
 import { runtimeFieldKeys, runtimeFields } from '../../../lib/store/runtime_fields';
@@ -40,6 +41,7 @@ export type ReportContent = Pick<ReportSource, 'status' | 'jobtype' | 'output'> 
 
 export interface JobsQueryFactory {
   list(
+    req: KibanaRequest,
     user: ReportingUser,
     page: number,
     size: number,
@@ -73,8 +75,9 @@ export function jobsQueryFactory(
   }
 
   return {
-    async list(user, page = 0, size = defaultSize, jobIds) {
+    async list(req, user, page = 0, size = defaultSize, jobIds) {
       const username = getUsername(user);
+      const spaceId = reportingCore.getSpaceId(req) || DEFAULT_SPACE_ID;
       const body = getSearchBody({
         size,
         from: size * page,
@@ -85,6 +88,15 @@ export function jobsQueryFactory(
                 must: [
                   { term: { created_by: username } },
                   ...(jobIds ? [{ ids: { values: jobIds } }] : []),
+                  {
+                    bool: {
+                      should: [
+                        { term: { space_id: spaceId } },
+                        // also show all reports created before space_id was added
+                        { bool: { must_not: { exists: { field: 'space_id' } } } },
+                      ],
+                    },
+                  },
                 ],
               },
             },

--- a/x-pack/platform/plugins/private/reporting/server/routes/internal/management/jobs.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/internal/management/jobs.ts
@@ -57,7 +57,7 @@ export function registerJobInfoRoutesInternal(reporting: ReportingCore) {
         const page = parseInt(queryPage, 10) || 0;
         const size = Math.min(100, parseInt(querySize, 10) || 10);
         const jobIds = queryIds ? queryIds.split(',') : null;
-        const results = await jobsQuery.list(user, page, size, jobIds);
+        const results = await jobsQuery.list(req, user, page, size, jobIds);
 
         counters.usageCounter();
 

--- a/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
@@ -24,6 +24,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./ilm_migration_apis'));
     loadTestFile(require.resolve('./security_roles_privileges'));
     loadTestFile(require.resolve('./spaces'));
+    loadTestFile(require.resolve('./list_jobs'));
 
     // CSV-specific
     loadTestFile(require.resolve('./csv/csv_v2'));

--- a/x-pack/test/reporting_api_integration/reporting_and_security/list_jobs.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/list_jobs.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { ReportApiJSON } from '@kbn/reporting-common/types';
+import { FtrProviderContext } from '../ftr_provider_context';
+
+// eslint-disable-next-line import/no-default-export
+export default function ({ getService }: FtrProviderContext) {
+  const spacesService = getService('spaces');
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const reportingAPI = getService('reportingAPI');
+
+  describe('List Reports', () => {
+    const spaceId = 'non_default_space';
+    before(async () => {
+      await spacesService.create({ id: spaceId, name: spaceId });
+      await kibanaServer.importExport.load(
+        `x-pack/test/functional/fixtures/kbn_archiver/reporting/ecommerce_kibana_non_default_space`,
+        { space: spaceId }
+      );
+      await reportingAPI.initEcommerce();
+      await esArchiver.load('x-pack/test/functional/es_archives/reporting/archived_reports');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/reporting/archived_reports');
+      await reportingAPI.teardownEcommerce();
+      await reportingAPI.deleteAllReports();
+      await spacesService.delete(spaceId);
+    });
+
+    it('should list reports filtered by current space or legacy reports with no space_id', async () => {
+      const res1 = await reportingAPI.generatePdf(
+        reportingAPI.REPORTING_USER_USERNAME,
+        reportingAPI.REPORTING_USER_PASSWORD,
+        {
+          browserTimezone: 'UTC',
+          title: 'test default-space PDF 1',
+          layout: { id: 'preserve_layout' },
+          locatorParams: [{ id: 'canvas', version: '7.14.0', params: {} }],
+          objectType: 'dashboard',
+          version: '7.14.0',
+        }
+      );
+      expect(res1.status).to.eql(200);
+      const reportDefaultSpace1Id = res1.body.job.id;
+
+      const res2 = await reportingAPI.generatePdf(
+        reportingAPI.REPORTING_USER_USERNAME,
+        reportingAPI.REPORTING_USER_PASSWORD,
+        {
+          browserTimezone: 'UTC',
+          title: 'test default-space PDF 2',
+          layout: { id: 'preserve_layout' },
+          locatorParams: [{ id: 'canvas', version: '7.14.0', params: {} }],
+          objectType: 'visualization',
+          version: '7.14.0',
+        }
+      );
+      expect(res2.status).to.eql(200);
+      const reportDefaultSpace2Id = res2.body.job.id;
+
+      const res3 = await reportingAPI.generatePdf(
+        reportingAPI.REPORTING_USER_USERNAME,
+        reportingAPI.REPORTING_USER_PASSWORD,
+        {
+          browserTimezone: 'UTC',
+          title: 'test custom space PDF',
+          layout: { id: 'preserve_layout' },
+          locatorParams: [{ id: 'canvas', version: '7.14.0', params: {} }],
+          objectType: 'dashboard',
+          version: '7.14.0',
+        },
+        spaceId
+      );
+      expect(res3.status).to.eql(200);
+      const reportNonDefaultSpace1Id = res3.body.job.id;
+
+      const listDefault = await reportingAPI.listReports(
+        reportingAPI.REPORTING_USER_USERNAME,
+        reportingAPI.REPORTING_USER_PASSWORD
+      );
+
+      const reportsInDefaultSpace = listDefault.body;
+      expect(reportsInDefaultSpace).to.have.length(4);
+
+      const reportsInDefaultSpaceIds = reportsInDefaultSpace.map(
+        (report: ReportApiJSON) => report.id
+      );
+      // listing should contain reports from the default space and legacy reports with no space_id
+      expect(reportsInDefaultSpaceIds).to.contain(reportDefaultSpace1Id);
+      expect(reportsInDefaultSpaceIds).to.contain(reportDefaultSpace2Id);
+      expect(reportsInDefaultSpaceIds).to.contain('krb7arhe164k0763b50bjm31');
+      expect(reportsInDefaultSpaceIds).to.contain('kraz9db6154g0763b5141viu');
+
+      // listing should not contain reports from custom space
+      expect(reportsInDefaultSpaceIds).not.to.contain(reportNonDefaultSpace1Id);
+
+      const listNonDefault = await reportingAPI.listReports(
+        reportingAPI.REPORTING_USER_USERNAME,
+        reportingAPI.REPORTING_USER_PASSWORD,
+        spaceId
+      );
+
+      const reportsInNonDefaultSpace = listNonDefault.body;
+      expect(reportsInNonDefaultSpace).to.have.length(3);
+
+      const reportsInNonDefaultSpaceIds = reportsInNonDefaultSpace.map(
+        (report: ReportApiJSON) => report.id
+      );
+
+      // listing should contain reports from the custom space and legacy reports with no space_id
+      expect(reportsInNonDefaultSpaceIds).to.contain(reportNonDefaultSpace1Id);
+      expect(reportsInNonDefaultSpaceIds).to.contain('krb7arhe164k0763b50bjm31');
+      expect(reportsInNonDefaultSpaceIds).to.contain('kraz9db6154g0763b5141viu');
+
+      // listing should not contain reports from default space
+      expect(reportsInNonDefaultSpaceIds).not.to.contain(reportDefaultSpace1Id);
+      expect(reportsInNonDefaultSpaceIds).not.to.contain(reportDefaultSpace2Id);
+    });
+  });
+}

--- a/x-pack/test/reporting_api_integration/services/scenarios.ts
+++ b/x-pack/test/reporting_api_integration/services/scenarios.ts
@@ -142,18 +142,30 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
     });
   };
 
-  const generatePdf = async (username: string, password: string, job: JobParamsPDFV2) => {
+  const generatePdf = async (
+    username: string,
+    password: string,
+    job: JobParamsPDFV2,
+    spaceId: string = 'default'
+  ) => {
     const jobParams = rison.encode(job);
+    const spacePrefix = spaceId !== 'default' ? `/s/${spaceId}` : '';
     return await supertestWithoutAuth
-      .post(`/api/reporting/generate/printablePdfV2`)
+      .post(`${spacePrefix}/api/reporting/generate/printablePdfV2`)
       .auth(username, password)
       .set('kbn-xsrf', 'xxx')
       .send({ jobParams });
   };
-  const generatePng = async (username: string, password: string, job: JobParamsPNGV2) => {
+  const generatePng = async (
+    username: string,
+    password: string,
+    job: JobParamsPNGV2,
+    spaceId: string = 'default'
+  ) => {
     const jobParams = rison.encode(job);
+    const spacePrefix = spaceId !== 'default' ? `/s/${spaceId}` : '';
     return await supertestWithoutAuth
-      .post(`/api/reporting/generate/pngV2`)
+      .post(`${spacePrefix}/api/reporting/generate/pngV2`)
       .auth(username, password)
       .set('kbn-xsrf', 'xxx')
       .send({ jobParams });
@@ -161,12 +173,13 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
   const generateCsv = async (
     job: JobParamsCSV,
     username = 'elastic',
-    password = process.env.TEST_KIBANA_PASS || 'changeme'
+    password = process.env.TEST_KIBANA_PASS || 'changeme',
+    spaceId: string = 'default'
   ) => {
     const jobParams = rison.encode(job);
-
+    const spacePrefix = spaceId !== 'default' ? `/s/${spaceId}` : '';
     return await supertestWithoutAuth
-      .post(`/api/reporting/generate/csv_searchsource`)
+      .post(`${spacePrefix}/api/reporting/generate/csv_searchsource`)
       .auth(username, password)
       .set('kbn-xsrf', 'xxx')
       .send({ jobParams });
@@ -206,6 +219,20 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
       .send()
       .expect(200);
     return job?.output?.error_code;
+  };
+
+  const listReports = async (
+    username = 'elastic',
+    password = process.env.TEST_KIBANA_PASS || 'changeme',
+    spaceId: string = 'default'
+  ) => {
+    const spacePrefix = spaceId !== 'default' ? `/s/${spaceId}` : '';
+    return await supertestWithoutAuth
+      .get(`${spacePrefix}${INTERNAL_ROUTES.JOBS.LIST}?page=0`)
+      .auth(username, password)
+      .set('kbn-xsrf', 'xxx')
+      .send()
+      .expect(200);
   };
 
   const deleteAllReports = async () => {
@@ -276,6 +303,7 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
     generatePdf,
     generatePng,
     generateCsv,
+    listReports,
     postJob,
     postJobJSON,
     getCompletedJobOutput,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Reporting] Report UI should only show reports generated in the current space. (#221375)](https://github.com/elastic/kibana/pull/221375)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-06-06T13:38:54Z","message":"[Response Ops][Reporting] Report UI should only show reports generated in the current space. (#221375)\n\nResolves https://github.com/elastic/kibana/issues/219881\n\n## Summary\n\n* Saves `space_id` in the report source document when a report is\ngenerated.\n* Updated the `list` API to filter by `space_id` (if available). The\nfilter also includes documents where `space_id` is not populated in\norder to maintain backwards compatibility with old reports that don't\ninclude the `space_id` field. This is an internal API so this change\nshould be allowed.\n* Associated Elasticsearch PR to add `space_id` to the report index\nmapping: https://github.com/elastic/elasticsearch/pull/128336\n\n## To Verify\n* On `main`, generate reports in different spaces\n* Switch to this branch and generate more reports in different spaces\n* Verify that you only see the new reports generated in the current\nspace + the old reports generated on `main` with no space id.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a55c72d020ae6149813f88261d7dbddf5e719aba","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:ResponseOps","Feature:Reporting:Framework","backport:version","v9.1.0","v8.19.0"],"title":"[Response Ops][Reporting] Report UI should only show reports generated in the current space.","number":221375,"url":"https://github.com/elastic/kibana/pull/221375","mergeCommit":{"message":"[Response Ops][Reporting] Report UI should only show reports generated in the current space. (#221375)\n\nResolves https://github.com/elastic/kibana/issues/219881\n\n## Summary\n\n* Saves `space_id` in the report source document when a report is\ngenerated.\n* Updated the `list` API to filter by `space_id` (if available). The\nfilter also includes documents where `space_id` is not populated in\norder to maintain backwards compatibility with old reports that don't\ninclude the `space_id` field. This is an internal API so this change\nshould be allowed.\n* Associated Elasticsearch PR to add `space_id` to the report index\nmapping: https://github.com/elastic/elasticsearch/pull/128336\n\n## To Verify\n* On `main`, generate reports in different spaces\n* Switch to this branch and generate more reports in different spaces\n* Verify that you only see the new reports generated in the current\nspace + the old reports generated on `main` with no space id.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a55c72d020ae6149813f88261d7dbddf5e719aba"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221375","number":221375,"mergeCommit":{"message":"[Response Ops][Reporting] Report UI should only show reports generated in the current space. (#221375)\n\nResolves https://github.com/elastic/kibana/issues/219881\n\n## Summary\n\n* Saves `space_id` in the report source document when a report is\ngenerated.\n* Updated the `list` API to filter by `space_id` (if available). The\nfilter also includes documents where `space_id` is not populated in\norder to maintain backwards compatibility with old reports that don't\ninclude the `space_id` field. This is an internal API so this change\nshould be allowed.\n* Associated Elasticsearch PR to add `space_id` to the report index\nmapping: https://github.com/elastic/elasticsearch/pull/128336\n\n## To Verify\n* On `main`, generate reports in different spaces\n* Switch to this branch and generate more reports in different spaces\n* Verify that you only see the new reports generated in the current\nspace + the old reports generated on `main` with no space id.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a55c72d020ae6149813f88261d7dbddf5e719aba"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->