### PR TITLE
[Discover] Fix cell actions extension not working for ES|QL computed columns

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_additional_cell_actions.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_additional_cell_actions.test.tsx
@@ -30,7 +30,6 @@ import {
   type DiscoverCellActionExecutionContext,
 } from '../types';
 import { createContextAwarenessMocks } from '../__mocks__';
-import { DataViewField } from '@kbn/data-views-plugin/common';
 
 let mockUuid = 0;
 
@@ -237,12 +236,12 @@ describe('createCellAction', () => {
         ...context,
         data: [
           {
-            field: new DataViewField({
-              name: 'test',
-              type: 'string',
-              aggregatable: true,
-              searchable: true,
-            }),
+            field: {
+              name: '',
+              type: '',
+              aggregatable: false,
+              searchable: false,
+            },
           },
         ],
         metadata: { instanceId: 'test', dataView: dataViewWithTimefieldMock },

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_additional_cell_actions.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_additional_cell_actions.ts
@@ -88,9 +88,10 @@ export const createCellAction = (
         return false;
       }
 
-      const field = data[0]?.field;
+      const fieldSpec = data[0]?.field;
+      const field = fieldSpec?.name ? metadata.dataView?.fields.create(fieldSpec) : undefined;
 
-      if (!field || !metadata.dataView?.getFieldByName(field.name)) {
+      if (!field) {
         return false;
       }
 

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_additional_cell_actions.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_additional_cell_actions.ts
@@ -58,6 +58,24 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await checkAlert('Another example data source action executed');
       });
 
+      it('should render additional cell actions for computed columns', async () => {
+        const state = kbnRison.encode({
+          dataSource: { type: 'esql' },
+          query: {
+            esql: 'from my-example-logs | sort @timestamp desc | eval foo = "bar"',
+          },
+          columns: ['foo'],
+        });
+        await PageObjects.common.navigateToActualUrl('discover', `?_a=${state}`, {
+          ensureCurrentUrl: false,
+        });
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await dataGrid.clickCellExpandButton(0, { columnName: 'foo' });
+        await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
+        await checkAlert('Example data source action executed');
+      });
+
       it('should not render incompatible cell action for message column', async () => {
         const state = kbnRison.encode({
           dataSource: { type: 'esql' },

--- a/x-pack/test_serverless/functional/test_suites/common/discover/context_awareness/extensions/_get_additional_cell_actions.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/context_awareness/extensions/_get_additional_cell_actions.ts
@@ -61,6 +61,24 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await checkAlert('Another example data source action executed');
       });
 
+      it('should render additional cell actions for computed columns', async () => {
+        const state = kbnRison.encode({
+          dataSource: { type: 'esql' },
+          query: {
+            esql: 'from my-example-logs | sort @timestamp desc | eval foo = "bar"',
+          },
+          columns: ['foo'],
+        });
+        await PageObjects.common.navigateToActualUrl('discover', `?_a=${state}`, {
+          ensureCurrentUrl: false,
+        });
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await dataGrid.clickCellExpandButton(0, { columnName: 'foo' });
+        await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
+        await checkAlert('Example data source action executed');
+      });
+
       it('should not render incompatible cell action for message column', async () => {
         const state = kbnRison.encode({
           dataSource: { type: 'esql' },


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Discover cell actions extension did not work for ES|QL computed columns.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->