### PR TITLE
[8.19] Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n` (#218371)

### DIFF
--- a/src/platform/packages/shared/kbn-test-jest-helpers/src/testing_library_react_helpers.tsx
+++ b/src/platform/packages/shared/kbn-test-jest-helpers/src/testing_library_react_helpers.tsx
@@ -22,7 +22,7 @@ export const renderWithKibanaRenderContext = (...args: Parameters<typeof render>
   );
 };
 
-export const renderReactTestingLibraryWithI18n = (...args: Parameters<typeof render>) => {
+export const renderWithI18n = (...args: Parameters<typeof render>) => {
   const [ui, ...remainingRenderArgs] = args;
   // Avoid using { wrapper: I18nProvider } in case the caller adds a custom wrapper.
   return render(<I18nProvider>{ui}</I18nProvider>, ...remainingRenderArgs);

--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/create_transform_button/create_transform_button.test.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/create_transform_button/create_transform_button.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { renderReactTestingLibraryWithI18n } from '@kbn/test-jest-helpers';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { CreateTransformButton } from './create_transform_button';
@@ -16,7 +16,7 @@ const queryClient = new QueryClient();
 
 describe('Transform: Transform List <CreateTransformButton />', () => {
   test('Minimal initialization', () => {
-    const { container } = renderReactTestingLibraryWithI18n(
+    const { container } = renderWithI18n(
       <QueryClientProvider client={queryClient}>
         <CreateTransformButton onClick={jest.fn()} transformNodes={1} />
       </QueryClientProvider>

--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/expanded_row.test.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/expanded_row.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import { renderReactTestingLibraryWithI18n } from '@kbn/test-jest-helpers';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import moment from 'moment-timezone';
@@ -34,7 +34,7 @@ describe('Transform: Transform List <ExpandedRow />', () => {
     // @ts-expect-error mock data is too loosely typed
     const item: TransformListRow = transformListRow;
 
-    renderReactTestingLibraryWithI18n(
+    renderWithI18n(
       <QueryClientProvider client={queryClient}>
         <ExpandedRow item={item} onAlertEdit={onAlertEdit} />
       </QueryClientProvider>

--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/transform_management_section.test.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/transform_management_section.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { renderReactTestingLibraryWithI18n } from '@kbn/test-jest-helpers';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { TransformManagementSection } from './transform_management_section';
@@ -17,7 +17,7 @@ const queryClient = new QueryClient();
 
 describe('Transform: <TransformManagementSection />', () => {
   test('Minimal initialization', () => {
-    const { container } = renderReactTestingLibraryWithI18n(
+    const { container } = renderWithI18n(
       <QueryClientProvider client={queryClient}>
         <TransformManagementSection />
       </QueryClientProvider>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details_json_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details_json_flyout.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { renderReactTestingLibraryWithI18n } from '@kbn/test-jest-helpers';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+
 import type { Agent } from '../../../../types';
 import { useStartServices } from '../../../../hooks';
 
@@ -34,9 +35,7 @@ describe('AgentDetailsJsonFlyout', () => {
   });
 
   const renderComponent = () => {
-    return renderReactTestingLibraryWithI18n(
-      <AgentDetailsJsonFlyout agent={agent} onClose={jest.fn()} />
-    );
+    return renderWithI18n(<AgentDetailsJsonFlyout agent={agent} onClose={jest.fn()} />);
   };
 
   it('renders a title with the agent id if host name is not defined', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { renderReactTestingLibraryWithI18n } from '@kbn/test-jest-helpers';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 
 import { useUpdateTags } from '../hooks';
 
@@ -32,7 +32,7 @@ describe('TagOptions', () => {
   });
 
   const renderComponent = () => {
-    return renderReactTestingLibraryWithI18n(
+    return renderWithI18n(
       <div>
         <TagOptions tagName={'agent'} isTagHovered={isTagHovered} onTagsUpdated={onTagsUpdated} />
       </div>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { renderReactTestingLibraryWithI18n } from '@kbn/test-jest-helpers';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 
 import { SecretFormRow } from './output_form_secret_form_row';
 
@@ -20,7 +20,7 @@ describe('SecretFormRow', () => {
   const useSecretsStorage = true;
 
   it('should switch to edit mode when the replace button is clicked', () => {
-    const { getByText, queryByText, container } = renderReactTestingLibraryWithI18n(
+    const { getByText, queryByText, container } = renderWithI18n(
       <SecretFormRow
         title={title}
         initialValue={initialValue}
@@ -44,7 +44,7 @@ describe('SecretFormRow', () => {
   });
 
   it('should not enable action links if the row is disabled', () => {
-    const { getByText, queryByText } = renderReactTestingLibraryWithI18n(
+    const { getByText, queryByText } = renderWithI18n(
       <SecretFormRow
         title={title}
         initialValue={initialValue}
@@ -65,7 +65,7 @@ describe('SecretFormRow', () => {
   });
 
   it('should call the cancelEdit function when the cancel button is clicked', () => {
-    const { getByText } = renderReactTestingLibraryWithI18n(
+    const { getByText } = renderWithI18n(
       <SecretFormRow
         title={title}
         initialValue={initialValue}
@@ -103,7 +103,7 @@ describe('SecretFormRow', () => {
   });
 
   it('should not display the cancel change button when no initial value is provided', () => {
-    const { queryByTestId } = renderReactTestingLibraryWithI18n(
+    const { queryByTestId } = renderWithI18n(
       <SecretFormRow
         title={title}
         clear={clear}
@@ -120,7 +120,7 @@ describe('SecretFormRow', () => {
   });
 
   it('should call the onToggleSecretStorage function when the use secret storage button is clicked in plain text mode', () => {
-    const { getByText, queryByTestId } = renderReactTestingLibraryWithI18n(
+    const { getByText, queryByTestId } = renderWithI18n(
       <SecretFormRow
         label={<div>Test Field</div>}
         useSecretsStorage={false}
@@ -139,7 +139,7 @@ describe('SecretFormRow', () => {
   });
 
   it('should display input normally and display a callout when the field is converted to secret storage', () => {
-    const { getByText, queryByText } = renderReactTestingLibraryWithI18n(
+    const { getByText, queryByText } = renderWithI18n(
       <SecretFormRow
         title={title}
         initialValue={initialValue}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
@@ -85,7 +85,7 @@ describe('SecretFormRow', () => {
   });
 
   it('should call the onToggleSecretStorage function when the revert link is clicked', () => {
-    const { getByText } = renderReactTestingLibraryWithI18n(
+    const { getByText } = renderWithI18n(
       <SecretFormRow
         title={title}
         clear={clear}

--- a/x-pack/solutions/observability/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/view_in_apm_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/view_in_apm_button.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { renderReactTestingLibraryWithI18n as render } from '@kbn/test-jest-helpers';
+import { renderWithI18n as render } from '@kbn/test-jest-helpers';
 
 import { ViewInAPMButton } from './view_in_apm_button';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/host_isolation_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/host_isolation_panel.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { renderReactTestingLibraryWithI18n as render } from '@kbn/test-jest-helpers';
+import { renderWithI18n as render } from '@kbn/test-jest-helpers';
 import { HostIsolationPanel } from '.';
 import { useKibana as mockUseKibana } from '../../../../lib/kibana/__mocks__';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/renderer.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { renderReactTestingLibraryWithI18n as render } from '@kbn/test-jest-helpers';
+import { renderWithI18n as render } from '@kbn/test-jest-helpers';
 import { removeExternalLinkText } from '@kbn/securitysolution-io-ts-utils';
 import { TestProviders } from '../../mock';
 import { MarkdownRenderer } from './renderer';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/callout.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { EndpointActionCallout } from './callout';
-import { renderReactTestingLibraryWithI18n as render } from '@kbn/test-jest-helpers';
+import { renderWithI18n as render } from '@kbn/test-jest-helpers';
 import { useFormData } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 jest.mock('@kbn/es-ui-shared-plugin/static/forms/hook_form_lib');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/header.test.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 
-import { renderReactTestingLibraryWithI18n as render } from '@kbn/test-jest-helpers';
+import { renderWithI18n as render } from '@kbn/test-jest-helpers';
 
 import { PanelHeader } from './header';
 import { allThreeTabs } from './hooks/use_tabs';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n` (#218371)](https://github.com/elastic/kibana/pull/218371)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christiane (Tina) Heiligers","email":"christiane.heiligers@elastic.co"},"sourceCommit":{"committedDate":"2025-04-21T07:21:59Z","message":"Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n` (#218371)\n\n## Summary\n\nThis PR only renames the helper, no test implementations were changed.\n\nWhy now?\n\nMigrating tests from Enzyme to RTL means that all usage of\n`mountWithIntl` has to change and will likely be replaced by the helper\nthat wraps RTL render with I18n. [A shorter name improves devEx](url).\n\nATM, consumption is limited to a few tests, reducing the number of\ncodeowner reviews required.\n\n### Identify risks\n\n- [x] In progress work and open PRs might fail. Updating from main will\nprompt an undefined function that will need to be renamed.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1fe09dcff4ec20ff877e17a181ed77c28e3e05d1","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","Team:Fleet","backport:prev-minor","Team:obs-ux-infra_services","v9.1.0","v9.0.1"],"title":"Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n`","number":218371,"url":"https://github.com/elastic/kibana/pull/218371","mergeCommit":{"message":"Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n` (#218371)\n\n## Summary\n\nThis PR only renames the helper, no test implementations were changed.\n\nWhy now?\n\nMigrating tests from Enzyme to RTL means that all usage of\n`mountWithIntl` has to change and will likely be replaced by the helper\nthat wraps RTL render with I18n. [A shorter name improves devEx](url).\n\nATM, consumption is limited to a few tests, reducing the number of\ncodeowner reviews required.\n\n### Identify risks\n\n- [x] In progress work and open PRs might fail. Updating from main will\nprompt an undefined function that will need to be renamed.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1fe09dcff4ec20ff877e17a181ed77c28e3e05d1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218371","number":218371,"mergeCommit":{"message":"Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n` (#218371)\n\n## Summary\n\nThis PR only renames the helper, no test implementations were changed.\n\nWhy now?\n\nMigrating tests from Enzyme to RTL means that all usage of\n`mountWithIntl` has to change and will likely be replaced by the helper\nthat wraps RTL render with I18n. [A shorter name improves devEx](url).\n\nATM, consumption is limited to a few tests, reducing the number of\ncodeowner reviews required.\n\n### Identify risks\n\n- [x] In progress work and open PRs might fail. Updating from main will\nprompt an undefined function that will need to be renamed.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1fe09dcff4ec20ff877e17a181ed77c28e3e05d1"}},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/218714","number":218714,"state":"MERGED","mergeCommit":{"sha":"2af22f2f0422d3038caa56dcc154b8db20eb6554","message":"[9.0] Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n` (#218371) (#218714)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [Renames`renderReactTestingLibraryWithI18n` to `renderWithI18n`\n(#218371)](https://github.com/elastic/kibana/pull/218371)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: Christiane (Tina) Heiligers <christiane.heiligers@elastic.co>"}}]}] BACKPORT-->