### PR TITLE
[Security Assistant] Fixes `llll` error

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/helpers.ts
@@ -21,7 +21,7 @@ export const getModelOrOss = (
   model?: string
 ): string | undefined => (llmType === 'openai' && isOssModel ? 'oss' : model);
 
-const TIME_FORMAT = 'llll [UTC]Z';
+const TIME_FORMAT = 'LLLL [UTC]Z';
 const UTC_CONVERSION_TIME_FORMAT = 'LT [UTC]';
 
 export const getFormattedTime = ({


### PR DESCRIPTION
## Summary

This is a weird one. If you add `elasticsearch.requestTimeout: 180000` and run **serverless**, say Hi to the assistant. It responds with an error message, and in your console you'll see this error:

```
[2025-06-03T13:49:36.991-04:00][ERROR][plugins.elasticAssistant] Error: Unable to compile DefaultAssistantGraph
TypeError: Cannot add property llll, object is not extensible
    at getDefaultAssistantGraph (graph.ts:150:11)
    at callAssistantGraph (index.ts:226:50)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at langChainExecute (helpers.ts:367:64)
    at post_actions_connector_execute.ts:186:18
    at CoreVersionedRoute.handle (core_versioned_route.ts:216:20)
    at Router.handle (router.ts:202:30)
    at handler (router.ts:187:9)
    at exports.Manager.execute (/Users/pjaramillo/ElasticGithub/kibana/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at Object.internals.handler (/Users/pjaramillo/ElasticGithub/kibana/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at exports.execute (/Users/pjaramillo/ElasticGithub/kibana/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at Request._lifecycle (/Users/pjaramillo/ElasticGithub/kibana/node_modules/@hapi/hapi/lib/request.js:370:32)
    at Request._execute (/Users/pjaramillo/ElasticGithub/kibana/node_modules/@hapi/hapi/lib/request.js:280:9)
```

This is an error related to `Object.freeze`. We narrowed the error down to [this line](https://github.com/elastic/kibana/blob/9f7cffc4f3c3ac63ef2f758b04a9d38fde865077/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/helpers.ts#L47). If you use `UTC_CONVERSION_TIME_FORMAT` instead of `TIME_FORMAT`, there is no error thrown. In both cases, I ran:
```
const localeData = moment.localeData();
console.log('Is frozen:', Object.isFrozen(localeData)):
```
to determine if the object was frozen due to the error. In both cases, this resolved to `true`, so locale was frozen in both, but only threw an `object is not extensible error` for `llll`. Looking [at the docs](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/), I saw you should be able to use uppercase or lowercase so I tried `LLLL` and this cleared the error.

I still do not understand this error. Why does it only fail in serverless? Why does it only fail when `elasticsearch.requestTimeout` is set?! This is so bizarre, and I'm at a loss. 

I at least fixed this error, but I'm not satisfied with my understanding. If the reviewer has any ideas, please let me know.
