### PR TITLE
[8.17] [Security Solution][Timeline] Refactor from styled-components to emotion (#222438)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.test.tsx
@@ -6,89 +6,85 @@
  */
 
 import React from 'react';
+import { screen, render, waitFor } from '@testing-library/react';
 
 import { TestProviders } from '../../../../common/mock/test_providers';
-import { useMountAppended } from '../../../../common/utils/use_mount_appended';
 
 import { DataProviders } from '.';
 import { TimelineId } from '../../../../../common/types/timeline';
 
 describe('DataProviders', () => {
-  const mount = useMountAppended();
-
   describe('rendering', () => {
-    const dropMessage = ['Drop', 'query', 'build', 'here'];
-
-    test('renders correctly against snapshot', () => {
-      const wrapper = mount(
-        <TestProviders>
-          <DataProviders data-test-subj="dataProviders-container" timelineId="foo" />
-        </TestProviders>
-      );
-      expect(wrapper.find(`[data-test-subj="dataProviders-container"]`)).toBeTruthy();
-      expect(wrapper.find(`[date-test-subj="drop-target-data-providers"]`)).toBeTruthy();
-    });
-
-    test('it should render a placeholder when there are zero data providers', () => {
-      const wrapper = mount(
+    test('renders correctly against snapshot', async () => {
+      const { container } = render(
         <TestProviders>
           <DataProviders timelineId="foo" />
         </TestProviders>
       );
 
-      dropMessage.forEach((word) => expect(wrapper.text()).toContain(word));
+      await waitFor(() => {
+        expect(
+          container.querySelector('.drop-target-data-providers-container')
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('dataProviders')).toBeInTheDocument();
+      });
     });
 
-    test('it renders the data providers', () => {
-      const wrapper = mount(
+    test('it should render a placeholder when there are zero data providers', async () => {
+      const dropMessage = ['Drop', 'query', 'build', 'here'];
+
+      const { container } = render(
         <TestProviders>
           <DataProviders timelineId="foo" />
         </TestProviders>
       );
 
-      expect(wrapper.find('[data-test-subj="empty"]').last().text()).toEqual(
+      await waitFor(() => {
+        dropMessage.forEach((word) => expect(container.textContent).toContain(word));
+      });
+    });
+
+    test('it renders the data providers', async () => {
+      render(
+        <TestProviders>
+          <DataProviders timelineId="foo" />
+        </TestProviders>
+      );
+
+      expect((await screen.findByTestId('empty')).textContent).toEqual(
         'Drop anythinghighlightedhere to build anORquery+ Add field'
       );
     });
 
     describe('resizable drop target', () => {
-      test('it may be resized vertically via a resize handle', () => {
-        const wrapper = mount(
+      test('it may be resized vertically via a resize handle', async () => {
+        render(
           <TestProviders>
             <DataProviders timelineId={TimelineId.test} />
           </TestProviders>
         );
 
-        expect(wrapper.find('[data-test-subj="dataProviders"]').first()).toHaveStyleRule(
-          'resize',
-          'vertical'
-        );
+        expect(await screen.findByTestId('dataProviders')).toHaveStyleRule('resize', 'vertical');
       });
 
-      test('it never grows taller than one third (33%) of the view height', () => {
-        const wrapper = mount(
+      test('it never grows taller than one third (33%) of the view height', async () => {
+        render(
           <TestProviders>
             <DataProviders timelineId={TimelineId.test} />
           </TestProviders>
         );
 
-        expect(wrapper.find('[data-test-subj="dataProviders"]').first()).toHaveStyleRule(
-          'max-height',
-          '33vh'
-        );
+        expect(await screen.findByTestId('dataProviders')).toHaveStyleRule('max-height', '33vh');
       });
 
-      test('it automatically displays scroll bars when the width or height of the data providers exceeds the drop target', () => {
-        const wrapper = mount(
+      test('it automatically displays scroll bars when the width or height of the data providers exceeds the drop target', async () => {
+        render(
           <TestProviders>
             <DataProviders timelineId={TimelineId.test} />
           </TestProviders>
         );
 
-        expect(wrapper.find('[data-test-subj="dataProviders"]').first()).toHaveStyleRule(
-          'overflow',
-          'auto'
-        );
+        expect(await screen.findByTestId('dataProviders')).toHaveStyleRule('overflow', 'auto');
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { rgba } from 'polished';
 import { useDispatch } from 'react-redux';
 import React, { useCallback, useMemo } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import { v4 as uuidv4 } from 'uuid';
 import { IS_DRAGGING_CLASS_NAME } from '@kbn/securitysolution-t-grid';
 import { EuiToolTip, EuiSuperSelect, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
@@ -37,15 +36,15 @@ const DropTargetDataProvidersContainer = styled.div`
   position: relative;
 
   .${IS_DRAGGING_CLASS_NAME} & .drop-target-data-providers {
-    background: ${({ theme }) => rgba(theme.eui.euiColorSuccess, 0.1)};
-    border: 0.2rem dashed ${({ theme }) => theme.eui.euiColorSuccess};
+    background: ${({ theme }) => theme.euiTheme.colors.backgroundBaseSuccess};
+    border: 0.2rem dashed ${({ theme }) => theme.euiTheme.colors.borderStrongSuccess};
 
     & .timeline-drop-area-empty__text {
-      color: ${({ theme }) => theme.eui.euiColorSuccess};
+      color: ${({ theme }) => theme.euiTheme.colors.textSuccess};
     }
 
     & .euiFormHelpText {
-      color: ${({ theme }) => theme.eui.euiColorSuccess};
+      color: ${({ theme }) => theme.euiTheme.colors.textSuccess};
     }
   }
 `;
@@ -55,15 +54,15 @@ const DropTargetDataProviders = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   position: relative;
-  border: 0.2rem dashed ${({ theme }) => theme.eui.euiColorMediumShade};
+  border: 0.2rem dashed ${({ theme }) => theme.euiTheme.colors.borderBaseFormsControl};
   border-radius: 5px;
-  padding: ${({ theme }) => theme.eui.euiSizeS} 0;
+  padding: ${({ theme }) => theme.euiTheme.size.s} 0;
   margin: 0px 0 0px 0;
   max-height: 33vh;
   min-height: 100px;
   overflow: auto;
   resize: vertical;
-  background-color: ${({ theme }) => theme.eui.euiFormBackgroundColor};
+  background-color: ${({ theme }) => theme.euiTheme.components.forms.background};
 `;
 
 DropTargetDataProviders.displayName = 'DropTargetDataProviders';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Security Solution][Timeline] Refactor from styled-components to emotion (#222438)](https://github.com/elastic/kibana/pull/222438)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicholas Peretti","email":"nicholas.peretti@elastic.co"},"sourceCommit":{"committedDate":"2025-06-05T11:09:09Z","message":"[Security Solution][Timeline] Refactor from styled-components to emotion (#222438)\n\n## Summary\n\nThis PR was originally addressing some dark-mode issues in the timeline.\nThose issues has been already fixed upstream but there are still\nvaluable contributions in this PR that should be considered anyways:\n\n1. unit test has been refactor to use `react-testing-library` instead of\n`enzyme`\n2. the styling for the timeline has been moved from `styled-components`\nto `emotion`\n3. the color tokens have been updated according to #199715 \n\n> [!important]\n>\n> #199715 also suggests to move away from the `success` tokens. However,\nin the drag-and-drop use-case the EUI team has confirmed that for now we\nshould prefer the `success` tokens until proper drag-and-drop tokens\nwill be produced\n\n## Screenshots\n\n> [!important]\n>\n> Light mode was not visually impacted by these changes, therefore no\nscreenshots have been provided\n\n### Empty query builder\n\n- The background of the query builder matches the general background now\n- The dashed border is a little bit lighter than before\n\n**Before**\n<img width=\"1205\" alt=\"dark-1-before\"\nsrc=\"https://github.com/user-attachments/assets/2008ddd3-f801-4646-8407-045de4dc3ebd\"\n/>\n\n**After**\n<img width=\"1206\" alt=\"dark-1-after\"\nsrc=\"https://github.com/user-attachments/assets/a93e4b7e-6666-4805-91d1-ab9b4c3f5b82\"\n/>\n\n### Drag-and-drop query builder\n\n- The border color is a bit washed up compared to the original one\n- The background green is darker and less teal\n\n**Before**\n<img width=\"1203\" alt=\"dark-2-before\"\nsrc=\"https://github.com/user-attachments/assets/b3d85b9e-3821-44c5-adaa-99719ca3aef6\"\n/>\n\n**After**\n<img width=\"1074\" alt=\"Screenshot 2025-06-04 at 18 45 16\"\nsrc=\"https://github.com/user-attachments/assets/41b4cbca-4654-4571-a59c-4976ca0930a5\"\n/>\n\n\n## Code overview\n\n- `[...]/timelines/components/timeline/data_providers/index.tsx`\n  - Replace `styled-components` with `emotion`\n- `styled-components` have an issue where the theme is always set to\n`LIGHT` in this component\n- after a bit of debugging the issue seems to come from eui, but the\ninvestigation was interrupted because\n    - `styled-components` are deprecated anyways\n- `[...]/timelines/components/timeline/data_providers/index.test.tsx`\n  - Refactor unit test from using `enzyme` to `react-testing-library`\n\n## Credits\n\nHuge thanks to @kapral18 for working on this with me.\n\n### Checklist\n\n<details>\n<summary>Expand</summary>\n\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n\n</details>\n\n---------\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>","sha":"4b7f8d9399503ce0c5c93e8ee844398dd2199810","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","Team: SecuritySolution","backport:prev-major","v9.1.0","v8.19.0"],"title":"[Security Solution][Timeline] Refactor from styled-components to emotion","number":222438,"url":"https://github.com/elastic/kibana/pull/222438","mergeCommit":{"message":"[Security Solution][Timeline] Refactor from styled-components to emotion (#222438)\n\n## Summary\n\nThis PR was originally addressing some dark-mode issues in the timeline.\nThose issues has been already fixed upstream but there are still\nvaluable contributions in this PR that should be considered anyways:\n\n1. unit test has been refactor to use `react-testing-library` instead of\n`enzyme`\n2. the styling for the timeline has been moved from `styled-components`\nto `emotion`\n3. the color tokens have been updated according to #199715 \n\n> [!important]\n>\n> #199715 also suggests to move away from the `success` tokens. However,\nin the drag-and-drop use-case the EUI team has confirmed that for now we\nshould prefer the `success` tokens until proper drag-and-drop tokens\nwill be produced\n\n## Screenshots\n\n> [!important]\n>\n> Light mode was not visually impacted by these changes, therefore no\nscreenshots have been provided\n\n### Empty query builder\n\n- The background of the query builder matches the general background now\n- The dashed border is a little bit lighter than before\n\n**Before**\n<img width=\"1205\" alt=\"dark-1-before\"\nsrc=\"https://github.com/user-attachments/assets/2008ddd3-f801-4646-8407-045de4dc3ebd\"\n/>\n\n**After**\n<img width=\"1206\" alt=\"dark-1-after\"\nsrc=\"https://github.com/user-attachments/assets/a93e4b7e-6666-4805-91d1-ab9b4c3f5b82\"\n/>\n\n### Drag-and-drop query builder\n\n- The border color is a bit washed up compared to the original one\n- The background green is darker and less teal\n\n**Before**\n<img width=\"1203\" alt=\"dark-2-before\"\nsrc=\"https://github.com/user-attachments/assets/b3d85b9e-3821-44c5-adaa-99719ca3aef6\"\n/>\n\n**After**\n<img width=\"1074\" alt=\"Screenshot 2025-06-04 at 18 45 16\"\nsrc=\"https://github.com/user-attachments/assets/41b4cbca-4654-4571-a59c-4976ca0930a5\"\n/>\n\n\n## Code overview\n\n- `[...]/timelines/components/timeline/data_providers/index.tsx`\n  - Replace `styled-components` with `emotion`\n- `styled-components` have an issue where the theme is always set to\n`LIGHT` in this component\n- after a bit of debugging the issue seems to come from eui, but the\ninvestigation was interrupted because\n    - `styled-components` are deprecated anyways\n- `[...]/timelines/components/timeline/data_providers/index.test.tsx`\n  - Refactor unit test from using `enzyme` to `react-testing-library`\n\n## Credits\n\nHuge thanks to @kapral18 for working on this with me.\n\n### Checklist\n\n<details>\n<summary>Expand</summary>\n\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n\n</details>\n\n---------\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>","sha":"4b7f8d9399503ce0c5c93e8ee844398dd2199810"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222438","number":222438,"mergeCommit":{"message":"[Security Solution][Timeline] Refactor from styled-components to emotion (#222438)\n\n## Summary\n\nThis PR was originally addressing some dark-mode issues in the timeline.\nThose issues has been already fixed upstream but there are still\nvaluable contributions in this PR that should be considered anyways:\n\n1. unit test has been refactor to use `react-testing-library` instead of\n`enzyme`\n2. the styling for the timeline has been moved from `styled-components`\nto `emotion`\n3. the color tokens have been updated according to #199715 \n\n> [!important]\n>\n> #199715 also suggests to move away from the `success` tokens. However,\nin the drag-and-drop use-case the EUI team has confirmed that for now we\nshould prefer the `success` tokens until proper drag-and-drop tokens\nwill be produced\n\n## Screenshots\n\n> [!important]\n>\n> Light mode was not visually impacted by these changes, therefore no\nscreenshots have been provided\n\n### Empty query builder\n\n- The background of the query builder matches the general background now\n- The dashed border is a little bit lighter than before\n\n**Before**\n<img width=\"1205\" alt=\"dark-1-before\"\nsrc=\"https://github.com/user-attachments/assets/2008ddd3-f801-4646-8407-045de4dc3ebd\"\n/>\n\n**After**\n<img width=\"1206\" alt=\"dark-1-after\"\nsrc=\"https://github.com/user-attachments/assets/a93e4b7e-6666-4805-91d1-ab9b4c3f5b82\"\n/>\n\n### Drag-and-drop query builder\n\n- The border color is a bit washed up compared to the original one\n- The background green is darker and less teal\n\n**Before**\n<img width=\"1203\" alt=\"dark-2-before\"\nsrc=\"https://github.com/user-attachments/assets/b3d85b9e-3821-44c5-adaa-99719ca3aef6\"\n/>\n\n**After**\n<img width=\"1074\" alt=\"Screenshot 2025-06-04 at 18 45 16\"\nsrc=\"https://github.com/user-attachments/assets/41b4cbca-4654-4571-a59c-4976ca0930a5\"\n/>\n\n\n## Code overview\n\n- `[...]/timelines/components/timeline/data_providers/index.tsx`\n  - Replace `styled-components` with `emotion`\n- `styled-components` have an issue where the theme is always set to\n`LIGHT` in this component\n- after a bit of debugging the issue seems to come from eui, but the\ninvestigation was interrupted because\n    - `styled-components` are deprecated anyways\n- `[...]/timelines/components/timeline/data_providers/index.test.tsx`\n  - Refactor unit test from using `enzyme` to `react-testing-library`\n\n## Credits\n\nHuge thanks to @kapral18 for working on this with me.\n\n### Checklist\n\n<details>\n<summary>Expand</summary>\n\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n\n</details>\n\n---------\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>","sha":"4b7f8d9399503ce0c5c93e8ee844398dd2199810"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/222792","number":222792,"state":"MERGED","mergeCommit":{"sha":"3d7ab4c3c36de859cf800af42298c7ce870b45b0","message":"[8.19] [Security Solution][Timeline] Refactor from styled-components to emotion (#222438) (#222792)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution][Timeline] Refactor from styled-components to\nemotion (#222438)](https://github.com/elastic/kibana/pull/222438)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicholas Peretti <nicholas.peretti@elastic.co>\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}}]}] BACKPORT-->