### PR TITLE
[8.19] [Discover] Removing Enzyme of discover_router.test.tsx (#222774)

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
@@ -6,84 +6,93 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
 import React from 'react';
-import type { ShallowWrapper } from 'enzyme';
-import { shallow } from 'enzyme';
-import type { RouteProps } from 'react-router-dom';
-import { Redirect } from 'react-router-dom';
-import { Route } from '@kbn/shared-ux-router';
-import { createSearchSessionMock } from '../__mocks__/search_session';
-import { discoverServiceMock as mockDiscoverServices } from '../__mocks__/services';
+import { createMemoryHistory } from 'history';
+
+
+// Mock dependencies to avoid issues with external modules like monaco
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  KibanaContextProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock the component dependencies
+jest.mock('./context', () => ({
+  ContextAppRoute: () => <div data-test-subj="context-app-route" />,
+}));
+
+jest.mock('./doc', () => ({
+  SingleDocRoute: () => <div data-test-subj="single-doc-route" />,
+}));
+
+jest.mock('./main', () => ({
+  DiscoverMainRoute: () => <div data-test-subj="discover-main-route" />,
+}));
+
+jest.mock('./view_alert', () => ({
+  ViewAlertRoute: () => <div data-test-subj="view-alert-route" />,
+}));
+
+jest.mock('./not_found', () => ({
+  NotFoundRoute: () => <div data-test-subj="not-found-route" />,
+}));
+
+// Import testing utilities after mocks
+import { render, screen } from '@testing-library/react';
+import { Router } from '@kbn/shared-ux-router';
 import { DiscoverRoutes } from './discover_router';
-import { DiscoverMainRoute } from './main';
-import { SingleDocRoute } from './doc';
-import { ContextAppRoute } from './context';
 import { mockCustomizationContext } from '../customizations/__mocks__/customization_context';
-import type { MainRouteProps } from './main/discover_main_route';
-
-let pathMap: Record<string, never> = {};
-
-const gatherRoutes = (wrapper: ShallowWrapper) => {
-  wrapper.find(Route).forEach((route) => {
-    const routeProps = route.props() as RouteProps;
-    const path = routeProps.path;
-    const children = routeProps.children;
-    if (typeof path === 'string') {
-      // @ts-expect-error
-      pathMap[path] = children ?? routeProps.render;
-    }
-  });
-};
+import { discoverServiceMock as mockDiscoverServices } from '../__mocks__/services';
 
 const mockExperimentalFeatures = {};
 
-const props: MainRouteProps = {
-  customizationContext: mockCustomizationContext,
-};
-
-describe('DiscoverRouter', () => {
-  beforeAll(() => {
-    pathMap = {};
-    const { history } = createSearchSessionMock();
-    const component = shallow(
+const renderWithRouter = (path: string) => {
+  const history = createMemoryHistory({
+    initialEntries: [path],
+  });
+  render(
+    <Router history={history}>
       <DiscoverRoutes
         services={mockDiscoverServices}
         history={history}
         customizationContext={mockCustomizationContext}
         experimentalFeatures={mockExperimentalFeatures}
       />
-    );
-    gatherRoutes(component);
-  });
+    </Router>
+  );
 
+  return history;
+};
+
+
+describe('DiscoverRouter', () => {
   it('should show DiscoverMainRoute component for / route', () => {
-    expect(pathMap['/']).toMatchObject(<DiscoverMainRoute {...props} />);
+    const history = renderWithRouter('/');
+    expect(screen.getByTestId('discover-main-route')).toBeInTheDocument();
+    expect(history.location.pathname).toBe('/');
   });
 
   it('should show DiscoverMainRoute component for /view/:id route', () => {
-    expect(pathMap['/view/:id']).toMatchObject(<DiscoverMainRoute {...props} />);
+    const history = renderWithRouter('/view/test-id');
+    expect(screen.getByTestId('discover-main-route')).toBeInTheDocument();
+    expect(history.location.pathname).toBe('/view/test-id');
   });
 
-  it('should show Redirect component for /doc/:dataView/:index/:type route', () => {
-    const redirectParams = {
-      match: {
-        params: {
-          dataView: '123',
-          index: '456',
-        },
-      },
-    };
-    const redirect = pathMap['/doc/:dataView/:index/:type'] as Function;
-    expect(typeof redirect).toBe('function');
-    expect(redirect(redirectParams)).toMatchObject(<Redirect to="/doc/123/456" />);
+  it('should redirect from /doc/:dataView/:index/:type to /doc/:dataView/:index', () => {
+    // Render with a path that should trigger the redirect
+    const history = renderWithRouter('/doc/123/456/type');
+    expect(screen.getByTestId('single-doc-route')).toBeInTheDocument();
+    expect(history.location.pathname).toBe('/doc/123/456');
   });
 
   it('should show SingleDocRoute component for /doc/:dataViewId/:index route', () => {
-    expect(pathMap['/doc/:dataViewId/:index']).toMatchObject(<SingleDocRoute />);
+    const history = renderWithRouter('/doc/test-dataview/test-index');
+    expect(screen.getByTestId('single-doc-route')).toBeInTheDocument();
+    expect(history.location.pathname).toBe('/doc/test-dataview/test-index');
   });
 
   it('should show ContextAppRoute component for /context/:dataViewId/:id route', () => {
-    expect(pathMap['/context/:dataViewId/:id']).toMatchObject(<ContextAppRoute />);
+    const history = renderWithRouter('/context/test-dataview/test-id');
+    expect(screen.getByTestId('context-app-route')).toBeInTheDocument();
+    expect(history.location.pathname).toBe('/context/test-dataview/test-id');
   });
 });

--- a/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
 
-
 // Mock dependencies to avoid issues with external modules like monaco
 jest.mock('@kbn/kibana-react-plugin/public', () => ({
   KibanaContextProvider: ({ children }: { children: React.ReactNode }) => children,
@@ -62,7 +61,6 @@ const renderWithRouter = (path: string) => {
 
   return history;
 };
-
 
 describe('DiscoverRouter', () => {
   it('should show DiscoverMainRoute component for / route', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover] Removing Enzyme of discover_router.test.tsx (#222774)](https://github.com/elastic/kibana/pull/222774)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Matthias Wilhelm","email":"matthias.wilhelm@elastic.co"},"sourceCommit":{"committedDate":"2025-06-06T13:40:02Z","message":"[Discover] Removing Enzyme of discover_router.test.tsx (#222774)\n\nMigrating discover_router.test.tsx to React Testing Library","sha":"1edde119a193ab9b23be2942c52e1d9ad2e2a64c","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","backport missing","Team:DataDiscovery","backport:version","v9.1.0","v8.19.0"],"title":"[Discover] Removing Enzyme of discover_router.test.tsx","number":222774,"url":"https://github.com/elastic/kibana/pull/222774","mergeCommit":{"message":"[Discover] Removing Enzyme of discover_router.test.tsx (#222774)\n\nMigrating discover_router.test.tsx to React Testing Library","sha":"1edde119a193ab9b23be2942c52e1d9ad2e2a64c"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222774","number":222774,"mergeCommit":{"message":"[Discover] Removing Enzyme of discover_router.test.tsx (#222774)\n\nMigrating discover_router.test.tsx to React Testing Library","sha":"1edde119a193ab9b23be2942c52e1d9ad2e2a64c"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->