### PR TITLE
[Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/types.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/types.ts
@@ -65,11 +65,7 @@ export interface ObservabilityAIAssistantChatService {
     systemMessage?: string;
     messages: Message[];
     persist: boolean;
-    disableFunctions:
-      | boolean
-      | {
-          except: string[];
-        };
+    disableFunctions: boolean;
     signal: AbortSignal;
     instructions?: Array<string | Instruction>;
     scopes: AssistantScope[];

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
@@ -33,12 +33,7 @@ const chatCompleteBaseRt = t.type({
     t.partial({
       conversationId: t.string,
       title: t.string,
-      disableFunctions: t.union([
-        toBooleanRt,
-        t.type({
-          except: t.array(t.string),
-        }),
-      ]),
+      disableFunctions: toBooleanRt,
       instructions: t.array(
         t.union([
           t.string,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -490,6 +490,15 @@ export class ObservabilityAIAssistantClient {
         },
       },
     };
+
+    this.dependencies.logger.debug(
+      () =>
+        `Options for inference client before anonymization: ${JSON.stringify({
+          ...options,
+          messages,
+        })}`
+    );
+
     if (stream) {
       return defer(() =>
         from(this.dependencies.anonymizationService.redactMessages(messages)).pipe(

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -202,11 +202,7 @@ export class ObservabilityAIAssistantClient {
     kibanaPublicUrl?: string;
     userInstructions?: Instruction[];
     simulateFunctionCalling?: boolean;
-    disableFunctions?:
-      | boolean
-      | {
-          except: string[];
-        };
+    disableFunctions?: boolean;
   }): Observable<Exclude<StreamingChatResponseEvent, ChatCompletionErrorEvent>> => {
     return withInferenceSpan('run_tools', () => {
       const isConversationUpdate = persist && !!predefinedConversationId;

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -250,7 +250,9 @@ export class ObservabilityAIAssistantClient {
             applicationInstructions: functionClient.getInstructions(),
             kbUserInstructions,
             apiUserInstructions,
-            availableFunctionNames: functionClient.getFunctions().map((fn) => fn.definition.name),
+            availableFunctionNames: disableFunctions
+              ? []
+              : functionClient.getFunctions().map((fn) => fn.definition.name),
           })
         ),
         shareReplay()

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -493,7 +493,7 @@ export class ObservabilityAIAssistantClient {
 
     this.dependencies.logger.debug(
       () =>
-        `Options for inference client before anonymization: ${JSON.stringify({
+        `Options for inference client for name: "${name}" before anonymization: ${JSON.stringify({
           ...options,
           messages,
         })}`
@@ -503,12 +503,6 @@ export class ObservabilityAIAssistantClient {
       return defer(() =>
         from(this.dependencies.anonymizationService.redactMessages(messages)).pipe(
           switchMap(({ redactedMessages }) => {
-            this.dependencies.logger.debug(
-              () =>
-                `Calling inference client for name: "${name}" with options: ${JSON.stringify(
-                  options
-                )}`
-            );
             return (
               this.dependencies.inferenceClient
                 .chatComplete({

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/operators/continue_conversation.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/operators/continue_conversation.ts
@@ -131,17 +131,13 @@ function getFunctionDefinitions({
 }: {
   functionClient: ChatFunctionClient;
   functionLimitExceeded: boolean;
-  disableFunctions:
-    | boolean
-    | {
-        except: string[];
-      };
+  disableFunctions: boolean;
 }) {
   if (functionLimitExceeded || disableFunctions === true) {
     return [];
   }
 
-  let systemFunctions = functionClient
+  const systemFunctions = functionClient
     .getFunctions()
     .map((fn) => fn.definition)
     .filter(
@@ -149,10 +145,6 @@ function getFunctionDefinitions({
         !def.visibility ||
         [FunctionVisibility.AssistantOnly, FunctionVisibility.All].includes(def.visibility)
     );
-
-  if (typeof disableFunctions === 'object') {
-    systemFunctions = systemFunctions.filter((fn) => disableFunctions.except.includes(fn.name));
-  }
 
   const actions = functionClient.getActions();
 
@@ -184,11 +176,7 @@ export function continueConversation({
   apiUserInstructions: Instruction[];
   kbUserInstructions: Instruction[];
   logger: Logger;
-  disableFunctions:
-    | boolean
-    | {
-        except: string[];
-      };
+  disableFunctions: boolean;
   connectorId: string;
   simulateFunctionCalling: boolean;
 }): Observable<MessageOrChatEvent> {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/223273

## Summary

### Problem
Tools are disabled for contextual insights by default. However, tools are not conditionally registered based on whether tools are disabled or not. Therefore, the system message includes instructions for tools even though tools are disabled for contextual insights. LLMs such as Claude, tries to call these tools and results in an error because we don't pass any tools to the LLM when `disableFunctions: true`

![contextual-insights-error-with-claude](https://github.com/user-attachments/assets/b638bbea-a3a7-4611-81b8-3bcc513fa994)

### Solution
Avoid passing tool instructions in the system message when tools are disabled.

https://github.com/user-attachments/assets/ba1a0016-4851-4ce7-9b40-efadbb96bd34

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->