### PR TITLE
fix(streams): scout tests

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/classic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/classic.spec.ts
@@ -10,7 +10,7 @@ import { testData, test } from '../fixtures';
 
 const DATA_STREAM_NAME = 'my-data-stream';
 
-test.describe('Classic Streams', { tag: ['@ess', '@svlOblt'] }, () => {
+test.describe('Classic Streams', { tag: ['@ess'] }, () => {
   test.beforeEach(async ({ kbnClient, esClient, browserAuth, pageObjects }) => {
     await kbnClient.importExport.load(testData.KBN_ARCHIVES.DASHBOARD);
     await esClient.indices.putIndexTemplate({

--- a/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
@@ -74,9 +74,12 @@ test.describe('Wired Streams', { tag: ['@ess', '@svlOblt'] }, () => {
       .getByRole('row', { name: 'attributes.custom_field' })
       .getByTestId('streamsAppActionsButton');
 
-    await actionsButtons.focus();
+    // await actionsButtons.focus();
     await actionsButtons.click();
 
+    await expect(
+      page.getByTestId('contextMenuPanelTitle').getByText('Field actions')
+    ).toBeVisible();
     await page.getByRole('button', { name: 'Map field' }).click();
     await page.getByRole('combobox').selectOption('keyword');
     await page.getByRole('button', { name: 'Save changes' }).click();

--- a/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
@@ -74,7 +74,7 @@ test.describe('Wired Streams', { tag: ['@ess', '@svlOblt'] }, () => {
       .getByRole('row', { name: 'attributes.custom_field' })
       .getByTestId('streamsAppActionsButton');
 
-    // await actionsButtons.focus();
+    await actionsButtons.focus();
     await actionsButtons.click();
 
     await expect(

--- a/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
@@ -8,7 +8,7 @@
 import { expect } from '@kbn/scout';
 import { testData, test } from '../fixtures';
 
-test.describe('Wired Streams', { tag: ['@ess', '@svlOblt'] }, () => {
+test.describe('Wired Streams', { tag: ['@ess'] }, () => {
   test.beforeEach(async ({ apiServices, kbnClient, browserAuth, pageObjects }) => {
     await kbnClient.importExport.load(testData.KBN_ARCHIVES.DASHBOARD);
     await apiServices.streams.enable();


### PR DESCRIPTION
Attempt to fix scout test failures on https://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/39946

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->