### PR TITLE
Add `logging_level` central config for EDOT .NET

### DIFF
--- a/src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts
+++ b/src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts
@@ -73,7 +73,10 @@ export const OPEN_TELEMETRY_AGENT_NAMES: OpenTelemetryAgentName[] = [
   'otlp/webjs',
 ];
 
-export const EDOT_AGENT_NAMES: OpenTelemetryAgentName[] = ['opentelemetry/java/elastic'];
+export const EDOT_AGENT_NAMES: OpenTelemetryAgentName[] = [
+  'opentelemetry/java/elastic',
+  'opentelemetry/dotnet/elastic'
+];
 
 export type JavaAgentName = 'java' | 'opentelemetry/java' | 'otlp/java';
 export const JAVA_AGENT_NAMES: JavaAgentName[] = ['java', 'opentelemetry/java', 'otlp/java'];

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -66,7 +66,7 @@ export const edotSDKSettings: RawSettingDefinition[] = [
       { text: 'fatal', value: 'fatal' },
       { text: 'off', value: 'off' },
     ],
-    includeAgents: ['opentelemetry/java/elastic'],
+    includeAgents: ['opentelemetry/java/elastic','opentelemetry/dotnet/elastic'],
   },
   {
     key: 'send_traces',

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -203,6 +203,12 @@ describe('filterByAgent', () => {
       );
     });
 
+    it('opentelemetry/dotnet/elastic', () => {
+      expect(getSettingKeysForAgent('opentelemetry/dotnet/elastic')).toEqual(
+        expect.arrayContaining(['logging_level'])
+      );
+    });
+
     it('"All" services (no agent name)', () => {
       expect(getSettingKeysForAgent(undefined)).toEqual(
         expect.arrayContaining(['transaction_max_spans', 'transaction_sample_rate'])

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
@@ -254,6 +254,29 @@ Object {
         },
       },
     },
+    "opentelemetry/dotnet/elastic": Object {
+      "agent": Object {
+        "activation_method": Array [],
+        "version": Array [],
+      },
+      "service": Object {
+        "framework": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "language": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "runtime": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+      },
+    },
     "opentelemetry/java": Object {
       "agent": Object {
         "activation_method": Array [
@@ -1205,6 +1228,7 @@ Object {
     "js-base": 0,
     "nodejs": 0,
     "opentelemetry": 4,
+    "opentelemetry/dotnet/elastic": 0,
     "opentelemetry/java": 5,
     "opentelemetry/java/elastic": 6,
     "otlp": 1,

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -921,6 +921,10 @@ describe('data telemetry collection tasks', () => {
                     key: 'opentelemetry/java/elastic',
                     services: { value: 6 },
                   },
+                  {
+                    key: 'opentelemetry/dotnet/elastic',
+                    services: { value: 7 },
+                  },
                 ],
               },
             },


### PR DESCRIPTION
This makes the existing `logging_level` agent configuration setting available to EDOT .NET agents (`opentelemetry/dotnet/elastic`).

This follows the same pattern as in #222883 by @trentm. I'm making it a draft as I'll need to update it once that is merged.