### PR TITLE
[ResponseOps] Cases analytics index configuration option

### DIFF
--- a/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -224,7 +224,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cases.files.maxSize (number?)',
         'xpack.cases.markdownPlugins.lens (boolean?)',
         'xpack.cases.stack.enabled (boolean?)',
-        'xpack.cases.analyticsIndex.enabled (boolean?)',
+        'xpack.cases.analytics.index.enabled (boolean?)',
         'xpack.ccr.ui.enabled (boolean?)',
         'xpack.cloud.base_url (string?)',
         'xpack.cloud.cname (string?)',

--- a/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -224,6 +224,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cases.files.maxSize (number?)',
         'xpack.cases.markdownPlugins.lens (boolean?)',
         'xpack.cases.stack.enabled (boolean?)',
+        'xpack.cases.analyticsIndex.enabled (boolean?)',
         'xpack.ccr.ui.enabled (boolean?)',
         'xpack.cloud.base_url (string?)',
         'xpack.cloud.cname (string?)',

--- a/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -224,7 +224,6 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cases.files.maxSize (number?)',
         'xpack.cases.markdownPlugins.lens (boolean?)',
         'xpack.cases.stack.enabled (boolean?)',
-        'xpack.cases.analytics.index.enabled (boolean?)',
         'xpack.ccr.ui.enabled (boolean?)',
         'xpack.cloud.base_url (string?)',
         'xpack.cloud.cname (string?)',

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
@@ -338,33 +338,6 @@ describe('SynchronizationTaskRunner', () => {
   });
 
   describe('Error handling', () => {
-    it('An error is thrown for invalid task state', async () => {
-      const getESClient = async () => esClient;
-
-      taskRunner = new SynchronizationTaskRunner({
-        logger,
-        getESClient,
-        taskInstance: {
-          ...taskInstance,
-          state: {
-            // A missing esReindexTaskId should have missing sync times
-            lastSyncAttempt: 'some-time',
-          },
-        },
-      });
-
-      try {
-        await taskRunner.run();
-      } catch (e) {
-        expect(isRetryableError(e)).toBe(null);
-      }
-
-      expect(logger.error).toBeCalledWith(
-        '[.internal.cases] Synchronization reindex failed. Error: Invalid task state.',
-        { tags: ['cai-synchronization', 'cai-synchronization-error', '.internal.cases'] }
-      );
-    });
-
     it('calls throwRetryableError if the esClient throws a retryable error', async () => {
       esClient.tasks.get.mockRejectedValueOnce(new esErrors.ConnectionError('My retryable error'));
 

--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -12,6 +12,7 @@ describe('config validation', () => {
     it('sets the defaults correctly', () => {
       expect(ConfigSchema.validate({})).toMatchInlineSnapshot(`
         Object {
+          "analytics": Object {},
           "files": Object {
             "allowedMimeTypes": Array [
               "image/aces",

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -24,9 +24,11 @@ export const ConfigSchema = schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),
   analytics: schema.object({
-    index: schema.object({
-      enabled: schema.boolean({ defaultValue: false }),
-    }),
+    index: schema.maybe(
+      schema.object({
+        enabled: schema.boolean({ defaultValue: false }),
+      })
+    ),
   }),
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -23,6 +23,9 @@ export const ConfigSchema = schema.object({
   stack: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),
+  analyticsIndex: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
 });
 
 export type ConfigType = TypeOf<typeof ConfigSchema>;

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -23,8 +23,10 @@ export const ConfigSchema = schema.object({
   stack: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),
-  analyticsIndex: schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
+  analytics: schema.object({
+    index: schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+    }),
   }),
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -28,6 +28,7 @@ function getConfig(overrides = {}) {
     markdownPlugins: { lens: true },
     files: { maxSize: 1, allowedMimeTypes: ALLOWED_MIME_TYPES },
     stack: { enabled: true },
+    analytics: {},
     ...overrides,
   };
 }

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -203,15 +203,16 @@ export class CasePlugin
 
     if (plugins.taskManager) {
       scheduleCasesTelemetryTask(plugins.taskManager, this.logger);
-      scheduleCasesAnalyticsSyncTasks({ taskManager: plugins.taskManager, logger: this.logger });
+      if (this.caseConfig.analyticsIndex.enabled) {
+        scheduleCasesAnalyticsSyncTasks({ taskManager: plugins.taskManager, logger: this.logger });
+        createCasesAnalyticsIndexes({
+          esClient: core.elasticsearch.client.asInternalUser,
+          logger: this.logger,
+          isServerless: this.isServerless,
+          taskManager: plugins.taskManager,
+        }).catch(() => {}); // it shouldn't reject, but just in case
+      }
     }
-
-    createCasesAnalyticsIndexes({
-      esClient: core.elasticsearch.client.asInternalUser,
-      logger: this.logger,
-      isServerless: this.isServerless,
-      taskManager: plugins.taskManager,
-    }).catch(() => {}); // it shouldn't reject, but just in case
 
     this.userProfileService.initialize({
       spaces: plugins.spaces,

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -203,7 +203,7 @@ export class CasePlugin
 
     if (plugins.taskManager) {
       scheduleCasesTelemetryTask(plugins.taskManager, this.logger);
-      if (this.caseConfig.analytics.index.enabled) {
+      if (this.caseConfig.analytics.index?.enabled) {
         scheduleCasesAnalyticsSyncTasks({ taskManager: plugins.taskManager, logger: this.logger });
         createCasesAnalyticsIndexes({
           esClient: core.elasticsearch.client.asInternalUser,

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -203,7 +203,7 @@ export class CasePlugin
 
     if (plugins.taskManager) {
       scheduleCasesTelemetryTask(plugins.taskManager, this.logger);
-      if (this.caseConfig.analyticsIndex.enabled) {
+      if (this.caseConfig.analytics.index.enabled) {
         scheduleCasesAnalyticsSyncTasks({ taskManager: plugins.taskManager, logger: this.logger });
         createCasesAnalyticsIndexes({
           esClient: core.elasticsearch.client.asInternalUser,


### PR DESCRIPTION
**Merging into a feature branch**

## Summary

This PR adds a configuration option to enable the cases analytics index logic.

`xpack.cases.analyticsIndex.enabled: true`

The task types are registered, but by default, no task is scheduled, and no index is created.

## How to review

**The previous PRs are not merged yet, so only commits after bd6f2b8e307fa0cb7da06358dd1836f767e3b5e1 should be reviewed.**



