### PR TITLE
[Incident Management] Add primary Add to case button

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.test.tsx
@@ -87,6 +87,53 @@ describe('Header Actions', () => {
       mockKibana();
       mockUseFetchRuleWithData();
     });
+    it('should offer an "Add to case" button which opens the add to case modal', async () => {
+      let attachments: any[] = [];
+
+      const useCasesAddToExistingCaseModalMock: any = jest.fn().mockImplementation(() => ({
+        open: ({ getAttachments }: { getAttachments: () => any[] }) => {
+          attachments = getAttachments();
+        },
+      })) as CasesPublicStart['hooks']['useCasesAddToExistingCaseModal'];
+
+      mockCases.hooks.useCasesAddToExistingCaseModal = useCasesAddToExistingCaseModalMock;
+
+      const { getByTestId } = render(
+        <HeaderActions
+          alert={alertWithGroupsAndTags}
+          alertIndex={'alert-index'}
+          alertStatus={alertWithGroupsAndTags.fields[ALERT_STATUS] as AlertStatus}
+          onUntrackAlert={mockOnUntrackAlert}
+        />
+      );
+
+      fireEvent.click(getByTestId('add-to-case-button'));
+
+      expect(attachments).toEqual([
+        {
+          alertId: mockAlertUuid,
+          index: 'alert-index',
+          rule: {
+            id: mockRuleId,
+            name: mockRuleName,
+          },
+          type: 'alert',
+        },
+      ]);
+    });
+
+    it('should not offer a "Snooze the rule" button', async () => {
+      const { queryByTestId } = render(
+        <HeaderActions
+          alert={alertWithGroupsAndTags}
+          alertIndex={'alert-index'}
+          alertStatus={alertWithGroupsAndTags.fields[ALERT_STATUS] as AlertStatus}
+          onUntrackAlert={mockOnUntrackAlert}
+        />
+      );
+
+      expect(queryByTestId('snooze-rule-button')).toBeFalsy();
+    });
 
     it('should display an actions button', () => {
       const { queryByTestId } = render(
@@ -100,41 +147,17 @@ describe('Header Actions', () => {
     });
 
     describe('when clicking the actions button', () => {
-      it('should offer an "Add to case" button which opens the add to case modal', async () => {
-        let attachments: any[] = [];
-
-        const useCasesAddToExistingCaseModalMock: any = jest.fn().mockImplementation(() => ({
-          open: ({ getAttachments }: { getAttachments: () => any[] }) => {
-            attachments = getAttachments();
-          },
-        })) as CasesPublicStart['hooks']['useCasesAddToExistingCaseModal'];
-
-        mockCases.hooks.useCasesAddToExistingCaseModal = useCasesAddToExistingCaseModalMock;
-
+      it('should offer a "Snooze the rule" button', async () => {
         const { getByTestId, findByTestId } = render(
           <HeaderActions
             alert={alertWithGroupsAndTags}
-            alertIndex={'alert-index'}
             alertStatus={alertWithGroupsAndTags.fields[ALERT_STATUS] as AlertStatus}
             onUntrackAlert={mockOnUntrackAlert}
           />
         );
 
         fireEvent.click(await findByTestId('alert-details-header-actions-menu-button'));
-
-        fireEvent.click(getByTestId('add-to-case-button'));
-
-        expect(attachments).toEqual([
-          {
-            alertId: mockAlertUuid,
-            index: 'alert-index',
-            rule: {
-              id: mockRuleId,
-              name: mockRuleName,
-            },
-            type: 'alert',
-          },
-        ]);
+        expect(getByTestId('snooze-rule-button')).toBeDefined();
       });
 
       it('should offer a "Edit rule" button which opens the edit rule flyout', async () => {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
@@ -121,14 +121,13 @@ export function HeaderActions({
         <EuiFlexItem grow={false}>
           <EuiButton
             fill
-            iconType="bellSlash"
-            onClick={handleOpenSnoozeModal}
-            disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
-            data-test-subj="snooze-rule-button"
+            iconType="plus"
+            onClick={handleAddToCase}
+            data-test-subj="add-to-case-button"
           >
             <EuiText size="s">
-              {i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
-                defaultMessage: 'Snooze the rule',
+              {i18n.translate('xpack.observability.alertDetails.addToCase', {
+                defaultMessage: 'Add to case',
               })}
             </EuiText>
           </EuiButton>
@@ -158,13 +157,14 @@ export function HeaderActions({
                 <EuiButtonEmpty
                   size="s"
                   color="text"
-                  iconType="plus"
-                  onClick={handleAddToCase}
-                  data-test-subj="add-to-case-button"
+                  iconType="bellSlash"
+                  onClick={handleOpenSnoozeModal}
+                  disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
+                  data-test-subj="snooze-rule-button"
                 >
                   <EuiText size="s">
-                    {i18n.translate('xpack.observability.alertDetails.addToCase', {
-                      defaultMessage: 'Add to case',
+                    {i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
+                      defaultMessage: 'Snooze the rule',
                     })}
                   </EuiText>
                 </EuiButtonEmpty>


### PR DESCRIPTION
This PR closes #216235 by swapping the primary `Snooze the rule` button with the `Add to case` acton.


https://github.com/user-attachments/assets/7b59fae0-9d16-4a31-95dc-a3890ab6632d

**Acceptance criteria:**
- This primary action for all alert details pages in observability should be "Add to case" ✅
- The snooze rule action can be moved to the sub actions menu ✅
- The existing "Add to case" action present in the sub menu (see below) should be removed (replaced by the primary button) ✅
- The button should allow the user to add this current alert to a new or existing case ✅


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->