### PR TITLE
[Discover] Remove actions header internal padding (#223175)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_header.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_header.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useLayoutEffect, useRef, useState } from 'react';
-import { EuiIconTip, EuiScreenReaderOnly, useEuiTheme } from '@elastic/eui';
+import { EuiIconTip, EuiScreenReaderOnly } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import ColumnHeaderTruncateContainer from '../../column_header_truncate_container';
@@ -16,7 +16,6 @@ import ColumnHeaderTruncateContainer from '../../column_header_truncate_containe
 export const ActionsHeader = ({ maxWidth }: { maxWidth: number }) => {
   const textRef = useRef<HTMLSpanElement>(null);
   const [showText, setShowText] = useState(false);
-  const { euiTheme } = useEuiTheme();
 
   useLayoutEffect(() => {
     if (!textRef.current) return;
@@ -29,39 +28,37 @@ export const ActionsHeader = ({ maxWidth }: { maxWidth: number }) => {
   });
 
   return (
-    <div css={{ padding: euiTheme.size.xs }}>
-      <ColumnHeaderTruncateContainer>
-        <EuiScreenReaderOnly>
-          <span>
-            {i18n.translate('unifiedDataTable.actionsColumnHeader', {
-              defaultMessage: 'Actions column',
-            })}
-          </span>
-        </EuiScreenReaderOnly>
-        {showText ? (
-          <span data-test-subj="unifiedDataTable_actionsColumnHeaderText">{actionsText}</span>
-        ) : (
-          <EuiIconTip
-            iconProps={{
-              'data-test-subj': 'unifiedDataTable_actionsColumnHeaderIcon',
-            }}
-            type="iInCircle"
-            content={actionsText}
-          />
-        )}
-        {/* Hidden measurement span */}
-        <span
-          ref={textRef}
-          css={css`
-            position: absolute;
-            visibility: hidden;
-            white-space: nowrap;
-            pointer-events: none;
-          `}
-        >
-          {actionsText}
+    <ColumnHeaderTruncateContainer>
+      <EuiScreenReaderOnly>
+        <span>
+          {i18n.translate('unifiedDataTable.actionsColumnHeader', {
+            defaultMessage: 'Actions column',
+          })}
         </span>
-      </ColumnHeaderTruncateContainer>
-    </div>
+      </EuiScreenReaderOnly>
+      {showText ? (
+        <span data-test-subj="unifiedDataTable_actionsColumnHeaderText">{actionsText}</span>
+      ) : (
+        <EuiIconTip
+          iconProps={{
+            'data-test-subj': 'unifiedDataTable_actionsColumnHeaderIcon',
+          }}
+          type="iInCircle"
+          content={actionsText}
+        />
+      )}
+      {/* Hidden measurement span */}
+      <span
+        ref={textRef}
+        css={css`
+          position: absolute;
+          visibility: hidden;
+          white-space: nowrap;
+          pointer-events: none;
+        `}
+      >
+        {actionsText}
+      </span>
+    </ColumnHeaderTruncateContainer>
   );
 };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/223175

Removes some internal padding that was added to the actions header - it causes the whole header style to break.

| Before | After |
|--------|------|
| ![image](https://github.com/user-attachments/assets/3fcdfbc9-1746-421e-8a43-977a3a519c17) | ![image](https://github.com/user-attachments/assets/06cd1190-4bdc-4f3c-9ed4-1f53b52829a3) |



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->