### PR TITLE
[ES|QL] Better handling of ccs and local sources in the registry

### DIFF
--- a/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
@@ -79,8 +79,9 @@ export const registerESQLExtensionsRoute = (
         })) as ResolveIndexResponse;
 
         const sources = {
-          ...localSources,
-          ...ccsSources,
+          indices: [...(localSources.indices ?? []), ...(ccsSources.indices ?? [])],
+          aliases: [...(localSources.aliases ?? []), ...(ccsSources.aliases ?? [])],
+          data_streams: [...(localSources.data_streams ?? []), ...(ccsSources.data_streams ?? [])],
         };
 
         // Validate solutionId


### PR DESCRIPTION
## Summary

Small fix on the way we are concatenating the 2 sources (local and ccs). Previously if one of the sources was empty such as 

```
{
  indices: [],
  data_streams: [],
   aliases: []
}
```

would return wrongly empty extensions.




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->