### PR TITLE
[Streams] Add the EIS pricing transparency callout in streams

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
@@ -383,7 +383,7 @@ export function ChatBody({
   const { conversationCalloutDismissed, tourCalloutDismissed } = useElasticLlmCalloutsStatus(false);
 
   const showElasticLlmCalloutInChat =
-    elasticManagedLlm &&
+    !!elasticManagedLlm &&
     connectors.selectedConnector === elasticManagedLlm.id &&
     !conversationCalloutDismissed &&
     tourCalloutDismissed;

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/utils/get_elastic_managed_llm_connector.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/utils/get_elastic_managed_llm_connector.ts
@@ -13,13 +13,13 @@ export const getElasticManagedLlmConnector = (
   connectors: UseGenAIConnectorsResult['connectors'] | undefined
 ) => {
   if (!Array.isArray(connectors) || connectors.length === 0) {
-    return false;
+    return undefined;
   }
 
-  return connectors.filter(
+  return connectors.find(
     (connector) =>
       connector.actionTypeId === INFERENCE_CONNECTOR_ACTION_TYPE_ID &&
       connector.isPreconfigured &&
       connector.config?.provider === 'elastic'
-  )[0];
+  );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/generate_pattern_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/generate_pattern_button.tsx
@@ -158,7 +158,7 @@ export const AdditionalChargesCallout = ({ aiFeatures }: AdditionalChargesCallou
     <EuiCallOut onDismiss={() => aiFeatures.acknowledgeAdditionalCharges(true)}>
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processorFlyout.managedConnectorTooltip"
-        defaultMessage="Elastic LLM is the new default for generating patterns and incurs <costLink>additional charges</costLink>. Other LLM connectors remain available. <learnMoreLink>Learn more</learnMoreLink>"
+        defaultMessage="Elastic Managed LLM is the new default for generating patterns and incurs <costLink>additional charges</costLink>. Other LLM connectors remain available. <learnMoreLink>Learn more</learnMoreLink>"
         values={{
           costLink: (...chunks: React.ReactNode[]) => (
             <EuiLink

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/generate_pattern_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/generate_pattern_button.tsx
@@ -21,6 +21,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useBoolean } from '@kbn/react-hooks';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { AIFeatures } from './use_ai_features';
 import { useKibana } from '../../../../../hooks/use_kibana';
 
@@ -140,17 +141,47 @@ export const GeneratePatternButton = ({
             </EuiFlexItem>
           )}
       </EuiFlexGroup>
-      {aiFeatures.isManagedAIConnector && !aiFeatures.hasAcknowledgedAdditionalCharges && (
-        <EuiCallOut onDismiss={() => aiFeatures.acknowledgeAdditionalCharges(true)}>
-          {i18n.translate(
-            'xpack.streams.streamDetailView.managementTab.enrichment.processorFlyout.managedConnectorTooltip',
-            {
-              defaultMessage:
-                'Generating patterns is powered by a preconfigured LLM. Additional charges apply',
-            }
-          )}
-        </EuiCallOut>
-      )}
     </>
+  );
+};
+
+export interface AdditionalChargesCalloutProps {
+  aiFeatures: AIFeatures;
+}
+
+export const AdditionalChargesCallout = ({ aiFeatures }: AdditionalChargesCalloutProps) => {
+  const {
+    core: { docLinks },
+  } = useKibana();
+
+  return (
+    <EuiCallOut onDismiss={() => aiFeatures.acknowledgeAdditionalCharges(true)}>
+      <FormattedMessage
+        id="xpack.streams.streamDetailView.managementTab.enrichment.processorFlyout.managedConnectorTooltip"
+        defaultMessage="Elastic LLM is the new default for generating patterns and incurs <costLink>additional charges</costLink>. Other LLM connectors remain available. <learnMoreLink>Learn more</learnMoreLink>"
+        values={{
+          costLink: (...chunks: React.ReactNode[]) => (
+            <EuiLink
+              href={docLinks?.links?.observability?.elasticManagedLlmUsageCost}
+              target="_blank"
+              rel="noopener noreferrer"
+              external
+            >
+              {chunks}
+            </EuiLink>
+          ),
+          learnMoreLink: (...chunks: React.ReactNode[]) => (
+            <EuiLink
+              href={docLinks?.links?.observability?.elasticManagedLlm}
+              target="_blank"
+              rel="noopener noreferrer"
+              external
+            >
+              {chunks}
+            </EuiLink>
+          ),
+        }}
+      />
+    </EuiCallOut>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_patterns_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_patterns_editor.tsx
@@ -27,6 +27,7 @@ import {
   EuiIcon,
   EuiButtonIcon,
   EuiFlexItem,
+  EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DraftGrokExpression, GrokCollection } from '@kbn/grok-ui';
@@ -36,7 +37,7 @@ import useObservable from 'react-use/lib/useObservable';
 import { useStreamsEnrichmentSelector } from '../../state_management/stream_enrichment_state_machine';
 import { SortableList } from '../../sortable_list';
 import { GrokPatternSuggestion } from './grok_pattern_suggestion';
-import { GeneratePatternButton } from './generate_pattern_button';
+import { GeneratePatternButton, AdditionalChargesCallout } from './generate_pattern_button';
 import { useGrokPatternSuggestion } from './use_grok_pattern_suggestion';
 import { useSimulatorSelector } from '../../state_management/stream_enrichment_state_machine';
 import { selectPreviewDocuments } from '../../state_management/simulation_state_machine/selectors';
@@ -145,39 +146,49 @@ export const GrokPatternsEditor = () => {
           onDismiss={() => refreshSuggestions(null)}
         />
       ) : (
-        <EuiFlexGroup gutterSize="l" alignItems="center">
-          {aiFeatures && (
+        <>
+          <EuiFlexGroup gutterSize="l" alignItems="center">
+            {aiFeatures && (
+              <EuiFlexItem grow={false}>
+                <GeneratePatternButton
+                  aiFeatures={aiFeatures}
+                  onClick={(connectorId) =>
+                    refreshSuggestions({
+                      connectorId,
+                      streamName: stream.name,
+                      samples: previewDocuments,
+                      fieldName: fieldValue,
+                    })
+                  }
+                  isLoading={suggestionsState.loading}
+                  isDisabled={!isValidField}
+                />
+              </EuiFlexItem>
+            )}
             <EuiFlexItem grow={false}>
-              <GeneratePatternButton
-                aiFeatures={aiFeatures}
-                onClick={(connectorId) =>
-                  refreshSuggestions({
-                    connectorId,
-                    streamName: stream.name,
-                    samples: previewDocuments,
-                    fieldName: fieldValue,
-                  })
-                }
-                isLoading={suggestionsState.loading}
-                isDisabled={!isValidField}
-              />
+              <EuiButtonEmpty
+                data-test-subj="streamsAppGrokPatternsEditorAddPatternButton"
+                onClick={handleAddPattern}
+                flush="left"
+                size="s"
+                isDisabled={suggestionsState.loading}
+              >
+                {i18n.translate(
+                  'xpack.streams.streamDetailView.managementTab.enrichment.processor.grokEditor.addPattern',
+                  { defaultMessage: 'Add pattern' }
+                )}
+              </EuiButtonEmpty>
             </EuiFlexItem>
-          )}
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              data-test-subj="streamsAppGrokPatternsEditorAddPatternButton"
-              onClick={handleAddPattern}
-              flush="left"
-              size="s"
-              isDisabled={suggestionsState.loading}
-            >
-              {i18n.translate(
-                'xpack.streams.streamDetailView.managementTab.enrichment.processor.grokEditor.addPattern',
-                { defaultMessage: 'Add pattern' }
-              )}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+          </EuiFlexGroup>
+          {aiFeatures &&
+            aiFeatures.isManagedAIConnector &&
+            !aiFeatures.hasAcknowledgedAdditionalCharges && (
+              <>
+                <EuiSpacer size="s" />
+                <AdditionalChargesCallout aiFeatures={aiFeatures} />
+              </>
+            )}
+        </>
       )}
     </>
   );


### PR DESCRIPTION
Fixes https://github.com/elastic/obs-ai-assistant-team/issues/256

Follow up to https://github.com/elastic/kibana/pull/222333

## Summary

Add the EIS pricing transparency callout in streams.

## Screenshot

<img width="1398" alt="Screenshot 2025-06-12 at 14 37 03" src="https://github.com/user-attachments/assets/c3498f61-4bc7-4da4-baae-3ee8308adb4a" />

## Testing

See email from Dario title "AI for everyone"

1. Run command -  `VAULT_ADDR={...} vault login -method oidc`
2. Run command - `node scripts/eis.js` (This will output the config for the connector which needs to be pasted to kibana.dev.yml)
3. Run Elasticsearch - `yarn es snapshot --license trial -E xpack.inference.elastic.url=http://localhost:8443`
4. Start Kibana as usual
5. The connector should be visible in the connectors list in Kibana and in the AI Assistant



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->