### PR TITLE
[9.0] [Obs AI Assistant] Check for documents before starting semantic text migration (#221152)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/startup_migrations/populate_missing_semantic_text_fields.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/startup_migrations/populate_missing_semantic_text_fields.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import { LockManagerService } from '@kbn/lock-manager';
+import pRetry from 'p-retry';
+import { resourceNames } from '..';
+import { waitForKbModel } from '../inference_endpoint';
+import { ObservabilityAIAssistantPluginStartDependencies } from '../../types';
+import { ObservabilityAIAssistantConfig } from '../../config';
+import { getInferenceIdFromWriteIndex } from '../knowledge_base_service/get_inference_id_from_write_index';
+
+const POPULATE_MISSING_SEMANTIC_TEXT_FIELDS_LOCK_ID = 'populate_missing_semantic_text_fields';
+export async function populateMissingSemanticTextFieldWithLock({
+  core,
+  logger,
+  config,
+  esClient,
+}: {
+  core: CoreSetup<ObservabilityAIAssistantPluginStartDependencies>;
+  logger: Logger;
+  config: ObservabilityAIAssistantConfig;
+  esClient: { asInternalUser: ElasticsearchClient };
+}) {
+  const lmService = new LockManagerService(core, logger);
+  await lmService.withLock(POPULATE_MISSING_SEMANTIC_TEXT_FIELDS_LOCK_ID, async () =>
+    populateMissingSemanticTextField({ core, esClient, logger, config })
+  );
+}
+
+// Ensures that every doc has populated the `semantic_text` field.
+async function populateMissingSemanticTextField({
+  core,
+  esClient,
+  logger,
+  config,
+}: {
+  core: CoreSetup<ObservabilityAIAssistantPluginStartDependencies>;
+  esClient: { asInternalUser: ElasticsearchClient };
+  logger: Logger;
+  config: ObservabilityAIAssistantConfig;
+}) {
+  logger.debug('Initalizing semantic text migration for knowledge base entries...');
+
+  const { count } = await esClient.asInternalUser.count({
+    index: resourceNames.writeIndexAlias.kb,
+    query: {
+      bool: {
+        must_not: {
+          exists: { field: 'semantic_text' },
+        },
+      },
+    },
+  });
+  logger.info(`Documents missing 'semantic_text' before migration: ${count}`);
+
+  if (count === 0) {
+    logger.debug('No documents missing semantic_text field, skipping migration.');
+    return;
+  }
+
+  await pRetry(
+    async () => {
+      const inferenceId = await getInferenceIdFromWriteIndex(esClient);
+      await waitForKbModel({ core, esClient, logger, config, inferenceId });
+
+      await esClient.asInternalUser.updateByQuery({
+        index: resourceNames.writeIndexAlias.kb,
+        requests_per_second: 100,
+        script: {
+          source: `ctx._source.semantic_text = ctx._source.text`,
+          lang: 'painless',
+        },
+        query: {
+          bool: {
+            filter: { exists: { field: 'text' } },
+            must_not: { exists: { field: 'semantic_text' } },
+          },
+        },
+      });
+    },
+    { retries: 10, minTimeout: 10_000 }
+  );
+
+  logger.debug('Semantic text migration completed successfully.');
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Obs AI Assistant] Check for documents before starting semantic text migration (#221152)](https://github.com/elastic/kibana/pull/221152)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-05-21T21:18:06Z","message":"[Obs AI Assistant] Check for documents before starting semantic text migration (#221152)\n\nCloses https://github.com/elastic/kibana/issues/221157\n\n## Summary\n\nWe run a semantic text migration at startup to add the semantic text\nfield to documents that were created before 8.17.\n\nBefore multilingual KB was introduced:\n- We created index assets for KB when the AI Assistant flyout opens.\n- Even if the user does not set up the KB, they will have a component\ntemplate pointing to the custom inference endpoint.\n\nWith the introduction of multilingual KB:\n- We moved some of the index creation to when setting up the KB. \n- We try to do the semantic_text migration at startup. During this\nmigration, for users who didn't set up the KB but had the index assets\ncreated at startup, the custom inference endpoint will be unavailable.\n- But since the migration uses the inference endpoint from the write\nindex, we try to access an endpoint that's not available.\n\nThis is the reason for this error to be logged.\n```\nInference endpoint \"obs_ai_assistant_kb_inference\" not found or unavailable: resource_not_found_exception\n\tRoot causes:\n\t\tresource_not_found_exception: Inference endpoint not found [obs_ai_assistant_kb_inference]\n```\n\nThere is no customer impact from this, just that the error that gets\nlogged is creating a lot of noise.\n\n## Solution\n\nThis PR checks whether there are documents without semantic_text before\nstarting the migration.\nAnd also reduced the log level to warn because we hit the `/status`\nendpoint once when a user opens the AI Assistant.\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"b1e7012477af991632a0ad2fdfccad743bcac3c6","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[Obs AI Assistant] Check for documents before starting semantic text migration","number":221152,"url":"https://github.com/elastic/kibana/pull/221152","mergeCommit":{"message":"[Obs AI Assistant] Check for documents before starting semantic text migration (#221152)\n\nCloses https://github.com/elastic/kibana/issues/221157\n\n## Summary\n\nWe run a semantic text migration at startup to add the semantic text\nfield to documents that were created before 8.17.\n\nBefore multilingual KB was introduced:\n- We created index assets for KB when the AI Assistant flyout opens.\n- Even if the user does not set up the KB, they will have a component\ntemplate pointing to the custom inference endpoint.\n\nWith the introduction of multilingual KB:\n- We moved some of the index creation to when setting up the KB. \n- We try to do the semantic_text migration at startup. During this\nmigration, for users who didn't set up the KB but had the index assets\ncreated at startup, the custom inference endpoint will be unavailable.\n- But since the migration uses the inference endpoint from the write\nindex, we try to access an endpoint that's not available.\n\nThis is the reason for this error to be logged.\n```\nInference endpoint \"obs_ai_assistant_kb_inference\" not found or unavailable: resource_not_found_exception\n\tRoot causes:\n\t\tresource_not_found_exception: Inference endpoint not found [obs_ai_assistant_kb_inference]\n```\n\nThere is no customer impact from this, just that the error that gets\nlogged is creating a lot of noise.\n\n## Solution\n\nThis PR checks whether there are documents without semantic_text before\nstarting the migration.\nAnd also reduced the log level to warn because we hit the `/status`\nendpoint once when a user opens the AI Assistant.\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"b1e7012477af991632a0ad2fdfccad743bcac3c6"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221152","number":221152,"mergeCommit":{"message":"[Obs AI Assistant] Check for documents before starting semantic text migration (#221152)\n\nCloses https://github.com/elastic/kibana/issues/221157\n\n## Summary\n\nWe run a semantic text migration at startup to add the semantic text\nfield to documents that were created before 8.17.\n\nBefore multilingual KB was introduced:\n- We created index assets for KB when the AI Assistant flyout opens.\n- Even if the user does not set up the KB, they will have a component\ntemplate pointing to the custom inference endpoint.\n\nWith the introduction of multilingual KB:\n- We moved some of the index creation to when setting up the KB. \n- We try to do the semantic_text migration at startup. During this\nmigration, for users who didn't set up the KB but had the index assets\ncreated at startup, the custom inference endpoint will be unavailable.\n- But since the migration uses the inference endpoint from the write\nindex, we try to access an endpoint that's not available.\n\nThis is the reason for this error to be logged.\n```\nInference endpoint \"obs_ai_assistant_kb_inference\" not found or unavailable: resource_not_found_exception\n\tRoot causes:\n\t\tresource_not_found_exception: Inference endpoint not found [obs_ai_assistant_kb_inference]\n```\n\nThere is no customer impact from this, just that the error that gets\nlogged is creating a lot of noise.\n\n## Solution\n\nThis PR checks whether there are documents without semantic_text before\nstarting the migration.\nAnd also reduced the log level to warn because we hit the `/status`\nendpoint once when a user opens the AI Assistant.\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"b1e7012477af991632a0ad2fdfccad743bcac3c6"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/221203","number":221203,"state":"MERGED","mergeCommit":{"sha":"5ef460d75822adf39f508f29daa1eaa8c78e458c","message":"[8.19] [Obs AI Assistant] Check for documents before starting semantic text migration (#221152) (#221203)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Obs AI Assistant] Check for documents before starting semantic text\nmigration (#221152)](https://github.com/elastic/kibana/pull/221152)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Viduni Wickramarachchi <viduni.wickramarachchi@elastic.co>"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->