### PR TITLE
chore: update @elastic/eslint-plugin-eui to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1405,7 +1405,7 @@
     "@cypress/debugging-proxy": "2.0.1",
     "@cypress/grep": "^4.0.1",
     "@cypress/webpack-preprocessor": "^6.0.2",
-    "@elastic/eslint-plugin-eui": "1.0.0",
+    "@elastic/eslint-plugin-eui": "2.0.0",
     "@elastic/makelogs": "^6.1.1",
     "@elastic/synthetics": "^1.18.0",
     "@emotion/babel-preset-css-prop": "^11.11.0",

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_bar_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_bar_chart.tsx
@@ -73,7 +73,6 @@ export const AssetInventoryBarChart = ({
   const baseTheme = useElasticChartsTheme();
   return (
     <div css={getChartStyles(euiTheme, xsFontSize)}>
-      {/* eslint-disable-next-line @elastic/eui/prefer-css-prop-for-static-styles */}
       <EuiProgress size="xs" color="accent" style={getProgressStyle(isFetching)} />
       {isLoading ? (
         <EuiFlexGroup

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,10 +2164,10 @@
     semver "^7.6.3"
     topojson-client "^3.1.0"
 
-"@elastic/eslint-plugin-eui@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-1.0.0.tgz#2db728692ab1f13e08826a65c2adb180c3962195"
-  integrity sha512-2CZ8w5+vJgruqWm5XEA1KENX+ZYAjMfkRyJtXafq4/jXIFLYCWqqAAWmVgrbY+DufLr405Zf8718L7Rp39TMEg==
+"@elastic/eslint-plugin-eui@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-2.0.0.tgz#dba9f302c3a611440c88d7c34371a86e6f2285ae"
+  integrity sha512-AIhCyMfRNz80CdKZEllVW4VgqfXQgv3wE875lt228MAmwd3tAwNh0mROp8++kWb0WJoLAYW4vypw873AMWqyEw==
 
 "@elastic/eui-amsterdam@npm:@elastic/eui@102.3.0-amsterdam.0":
   version "102.3.0-amsterdam.0"


### PR DESCRIPTION
`@elastic/eslint-plugin-eui`: `1.0.0` ⏩ `2.0.0`

[Questions? Please see our Kibana upgrade FAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)

## Changes

This PR updates the `@elastic/eslint-plugin-eui` version to latest: [v2.0.0](https://www.npmjs.com/package/@elastic/eslint-plugin-eui/v/2.0.0).

## Package updates



### `@elastic/eslint-plugin-eui`

**Breaking changes**

- Remove `prefer-css-prop-for-static-styles` rule because it produces too many warnings. Static code analysis cannot flag dynamic styles with confidence because it doesn't run the code to asses runtime values. We will explore runtime solutions. ([#8760](https://github.com/elastic/eui/pull/8760))
