### PR TITLE
[8.19] [Cloud Security] Enable agentless auto upgrade Kibana daily task (#221202)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -27,7 +27,7 @@ const _allowedExperimentalValues = {
   enableReusableIntegrationPolicies: true,
   asyncDeployPolicies: true,
   enableExportCSV: true,
-  enabledUpgradeAgentlessDeploymentsTask: false,
+  enabledUpgradeAgentlessDeploymentsTask: true,
   enableAutomaticAgentUpgrades: true,
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Cloud Security] Enable agentless auto upgrade Kibana daily task (#221202)](https://github.com/elastic/kibana/pull/221202)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"seanrathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2025-06-06T16:17:05Z","message":"[Cloud Security] Enable agentless auto upgrade Kibana daily task (#221202)","sha":"0eb5007155859955d68fdb5182cb331add9e75f2","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","Team:Cloud Security","ci:build-cloud-image","backport:version","v9.1.0","v8.19.0"],"title":"[Cloud Security] Enable agentless auto upgrade Kibana daily task","number":221202,"url":"https://github.com/elastic/kibana/pull/221202","mergeCommit":{"message":"[Cloud Security] Enable agentless auto upgrade Kibana daily task (#221202)","sha":"0eb5007155859955d68fdb5182cb331add9e75f2"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221202","number":221202,"mergeCommit":{"message":"[Cloud Security] Enable agentless auto upgrade Kibana daily task (#221202)","sha":"0eb5007155859955d68fdb5182cb331add9e75f2"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->