### PR TITLE
[8.19] [Security Solution] Remove unneeded isPreview prop in highlighted fields (#223321)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/index.tsx
@@ -51,7 +51,7 @@ export const AIForSOCPanel: React.FC<Partial<AIForSOCDetailsProps>> = memo(() =>
             <HighlightedFields
               dataFormattedForFieldBrowser={dataFormattedForFieldBrowser}
               investigationFields={investigationFields}
-              isPreview={false}
+              showCellActions={false}
             />
           </EuiFlexItem>
           {attackDiscoveryAlertsEnabled && (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.test.tsx
@@ -39,9 +39,9 @@ const renderHighlightedFields = (showEditButton = false) =>
       <HighlightedFields
         dataFormattedForFieldBrowser={mockContextValue.dataFormattedForFieldBrowser}
         investigationFields={mockContextValue.investigationFields}
-        isPreview={mockContextValue.isPreview}
         scopeId={mockContextValue.scopeId}
         showEditButton={showEditButton}
+        showCellActions={false}
       />
     </TestProviders>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
@@ -41,11 +41,6 @@ export interface HighlightedFieldsTableRow {
      */
     scopeId: string;
     /**
-     * Boolean to indicate this field is shown in a preview
-     * Only needed if alerts page flyout (which uses CellActions), NOT in the AI for SOC alert summary flyout.
-     */
-    isPreview: boolean;
-    /**
      * If true, cell actions will be shown on hover
      */
     showCellActions: boolean;
@@ -115,19 +110,15 @@ export interface HighlightedFieldsProps {
    */
   investigationFields: string[];
   /**
-   * Boolean to indicate whether flyout is opened in rule preview
-   */
-  isPreview: boolean;
-  /**
    * Maintain backwards compatibility // TODO remove when possible
    * Only needed if alerts page flyout (which uses CellActions), NOT in the AI for SOC alert summary flyout.
    */
   scopeId?: string;
   /**
    * If true, cell actions will be shown on hover.
-   * This is false by default (for the AI for SOC alert summary page) and will be true for the alerts page.
+   * This is false for the AI for SOC alert summary page and true for the alerts page.
    */
-  showCellActions?: boolean;
+  showCellActions: boolean;
   /**
    * If true, the edit button will be shown on hover (granted that the editHighlightedFieldsEnabled is also turned on).
    * This is false by default (for the AI for SOC alert summary page) and will be true for the alerts page.
@@ -143,9 +134,8 @@ export const HighlightedFields = memo(
   ({
     dataFormattedForFieldBrowser,
     investigationFields,
-    isPreview,
     scopeId = '',
-    showCellActions = false,
+    showCellActions,
     showEditButton = false,
   }: HighlightedFieldsProps) => {
     const [isEditLoading, setIsEditLoading] = useState(false);
@@ -155,9 +145,8 @@ export const HighlightedFields = memo(
       investigationFields,
     });
     const items = useMemo(
-      () =>
-        convertHighlightedFieldsToTableRow(highlightedFields, scopeId, isPreview, showCellActions),
-      [highlightedFields, scopeId, isPreview, showCellActions]
+      () => convertHighlightedFieldsToTableRow(highlightedFields, scopeId, showCellActions),
+      [highlightedFields, scopeId, showCellActions]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
@@ -25,7 +25,7 @@ const KEY = 'investigation';
  * It contains investigation guide (alerts only) and highlighted fields.
  */
 export const InvestigationSection = memo(() => {
-  const { dataFormattedForFieldBrowser, getFieldsData, investigationFields, isPreview, scopeId } =
+  const { dataFormattedForFieldBrowser, getFieldsData, investigationFields, scopeId } =
     useDocumentDetailsContext();
   const eventKind = getField(getFieldsData('event.kind'));
 
@@ -55,7 +55,6 @@ export const InvestigationSection = memo(() => {
       <HighlightedFields
         dataFormattedForFieldBrowser={dataFormattedForFieldBrowser}
         investigationFields={investigationFields}
-        isPreview={isPreview}
         scopeId={scopeId}
         showCellActions={true}
         showEditButton={editHighlightedFieldsEnabled}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils/highlighted_fields_helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils/highlighted_fields_helpers.test.ts
@@ -11,7 +11,6 @@ import {
 } from './highlighted_fields_helpers';
 
 const scopeId = 'scopeId';
-const isPreview = false;
 const showCellActions = false;
 
 describe('convertHighlightedFieldsToTableRow', () => {
@@ -21,20 +20,19 @@ describe('convertHighlightedFieldsToTableRow', () => {
         values: ['host-1'],
       },
     };
-    expect(
-      convertHighlightedFieldsToTableRow(highlightedFields, scopeId, isPreview, showCellActions)
-    ).toEqual([
-      {
-        field: 'host.name',
-        description: {
+    expect(convertHighlightedFieldsToTableRow(highlightedFields, scopeId, showCellActions)).toEqual(
+      [
+        {
           field: 'host.name',
-          values: ['host-1'],
-          scopeId: 'scopeId',
-          isPreview,
-          showCellActions,
+          description: {
+            field: 'host.name',
+            values: ['host-1'],
+            scopeId: 'scopeId',
+            showCellActions,
+          },
         },
-      },
-    ]);
+      ]
+    );
   });
 
   it('should convert take override name over default name and use original values if not present in the override', () => {
@@ -44,21 +42,20 @@ describe('convertHighlightedFieldsToTableRow', () => {
         values: ['host-1'],
       },
     };
-    expect(
-      convertHighlightedFieldsToTableRow(highlightedFields, scopeId, isPreview, showCellActions)
-    ).toEqual([
-      {
-        field: 'host.name-override',
-        description: {
+    expect(convertHighlightedFieldsToTableRow(highlightedFields, scopeId, showCellActions)).toEqual(
+      [
+        {
           field: 'host.name-override',
-          originalField: 'host.name',
-          values: ['host-1'],
-          scopeId: 'scopeId',
-          isPreview,
-          showCellActions,
+          description: {
+            field: 'host.name-override',
+            originalField: 'host.name',
+            values: ['host-1'],
+            scopeId: 'scopeId',
+            showCellActions,
+          },
         },
-      },
-    ]);
+      ]
+    );
   });
 
   it('should convert take override name over default name and use provided values', () => {
@@ -68,21 +65,20 @@ describe('convertHighlightedFieldsToTableRow', () => {
         values: ['host-1'],
       },
     };
-    expect(
-      convertHighlightedFieldsToTableRow(highlightedFields, scopeId, isPreview, showCellActions)
-    ).toEqual([
-      {
-        field: 'host.name-override',
-        description: {
+    expect(convertHighlightedFieldsToTableRow(highlightedFields, scopeId, showCellActions)).toEqual(
+      [
+        {
           field: 'host.name-override',
-          originalField: 'host.name',
-          values: ['value override!'],
-          scopeId: 'scopeId',
-          isPreview,
-          showCellActions,
+          description: {
+            field: 'host.name-override',
+            originalField: 'host.name',
+            values: ['value override!'],
+            scopeId: 'scopeId',
+            showCellActions,
+          },
         },
-      },
-    ]);
+      ]
+    );
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils/highlighted_fields_helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils/highlighted_fields_helpers.ts
@@ -19,7 +19,6 @@ import type { HighlightedFieldsTableRow } from '../../right/components/highlight
 export const convertHighlightedFieldsToTableRow = (
   highlightedFields: UseHighlightedFieldsResult,
   scopeId: string,
-  isPreview: boolean,
   showCellActions: boolean
 ): HighlightedFieldsTableRow[] => {
   const fieldNames = Object.keys(highlightedFields);
@@ -38,7 +37,6 @@ export const convertHighlightedFieldsToTableRow = (
         ...(overrideFieldName ? { originalField: fieldName } : {}),
         values,
         scopeId,
-        isPreview,
         showCellActions,
       },
     };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Remove unneeded isPreview prop in highlighted fields (#223321)](https://github.com/elastic/kibana/pull/223321)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-11T16:15:57Z","message":"[Security Solution] Remove unneeded isPreview prop in highlighted fields (#223321)\n\n## Summary\n\n`isPreview` check is not used and no longer needed. No change to UI\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"1ca1e7981377524ef898f8ca77a69bd82ac90b9b","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:version","v9.1.0","v8.19.0"],"title":"[Security Solution] Remove unneeded isPreview prop in highlighted fields","number":223321,"url":"https://github.com/elastic/kibana/pull/223321","mergeCommit":{"message":"[Security Solution] Remove unneeded isPreview prop in highlighted fields (#223321)\n\n## Summary\n\n`isPreview` check is not used and no longer needed. No change to UI\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"1ca1e7981377524ef898f8ca77a69bd82ac90b9b"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223321","number":223321,"mergeCommit":{"message":"[Security Solution] Remove unneeded isPreview prop in highlighted fields (#223321)\n\n## Summary\n\n`isPreview` check is not used and no longer needed. No change to UI\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"1ca1e7981377524ef898f8ca77a69bd82ac90b9b"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->