### PR TITLE
Lucene timeline Filter

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.test.ts
@@ -5,10 +5,53 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
 import type { DataProvider } from '../../../../common/types/timeline';
-import { convertToBuildEsQuery, buildGlobalQuery } from '.';
+import { convertToBuildEsQuery, buildGlobalQuery, combineQueries } from '.';
 import { mockDataViewSpec } from '../../mock';
+
+/** A search bar filter (displayed below the KQL / Lucene search bar ) */
+const filters = [
+  {
+    meta: {
+      alias: null,
+      negate: false,
+      disabled: false,
+      type: 'exists',
+      key: '_id',
+      value: 'exists',
+    },
+    query: {
+      exists: {
+        field: '_id',
+      },
+    },
+  },
+];
+
+const dataProviders: DataProvider = {
+  and: [],
+  enabled: true,
+  id: 'some-id',
+  name: 'p1',
+  excluded: false,
+  kqlQuery: '',
+  queryMatch: {
+    field: 'host.name',
+    value: ['p1', 'p2'],
+    operator: 'includes',
+    displayField: 'host.name',
+    displayValue: '( p1 OR p2 )',
+  },
+};
+
+const config = {
+  allowLeadingWildcards: true,
+  queryStringOptions: {
+    analyze_wildcard: true,
+  },
+  ignoreFilterIfFieldNotInIndex: false,
+  dateFormatTZ: 'Browser',
+};
 
 describe('convertToBuildEsQuery', () => {
   /**
@@ -29,34 +72,6 @@ describe('convertToBuildEsQuery', () => {
     },
   ];
 
-  /** A search bar filter (displayed below the KQL / Lucene search bar ) */
-  const filters = [
-    {
-      meta: {
-        alias: null,
-        negate: false,
-        disabled: false,
-        type: 'exists',
-        key: '_id',
-        value: 'exists',
-      },
-      query: {
-        exists: {
-          field: '_id',
-        },
-      },
-    },
-  ];
-
-  const config = {
-    allowLeadingWildcards: true,
-    queryStringOptions: {
-      analyze_wildcard: true,
-    },
-    ignoreFilterIfFieldNotInIndex: false,
-    dateFormatTZ: 'Browser',
-  };
-
   it('should, by default, build a query where the `nested` fields syntax includes the `"ignore_unmapped":true` option', () => {
     const [converted, _] = convertToBuildEsQuery({
       config,
@@ -65,7 +80,7 @@ describe('convertToBuildEsQuery', () => {
       filters,
     });
 
-    expect(JSON.parse(converted ?? '')).to.eql({
+    expect(JSON.parse(converted ?? '')).toMatchObject({
       bool: {
         must: [],
         filter: [
@@ -180,7 +195,7 @@ describe('convertToBuildEsQuery', () => {
       filters,
     });
 
-    expect(JSON.parse(converted ?? '')).to.eql({
+    expect(JSON.parse(converted ?? '')).toMatchObject({
       bool: {
         must: [],
         filter: [
@@ -277,6 +292,302 @@ describe('convertToBuildEsQuery', () => {
       },
     });
   });
+
+  it('should combine lucene query & multiple kqlQueries with AND operator correctly', () => {
+    const luceneQuery = {
+      query: 'host.name: va1 OR val2',
+      language: 'lucene',
+    };
+
+    const kqlQuery1 = {
+      query: 'user.name: "val1" OR user.name: "val2"',
+      language: 'kuery',
+    };
+
+    const kqlQuery2 = {
+      query: 'host.name: "val3" OR host.name: "val4"',
+      language: 'kuery',
+    };
+
+    const [converted, _] = convertToBuildEsQuery({
+      config,
+      queries: [kqlQuery1, kqlQuery2],
+      dataViewSpec: mockDataViewSpec,
+      filters: [],
+      luceneQuery,
+    });
+
+    expect(JSON.parse(converted ?? '')).toMatchObject({
+      bool: {
+        filter: [
+          {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          'user.name': 'val1',
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          'user.name': 'val2',
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+          {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          'host.name': 'val3',
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          'host.name': 'val4',
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+          {
+            query_string: {
+              query: 'host.name: va1 OR val2',
+              analyze_wildcard: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('should combine lucene query & kqlQuery with OR operator correctly', () => {
+    const luceneQuery = {
+      query: 'host.name: va1 OR val2',
+      language: 'lucene',
+    };
+
+    const kqlQuery = {
+      query: 'user.name: "val1" OR user.name: "val2"',
+      language: 'kuery',
+    };
+
+    const [converted, _] = convertToBuildEsQuery({
+      config,
+      queries: [kqlQuery],
+      dataViewSpec: mockDataViewSpec,
+      filters: [],
+      luceneQuery,
+      operator: 'or',
+    });
+
+    expect(JSON.parse(converted ?? '')).toMatchObject({
+      bool: {
+        should: [
+          {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          'user.name': 'val1',
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          'user.name': 'val2',
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+          {
+            query_string: {
+              query: 'host.name: va1 OR val2',
+              analyze_wildcard: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('combineQueries', () => {
+  describe('lucene query', () => {
+    describe('Mode: filter', () => {
+      const kqlMode = 'filter';
+      it('should combine filters + dataProvider and luceneQuery', () => {
+        const luceneQuery = {
+          query: 'host.name: va1 OR val2',
+          language: 'lucene',
+        };
+
+        const combinedQueries = combineQueries({
+          config,
+          dataProviders: [dataProviders],
+          kqlQuery: luceneQuery,
+          kqlMode,
+          filters: [],
+          dataViewSpec: mockDataViewSpec,
+          browserFields: {},
+        });
+
+        expect(JSON.parse(combinedQueries?.filterQuery as string)).toMatchObject({
+          bool: {
+            filter: [
+              {
+                bool: {
+                  should: [
+                    {
+                      bool: {
+                        should: [
+                          {
+                            match: {
+                              'host.name': 'p1',
+                            },
+                          },
+                        ],
+                        minimum_should_match: 1,
+                      },
+                    },
+                    {
+                      bool: {
+                        should: [
+                          {
+                            match: {
+                              'host.name': 'p2',
+                            },
+                          },
+                        ],
+                        minimum_should_match: 1,
+                      },
+                    },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+              {
+                query_string: {
+                  query: 'host.name: va1 OR val2',
+                  analyze_wildcard: true,
+                },
+              },
+            ],
+          },
+        });
+      });
+    });
+    describe('Mode: `search`', () => {
+      const kqlMode = 'search';
+      it('should combine filters + dataProvider and luceneQuery', () => {
+        const luceneQuery = {
+          query: 'host.name: va1 OR val2',
+          language: 'lucene',
+        };
+
+        const combinedQueries = combineQueries({
+          config,
+          dataProviders: [dataProviders],
+          kqlQuery: luceneQuery,
+          kqlMode,
+          filters: [],
+          dataViewSpec: mockDataViewSpec,
+          browserFields: {},
+        });
+
+        expect(JSON.parse(combinedQueries?.filterQuery as string)).toMatchObject({
+          bool: {
+            should: [
+              {
+                bool: {
+                  should: [
+                    {
+                      bool: {
+                        should: [
+                          {
+                            match: {
+                              'host.name': 'p1',
+                            },
+                          },
+                        ],
+                        minimum_should_match: 1,
+                      },
+                    },
+                    {
+                      bool: {
+                        should: [
+                          {
+                            match: {
+                              'host.name': 'p2',
+                            },
+                          },
+                        ],
+                        minimum_should_match: 1,
+                      },
+                    },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+              {
+                query_string: {
+                  query: 'host.name: va1 OR val2',
+                  analyze_wildcard: true,
+                },
+              },
+            ],
+          },
+        });
+      });
+    });
+  });
 });
 
 describe('buildGlobalQuery', () => {
@@ -301,6 +612,6 @@ describe('buildGlobalQuery', () => {
 
     const query = buildGlobalQuery(providers, {});
 
-    expect(query).to.equal('host.name : (p1 OR p2)');
+    expect(query).toBe('host.name : (p1 OR p2)');
   });
 });


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



