### PR TITLE
[8.19] [Attack Discovery][Scheduling] Add a `adhoc` alerts index for the manually generated attack discoveries (#12484) (#222584)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
@@ -76,6 +76,7 @@ export const DEFEND_INSIGHTS_BY_ID = `${DEFEND_INSIGHTS}/{id}`;
 export const ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG =
   'securitySolution.assistantAttackDiscoverySchedulingEnabled' as const;
 export const ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID = 'attack-discovery' as const;
+export const ATTACK_DISCOVERY_SCHEDULES_CONSUMER_ID = 'siem' as const;
 
 export const ATTACK_DISCOVERY = `${ELASTIC_AI_ASSISTANT_INTERNAL_URL}/attack_discovery` as const;
 export const ATTACK_DISCOVERY_BULK = `${ATTACK_DISCOVERY}/_bulk` as const;
@@ -119,12 +120,6 @@ export const ATTACK_DISCOVERY_ALERTS_ENABLED_FEATURE_FLAG =
  */
 export const ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX =
   '.alerts-security.attack.discovery.alerts' as const;
-
-/**
- * The prefix for all ad hoc Attack discovery alerts index resources.
- */
-export const ATTACK_DISCOVERY_ALERTS_AD_HOC_INDEX_RESOURCE_PREFIX =
-  `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-ad-hoc` as const;
 
 /**
  * The server timeout is set to 4 minutes to allow for long-running requests.

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/data_source_exclusions.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/data_source_exclusions.ts
@@ -25,6 +25,8 @@ export const defaultExclusions: DataSourceExclusions = {
   '.internal.alerts*': ['readOnly'],
   '.preview.alerts*': ['readOnly'],
   '.internal.preview.alerts*': ['readOnly'],
+  '.adhoc.alerts*': ['readOnly'],
+  '.internal.adhoc.alerts*': ['readOnly'],
   '.lists-*': ['readOnly'],
   '.items-*': ['readOnly'],
   '.logs-endpoint.actions-*': ['readOnly'],

--- a/x-pack/platform/plugins/shared/rule_registry/server/rule_data_client/rule_data_client.mock.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/rule_data_client/rule_data_client.mock.ts
@@ -31,7 +31,7 @@ export const createRuleDataClientMock = (
     indexName,
     kibanaVersion: '7.16.0',
     isWriteEnabled: jest.fn(() => true),
-    indexNameWithNamespace: jest.fn((namespace: string) => indexName + namespace),
+    indexNameWithNamespace: jest.fn((namespace: string) => `${indexName}-${namespace}`),
 
     // @ts-ignore 4.3.5 upgrade
     getReader: jest.fn((_options?: { namespace?: string }) => ({

--- a/x-pack/solutions/security/plugins/elastic_assistant/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/elastic_assistant/kibana.jsonc
@@ -21,6 +21,7 @@
       "data",
       "eventLog",
       "ml",
+      "ruleRegistry",
       "taskManager",
       "licensing",
       "llmTasks",

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts
@@ -14,7 +14,6 @@ import type {
   KibanaRequest,
   SavedObjectsClientContract,
 } from '@kbn/core/server';
-import { ATTACK_DISCOVERY_ALERTS_AD_HOC_INDEX_RESOURCE_PREFIX } from '@kbn/elastic-assistant-common';
 import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
 import type { MlPluginSetup } from '@kbn/ml-plugin/server';
 import { Subject } from 'rxjs';
@@ -27,6 +26,7 @@ import {
 import { omit, some } from 'lodash';
 import { InstallationStatus } from '@kbn/product-doc-base-plugin/common/install_status';
 import { TrainedModelsProvider } from '@kbn/ml-plugin/server/shared_services/providers';
+import { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import { alertSummaryFieldsFieldMap } from '../ai_assistant_data_clients/alert_summary/field_maps_configuration';
 import { attackDiscoveryFieldMap } from '../lib/attack_discovery/persistence/field_maps_configuration/field_maps_configuration';
 import { defendInsightsFieldMap } from '../ai_assistant_data_clients/defend_insights/field_maps_configuration';
@@ -58,7 +58,6 @@ import {
   GetAIAssistantKnowledgeBaseDataClientParams,
 } from '../ai_assistant_data_clients/knowledge_base';
 import { AttackDiscoveryDataClient } from '../lib/attack_discovery/persistence';
-import { attackDiscoveryAlertFieldMap } from '../lib/attack_discovery/schedules/fields';
 import { DefendInsightsDataClient } from '../ai_assistant_data_clients/defend_insights';
 import { createGetElserId, ensureProductDocumentationInstalled } from './helpers';
 import { hasAIAssistantLicense } from '../routes/helpers';
@@ -89,7 +88,6 @@ export interface AIAssistantServiceOpts {
   taskManager: TaskManagerSetupContract;
   pluginStop$: Subject<void>;
   productDocManager: Promise<ProductDocBaseStartContract['management']>;
-  savedAttackDiscoveries?: boolean; // feature flag
 }
 
 export interface CreateAIAssistantClientParams {
@@ -107,8 +105,7 @@ export type CreateDataStream = (params: {
     | 'prompts'
     | 'attackDiscovery'
     | 'defendInsights'
-    | 'alertSummary'
-    | 'attackDiscoveryAlerts';
+    | 'alertSummary';
   fieldMap: FieldMap;
   kibanaVersion: string;
   spaceId?: string;
@@ -127,7 +124,6 @@ export class AIAssistantService {
   private alertSummaryDataStream: DataStreamSpacesAdapter;
   private anonymizationFieldsDataStream: DataStreamSpacesAdapter;
   private attackDiscoveryDataStream: DataStreamSpacesAdapter;
-  private attackDiscoveryAlertsDataStream: DataStreamSpacesAdapter | null;
   private defendInsightsDataStream: DataStreamSpacesAdapter;
   private resourceInitializationHelper: ResourceInstallationHelper;
   private initPromise: Promise<InitializationPromise>;
@@ -135,13 +131,11 @@ export class AIAssistantService {
   private hasInitializedV2KnowledgeBase: boolean = false;
   private productDocManager?: ProductDocBaseStartContract['management'];
   private isProductDocumentationInProgress: boolean = false;
-  private savedAttackDiscoveries: boolean = false; // feature flag
 
   constructor(private readonly options: AIAssistantServiceOpts) {
     this.initialized = false;
     this.getElserId = createGetElserId(options.ml.trainedModelsProvider);
     this.elserInferenceId = options.elserInferenceId;
-    this.savedAttackDiscoveries = options.savedAttackDiscoveries ?? false;
 
     this.conversationsDataStream = this.createDataStream({
       resource: 'conversations',
@@ -168,17 +162,6 @@ export class AIAssistantService {
       kibanaVersion: options.kibanaVersion,
       fieldMap: attackDiscoveryFieldMap,
     });
-
-    if (options.savedAttackDiscoveries) {
-      // the `savedAttackDiscoveries` feature flag is enabled
-      this.attackDiscoveryAlertsDataStream = this.createDataStream({
-        resource: 'attackDiscoveryAlerts',
-        kibanaVersion: options.kibanaVersion,
-        fieldMap: attackDiscoveryAlertFieldMap,
-      });
-    } else {
-      this.attackDiscoveryAlertsDataStream = null;
-    }
 
     this.defendInsightsDataStream = this.createDataStream({
       resource: 'defendInsights',
@@ -446,15 +429,6 @@ export class AIAssistantService {
         pluginStop$: this.options.pluginStop$,
       });
 
-      if (this.savedAttackDiscoveries && this.attackDiscoveryAlertsDataStream != null) {
-        // The `savedAttackDiscoveries` feature flag is enabled
-        await this.attackDiscoveryAlertsDataStream.install({
-          esClient,
-          logger: this.options.logger,
-          pluginStop$: this.options.pluginStop$,
-        });
-      }
-
       await this.defendInsightsDataStream.install({
         esClient,
         logger: this.options.logger,
@@ -485,9 +459,6 @@ export class AIAssistantService {
       prompts: getResourceName('component-template-prompts'),
       anonymizationFields: getResourceName(ANONYMIZATION_FIELDS_COMPONENT_TEMPLATE),
       attackDiscovery: getResourceName('component-template-attack-discovery'),
-      attackDiscoveryAlerts: getResourceName(
-        `${ATTACK_DISCOVERY_ALERTS_AD_HOC_INDEX_RESOURCE_PREFIX}-component-template`
-      ),
       defendInsights: getResourceName('component-template-defend-insights'),
     },
     aliases: {
@@ -497,7 +468,6 @@ export class AIAssistantService {
       prompts: getResourceName('prompts'),
       anonymizationFields: getResourceName(ANONYMIZATION_FIELDS_RESOURCE),
       attackDiscovery: getResourceName('attack-discovery'),
-      attackDiscoveryAlerts: ATTACK_DISCOVERY_ALERTS_AD_HOC_INDEX_RESOURCE_PREFIX,
       defendInsights: getResourceName('defend-insights'),
     },
     indexPatterns: {
@@ -507,7 +477,6 @@ export class AIAssistantService {
       prompts: getResourceName('prompts*'),
       anonymizationFields: getResourceName(ANONYMIZATION_FIELDS_INDEX_PATTERN),
       attackDiscovery: getResourceName('attack-discovery*'),
-      attackDiscoveryAlerts: `${ATTACK_DISCOVERY_ALERTS_AD_HOC_INDEX_RESOURCE_PREFIX}*`,
       defendInsights: getResourceName('defend-insights*'),
     },
     indexTemplate: {
@@ -517,7 +486,6 @@ export class AIAssistantService {
       prompts: getResourceName('index-template-prompts'),
       anonymizationFields: getResourceName(ANONYMIZATION_FIELDS_INDEX_TEMPLATE),
       attackDiscovery: getResourceName('index-template-attack-discovery'),
-      attackDiscoveryAlerts: `${ATTACK_DISCOVERY_ALERTS_AD_HOC_INDEX_RESOURCE_PREFIX}-index-template`,
       defendInsights: getResourceName('index-template-defend-insights'),
     },
     pipelines: {
@@ -643,7 +611,9 @@ export class AIAssistantService {
   }
 
   public async createAttackDiscoveryDataClient(
-    opts: CreateAIAssistantClientParams
+    opts: CreateAIAssistantClientParams & {
+      adhocAttackDiscoveryDataClient: IRuleDataClient | undefined;
+    }
   ): Promise<AttackDiscoveryDataClient | null> {
     const res = await this.checkResourcesInstallation(opts);
 
@@ -652,8 +622,7 @@ export class AIAssistantService {
     }
 
     return new AttackDiscoveryDataClient({
-      attackDiscoveryAlertsIndexPatternsResourceName:
-        this.resourceNames.aliases.attackDiscoveryAlerts,
+      adhocAttackDiscoveryDataClient: opts.adhocAttackDiscoveryDataClient,
       logger: this.options.logger.get('attackDiscovery'),
       currentUser: opts.currentUser,
       elasticsearchClientPromise: this.options.elasticsearchClientPromise,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_attack_discovery_alerts/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_attack_discovery_alerts/index.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { Logger } from '@kbn/core/server';
 import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
+import { IRuleDataReader } from '@kbn/rule-registry-plugin/server';
 import { isEmpty } from 'lodash/fp';
 
+import { estypes } from '@elastic/elasticsearch';
 import { getIdsQuery } from './get_ids_query';
 import { AttackDiscoveryAlertDocument } from '../../../schedules/types';
 import { transformSearchResponseToAlerts } from '../../transforms/transform_search_response_to_alerts';
@@ -16,13 +18,13 @@ import { transformSearchResponseToAlerts } from '../../transforms/transform_sear
 export const getCreatedAttackDiscoveryAlerts = async ({
   attackDiscoveryAlertsIndex,
   createdDocumentIds,
-  esClient,
   logger,
+  readDataClient,
 }: {
   attackDiscoveryAlertsIndex: string;
   createdDocumentIds: string[];
-  esClient: ElasticsearchClient;
   logger: Logger;
+  readDataClient: IRuleDataReader;
 }): Promise<AttackDiscoveryAlert[]> => {
   if (isEmpty(createdDocumentIds)) {
     logger.debug(
@@ -36,11 +38,16 @@ export const getCreatedAttackDiscoveryAlerts = async ({
   try {
     const idsQuery = getIdsQuery(createdDocumentIds);
 
-    const response = await esClient.search<AttackDiscoveryAlertDocument>({
-      index: attackDiscoveryAlertsIndex,
+    // For some reason inside the rule data client we cast the response from `estypes.SearchResponse`
+    // into the ` as unknown as ESSearchResponse<TAlertDoc, TSearchRequest>`.
+    // Within the attack discovery we work with the `estypes` and thus here we cast response back.
+    const response = (await readDataClient.search<
+      estypes.SearchRequest,
+      AttackDiscoveryAlertDocument
+    >({
       size: createdDocumentIds.length,
       ...idsQuery,
-    });
+    })) as unknown as estypes.SearchResponse<AttackDiscoveryAlertDocument>;
 
     const { data } = transformSearchResponseToAlerts({
       logger,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/index.test.ts
@@ -5,19 +5,21 @@
  * 2.0.
  */
 
-import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { loggerMock } from '@kbn/logging-mocks';
+import { ruleRegistryMocks } from '@kbn/rule-registry-plugin/server/mocks';
 
 import { createAttackDiscoveryAlerts } from '.';
 import { mockAuthenticatedUser } from '../../../../__mocks__/mock_authenticated_user';
 import { mockCreateAttackDiscoveryAlertsParams } from '../../../../__mocks__/mock_create_attack_discovery_alerts_params';
 
+const ADHOC_ALERTS_INDEX = 'mock-index' as const;
+const ruleDataClientMock = ruleRegistryMocks.createRuleDataClient(ADHOC_ALERTS_INDEX);
+
 describe('createAttackDiscoveryAlerts', () => {
-  const mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
   const mockLogger = loggerMock.create();
   const mockNow = new Date('2025-04-24T17:36:25.812Z');
   const spaceId = 'default';
-  const attackDiscoveryAlertsIndex = 'mock-index';
+  const bulkMock = jest.fn();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -31,10 +33,9 @@ describe('createAttackDiscoveryAlerts', () => {
     };
 
     const result = await createAttackDiscoveryAlerts({
-      attackDiscoveryAlertsIndex,
+      adhocAttackDiscoveryDataClient: ruleDataClientMock,
       authenticatedUser: mockAuthenticatedUser,
       createAttackDiscoveryAlertsParams: mockParams,
-      esClient: mockEsClient,
       logger: mockLogger,
       spaceId,
     });
@@ -43,26 +44,28 @@ describe('createAttackDiscoveryAlerts', () => {
   });
 
   it('throws an error if bulk insertion fails', async () => {
-    mockEsClient.bulk.mockResolvedValue({
-      items: [
-        {
-          create: {
-            _index: 'mock-index',
-            status: 400,
-            error: { reason: 'Test error', type: 'test_error' },
+    bulkMock.mockResolvedValue({
+      body: {
+        items: [
+          {
+            create: {
+              _index: 'mock-index',
+              status: 400,
+              error: { reason: 'Test error', type: 'test_error' },
+            },
           },
-        },
-      ],
-      errors: true,
-      took: 1,
+        ],
+        errors: true,
+        took: 1,
+      },
     });
+    (ruleDataClientMock.getWriter as jest.Mock).mockResolvedValue({ bulk: bulkMock });
 
     await expect(
       createAttackDiscoveryAlerts({
-        attackDiscoveryAlertsIndex,
+        adhocAttackDiscoveryDataClient: ruleDataClientMock,
         authenticatedUser: mockAuthenticatedUser,
         createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-        esClient: mockEsClient,
         logger: mockLogger,
         spaceId,
       })
@@ -70,29 +73,32 @@ describe('createAttackDiscoveryAlerts', () => {
   });
 
   it('logs an error if fetching created alerts fails', async () => {
-    mockEsClient.bulk.mockResolvedValue({
-      items: [
-        {
-          create: {
-            result: 'created',
-            _id: 'mock-id-1',
-            _index: 'mock-index',
-            status: 201,
+    bulkMock.mockResolvedValue({
+      body: {
+        items: [
+          {
+            create: {
+              result: 'created',
+              _id: 'mock-id-1',
+              _index: 'mock-index',
+              status: 201,
+            },
           },
-        },
-      ],
-      errors: false,
-      took: 1,
+        ],
+        errors: false,
+        took: 1,
+      },
     });
+    (ruleDataClientMock.getWriter as jest.Mock).mockResolvedValue({ bulk: bulkMock });
 
-    mockEsClient.search.mockRejectedValue(new Error('Search error'));
+    const searchMock = jest.fn().mockRejectedValue(new Error('Search error'));
+    (ruleDataClientMock.getReader as jest.Mock).mockReturnValue({ search: searchMock });
 
     await expect(
       createAttackDiscoveryAlerts({
-        attackDiscoveryAlertsIndex,
+        adhocAttackDiscoveryDataClient: ruleDataClientMock,
         authenticatedUser: mockAuthenticatedUser,
         createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-        esClient: mockEsClient,
         logger: mockLogger,
         spaceId,
       })

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_scheduled_and_ad_hoc_index_pattern/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_scheduled_and_ad_hoc_index_pattern/index.test.ts
@@ -5,26 +5,40 @@
  * 2.0.
  */
 
+import { ruleRegistryMocks } from '@kbn/rule-registry-plugin/server/mocks';
+import { ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX } from '@kbn/elastic-assistant-common';
+
 import { getScheduledAndAdHocIndexPattern } from '.';
+
+const ADHOC_ALERTS_INDEX = '.adhoc.alerts-security.attack.discovery.alerts' as const;
+const ruleDataClientMock = ruleRegistryMocks.createRuleDataClient(ADHOC_ALERTS_INDEX);
 
 describe('getScheduledAndAdHocIndexPattern', () => {
   it('returns the expected pattern for the `default` spaceId', () => {
     const spaceId = 'default';
 
-    const result = getScheduledAndAdHocIndexPattern(spaceId);
+    const result = getScheduledAndAdHocIndexPattern(spaceId, ruleDataClientMock);
 
     expect(result).toBe(
-      '.alerts-security.attack.discovery.alerts-default,.alerts-security.attack.discovery.alerts-ad-hoc-default'
+      `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-default,${ADHOC_ALERTS_INDEX}-default`
     );
   });
 
   it('returns the expected pattern for a non-default spaceId', () => {
     const spaceId = 'another-space';
 
-    const result = getScheduledAndAdHocIndexPattern(spaceId);
+    const result = getScheduledAndAdHocIndexPattern(spaceId, ruleDataClientMock);
 
     expect(result).toBe(
-      '.alerts-security.attack.discovery.alerts-another-space,.alerts-security.attack.discovery.alerts-ad-hoc-another-space'
+      `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-another-space,${ADHOC_ALERTS_INDEX}-another-space`
     );
+  });
+
+  it('returns the expected pattern when rule data client does not exist', () => {
+    const spaceId = 'test-space';
+
+    const result = getScheduledAndAdHocIndexPattern(spaceId);
+
+    expect(result).toBe(`${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-test-space`);
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_scheduled_and_ad_hoc_index_pattern/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_scheduled_and_ad_hoc_index_pattern/index.ts
@@ -6,9 +6,15 @@
  */
 
 import { ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX } from '@kbn/elastic-assistant-common';
+import { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 
-export const getScheduledAndAdHocIndexPattern = (spaceId: string): string =>
-  [
+export const getScheduledAndAdHocIndexPattern = (
+  spaceId: string,
+  adhocAttackDiscoveryDataClient?: IRuleDataClient
+): string => {
+  const adhocAlertsIndex = adhocAttackDiscoveryDataClient?.indexNameWithNamespace(spaceId);
+  return [
     `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-${spaceId}`, // scheduled
-    `${ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX}-ad-hoc-${spaceId}`, // ad-hoc
+    ...(adhocAlertsIndex ? [adhocAlertsIndex] : []), // ad-hoc
   ].join(',');
+};

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/index.ts
@@ -16,9 +16,9 @@ import {
   type GetAttackDiscoveryGenerationsResponse,
   type PostAttackDiscoveryGenerationsDismissResponse,
 } from '@kbn/elastic-assistant-common';
-import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';
 import { AuthenticatedUser } from '@kbn/core-security-common';
 import type { Logger } from '@kbn/core/server';
+import { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 
 import {
   AIAssistantDataClient,
@@ -30,7 +30,6 @@ import { findAttackDiscoveryByConnectorId } from './find_attack_discovery_by_con
 import { updateAttackDiscovery } from './update_attack_discovery/update_attack_discovery';
 import { createAttackDiscovery } from './create_attack_discovery/create_attack_discovery';
 import { createAttackDiscoveryAlerts } from './create_attack_discovery_alerts';
-import { getIndexTemplateAndPattern } from '../../data_stream/helpers';
 import { getAttackDiscovery } from './get_attack_discovery/get_attack_discovery';
 import { getAttackDiscoveryGenerations } from './get_attack_discovery_generations';
 import { getAttackDiscoveryGenerationByIdQuery } from './get_attack_discovery_generation_by_id_query';
@@ -39,7 +38,6 @@ import { getCombinedFilter } from './get_combined_filter';
 import { getFindAttackDiscoveryAlertsAggregation } from './get_find_attack_discovery_alerts_aggregation';
 import { AttackDiscoveryAlertDocument } from '../schedules/types';
 import { transformSearchResponseToAlerts } from './transforms/transform_search_response_to_alerts';
-import { IIndexPatternString } from '../../../types';
 import { getScheduledAndAdHocIndexPattern } from './get_scheduled_and_ad_hoc_index_pattern';
 import { getUpdateAttackDiscoveryAlertsQuery } from '../get_update_attack_discovery_alerts_query';
 
@@ -47,19 +45,16 @@ const FIRST_PAGE = 1; // CAUTION: sever-side API uses a 1-based page index conve
 const DEFAULT_PER_PAGE = 10;
 
 type AttackDiscoveryDataClientParams = AIAssistantDataClientParams & {
-  attackDiscoveryAlertsIndexPatternsResourceName: string;
+  adhocAttackDiscoveryDataClient: IRuleDataClient | undefined;
 };
 
 export class AttackDiscoveryDataClient extends AIAssistantDataClient {
-  private attackDiscoveryAlertsIndexTemplateAndPattern: IIndexPatternString;
+  private adhocAttackDiscoveryDataClient: IRuleDataClient | undefined;
 
   constructor(public readonly options: AttackDiscoveryDataClientParams) {
     super(options);
 
-    this.attackDiscoveryAlertsIndexTemplateAndPattern = getIndexTemplateAndPattern(
-      this.options.attackDiscoveryAlertsIndexPatternsResourceName,
-      this.options.spaceId ?? DEFAULT_NAMESPACE_STRING
-    );
+    this.adhocAttackDiscoveryDataClient = this.options.adhocAttackDiscoveryDataClient;
   }
 
   /**
@@ -118,13 +113,13 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
     authenticatedUser: AuthenticatedUser;
     createAttackDiscoveryAlertsParams: CreateAttackDiscoveryAlertsParams;
   }): Promise<AttackDiscoveryAlert[]> => {
-    const esClient = await this.options.elasticsearchClientPromise;
-
+    if (this.adhocAttackDiscoveryDataClient === undefined) {
+      throw new Error('`adhocAttackDiscoveryDataClient` is required');
+    }
     return createAttackDiscoveryAlerts({
-      attackDiscoveryAlertsIndex: this.attackDiscoveryAlertsIndexTemplateAndPattern.alias,
+      adhocAttackDiscoveryDataClient: this.adhocAttackDiscoveryDataClient,
       authenticatedUser,
       createAttackDiscoveryAlertsParams,
-      esClient,
       logger: this.options.logger,
       spaceId: this.spaceId,
     });
@@ -217,7 +212,7 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
     } = findAttackDiscoveryAlertsParams;
 
     const spaceId = this.spaceId;
-    const index = getScheduledAndAdHocIndexPattern(spaceId);
+    const index = getScheduledAndAdHocIndexPattern(spaceId, this.adhocAttackDiscoveryDataClient);
 
     const filter = combineFindAttackDiscoveryFilters({
       alertIds,
@@ -341,7 +336,10 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
 
     const esClient = await this.options.elasticsearchClientPromise;
 
-    const indexPattern = getScheduledAndAdHocIndexPattern(this.spaceId);
+    const indexPattern = getScheduledAndAdHocIndexPattern(
+      this.spaceId,
+      this.adhocAttackDiscoveryDataClient
+    );
 
     if (ids.length === 0) {
       logger.debug(

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/data_client/index.ts
@@ -10,6 +10,7 @@ import { RulesClient } from '@kbn/alerting-plugin/server';
 import { Logger } from '@kbn/core/server';
 import {
   ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_CONSUMER_ID,
   AttackDiscoverySchedule,
   AttackDiscoveryScheduleCreateProps,
   AttackDiscoveryScheduleParams,
@@ -80,7 +81,7 @@ export class AttackDiscoveryScheduleDataClient {
         actions,
         ...(systemActions.length ? { systemActions } : {}),
         alertTypeId: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
-        consumer: 'siem',
+        consumer: ATTACK_DISCOVERY_SCHEDULES_CONSUMER_ID,
         enabled,
         tags: [],
         ...restScheduleAttributes,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts
@@ -8,10 +8,15 @@
 import { PluginInitializerContext, CoreStart, Plugin, Logger } from '@kbn/core/server';
 
 import {
+  ATTACK_DISCOVERY_ALERTS_ENABLED_FEATURE_FLAG,
+  ATTACK_DISCOVERY_SCHEDULES_CONSUMER_ID,
   ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG,
   AssistantFeatures,
 } from '@kbn/elastic-assistant-common';
 import { ReplaySubject, type Subject } from 'rxjs';
+import { ECS_COMPONENT_TEMPLATE_NAME } from '@kbn/alerting-plugin/server';
+import { Dataset, IRuleDataClient, IndexOptions } from '@kbn/rule-registry-plugin/server';
+import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
 import { events } from './lib/telemetry/event_based_telemetry';
 import {
   AssistantTool,
@@ -32,6 +37,8 @@ import { appContextService } from './services/app_context';
 import { removeLegacyQuickPrompt } from './ai_assistant_service/helpers';
 import { getAttackDiscoveryScheduleType } from './lib/attack_discovery/schedules/register_schedule/definition';
 import type { ConfigSchema } from './config_schema';
+import { attackDiscoveryAlertFieldMap } from './lib/attack_discovery/schedules/fields';
+import { ATTACK_DISCOVERY_ALERTS_CONTEXT } from './lib/attack_discovery/schedules/constants';
 
 export class ElasticAssistantPlugin
   implements
@@ -80,7 +87,6 @@ export class ElasticAssistantPlugin
         .getStartServices()
         .then(([_, { productDocBase }]) => productDocBase.management),
       pluginStop$: this.pluginStop$,
-      savedAttackDiscoveries: true,
     });
 
     const requestContextFactory = new RequestContextFactory({
@@ -116,8 +122,9 @@ export class ElasticAssistantPlugin
         // read all feature flags:
         void Promise.all([
           featureFlags.getBooleanValue(ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG, false),
+          featureFlags.getBooleanValue(ATTACK_DISCOVERY_ALERTS_ENABLED_FEATURE_FLAG, false),
           // add more feature flags here
-        ]).then(([assistantAttackDiscoverySchedulingEnabled]) => {
+        ]).then(([assistantAttackDiscoverySchedulingEnabled, attackDiscoveryAlertsEnabled]) => {
           if (assistantAttackDiscoverySchedulingEnabled) {
             // Register Attack Discovery Schedule type
             plugins.alerting.registerType(
@@ -128,6 +135,28 @@ export class ElasticAssistantPlugin
               })
             );
           }
+          let adhocAttackDiscoveryDataClient: IRuleDataClient | undefined;
+          if (attackDiscoveryAlertsEnabled) {
+            // Initialize index for ad-hoc generated attack discoveries
+            const { ruleDataService } = plugins.ruleRegistry;
+
+            const ruleDataServiceOptions: IndexOptions = {
+              feature: ATTACK_DISCOVERY_SCHEDULES_CONSUMER_ID,
+              registrationContext: ATTACK_DISCOVERY_ALERTS_CONTEXT,
+              dataset: Dataset.alerts,
+              additionalPrefix: '.adhoc',
+              componentTemplateRefs: [ECS_COMPONENT_TEMPLATE_NAME],
+              componentTemplates: [
+                {
+                  name: 'mappings',
+                  mappings: mappingFromFieldMap(attackDiscoveryAlertFieldMap),
+                },
+              ],
+            };
+            adhocAttackDiscoveryDataClient =
+              ruleDataService.initializeIndex(ruleDataServiceOptions);
+          }
+          requestContextFactory.setup(adhocAttackDiscoveryDataClient);
         });
       })
       .catch((error) => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/request_context_factory.ts
@@ -10,6 +10,7 @@ import { memoize } from 'lodash';
 import type { Logger, KibanaRequest, RequestHandlerContext } from '@kbn/core/server';
 import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';
 import type { IEventLogger } from '@kbn/event-log-plugin/server';
+import { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import {
   ElasticAssistantApiRequestHandlerContext,
   ElasticAssistantPluginCoreSetupDependencies,
@@ -20,6 +21,7 @@ import { AIAssistantService } from '../ai_assistant_service';
 import { appContextService } from '../services/app_context';
 
 export interface IRequestContextFactory {
+  setup(adhocAttackDiscoveryDataClient: IRuleDataClient | undefined): void;
   create(
     context: RequestHandlerContext,
     request: KibanaRequest,
@@ -39,10 +41,15 @@ interface ConstructorOptions {
 export class RequestContextFactory implements IRequestContextFactory {
   private readonly logger: Logger;
   private readonly assistantService: AIAssistantService;
+  private adhocAttackDiscoveryDataClient: IRuleDataClient | undefined;
 
   constructor(private readonly options: ConstructorOptions) {
     this.logger = options.logger;
     this.assistantService = options.assistantService;
+  }
+
+  public setup(adhocAttackDiscoveryDataClient: IRuleDataClient | undefined) {
+    this.adhocAttackDiscoveryDataClient = adhocAttackDiscoveryDataClient;
   }
 
   public async create(
@@ -147,6 +154,7 @@ export class RequestContextFactory implements IRequestContextFactory {
           licensing: context.licensing,
           logger: this.logger,
           currentUser,
+          adhocAttackDiscoveryDataClient: this.adhocAttackDiscoveryDataClient,
         });
       }),
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
@@ -52,6 +52,7 @@ import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import { ProductDocBaseStartContract } from '@kbn/product-doc-base-plugin/server';
 import { AlertingServerSetup, AlertingServerStart } from '@kbn/alerting-plugin/server';
 import type { IEventLogger, IEventLogService } from '@kbn/event-log-plugin/server';
+import type { RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
 import type { GetAIAssistantKnowledgeBaseDataClientParams } from './ai_assistant_data_clients/knowledge_base';
 import { AttackDiscoveryDataClient } from './lib/attack_discovery/persistence';
 import {
@@ -118,6 +119,7 @@ export interface ElasticAssistantPluginSetupDependencies {
   alerting: AlertingServerSetup;
   eventLog: IEventLogService; // for writing to the event log
   ml: MlPluginSetup;
+  ruleRegistry: RuleRegistryPluginSetupContract;
   taskManager: TaskManagerSetupContract;
   spaces?: SpacesPluginSetup;
 }
@@ -185,7 +187,6 @@ export interface AssistantResourceNames {
     prompts: string;
     anonymizationFields: string;
     attackDiscovery: string;
-    attackDiscoveryAlerts: string;
     defendInsights: string;
   };
   indexTemplate: {
@@ -195,7 +196,6 @@ export interface AssistantResourceNames {
     prompts: string;
     anonymizationFields: string;
     attackDiscovery: string;
-    attackDiscoveryAlerts: string;
     defendInsights: string;
   };
   aliases: {
@@ -205,7 +205,6 @@ export interface AssistantResourceNames {
     prompts: string;
     anonymizationFields: string;
     attackDiscovery: string;
-    attackDiscoveryAlerts: string;
     defendInsights: string;
   };
   indexPatterns: {
@@ -215,7 +214,6 @@ export interface AssistantResourceNames {
     prompts: string;
     anonymizationFields: string;
     attackDiscovery: string;
-    attackDiscoveryAlerts: string;
     defendInsights: string;
   };
   pipelines: {

--- a/x-pack/solutions/security/plugins/elastic_assistant/tsconfig.json
+++ b/x-pack/solutions/security/plugins/elastic_assistant/tsconfig.json
@@ -63,6 +63,7 @@
     "@kbn/rule-data-utils",
     "@kbn/alerting-types",
     "@kbn/zod-helpers",
+    "@kbn/rule-registry-plugin"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/signals/query_signals_route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/signals/query_signals_route.test.ts
@@ -25,7 +25,7 @@ describe('query for signal', () => {
   context.core.elasticsearch.client.asCurrentUser.search.mockResolvedValue(
     elasticsearchClientMock.createSuccessTransportRequestPromise(getEmptySignalsResponse())
   );
-  const ruleDataClient = ruleRegistryMocks.createRuleDataClient('.alerts-security.alerts-');
+  const ruleDataClient = ruleRegistryMocks.createRuleDataClient('.alerts-security.alerts');
 
   beforeEach(() => {
     server = serverMock.create();

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
@@ -122,7 +122,7 @@ describe('buildRiskScoreQuery search strategy', () => {
   test('should search alerts on the alerts index pattern', async () => {
     await riskScore.parse(mockOptions, mockSearchStrategyResponse, mockDeps);
 
-    expect(searchMock.mock.calls[0][0].index).toEqual(`${ALERT_INDEX_PATTERN}${TEST_SPACE_ID}`);
+    expect(searchMock.mock.calls[0][0].index).toEqual(`${ALERT_INDEX_PATTERN}-${TEST_SPACE_ID}`);
   });
 
   test('should enhance data with alerts count', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Attack Discovery][Scheduling] Add a `adhoc` alerts index for the manually generated attack discoveries (#12484) (#222584)](https://github.com/elastic/kibana/pull/222584)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2025-06-11T22:58:37Z","message":"[Attack Discovery][Scheduling] Add a `adhoc` alerts index for the manually generated attack discoveries (#12484) (#222584)\n\n## Summary\n\nMain ticket ([Internal\nlink](https://github.com/elastic/security-team/issues/12484))\n\nWith these changes we switch from temporarily (while behind the feature\nflag) used data stream `.alerts-security.attack.discovery.alerts-ad-hoc`\nto a one created and setup by Alerting Framework\n`.adhoc.alerts-security.attack.discovery.alerts`. This index used to\nstore \"ad-hoc\" attack discovery alerts generated by user manually and\ninitially visible only to that user with the option to share those\nalerts to other people in the same organization.\n\nThere should be no visual changes, only the underlying index changed for\nthe manually generated attack discovery alerts.\n\n**To test**:\n1. Generate attack discovery via \"Generate\" button on Attack Discovery\npage\n2. Check generated alerts within the\n`.adhoc.alerts-security.attack.discovery.alerts*` index\n\n```\nGET .adhoc.alerts-security.attack.discovery.alerts*/_search\n```\n\n## NOTES\n\nThe feature is hidden behind the feature flag (in `kibana.dev.yml`):\n\n```\nfeature_flags.overrides:\n  securitySolution.attackDiscoveryAlertsEnabled: true\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2c5d5a49d744cb0d4f8b5bd7580dc89ebfb9f64e","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Team:Security Generative AI","backport:version","v9.1.0","v8.19.0"],"title":"[Attack Discovery][Scheduling] Add a `adhoc` alerts index for the manually generated attack discoveries (#12484)","number":222584,"url":"https://github.com/elastic/kibana/pull/222584","mergeCommit":{"message":"[Attack Discovery][Scheduling] Add a `adhoc` alerts index for the manually generated attack discoveries (#12484) (#222584)\n\n## Summary\n\nMain ticket ([Internal\nlink](https://github.com/elastic/security-team/issues/12484))\n\nWith these changes we switch from temporarily (while behind the feature\nflag) used data stream `.alerts-security.attack.discovery.alerts-ad-hoc`\nto a one created and setup by Alerting Framework\n`.adhoc.alerts-security.attack.discovery.alerts`. This index used to\nstore \"ad-hoc\" attack discovery alerts generated by user manually and\ninitially visible only to that user with the option to share those\nalerts to other people in the same organization.\n\nThere should be no visual changes, only the underlying index changed for\nthe manually generated attack discovery alerts.\n\n**To test**:\n1. Generate attack discovery via \"Generate\" button on Attack Discovery\npage\n2. Check generated alerts within the\n`.adhoc.alerts-security.attack.discovery.alerts*` index\n\n```\nGET .adhoc.alerts-security.attack.discovery.alerts*/_search\n```\n\n## NOTES\n\nThe feature is hidden behind the feature flag (in `kibana.dev.yml`):\n\n```\nfeature_flags.overrides:\n  securitySolution.attackDiscoveryAlertsEnabled: true\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2c5d5a49d744cb0d4f8b5bd7580dc89ebfb9f64e"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222584","number":222584,"mergeCommit":{"message":"[Attack Discovery][Scheduling] Add a `adhoc` alerts index for the manually generated attack discoveries (#12484) (#222584)\n\n## Summary\n\nMain ticket ([Internal\nlink](https://github.com/elastic/security-team/issues/12484))\n\nWith these changes we switch from temporarily (while behind the feature\nflag) used data stream `.alerts-security.attack.discovery.alerts-ad-hoc`\nto a one created and setup by Alerting Framework\n`.adhoc.alerts-security.attack.discovery.alerts`. This index used to\nstore \"ad-hoc\" attack discovery alerts generated by user manually and\ninitially visible only to that user with the option to share those\nalerts to other people in the same organization.\n\nThere should be no visual changes, only the underlying index changed for\nthe manually generated attack discovery alerts.\n\n**To test**:\n1. Generate attack discovery via \"Generate\" button on Attack Discovery\npage\n2. Check generated alerts within the\n`.adhoc.alerts-security.attack.discovery.alerts*` index\n\n```\nGET .adhoc.alerts-security.attack.discovery.alerts*/_search\n```\n\n## NOTES\n\nThe feature is hidden behind the feature flag (in `kibana.dev.yml`):\n\n```\nfeature_flags.overrides:\n  securitySolution.attackDiscoveryAlertsEnabled: true\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2c5d5a49d744cb0d4f8b5bd7580dc89ebfb9f64e"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->