### PR TITLE
Fix crash caused by freezing Moment.js Locale objects in `deepFreeze`

### DIFF
--- a/src/platform/packages/shared/kbn-std/src/deep_freeze.ts
+++ b/src/platform/packages/shared/kbn-std/src/deep_freeze.ts
@@ -8,6 +8,7 @@
  */
 
 import type { RecursiveReadonly } from '@kbn/utility-types';
+import moment from 'moment-timezone';
 
 /** @public */
 export type Freezable = { [k: string]: any } | any[];
@@ -23,8 +24,16 @@ export function deepFreeze<T extends Freezable>(object: T) {
   // recursively frozen as well
   for (const value of Object.values(object)) {
     if (value !== null && typeof value === 'object') {
+      if (isMomentLocale(value)) {
+        // Skip moment.Locale instances, moment should not be frozen
+        continue;
+      }
       deepFreeze(value);
     }
   }
   return Object.freeze(object) as RecursiveReadonly<T>;
+}
+
+function isMomentLocale(obj: any): obj is moment.Locale {
+  return obj && typeof obj === 'object' && '_longDateFormat' in obj;
 }

--- a/src/platform/packages/shared/kbn-std/src/deep_freeze.ts
+++ b/src/platform/packages/shared/kbn-std/src/deep_freeze.ts
@@ -34,6 +34,6 @@ export function deepFreeze<T extends Freezable>(object: T) {
   return Object.freeze(object) as RecursiveReadonly<T>;
 }
 
-function isMomentLocale(obj: any): obj is moment.Locale {
-  return obj && typeof obj === 'object' && '_longDateFormat' in obj;
+function isMomentLocale(obj: unknown): obj is moment.Locale {
+  return obj !== null && typeof obj === 'object' && '_longDateFormat' in obj;
 }


### PR DESCRIPTION
### Summary

When setting `elasticsearch.requestTimeout: 180000` and running serverless, sending a request to the security assistant triggers this error:

```
TypeError: Cannot add property llll, object is not extensible
at getDefaultAssistantGraph (graph.ts:150:11)
...
```

This error is caused by attempting to `Object.freeze` Moment.js `Locale` objects, which have mutable internal properties like `_longDateFormat`. Freezing these objects makes them non-extensible and breaks Moment’s internal behavior.

The root cause was traced to `deepFreeze` [being called on config objects](https://github.com/elastic/kibana/blob/bab214e6319750e05a07ab1f6ff9e4af2c738d3b/src/core/packages/plugins/server-internal/src/legacy_config.ts#L35-L39) containing Moment durations, which internally hold Moment `Locale` instances.

### Fix

This change updates `deepFreeze` to detect Moment `Locale` objects by checking for the `_longDateFormat` property and skip freezing them, avoiding the error while preserving the immutability of the rest of the config.

For more context on why freezing Moment internals is problematic, see [Moment.js issue #3118](https://github.com/moment/moment/issues/3118).

### Open questions

I'm still not sure why this is only on serverless and why the `elasticsearch.requestTimeout` needs to be set. Even when this config is not set, the default values were still being passed to the `deepFreeze`, and I believe this code is used in both serverless and non-serverless. Anyone have insight from @elastic/kibana-core? Maybe @pgayvallet?

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->