### PR TITLE
chore(streams): disable wired streams scout test until we figure out flakiness issue

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/ui_tests/tests/wired.spec.ts
@@ -8,7 +8,7 @@
 import { expect } from '@kbn/scout';
 import { testData, test } from '../fixtures';
 
-test.describe('Wired Streams', { tag: ['@ess'] }, () => {
+test.describe.skip('Wired Streams', { tag: ['@ess'] }, () => {
   test.beforeEach(async ({ apiServices, kbnClient, browserAuth, pageObjects }) => {
     await kbnClient.importExport.load(testData.KBN_ARCHIVES.DASHBOARD);
     await apiServices.streams.enable();


### PR DESCRIPTION
While we figure out the reason behind the test flakiness, let's disable them 

https://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/40046

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->