### PR TITLE
[8.19] [Obs] Convert EuiErrorBoundary to KibanaErrorBoundary for Obs UX Management owned components (#223145)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/observability_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/observability_annotation.tsx
@@ -12,7 +12,6 @@ import {
   TooltipSpec,
   TooltipType,
 } from '@elastic/charts';
-import { EuiErrorBoundary } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { useFormContext } from 'react-hook-form';
@@ -55,7 +54,7 @@ export function ObservabilityAnnotations({
   ];
 
   return (
-    <EuiErrorBoundary>
+    <>
       <Tooltip {...(tooltipSpecs ?? {})} actions={actions} type={TooltipType.VerticalCursor} />
       {annotations?.map((annotation, index) => (
         <ObsAnnotation annotation={annotation} key={annotation.id ?? index} />
@@ -63,7 +62,7 @@ export function ObservabilityAnnotations({
 
       <NewLineAnnotation slo={slo} isCreateOpen={isCreateOpen} />
       <NewRectAnnotation slo={slo} isCreateOpen={isCreateOpen} />
-    </EuiErrorBoundary>
+    </>
   );
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs] Convert EuiErrorBoundary to KibanaErrorBoundary for Obs UX Management owned components (#223145)](https://github.com/elastic/kibana/pull/223145)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-06-11T13:46:05Z","message":"[Obs] Convert EuiErrorBoundary to KibanaErrorBoundary for Obs UX Management owned components (#223145)\n\n## Summary\n\nResolves\n[#4567](https://github.com/elastic/observability-dev/issues/4567)\n\nConvert EuiErrorBoundary to KibanaErrorBoundary for Obs UX owned\ncomponents","sha":"110631493da612816c544fa1eb826d31a292e130","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-management","v9.1.0","author:obs-ux-management"],"title":"[Obs] Convert EuiErrorBoundary to KibanaErrorBoundary for Obs UX Management owned components","number":223145,"url":"https://github.com/elastic/kibana/pull/223145","mergeCommit":{"message":"[Obs] Convert EuiErrorBoundary to KibanaErrorBoundary for Obs UX Management owned components (#223145)\n\n## Summary\n\nResolves\n[#4567](https://github.com/elastic/observability-dev/issues/4567)\n\nConvert EuiErrorBoundary to KibanaErrorBoundary for Obs UX owned\ncomponents","sha":"110631493da612816c544fa1eb826d31a292e130"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223145","number":223145,"mergeCommit":{"message":"[Obs] Convert EuiErrorBoundary to KibanaErrorBoundary for Obs UX Management owned components (#223145)\n\n## Summary\n\nResolves\n[#4567](https://github.com/elastic/observability-dev/issues/4567)\n\nConvert EuiErrorBoundary to KibanaErrorBoundary for Obs UX owned\ncomponents","sha":"110631493da612816c544fa1eb826d31a292e130"}}]}] BACKPORT-->