### PR TITLE
[Security Solution] Add breakdown of customized fields in detection rules to snapshot telemetry

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_security.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_security.json
@@ -5390,6 +5390,38 @@
                       }
                     }
                   }
+                },
+                "detection_rules_customization_status": {
+                  "properties": {
+                    "rules_with_missing_base_version": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "Number of rules with missing base version"
+                      }
+                    },
+                    "customized_fields_breakdown": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "field": {
+                            "type": "keyword",
+                            "_meta": {
+                              "description": "Field name"
+                            }
+                          },
+                          "count": {
+                            "type": "long",
+                            "_meta": {
+                              "description": "Number of rules customizing this field"
+                            }
+                          }
+                        }
+                      },
+                      "_meta": {
+                        "description": "Breakdown of how many rules customized each field (field, count)"
+                      }
+                    }
+                  }
                 }
               }
             },

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/collector.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/collector.ts
@@ -3489,6 +3489,28 @@ export const registerCollector: RegisterCollector = ({
               },
             },
           },
+          detection_rules_customization_status: {
+            rules_with_missing_base_version: {
+              type: 'long',
+              _meta: { description: 'Number of rules with missing base version' },
+            },
+            customized_fields_breakdown: {
+              type: 'array',
+              items: {
+                field: {
+                  type: 'keyword',
+                  _meta: { description: 'Field name' },
+                },
+                count: {
+                  type: 'long',
+                  _meta: { description: 'Number of rules customizing this field' },
+                },
+              },
+              _meta: {
+                description: 'Breakdown of how many rules customized each field (field, count)',
+              },
+            },
+          },
         },
         ml_jobs: {
           ml_job_usage: {

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_initial_usage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_initial_usage.ts
@@ -9,6 +9,7 @@ import type { DetectionMetrics } from './types';
 
 import { getInitialMlJobUsage } from './ml_jobs/get_initial_usage';
 import {
+  getInitialCustomizedFieldsStatus,
   getInitialEventLogUsage,
   getInitialRulesUsage,
   getInitialSpacesUsage,
@@ -28,6 +29,7 @@ export const getInitialDetectionMetrics = (): DetectionMetrics => ({
     detection_rule_detail: [],
     detection_rule_usage: getInitialRulesUsage(),
     detection_rule_status: getInitialEventLogUsage(),
+    detection_rule_customized_fields_status: getInitialCustomizedFieldsStatus(),
     spaces_usage: getInitialSpacesUsage(),
   },
   legacy_siem_signals: getInitialLegacySiemSignalsUsage(),

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.ts
@@ -12,6 +12,7 @@ import type { DetectionMetrics } from './types';
 import { getMlJobMetrics } from './ml_jobs/get_metrics';
 import { getRuleMetrics } from './rules/get_metrics';
 import {
+  getInitialCustomizedFieldsStatus,
   getInitialEventLogUsage,
   getInitialRulesUsage,
   getInitialSpacesUsage,
@@ -59,6 +60,7 @@ export const getDetectionsMetrics = async ({
             detection_rule_detail: [],
             detection_rule_usage: getInitialRulesUsage(),
             detection_rule_status: getInitialEventLogUsage(),
+            detection_rule_customized_fields_status: getInitialCustomizedFieldsStatus(),
             spaces_usage: getInitialSpacesUsage(),
           },
     legacy_siem_signals:

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/ml_jobs/get_metrics.mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/ml_jobs/get_metrics.mocks.ts
@@ -315,6 +315,7 @@ export const getMockRuleSearchResponse = (
           tags: ['Elastic', 'Cloud', 'Azure', 'Continuous Monitoring', 'SecOps', 'Monitoring'],
           alertTypeId: 'siem.queryRule',
           consumer: 'siem',
+          revision: 4,
           params: {
             author: ['Elastic'],
             description:
@@ -333,6 +334,35 @@ export const getMockRuleSearchResponse = (
             outputIndex: '.siem-signals',
             maxSignals: 100,
             riskScore: 47,
+            riskScoreMapping: [],
+            severity: 'low',
+            severityMapping: [
+              {
+                field: 'kibana.alert.severity',
+                value: 'low',
+                operator: 'equals',
+                severity: 'low',
+              },
+            ],
+            threat: [
+              {
+                framework: 'MITRE ATT&CK',
+                tactic: {
+                  id: 'TA0040',
+                  name: 'Impact',
+                  reference: 'https://attack.mitre.org/tactics/TA0040/',
+                },
+                technique: [
+                  {
+                    id: 'T1564.001',
+                    name: 'Hide Artifacts: Indicator Removal on Host',
+                    reference: 'https://attack.mitre.org/techniques/T1564/001/',
+                  },
+                ],
+                reference:
+                  'https://attack.mitre.org/techniques/T1564/001/#mitigation-azure-activity-logs',
+              },
+            ],
             timestampOverride: 'event.ingested',
             to: 'now',
             type: 'query',
@@ -360,13 +390,27 @@ export const getMockRuleSearchResponse = (
           muteAll: true,
           mutedInstanceIds: [],
           monitoring: {
-            execution: {
+            run: {
               history: [],
               calculated_metrics: {
                 success_ratio: 1,
                 p99: 7981,
                 p50: 1653,
                 p95: 6523.699999999996,
+              },
+              last_run: {
+                outcome: 'succeeded' as 'succeeded',
+                outcomeOrder: 1,
+                warning: null,
+                outcomeMsg: ['Mocked last run'],
+                alertsCount: {
+                  active: 0,
+                  new: 0,
+                  recovered: 0,
+                  ignored: 0,
+                },
+                timestamp: new Date().toISOString(),
+                metrics: {},
               },
             },
           },

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_customized_fields_status.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_customized_fields_status.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { getCustomizedFieldsStatus } from './get_customized_fields_status';
+import { getInitialCustomizedFieldsStatus } from './get_initial_usage';
+import { createPrebuiltRuleAssetsClient as createPrebuiltRuleAssetsClientMock } from '../../../lib/detection_engine/prebuilt_rules/logic/rule_assets/__mocks__/prebuilt_rule_assets_client';
+import { savedRuleMock } from '../../../../public/detection_engine/rule_management/logic/mock';
+import type { QueryRule } from '../../../../common/api/detection_engine/model/rule_schema/rule_schemas.gen';
+
+let mockPrebuiltRuleAssetsClient: ReturnType<typeof createPrebuiltRuleAssetsClientMock>;
+jest.mock(
+  '../../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client',
+  () => ({
+    createPrebuiltRuleAssetsClient: () => mockPrebuiltRuleAssetsClient,
+  })
+);
+
+describe('getCustomizedFieldsStatus', () => {
+  const logger = loggingSystemMock.createLogger();
+  const savedObjectsClient = savedObjectsClientMock.create();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrebuiltRuleAssetsClient = createPrebuiltRuleAssetsClientMock();
+  });
+
+  it('returns initial status if no rule objects', async () => {
+    const result = await getCustomizedFieldsStatus({
+      savedObjectsClient,
+      ruleResponsesForPrebuiltRules: [],
+      logger,
+    });
+    expect(result).toEqual(getInitialCustomizedFieldsStatus());
+  });
+
+  it('logs and returns initial status if an error is thrown', async () => {
+    const ruleResponsesForPrebuiltRules = [savedRuleMock];
+    mockPrebuiltRuleAssetsClient.fetchAssetsByVersion.mockResolvedValueOnce([
+      {
+        rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+        version: '5',
+      },
+    ]);
+
+    const result = await getCustomizedFieldsStatus({
+      savedObjectsClient,
+      ruleResponsesForPrebuiltRules,
+      logger,
+    });
+    expect(logger.error).toHaveBeenCalled();
+    expect(result).toEqual(getInitialCustomizedFieldsStatus());
+  });
+
+  it('returns empty breakdown for a non-customized rule', async () => {
+    const ruleResponsesForPrebuiltRules = [savedRuleMock]; // This is the current version of the rule
+
+    // This is the base version (also used as the target version in the diff)
+    mockPrebuiltRuleAssetsClient.fetchAssetsByVersion.mockResolvedValueOnce([
+      {
+        name: savedRuleMock.name,
+        description: savedRuleMock.description,
+        rule_id: savedRuleMock.rule_id,
+        rule_type: savedRuleMock.type,
+        language: (savedRuleMock as QueryRule).language,
+        index: (savedRuleMock as QueryRule).index,
+        query: (savedRuleMock as QueryRule).query,
+        filters: (savedRuleMock as QueryRule).filters,
+        type: savedRuleMock.type,
+        risk_score: savedRuleMock.risk_score,
+        severity: savedRuleMock.severity,
+        version: savedRuleMock.version,
+        tags: savedRuleMock.tags,
+      },
+    ]);
+    const result = await getCustomizedFieldsStatus({
+      savedObjectsClient,
+      ruleResponsesForPrebuiltRules,
+      logger,
+    });
+    expect(result).toEqual({
+      rules_with_missing_base_version: 0,
+      customized_fields_breakdown: [],
+    });
+  });
+
+  it('returns breakdown for a customized rule', async () => {
+    const ruleResponsesForPrebuiltRules = [savedRuleMock]; // This is the current version of the rule
+
+    // This is the base version (also used as the target version in the diff)
+    // Simulate a customized rule by changing some fields in the base version
+    mockPrebuiltRuleAssetsClient.fetchAssetsByVersion.mockResolvedValueOnce([
+      {
+        name: 'Base Rule Name', // Different name
+        description: 'Base Rule Description', // Different description
+        rule_id: savedRuleMock.rule_id,
+        rule_type: savedRuleMock.type,
+        language: (savedRuleMock as QueryRule).language,
+        index: (savedRuleMock as QueryRule).index,
+        query: (savedRuleMock as QueryRule).query,
+        filters: (savedRuleMock as QueryRule).filters,
+        type: savedRuleMock.type,
+        risk_score: savedRuleMock.risk_score,
+        severity: savedRuleMock.severity,
+        version: savedRuleMock.version,
+        tags: savedRuleMock.tags,
+      },
+    ]);
+    const result = await getCustomizedFieldsStatus({
+      savedObjectsClient,
+      ruleResponsesForPrebuiltRules,
+      logger,
+    });
+    expect(result).toEqual({
+      rules_with_missing_base_version: 0,
+      customized_fields_breakdown: [
+        {
+          count: 1,
+          field: 'name',
+        },
+        {
+          count: 1,
+          field: 'description',
+        },
+      ],
+    });
+  });
+
+  it('returns breakdown for two customized rules', async () => {
+    const savedRuleMock2 = {
+      ...savedRuleMock,
+      rule_id: 'bbd3106e-b4b5-4d7c-a1a2-47531d6a2baf-2', // rule_id must be unique, it is used as a key
+    };
+    const ruleResponsesForPrebuiltRules = [savedRuleMock, savedRuleMock2]; // This is the current version of the rule
+
+    // This is the base version (also used as the target version in the diff)
+    // Simulate a customized rule by changing some fields in the base version
+    mockPrebuiltRuleAssetsClient.fetchAssetsByVersion.mockResolvedValueOnce([
+      {
+        name: 'Base Rule Name', // Different name
+        description: 'Base Rule Description', // Different description
+        rule_id: savedRuleMock.rule_id,
+        rule_type: savedRuleMock.type,
+        language: (savedRuleMock as QueryRule).language,
+        index: (savedRuleMock as QueryRule).index,
+        query: (savedRuleMock as QueryRule).query,
+        filters: (savedRuleMock as QueryRule).filters,
+        type: savedRuleMock.type,
+        risk_score: savedRuleMock.risk_score,
+        severity: savedRuleMock.severity,
+        version: savedRuleMock.version,
+        tags: savedRuleMock.tags,
+      },
+      {
+        name: 'Base Rule Name 2', // Different name
+        description: 'Base Rule Description 2', // Different description
+        rule_id: 'bbd3106e-b4b5-4d7c-a1a2-47531d6a2baf-2', // rule_id must match the second rule
+        rule_type: savedRuleMock2.type,
+        language: (savedRuleMock2 as QueryRule).language,
+        index: (savedRuleMock2 as QueryRule).index,
+        query: (savedRuleMock2 as QueryRule).query,
+        filters: (savedRuleMock2 as QueryRule).filters,
+        type: savedRuleMock2.type,
+        risk_score: savedRuleMock2.risk_score,
+        severity: savedRuleMock2.severity,
+        version: savedRuleMock2.version,
+        tags: [...savedRuleMock2.tags, 'new-tag'], // Adding a new tag to simulate customization
+      },
+    ]);
+    const result = await getCustomizedFieldsStatus({
+      savedObjectsClient,
+      ruleResponsesForPrebuiltRules,
+      logger,
+    });
+    expect(result).toEqual({
+      rules_with_missing_base_version: 0,
+      customized_fields_breakdown: [
+        {
+          count: 2,
+          field: 'name',
+        },
+        {
+          count: 2,
+          field: 'description',
+        },
+        {
+          count: 1,
+          field: 'tags',
+        },
+      ],
+    });
+  });
+
+  it('returns breakdown for two customized rules, one missing base version', async () => {
+    const savedRuleMock2 = {
+      ...savedRuleMock,
+      rule_id: 'bbd3106e-b4b5-4d7c-a1a2-47531d6a2baf-2', // rule_id must be unique, it is used as a key
+    };
+    const ruleResponsesForPrebuiltRules = [savedRuleMock, savedRuleMock2]; // This is the current version of the rule
+
+    // This is the base version (also used as the target version in the diff)
+    // Simulate a customized rule by changing some fields in the base version
+    // This time we return only one asset, simulating that the second rule, savedRuleMock2, is missing its base version
+    mockPrebuiltRuleAssetsClient.fetchAssetsByVersion.mockResolvedValueOnce([
+      {
+        name: 'Base Rule Name', // Different name
+        description: 'Base Rule Description', // Different description
+        rule_id: savedRuleMock.rule_id,
+        rule_type: savedRuleMock.type,
+        language: (savedRuleMock as QueryRule).language,
+        index: (savedRuleMock as QueryRule).index,
+        query: (savedRuleMock as QueryRule).query,
+        filters: (savedRuleMock as QueryRule).filters,
+        type: savedRuleMock.type,
+        risk_score: savedRuleMock.risk_score,
+        severity: 'medium', // Different severity
+        version: savedRuleMock.version,
+        tags: savedRuleMock.tags,
+      },
+    ]);
+    const result = await getCustomizedFieldsStatus({
+      savedObjectsClient,
+      ruleResponsesForPrebuiltRules,
+      logger,
+    });
+    expect(result).toEqual({
+      rules_with_missing_base_version: 1,
+      customized_fields_breakdown: [
+        {
+          count: 1,
+          field: 'name',
+        },
+        {
+          count: 1,
+          field: 'description',
+        },
+        {
+          count: 1,
+          field: 'severity',
+        },
+      ],
+    });
+  });
+
+  it('returns breakdown for many rules, testing batch processing', async () => {
+    const ruleResponsesForPrebuiltRules = Array.from({ length: 30 }, (_, i) => ({
+      ...savedRuleMock,
+      rule_id: `rule-id-${i + 1}`,
+    }));
+
+    // This is the base version (also used as the target version in the diff)
+    // Simulate a customized rule by changing some fields in the base version
+    // This time we return only one asset, simulating that the second rule, savedRuleMock2, is missing its base version
+    mockPrebuiltRuleAssetsClient.fetchAssetsByVersion.mockResolvedValueOnce(
+      Array.from({ length: 30 }, (_, i) => ({
+        name: `Base Rule Name ${i + 1}`, // Different name
+        description: `Base Rule Description ${i + 1}`, // Different description
+        rule_id: `rule-id-${i + 1}`,
+        rule_type: savedRuleMock.type,
+        language: (savedRuleMock as QueryRule).language,
+        index: (savedRuleMock as QueryRule).index,
+        query: (savedRuleMock as QueryRule).query,
+        filters: (savedRuleMock as QueryRule).filters,
+        type: savedRuleMock.type,
+        risk_score: 74, // Different risk score
+        severity: `medium`, // Different severity
+        version: savedRuleMock.version,
+        tags: savedRuleMock.tags,
+      }))
+    );
+    const result = await getCustomizedFieldsStatus({
+      savedObjectsClient,
+      ruleResponsesForPrebuiltRules,
+      logger,
+    });
+    expect(result).toEqual({
+      rules_with_missing_base_version: 0,
+      customized_fields_breakdown: [
+        {
+          count: 30,
+          field: 'name',
+        },
+        {
+          count: 30,
+          field: 'description',
+        },
+        {
+          count: 30,
+          field: 'severity',
+        },
+        {
+          count: 30,
+          field: 'risk_score',
+        },
+      ],
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_customized_fields_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_customized_fields_status.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract, Logger } from '@kbn/core/server';
+import type { PrebuiltRuleAsset } from '../../../lib/detection_engine/prebuilt_rules/model/rule_assets/prebuilt_rule_asset';
+import type { RuleResponse } from '../../../../common/api/detection_engine/model/rule_schema/rule_schemas.gen';
+import type { CalculateRuleDiffResult } from '../../../lib/detection_engine/prebuilt_rules/logic/diff/calculate_rule_diff';
+import { calculateRuleDiff } from '../../../lib/detection_engine/prebuilt_rules/logic/diff/calculate_rule_diff';
+import { createPrebuiltRuleAssetsClient } from '../../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+import { ThreeWayDiffOutcome } from '../../../../common/api/detection_engine/prebuilt_rules/model/diff/three_way_diff/three_way_diff_outcome';
+
+export interface CustomizedFieldsStats {
+  rules_with_missing_base_version: number;
+  customized_fields_breakdown: Array<{ field: string; count: number }>;
+}
+
+export interface GetCustomizedFieldsStatsOptions {
+  savedObjectsClient: SavedObjectsClientContract;
+  ruleResponsesForPrebuiltRules: RuleResponse[];
+  logger: Logger;
+}
+
+export const getCustomizedFieldsStatus = async ({
+  savedObjectsClient,
+  ruleResponsesForPrebuiltRules,
+  logger,
+}: GetCustomizedFieldsStatsOptions): Promise<CustomizedFieldsStats> => {
+  try {
+    const ruleAssetsClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
+
+    const prebuiltRuleVersions = ruleResponsesForPrebuiltRules.map((rule) => ({
+      rule_id: rule.rule_id,
+      version: rule.version,
+    }));
+    const prebuiltRuleAssets = await ruleAssetsClient.fetchAssetsByVersion(prebuiltRuleVersions);
+    if (!prebuiltRuleAssets || !prebuiltRuleAssets.length) {
+      logger.warn(
+        'No prebuilt rule assets found for the provided rule responses. Returning empty stats.'
+      );
+      return { rules_with_missing_base_version: 0, customized_fields_breakdown: [] };
+    }
+    const ruleIdToRuleResponseMap = new Map<string, RuleResponse>(
+      ruleResponsesForPrebuiltRules.map((ruleResponse) => [ruleResponse.rule_id, ruleResponse])
+    );
+    const diffResult = await calculateFieldsDiffsInBatches(
+      prebuiltRuleAssets,
+      ruleIdToRuleResponseMap,
+      logger
+    );
+
+    return {
+      rules_with_missing_base_version: ruleIdToRuleResponseMap.size - prebuiltRuleAssets.length,
+      customized_fields_breakdown: calculateFieldsBreakdown(diffResult),
+    };
+  } catch (err) {
+    logger.error(
+      `Failed to get customized fields stats: ${err instanceof Error ? err.message : String(err)}`
+    );
+
+    return { rules_with_missing_base_version: 0, customized_fields_breakdown: [] };
+  }
+};
+
+async function calculateFieldsDiffsInBatches(
+  prebuiltRuleAssets: PrebuiltRuleAsset[],
+  ruleIdToRuleResponseMap: Map<string, RuleResponse>,
+  logger: Logger
+) {
+  const BATCH_SIZE = 25;
+  const diffResult: CalculateRuleDiffResult[] = [];
+  let failuresCount = 0;
+
+  for (let i = 0; i < prebuiltRuleAssets.length; i += BATCH_SIZE) {
+    const batch = prebuiltRuleAssets.slice(i, i + BATCH_SIZE);
+    let batchDiffResults: CalculateRuleDiffResult[] = [];
+    batchDiffResults = batch
+      .map((asset) => {
+        try {
+          return calculateRuleDiff({
+            current: ruleIdToRuleResponseMap.get(asset.rule_id),
+            base: asset,
+            target: asset,
+          });
+        } catch (err) {
+          logger.error(
+            `Failed to calculate rule diff for rule with rule_id: ${asset.rule_id}, version: ${
+              asset.version
+            }): ${err instanceof Error ? err.message : String(err)}`
+          );
+          failuresCount++;
+          return null;
+        }
+      })
+      .filter(Boolean) as CalculateRuleDiffResult[];
+
+    diffResult.push(...batchDiffResults);
+
+    const processed = Math.min(i + BATCH_SIZE, prebuiltRuleAssets.length);
+    logger.debug(
+      `Processed fields diffs of ${processed} out of ${
+        prebuiltRuleAssets.length
+      } rules (failed in this batch: ${batch.length - batchDiffResults.length})`
+    );
+
+    // Small delay between batches to prevent cluster overload
+    if (processed < prebuiltRuleAssets.length) {
+      await new Promise((resolve) => setTimeout(resolve, 100)); // 100ms delay
+    }
+  }
+
+  logger.info(
+    `Successfully calculated fields diffs for ${diffResult.length} out of ${prebuiltRuleAssets.length} rules.`
+  );
+  if (failuresCount > 0) {
+    logger.warn(
+      `Some rules failed to calculate fields diffs, check the logs for more details. Total failures: ${failuresCount}`
+    );
+  }
+
+  return diffResult;
+}
+
+function calculateFieldsBreakdown(
+  diffResult: CalculateRuleDiffResult[]
+): Array<{ field: string; count: number }> {
+  const fieldCounts = diffResult
+    .flatMap((diff) =>
+      Object.entries(diff.ruleDiff?.fields ?? {})
+        .filter(
+          ([, fieldDiff]) => fieldDiff.diff_outcome === ThreeWayDiffOutcome.CustomizedValueNoUpdate
+        )
+        .map(([fieldName]) => fieldName)
+    )
+    .reduce<Record<string, number>>((acc, field) => {
+      acc[field] = (acc[field] ?? 0) + 1;
+      return acc;
+    }, {});
+
+  return Object.entries(fieldCounts).map(([field, count]) => ({ field, count }));
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
@@ -13,6 +13,7 @@ import type {
   SingleEventMetric,
   AlertSuppressionUsage,
   SpacesUsage,
+  CustomizedFieldsStatus,
 } from './types';
 
 export const initialAlertSuppression: AlertSuppressionUsage = {
@@ -146,6 +147,11 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     legacy_investigation_fields: 0,
     alert_suppression: initialAlertSuppression,
   },
+});
+
+export const getInitialCustomizedFieldsStatus = (): CustomizedFieldsStatus => ({
+  rules_with_missing_base_version: 0,
+  customized_fields_breakdown: [],
 });
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/types.ts
@@ -49,10 +49,16 @@ export interface SpacesUsage {
   rules_in_spaces: number[];
 }
 
+export interface CustomizedFieldsStatus {
+  rules_with_missing_base_version: number;
+  customized_fields_breakdown: Array<{ field: string; count: number }>;
+}
+
 export interface RuleAdoption {
   detection_rule_detail: RuleMetric[];
   detection_rule_usage: RulesTypeUsage;
   detection_rule_status: EventLogStatusMetric;
+  detection_rule_customized_fields_status: CustomizedFieldsStatus;
   spaces_usage: SpacesUsage;
 }
 


### PR DESCRIPTION
**Partially resolves: #140369**

## Summary

This is the third of a series of PRs I am planning to create to cover the requirements in the #140369 ticket. 

The requirements covered in this PR is: "**Breakdown of which fields are being customized.**" and "**Missing base versions**"

I am adding a new "detection_rules_customization_status" field in the cluster data. It represent information about how many times a field was customized across all rules. It contains also information for how many rules this calculation was not possible due to missing base version.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
