### PR TITLE
[Security Assistant] Fix telemetry tool reporting

### DIFF
--- a/x-pack/platform/packages/shared/kbn-langchain/server/tracers/telemetry/telemetry_tracer.test.ts
+++ b/x-pack/platform/packages/shared/kbn-langchain/server/tracers/telemetry/telemetry_tracer.test.ts
@@ -162,7 +162,6 @@ describe('TelemetryTracer', () => {
         elasticTools,
         telemetry,
         telemetryParams,
-        totalTools: 9,
       },
       logger
     );
@@ -173,7 +172,6 @@ describe('TelemetryTracer', () => {
     expect(telemetryTracer.elasticTools).toEqual(elasticTools);
     expect(telemetryTracer.telemetry).toBe(telemetry);
     expect(telemetryTracer.telemetryParams).toBe(telemetryParams);
-    expect(telemetryTracer.totalTools).toBe(9);
   });
 
   it('should not log and report event on chain end if parent_run_id exists', async () => {

--- a/x-pack/platform/packages/shared/kbn-langchain/server/tracers/telemetry/telemetry_tracer.ts
+++ b/x-pack/platform/packages/shared/kbn-langchain/server/tracers/telemetry/telemetry_tracer.ts
@@ -21,7 +21,6 @@ export interface LangChainTracerFields extends BaseCallbackHandlerInput {
   elasticTools: string[];
   telemetry: AnalyticsServiceSetup;
   telemetryParams: TelemetryParams;
-  totalTools: number;
 }
 interface ToolRunStep {
   action: {
@@ -37,14 +36,12 @@ export class TelemetryTracer extends BaseTracer implements LangChainTracerFields
   elasticTools: string[];
   telemetry: AnalyticsServiceSetup;
   telemetryParams: TelemetryParams;
-  totalTools: number;
   constructor(fields: LangChainTracerFields, logger: Logger) {
     super(fields);
     this.logger = logger.get('telemetryTracer');
     this.elasticTools = fields.elasticTools;
     this.telemetry = fields.telemetry;
     this.telemetryParams = fields.telemetryParams;
-    this.totalTools = fields.totalTools;
   }
 
   async onChainEnd(run: Run): Promise<void> {


### PR DESCRIPTION
In order to collect telemetry on what tools were invoked while ensuring no customer data is collected (i.e. custom tool names), the `TelemetryTracer` collects a parameter called `elasticTools`. This parameter is a list of the tools BEFORE custom knowledge base tools are added. Somehow, this line got moved below where the knowledge base tools were added, so unknown tool names were attempted to be sent to telemetry and an error was thrown. Moving the `elasticTools` definition above where the knowledge base tools are added fixes the issue. I added a comment in the code along with a test to prevent this from happening again. I also removed an unused parameter `totalTools`.

### Before

```
Invoke invoke_assistant_success telemetry:
{
  "actionTypeId": ".bedrock",
  "assistantStreamingEnabled": true,
  "isEnabledKnowledgeBase": true,
  "durationMs": 41993,
  "toolsInvoked": {
    "CoolestToolest": 1,
  }
}

Error in handler TelemetryTracer, handleChainEnd: Error: Failed to validate payload coming from "Event Type 'invoke_assistant_success'":
	- [toolsInvoked]: excess key 'CoolestToolest' found
```


### After

```
Invoke invoke_assistant_success telemetry:
{
  "actionTypeId": ".bedrock",
  "assistantStreamingEnabled": true,
  "isEnabledKnowledgeBase": true,
  "durationMs": 41993,
  "toolsInvoked": {
    "CustomTool": 1,
  }
}
```

## Testing

Create a knowledge base index entry. Ask the assistant a question that will trigger the custom tool. Confirm that `invoke_assistant_success` was called with the param `CustomTool` and not the name of your actual tool, and that `Error in handler TelemetryTracer` does not appear in your logs.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->