### PR TITLE
[8.19] [Security Solution] [Security Assistant] Poll for evaluation completion in FTR tests (#222487)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/get_evaluate_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/get_evaluate_route.gen.ts
@@ -20,4 +20,10 @@ export type GetEvaluateResponse = z.infer<typeof GetEvaluateResponse>;
 export const GetEvaluateResponse = z.object({
   datasets: z.array(z.string()),
   graphs: z.array(z.string()),
+  results: z.array(
+    z.object({
+      id: z.string(),
+      status: z.string(),
+    })
+  ),
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/get_evaluate_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/get_evaluate_route.schema.yaml
@@ -28,9 +28,22 @@ paths:
                     type: array
                     items:
                       type: string
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        status:
+                          type: string
+                      required:
+                        - id
+                        - status
                 required:
                   - datasets
                   - graphs
+                  - results
         "400":
           description: Generic Error
           content:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/post_evaluate_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/post_evaluate_route.gen.ts
@@ -21,7 +21,7 @@ import { ScreenContext } from '../common_attributes.gen';
 
 export type PostEvaluateBody = z.infer<typeof PostEvaluateBody>;
 export const PostEvaluateBody = z.object({
-  graphs: z.array(z.string()),
+  graphs: z.array(z.string()).min(1).max(1),
   datasetName: z.string(),
   evaluatorConnectorId: z.string().optional(),
   connectorIds: z.array(z.string()),

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/post_evaluate_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/evaluation/post_evaluate_route.schema.yaml
@@ -59,6 +59,8 @@ components:
           type: array
           items:
             type: string
+          minItems: 1
+          maxItems: 1
         datasetName:
           type: string
         evaluatorConnectorId:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/evaluation_settings/evaluation_settings.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/evaluation_settings/evaluation_settings.tsx
@@ -397,6 +397,7 @@ export const EvaluationSettings: React.FC = React.memo(() => {
             onCreateOption={onGraphOptionsCreate}
             options={graphOptions}
             selectedOptions={selectedGraphOptions}
+            singleSelection // Remove once post_evaluate support running multiple graphs
             onChange={onGraphOptionsChange}
           />
         </EuiFormRow>

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/evaluation_settings/translations.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/evaluation_settings/translations.ts
@@ -125,7 +125,7 @@ export const GRAPHS_LABEL = i18n.translate(
 export const GRAPHS_DESCRIPTION = i18n.translate(
   'xpack.elasticAssistant.assistant.settings.evaluationSettings.graphsDescription',
   {
-    defaultMessage: 'Select the different graphs to evaluate the dataset against.',
+    defaultMessage: 'Select a graph to evaluate the dataset against.',
   }
 );
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/evaluation/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/evaluation/index.test.ts
@@ -57,6 +57,7 @@ const langSmithApiKey = 'test-api-key';
 const langSmithProject = 'test-lang-smith-project';
 const logger = loggerMock.create();
 const mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+const mockEsClientInternalUser = elasticsearchServiceMock.createElasticsearchClient();
 const runName = 'test-run-name';
 
 const connectors = [
@@ -133,6 +134,7 @@ describe('evaluateAttackDiscovery', () => {
       connectorTimeout,
       datasetName,
       esClient: mockEsClient,
+      esClientInternalUser: mockEsClientInternalUser,
       evaluationId,
       evaluatorConnectorId,
       langSmithApiKey,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/evaluation/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/evaluation/index.ts
@@ -22,6 +22,7 @@ import { AttackDiscoveryGraphMetadata } from '../../langchain/graphs';
 import { DefaultAttackDiscoveryGraph } from '../graphs/default_attack_discovery_graph';
 import { getLlmType } from '../../../routes/utils';
 import { runEvaluations } from './run_evaluations';
+import { createOrUpdateEvaluationResults, EvaluationStatus } from '../../../routes/evaluate/utils';
 
 interface ConnectorWithPrompts extends Connector {
   prompts: CombinedPrompts;
@@ -35,6 +36,7 @@ export const evaluateAttackDiscovery = async ({
   connectorTimeout,
   datasetName,
   esClient,
+  esClientInternalUser,
   evaluationId,
   evaluatorConnectorId,
   langSmithApiKey,
@@ -51,6 +53,7 @@ export const evaluateAttackDiscovery = async ({
   connectorTimeout: number;
   datasetName: string;
   esClient: ElasticsearchClient;
+  esClientInternalUser: ElasticsearchClient;
   evaluationId: string;
   evaluatorConnectorId: string | undefined;
   langSmithApiKey: string | undefined;
@@ -126,5 +129,11 @@ export const evaluateAttackDiscovery = async ({
       langSmithApiKey,
       logger,
     });
+  });
+
+  await createOrUpdateEvaluationResults({
+    evaluationResults: [{ id: evaluationId, status: EvaluationStatus.COMPLETE }],
+    esClientInternalUser,
+    logger,
   });
 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
@@ -38,7 +38,12 @@ import { buildResponse } from '../../lib/build_response';
 import { AssistantDataClients } from '../../lib/langchain/executors/types';
 import { AssistantToolParams, ElasticAssistantRequestHandlerContext } from '../../types';
 import { DEFAULT_PLUGIN_NAME, performChecks } from '../helpers';
-import { fetchLangSmithDataset } from './utils';
+import {
+  createOrUpdateEvaluationResults,
+  EvaluationStatus,
+  fetchLangSmithDataset,
+  setupEvaluationIndex,
+} from './utils';
 import { transformESSearchToAnonymizationFields } from '../../ai_assistant_data_clients/anonymization_fields/helpers';
 import { EsAnonymizationFieldsSchema } from '../../ai_assistant_data_clients/anonymization_fields/types';
 import { evaluateAttackDiscovery } from '../../lib/attack_discovery/evaluation';
@@ -155,6 +160,15 @@ export const postEvaluateRoute = (
           // Setup graph params
           // Get a scoped esClient for esStore + writing results to the output index
           const esClient = ctx.core.elasticsearch.client.asCurrentUser;
+          const esClientInternalUser = ctx.core.elasticsearch.client.asInternalUser;
+
+          // Create output index for writing results and write current eval as RUNNING
+          await setupEvaluationIndex({ esClientInternalUser, logger });
+          await createOrUpdateEvaluationResults({
+            evaluationResults: [{ id: evaluationId, status: EvaluationStatus.RUNNING }],
+            esClientInternalUser,
+            logger,
+          });
 
           const inference = ctx.elasticAssistant.inference;
           const productDocsAvailable =
@@ -221,6 +235,7 @@ export const postEvaluateRoute = (
                 connectorTimeout: ROUTE_HANDLER_TIMEOUT,
                 datasetName,
                 esClient,
+                esClientInternalUser,
                 evaluationId,
                 evaluatorConnectorId,
                 langSmithApiKey,
@@ -453,6 +468,11 @@ export const postEvaluateRoute = (
               maxConcurrency: 3,
             })
               .then((output) => {
+                void createOrUpdateEvaluationResults({
+                  evaluationResults: [{ id: evaluationId, status: EvaluationStatus.COMPLETE }],
+                  esClientInternalUser,
+                  logger,
+                });
                 logger.debug(`runResp:\n ${JSON.stringify(output, null, 2)}`);
               })
               .catch((err) => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/utils.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { Client, Example } from 'langsmith';
-import type { Logger } from '@kbn/core/server';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { isLangSmithEnabled } from '@kbn/langchain/server/tracers/langsmith';
 import { isEmpty } from 'lodash';
 
@@ -63,7 +63,149 @@ export const fetchLangSmithDatasets = async ({
 
     return datasets.map((d) => d.name).sort();
   } catch (e) {
-    logger.error(`Error fetching datasets from LangSmith: ${e.message}`);
+    logger.debug(`Error fetching datasets from LangSmith: ${e.message}`);
     return [];
+  }
+};
+
+export const EVALUATION_RESULTS_INDEX = '.kibana_elastic-ai-assistant-evaluations-default';
+export const EVALUATION_RESULTS_ILM_POLICY = 'security-assistant-evaluation-data-policy';
+export const EvaluationStatus = {
+  RUNNING: 'running',
+  COMPLETE: 'complete',
+  UNKNOWN: 'unknown',
+} as const;
+export type EvaluationStatus = (typeof EvaluationStatus)[keyof typeof EvaluationStatus];
+
+/**
+ * Asynchronously retrieves evaluation results from the Elasticsearch index.
+ *
+ * @param {Object} params - The function parameters.
+ * @param {ElasticsearchClient} params.esClientInternalUser - The Elasticsearch client used to perform the search query.
+ * @param {Logger} params.logger - The logger instance used to log errors if the operation fails.
+ * @returns {Promise<Array<{ id: string; status: EvaluationStatus }>>} A promise that resolves to an array of evaluation results,
+ *   each containing an `id` and `status`. If an error occurs, an empty array is returned.
+ */
+export const getEvaluationResults = async ({
+  esClientInternalUser,
+  logger,
+}: {
+  esClientInternalUser: ElasticsearchClient;
+  logger: Logger;
+}): Promise<Array<{ id: string; status: EvaluationStatus }>> => {
+  try {
+    const resp = await esClientInternalUser.search<{
+      evaluation_id: string;
+      status: EvaluationStatus;
+    }>({
+      index: EVALUATION_RESULTS_INDEX,
+      size: 100,
+      _source: ['evaluation_id', 'status'],
+      query: { match_all: {} },
+    });
+
+    return (
+      resp.hits.hits.map((hit) => ({
+        id: hit._source?.evaluation_id ?? '',
+        status: hit._source?.status ?? EvaluationStatus.UNKNOWN,
+      })) || []
+    );
+  } catch (e) {
+    logger.error(`Error fetching evaluation results: ${e.message}`);
+    return [];
+  }
+};
+
+/**
+ * Sets up the evaluation index and ILM (Index Lifecycle Management) policy for storing
+ * evaluation data in Elasticsearch. This function ensures that the required ILM policy
+ * and index are created if they do not already exist.
+ *
+ * @param {Object} params - An object containing the necessary dependencies.
+ * @param {ElasticsearchClient} params.esClientInternalUser - The Elasticsearch client used to interact with the Elasticsearch cluster.
+ * @param {Logger} params.logger - The logger instance used for logging actions and errors.
+ * @returns {Promise<void>} A promise that resolves when the setup process is complete.
+ */
+export const setupEvaluationIndex = async ({
+  esClientInternalUser,
+  logger,
+}: {
+  esClientInternalUser: ElasticsearchClient;
+  logger: Logger;
+}): Promise<void> => {
+  try {
+    // Check if ILM policy exists
+    const ilmExists = await esClientInternalUser.ilm
+      .getLifecycle({ name: EVALUATION_RESULTS_ILM_POLICY })
+      .catch(() => null);
+    if (!ilmExists || !ilmExists[EVALUATION_RESULTS_ILM_POLICY]) {
+      await esClientInternalUser.ilm.putLifecycle({
+        name: EVALUATION_RESULTS_ILM_POLICY,
+        policy: {
+          phases: {
+            hot: { actions: {} },
+            delete: { min_age: '1d', actions: { delete: {} } },
+          },
+        },
+      });
+    } else {
+      logger.info('Evaluation results ILM already exists');
+    }
+
+    // Check if the index exists
+    const indexExists = await esClientInternalUser.indices.exists({
+      index: EVALUATION_RESULTS_INDEX,
+    });
+    if (!indexExists) {
+      await esClientInternalUser.indices.create({
+        index: EVALUATION_RESULTS_INDEX,
+        settings: {
+          'index.lifecycle.name': EVALUATION_RESULTS_ILM_POLICY,
+        },
+      });
+      logger.info('Evaluation results index already exists');
+    } else {
+      logger.info('Evaluation results index already exists');
+    }
+  } catch (e) {
+    logger.error(`Error setting up evaluation results index/ILM: ${e.message}`);
+  }
+};
+
+/**
+ * Creates or updates evaluation result documents in the evaluation results index.
+ * Each result is indexed using its `id` as the document ID, allowing for upsert behavior.
+ * Errors during indexing are logged but do not interrupt processing of other results.
+ *
+ * @param {Object} params - The function parameters.
+ * @param {Array<{ id: string; status: EvaluationStatus }>} params.evaluationResults - Array of evaluation results to index or update.
+ * @param {ElasticsearchClient} params.esClientInternalUser - Elasticsearch client instance for performing index operations.
+ * @param {Logger} params.logger - Logger instance for error reporting.
+ * @returns {Promise<void>} A promise that resolves when all results have been processed.
+ */
+export const createOrUpdateEvaluationResults = async ({
+  evaluationResults,
+  esClientInternalUser,
+  logger,
+}: {
+  evaluationResults: Array<{ id: string; status: EvaluationStatus }>;
+  esClientInternalUser: ElasticsearchClient;
+  logger: Logger;
+}): Promise<void> => {
+  for (const result of evaluationResults) {
+    try {
+      await esClientInternalUser.index({
+        index: EVALUATION_RESULTS_INDEX,
+        id: result.id,
+        document: {
+          '@timestamp': new Date().toISOString(),
+          evaluation_id: result.id,
+          status: result.status,
+        },
+        refresh: 'wait_for',
+      });
+    } catch (e) {
+      logger.error(`Failed to index evaluation result ${result.id}: ${e.message}`);
+    }
   }
 };

--- a/x-pack/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/configs/ess.config.ts
@@ -36,6 +36,13 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--xpack.actions.allowedHosts=["*"]`,
         `--xpack.securitySolution.enableExperimental=["assistantModelEvaluation"]`,
         ...getTinyElserServerArgs(),
+        // Uncomment to enable debug logger to see full eval traces in kibana logs
+        // `--logging.loggers=${JSON.stringify([
+        //   {
+        //     name: 'plugins.elasticAssistant',
+        //     level: 'debug',
+        //   },
+        // ])}`,
       ],
     },
     testFiles: [require.resolve('..')],

--- a/x-pack/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/evaluations.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/evaluations.ts
@@ -25,6 +25,9 @@ import {
 import { MachineLearningProvider } from '../../../../../functional/services/ml';
 import { routeWithNamespace } from '../../../../../common/utils/security_solution';
 import { loadEvalKnowledgeBaseEntries } from '../data/kb_entries';
+import { waitForEvaluationComplete } from './utils';
+
+const TEST_TIMOUT = 60 * 60 * 1000;
 
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
@@ -99,13 +102,16 @@ export default ({ getService }: FtrProviderContext) => {
             datasetName: 'ES|QL Generation Regression Suite',
           };
           const route = routeWithNamespace(ELASTIC_AI_ASSISTANT_EVALUATE_URL);
-          await supertest
+          const {
+            body: { evaluationId },
+          } = await supertest
             .post(route)
             .set('kbn-xsrf', 'true')
             .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
             .send(evalPayload)
             .expect(200);
-        });
+          await waitForEvaluationComplete({ evaluationId, supertest, log, timeout: TEST_TIMOUT });
+        }).timeout(TEST_TIMOUT);
 
         // Uses attack discovery alerts from episodes 1-8
         it('should successfully run the "Alerts RAG Regression (Episodes 1-8)" dataset', async () => {
@@ -115,13 +121,16 @@ export default ({ getService }: FtrProviderContext) => {
             datasetName: 'Alerts RAG Regression (Episodes 1-8)',
           };
           const route = routeWithNamespace(ELASTIC_AI_ASSISTANT_EVALUATE_URL);
-          await supertest
+          const {
+            body: { evaluationId },
+          } = await supertest
             .post(route)
             .set('kbn-xsrf', 'true')
             .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
             .send(evalPayload)
             .expect(200);
-        });
+          await waitForEvaluationComplete({ evaluationId, supertest, log, timeout: TEST_TIMOUT });
+        }).timeout(TEST_TIMOUT);
 
         it('should successfully run the "Assistant Eval: Custom Knowledge" dataset', async () => {
           await loadEvalKnowledgeBaseEntries(supertest, log);
@@ -131,13 +140,16 @@ export default ({ getService }: FtrProviderContext) => {
             datasetName: 'Assistant Eval: Custom Knowledge',
           };
           const route = routeWithNamespace(ELASTIC_AI_ASSISTANT_EVALUATE_URL);
-          await supertest
+          const {
+            body: { evaluationId },
+          } = await supertest
             .post(route)
             .set('kbn-xsrf', 'true')
             .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
             .send(evalPayload)
             .expect(200);
-        });
+          await waitForEvaluationComplete({ evaluationId, supertest, log, timeout: TEST_TIMOUT });
+        }).timeout(TEST_TIMOUT);
       });
 
       describe('Attack Discovery', () => {
@@ -149,13 +161,16 @@ export default ({ getService }: FtrProviderContext) => {
             datasetName: 'Eval AD: All Scenarios',
           };
           const route = routeWithNamespace(ELASTIC_AI_ASSISTANT_EVALUATE_URL);
-          await supertest
+          const {
+            body: { evaluationId },
+          } = await supertest
             .post(route)
             .set('kbn-xsrf', 'true')
             .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
             .send(evalPayload)
             .expect(200);
-        });
+          await waitForEvaluationComplete({ evaluationId, supertest, log, timeout: TEST_TIMOUT });
+        }).timeout(TEST_TIMOUT);
       });
     });
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/utils.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/utils.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type SuperTest from 'supertest';
+import type { ToolingLog } from '@kbn/tooling-log';
+import {
+  API_VERSIONS,
+  ELASTIC_AI_ASSISTANT_EVALUATE_URL,
+  GetEvaluateResponse,
+} from '@kbn/elastic-assistant-common';
+import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
+import { routeWithNamespace, waitFor } from '../../../../../common/utils/security_solution';
+
+export const waitForEvaluationComplete = async ({
+  evaluationId,
+  supertest,
+  log,
+  timeout = 1_200_000, // 20min default
+}: {
+  evaluationId: string;
+  supertest: SuperTest.Agent;
+  log: ToolingLog;
+  timeout?: number;
+}) => {
+  await waitFor(
+    async () => {
+      const route = routeWithNamespace(ELASTIC_AI_ASSISTANT_EVALUATE_URL);
+      const { body, status } = await supertest
+        .get(route)
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1);
+
+      return (
+        status === 200 &&
+        (body as GetEvaluateResponse).results.some(
+          (result) => result.id === evaluationId && result.status === 'complete'
+        )
+      );
+    },
+    'waitForEvaluationComplete',
+    log,
+    timeout,
+    1000 // poll every 1s
+  );
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] [Security Assistant] Poll for evaluation completion in FTR tests (#222487)](https://github.com/elastic/kibana/pull/222487)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Garrett Spong","email":"spong@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-11T21:47:07Z","message":"[Security Solution] [Security Assistant] Poll for evaluation completion in FTR tests (#222487)\n\n## Summary\n\nThis PR fixes an issue with running our Security Assistant evals on CI\nwhere the tests would finish and cleanup before the evaluations would\nactually complete. There was no issue with actually running the\nevaluations, they would finish without error, however since the tests\nwould complete beforehand, the required resources (alerts, kb docs,\nelser, etc) would be cleaned up and the evaluations wouldn't pass.\n\nThe issue has been fixed by polling for evaluation completion before\nletting the tests complete. This was accomplished by writing evaluation\nresults (`id`/`status`) to a new ephemeral index\n`.kibana-elastic-ai-assistant-evaluations-default` with an ILM policy of\n`1d`, and then updating the GET evaluation route to include a `results`\narray that can be used to confirm the status of the evaluation.\n\n\nNote: There is no impact to production deployments with these changes as\nall evaluation routes are gated behind the evaluation feature flag,\nwhich can be enabled by adding the below configuration to your\n`kibana.dev.yml`:\n\n\n```\nxpack.securitySolution.enableExperimental:\n  - \"assistantModelEvaluation\"\n```\n---\n\n## Results\n\n[Successful\nBuild](https://buildkite.com/elastic/kibana-pull-request/builds/306787/summary/annotations?jid=019756d8-e32f-4366-be5c-0f766a7c2934)\nwith `33m16s` runtime\n\n[ES|QL Generation\nRegression](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/261dcc59-fbe7-4397-a662-ff94042f666c/compare?selectedSessions=3303dbd1-4b29-4e36-900e-fc17ccfc923b,0acddaab-badb-4830-b731-170a3c122fcb,b8c300dc-3947-4c47-96d0-e3224be44d59,ce88d37d-6083-41ed-bcc7-989a2efc9c33&baseline=3303dbd1-4b29-4e36-900e-fc17ccfc923b)\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/45750385-56c1-424d-bdc7-19ef1e378416\"\n/>\n</p> \n\n\n\n\n\n\n\n[Alerts RAG Regression (Episodes\n1-8)](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/bd5bba1d-97aa-4512-bce7-b09aa943c651/compare?selectedSessions=f99b3bc7-bebf-4338-8cc5-96cff42015ab,776083c7-733b-476f-9a2e-ab90f62ba95b,f2036996-be11-45af-ab48-ee407b417679,7c02109b-ff7e-4b7c-8273-937a269f8924&baseline=f99b3bc7-bebf-4338-8cc5-96cff42015ab)\n\n> [!NOTE]\n> Need to either update dataset's referenced output to match the more\nverbose outputs of the tests, or to tune the evaluator prompt to be more\nlax as this is incorrectly the impacting correctness value. Examples\nneeding updated:\n>\n> Example: #9e6e\n> Example: #d33b\n> Example: #e4c6\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/61b8711a-f9bc-4b0b-93ce-cb9436864857\"\n/>\n</p> \n\n\n\n\n[Assistant Eval: Custom\nKnowledge](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/2d5f7c18-4bf4-4cdb-97a1-16e39a865cab/compare?selectedSessions=589cbefa-893d-411e-86ea-cf2fe01d352e,4f0e797e-b6fa-4aa6-b707-3fd952d9eccb,75a78e49-0ae4-4edd-b6c5-35a1ea2cafa8,3b7bef1e-69e7-4692-b156-acf30992383d&baseline=589cbefa-893d-411e-86ea-cf2fe01d352e)\n\n> [!NOTE]\n> Quite a few failures here which seem to be stemming from either\nmis-matches in anonymization values when referencing specific host names\n(differing from example alerts used in tests vs data set generation), or\nthe [KBRetrival tool not even being\ncalled](https://smith.langchain.com/public/d76c989e-f467-43a6-b606-c601e986d382/r).\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/1a57efbc-8615-4209-9483-7aee69f2a622\"\n/>\n</p> \n\n\n\n[Eval AD: All\nScenarios](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/4690ee16-9df5-416c-8bf0-b62bc2f2aba9/compare?selectedSessions=2ca55bc8-7b26-4f4a-909d-5e86ceddc53d,3694531a-32e0-4216-b91b-9136e7523bbb,6daa7be3-6b9b-44d3-bac3-6ba6980accfd,ad741ca8-07bf-4bfe-ba85-6b271e9c3e34&baseline=2ca55bc8-7b26-4f4a-909d-5e86ceddc53d&textDisplayMode=compact&compare-experiment-tab=0)\n\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/7e946207-290d-450f-a6ad-e679c8b60f0b\"\n/>\n</p> \n\n\n## Next Steps\n\n* Need to improve the `Alerts RAG Regression (Episodes 1-8)` and\n`Assistant Eval: Custom Knowledge` suites as correctness is being\nimpacted by a few factors: more verbose output from some models,\nevaluator prompt, example alerts/anonymization mis-matching, or missed\ntool calls\n* Add telemetry for writing execution times and single correctness score\nper model per suite\n  * Optionally write as console output/test artifact when running tests \n* Output link to LangSmith results in console output","sha":"dffa277e091bba8dbe9a325b4478cedb56de771a","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Security Generative AI","Feature:Assistant Evaluation","backport:version","v9.1.0","v8.19.0","ci:security-genai-run-evals"],"title":"[Security Solution] [Security Assistant] Poll for evaluation completion in FTR tests","number":222487,"url":"https://github.com/elastic/kibana/pull/222487","mergeCommit":{"message":"[Security Solution] [Security Assistant] Poll for evaluation completion in FTR tests (#222487)\n\n## Summary\n\nThis PR fixes an issue with running our Security Assistant evals on CI\nwhere the tests would finish and cleanup before the evaluations would\nactually complete. There was no issue with actually running the\nevaluations, they would finish without error, however since the tests\nwould complete beforehand, the required resources (alerts, kb docs,\nelser, etc) would be cleaned up and the evaluations wouldn't pass.\n\nThe issue has been fixed by polling for evaluation completion before\nletting the tests complete. This was accomplished by writing evaluation\nresults (`id`/`status`) to a new ephemeral index\n`.kibana-elastic-ai-assistant-evaluations-default` with an ILM policy of\n`1d`, and then updating the GET evaluation route to include a `results`\narray that can be used to confirm the status of the evaluation.\n\n\nNote: There is no impact to production deployments with these changes as\nall evaluation routes are gated behind the evaluation feature flag,\nwhich can be enabled by adding the below configuration to your\n`kibana.dev.yml`:\n\n\n```\nxpack.securitySolution.enableExperimental:\n  - \"assistantModelEvaluation\"\n```\n---\n\n## Results\n\n[Successful\nBuild](https://buildkite.com/elastic/kibana-pull-request/builds/306787/summary/annotations?jid=019756d8-e32f-4366-be5c-0f766a7c2934)\nwith `33m16s` runtime\n\n[ES|QL Generation\nRegression](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/261dcc59-fbe7-4397-a662-ff94042f666c/compare?selectedSessions=3303dbd1-4b29-4e36-900e-fc17ccfc923b,0acddaab-badb-4830-b731-170a3c122fcb,b8c300dc-3947-4c47-96d0-e3224be44d59,ce88d37d-6083-41ed-bcc7-989a2efc9c33&baseline=3303dbd1-4b29-4e36-900e-fc17ccfc923b)\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/45750385-56c1-424d-bdc7-19ef1e378416\"\n/>\n</p> \n\n\n\n\n\n\n\n[Alerts RAG Regression (Episodes\n1-8)](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/bd5bba1d-97aa-4512-bce7-b09aa943c651/compare?selectedSessions=f99b3bc7-bebf-4338-8cc5-96cff42015ab,776083c7-733b-476f-9a2e-ab90f62ba95b,f2036996-be11-45af-ab48-ee407b417679,7c02109b-ff7e-4b7c-8273-937a269f8924&baseline=f99b3bc7-bebf-4338-8cc5-96cff42015ab)\n\n> [!NOTE]\n> Need to either update dataset's referenced output to match the more\nverbose outputs of the tests, or to tune the evaluator prompt to be more\nlax as this is incorrectly the impacting correctness value. Examples\nneeding updated:\n>\n> Example: #9e6e\n> Example: #d33b\n> Example: #e4c6\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/61b8711a-f9bc-4b0b-93ce-cb9436864857\"\n/>\n</p> \n\n\n\n\n[Assistant Eval: Custom\nKnowledge](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/2d5f7c18-4bf4-4cdb-97a1-16e39a865cab/compare?selectedSessions=589cbefa-893d-411e-86ea-cf2fe01d352e,4f0e797e-b6fa-4aa6-b707-3fd952d9eccb,75a78e49-0ae4-4edd-b6c5-35a1ea2cafa8,3b7bef1e-69e7-4692-b156-acf30992383d&baseline=589cbefa-893d-411e-86ea-cf2fe01d352e)\n\n> [!NOTE]\n> Quite a few failures here which seem to be stemming from either\nmis-matches in anonymization values when referencing specific host names\n(differing from example alerts used in tests vs data set generation), or\nthe [KBRetrival tool not even being\ncalled](https://smith.langchain.com/public/d76c989e-f467-43a6-b606-c601e986d382/r).\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/1a57efbc-8615-4209-9483-7aee69f2a622\"\n/>\n</p> \n\n\n\n[Eval AD: All\nScenarios](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/4690ee16-9df5-416c-8bf0-b62bc2f2aba9/compare?selectedSessions=2ca55bc8-7b26-4f4a-909d-5e86ceddc53d,3694531a-32e0-4216-b91b-9136e7523bbb,6daa7be3-6b9b-44d3-bac3-6ba6980accfd,ad741ca8-07bf-4bfe-ba85-6b271e9c3e34&baseline=2ca55bc8-7b26-4f4a-909d-5e86ceddc53d&textDisplayMode=compact&compare-experiment-tab=0)\n\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/7e946207-290d-450f-a6ad-e679c8b60f0b\"\n/>\n</p> \n\n\n## Next Steps\n\n* Need to improve the `Alerts RAG Regression (Episodes 1-8)` and\n`Assistant Eval: Custom Knowledge` suites as correctness is being\nimpacted by a few factors: more verbose output from some models,\nevaluator prompt, example alerts/anonymization mis-matching, or missed\ntool calls\n* Add telemetry for writing execution times and single correctness score\nper model per suite\n  * Optionally write as console output/test artifact when running tests \n* Output link to LangSmith results in console output","sha":"dffa277e091bba8dbe9a325b4478cedb56de771a"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222487","number":222487,"mergeCommit":{"message":"[Security Solution] [Security Assistant] Poll for evaluation completion in FTR tests (#222487)\n\n## Summary\n\nThis PR fixes an issue with running our Security Assistant evals on CI\nwhere the tests would finish and cleanup before the evaluations would\nactually complete. There was no issue with actually running the\nevaluations, they would finish without error, however since the tests\nwould complete beforehand, the required resources (alerts, kb docs,\nelser, etc) would be cleaned up and the evaluations wouldn't pass.\n\nThe issue has been fixed by polling for evaluation completion before\nletting the tests complete. This was accomplished by writing evaluation\nresults (`id`/`status`) to a new ephemeral index\n`.kibana-elastic-ai-assistant-evaluations-default` with an ILM policy of\n`1d`, and then updating the GET evaluation route to include a `results`\narray that can be used to confirm the status of the evaluation.\n\n\nNote: There is no impact to production deployments with these changes as\nall evaluation routes are gated behind the evaluation feature flag,\nwhich can be enabled by adding the below configuration to your\n`kibana.dev.yml`:\n\n\n```\nxpack.securitySolution.enableExperimental:\n  - \"assistantModelEvaluation\"\n```\n---\n\n## Results\n\n[Successful\nBuild](https://buildkite.com/elastic/kibana-pull-request/builds/306787/summary/annotations?jid=019756d8-e32f-4366-be5c-0f766a7c2934)\nwith `33m16s` runtime\n\n[ES|QL Generation\nRegression](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/261dcc59-fbe7-4397-a662-ff94042f666c/compare?selectedSessions=3303dbd1-4b29-4e36-900e-fc17ccfc923b,0acddaab-badb-4830-b731-170a3c122fcb,b8c300dc-3947-4c47-96d0-e3224be44d59,ce88d37d-6083-41ed-bcc7-989a2efc9c33&baseline=3303dbd1-4b29-4e36-900e-fc17ccfc923b)\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/45750385-56c1-424d-bdc7-19ef1e378416\"\n/>\n</p> \n\n\n\n\n\n\n\n[Alerts RAG Regression (Episodes\n1-8)](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/bd5bba1d-97aa-4512-bce7-b09aa943c651/compare?selectedSessions=f99b3bc7-bebf-4338-8cc5-96cff42015ab,776083c7-733b-476f-9a2e-ab90f62ba95b,f2036996-be11-45af-ab48-ee407b417679,7c02109b-ff7e-4b7c-8273-937a269f8924&baseline=f99b3bc7-bebf-4338-8cc5-96cff42015ab)\n\n> [!NOTE]\n> Need to either update dataset's referenced output to match the more\nverbose outputs of the tests, or to tune the evaluator prompt to be more\nlax as this is incorrectly the impacting correctness value. Examples\nneeding updated:\n>\n> Example: #9e6e\n> Example: #d33b\n> Example: #e4c6\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/61b8711a-f9bc-4b0b-93ce-cb9436864857\"\n/>\n</p> \n\n\n\n\n[Assistant Eval: Custom\nKnowledge](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/2d5f7c18-4bf4-4cdb-97a1-16e39a865cab/compare?selectedSessions=589cbefa-893d-411e-86ea-cf2fe01d352e,4f0e797e-b6fa-4aa6-b707-3fd952d9eccb,75a78e49-0ae4-4edd-b6c5-35a1ea2cafa8,3b7bef1e-69e7-4692-b156-acf30992383d&baseline=589cbefa-893d-411e-86ea-cf2fe01d352e)\n\n> [!NOTE]\n> Quite a few failures here which seem to be stemming from either\nmis-matches in anonymization values when referencing specific host names\n(differing from example alerts used in tests vs data set generation), or\nthe [KBRetrival tool not even being\ncalled](https://smith.langchain.com/public/d76c989e-f467-43a6-b606-c601e986d382/r).\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/1a57efbc-8615-4209-9483-7aee69f2a622\"\n/>\n</p> \n\n\n\n[Eval AD: All\nScenarios](https://smith.langchain.com/o/b739bf24-7ba4-4994-b632-65dd677ac74e/datasets/4690ee16-9df5-416c-8bf0-b62bc2f2aba9/compare?selectedSessions=2ca55bc8-7b26-4f4a-909d-5e86ceddc53d,3694531a-32e0-4216-b91b-9136e7523bbb,6daa7be3-6b9b-44d3-bac3-6ba6980accfd,ad741ca8-07bf-4bfe-ba85-6b271e9c3e34&baseline=2ca55bc8-7b26-4f4a-909d-5e86ceddc53d&textDisplayMode=compact&compare-experiment-tab=0)\n\n\n<p align=\"center\">\n<img width=\"800\"\nsrc=\"https://github.com/user-attachments/assets/7e946207-290d-450f-a6ad-e679c8b60f0b\"\n/>\n</p> \n\n\n## Next Steps\n\n* Need to improve the `Alerts RAG Regression (Episodes 1-8)` and\n`Assistant Eval: Custom Knowledge` suites as correctness is being\nimpacted by a few factors: more verbose output from some models,\nevaluator prompt, example alerts/anonymization mis-matching, or missed\ntool calls\n* Add telemetry for writing execution times and single correctness score\nper model per suite\n  * Optionally write as console output/test artifact when running tests \n* Output link to LangSmith results in console output","sha":"dffa277e091bba8dbe9a325b4478cedb56de771a"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->