### PR TITLE
[ES|QL][Extensions registry] Preparation for new extensions

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -521,10 +521,12 @@ export const ESQLEditor = memo(function ESQLEditor({
             (await kibana.services?.esql?.getEditorExtensionsAutocomplete(
               queryString,
               activeSolutionId
-            )) ?? []
+            )) ?? { recommendedQueries: [] }
           );
         }
-        return [];
+        return {
+          recommendedQueries: [],
+        };
       },
       getInferenceEndpoints: kibana.services?.esql?.getInferenceEndpointsAutocomplete,
     };

--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -108,7 +108,7 @@ export interface EsqlPluginStartBase {
   getEditorExtensionsAutocomplete: (
     queryString: string,
     activeSolutionId: string
-  ) => Promise<RecommendedQuery[]>;
+  ) => Promise<{ recommendedQueries: RecommendedQuery[] }>;
   variablesService: ESQLVariableService;
   getLicense: () => Promise<ILicense | undefined>;
   getInferenceEndpointsAutocomplete: () => Promise<InferenceEndpointsAutocompleteResult>;

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
@@ -98,12 +98,14 @@ export const timeseriesIndices: IndexAutocompleteItem[] = [
   },
 ];
 
-export const editorExtensions = [
-  {
-    name: 'Logs Count by Host',
-    query: 'from logs* | STATS count(*) by host',
-  },
-];
+export const editorExtensions = {
+  recommendedQueries: [
+    {
+      name: 'Logs Count by Host',
+      query: 'from logs* | STATS count(*) by host',
+    },
+  ],
+};
 
 export const inferenceEndpoints: InferenceEndpointAutocompleteItem[] = [
   {
@@ -146,9 +148,11 @@ export function getCallbackMocks(): ESQLCallbacks {
     getTimeseriesIndices: jest.fn(async () => ({ indices: timeseriesIndices })),
     getEditorExtensions: jest.fn(async (queryString: string) => {
       if (queryString.includes('logs*')) {
-        return editorExtensions;
+        return {
+          recommendedQueries: editorExtensions.recommendedQueries,
+        };
       }
-      return [];
+      return { recommendedQueries: [] };
     }),
     getInferenceEndpoints: jest.fn(async (taskType: InferenceTaskType) => ({ inferenceEndpoints })),
   };

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -311,9 +311,11 @@ export function createCustomCallbackMocks(
     getTimeseriesIndices: jest.fn(async () => ({ indices: timeseriesIndices })),
     getEditorExtensions: jest.fn(async (queryString: string) => {
       if (queryString.includes('logs*')) {
-        return editorExtensions;
+        return {
+          recommendedQueries: editorExtensions.recommendedQueries,
+        };
       }
-      return [];
+      return { recommendedQueries: [] };
     }),
     getInferenceEndpoints: jest.fn(async () => ({ inferenceEndpoints })),
   };

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -95,7 +95,7 @@ describe('autocomplete', () => {
     );
     testSuggestions('/', [
       ...sourceCommands.map((name) => name.toUpperCase() + ' '),
-      ...mapRecommendedQueriesFromExtensions(editorExtensions),
+      ...mapRecommendedQueriesFromExtensions(editorExtensions.recommendedQueries),
       ...recommendedQuerySuggestions.map((q) => q.queryString),
     ]);
     const commands = commandDefinitions
@@ -255,7 +255,7 @@ describe('autocomplete', () => {
     );
     testSuggestions('f/', [
       ...sourceCommands.map((cmd) => `${cmd.toUpperCase()} `),
-      ...mapRecommendedQueriesFromExtensions(editorExtensions),
+      ...mapRecommendedQueriesFromExtensions(editorExtensions.recommendedQueries),
       ...recommendedQuerySuggestions.map((q) => q.queryString),
     ]);
 
@@ -482,7 +482,7 @@ describe('autocomplete', () => {
     // Source command
     testSuggestions('F/', [
       ...['FROM ', 'ROW ', 'SHOW '].map(attachTriggerCommand),
-      ...mapRecommendedQueriesFromExtensions(editorExtensions),
+      ...mapRecommendedQueriesFromExtensions(editorExtensions.recommendedQueries),
       ...recommendedQuerySuggestions.map((q) => q.queryString),
     ]);
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -142,10 +142,12 @@ export async function suggest(
           resourceRetriever,
           innerText
         );
-        const editorExtensions =
-          (await resourceRetriever?.getEditorExtensions?.(fromCommand)) ?? [];
-        const recommendedQueriesSuggestionsFromExtensions =
-          mapRecommendedQueriesFromExtensions(editorExtensions);
+        const editorExtensions = (await resourceRetriever?.getEditorExtensions?.(fromCommand)) ?? {
+          recommendedQueries: [],
+        };
+        const recommendedQueriesSuggestionsFromExtensions = mapRecommendedQueriesFromExtensions(
+          editorExtensions.recommendedQueries
+        );
 
         const recommendedQueriesSuggestionsFromStaticTemplates =
           await getRecommendedQueriesSuggestionsFromStaticTemplates(
@@ -354,9 +356,12 @@ async function getSuggestionsWithinCommandExpression(
 
   // Function returning suggestions from static templates and editor extensions
   const getRecommendedQueries = async (queryString: string, prefix: string = '') => {
-    const editorExtensions = (await callbacks?.getEditorExtensions?.(queryString)) ?? [];
-    const recommendedQueriesFromExtensions =
-      getRecommendedQueriesTemplatesFromExtensions(editorExtensions);
+    const editorExtensions = (await callbacks?.getEditorExtensions?.(queryString)) ?? {
+      recommendedQueries: [],
+    };
+    const recommendedQueriesFromExtensions = getRecommendedQueriesTemplatesFromExtensions(
+      editorExtensions.recommendedQueries
+    );
 
     const recommendedQueriesFromTemplates =
       await getRecommendedQueriesSuggestionsFromStaticTemplates(getColumnsByType, prefix);

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
@@ -51,7 +51,9 @@ export interface ESQLCallbacks {
   canSuggestVariables?: () => boolean;
   getJoinIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
   getTimeseriesIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
-  getEditorExtensions?: (queryString: string) => Promise<RecommendedQuery[]>;
+  getEditorExtensions?: (
+    queryString: string
+  ) => Promise<{ recommendedQueries: RecommendedQuery[] }>;
   getInferenceEndpoints?: (
     taskType: InferenceTaskType
   ) => Promise<InferenceEndpointsAutocompleteResult>;

--- a/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
@@ -86,7 +86,6 @@ export const registerESQLExtensionsRoute = (
 
         // Validate solutionId
         const validSolutionId = isSolutionId(solutionId) ? solutionId : 'oblt'; // No solutionId provided, or invalid
-        // return the recommended queries for now, we will add more extensions later
         const recommendedQueries = extensionsRegistry.getRecommendedQueries(
           query,
           sources,

--- a/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
@@ -93,7 +93,9 @@ export const registerESQLExtensionsRoute = (
           validSolutionId
         );
         return response.ok({
-          body: recommendedQueries,
+          body: {
+            recommendedQueries,
+          },
         });
       } catch (error) {
         logger.get().debug(error);


### PR DESCRIPTION
## Summary

Prepares the registry for more extensions.

In the MVP we were immediately returning the recommended queries. This PR changes the response to from an aray of queries to an object with recommended queries as a property. This will allow us to add more extensions points in the future (such as recommended fields)

**Note**: No changes have been introduced to the api

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->