### PR TITLE
[ResponseOps] Enable scrolling in `ConnectorAddModal`

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.tsx
@@ -237,6 +237,7 @@ const ConnectorAddModal = ({
       css={css`
         z-index: 9000;
         width: ${actionTypeRegistry.get(actionType.id).modalWidth};
+        overflow-y: auto;
       `}
       data-test-subj="connectorAddModal"
       onClose={closeModal}


### PR DESCRIPTION
## Summary

`ConnectorAddModal` has `overflow: hidden;` (inherited from the default `EuiModal` css) which prevents scrolling on longer forms. The user could still use `tab` key to complete the form, but is unable to scroll:

https://github.com/user-attachments/assets/d711fbaf-ec31-44c9-8c6a-fb362a51a4f6


Adding `overflow-y: auto` enables scrolling:

https://github.com/user-attachments/assets/183f0e4a-d92f-4ffd-aabc-1db3f9b402f0


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->