### PR TITLE
add es-cache to cleaned folders

### DIFF
--- a/kbn_pm/src/commands/clean_command.mjs
+++ b/kbn_pm/src/commands/clean_command.mjs
@@ -11,6 +11,8 @@ import { dedent } from '../lib/indent.mjs';
 import { cleanPaths } from '../lib/clean.mjs';
 import * as Bazel from '../lib/bazel.mjs';
 import { findPluginCleanPaths } from '../lib/find_clean_paths.mjs';
+import Path from 'path';
+import { REPO_ROOT } from '../lib/paths.mjs';
 
 /** @type {import('../lib/command').Command} */
 export const command = {
@@ -33,7 +35,10 @@ export const command = {
       you might need to run 'yarn kbn reset'.
     `);
 
-    await cleanPaths(log, await findPluginCleanPaths(log));
+    await cleanPaths(log, [
+      ...(await findPluginCleanPaths(log)),
+      Path.resolve(REPO_ROOT, '.es', 'cache'),
+    ]);
 
     // Runs Bazel soft clean
     if (await Bazel.isInstalled(log)) {

--- a/kbn_pm/src/commands/reset_command.mjs
+++ b/kbn_pm/src/commands/reset_command.mjs
@@ -38,6 +38,7 @@ export const command = {
       Path.resolve(REPO_ROOT, 'node_modules'),
       Path.resolve(REPO_ROOT, 'x-pack/node_modules'),
       Path.resolve(REPO_ROOT, 'data'),
+      Path.resolve(REPO_ROOT, '.es'),
       ...readCleanPatterns(REPO_ROOT),
       ...(await findPluginCleanPaths(log)),
     ]);


### PR DESCRIPTION
## Summary
Currently, `yarn kbn clean` nor `yarn kbn reset` won't remove cached ES snapshot builds. This might cause issues for developers when switching between branches with major changes. (see: https://elastic.slack.com/archives/C5UDAFZQU/p1749628993034289)

This PR adds a softer and a harder clean to `clean` and `reset` respectively. 

<!--ONMERGE {"backportTargets":["7.17","8.17","8.18","8.19","9.0"]} ONMERGE-->