### PR TITLE
[Core] Udpate pricing service docs

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -8,10 +8,12 @@ valid modes are currently: `es`, `oblt`, `security` and `chat`
 configuration is applied in the following order, later values override
  1. serverless.yml (serverless configs go first)
  2. serverless.{mode}.yml (serverless configs go first)
- 3. base config, in this preference order:
+ 3. serverless.{mode}.{tier}.yml (serverless specific tier configs if tier is set)
+ 4. base config, in this preference order:
   - my-config.yml(s) (set by --config)
   - env-config.yml (described by `env.KBN_CONFIG_PATHS`)
   - kibana.yml (default @ `env.KBN_PATH_CONF`/kibana.yml)
- 4. kibana.dev.yml
- 5. serverless.dev.yml
- 6. serverless.{mode}.dev.yml
+ 5. kibana.dev.yml
+ 6. serverless.dev.yml
+ 7. serverless.{mode}.dev.yml
+ 8. serverless.{mode}.{tier}.dev.yml

--- a/src/core/packages/pricing/browser-internal/README.md
+++ b/src/core/packages/pricing/browser-internal/README.md
@@ -93,7 +93,7 @@ When testing components that use the pricing service, you can use the `@kbn/core
 ```typescript
 import { pricingServiceMock } from '@kbn/core-pricing-browser-mocks';
 import { render } from '@testing-library/react';
-import { CoreContext } from '@kbn/core-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { MyComponent } from './my_component';
 
 describe('MyComponent', () => {
@@ -113,9 +113,10 @@ describe('MyComponent', () => {
   
   it('renders feature1 when available', () => {
     const { getByText } = render(
-      <CoreContext.Provider value={{ services: { pricing: pricingStart } }}>
+      // The Kibana context provides the services in the react tree, but it's not necessarily required if the services are provided by other means
+      <KibanaContextProvider services={{ pricing: pricingStart }}>
         <MyComponent />
-      </CoreContext.Provider>
+      </KibanaContextProvider>
     );
     
     expect(getByText('Use Feature 1')).toBeInTheDocument();


### PR DESCRIPTION
## 📓 Summary

Update a wrong reference in a client-side documentation example and update list of loaded configs.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->