### PR TITLE
fix(slo): use correct timeslice window duration as bucket size in good vs bad events

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/good_bad_events_chart.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/good_bad_events_chart.tsx
@@ -34,6 +34,8 @@ export interface Props {
   onBrushed?: (timeBounds: TimeBounds) => void;
 }
 
+const DEFAULT_INTERVAL = 10 * 60 * 1_000; // 10 minutes in milliseconds
+
 export function GoodBadEventsChart({ data, slo, onBrushed }: Props) {
   const { charts, uiSettings, discover } = useKibana().services;
   const { euiTheme } = useEuiTheme();
@@ -50,7 +52,7 @@ export function GoodBadEventsChart({ data, slo, onBrushed }: Props) {
   const intervalInMilliseconds =
     data && data.length > 2
       ? moment(data[1].date).valueOf() - moment(data[0].date).valueOf()
-      : 10 * 60000;
+      : DEFAULT_INTERVAL;
 
   const goodEventId = i18n.translate('xpack.slo.sloDetails.eventsChartPanel.goodEventsLabel', {
     defaultMessage: 'Good events',
@@ -65,8 +67,8 @@ export function GoodBadEventsChart({ data, slo, onBrushed }: Props) {
     const isGoodEventClicked = eventDetail.specId === goodEventId;
     const isBadEventClicked = eventDetail.specId === badEventId;
     const timeRange = {
-      from: moment(datum.x).toISOString(),
-      to: moment(datum.x).add(intervalInMilliseconds, 'ms').toISOString(),
+      from: moment(datum.x).startOf('minute').toISOString(),
+      to: moment(datum.x).add(intervalInMilliseconds, 'ms').startOf('minute').toISOString(),
       mode: 'absolute' as const,
     };
     openInDiscover({

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/slo_details.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/slo_details.tsx
@@ -36,16 +36,20 @@ export interface Props {
   selectedTabId: SloTabId;
 }
 export function SloDetails({ slo, isAutoRefreshing, selectedTabId }: Props) {
-  const [range, setRange] = useState<{ from: Date; to: Date }>({
-    from: moment().subtract(1, 'day').toDate(),
-    to: new Date(),
+  const [range, setRange] = useState<{ from: Date; to: Date }>(() => {
+    const now = new Date();
+    return {
+      from: moment(now).subtract(1, 'day').toDate(),
+      to: now,
+    };
   });
 
   useEffect(() => {
     let intervalId: any;
     if (isAutoRefreshing) {
       intervalId = setInterval(() => {
-        setRange({ from: moment().subtract(1, 'day').toDate(), to: new Date() });
+        const now = new Date();
+        setRange({ from: moment(now).subtract(1, 'day').toDate(), to: now });
       }, 60 * 1000);
     }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_preview_data.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_preview_data.ts
@@ -46,6 +46,8 @@ interface Options {
   groupBy?: string[];
 }
 
+const RANGE_DURATION_25HOURS_LIMIT = 25 * 60 * 60 * 1000; // 25 hours in milliseconds
+
 export class GetPreviewData {
   constructor(
     private esClient: ElasticsearchClient,
@@ -838,7 +840,7 @@ export class GetPreviewData {
       // they've breached the threshold.
       const rangeDuration = moment(params.range.to).diff(params.range.from, 'ms');
       const bucketSize =
-        rangeDuration <= 86_400_000 && params.objective?.timesliceWindow
+        rangeDuration <= RANGE_DURATION_25HOURS_LIMIT && params.objective?.timesliceWindow
           ? params.objective.timesliceWindow.asMinutes()
           : Math.max(
               calculateAuto.near(100, moment.duration(rangeDuration, 'ms'))?.asMinutes() ?? 0,

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_preview_data.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_preview_data.ts
@@ -46,7 +46,7 @@ interface Options {
   groupBy?: string[];
 }
 
-const RANGE_DURATION_25HOURS_LIMIT = 25 * 60 * 60 * 1000; // 25 hours in milliseconds
+const RANGE_DURATION_24HOURS_LIMIT = 24 * 60 * 60 * 1000 + 60 * 1000; // 24 hours and 1min in milliseconds
 
 export class GetPreviewData {
   constructor(
@@ -840,7 +840,7 @@ export class GetPreviewData {
       // they've breached the threshold.
       const rangeDuration = moment(params.range.to).diff(params.range.from, 'ms');
       const bucketSize =
-        rangeDuration <= RANGE_DURATION_25HOURS_LIMIT && params.objective?.timesliceWindow
+        rangeDuration <= RANGE_DURATION_24HOURS_LIMIT && params.objective?.timesliceWindow
           ? params.objective.timesliceWindow.asMinutes()
           : Math.max(
               calculateAuto.near(100, moment.duration(rangeDuration, 'ms'))?.asMinutes() ?? 0,


### PR DESCRIPTION
### Summary

Resolves https://github.com/elastic/kibana/issues/223016

This PR fixes the bucket size used in the good v bad events chart in two ways:
1. The range computed on the client could be off by a few ms. I fixed that by making sure it is exactly 24hours.
2. The API was expecting a range duration limit of exactly 24hours. I've added 1min buffer to it.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->