### PR TITLE
[Connectors] Apply `autoFocus` prop to `cc` and `bcc` elements on email connector form

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_params.tsx
@@ -156,6 +156,7 @@ export const EmailParamsFields = ({
           )}
         >
           <EuiComboBox
+            autoFocus
             noSuggestions
             isInvalid={isCCInvalid}
             isLoading={isLoading}
@@ -199,6 +200,7 @@ export const EmailParamsFields = ({
           )}
         >
           <EuiComboBox
+            autoFocus
             noSuggestions
             isInvalid={isBCCInvalid}
             isDisabled={isDisabled}


### PR DESCRIPTION
## Summary

Resolves #212419.

In the Synthetics plugin, we are referencing the action connector form provided for Email. The a11y audit noted that the `Cc` and `Bcc` features on this form break the focus flow and make the page inaccessible. This patch will apply `autoFocus` to the combo box elements that get rendered when these buttons are clicked, thus allowing screen reader and keyboard-only users to navigate the UI properly.

**NOTE:** you may see an example of the failure on the linked issue. I have re-created the flow using VoiceOver and keyboard navigation and included a GIF of it below.

## Example

![20250612155139](https://github.com/user-attachments/assets/db8fff12-6fa7-43c8-889d-e05f2473f8e8)



<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->