### PR TITLE
[9.0] [Lens] Do not break when the table has no data (#217937)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/columns.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/columns.test.tsx
@@ -32,6 +32,12 @@ const table: Datatable = {
   ],
   rows: [{ a: 123 }],
 };
+
+const emptyTable: Datatable = {
+  type: 'datatable',
+  columns: [],
+  rows: [],
+};
 const visibleColumns = ['a'];
 const cellValueAction: LensCellValueAction = {
   displayName: 'Test',
@@ -168,6 +174,13 @@ describe('getContentData', () => {
       });
       renderCellAction(cellActions, 2);
       expect(screen.getByRole('button')).toHaveTextContent('Test');
+    });
+
+    it('should not fail for a table with empty data', () => {
+      const columns = callCreateGridColumns({
+        table: emptyTable,
+      });
+      expect(columns).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Lens] Do not break when the table has no data (#217937)](https://github.com/elastic/kibana/pull/217937)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-04-15T12:03:09Z","message":"[Lens] Do not break when the table has no data (#217937)\n\n## Summary\n\nWhen the datatable comes with empty results the visualization fails with\nbad way\n\n<img width=\"396\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b4e266d7-edbd-452b-9192-84c957fe98db\"\n/>\n\n\nWith the fix\n<img width=\"756\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d061d29e-9246-432a-944b-308b88d161e7\"\n/>\n\n\n\nHow to replicate:\n\n- Create a field ES|QL control with 2 values (extension and geo.dest).\nYou can do it with multiple ways. I created with typing `FROM\nkibana_sample_data_logs | STATS count = COUNT(*) BY` and then `Create\ncontrol`.\n- Use the variable in another panel with query: `FROM\nkibana_sample_data_logs | WHERE ??field == \"css\" | KEEP extension` (The\ncontrol value should be in the extension). This will work\n- Select the second field (geo.dest). This will return an empty query\nand will break the table viz.\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"fa2d3912f408326980241df394c51bd87074e21c","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Lens","Feature:ES|QL","backport:version","v9.1.0","v8.19.0"],"title":"[Lens] Do not break when the table has no data","number":217937,"url":"https://github.com/elastic/kibana/pull/217937","mergeCommit":{"message":"[Lens] Do not break when the table has no data (#217937)\n\n## Summary\n\nWhen the datatable comes with empty results the visualization fails with\nbad way\n\n<img width=\"396\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b4e266d7-edbd-452b-9192-84c957fe98db\"\n/>\n\n\nWith the fix\n<img width=\"756\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d061d29e-9246-432a-944b-308b88d161e7\"\n/>\n\n\n\nHow to replicate:\n\n- Create a field ES|QL control with 2 values (extension and geo.dest).\nYou can do it with multiple ways. I created with typing `FROM\nkibana_sample_data_logs | STATS count = COUNT(*) BY` and then `Create\ncontrol`.\n- Use the variable in another panel with query: `FROM\nkibana_sample_data_logs | WHERE ??field == \"css\" | KEEP extension` (The\ncontrol value should be in the extension). This will work\n- Select the second field (geo.dest). This will return an empty query\nand will break the table viz.\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"fa2d3912f408326980241df394c51bd87074e21c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217937","number":217937,"mergeCommit":{"message":"[Lens] Do not break when the table has no data (#217937)\n\n## Summary\n\nWhen the datatable comes with empty results the visualization fails with\nbad way\n\n<img width=\"396\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b4e266d7-edbd-452b-9192-84c957fe98db\"\n/>\n\n\nWith the fix\n<img width=\"756\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d061d29e-9246-432a-944b-308b88d161e7\"\n/>\n\n\n\nHow to replicate:\n\n- Create a field ES|QL control with 2 values (extension and geo.dest).\nYou can do it with multiple ways. I created with typing `FROM\nkibana_sample_data_logs | STATS count = COUNT(*) BY` and then `Create\ncontrol`.\n- Use the variable in another panel with query: `FROM\nkibana_sample_data_logs | WHERE ??field == \"css\" | KEEP extension` (The\ncontrol value should be in the extension). This will work\n- Select the second field (geo.dest). This will return an empty query\nand will break the table viz.\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"fa2d3912f408326980241df394c51bd87074e21c"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/218254","number":218254,"state":"MERGED","mergeCommit":{"sha":"d35ae396a663a340f859f5fb29ef98fff52fb8ca","message":"[8.x] [Lens] Do not break when the table has no data (#217937) (#218254)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Lens] Do not break when the table has no data\n(#217937)](https://github.com/elastic/kibana/pull/217937)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>"}}]}] BACKPORT-->