### PR TITLE
[8.18] [Lens] Fix the button text for going back to the aggregation based visualization (#222823)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -27,6 +27,7 @@ import type {
 import {
   ACTION_CONVERT_DASHBOARD_PANEL_TO_LENS,
   DASHBOARD_VISUALIZATION_PANEL_TRIGGER,
+  ACTION_CONVERT_AGG_BASED_TO_LENS,
   VisualizationsSetup,
   VisualizationsStart,
 } from '@kbn/visualizations-plugin/public';
@@ -666,7 +667,7 @@ export class LensPlugin {
     startDependencies.uiActions.addTriggerAction(
       AGG_BASED_VISUALIZATION_TRIGGER,
       convertToLensActionFactory(
-        ACTION_CONVERT_DASHBOARD_PANEL_TO_LENS,
+        ACTION_CONVERT_AGG_BASED_TO_LENS,
         i18n.translate('xpack.lens.visualizeAggBasedLegend', {
           defaultMessage: 'Visualize agg based chart',
         }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Lens] Fix the button text for going back to the aggregation based visualization (#222823)](https://github.com/elastic/kibana/pull/222823)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"72010092+andrimal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-10T10:47:12Z","message":"[Lens] Fix the button text for going back to the aggregation based visualization (#222823)\n\n## Summary\n\nFix #203977 \n\nWhen the user clicked 'Edit visualization in Lens' from an aggregation\nvisualization, the button to return to the aggregation based\nvisualization editor showed the wrong app to return to (Dashboard). This\nPR fixes the button text to return to the aggregation based\nvisualization.\n\nBefore: \n![Kapture 2025-06-05 at 16 42\n22](https://github.com/user-attachments/assets/6bca154a-b550-41f6-ac59-08f36fe27545)\n\nAfter: \n![Kapture 2025-06-05 at 16 33\n39](https://github.com/user-attachments/assets/d272e9c2-794e-487f-a322-17571b7b13d5)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"95f74bec29f56fe638962b1fcd36b17c95c415f1","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[Lens] Fix the button text for going back to the aggregation based visualization","number":222823,"url":"https://github.com/elastic/kibana/pull/222823","mergeCommit":{"message":"[Lens] Fix the button text for going back to the aggregation based visualization (#222823)\n\n## Summary\n\nFix #203977 \n\nWhen the user clicked 'Edit visualization in Lens' from an aggregation\nvisualization, the button to return to the aggregation based\nvisualization editor showed the wrong app to return to (Dashboard). This\nPR fixes the button text to return to the aggregation based\nvisualization.\n\nBefore: \n![Kapture 2025-06-05 at 16 42\n22](https://github.com/user-attachments/assets/6bca154a-b550-41f6-ac59-08f36fe27545)\n\nAfter: \n![Kapture 2025-06-05 at 16 33\n39](https://github.com/user-attachments/assets/d272e9c2-794e-487f-a322-17571b7b13d5)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"95f74bec29f56fe638962b1fcd36b17c95c415f1"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222823","number":222823,"mergeCommit":{"message":"[Lens] Fix the button text for going back to the aggregation based visualization (#222823)\n\n## Summary\n\nFix #203977 \n\nWhen the user clicked 'Edit visualization in Lens' from an aggregation\nvisualization, the button to return to the aggregation based\nvisualization editor showed the wrong app to return to (Dashboard). This\nPR fixes the button text to return to the aggregation based\nvisualization.\n\nBefore: \n![Kapture 2025-06-05 at 16 42\n22](https://github.com/user-attachments/assets/6bca154a-b550-41f6-ac59-08f36fe27545)\n\nAfter: \n![Kapture 2025-06-05 at 16 33\n39](https://github.com/user-attachments/assets/d272e9c2-794e-487f-a322-17571b7b13d5)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"95f74bec29f56fe638962b1fcd36b17c95c415f1"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->