### PR TITLE
[Lens] Move from `lodash.cloneDeep` to native `structuredClone`

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/app.test.tsx
@@ -28,7 +28,6 @@ import { buildExistsFilter, FilterStateStore } from '@kbn/es-query';
 import type { FieldSpec } from '@kbn/data-plugin/common';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { serverlessMock } from '@kbn/serverless/public/mocks';
-import { cloneDeep } from 'lodash';
 import moment from 'moment';
 import { setState, LensAppState } from '../state_management';
 import { coreMock } from '@kbn/core/public/mocks';
@@ -54,7 +53,7 @@ const waitToLoad = async () =>
   await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
 
 function getLensDocumentMock(propsOverrides?: Partial<LensDocument>) {
-  return cloneDeep({ ...defaultDoc, ...propsOverrides });
+  return structuredClone({ ...defaultDoc, ...propsOverrides });
 }
 
 describe('Lens App', () => {

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/app_helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/app_helpers.test.ts
@@ -9,11 +9,10 @@ import { renderHook, act } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 import { UseNavigateBackToAppProps, useNavigateBackToApp } from './app_helpers';
 import { defaultDoc, makeDefaultServices } from '../mocks/services_mock';
-import { cloneDeep } from 'lodash';
 import { LensDocument } from '../persistence';
 
 function getLensDocumentMock(someProps?: Partial<LensDocument>) {
-  return cloneDeep({ ...defaultDoc, ...someProps });
+  return structuredClone({ ...defaultDoc, ...someProps });
 }
 
 const getApplicationMock = () => makeDefaultServices().application;

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { cloneDeep, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { AggregateQuery, isOfAggregateQueryType, Query } from '@kbn/es-query';
@@ -1019,7 +1019,7 @@ export const LensTopNavMenu = ({
       // by Redux Toolkit. `filterManager.setFilters` will then try to modify
       // the query's filters, which will throw an error. To avoid this, we need
       // to clone the filters before passing them to `filterManager.setFilters`.
-      const savedQueryFilters = cloneDeep(newSavedQuery.attributes.filters || []);
+      const savedQueryFilters = structuredClone(newSavedQuery.attributes.filters || []);
       const globalFilters = data.query.filterManager.getGlobalFilters();
       data.query.filterManager.setFilters([...globalFilters, ...savedQueryFilters]);
       dispatchSetState({

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -11,7 +11,7 @@ import {
   formatESQLColumns,
   mapVariableToColumn,
 } from '@kbn/esql-utils';
-import { isEqual, cloneDeep } from 'lodash';
+import { isEqual } from 'lodash';
 import { type AggregateQuery, buildEsQuery } from '@kbn/es-query';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { ESQLRow } from '@kbn/es-types';
@@ -197,7 +197,7 @@ export const injectESQLQueryIntoLensLayers = (
     return attributes;
   }
 
-  const datasourceState = cloneDeep(attributes.state.datasourceStates[datasourceId]);
+  const datasourceState = structuredClone(attributes.state.datasourceStates[datasourceId]);
 
   if (datasourceState && datasourceState.layers) {
     Object.values(datasourceState.layers).forEach((layer) => {

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.test.ts
@@ -46,7 +46,6 @@ import {
   MedianIndexPatternColumn,
 } from './operations';
 import { createMockedFullReference } from './operations/mocks';
-import { cloneDeep } from 'lodash';
 import { Datatable, DatatableColumn } from '@kbn/expressions-plugin/common';
 import { filterAndSortUserMessages } from '../../app_plugin/get_application_user_messages';
 import { createMockFramePublicAPI } from '../../mocks';
@@ -4227,7 +4226,7 @@ describe('IndexPattern Data Source', () => {
     });
 
     it('should be false if datasource states differ', () => {
-      const differentPersistableState = cloneDeep(persistableState);
+      const differentPersistableState = structuredClone(persistableState);
       differentPersistableState.layers[layerId].columnOrder = ['something else'];
 
       expect(

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/terms/terms.test.tsx
@@ -39,7 +39,6 @@ import { getOperationSupportMatrix } from '../../../dimension_panel/operation_su
 import { FieldSelect } from '../../../dimension_panel/field_select';
 import { ReferenceEditor } from '../../../dimension_panel/reference_editor';
 import { IndexPattern } from '../../../../../types';
-import { cloneDeep } from 'lodash';
 import { IncludeExcludeRow } from './include_exclude_options';
 import { TERMS_MULTI_TERMS_AND_SCRIPTED_FIELDS } from '../../../../../user_messages_ids';
 
@@ -3271,11 +3270,11 @@ describe('terms', () => {
     it('reports correct number of values', () => {
       const termsSize = 5;
 
-      const withoutOther = cloneDeep(layer.columns.col1 as TermsIndexPatternColumn);
+      const withoutOther = structuredClone(layer.columns.col1 as TermsIndexPatternColumn);
       withoutOther.params.size = termsSize;
       withoutOther.params.otherBucket = false;
 
-      const withOther = cloneDeep(withoutOther);
+      const withOther = structuredClone(withoutOther);
       withOther.params.otherBucket = true;
 
       expect(termsOperation.getMaxPossibleNumValues!(withoutOther)).toBe(termsSize);

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { cloneDeep } from 'lodash';
 import { MiddlewareAPI } from '@reduxjs/toolkit';
 import { i18n } from '@kbn/i18n';
 import { History } from 'history';
@@ -349,7 +348,7 @@ export async function loadInitial(
   }
   if (initialStateFromLocator) {
     const newFilters = initialStateFromLocator.filters
-      ? cloneDeep(initialStateFromLocator.filters)
+      ? structuredClone(initialStateFromLocator.filters)
       : undefined;
 
     if (newFilters) {
@@ -390,7 +389,7 @@ export async function loadInitial(
   ) {
     const newFilters =
       initialContext && 'searchFilters' in initialContext && initialContext.searchFilters
-        ? cloneDeep(initialContext.searchFilters)
+        ? structuredClone(initialContext.searchFilters)
         : undefined;
 
     if (newFilters) {

--- a/x-pack/platform/plugins/shared/lens/public/utils.ts
+++ b/x-pack/platform/plugins/shared/lens/public/utils.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { set } from '@kbn/safer-lodash-set';
-import { uniq, cloneDeep } from 'lodash';
+import { uniq } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment-timezone';
 import type { Serializable } from '@kbn/utility-types';
@@ -287,7 +287,7 @@ export function renewIDs<T = unknown>(
   forRenewIds: string[],
   getNewId: (id: string) => string | undefined
 ): T {
-  obj = cloneDeep(obj);
+  obj = structuredClone(obj);
   const recursiveFn = (
     item: Serializable,
     parent?: Record<string, Serializable> | Serializable[],

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/partition/runtime_state/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/partition/runtime_state/index.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { cloneDeep } from 'lodash';
-
 import { PieVisualizationState } from '../../../../common/types';
 import { GeneralDatasourceStates } from '../../../state_management';
 
@@ -18,6 +16,6 @@ export function convertToRuntimeState(
 ): PieVisualizationState {
   return getRuntimeConverters(datasourceStates).reduce(
     (newState, fn) => fn(newState),
-    cloneDeep(state)
+    structuredClone(state)
   );
 }

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/partition/visualization.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/partition/visualization.test.ts
@@ -19,7 +19,6 @@ import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks'
 import { createMockDatasource, createMockFramePublicAPI } from '../../mocks';
 import { FramePublicAPI, OperationDescriptor, Visualization } from '../../types';
 import { themeServiceMock } from '@kbn/core/public/mocks';
-import { cloneDeep } from 'lodash';
 import { PartitionChartsMeta } from './partition_charts_meta';
 import { CollapseFunction } from '../../../common/expressions';
 import { PaletteOutput } from '@kbn/coloring';
@@ -95,7 +94,7 @@ describe('pie_visualization', () => {
       });
 
       it("doesn't count collapsed dimensions", () => {
-        const localState = cloneDeep(state);
+        const localState = structuredClone(state);
         localState.layers[0].collapseFns = {
           [colIds[0]]: 'some-fn' as CollapseFunction,
         };
@@ -106,7 +105,7 @@ describe('pie_visualization', () => {
       });
 
       it('counts multiple metrics as an extra bucket dimension', () => {
-        const localState = cloneDeep(state);
+        const localState = structuredClone(state);
         localState.layers[0].primaryGroups.pop();
         expect(
           pieVisualization.getUserMessages!(localState, { frame: {} as FramePublicAPI })
@@ -591,7 +590,7 @@ describe('pie_visualization', () => {
 
         expect(findPrimaryGroup(getConfig(state))?.supportsMoreColumns).toBeFalsy();
 
-        const stateWithCollapsed = cloneDeep(state);
+        const stateWithCollapsed = structuredClone(state);
         stateWithCollapsed.layers[0].collapseFns = { '1': 'sum' };
 
         expect(findPrimaryGroup(getConfig(stateWithCollapsed))?.supportsMoreColumns).toBeTruthy();
@@ -619,7 +618,7 @@ describe('pie_visualization', () => {
 
         expect(findPrimaryGroup(getConfig(state))?.supportsMoreColumns).toBeTruthy();
 
-        const stateWithMultipleMetrics = cloneDeep(state);
+        const stateWithMultipleMetrics = structuredClone(state);
         stateWithMultipleMetrics.layers[0].metrics.push('1', '2');
 
         expect(
@@ -645,7 +644,7 @@ describe('pie_visualization', () => {
 
         expect(findPrimaryGroup(getConfig(state))?.supportsMoreColumns).toBeTruthy();
 
-        const stateWithMultipleMetrics = cloneDeep(state);
+        const stateWithMultipleMetrics = structuredClone(state);
         stateWithMultipleMetrics.layers[0].metrics.push('1', '2');
 
         expect(

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/revert_changes_action.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/revert_changes_action.test.tsx
@@ -8,7 +8,6 @@
 import { OverlayRef } from '@kbn/core-mount-utils-browser';
 import { IToasts } from '@kbn/core-notifications-browser';
 import { PointInTimeEventAnnotationConfig } from '@kbn/event-annotation-common';
-import { cloneDeep } from 'lodash';
 import {
   XYByReferenceAnnotationLayerConfig,
   XYByValueAnnotationLayerConfig,
@@ -38,7 +37,7 @@ describe('revert changes routine', () => {
     ...byValueLayer,
     annotationGroupId: 'shouldnt show up',
     __lastSaved: {
-      ...cloneDeep(byValueLayer),
+      ...structuredClone(byValueLayer),
 
       // some differences
       annotations: [

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/revert_changes_action.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/revert_changes_action.tsx
@@ -19,7 +19,6 @@ import {
 import { i18n } from '@kbn/i18n';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { CoreStart } from '@kbn/core/public';
-import { cloneDeep } from 'lodash';
 import { OverlayRef } from '@kbn/core-mount-utils-browser';
 import { IToasts } from '@kbn/core-notifications-browser';
 import type { LayerAction, StateSetter } from '../../../../types';
@@ -98,7 +97,7 @@ export const revert = ({
 
     indexPatternId: layer.__lastSaved.indexPatternId,
     ignoreGlobalFilters: layer.__lastSaved.ignoreGlobalFilters,
-    annotations: cloneDeep(layer.__lastSaved.annotations),
+    annotations: structuredClone(layer.__lastSaved.annotations),
     __lastSaved: layer.__lastSaved,
   };
   setState({

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/unlink_action.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/annotations/actions/unlink_action.test.ts
@@ -12,7 +12,6 @@ import {
 } from '../../types';
 import { toastsServiceMock } from '@kbn/core-notifications-browser-mocks/src/toasts_service.mock';
 import { PointInTimeEventAnnotationConfig } from '@kbn/event-annotation-common';
-import { cloneDeep } from 'lodash';
 import { getUnlinkLayerAction } from './unlink_action';
 
 describe('annotation group unlink actions', () => {
@@ -39,7 +38,7 @@ describe('annotation group unlink actions', () => {
     ...byValueLayer,
     annotationGroupId: 'shouldnt show up',
     __lastSaved: {
-      ...cloneDeep(byValueLayer),
+      ...structuredClone(byValueLayer),
       title: 'My library group',
       description: '',
       tags: [],

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/persistence.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/persistence.ts
@@ -7,7 +7,6 @@
 
 import type { SavedObjectReference } from '@kbn/core/public';
 import { EVENT_ANNOTATION_GROUP_TYPE } from '@kbn/event-annotation-common';
-import { cloneDeep } from 'lodash';
 
 import { layerTypes } from '../../../common/layer_types';
 import { AnnotationGroups } from '../../types';
@@ -87,7 +86,7 @@ export function convertPersistedState(
   annotationGroups?: AnnotationGroups,
   references?: SavedObjectReference[]
 ) {
-  return cloneDeep(injectReferences(state, annotationGroups, references));
+  return structuredClone(injectReferences(state, annotationGroups, references));
 }
 
 export function convertToPersistable(state: XYState) {
@@ -253,7 +252,7 @@ function injectReferences(
               ...commonProps,
               ignoreGlobalFilters: annotationGroup.ignoreGlobalFilters,
               indexPatternId: annotationGroup.indexPatternId,
-              annotations: cloneDeep(annotationGroup.annotations),
+              annotations: structuredClone(annotationGroup.annotations),
             };
           } else {
             // a linked by-value layer gets settings from visualization state while
@@ -262,7 +261,7 @@ function injectReferences(
               ...commonProps,
               ignoreGlobalFilters: persistedLayer.ignoreGlobalFilters,
               indexPatternId: getIndexPatternIdFromReferences(persistedLayer.layerId),
-              annotations: cloneDeep(persistedLayer.annotations),
+              annotations: structuredClone(persistedLayer.annotations),
               cachedMetadata: persistedLayer.cachedMetadata,
             };
           }

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/runtime_state/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/runtime_state/index.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { cloneDeep } from 'lodash';
-
 import { GeneralDatasourceStates } from '../../../state_management';
 import { XYState } from '../types';
 import { getRuntimeConverters } from './converters';
@@ -17,6 +15,6 @@ export function convertToRuntimeState(
 ): XYState {
   return getRuntimeConverters(datasourceStates).reduce(
     (newState, fn) => fn(newState),
-    cloneDeep(state)
+    structuredClone(state)
   );
 }

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.test.tsx
@@ -51,7 +51,6 @@ import {
   isAnnotationsLayer,
   isByReferenceAnnotationsLayer,
 } from './visualization_helpers';
-import { cloneDeep } from 'lodash';
 import { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
 import {
   XYPersistedByReferenceAnnotationLayerConfig,
@@ -3772,7 +3771,7 @@ describe('xy_visualization', () => {
         annotationGroupId: `annotation-group-id-${index}`,
         __lastSaved: {
           ...byValueLayer,
-          annotations: cloneDeep(byValueLayer.annotations),
+          annotations: structuredClone(byValueLayer.annotations),
           title: 'My saved object title',
           description: 'some description',
           tags: [],

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization_helpers.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization_helpers.tsx
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { cloneDeep, uniq } from 'lodash';
+import { uniq } from 'lodash';
 import { IconChartBarHorizontal, IconChartBarStacked, IconChartMixedXy } from '@kbn/chart-icons';
 import type { LayerType as XYLayerType } from '@kbn/expression-xy-plugin/common';
 import {
@@ -355,7 +355,7 @@ const newLayerFn = {
         layerType: layerTypes.ANNOTATIONS,
         annotationGroupId,
 
-        annotations: cloneDeep(libraryGroupConfig.annotations),
+        annotations: structuredClone(libraryGroupConfig.annotations),
         indexPatternId: libraryGroupConfig.indexPatternId,
         ignoreGlobalFilters: libraryGroupConfig.ignoreGlobalFilters,
         __lastSaved: libraryGroupConfig,


### PR DESCRIPTION
## Summary

Noticed we use a lot `cloneDeep` while reviewing #222160 so I've revisited Lens to use the native structuredClone.

The obvious question is: is structuredClone fast enough? I've setup a (micro) benchmark to compare the two [here](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJZeGVGTlFuWHljX3pPaUdlVkM0M2kiLCJjb2RlIjoibG9kYXNoLmNsb25lRGVlcChEQVRBKSIsIm5hbWUiOiJsb2Rhc2guY2xvbmVEZWVwIiwiZGVwZW5kZW5jaWVzIjpbeyJ1cmwiOiJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2xvZGFzaEA0LjE3LjIxLytlc20iLCJuYW1lIjoibG9kYXNoIiwiZXNtIjp0cnVlfV19LHsiaWQiOiI0aGR0SXQ4bVlianEyaENEQ1l3d0UiLCJjb2RlIjoic3RydWN0dXJlZENsb25lKERBVEEpIiwibmFtZSI6InN0cnVjdHVyZWRDbG9uZSIsImRlcGVuZGVuY2llcyI6W119XSwiY29uZmlnIjp7Im5hbWUiOiJCYXNpYyBleGFtcGxlIiwicGFyYWxsZWwiOnRydWUsImdsb2JhbFRlc3RDb25maWciOnsiZGVwZW5kZW5jaWVzIjpbXX0sImRhdGFDb2RlIjoicmV0dXJuIFtcbiAge1xuICAgIFwiX2lkXCI6IFwiNjg0ODA1NzIwN2FiYjE1OTM3N2VlYWJhXCIsXG4gICAgXCJpbmRleFwiOiAwLFxuICAgIFwiZ3VpZFwiOiBcIjVlMzUyZGY5LWMyNGEtNDRmYy1iZGU5LTNjNWIwNmZmOWMzZVwiLFxuICAgIFwiaXNBY3RpdmVcIjogZmFsc2UsXG4gICAgXCJiYWxhbmNlXCI6IFwiJDEsNjY0LjgwXCIsXG4gICAgXCJwaWN0dXJlXCI6IFwiaHR0cDovL3BsYWNlaG9sZC5pdC8zMngzMlwiLFxuICAgIFwiYWdlXCI6IDIxLFxuICAgIFwiZXllQ29sb3JcIjogXCJicm93blwiLFxuICAgIFwibmFtZVwiOiBcIkRlYW5uZSBNaXJhbmRhXCIsXG4gICAgXCJnZW5kZXJcIjogXCJmZW1hbGVcIixcbiAgICBcImNvbXBhbnlcIjogXCJEVU9GTEVYXCIsXG4gICAgXCJlbWFpbFwiOiBcImRlYW5uZW1pcmFuZGFAZHVvZmxleC5jb21cIixcbiAgICBcInBob25lXCI6IFwiKzEgKDkxNCkgNDc3LTIxODBcIixcbiAgICBcImFkZHJlc3NcIjogXCIyMTEgU2Fja2V0dCBTdHJlZXQsIEJpZGRsZSwgS2Fuc2FzLCA0MTc4XCIsXG4gICAgXCJhYm91dFwiOiBcIkV4IG1hZ25hIHNpbnQgYW5pbSBpbmNpZGlkdW50IG1pbmltIGR1aXMgY29uc2VjdGV0dXIgc3VudCBjb25zZWN0ZXR1ciBjdWxwYSBsYWJvcnVtIHVsbGFtY28uIExhYm9ydW0gbm9uIGVsaXQgZnVnaWF0IGNvbnNlY3RldHVyIG5pc2kgYXV0ZSBhbWV0LiBOdWxsYSBlYSB0ZW1wb3IgbGFib3JlIHZvbHVwdGF0ZSBlYS4gTWluaW0gbnVsbGEgY29tbW9kbyBkb2xvciBlaXVzbW9kIGlydXJlIHF1aSBldSBhZGlwaXNpY2luZyBzdW50IGFkIGVuaW0uIFNpbnQgb2NjYWVjYXQgcXVpcyBlbmltIG5vbiBlaXVzbW9kIGVzdCBkZXNlcnVudCByZXByZWhlbmRlcml0LiBDb21tb2RvIGN1cGlkYXRhdCBtaW5pbSBjdWxwYSB1bGxhbWNvIGRvIGN1cGlkYXRhdC4gQWQgdm9sdXB0YXRlIGlkIG1pbmltIG9mZmljaWEgZWxpdCBxdWkgYWxpcXVhIGNvbW1vZG8gdmVuaWFtLlxcclxcblwiLFxuICAgIFwicmVnaXN0ZXJlZFwiOiBcIjIwMTgtMDgtMTFUMTI6NTQ6MTYgLTAyOjAwXCIsXG4gICAgXCJsYXRpdHVkZVwiOiAtNjYuNzE2Mjg4LFxuICAgIFwibG9uZ2l0dWRlXCI6IC0zMS41MDA0NTYsXG4gICAgXCJ0YWdzXCI6IFtcbiAgICAgIFwiZXRcIixcbiAgICAgIFwiYW5pbVwiLFxuICAgICAgXCJkb2xvclwiLFxuICAgICAgXCJzaXRcIixcbiAgICAgIFwiZWxpdFwiLFxuICAgICAgXCJlc3NlXCIsXG4gICAgICBcImV1XCJcbiAgICBdLFxuICAgIFwiZnJpZW5kc1wiOiBbXG4gICAgICB7XG4gICAgICAgIFwiaWRcIjogMCxcbiAgICAgICAgXCJuYW1lXCI6IFwiTWVhZ2FuIFN1dHRvblwiXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBcImlkXCI6IDEsXG4gICAgICAgIFwibmFtZVwiOiBcIlRvbmkgU3VsbGl2YW5cIlxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgXCJpZFwiOiAyLFxuICAgICAgICBcIm5hbWVcIjogXCJHZW9yZ2UgUGl0dG1hblwiXG4gICAgICB9XG4gICAgXSxcbiAgICBcImdyZWV0aW5nXCI6IFwiSGVsbG8sIERlYW5uZSBNaXJhbmRhISBZb3UgaGF2ZSA5IHVucmVhZCBtZXNzYWdlcy5cIixcbiAgICBcImZhdm9yaXRlRnJ1aXRcIjogXCJiYW5hbmFcIlxuICB9XG5dIn19)

The two looks like they are within the same performance.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->