### PR TITLE
[Dashboards as Code][Embeddable API Integration] Make EmbeddableContentManagementRegistry async

### DIFF
--- a/examples/embeddable_examples/public/plugin.ts
+++ b/examples/embeddable_examples/public/plugin.ts
@@ -33,8 +33,6 @@ import { SAVED_BOOK_ID } from './react_embeddables/saved_book/constants';
 import { registerCreateSavedBookAction } from './react_embeddables/saved_book/create_saved_book_action';
 import { registerAddSearchPanelAction } from './react_embeddables/search/register_add_search_panel_action';
 import { registerSearchEmbeddable } from './react_embeddables/search/register_search_embeddable';
-import { bookCmDefinitions } from '../common/book/content_management/cm_services';
-import { fieldListCmDefinitions } from '../common/field_list/content_management/cm_services';
 import { BOOK_CONTENT_ID, BOOK_LATEST_VERSION } from '../common/book/content_management/schema';
 import { setKibanaServices } from './kibana_services';
 import { BookSerializedState } from './react_embeddables/saved_book/types';
@@ -103,8 +101,16 @@ export class EmbeddableExamplesPlugin implements Plugin<void, void, SetupDeps, S
       new Promise((resolve) => startServicesPromise.then(([_, startDeps]) => resolve(startDeps)))
     );
 
-    embeddable.registerEmbeddableContentManagementDefinition(bookCmDefinitions);
-    embeddable.registerEmbeddableContentManagementDefinition(fieldListCmDefinitions);
+    embeddable.registerEmbeddableContentManagementDefinition('book', async () => {
+      const { bookCmDefinitions } = await import('../common/book/content_management/cm_services');
+      return bookCmDefinitions;
+    });
+    embeddable.registerEmbeddableContentManagementDefinition('field_list', async () => {
+      const { fieldListCmDefinitions } = await import(
+        '../common/field_list/content_management/cm_services'
+      );
+      return fieldListCmDefinitions;
+    });
 
     contentManagement.registry.register({
       id: BOOK_CONTENT_ID,

--- a/examples/embeddable_examples/server/plugin.ts
+++ b/examples/embeddable_examples/server/plugin.ts
@@ -44,7 +44,9 @@ export class EmbeddableExamplesPlugin implements Plugin<void, void, SetupDeps, S
       },
     });
 
-    embeddable.registerEmbeddableContentManagementDefinition(bookCmDefinitionsWithSchemas);
+    embeddable.registerEmbeddableContentManagementDefinition('book', () =>
+      Promise.resolve(bookCmDefinitionsWithSchemas)
+    );
 
     return {};
   }

--- a/src/platform/plugins/shared/dashboard/server/content_management/dashboard_storage.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/dashboard_storage.ts
@@ -196,10 +196,15 @@ export class DashboardStorage {
       outcome,
     } = await soClient.resolve<DashboardSavedObjectAttributes>(DASHBOARD_SAVED_OBJECT_TYPE, id);
 
-    const { item, error: itemError } = savedObjectToItem(savedObject, this.embeddable, false, {
-      getTagNamesFromReferences: (references: SavedObjectReference[]) =>
-        this.getTagNamesFromReferences(references, allTags),
-    });
+    const { item, error: itemError } = await savedObjectToItem(
+      savedObject,
+      this.embeddable,
+      false,
+      {
+        getTagNamesFromReferences: (references: SavedObjectReference[]) =>
+          this.getTagNamesFromReferences(references, allTags),
+      }
+    );
     if (itemError) {
       throw Boom.badRequest(`Invalid response. ${itemError.message}`);
     }
@@ -286,10 +291,15 @@ export class DashboardStorage {
       { ...optionsToLatest, references: soReferences }
     );
 
-    const { item, error: itemError } = savedObjectToItem(savedObject, this.embeddable, false, {
-      getTagNamesFromReferences: (references: SavedObjectReference[]) =>
-        this.getTagNamesFromReferences(references, allTags),
-    });
+    const { item, error: itemError } = await savedObjectToItem(
+      savedObject,
+      this.embeddable,
+      false,
+      {
+        getTagNamesFromReferences: (references: SavedObjectReference[]) =>
+          this.getTagNamesFromReferences(references, allTags),
+      }
+    );
     if (itemError) {
       throw Boom.badRequest(`Invalid response. ${itemError.message}`);
     }
@@ -373,7 +383,7 @@ export class DashboardStorage {
       }
     );
 
-    const { item, error: itemError } = savedObjectToItem(
+    const { item, error: itemError } = await savedObjectToItem(
       partialSavedObject,
       this.embeddable,
       true,
@@ -448,7 +458,7 @@ export class DashboardStorage {
     const hits = await Promise.all(
       soResponse.saved_objects
         .map(async (so) => {
-          const { item } = savedObjectToItem(so, this.embeddable, false, {
+          const { item } = await savedObjectToItem(so, this.embeddable, false, {
             allowedAttributes: soQuery.fields,
             allowedReferences: optionsToLatest?.includeReferences,
             getTagNamesFromReferences: (references: SavedObjectReference[]) =>

--- a/src/platform/plugins/shared/dashboard/server/content_management/v3/cm_services.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v3/cm_services.ts
@@ -33,7 +33,7 @@ import {
   DEFAULT_PANEL_WIDTH,
   DEFAULT_DASHBOARD_OPTIONS,
 } from '../../../common/content_management';
-import { getResultV3ToV2 } from './transform_utils';
+// import { getResultV3ToV2 } from './transform_utils';
 
 const apiError = schema.object({
   error: schema.string(),
@@ -230,7 +230,7 @@ const searchSourceSchema = schema.object(
   { defaultValue: {}, unknowns: 'allow' }
 );
 
-const sectionGridDataSchema = schema.object({
+export const sectionGridDataSchema = schema.object({
   y: schema.number({ meta: { description: 'The y coordinate of the section in grid units' } }),
   i: schema.maybe(
     schema.string({
@@ -564,8 +564,8 @@ export const getServiceDefinition = (embeddable: EmbeddableStart): ServicesDefin
     out: {
       result: {
         schema: dashboardGetResultSchema,
-        // TODO Ignoring references for now...
-        down: (data) => getResultV3ToV2(data, embeddable),
+        // TODO Ignoring down transforms for now since it needs to be a promise.
+        // down: (data) => getResultV3ToV2(data, embeddable),
       },
     },
   },

--- a/src/platform/plugins/shared/dashboard/server/content_management/v3/types.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v3/types.ts
@@ -23,6 +23,7 @@ import {
   dashboardItemSchema,
   controlGroupInputSchema,
   panelGridDataSchema,
+  sectionGridDataSchema,
   panelSchema,
   sectionSchema,
   dashboardAttributesSchema,
@@ -45,7 +46,9 @@ export type DashboardPanel = Omit<TypeOf<typeof panelSchema>, 'panelConfig'> & {
   panelConfig: TypeOf<typeof panelSchema>['panelConfig'] & { [key: string]: any };
   gridData: GridData;
 };
-export type DashboardSection = TypeOf<typeof sectionSchema>;
+export type DashboardSection = Omit<TypeOf<typeof sectionSchema>, 'gridData'> & {
+  gridData: SectionGridData;
+};
 export type DashboardAttributes = Omit<TypeOf<typeof dashboardAttributesSchema>, 'panels'> & {
   panels: Array<DashboardPanel | DashboardSection>;
 };
@@ -58,6 +61,7 @@ export type PartialDashboardItem = Omit<DashboardItem, 'attributes' | 'reference
 
 export type ControlGroupAttributes = TypeOf<typeof controlGroupInputSchema>;
 export type GridData = WithRequiredProperty<TypeOf<typeof panelGridDataSchema>, 'i'>;
+export type SectionGridData = WithRequiredProperty<TypeOf<typeof sectionGridDataSchema>, 'i'>;
 
 export type DashboardGetIn = GetIn<typeof CONTENT_ID>;
 export type DashboardGetOut = TypeOf<typeof dashboardGetResultSchema>;

--- a/src/platform/plugins/shared/embeddable/common/embeddable_content_management/registry.ts
+++ b/src/platform/plugins/shared/embeddable/common/embeddable_content_management/registry.ts
@@ -10,26 +10,31 @@
 import { EmbeddableContentManagementDefinition } from '..';
 
 export class EmbeddableContentManagementRegistry {
-  private registry: Map<string, EmbeddableContentManagementDefinition> = new Map();
+  private registry: Map<string, () => Promise<EmbeddableContentManagementDefinition>> = new Map();
 
   public registerContentManagementDefinition = (
-    definition: EmbeddableContentManagementDefinition
+    id: string,
+    getDefinition: () => Promise<EmbeddableContentManagementDefinition>
   ) => {
-    if (this.registry.has(definition.id)) {
-      throw new Error(
-        `Content management definition for type "${definition.id}" is already registered.`
-      );
+    if (this.registry.has(id)) {
+      throw new Error(`Content management definition for type "${id}" is already registered.`);
     }
 
-    if (!(definition.latestVersion in definition.versions)) {
-      throw new Error(
-        `Content management definition for type "${definition.id}" does not include the current version "${definition.latestVersion}".`
-      );
-    }
-    this.registry.set(definition.id, definition);
+    // if (!(definition.latestVersion in definition.versions)) {
+    //   throw new Error(
+    //     `Content management definition for type "${definition.id}" does not include the current version "${definition.latestVersion}".`
+    //   );
+    // }
+    this.registry.set(id, getDefinition);
   };
 
-  public getContentManagementDefinition = (id: string) => {
-    return this.registry.get(id);
+  public getContentManagementDefinition = async (
+    id: string
+  ): Promise<EmbeddableContentManagementDefinition | undefined> => {
+    const getDefinition = this.registry.get(id);
+    if (!getDefinition) {
+      return;
+    }
+    return await getDefinition();
   };
 }

--- a/src/platform/plugins/shared/embeddable/common/types.ts
+++ b/src/platform/plugins/shared/embeddable/common/types.ts
@@ -65,5 +65,5 @@ export interface CommonEmbeddableStartContract {
 export interface CanGetEmbeddableContentManagementDefinition {
   getEmbeddableContentManagementDefinition: (
     id: string
-  ) => EmbeddableContentManagementDefinition | undefined;
+  ) => Promise<EmbeddableContentManagementDefinition | undefined>;
 }

--- a/src/platform/plugins/shared/embeddable/public/types.ts
+++ b/src/platform/plugins/shared/embeddable/public/types.ts
@@ -19,11 +19,11 @@ import type { registerAddFromLibraryType } from './add_from_library/registry';
 import type { registerReactEmbeddableFactory } from './react_embeddable_system';
 import type { EmbeddableStateTransfer } from './state_transfer';
 import type {
-  EmbeddableContentManagementDefinition,
   EmbeddableStateWithType,
   CanGetEmbeddableContentManagementDefinition,
 } from '../common';
 import { EnhancementRegistryDefinition } from './enhancements/types';
+import { EmbeddableContentManagementRegistry } from '../common/embeddable_content_management/registry';
 
 export interface EmbeddableSetupDependencies {
   uiActions: UiActionsSetup;
@@ -72,9 +72,7 @@ export interface EmbeddableSetup {
    */
   registerReactEmbeddableFactory: typeof registerReactEmbeddableFactory;
 
-  registerEmbeddableContentManagementDefinition: (
-    definition: EmbeddableContentManagementDefinition
-  ) => void;
+  registerEmbeddableContentManagementDefinition: EmbeddableContentManagementRegistry['registerContentManagementDefinition'];
 
   /**
    * @deprecated

--- a/src/platform/plugins/shared/embeddable/server/plugin.ts
+++ b/src/platform/plugins/shared/embeddable/server/plugin.ts
@@ -31,25 +31,20 @@ import {
   EmbeddableStateWithType,
   CommonEmbeddableStartContract,
   EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
+  CanGetEmbeddableContentManagementDefinition,
 } from '../common/types';
 import { getAllMigrations } from '../common/lib/get_all_migrations';
 import { EmbeddableContentManagementRegistry } from '../common/embeddable_content_management/registry';
 
 export interface EmbeddableSetup extends PersistableStateService<EmbeddableStateWithType> {
   registerEmbeddableFactory: (factory: EmbeddableRegistryDefinition) => void;
-  registerEmbeddableContentManagementDefinition: (
-    definition: EmbeddableContentManagementDefinition
-  ) => void;
+  registerEmbeddableContentManagementDefinition: EmbeddableContentManagementRegistry['registerContentManagementDefinition'];
   registerEnhancement: (enhancement: EnhancementRegistryDefinition) => void;
   getAllMigrations: () => MigrateFunctionsObject;
 }
 
-export type EmbeddableStart = PersistableStateService<EmbeddableStateWithType> & {
-  getEmbeddableContentManagementDefinition: (
-    id: string
-  ) => EmbeddableContentManagementDefinition | undefined;
-};
+export type EmbeddableStart = PersistableStateService<EmbeddableStateWithType> &
+  CanGetEmbeddableContentManagementDefinition;
 
 export class EmbeddableServerPlugin implements Plugin<EmbeddableSetup, EmbeddableStart> {
   private readonly embeddableFactories: EmbeddableFactoryRegistry = new Map();


### PR DESCRIPTION
Note: _This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to support embeddable integrations with Dashboards as Code._

Makes the `EmbeddableContentManagementRegistry` an async registry to reduce bundle size.