### PR TITLE
[WIP] - Add dataview cache to toSpec call

### DIFF
--- a/src/platform/plugins/shared/data_views/common/types.ts
+++ b/src/platform/plugins/shared/data_views/common/types.ts
@@ -559,6 +559,8 @@ export type DataViewSpec = {
   allowHidden?: boolean;
 };
 
+export type DataViewMinimalSpec = Omit<DataViewSpec, 'fields'>;
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SourceFilter = {
   value: string;


### PR DESCRIPTION
## Summary

This PR introduces a basic cache for the `.toSpec()` call of a DataView instance. The rationale behind this is due to the potential performance impact of these calls when fields are included. Often this isn't seen in local development, but when testing with enough fields (500K+), this can be significantly noticeable.

This is much older code, but in security we've worked around this by essentially caching the basic fields necessary for the spec [here](https://github.com/elastic/kibana/blob/22e6f78b843d8fc6a4504e3baae065340323f882/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx#L152-L159) and then passing that around through the application [here](https://github.com/elastic/kibana/blob/86312f378d65f9b36b21e78f1398d5a766281f0d/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx#L76-L88) to be able to generate dataViews via `new DataView(sourcererSpec)`. We're updating this logic to get the actual dataviews via `dataViews.get` and making use of `dataView.toSpec` to rely on the up to date fields from that call, rather than caching them separately in redux, Unfortunately this may introduce performance impacts due to the necessity for fields in many of our components and caching not being built in to the class.
 We can keep our current redux pattern, but we would like to rely on the DataView service more rather than having workaround.  
 

Prior art: https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-lens-embeddable-utils/attribute_builder/data_view_cache.ts

Similar approach [here](https://github.com/lgestc/kibana/pull/4/files#diff-1349d275f7e6a87fd5a7104b144d5a234a79f27b187998a576a02b981f479ce1) based on our dataView refactoring. 