### PR TITLE
[Discover] Fix incorrect export flyout title

### DIFF
--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -199,7 +199,7 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
                   id="share.export.flyoutTitle"
                   defaultMessage="Export {objectType} as {type}"
                   values={{
-                    objectType: (objectTypeAlias ?? objectType).toLocaleLowerCase(),
+                    objectType: objectTypeAlias ?? objectType.toLocaleLowerCase(),
                     type: selectedMenuItem?.config.label,
                   }}
                 />

--- a/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
+++ b/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
@@ -71,6 +71,7 @@ export class ShareMenuManager {
       allowShortUrl,
       objectId,
       objectType,
+      objectTypeAlias,
       objectTypeMeta,
       sharingData,
       menuItems,
@@ -101,6 +102,7 @@ export class ShareMenuManager {
         shareContext: {
           objectId,
           objectType,
+          objectTypeAlias,
           objectTypeMeta,
           anchorElement,
           publicAPIEnabled,


### PR DESCRIPTION
## Summary

This PR fixes an issue where the export flyout title was incorrect when exporting Discover sessions as CSVs. This was raised [here](https://github.com/elastic/kibana/pull/217109#discussion_r2077831825) during the original work and most of the fix was already implemented, but `objectTypeAlias` wasn't being passed to the React context.

Before:
<img width="1119" alt="old" src="https://github.com/user-attachments/assets/374f5e00-2bc1-46a6-a260-7a88d1e7ec82" />

After:
<img width="1119" alt="new" src="https://github.com/user-attachments/assets/9b28a019-4fb9-4011-9dd5-ed2fbdbc1807" />

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)