### PR TITLE
[8.19] [Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled (#223278)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/types.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/types.ts
@@ -65,11 +65,7 @@ export interface ObservabilityAIAssistantChatService {
     systemMessage?: string;
     messages: Message[];
     persist: boolean;
-    disableFunctions:
-      | boolean
-      | {
-          except: string[];
-        };
+    disableFunctions: boolean;
     signal: AbortSignal;
     instructions?: Array<string | Instruction>;
     scopes: AssistantScope[];

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
@@ -33,12 +33,7 @@ const chatCompleteBaseRt = t.type({
     t.partial({
       conversationId: t.string,
       title: t.string,
-      disableFunctions: t.union([
-        toBooleanRt,
-        t.type({
-          except: t.array(t.string),
-        }),
-      ]),
+      disableFunctions: toBooleanRt,
       instructions: t.array(
         t.union([
           t.string,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -248,17 +248,11 @@ export class ObservabilityAIAssistantClient {
             applicationInstructions: functionClient.getInstructions(),
             kbUserInstructions,
             apiUserInstructions,
-<<<<<<< HEAD
-            availableFunctionNames: functionClient.getFunctions().map((fn) => fn.definition.name),
-          });
-        }),
-=======
             availableFunctionNames: disableFunctions
               ? []
               : functionClient.getFunctions().map((fn) => fn.definition.name),
-          })
-        ),
->>>>>>> 2ae790506fc ([Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled (#223278))
+          });
+        }),
         shareReplay()
       );
 
@@ -502,10 +496,7 @@ export class ObservabilityAIAssistantClient {
 
     this.dependencies.logger.debug(
       () =>
-        `Options for inference client for name: "${name}" before anonymization: ${JSON.stringify({
-          ...options,
-          messages,
-        })}`
+        `Calling inference client with for name: "${name}" with options: ${JSON.stringify(options)}`
     );
 
     if (stream) {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -201,11 +201,7 @@ export class ObservabilityAIAssistantClient {
     kibanaPublicUrl?: string;
     userInstructions?: Instruction[];
     simulateFunctionCalling?: boolean;
-    disableFunctions?:
-      | boolean
-      | {
-          except: string[];
-        };
+    disableFunctions?: boolean;
   }): Observable<Exclude<StreamingChatResponseEvent, ChatCompletionErrorEvent>> => {
     return withInferenceSpan('run_tools', () => {
       const isConversationUpdate = persist && !!predefinedConversationId;
@@ -252,9 +248,17 @@ export class ObservabilityAIAssistantClient {
             applicationInstructions: functionClient.getInstructions(),
             kbUserInstructions,
             apiUserInstructions,
+<<<<<<< HEAD
             availableFunctionNames: functionClient.getFunctions().map((fn) => fn.definition.name),
           });
         }),
+=======
+            availableFunctionNames: disableFunctions
+              ? []
+              : functionClient.getFunctions().map((fn) => fn.definition.name),
+          })
+        ),
+>>>>>>> 2ae790506fc ([Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled (#223278))
         shareReplay()
       );
 
@@ -498,7 +502,10 @@ export class ObservabilityAIAssistantClient {
 
     this.dependencies.logger.debug(
       () =>
-        `Calling inference client with for name: "${name}" with options: ${JSON.stringify(options)}`
+        `Options for inference client for name: "${name}" before anonymization: ${JSON.stringify({
+          ...options,
+          messages,
+        })}`
     );
 
     if (stream) {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/operators/continue_conversation.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/operators/continue_conversation.ts
@@ -131,17 +131,13 @@ function getFunctionDefinitions({
 }: {
   functionClient: ChatFunctionClient;
   functionLimitExceeded: boolean;
-  disableFunctions:
-    | boolean
-    | {
-        except: string[];
-      };
+  disableFunctions: boolean;
 }) {
   if (functionLimitExceeded || disableFunctions === true) {
     return [];
   }
 
-  let systemFunctions = functionClient
+  const systemFunctions = functionClient
     .getFunctions()
     .map((fn) => fn.definition)
     .filter(
@@ -149,10 +145,6 @@ function getFunctionDefinitions({
         !def.visibility ||
         [FunctionVisibility.AssistantOnly, FunctionVisibility.All].includes(def.visibility)
     );
-
-  if (typeof disableFunctions === 'object') {
-    systemFunctions = systemFunctions.filter((fn) => disableFunctions.except.includes(fn.name));
-  }
 
   const actions = functionClient.getActions();
 
@@ -184,11 +176,7 @@ export function continueConversation({
   apiUserInstructions: Instruction[];
   kbUserInstructions: Instruction[];
   logger: Logger;
-  disableFunctions:
-    | boolean
-    | {
-        except: string[];
-      };
+  disableFunctions: boolean;
   connectorId: string;
   simulateFunctionCalling: boolean;
 }): Observable<MessageOrChatEvent> {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled (#223278)](https://github.com/elastic/kibana/pull/223278)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-06-12T14:56:43Z","message":"[Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled (#223278)\n\nCloses https://github.com/elastic/kibana/issues/223273\n\n## Summary\n\n### Problem\nTools are disabled for contextual insights by default. However, tools\nare not conditionally registered based on whether tools are disabled or\nnot. Therefore, the system message includes instructions for tools even\nthough tools are disabled for contextual insights. LLMs such as Claude,\ntries to call these tools and results in an error because we don't pass\nany tools to the LLM when `disableFunctions: true`\n\n\n![contextual-insights-error-with-claude](https://github.com/user-attachments/assets/b638bbea-a3a7-4611-81b8-3bcc513fa994)\n\n### Solution\nAvoid passing tool instructions in the system message when tools are\ndisabled.\n\n\nhttps://github.com/user-attachments/assets/ba1a0016-4851-4ce7-9b40-efadbb96bd34\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2ae790506fcf21aff490d06ea56725d3ce76fbcb","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled","number":223278,"url":"https://github.com/elastic/kibana/pull/223278","mergeCommit":{"message":"[Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled (#223278)\n\nCloses https://github.com/elastic/kibana/issues/223273\n\n## Summary\n\n### Problem\nTools are disabled for contextual insights by default. However, tools\nare not conditionally registered based on whether tools are disabled or\nnot. Therefore, the system message includes instructions for tools even\nthough tools are disabled for contextual insights. LLMs such as Claude,\ntries to call these tools and results in an error because we don't pass\nany tools to the LLM when `disableFunctions: true`\n\n\n![contextual-insights-error-with-claude](https://github.com/user-attachments/assets/b638bbea-a3a7-4611-81b8-3bcc513fa994)\n\n### Solution\nAvoid passing tool instructions in the system message when tools are\ndisabled.\n\n\nhttps://github.com/user-attachments/assets/ba1a0016-4851-4ce7-9b40-efadbb96bd34\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2ae790506fcf21aff490d06ea56725d3ce76fbcb"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223278","number":223278,"mergeCommit":{"message":"[Obs AI Assistant] Avoid adding tool instructions to the system message when tools are disabled (#223278)\n\nCloses https://github.com/elastic/kibana/issues/223273\n\n## Summary\n\n### Problem\nTools are disabled for contextual insights by default. However, tools\nare not conditionally registered based on whether tools are disabled or\nnot. Therefore, the system message includes instructions for tools even\nthough tools are disabled for contextual insights. LLMs such as Claude,\ntries to call these tools and results in an error because we don't pass\nany tools to the LLM when `disableFunctions: true`\n\n\n![contextual-insights-error-with-claude](https://github.com/user-attachments/assets/b638bbea-a3a7-4611-81b8-3bcc513fa994)\n\n### Solution\nAvoid passing tool instructions in the system message when tools are\ndisabled.\n\n\nhttps://github.com/user-attachments/assets/ba1a0016-4851-4ce7-9b40-efadbb96bd34\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2ae790506fcf21aff490d06ea56725d3ce76fbcb"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->