### PR TITLE
enable streaming for OSS models

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
@@ -126,7 +126,7 @@ export const streamGraph = async ({
     const pushStreamUpdate = async () => {
       for await (const { event, data, tags } of stream) {
         if ((tags || []).includes(AGENT_NODE_TAG)) {
-          if (event === 'on_chat_model_stream' && !inputs.isOssModel) {
+          if (event === 'on_chat_model_stream') {
             const msg = data.chunk as AIMessageChunk;
             if (!didEnd && !msg.tool_call_chunks?.length && msg.content.length) {
               push({ payload: msg.content as string, type: 'content' });


### PR DESCRIPTION
## Summary

Streaming for OSS models was disabled in this PR https://github.com/elastic/kibana/pull/219024/files#r2110125149

While Patryk is on paternity leave and no comment was left, Kenneth's guess is that it was disabled because it was leaking reasoning rather than only streaming the final response. The purpose of this PR is to confirm that, and if it's true add a comment explaining why. If it's not true, we will re-enable streaming.