### PR TITLE
[Config] Apply pricing config overrides from CLI options

### DIFF
--- a/src/cli/serve/compile_config_stack.js
+++ b/src/cli/serve/compile_config_stack.js
@@ -33,7 +33,7 @@ export function compileConfigStack({
   devConfig,
   dev,
   serverless,
-  securityProductTier,
+  unknownOptions,
 }) {
   const cliConfigs = configOverrides || [];
   const envConfigs = getEnvConfigs();
@@ -62,7 +62,9 @@ export function compileConfigStack({
   // Security specific configs
   if (serverlessMode === 'security') {
     // Security specific tier configs
-    const serverlessSecurityTier = securityProductTier || getSecurityTierFromCfg(configs);
+    const serverlessSecurityTier =
+      _.get(unknownOptions, 'xpack.securitySolutionServerless.productTypes[0].product_tier') ||
+      getSecurityTierFromCfg(configs);
     if (serverlessSecurityTier) {
       configs.push(resolveConfig(`serverless.${serverlessMode}.${serverlessSecurityTier}.yml`));
       if (dev && devConfig !== false) {
@@ -75,9 +77,11 @@ export function compileConfigStack({
 
   // Pricing specific tier configs
   const config = getConfigFromFiles(configs.filter(isNotNull));
-  const isPricingTiersEnabled = _.get(config, 'pricing.tiers.enabled', false);
+  const isPricingTiersEnabled =
+    _.get(unknownOptions, 'pricing.tiers.enabled') ?? _.get(config, 'pricing.tiers.enabled', false);
+
   if (isPricingTiersEnabled) {
-    const tier = getServerlessProjectTierFromConfig(config);
+    const tier = getServerlessProjectTierFromConfig(config, unknownOptions);
     if (tier) {
       configs.push(resolveConfig(`serverless.${serverlessMode}.${tier}.yml`));
       if (dev && devConfig !== false) {
@@ -118,8 +122,9 @@ function getSecurityTierFromCfg(configs) {
  * @param {string[]} config Configuration object from merged configs
  * @returns {ServerlessProjectTier|undefined} The serverless project tier in the summed configs
  */
-function getServerlessProjectTierFromConfig(config) {
-  const products = _.get(config, 'pricing.tiers.products', []);
+function getServerlessProjectTierFromConfig(config, unknownOptions) {
+  const products =
+    _.get(unknownOptions, 'pricing.tiers.products') ?? _.get(config, 'pricing.tiers.products', []);
 
   // Constraint tier to be the same for
   const uniqueTiers = _.uniqBy(products, 'tier');

--- a/src/cli/serve/compile_config_stack.js
+++ b/src/cli/serve/compile_config_stack.js
@@ -62,9 +62,7 @@ export function compileConfigStack({
   // Security specific configs
   if (serverlessMode === 'security') {
     // Security specific tier configs
-    const serverlessSecurityTier =
-      _.get(unknownOptions, 'xpack.securitySolutionServerless.productTypes[0].product_tier') ||
-      getSecurityTierFromCfg(configs);
+    const serverlessSecurityTier = getServerlessSecurityTier(configs, unknownOptions);
     if (serverlessSecurityTier) {
       configs.push(resolveConfig(`serverless.${serverlessMode}.${serverlessSecurityTier}.yml`));
       if (dev && devConfig !== false) {
@@ -106,9 +104,16 @@ function getServerlessModeFromCfg(configs) {
 /** @typedef {'search_ai_lake' | 'essentials' | 'complete'} ServerlessSecurityTier */
 /**
  * @param {string[]} configs List of configuration file paths
+ * @param {Record<string, unknown>} unknownOptions
  * @returns {ServerlessSecurityTier|undefined} The serverless security tier in the summed configs
  */
-function getSecurityTierFromCfg(configs) {
+function getServerlessSecurityTier(configs, unknownOptions) {
+  const productTypeOverride = _.get(
+    unknownOptions,
+    'xpack.securitySolutionServerless.productTypes[0].product_tier'
+  );
+  if (productTypeOverride) return productTypeOverride;
+
   const config = getConfigFromFiles(configs.filter(isNotNull));
 
   // A product type is always present and for multiple addons in the config the product type/tier is always the same for all of them,

--- a/src/cli/serve/compile_config_stack.test.js
+++ b/src/cli/serve/compile_config_stack.test.js
@@ -116,7 +116,17 @@ describe('compileConfigStack', () => {
       const configList = compileConfigStack({
         serverless: 'security',
         dev: true,
-        securityProductTier: productTier,
+        unknownOptions: {
+          xpack: {
+            securitySolutionServerless: {
+              productTypes: [
+                {
+                  product_tier: productTier,
+                },
+              ],
+            },
+          },
+        },
       }).map(toFileNames);
 
       expect(configList).toEqual([
@@ -227,6 +237,65 @@ describe('pricing tiers configuration', () => {
     const configList = compileConfigStack({
       serverless: 'oblt',
       dev: true,
+    }).map(toFileNames);
+
+    expect(configList).toEqual([
+      'serverless.yml',
+      'serverless.oblt.yml',
+      'kibana.yml',
+      'kibana.dev.yml',
+      'serverless.dev.yml',
+      'serverless.oblt.dev.yml',
+      'serverless.oblt.complete.yml',
+      'serverless.oblt.complete.dev.yml',
+    ]);
+  });
+
+  it('adds pricing tier config from unknownOptions when pricing.tiers.enabled is true', async () => {
+    getConfigFromFiles.mockImplementationOnce(() => {
+      return {
+        serverless: 'oblt',
+      };
+    });
+
+    const configList = compileConfigStack({
+      serverless: 'oblt',
+      unknownOptions: {
+        pricing: {
+          tiers: {
+            enabled: true,
+            products: [{ name: 'observability', tier: 'essentials' }],
+          },
+        },
+      },
+    }).map(toFileNames);
+
+    expect(configList).toEqual([
+      'serverless.yml',
+      'serverless.oblt.yml',
+      'kibana.yml',
+      'serverless.oblt.essentials.yml',
+    ]);
+  });
+
+  it('adds pricing tier config from unknownOptions with dev mode when pricing.tiers.enabled is true', async () => {
+    getConfigFromFiles.mockImplementationOnce(() => {
+      return {
+        serverless: 'oblt',
+      };
+    });
+
+    const configList = compileConfigStack({
+      serverless: 'oblt',
+      dev: true,
+      unknownOptions: {
+        pricing: {
+          tiers: {
+            enabled: true,
+            products: [{ name: 'observability', tier: 'complete' }],
+          },
+        },
+      },
     }).map(toFileNames);
 
     expect(configList).toEqual([

--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -286,10 +286,7 @@ export default function (program) {
       devConfig: opts.devConfig,
       dev: opts.dev,
       serverless: opts.serverless || unknownOptions.serverless,
-      securityProductTier: _.get(
-        unknownOptions,
-        'xpack.securitySolutionServerless.productTypes[0].product_tier'
-      ),
+      unknownOptions,
     });
 
     const configsEvaluated = getConfigFromFiles(configs);


### PR DESCRIPTION
## 📓 Summary

When starting Kibana with CLI config overrides, the ones that looked up for the tier and loaded the appropriate configuration file were not wired, resulting in the override being ineffective.

This change fixes the behaviour, giving precedence to unknown CLI args that might override the `pricing` configuration and correctly configure Kibana. 

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->