### PR TITLE
[Security solution][Endpoint] Fix run endpoint script to ensure that creation of default agent policies to has a valid namespace

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
@@ -993,7 +993,7 @@ export const getOrCreateDefaultAgentPolicy = async ({
     policy: {
       name: policyName,
       description: `Policy created by security solution tooling: ${__filename}`,
-      namespace: spaceId,
+      namespace: spaceId.replace(/-/g, '_'),
       monitoring_enabled: ['logs', 'metrics'],
       ...overrides,
     },


### PR DESCRIPTION
## Summary

- Fix run endpoint script to ensure that creation of default agent policies to has a valid namespace




