### PR TITLE
[SLO] Remove duplicate header Annotations entry

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/components/header_menu/header_menu.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/header_menu/header_menu.tsx
@@ -53,14 +53,6 @@ export function HeaderMenu(): React.ReactElement | null {
                 defaultMessage: 'Manage SLOs',
               })}
             </EuiHeaderLink>
-            <EuiHeaderLink
-              color="primary"
-              href={http.basePath.prepend('/app/observability/annotations')}
-            >
-              {i18n.translate('xpack.slo.home.annotations', {
-                defaultMessage: 'Annotations',
-              })}
-            </EuiHeaderLink>
           </EuiHeaderLinks>
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
## 📓 Summary

Remove duplicate **Annotations** entry from the header menu.

### Before

![screenshot_2025-06-11_at_12 41 03](https://github.com/user-attachments/assets/5c4014d6-9d0b-4478-b52b-d8a2639e6ed8)

### After
<img width="542" alt="Screenshot 2025-06-11 at 12 54 45" src="https://github.com/user-attachments/assets/266279ec-4b93-4ada-bb4a-f6ccee7b3586" />


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->