### PR TITLE
[Renovate] Update Vega config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2211,7 +2211,7 @@
         "release_note:skip",
         "backport:prev-minor"
       ],
-      "recreateWhen": "never",
+      "dependencyDashboardApproval": true,
       "minimumReleaseAge": "7 days",
       "enabled": true
     },


### PR DESCRIPTION
## Summary

This PR replaces [`recreateWhen`](https://docs.renovatebot.com/configuration-options/#recreatewhen) for [`dependencyDashboardApproval`](https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval). 

As it is, renovate will keep creating PRs and undue noice for any new version in the Vega group. But these will not be supported in kibana for months possibly longer.

Thus, we need to be more aggressive way of preventing Vega upgrade PRs. With this change we now need to manually trigger Vega renovate upgrade PRs from the [Dependency Dashboard](https://github.com/elastic/kibana/issues/190549).