### PR TITLE
chore(slo): show on discover the clicked bar events

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/events_chart_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/events_chart_panel.tsx
@@ -114,7 +114,7 @@ export function EventsChartPanel({ slo, range, hideRangeDurationLabel = false, o
                 })}
                 data-test-subj="sloDetailDiscoverLink"
               >
-                <EuiIcon type="sortRight" style={{ marginRight: '4px' }} />
+                <EuiIcon type="sortRight" css={{ marginRight: '4px' }} />
                 <FormattedMessage
                   id="xpack.slo.sloDetails.viewEventsLink"
                   defaultMessage="View events"

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/good_bad_events_chart.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/good_bad_events_chart.tsx
@@ -62,13 +62,21 @@ export function GoodBadEventsChart({ data, slo, onBrushed }: Props) {
 
   const barClickHandler = (params: XYChartElementEvent[]) => {
     const [datum, eventDetail] = params[0];
-    const isBad = eventDetail.specId === badEventId;
+    const isGoodEventClicked = eventDetail.specId === goodEventId;
+    const isBadEventClicked = eventDetail.specId === badEventId;
     const timeRange = {
       from: moment(datum.x).toISOString(),
       to: moment(datum.x).add(intervalInMilliseconds, 'ms').toISOString(),
       mode: 'absolute' as const,
     };
-    openInDiscover({ slo, showBad: isBad, showGood: !isBad, timeRange, discover, uiSettings });
+    openInDiscover({
+      slo,
+      showBad: isBadEventClicked,
+      showGood: isGoodEventClicked,
+      timeRange,
+      discover,
+      uiSettings,
+    });
   };
 
   return (

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/utils/get_discover_link.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/utils/get_discover_link.ts
@@ -99,6 +99,7 @@ function createDiscoverLocator({
         alias: i18n.translate('xpack.slo.sloDetails.totalFilterLabel', {
           defaultMessage: 'Total events',
         }),
+        disabled: showGood || showBad,
         value: JSON.stringify(customTotalFilter),
         index: indexId,
       },


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/223008

### Summary

This PR enhances the good vs bad charts by filtering the clicked events when redirecting to discover. When clicking on View Events, we keep the default behaviour of showing the total events

For example, if the user clicks on the good events (resp. bad events) bar, we will select the "good events" (resp. bad events) filter on discover.

### Manual testing

- Run data forge
- Create some SLOs with and without groups
- Verify the good events bar redirects to discover with good events filter enabled
- Verify the bad events bar redirects to discover with bad events filter enabled
- Verify the "View Events" link redirects to discover with total events filter enabled



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->