### PR TITLE
[Security Solution] fix uninstall token service space awareness

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -333,6 +333,7 @@ export async function getFullAgentPolicy(
     const tokenHash =
       (await appContextService
         .getUninstallTokenService()
+        ?.scoped(soClient.getCurrentNamespace())
         ?.getHashedTokenForPolicyId(fullAgentPolicy.id)) ?? '';
 
     fullAgentPolicy.agent.protection = {


### PR DESCRIPTION
## Summary

Fixes an issue where the uninstall token cannot be fetched with space awareness enabled.