### PR TITLE
[8.19] [Config] Apply pricing config overrides from CLI options (#223386)

### DIFF
--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -282,6 +282,7 @@ export default function (program) {
       devConfig: opts.devConfig,
       dev: opts.dev,
       serverless: opts.serverless || unknownOptions.serverless,
+      unknownOptions,
     });
 
     const configsEvaluated = getConfigFromFiles(configs);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Config] Apply pricing config overrides from CLI options (#223386)](https://github.com/elastic/kibana/pull/223386)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Antonio Ghiani","email":"marcoantonio.ghiani01@gmail.com"},"sourceCommit":{"committedDate":"2025-06-11T13:36:07Z","message":"[Config] Apply pricing config overrides from CLI options (#223386)\n\n## 📓 Summary\n\nWhen starting Kibana with CLI config overrides, the ones that looked up\nfor the tier and loaded the appropriate configuration file were not\nwired, resulting in the override being ineffective.\n\nThis change fixes the behaviour, giving precedence to unknown CLI args\nthat might override the `pricing` configuration and correctly configure\nKibana.","sha":"551715e309c8953545f49e0b182edf7a5997ca07","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0"],"title":"[Config] Apply pricing config overrides from CLI options","number":223386,"url":"https://github.com/elastic/kibana/pull/223386","mergeCommit":{"message":"[Config] Apply pricing config overrides from CLI options (#223386)\n\n## 📓 Summary\n\nWhen starting Kibana with CLI config overrides, the ones that looked up\nfor the tier and loaded the appropriate configuration file were not\nwired, resulting in the override being ineffective.\n\nThis change fixes the behaviour, giving precedence to unknown CLI args\nthat might override the `pricing` configuration and correctly configure\nKibana.","sha":"551715e309c8953545f49e0b182edf7a5997ca07"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223386","number":223386,"mergeCommit":{"message":"[Config] Apply pricing config overrides from CLI options (#223386)\n\n## 📓 Summary\n\nWhen starting Kibana with CLI config overrides, the ones that looked up\nfor the tier and loaded the appropriate configuration file were not\nwired, resulting in the override being ineffective.\n\nThis change fixes the behaviour, giving precedence to unknown CLI args\nthat might override the `pricing` configuration and correctly configure\nKibana.","sha":"551715e309c8953545f49e0b182edf7a5997ca07"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->