### PR TITLE
[Lens][ExpressionRenderer] Embeddable should render within the existing React tree

### DIFF
--- a/src/platform/plugins/shared/chart_expressions/expression_metric/public/expression_renderers/metric_vis_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_metric/public/expression_renderers/metric_vis_renderer.tsx
@@ -25,6 +25,7 @@ import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
 import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
 import { ExpressionMetricPluginStart } from '../plugin';
 import { EXPRESSION_METRIC_NAME, MetricVisRenderConfig, VisParams } from '../../common';
+import type { MetricVisComponentProps } from '../components/metric_vis';
 
 async function metricFilterable(
   dimensions: VisParams['dimensions'],
@@ -54,27 +55,52 @@ interface ExpressionMetricVisRendererDependencies {
   getStartDeps: StartServicesGetter<ExpressionMetricPluginStart>;
 }
 
-export const getMetricVisRenderer = (
-  deps: ExpressionMetricVisRendererDependencies
-): (() => ExpressionRenderDefinition<MetricVisRenderConfig>) => {
-  return () => ({
-    name: EXPRESSION_METRIC_NAME,
-    displayName: 'metric visualization',
-    reuseDomNode: true,
-    render: async (domNode, { visData, visConfig, overrides }, handlers) => {
-      const performanceTracker = createPerformanceTracker({
-        type: PERFORMANCE_TRACKER_TYPES.PANEL,
-        subType: EXPRESSION_METRIC_NAME,
-      });
+function getMetricComponent(
+  plugins: ExpressionMetricPluginStart,
+  { visData, visConfig, overrides }: MetricVisRenderConfig,
+  handlers: IInterpreterRenderHandlers,
+  MetricVis: React.ComponentType<MetricVisComponentProps>,
+  performanceTracker: ReturnType<typeof createPerformanceTracker>
+) {
+  const renderComplete = () => {
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
 
-      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+    const executionContext = handlers.getExecutionContext();
+    const containerType = extractContainerType(executionContext);
+    const visualizationType = extractVisualizationType(executionContext);
 
-      const { core, plugins } = deps.getStartDeps();
+    if (containerType && visualizationType) {
+      plugins.usageCollection?.reportUiCounter(containerType, METRIC_TYPE.COUNT, [
+        `render_${visualizationType}_metric`,
+      ]);
+    }
 
-      handlers.onDestroy(() => {
-        unmountComponentAtNode(domNode);
-      });
+    handlers.done();
+  };
 
+  return {
+    Component: ({ filterable }: { filterable: boolean }) => (
+      <div
+        data-test-subj="mtrVis"
+        css={css`
+          height: 100%;
+          width: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        `}
+      >
+        <MetricVis
+          data={visData}
+          config={visConfig}
+          renderComplete={renderComplete}
+          fireEvent={handlers.event}
+          filterable={filterable}
+          overrides={overrides}
+        />
+      </div>
+    ),
+    getFilterable: async () => {
       const filterable = visData.rows.length
         ? await metricFilterable(
             visConfig.dimensions,
@@ -82,51 +108,84 @@ export const getMetricVisRenderer = (
             handlers.hasCompatibleActions?.bind(handlers)
           )
         : false;
+      return filterable;
+    },
+  };
+}
 
-      const renderComplete = () => {
-        performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
-
-        const executionContext = handlers.getExecutionContext();
-        const containerType = extractContainerType(executionContext);
-        const visualizationType = extractVisualizationType(executionContext);
-
-        if (containerType && visualizationType) {
-          plugins.usageCollection?.reportUiCounter(containerType, METRIC_TYPE.COUNT, [
-            `render_${visualizationType}_metric`,
-          ]);
-        }
-
-        handlers.done();
-      };
+export const getMetricVisRenderer = (
+  deps: ExpressionMetricVisRendererDependencies
+): (() => ExpressionRenderDefinition<MetricVisRenderConfig>) => {
+  return () => ({
+    name: EXPRESSION_METRIC_NAME,
+    displayName: 'metric visualization',
+    reuseDomNode: true,
+    render: async (domNode, config, handlers) => {
+      const performanceTracker = createPerformanceTracker({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        subType: EXPRESSION_METRIC_NAME,
+      });
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+      const { core, plugins } = deps.getStartDeps();
+      handlers.onDestroy(() => {
+        unmountComponentAtNode(domNode);
+      });
 
       const { MetricVis } = await import('../components/metric_vis');
-
+      const { Component, getFilterable } = getMetricComponent(
+        plugins,
+        config,
+        handlers,
+        MetricVis,
+        performanceTracker
+      );
+      const filterable = await getFilterable();
       performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
 
       render(
         <KibanaRenderContextProvider {...core}>
-          <div
-            data-test-subj="mtrVis"
-            css={css`
-              height: 100%;
-              width: 100%;
-              display: flex;
-              align-items: center;
-              justify-content: center;
-            `}
-          >
-            <MetricVis
-              data={visData}
-              config={visConfig}
-              renderComplete={renderComplete}
-              fireEvent={handlers.event}
-              filterable={filterable}
-              overrides={overrides}
-            />
-          </div>
+          <Component filterable={filterable} />
         </KibanaRenderContextProvider>,
         domNode
       );
+    },
+    loadComponent: async () => {
+      const { MetricVis } = await import('../components/metric_vis');
+      const performanceTracker = createPerformanceTracker({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        subType: EXPRESSION_METRIC_NAME,
+      });
+      return ({
+        config,
+        handlers,
+      }: {
+        config: MetricVisRenderConfig;
+        handlers: IInterpreterRenderHandlers;
+      }) => {
+        performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+        const [filterable, setFilterable] = React.useState<boolean | undefined>(undefined);
+
+        const { Component, getFilterable } = getMetricComponent(
+          deps.getStartDeps().plugins,
+          config,
+          handlers,
+          MetricVis,
+          performanceTracker
+        );
+        React.useEffect(() => {
+          const updateLazyFilterable = async () => {
+            setFilterable(await getFilterable());
+          };
+          updateLazyFilterable();
+        }, [getFilterable]);
+
+        if (filterable == null) {
+          return null;
+        }
+        performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
+
+        return <Component filterable={filterable} />;
+      };
     },
   });
 };

--- a/src/platform/plugins/shared/expressions/common/expression_renderers/expression_renderer.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_renderers/expression_renderer.ts
@@ -17,9 +17,11 @@ export class ExpressionRenderer<Config = unknown> {
   public readonly validate: () => void | Error;
   public readonly reuseDomNode: boolean;
   public readonly render: ExpressionRenderDefinition<Config>['render'];
+  public readonly loadComponent?: ExpressionRenderDefinition<Config>['loadComponent'];
 
   constructor(config: ExpressionRenderDefinition<Config>) {
-    const { name, displayName, help, validate, reuseDomNode, render, namespace } = config;
+    const { name, displayName, help, validate, reuseDomNode, render, namespace, loadComponent } =
+      config;
 
     this.name = name;
     this.namespace = namespace;
@@ -28,5 +30,6 @@ export class ExpressionRenderer<Config = unknown> {
     this.validate = validate || (() => {});
     this.reuseDomNode = Boolean(reuseDomNode);
     this.render = render;
+    this.loadComponent = loadComponent;
   }
 }

--- a/src/platform/plugins/shared/expressions/common/expression_renderers/types.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_renderers/types.ts
@@ -49,6 +49,10 @@ export interface ExpressionRenderDefinition<Config = unknown> {
     config: Config,
     handlers: IInterpreterRenderHandlers
   ) => void | Promise<void>;
+
+  loadComponent?: () => Promise<
+    React.ComponentType<{ config: Config; handlers: IInterpreterRenderHandlers }>
+  >;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/platform/plugins/shared/expressions/public/loader.ts
+++ b/src/platform/plugins/shared/expressions/public/loader.ts
@@ -57,6 +57,7 @@ export class ExpressionLoader {
     this.renderHandler = new ExpressionRenderHandler(element, {
       interactive: params?.interactive,
       onRenderError: params && params.onRenderError,
+      onRenderComponent: params && params.onRenderComponent,
       renderMode: params?.renderMode,
       syncColors: params?.syncColors,
       syncTooltips: params?.syncTooltips,

--- a/src/platform/plugins/shared/expressions/public/react_expression_renderer/react_expression_renderer.tsx
+++ b/src/platform/plugins/shared/expressions/public/react_expression_renderer/react_expression_renderer.tsx
@@ -41,7 +41,7 @@ export function ReactExpressionRenderer({
 }: ReactExpressionRendererProps) {
   const nodeRef = useRef<HTMLDivElement>(null);
   const { euiTheme } = useEuiTheme();
-  const { error, isEmpty, isLoading } = useExpressionRenderer(nodeRef, {
+  const { error, isEmpty, isLoading, Component } = useExpressionRenderer(nodeRef, {
     ...expressionRendererOptions,
     hasCustomErrorRenderer: !!renderError,
   });
@@ -62,7 +62,19 @@ export function ReactExpressionRenderer({
           ...(isEmpty || !!error ? { display: 'none' } : {}),
         })}
         ref={nodeRef}
-      />
+      >
+        {Component && !error && <Component />}
+      </div>
+      {/* <div
+        className="expExpressionRenderer__expression"
+        css={css({
+          width: '100%',
+          height: '100%',
+          ...(padding ? { padding: euiTheme.size[padding] } : {}),
+          ...(isEmpty || !!error ? { display: 'none' } : {}),
+        })}
+        ref={nodeRef}
+      /> */}
     </div>
   );
 }

--- a/src/platform/plugins/shared/expressions/public/react_expression_renderer/use_expression_renderer.ts
+++ b/src/platform/plugins/shared/expressions/public/react_expression_renderer/use_expression_renderer.ts
@@ -44,6 +44,7 @@ interface ExpressionRendererState {
   isEmpty: boolean;
   isLoading: boolean;
   error: null | ExpressionRenderError;
+  Component: null | React.ComponentType;
 }
 
 export function useExpressionRenderer(
@@ -60,12 +61,13 @@ export function useExpressionRenderer(
     ...loaderParams
   }: ExpressionRendererParams
 ): ExpressionRendererState {
-  const [{ error, isEmpty, isLoading }, setState] = useReducer<
+  const [{ error, isEmpty, isLoading, Component }, setState] = useReducer<
     Reducer<ExpressionRendererState, Partial<ExpressionRendererState>>
   >((currentState, newState) => ({ ...currentState, ...newState }), {
     isEmpty: true,
     isLoading: false,
     error: null,
+    Component: null,
   });
 
   const memoizedOptions = useShallowMemo({ expression, params: useShallowMemo(loaderParams) });
@@ -106,6 +108,9 @@ export function useExpressionRenderer(
           });
 
           return debouncedLoaderParams.onRenderError?.(domNode, newError, handlers);
+        },
+        onRenderComponent: (_Component) => {
+          setState({ Component: _Component });
         },
       });
 
@@ -192,5 +197,6 @@ export function useExpressionRenderer(
     error,
     isEmpty,
     isLoading: isLoading || isDebounced,
+    Component,
   };
 }

--- a/src/platform/plugins/shared/expressions/public/types/index.ts
+++ b/src/platform/plugins/shared/expressions/public/types/index.ts
@@ -10,6 +10,7 @@
 import type { KibanaExecutionContext } from '@kbn/core/public';
 import { Adapters } from '@kbn/inspector-plugin/public';
 import { ExecutionContextSearch } from '@kbn/es-query';
+import type { ComponentType } from 'react';
 import {
   IInterpreterRenderHandlers,
   ExpressionValue,
@@ -47,6 +48,7 @@ export interface IExpressionLoaderParams {
   inspectorAdapters?: Adapters;
   interactive?: boolean;
   onRenderError?: RenderErrorHandlerFnType;
+  onRenderComponent?: (Component: ComponentType) => void;
   searchSessionId?: string;
   renderMode?: RenderMode;
   syncColors?: boolean;


### PR DESCRIPTION
## Summary

Fixes #222747 

This PR is based off @Dosant PR here: https://github.com/elastic/kibana/pull/212562 but specifically targeting Lens only embeddables.
Tasks:
* [x] ExpressionRenderer new logic
* [x] Table vis
* [x] Metric Vis
* [ ] Legacy Metric
* [ ] Partition
* [ ] XY
* [ ] Heatmap
* [ ] Gauge
* [ ] Tag cloud

Example of rendering without the new root:
<img width="496" alt="Screenshot 2025-06-09 at 14 59 13" src="https://github.com/user-attachments/assets/ad768419-60c5-4bf4-9280-5c4bee8fe3fe" />
