### PR TITLE
[Security Solution][Threat Hunting] Replace heavy accessibility rtl selectors

### DIFF
--- a/src/platform/packages/shared/kbn-cell-actions/.eslintrc.js
+++ b/src/platform/packages/shared/kbn-cell-actions/.eslintrc.js
@@ -81,6 +81,25 @@ const RESTRICTED_IMPORTS_PATHS = [
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
 ];
 
 const ROOT_DIR = execSync('git rev-parse --show-toplevel', {

--- a/src/platform/packages/shared/kbn-cell-actions/.eslintrc.js
+++ b/src/platform/packages/shared/kbn-cell-actions/.eslintrc.js
@@ -70,8 +70,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -102,17 +100,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -194,7 +186,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_popover.test.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_popover.test.tsx
@@ -32,7 +32,7 @@ describe('ExtraActionsPopOver', () => {
     const executeAction = jest.fn();
     const closePopOver = jest.fn();
     const action = { ...makeAction('test-action'), execute: executeAction };
-    const { getByLabelText } = render(
+    const { getByTestId } = render(
       <ExtraActionsPopOver
         {...defaultProps}
         isOpen={true}
@@ -42,7 +42,7 @@ describe('ExtraActionsPopOver', () => {
     );
 
     await act(async () => {
-      await fireEvent.click(getByLabelText('test-action'));
+      await fireEvent.click(getByTestId('actionItem-test-action'));
     });
 
     expect(executeAction).toHaveBeenCalled();
@@ -66,7 +66,7 @@ describe('ExtraActionsPopOverWithAnchor', () => {
     const executeAction = jest.fn();
     const closePopOver = jest.fn();
     const action = { ...makeAction('test-action'), execute: executeAction };
-    const { getByLabelText } = render(
+    const { getByTestId } = render(
       <ExtraActionsPopOverWithAnchor
         {...defaultProps}
         isOpen={true}
@@ -76,7 +76,7 @@ describe('ExtraActionsPopOverWithAnchor', () => {
       />
     );
 
-    fireEvent.click(getByLabelText('test-action'));
+    fireEvent.click(getByTestId('actionItem-test-action'));
 
     expect(executeAction).toHaveBeenCalled();
     expect(closePopOver).toHaveBeenCalled();

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.test.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.test.tsx
@@ -49,7 +49,7 @@ describe('HoverActionsPopover', () => {
     const getActionsPromise = Promise.resolve([action]);
     const getActions = () => getActionsPromise;
 
-    const { queryByLabelText, getByTestId } = render(
+    const { queryByTestId, getByTestId } = render(
       <CellActionsProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover {...defaultProps}>
           <TestComponent />
@@ -62,7 +62,7 @@ describe('HoverActionsPopover', () => {
       jest.runAllTimers();
     });
 
-    expect(queryByLabelText('test-action')).toBeInTheDocument();
+    expect(queryByTestId('actionItem-test-action')).toBeInTheDocument();
   });
 
   it('hide actions when mouse stops hovering', async () => {
@@ -70,7 +70,7 @@ describe('HoverActionsPopover', () => {
     const getActionsPromise = Promise.resolve([action]);
     const getActions = () => getActionsPromise;
 
-    const { queryByLabelText, getByTestId } = render(
+    const { queryByTestId, getByTestId } = render(
       <CellActionsProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover {...defaultProps}>
           <TestComponent />
@@ -88,7 +88,7 @@ describe('HoverActionsPopover', () => {
       fireEvent.mouseLeave(getByTestId('test-component'));
     });
 
-    expect(queryByLabelText('test-action')).not.toBeInTheDocument();
+    expect(queryByTestId('actionItem-test-action')).not.toBeInTheDocument();
   });
 
   it('renders extra actions button', async () => {
@@ -117,7 +117,7 @@ describe('HoverActionsPopover', () => {
     const getActionsPromise = Promise.resolve(actions);
     const getActions = () => getActionsPromise;
 
-    const { getByTestId, getByLabelText } = render(
+    const { getByTestId } = render(
       <CellActionsProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover {...defaultProps} visibleCellActions={1}>
           <TestComponent />
@@ -134,7 +134,7 @@ describe('HoverActionsPopover', () => {
       fireEvent.click(getByTestId('showExtraActionsButton'));
     });
 
-    expect(getByLabelText('test-action-2')).toBeInTheDocument();
+    expect(getByTestId('actionItem-test-action-2')).toBeInTheDocument();
   });
 
   it('does not render visible actions if extra actions are already rendered', async () => {
@@ -147,7 +147,7 @@ describe('HoverActionsPopover', () => {
     const getActionsPromise = Promise.resolve(actions);
     const getActions = () => getActionsPromise;
 
-    const { getByTestId, queryByLabelText } = render(
+    const { getByTestId, queryByTestId } = render(
       <CellActionsProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover {...defaultProps} visibleCellActions={2}>
           <TestComponent />
@@ -169,15 +169,15 @@ describe('HoverActionsPopover', () => {
       jest.runAllTimers();
     });
 
-    expect(queryByLabelText('test-action-1')).not.toBeInTheDocument();
-    expect(queryByLabelText('test-action-2')).toBeInTheDocument();
-    expect(queryByLabelText('test-action-3')).toBeInTheDocument();
+    expect(queryByTestId('actionItem-test-action-1')).not.toBeInTheDocument();
+    expect(queryByTestId('actionItem-test-action-2')).toBeInTheDocument();
+    expect(queryByTestId('actionItem-test-action-3')).toBeInTheDocument();
   });
   it('does not add css positioning when anchorPosition = downCenter', async () => {
     const getActionsPromise = Promise.resolve([makeAction('test-action')]);
     const getActions = () => getActionsPromise;
 
-    const { getByLabelText, getByTestId } = render(
+    const { getByTestId } = render(
       <CellActionsProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover {...defaultProps} anchorPosition="downCenter">
           <TestComponent />
@@ -190,13 +190,15 @@ describe('HoverActionsPopover', () => {
       jest.runAllTimers();
     });
 
-    expect(Object.values(getByLabelText('Actions').style).includes('margin-top')).toEqual(false);
+    expect(Object.values(getByTestId('hoverActionsPopover').style).includes('margin-top')).toEqual(
+      false
+    );
   });
   it('adds css positioning when anchorPosition = rightCenter', async () => {
     const getActionsPromise = Promise.resolve([makeAction('test-action')]);
     const getActions = () => getActionsPromise;
 
-    const { getByLabelText, getByTestId } = render(
+    const { getByTestId } = render(
       <CellActionsProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover {...defaultProps} anchorPosition="rightCenter">
           <TestComponent />
@@ -209,7 +211,9 @@ describe('HoverActionsPopover', () => {
       jest.runAllTimers();
     });
 
-    expect(Object.values(getByLabelText('Actions').style).includes('margin-top')).toEqual(true);
+    expect(Object.values(getByTestId('hoverActionsPopover').style).includes('margin-top')).toEqual(
+      true
+    );
   });
 });
 

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/inline_actions.test.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/inline_actions.test.tsx
@@ -47,7 +47,7 @@ describe('InlineActions', () => {
       makeAction('action-5'),
     ]);
     const getActions = () => getActionsPromise;
-    const { queryAllByRole } = render(
+    const { getAllByTestId } = render(
       <CellActionsProvider getTriggerCompatibleActions={getActions}>
         <InlineActions {...defaultProps} />
       </CellActionsProvider>
@@ -57,6 +57,6 @@ describe('InlineActions', () => {
       await getActionsPromise;
     });
 
-    expect(queryAllByRole('button').length).toBe(5);
+    expect(getAllByTestId(/actionItem-action-/).length).toBe(5);
   });
 });

--- a/src/platform/packages/shared/kbn-securitysolution-ecs/.eslintrc.js
+++ b/src/platform/packages/shared/kbn-securitysolution-ecs/.eslintrc.js
@@ -70,7 +70,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -82,17 +81,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -174,7 +167,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/src/platform/packages/shared/kbn-unified-data-table/.eslintrc.js
+++ b/src/platform/packages/shared/kbn-unified-data-table/.eslintrc.js
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/src/platform/packages/shared/kbn-unified-data-table/.eslintrc.js
+++ b/src/platform/packages/shared/kbn-unified-data-table/.eslintrc.js
@@ -70,6 +70,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -95,14 +96,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -184,7 +182,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/comparison_controls.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/comparison_controls.test.tsx
@@ -56,7 +56,7 @@ const renderComparisonControls = ({
   };
   render(<Wrapper />);
   const getComparisonSettingsButton = () =>
-    screen.getByRole('button', { name: 'Comparison settings' });
+    screen.getByTestId('unifiedDataTableComparisonSettings');
   const getShowDiffSwitch = () => screen.getByTestId('unifiedDataTableShowDiffSwitch');
   const getDiffModeEntry = (mode: DocumentDiffMode) =>
     screen.getByTestId(`unifiedDataTableDiffMode-${mode}`);
@@ -77,19 +77,19 @@ const renderComparisonControls = ({
     clickShowDiffSwitch: async () =>
       await userEvent.click(getShowDiffSwitch(), { pointerEventsCheck: 0 }),
     clickDiffModeFullValueButton: async () =>
-      await userEvent.click(screen.getByRole('button', { name: 'Full value' }), {
+      await userEvent.click(getDiffModeEntry('basic'), {
         pointerEventsCheck: 0,
       }),
     clickDiffModeByCharacterButton: async () =>
-      await userEvent.click(screen.getByRole('button', { name: 'By character' }), {
+      await userEvent.click(getDiffModeEntry('chars'), {
         pointerEventsCheck: 0,
       }),
     clickDiffModeByWordButton: async () =>
-      await userEvent.click(screen.getByRole('button', { name: 'By word' }), {
+      await userEvent.click(getDiffModeEntry('words'), {
         pointerEventsCheck: 0,
       }),
     clickDiffModeByLineButton: async () =>
-      await userEvent.click(screen.getByRole('button', { name: 'By line' }), {
+      await userEvent.click(getDiffModeEntry('lines'), {
         pointerEventsCheck: 0,
       }),
     getDiffModeEntry,
@@ -108,7 +108,7 @@ const renderComparisonControls = ({
     getShowDiffDecorationsSwitch,
     clickShowDiffDecorationsSwitch: async () =>
       await userEvent.click(getShowDiffDecorationsSwitch(), { pointerEventsCheck: 0 }),
-    getExitComparisonButton: () => screen.getByRole('button', { name: 'Exit comparison mode' }),
+    getExitComparisonButton: () => screen.getByTestId('unifiedDataTableExitDocumentComparison'),
     isCompareActive: () => screen.queryByText('Comparison active') !== null,
   };
 };

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_column.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/custom_control_columns/actions_column/actions_column.test.tsx
@@ -370,8 +370,8 @@ describe('getActionsColumn', () => {
       );
 
       // The rest of the items are in a menu
-      expect(screen.getByLabelText('Additional actions')).toBeVisible();
-      await user.click(screen.getByLabelText('Additional actions'));
+      expect(screen.getByTestId('unifiedDataTable_additionalRowControl_actionsMenu')).toBeVisible();
+      await user.click(screen.getByTestId('unifiedDataTable_additionalRowControl_actionsMenu'));
 
       rowAdditionalLeadingControls.slice(1).forEach((control) => {
         expect(screen.getByTestId(`unifiedDataTable_rowMenu_${control.id}`)).toBeVisible();

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -471,10 +471,10 @@ describe('UnifiedDataTable', () => {
       screen.getByTestId(`dataGridHeaderCellActionButton-${name}`);
     const getCellValuesByColumn = () => {
       const columns = screen
-        .getAllByRole('columnheader')
+        .getAllByTestId(/dataGridHeaderCell-/)
         .map((header) => header.dataset.gridcellColumnId!);
       const values = screen
-        .getAllByRole('gridcell')
+        .getAllByTestId('dataGridRowCell')
         .map((cell) => cell.querySelector('.unifiedDataTable__cellValue')?.textContent ?? '');
       return values.reduce<Record<string, string[]>>((acc, value, i) => {
         const column = columns[i % columns.length];
@@ -509,9 +509,7 @@ describe('UnifiedDataTable', () => {
         ]);
         await userEvent.click(getColumnActions('message'));
         await waitForEuiPopoverOpen();
-        // Column sort button incorrectly renders as "Sort " instead
-        // of "Sort Z-A" in Jest tests, so we need to find it by index
-        await userEvent.click(screen.getAllByRole('button', { name: /Sort/ })[2]);
+        await userEvent.click(screen.getByTitle(/Sort\s+Z-A/im).closest('button')!);
         await waitFor(() => {
           values = getCellValuesByColumn();
           expect(values.message).toEqual([
@@ -555,9 +553,7 @@ describe('UnifiedDataTable', () => {
         ]);
         await userEvent.click(getColumnActions('message'));
         await waitForEuiPopoverOpen();
-        // Column sort button incorrectly renders as "Sort " instead
-        // of "Sort Z-A" in Jest tests, so we need to find it by index
-        await userEvent.click(screen.getAllByRole('button', { name: /Sort/ })[2]);
+        await userEvent.click(screen.getByTitle(/Sort\s+Z-A/im).closest('button')!);
         await waitFor(() => {
           values = getCellValuesByColumn();
           expect(values.message).toEqual([
@@ -1170,7 +1166,7 @@ describe('UnifiedDataTable', () => {
 
     const getColumnHeaders = () =>
       screen
-        .getAllByRole('columnheader')
+        .getAllByTestId(/dataGridHeaderCell-/)
         .map((header) => header.querySelector('.euiDataGridHeaderCell__content')?.textContent);
 
     const getCellValues = () =>
@@ -1307,18 +1303,18 @@ describe('UnifiedDataTable', () => {
   describe('columns', () => {
     // Default column width in EUI is hardcoded to 100px for Jest envs
     const EUI_DEFAULT_COLUMN_WIDTH = '100px';
-    const getColumnHeader = (name: string) => screen.getByRole('columnheader', { name });
-    const queryColumnHeader = (name: string) => screen.queryByRole('columnheader', { name });
+    const getColumnHeader = (name: string) => screen.getByTestId(`dataGridHeaderCell-${name}`);
+    const queryColumnHeader = (name: string) => screen.queryByTestId(`dataGridHeaderCell-${name}`);
     const openColumnActions = async (name: string) => {
       const actionsButton = screen.getByTestId(`dataGridHeaderCellActionButton-${name}`);
       await userEvent.click(actionsButton);
       await waitForEuiPopoverOpen();
     };
-    const clickColumnAction = async (name: string) => {
-      const action = screen.getByRole('button', { name });
+    const clickColumnAction = async (title: string) => {
+      const action = screen.getByTitle(title).closest('button')!;
       await userEvent.click(action);
     };
-    const queryButton = (name: string) => screen.queryByRole('button', { name });
+    const queryButton = (title: string) => screen.queryByTitle(title)?.closest('button') ?? null;
 
     it(
       'should reset the last column to auto width if only absolute width columns remain',

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
@@ -262,12 +262,12 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
         onChangeRowHeight: jest.fn(),
         onChangeRowHeightLines: jest.fn(),
       });
-      expect(screen.getByLabelText('Body cell lines')).toBeInTheDocument();
+      expect(screen.getByTestId('unifiedDataTableRowHeightSettings')).toBeInTheDocument();
     });
 
     it('should not render rowHeight if onChangeRowHeight and onChangeRowHeightLines are undefined', () => {
       renderDisplaySettings();
-      expect(screen.queryByLabelText('Body cell lines')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('unifiedDataTableRowHeightSettings')).not.toBeInTheDocument();
     });
 
     it('should call onChangeRowHeight and onChangeRowHeightLines when the rowHeight changes', async () => {
@@ -278,9 +278,11 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
         onChangeRowHeight,
         onChangeRowHeightLines,
       });
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: 5 } });
+      fireEvent.change(screen.getByTestId('unifiedDataTableRowHeightSettings_lineCountNumber'), {
+        target: { value: 5 },
+      });
       expect(onChangeRowHeightLines).toHaveBeenCalledWith(5, true);
-      await userEvent.click(screen.getByRole('button', { name: 'Auto' }));
+      await userEvent.click(screen.getByTestId('unifiedDataTableRowHeightSettings_rowHeight_auto'));
       expect(onChangeRowHeight).toHaveBeenCalledWith('auto');
     });
   });
@@ -291,12 +293,14 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
         onChangeHeaderRowHeight: jest.fn(),
         onChangeHeaderRowHeightLines: jest.fn(),
       });
-      expect(screen.getByLabelText('Max header cell lines')).toBeInTheDocument();
+      expect(screen.getByTestId('unifiedDataTableHeaderRowHeightSettings')).toBeInTheDocument();
     });
 
     it('should not render headerRowHeight if onChangeHeaderRowHeight and onChangeHeaderRowHeightLines are undefined', () => {
       renderDisplaySettings();
-      expect(screen.queryByLabelText('Max header cell lines')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('unifiedDataTableHeaderRowHeightSettings')
+      ).not.toBeInTheDocument();
     });
 
     it('should call onChangeHeaderRowHeight and onChangeHeaderRowHeightLines when the headerRowHeight changes', async () => {
@@ -307,9 +311,14 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
         onChangeHeaderRowHeight,
         onChangeHeaderRowHeightLines,
       });
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: 3 } });
+      fireEvent.change(
+        screen.getByTestId('unifiedDataTableHeaderRowHeightSettings_lineCountNumber'),
+        { target: { value: 3 } }
+      );
       expect(onChangeHeaderRowHeightLines).toHaveBeenCalledWith(3, true);
-      await userEvent.click(screen.getByRole('button', { name: 'Auto' }));
+      await userEvent.click(
+        screen.getByTestId('unifiedDataTableHeaderRowHeightSettings_rowHeight_auto')
+      );
       expect(onChangeHeaderRowHeight).toHaveBeenCalledWith('auto');
     });
   });

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
@@ -411,7 +411,7 @@ describe('document selection', () => {
         getButton: async () => {
           const menuButton = await screen.findByTestId('unifiedDataTableSelectionBtn');
           await userEvent.click(menuButton);
-          return screen.queryByRole('button', { name: /Compare/ });
+          return screen.queryByTestId('unifiedDataTableCompareSelectedDocuments');
         },
       };
     };

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.test.tsx
@@ -48,39 +48,63 @@ const renderRowHeightSettings = ({
 describe('RowHeightSettings', () => {
   it('should set rowHight to Custom by default', async () => {
     renderRowHeightSettings();
-    expect(screen.getByRole('button', { name: 'Auto', pressed: false })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Custom', pressed: true })).toBeInTheDocument();
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_auto')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_custom')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
   it('should set rowHeight when the selected button changes', async () => {
     renderRowHeightSettings();
-    expect(screen.getByRole('button', { name: 'Auto', pressed: false })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Custom', pressed: true })).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', { name: 'Auto' }));
-    expect(screen.getByRole('button', { name: 'Auto', pressed: true })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Custom', pressed: false })).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', { name: 'Custom' }));
-    expect(screen.getByRole('button', { name: 'Auto', pressed: false })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Custom', pressed: true })).toBeInTheDocument();
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_auto')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_custom')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await userEvent.click(screen.getByTestId('rowHeightSettings_rowHeight_auto'));
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_auto')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_custom')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    await userEvent.click(screen.getByTestId('rowHeightSettings_rowHeight_custom'));
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_auto')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    expect(screen.getByTestId('rowHeightSettings_rowHeight_custom')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
   it('should disable FieldNumber when Auto is selected', async () => {
     renderRowHeightSettings();
-    await userEvent.click(screen.getByRole('button', { name: 'Auto' }));
-    expect(screen.getByRole('spinbutton')).toBeDisabled();
+    await userEvent.click(screen.getByTestId('rowHeightSettings_rowHeight_auto'));
+    expect(screen.getByTestId('rowHeightSettings_lineCountNumber')).toBeDisabled();
   });
 
   it('field number should persevere previously selected Custom number after changing rowHight to Auto', async () => {
     renderRowHeightSettings();
 
-    const fieldNumber = screen.getByRole('spinbutton');
+    const fieldNumber = screen.getByTestId('rowHeightSettings_lineCountNumber');
     expect(fieldNumber).toHaveValue(3);
     fireEvent.change(fieldNumber, {
       target: { value: 10 },
     });
     expect(fieldNumber).toHaveValue(10);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Auto' }));
+    await userEvent.click(screen.getByTestId('rowHeightSettings_rowHeight_auto'));
 
     expect(fieldNumber).toHaveValue(10);
   });

--- a/x-pack/platform/plugins/shared/timelines/.eslintrc.js
+++ b/x-pack/platform/plugins/shared/timelines/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -93,14 +94,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -182,7 +180,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/platform/plugins/shared/timelines/.eslintrc.js
+++ b/x-pack/platform/plugins/shared/timelines/.eslintrc.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/platform/plugins/shared/timelines/public/components/hover_actions/actions/add_to_timeline.test.tsx
+++ b/x-pack/platform/plugins/shared/timelines/public/components/hover_actions/actions/add_to_timeline.test.tsx
@@ -86,6 +86,8 @@ const providerB: DataProvider = {
   },
 };
 
+const getButton = () => screen.getByTestId('add-to-timeline');
+
 describe('add to timeline', () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -103,11 +105,11 @@ describe('add to timeline', () => {
     });
 
     test('it renders the button icon', () => {
-      expect(screen.getByRole('button')).toHaveClass('timelines__hoverActionButton');
+      expect(getButton()).toHaveClass('timelines__hoverActionButton');
     });
 
     test('it has the expected aria label', () => {
-      expect(screen.getByLabelText(i18n.ADD_TO_TIMELINE)).toBeInTheDocument();
+      expect(getButton()).toHaveAttribute('aria-label', i18n.ADD_TO_TIMELINE);
     });
   });
 
@@ -126,11 +128,11 @@ describe('add to timeline', () => {
     });
 
     test('it renders the component provided via the `Component` prop', () => {
-      expect(screen.getByRole('button')).toHaveClass('euiButtonEmpty');
+      expect(getButton()).toHaveClass('euiButtonEmpty');
     });
 
     test('it has the expected aria label', () => {
-      expect(screen.getByLabelText(i18n.ADD_TO_TIMELINE)).toBeInTheDocument();
+      expect(getButton()).toHaveAttribute('aria-label', i18n.ADD_TO_TIMELINE);
     });
   });
 
@@ -174,7 +176,7 @@ describe('add to timeline', () => {
         </TestProviders>
       );
 
-      fireEvent.click(screen.getByRole('button'));
+      fireEvent.click(getButton());
 
       expect(mockStartDragToTimeline).toBeCalled();
     });
@@ -186,7 +188,7 @@ describe('add to timeline', () => {
         </TestProviders>
       );
 
-      fireEvent.click(screen.getByRole('button'));
+      fireEvent.click(getButton());
 
       expect(mockStartDragToTimeline).not.toBeCalled();
     });
@@ -203,7 +205,7 @@ describe('add to timeline', () => {
         </TestProviders>
       );
 
-      fireEvent.click(screen.getByRole('button'));
+      fireEvent.click(getButton());
 
       expect(mockDispatch).toHaveBeenCalledTimes(1);
 
@@ -238,7 +240,7 @@ describe('add to timeline', () => {
         </TestProviders>
       );
 
-      fireEvent.click(screen.getByRole('button'));
+      fireEvent.click(getButton());
 
       expect(mockDispatch).toHaveBeenCalledTimes(2);
 
@@ -275,7 +277,7 @@ describe('add to timeline', () => {
         </TestProviders>
       );
 
-      fireEvent.click(screen.getByRole('button'));
+      fireEvent.click(getButton());
 
       expect(onClick).toBeCalled();
     });
@@ -432,7 +434,7 @@ describe('add to timeline', () => {
         </TestProviders>
       );
 
-      fireEvent.click(screen.getByRole('button'));
+      fireEvent.click(getButton());
 
       const message: SuccessMessageProps = {
         children: i18n.ADDED_TO_TIMELINE_OR_TEMPLATE_MESSAGE(providerA.name, true),
@@ -454,7 +456,7 @@ describe('add to timeline', () => {
         </TestProviders>
       );
 
-      fireEvent.click(screen.getByRole('button'));
+      fireEvent.click(getButton());
 
       const message: SuccessMessageProps = {
         children: i18n.ADDED_TO_TIMELINE_OR_TEMPLATE_MESSAGE(providerA.name, false),

--- a/x-pack/solutions/security/packages/connectors/.eslintrc.js
+++ b/x-pack/solutions/security/packages/connectors/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -81,17 +79,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -173,7 +165,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/packages/data-table/.eslintrc.js
+++ b/x-pack/solutions/security/packages/data-table/.eslintrc.js
@@ -93,14 +93,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -182,7 +179,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/packages/data-table/.eslintrc.js
+++ b/x-pack/solutions/security/packages/data-table/.eslintrc.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/packages/data-table/components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/packages/data-table/components/data_table/index.test.tsx
@@ -256,7 +256,7 @@ describe('DataTable', () => {
     fireEvent.click(screen.getByTestId('dataGridColumnSelectorButton'));
 
     // `EuiDataGrid` renders switches for hiding in the `Columns` popover when `showColumnSelector.allowHide` is `true`
-    const switches = await screen.queryAllByRole('switch');
+    const switches = await screen.queryAllByTestId(/dataGridColumnSelectorToggleColumnVisibility-/);
 
     expect(switches.length).toBe(0); // no switches are rendered, because `allowHide` is `false`
   });

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/.eslintrc.js
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -81,17 +79,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -173,7 +165,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/historical_results/historical_results_list/historical_result/index.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/historical_results/historical_results_list/historical_result/index.tsx
@@ -11,9 +11,9 @@ import { EuiSpacer } from '@elastic/eui';
 import type { HistoricalResult as HistoricalResultType } from '../../../../../../../types';
 import { IndexStatsPanel } from '../../../index_stats_panel';
 import { HistoricalCheckFields } from './historical_check_fields';
-// eslint-disable-next-line no-restricted-imports
+
 import { isNonLegacyHistoricalResult } from './utils/is_non_legacy_historical_result';
-// eslint-disable-next-line no-restricted-imports
+
 import { LegacyHistoricalCheckFields } from './legacy_historical_check_fields';
 
 export interface Props {

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/historical_results/historical_results_list/historical_result/legacy_historical_check_fields/index.test.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/historical_results/historical_results_list/historical_result/legacy_historical_check_fields/index.test.tsx
@@ -155,7 +155,7 @@ describe('LegacyHistoricalCheckFields', () => {
 
         expect(wrapper).toBeInTheDocument();
 
-        const addToNewCase = screen.getByLabelText('Add to new case');
+        const addToNewCase = screen.getByTestId('addToNewCase');
         expect(addToNewCase).toBeInTheDocument();
         await act(async () => userEvent.click(addToNewCase));
         expect(openCreateCaseFlyout).toHaveBeenCalledWith({
@@ -163,7 +163,7 @@ describe('LegacyHistoricalCheckFields', () => {
           headerContent: expect.anything(),
         });
 
-        const copyToClipboardElement = screen.getByLabelText('Copy to clipboard');
+        const copyToClipboardElement = screen.getByTestId('copyToClipboard');
         expect(copyToClipboardElement).toBeInTheDocument();
         await act(async () => userEvent.click(copyToClipboardElement));
         expect(copyToClipboard).toHaveBeenCalledWith(markdownComments.join('\n'));

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/historical_results/historical_results_list/historical_result/utils/is_non_legacy_historical_result.test.ts
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/historical_results/historical_results_list/historical_result/utils/is_non_legacy_historical_result.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { getHistoricalResultStub } from '../../../../../../../../stub/get_historical_result_stub';
-// eslint-disable-next-line no-restricted-imports
+
 import { isNonLegacyHistoricalResult } from './is_non_legacy_historical_result';
 
 describe('isNonLegacyHistoricalResult', () => {

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_result_badge/index.test.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_result_badge/index.test.tsx
@@ -32,7 +32,9 @@ describe('IndexResultBadge', () => {
 
       await userEvent.hover(screen.getByTestId('indexResultBadge'));
 
-      await waitFor(() => expect(screen.getByRole('tooltip')).toHaveTextContent('Tooltip text'));
+      await waitFor(() =>
+        expect(screen.getByText('Tooltip text').closest('[role="tooltip"]')).toBeInTheDocument()
+      );
     });
   });
 });

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/utils/columns.test.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/utils/columns.test.tsx
@@ -24,9 +24,7 @@ import {
   getSummaryTableILMPhaseColumn,
   getSummaryTableSizeInBytesColumn,
 } from './columns';
-import { VIEW_HISTORY } from '../translations';
 import type { IndexSummaryTableItem } from '../../../../../types';
-import { CHECK_NOW } from '../../translations';
 
 const defaultBytesFormat = '0,0.[0]b';
 const formatBytes = (value: number | undefined) =>
@@ -142,7 +140,7 @@ describe('helpers', () => {
           </TestExternalProviders>
         );
 
-        expect(screen.getByLabelText(CHECK_NOW)).toBeInTheDocument();
+        expect(screen.getByTestId(`checkNowAction-${indexName}`)).toBeInTheDocument();
       });
 
       test('it invokes the `onCheckNowAction` with the index name when the check now button is clicked', async () => {
@@ -168,7 +166,7 @@ describe('helpers', () => {
           </TestExternalProviders>
         );
 
-        const button = screen.getByLabelText(CHECK_NOW);
+        const button = screen.getByTestId(`checkNowAction-${indexName}`);
         await userEvent.click(button);
 
         expect(onCheckNowAction).toBeCalledWith(indexSummaryTableItem.indexName);
@@ -198,7 +196,7 @@ describe('helpers', () => {
           </TestExternalProviders>
         );
 
-        const button = screen.getByLabelText(VIEW_HISTORY);
+        const button = screen.getByTestId(`viewHistoryAction-${indexName}`);
         await userEvent.click(button);
 
         expect(onViewHistoryAction).toBeCalledWith(indexSummaryTableItem.indexName);

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_summary/ilm_phase_filter/index.test.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/data_quality_summary/ilm_phase_filter/index.test.tsx
@@ -33,7 +33,7 @@ describe('IlmPhaseFilter', () => {
       </TestExternalProviders>
     );
     expect(screen.getByTestId('selectIlmPhases')).toBeInTheDocument();
-    expect(screen.getByLabelText('ILM phase')).toBeInTheDocument();
+    expect(screen.getByTestId('comboBoxSearchInput')).toBeInTheDocument();
     expect(screen.getByText('hot')).toBeInTheDocument();
     expect(screen.getByText('warm')).toBeInTheDocument();
     expect(screen.getByText('unmanaged')).toBeInTheDocument();
@@ -84,7 +84,9 @@ describe('IlmPhaseFilter', () => {
       await userEvent.hover(screen.getByTestId('comboBoxSearchInput'));
 
       await waitFor(() =>
-        expect(screen.getByRole('tooltip')).toHaveTextContent(INDEX_LIFECYCLE_MANAGEMENT_PHASES)
+        expect(
+          screen.getByText(INDEX_LIFECYCLE_MANAGEMENT_PHASES).closest('[role="tooltip"]')
+        ).toBeInTheDocument()
       );
     });
   });
@@ -122,9 +124,11 @@ describe('IlmPhaseFilter', () => {
         await userEvent.click(searchInput);
         await userEvent.hover(screen.getByText(option.toLowerCase()), { pointerEventsCheck: 0 });
 
-        await waitFor(() =>
-          expect(screen.getByRole('tooltip')).toHaveTextContent(tooltipDescription)
-        );
+        await waitFor(() => {
+          return expect(
+            screen.getByText(`${option}: ${tooltipDescription}`).closest('[role="tooltip"]')
+          ).toBeInTheDocument();
+        });
       });
     });
   });

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/stats_rollup/index.test.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/stats_rollup/index.test.tsx
@@ -125,9 +125,11 @@ describe('StatsRollup', () => {
         await userEvent.hover(screen.getByText(statLabelText));
 
         await waitFor(() =>
-          expect(screen.getByRole('tooltip')).toHaveTextContent(
-            patternTooltipText.replace('{pattern}', 'my-pattern')
-          )
+          expect(
+            screen
+              .getByText(patternTooltipText.replace('{pattern}', 'my-pattern'))
+              .closest('[role="tooltip"]')
+          ).toBeInTheDocument()
         );
       });
     });
@@ -151,7 +153,9 @@ describe('StatsRollup', () => {
         await userEvent.hover(screen.getByText(statLabelText));
 
         await waitFor(() =>
-          expect(screen.getByRole('tooltip')).toHaveTextContent(noPatternTooltipText)
+          expect(
+            screen.getByText(noPatternTooltipText).closest('[role="tooltip"]')
+          ).toBeInTheDocument()
         );
       });
     });

--- a/x-pack/solutions/security/packages/features/.eslintrc.js
+++ b/x-pack/solutions/security/packages/features/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -81,17 +79,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -173,7 +165,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/packages/navigation/.eslintrc.js
+++ b/x-pack/solutions/security/packages/navigation/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -81,17 +79,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -173,7 +165,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/packages/side-nav/.eslintrc.js
+++ b/x-pack/solutions/security/packages/side-nav/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -81,17 +79,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -173,7 +165,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/packages/upselling/.eslintrc.js
+++ b/x-pack/solutions/security/packages/upselling/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -81,17 +79,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -173,7 +165,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/.eslintrc.js
@@ -78,6 +78,25 @@ const RESTRICTED_IMPORTS_PATHS = [
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
 ];
 
 const ROOT_DIR = execSync('git rev-parse --show-toplevel', {

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/.eslintrc.js
@@ -68,7 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -99,17 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -191,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -81,17 +79,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -173,7 +165,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/alert_count_by_rule_by_status.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/alert_count_by_rule_by_status.test.tsx
@@ -69,8 +69,8 @@ describe('AlertCountByRuleByStatus', () => {
   });
 
   it('should render the table columns', () => {
-    const { getAllByRole } = renderComponent();
-    const columnHeaders = getAllByRole('columnheader');
+    const { getAllByTestId } = renderComponent();
+    const columnHeaders = getAllByTestId(/tableHeaderCell/);
 
     expect(columnHeaders.at(0)).toHaveTextContent(COLUMN_HEADER_RULE_NAME);
     expect(columnHeaders.at(1)).toHaveTextContent(COLUMN_HEADER_COUNT);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/investigate_in_timeline_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/investigate_in_timeline_button.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { InvestigateInTimelineButton } from './investigate_in_timeline_button';
@@ -27,13 +27,17 @@ describe('InvestigateInTimelineButton', () => {
       const dataProviders = ['127.0.0.1', '::1', '10.1.2.3', '2001:0DB8:AC10:FE01::'].map(
         (ipValue) => getDataProvider('host.ip', '', ipValue)
       );
-      render(
+      const { container } = render(
         <TestProviders>
           <InvestigateInTimelineButton asEmptyButton={true} dataProviders={dataProviders} />
         </TestProviders>
       );
-      expect(screen.queryByLabelText(ACTION_INVESTIGATE_IN_TIMELINE)).toBeInTheDocument();
-      expect(screen.queryByLabelText(ACTION_INVESTIGATE_IN_TIMELINE)).not.toBeDisabled();
+      expect(
+        container.querySelector(`[aria-label="${ACTION_INVESTIGATE_IN_TIMELINE}"]`)
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector(`[aria-label="${ACTION_INVESTIGATE_IN_TIMELINE}"]`)
+      ).not.toBeDisabled();
     });
 
     it('should be disabled when the user has insufficient privileges', () => {
@@ -43,12 +47,14 @@ describe('InvestigateInTimelineButton', () => {
       const dataProviders = ['127.0.0.1', '::1', '10.1.2.3', '2001:0DB8:AC10:FE01::'].map(
         (ipValue) => getDataProvider('host.ip', '', ipValue)
       );
-      render(
+      const { container } = render(
         <TestProviders>
           <InvestigateInTimelineButton asEmptyButton={true} dataProviders={dataProviders} />
         </TestProviders>
       );
-      expect(screen.queryByLabelText(ACTION_INVESTIGATE_IN_TIMELINE)).toBeDisabled();
+      expect(
+        container.querySelector(`[aria-label="${ACTION_INVESTIGATE_IN_TIMELINE}"]`)
+      ).toBeDisabled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.test.tsx
@@ -84,7 +84,8 @@ describe('Modal Inspect', () => {
         'true'
       );
 
-      const responseTextContent = screen.getByRole('tabpanel').textContent ?? '';
+      const responseTextContent =
+        screen.getByTestId('modal-inspect-response-preview').textContent ?? '';
       expect(JSON.parse(responseTextContent)).toMatchObject({
         took: 880,
         timed_out: false,
@@ -145,7 +146,8 @@ describe('Modal Inspect', () => {
         'true'
       );
 
-      const requestTextContent = screen.getByRole('tabpanel').textContent ?? '';
+      const requestTextContent =
+        screen.getByTestId('modal-inspect-request-preview').textContent ?? '';
 
       expect(JSON.parse(requestTextContent)).toMatchObject({
         aggregations: {
@@ -178,7 +180,8 @@ describe('Modal Inspect', () => {
         'true'
       );
 
-      const requestTextContent = screen.getByRole('tabpanel').textContent ?? '';
+      const requestTextContent =
+        screen.getByTestId('modal-inspect-request-preview').textContent ?? '';
 
       expect(requestTextContent).toMatch(esqlQuery);
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/links/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/links/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/links/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/links/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/links/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/links/helpers.test.tsx
@@ -40,7 +40,7 @@ describe('MoreReputationLinksContainer', () => {
       />
     );
 
-    expect(screen.getByRole('link')).toHaveTextContent('item6');
+    expect(screen.getByText('item6')).toBeInTheDocument();
   });
 
   test('it should render all the items when overflowIndexStart is zero', () => {
@@ -53,7 +53,7 @@ describe('MoreReputationLinksContainer', () => {
       />
     );
 
-    expect(screen.getAllByRole('link')).toHaveLength(6);
+    expect(screen.getAllByText(/item\d/)).toHaveLength(6);
   });
 
   test('it should have the eui-yScroll to enable scrolling', () => {
@@ -111,7 +111,7 @@ describe('ReputationLinksOverflow', () => {
       </TestProviders>
     );
 
-    expect(wrapper.getByRole('button')).toHaveTextContent('+1 More');
+    expect(wrapper.getByText('+1 More')).toBeInTheDocument();
     expect(wrapper.queryByTestId('more-container')).toBeNull();
   });
 
@@ -126,7 +126,7 @@ describe('ReputationLinksOverflow', () => {
         />
       </TestProviders>
     );
-    fireEvent.click(wrapper.getByRole('button'));
+    fireEvent.click(wrapper.getByText('+1 More'));
 
     expect(wrapper.queryByTestId('more-container')).toHaveTextContent('item6');
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/.eslintrc.js
@@ -79,6 +79,25 @@ const RESTRICTED_IMPORTS_PATHS = [
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
 ];
 
 const ROOT_DIR = execSync('git rev-parse --show-toplevel', {

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -100,17 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboards_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboards_table.test.tsx
@@ -64,7 +64,7 @@ describe('Dashboards table', () => {
   it('should filter two rows using the search box', () => {
     const result = renderDashboardTable();
 
-    const input = result.getByRole('searchbox');
+    const input = result.getByPlaceholderText('Search...');
     fireEvent.change(input, { target: { value: 'dashboard' } });
 
     expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(2);
@@ -78,7 +78,7 @@ describe('Dashboards table', () => {
   it('should filter only one row using the search box', () => {
     const result = renderDashboardTable();
 
-    const input = result.getByRole('searchbox');
+    const input = result.getByPlaceholderText('Search...');
     fireEvent.change(input, { target: { value: DASHBOARD_TABLE_ITEMS[0].title } });
 
     expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
@@ -90,7 +90,7 @@ describe('Dashboards table', () => {
   it('should filter by description using the search box', () => {
     const result = renderDashboardTable();
 
-    const input = result.getByRole('searchbox');
+    const input = result.getByPlaceholderText('Search...');
     fireEvent.change(input, { target: { value: DASHBOARD_TABLE_ITEMS[0].description } });
 
     expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
@@ -101,7 +101,7 @@ describe('Dashboards table', () => {
   it('should filter with case insensitive text using the search box', () => {
     const result = renderDashboardTable();
 
-    const input = result.getByRole('searchbox');
+    const input = result.getByPlaceholderText('Search...');
     fireEvent.change(input, { target: { value: DASHBOARD_TABLE_ITEMS[0].title.toUpperCase() } });
 
     expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
@@ -112,7 +112,7 @@ describe('Dashboards table', () => {
   it('should filter out special characters except hyphens & underscores', () => {
     const result = renderDashboardTable();
 
-    const input = result.getByRole('searchbox');
+    const input = result.getByPlaceholderText('Search...');
     fireEvent.change(input, { target: { value: '"_title"' } });
 
     expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -93,14 +94,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -182,7 +180,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/.eslintrc.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -93,14 +94,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -182,7 +180,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/.eslintrc.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.test.tsx
@@ -33,28 +33,32 @@ describe('Alert by rule chart', () => {
   });
 
   test('should render the table correctly with data', () => {
-    const { queryAllByRole } = render(
+    const { container } = render(
       <TestProviders>
         <AlertsByRule data={parsedAlerts} isLoading={false} showCellActions={true} />
       </TestProviders>
     );
 
     parsedAlerts.forEach((_, i) => {
-      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].rule);
-      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].value.toString());
-      expect(queryAllByRole('row')[i + 1].children).toHaveLength(3);
+      expect(container.querySelectorAll('.euiTableRow')[i].textContent).toContain(
+        parsedAlerts[i].rule
+      );
+      expect(container.querySelectorAll('.euiTableRow')[i].textContent).toContain(
+        parsedAlerts[i].value.toString()
+      );
+      expect(container.querySelectorAll('.euiTableRow')[i].children).toHaveLength(3);
     });
   });
 
   test('should render the table without the third columns (for cell actions)', () => {
-    const { queryAllByRole } = render(
+    const { container } = render(
       <TestProviders>
         <AlertsByRule data={parsedAlerts} isLoading={false} showCellActions={false} />
       </TestProviders>
     );
 
     parsedAlerts.forEach((_, i) => {
-      expect(queryAllByRole('row')[i + 1].children).toHaveLength(2);
+      expect(container.querySelectorAll('.euiTableRow')[i].children).toHaveLength(2);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsProgressBarPanel } from '.';
 import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
-import { STACK_BY_ARIA_LABEL } from '../common/translations';
 import type { GroupBySelection } from './types';
 import { useStackByFields } from '../common/hooks';
 
@@ -27,8 +26,6 @@ jest.mock('../../../../common/components/cell_actions', () => ({
 
 jest.mock('../alerts_summary_charts_panel/use_summary_chart_data');
 const mockUseSummaryChartData = useSummaryChartData as jest.Mock;
-
-const options = ['host.name', 'user.name', 'source.ip', 'destination.ip'];
 
 describe('Alert by grouping', () => {
   const defaultProps = {
@@ -84,32 +81,39 @@ describe('Alert by grouping', () => {
     });
 
     test('combo box renders corrected options', async () => {
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <AlertsProgressBarPanel {...defaultProps} setGroupBySelection={setGroupBySelection} />
         </TestProviders>
       );
-      const comboBox = screen.getByRole('combobox', { name: STACK_BY_ARIA_LABEL });
+
+      const comboBox = getByTestId('comboBoxSearchInput');
       act(() => {
         if (comboBox) {
           comboBox.focus(); // display the combo box options
         }
       });
 
-      const optionsFound = screen.getAllByRole('option').map((option) => option.textContent);
-      options.forEach((option, i) => {
-        expect(optionsFound[i]).toEqual(option);
+      const optionsFound = screen.getAllByTitle(
+        /host\.name|user\.name|source\.ip|destination\.ip/i
+      );
+
+      screen.debug(optionsFound);
+
+      optionsFound.forEach((optionFound) => {
+        expect(optionFound).toBeInTheDocument();
       });
     });
 
     test('it invokes setGroupBySelection when an option is selected', async () => {
       const toBeSelected = 'user.name';
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <AlertsProgressBarPanel {...defaultProps} setGroupBySelection={setGroupBySelection} />
         </TestProviders>
       );
-      const comboBox = screen.getByRole('combobox', { name: STACK_BY_ARIA_LABEL });
+      const comboBox = getByTestId('comboBoxSearchInput');
+
       act(() => {
         if (comboBox) {
           comboBox.focus(); // display the combo box options

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_context_menu/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_context_menu/index.test.tsx
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import React from 'react';
 
-import { RESET_GROUP_BY_FIELDS } from '../chart_settings_popover/configurations/default/translations';
-import { CHART_SETTINGS_POPOVER_ARIA_LABEL } from '../chart_settings_popover/translations';
-import { INSPECT } from '../../../../../common/components/inspect/translations';
 import { DEFAULT_STACK_BY_FIELD, DEFAULT_STACK_BY_FIELD1 } from '../../common/config';
 import { TestProviders } from '../../../../../common/mock';
 import { ChartContextMenu } from '.';
@@ -21,7 +18,7 @@ describe('ChartContextMenu', () => {
   beforeEach(() => jest.clearAllMocks());
 
   test('it renders the chart context menu button', () => {
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -33,13 +30,11 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    expect(
-      screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL })
-    ).toBeInTheDocument();
+    expect(getByTestId('chart-settings-popover-button')).toBeInTheDocument();
   });
 
   test('it renders the Inspect menu item', async () => {
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -51,18 +46,18 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+    const menuButton = getByTestId('chart-settings-popover-button');
     menuButton.click();
     await waitForEuiPopoverOpen();
 
-    expect(screen.getByRole('button', { name: INSPECT })).toBeInTheDocument();
+    expect(getByTestId('inspect')).toBeInTheDocument();
   });
 
   test('it invokes `setStackBy` and `setStackByField1` when the Reset group by fields menu item selected', async () => {
     const setStackBy = jest.fn();
     const setStackByField1 = jest.fn();
 
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -74,11 +69,11 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+    const menuButton = getByTestId('chart-settings-popover-button');
     menuButton.click();
     await waitForEuiPopoverOpen();
 
-    const resetMenuItem = screen.getByRole('button', { name: RESET_GROUP_BY_FIELDS });
+    const resetMenuItem = getByTestId('reset-group-by');
     resetMenuItem.click();
 
     expect(setStackBy).toBeCalledWith('kibana.alert.rule.name');
@@ -88,7 +83,7 @@ describe('ChartContextMenu', () => {
   test('it invokes `onReset` when the `Reset group by fields` menu item clicked', async () => {
     const onReset = jest.fn();
 
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -101,11 +96,11 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+    const menuButton = getByTestId('chart-settings-popover-button');
     fireEvent.click(menuButton);
     await waitForEuiPopoverOpen();
 
-    const resetMenuItem = screen.getByRole('button', { name: RESET_GROUP_BY_FIELDS });
+    const resetMenuItem = getByTestId('reset-group-by');
     fireEvent.click(resetMenuItem);
 
     expect(onReset).toBeCalled();

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/configurations/default/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/configurations/default/index.tsx
@@ -46,6 +46,7 @@ export const useChartSettingsPopoverConfiguration = ({
               setIsPopoverOpen(false);
               handleClick();
             },
+            'data-test-subj': 'inspect',
           },
           {
             name: i18n.RESET_GROUP_BY_FIELDS,
@@ -53,6 +54,7 @@ export const useChartSettingsPopoverConfiguration = ({
               setIsPopoverOpen(false);
               onResetStackByFields();
             },
+            'data-test-subj': 'reset-group-by',
           },
         ],
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/index.test.tsx
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
-import { CHART_SETTINGS_POPOVER_ARIA_LABEL } from './translations';
 import { ChartSettingsPopover } from '.';
 
 describe('ChartSettingsPopover', () => {
@@ -31,7 +30,7 @@ describe('ChartSettingsPopover', () => {
   ];
 
   it('renders the chart settings popover', () => {
-    render(
+    const { getByTestId } = render(
       <ChartSettingsPopover
         initialPanelId={initialPanelId}
         isPopoverOpen={false}
@@ -40,8 +39,6 @@ describe('ChartSettingsPopover', () => {
       />
     );
 
-    expect(
-      screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL })
-    ).toBeInTheDocument();
+    expect(getByTestId('chart-settings-popover-button')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/index.tsx
@@ -40,6 +40,7 @@ const ChartSettingsPopoverComponent: React.FC<Props> = ({
         iconType="boxesVertical"
         onClick={onButtonClick}
         size="xs"
+        data-test-subj="chart-settings-popover-button"
       />
     ),
     [onButtonClick]

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.test.tsx
@@ -10,8 +10,6 @@ import React from 'react';
 
 import { useAlertsLocalStorage } from './alerts_local_storage';
 import type { Status } from '../../../../../common/api/detection_engine';
-import { RESET_GROUP_BY_FIELDS } from './chart_settings_popover/configurations/default/translations';
-import { CHART_SETTINGS_POPOVER_ARIA_LABEL } from './chart_settings_popover/translations';
 import { mockBrowserFields } from '../../../../common/containers/source/mock';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { TestProviders } from '../../../../common/mock';
@@ -140,10 +138,10 @@ const defaultProps = {
 };
 
 const resetGroupByFields = () => {
-  const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+  const menuButton = screen.getByTestId('chart-settings-popover-button');
   fireEvent.click(menuButton);
 
-  const resetMenuItem = screen.getByRole('button', { name: RESET_GROUP_BY_FIELDS });
+  const resetMenuItem = screen.getByTestId('reset-group-by');
   fireEvent.click(resetMenuItem);
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.test.tsx
@@ -12,7 +12,6 @@ import 'jest-styled-components';
 
 import { TestProviders } from '../../../../common/mock';
 import { KpiPanel, StackByComboBox } from './components';
-import * as i18n from './translations';
 import { useStackByFields } from './hooks';
 
 jest.mock('./hooks');
@@ -108,7 +107,7 @@ describe('components', () => {
       const onSelect = jest.fn();
       const optionToSelect = 'agent.hostname';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -122,7 +121,7 @@ describe('components', () => {
         </TestProviders>
       );
 
-      const comboBox = screen.getByRole('combobox', { name: i18n.STACK_BY_ARIA_LABEL });
+      const comboBox = getByTestId('comboBoxSearchInput');
       comboBox.focus(); // display the combo box options
 
       const option = await screen.findByText(optionToSelect);
@@ -132,7 +131,7 @@ describe('components', () => {
     });
 
     test('it does NOT disable the combo box by default', () => {
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -142,13 +141,12 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByRole('combobox', { name: i18n.STACK_BY_ARIA_LABEL })).not.toHaveAttribute(
-        'disabled'
-      );
+      const comboBox = getByTestId('comboBoxSearchInput');
+      expect(comboBox).not.toHaveAttribute('disabled');
     });
 
     test('it disables the combo box when `isDisabled` is true', () => {
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -159,15 +157,14 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByRole('combobox', { name: i18n.STACK_BY_ARIA_LABEL })).toHaveAttribute(
-        'disabled'
-      );
+      const comboBox = getByTestId('comboBoxSearchInput');
+      expect(comboBox).toHaveAttribute('disabled');
     });
 
     test('overrides the default accessible name via the `aria-label` prop when provided', () => {
       const customAccessibleName = 'custom';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             aria-label={customAccessibleName}
@@ -179,13 +176,16 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByRole('combobox', { name: customAccessibleName })).toBeInTheDocument();
+      expect(getByTestId('comboBoxSearchInput')).toHaveAttribute(
+        'aria-label',
+        customAccessibleName
+      );
     });
 
     test('it renders the default label', () => {
       const defaultLabel = 'Stack by';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -195,13 +195,13 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByLabelText(defaultLabel)).toBeInTheDocument();
+      expect(getByTestId('stackByComboBox')).toHaveTextContent(defaultLabel);
     });
 
     test('it overrides the default label when `prepend` is specified', () => {
       const prepend = 'Group by';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -212,7 +212,7 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByLabelText(prepend)).toBeInTheDocument();
+      expect(getByTestId('stackByComboBox')).toHaveTextContent(prepend);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/field_selection.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/field_selection.test.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import type { Props } from './field_selection';
 import { FieldSelection } from './field_selection';
-import { GROUP_BY_LABEL, GROUP_BY_TOP_LABEL } from './translations';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -34,7 +33,7 @@ describe('FieldSelection', () => {
       </TestProviders>
     );
 
-    expect(screen.getByRole('combobox', { name: GROUP_BY_LABEL })).toBeInTheDocument();
+    expect(screen.getByTestId('groupBy')).toBeInTheDocument();
   });
 
   test('it renders the (second) "Group by top" selection', () => {
@@ -44,7 +43,7 @@ describe('FieldSelection', () => {
       </TestProviders>
     );
 
-    expect(screen.getByRole('combobox', { name: GROUP_BY_TOP_LABEL })).toBeInTheDocument();
+    expect(screen.getByTestId('groupByTop')).toBeInTheDocument();
   });
 
   test('it renders the chart options context menu using the provided `uniqueQueryId`', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.test.tsx
@@ -49,28 +49,32 @@ describe('Severity level chart', () => {
   });
 
   it('should render the table correctly with data', () => {
-    const { queryAllByRole, getByTestId } = render(
+    const { container, getByTestId } = render(
       <TestProviders>
         <SeverityLevelChart data={parsedAlerts} isLoading={false} showCellActions={true} />
       </TestProviders>
     );
     expect(getByTestId('severity-level-table')).toBeInTheDocument();
     parsedAlerts.forEach((_, i) => {
-      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].label);
-      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].value.toString());
-      expect(queryAllByRole('row')[i + 1].children).toHaveLength(3);
+      expect(container.querySelectorAll('.euiTableRow')[i].textContent).toContain(
+        parsedAlerts[i].label
+      );
+      expect(container.querySelectorAll('.euiTableRow')[i].textContent).toContain(
+        parsedAlerts[i].value.toString()
+      );
+      expect(container.querySelectorAll('.euiTableRow')[i].children).toHaveLength(3);
     });
   });
 
   it('should render the table without the third columns (cell actions)', () => {
-    const { queryAllByRole, getByTestId } = render(
+    const { container, getByTestId } = render(
       <TestProviders>
         <SeverityLevelChart data={parsedAlerts} isLoading={false} showCellActions={false} />
       </TestProviders>
     );
     expect(getByTestId('severity-level-table')).toBeInTheDocument();
     parsedAlerts.forEach((_, i) => {
-      expect(queryAllByRole('row')[i + 1].children).toHaveLength(2);
+      expect(container.querySelectorAll('.euiTableRow')[i].children).toHaveLength(2);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -93,14 +94,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -182,7 +180,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/.eslintrc.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -100,17 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -192,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/.eslintrc.js
@@ -79,6 +79,25 @@ const RESTRICTED_IMPORTS_PATHS = [
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
 ];
 
 const ROOT_DIR = execSync('git rev-parse --show-toplevel', {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/authentications_host_table.test.tsx
@@ -68,13 +68,13 @@ describe('Authentication Host Table Component', () => {
 
   describe('columns', () => {
     test('on hosts page, we expect to get all 9 columns', () => {
-      const { queryAllByRole, queryByText } = render(
+      const { queryAllByTestId, queryByText } = render(
         <TestProviders>
           <AuthenticationsHostTable {...defaultProps} />
         </TestProviders>
       );
 
-      expect(queryAllByRole('columnheader').length).toEqual(9);
+      expect(queryAllByTestId(/tableHeaderCell_/).length).toEqual(9);
 
       // it should have Last Successful Destination column
       expect(queryByText(i18n.LAST_SUCCESSFUL_DESTINATION)).toBeInTheDocument();
@@ -83,13 +83,13 @@ describe('Authentication Host Table Component', () => {
     });
 
     test('on hosts page, we expect to get 7 user details columns', () => {
-      const { queryAllByRole, queryByText } = render(
+      const { queryAllByTestId, queryByText } = render(
         <TestProviders>
           <AuthenticationsHostTable {...defaultProps} type={hostsModel.HostsType.details} />
         </TestProviders>
       );
 
-      expect(queryAllByRole('columnheader').length).toEqual(7);
+      expect(queryAllByTestId(/tableHeaderCell_/).length).toEqual(7);
 
       // it should not have Successful Destination column
       expect(queryByText(i18n.LAST_SUCCESSFUL_DESTINATION)).not.toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_item_header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_item_header.test.tsx
@@ -15,16 +15,16 @@ describe('StatItemHeader', () => {
   beforeEach(() => {});
 
   it('renders expand button', () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <StatItemHeader onToggle={mockOnToggle} isToggleExpanded={true} />
     );
-    expect(getByRole('button')).toHaveAttribute('title', 'Open');
+    expect(getByTestId('query-toggle-stat')).toHaveAttribute('title', 'Open');
   });
 
   it('renders collapse button', () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <StatItemHeader onToggle={mockOnToggle} isToggleExpanded={false} />
     );
-    expect(getByRole('button')).toHaveAttribute('title', 'Closed');
+    expect(getByTestId('query-toggle-stat')).toHaveAttribute('title', 'Closed');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/map_tool_tip/map_tool_tip.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/map_tool_tip/map_tool_tip.test.tsx
@@ -57,8 +57,8 @@ describe('MapToolTipComponent', () => {
   });
 
   it('shows a loading spinner initially', () => {
-    renderComponent();
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    const { container } = renderComponent();
+    expect(container.querySelector('[role="progressbar"]')).toBeInTheDocument();
   });
 
   it('displays an error message when isError is true', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/all_users/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/all_users/index.test.tsx
@@ -27,7 +27,7 @@ describe('Users Table Component', () => {
   describe('rendering', () => {
     test('it renders the users table', () => {
       const userName = 'testUser';
-      const { getByTestId, getAllByRole, getByText } = render(
+      const { getByTestId, getAllByTestId, getByText } = render(
         <TestProviders>
           <UsersTable
             users={[
@@ -50,7 +50,7 @@ describe('Users Table Component', () => {
       );
 
       expect(getByTestId('table-allUsers-loading-false')).toBeInTheDocument();
-      expect(getAllByRole('columnheader').length).toBe(4);
+      expect(getAllByTestId(/tableHeaderCell_/).length).toBe(4);
       expect(getByText(userName)).toBeInTheDocument();
     });
 
@@ -81,7 +81,7 @@ describe('Users Table Component', () => {
     test('it renders "Host Risk classfication" column when "isPlatinumOrTrialLicense" is truthy', () => {
       mockUseMlCapabilities.mockReturnValue({ isPlatinumOrTrialLicense: true });
 
-      const { getAllByRole, getByText } = render(
+      const { getAllByTestId, getByText } = render(
         <TestProviders>
           <UsersTable
             users={[
@@ -108,14 +108,14 @@ describe('Users Table Component', () => {
         </TestProviders>
       );
 
-      expect(getAllByRole('columnheader').length).toBe(5);
+      expect(getAllByTestId(/tableHeaderCell_/).length).toBe(5);
       expect(getByText('Critical')).toBeInTheDocument();
     });
 
     test("it doesn't renders 'Host Risk classfication' column when 'isPlatinumOrTrialLicense' is falsy", () => {
       mockUseMlCapabilities.mockReturnValue({ isPlatinumOrTrialLicense: false });
 
-      const { getAllByRole, queryByText } = render(
+      const { getAllByTestId, queryByText } = render(
         <TestProviders>
           <UsersTable
             users={[
@@ -142,7 +142,7 @@ describe('Users Table Component', () => {
         </TestProviders>
       );
 
-      expect(getAllByRole('columnheader').length).toBe(4);
+      expect(getAllByTestId(/tableHeaderCell_/).length).toBe(4);
       expect(queryByText('Critical')).not.toBeInTheDocument();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/attack_discovery_widget.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/attack_discovery_widget.test.tsx
@@ -49,13 +49,13 @@ describe('AttackDiscoveryWidget', () => {
       data: null,
     });
 
-    render(
+    const { container } = render(
       <TestProviders>
         <AttackDiscoveryWidget alertId={'123'} />
       </TestProviders>
     );
 
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(container.querySelector('[role="progressbar"]')).toBeInTheDocument();
   });
 
   it('should render no results message when no data is available', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/suggested_prompts.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/suggested_prompts.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { SuggestedPrompts } from './suggested_prompts';
 import { useAssistantContext, useAssistantOverlay } from '@kbn/elastic-assistant';
 
@@ -30,19 +30,18 @@ describe('SuggestedPrompts', () => {
   });
 
   it('renders the suggested prompts', () => {
-    render(
+    const { container } = render(
       <SuggestedPrompts
         getPromptContext={jest.fn()}
         ruleName="Test Rule"
         timestamp="2023-01-01T00:00:00Z"
       />
     );
-
-    expect(screen.getAllByRole('button')).toHaveLength(3); // Assuming there are 3 prompts
+    expect(container.querySelectorAll('button')).toHaveLength(3); // Assuming there are 3 prompts
   });
 
   it('calls showAssistantOverlay when a prompt is clicked', () => {
-    render(
+    const { container } = render(
       <SuggestedPrompts
         getPromptContext={jest.fn()}
         ruleName="Test Rule"
@@ -50,14 +49,14 @@ describe('SuggestedPrompts', () => {
       />
     );
 
-    const firstPromptButton = screen.getAllByRole('button')[0];
+    const firstPromptButton = container.querySelectorAll('button')[0];
     fireEvent.click(firstPromptButton);
 
     expect(mockShowAssistantOverlay).toHaveBeenCalledWith(true);
   });
 
   it('displays the correct title and description in the overlay', () => {
-    render(
+    const { container } = render(
       <SuggestedPrompts
         getPromptContext={jest.fn()}
         ruleName="Test Rule"
@@ -65,7 +64,7 @@ describe('SuggestedPrompts', () => {
       />
     );
 
-    const firstPromptButton = screen.getAllByRole('button')[0];
+    const firstPromptButton = container.querySelectorAll('button')[0];
     fireEvent.click(firstPromptButton);
 
     expect(mockShowAssistantOverlay).toHaveBeenCalledWith(true);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -93,14 +94,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -182,7 +180,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/.eslintrc.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.test.tsx
@@ -82,7 +82,9 @@ describe('CorrelationsDetailsAlertsTable', () => {
   });
 
   it('renders EuiBasicTable with correct props', () => {
-    const { getByTestId, getAllByTestId, queryAllByRole } = renderCorrelationsTable();
+    const { container, getByTestId, getAllByTestId, queryAllByTestId } = renderCorrelationsTable(
+      mockContextValue.scopeId
+    );
 
     expect(getByTestId(`${TEST_ID}InvestigateInTimeline`)).toBeInTheDocument();
     expect(getByTestId(`${TEST_ID}Table`)).toBeInTheDocument();
@@ -90,12 +92,14 @@ describe('CorrelationsDetailsAlertsTable', () => {
 
     expect(jest.mocked(usePaginatedAlerts)).toHaveBeenCalled();
 
-    expect(queryAllByRole('columnheader').length).toBe(5);
-    expect(queryAllByRole('row').length).toBe(3); // 1 header row and 2 data rows
-    expect(queryAllByRole('row')[1].textContent).toContain('Jan 1, 2022 @ 00:00:00.000');
-    expect(queryAllByRole('row')[1].textContent).toContain('Reason1');
-    expect(queryAllByRole('row')[1].textContent).toContain('Rule1');
-    expect(queryAllByRole('row')[1].textContent).toContain('Severity1');
+    expect(queryAllByTestId(/tableHeaderCell_/).length).toBe(5);
+    expect(container.querySelectorAll('.euiTableRow').length).toBe(2); // 2 data rows
+    expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain(
+      'Jan 1, 2022 @ 00:00:00.000'
+    );
+    expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('Reason1');
+    expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('Rule1');
+    expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('Severity1');
   });
 
   it('renders open preview button', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.test.tsx
@@ -259,11 +259,11 @@ describe('<HostDetails />', () => {
       });
       mockUseHasSecurityCapability.mockReturnValue(true);
 
-      const { queryAllByRole } = renderHostDetails(mockContextValue);
-      expect(queryAllByRole('columnheader').length).toBe(3);
-      expect(queryAllByRole('row')[1].textContent).toContain('test user');
-      expect(queryAllByRole('row')[1].textContent).toContain('100.XXX.XXX');
-      expect(queryAllByRole('row')[1].textContent).toContain('Low');
+      const { container, queryAllByTestId } = renderHostDetails(mockContextValue);
+      expect(queryAllByTestId(/tableHeaderCell_/).length).toBe(3);
+      expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('test user');
+      expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('100.XXX.XXX');
+      expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('Low');
     });
 
     it('should not render host risk score column when user has no entity-risk capability', () => {
@@ -273,13 +273,13 @@ describe('<HostDetails />', () => {
       });
       mockUseHasSecurityCapability.mockReturnValue(false);
 
-      const { queryAllByRole } = renderHostDetails(mockContextValue);
-      expect(queryAllByRole('columnheader').length).toBe(2);
+      const { queryAllByTestId } = renderHostDetails(mockContextValue);
+      expect(queryAllByTestId(/tableHeaderCell_/).length).toBe(2);
     });
 
     it('should not render host risk score column when license is not valid', () => {
-      const { queryAllByRole } = renderHostDetails(mockContextValue);
-      expect(queryAllByRole('columnheader').length).toBe(2);
+      const { queryAllByTestId } = renderHostDetails(mockContextValue);
+      expect(queryAllByTestId(/tableHeaderCell_/).length).toBe(2);
     });
 
     it('should render empty table if no related user is returned', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.test.tsx
@@ -248,16 +248,16 @@ describe('<UserDetails />', () => {
         isPlatinumOrTrialLicense: true,
         capabilities: {},
       });
-      const { queryAllByRole } = renderUserDetails(mockContextValue);
-      expect(queryAllByRole('columnheader').length).toBe(3);
-      expect(queryAllByRole('row')[1].textContent).toContain('test host');
-      expect(queryAllByRole('row')[1].textContent).toContain('100.XXX.XXX');
-      expect(queryAllByRole('row')[1].textContent).toContain('Low');
+      const { container, queryAllByTestId } = renderUserDetails(mockContextValue);
+      expect(queryAllByTestId(/tableHeaderCell_/).length).toBe(3);
+      expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('test host');
+      expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('100.XXX.XXX');
+      expect(container.querySelectorAll('.euiTableRow')[0].textContent).toContain('Low');
     });
 
     it('should not render host risk score column when license is not valid', () => {
-      const { queryAllByRole } = renderUserDetails(mockContextValue);
-      expect(queryAllByRole('columnheader').length).toBe(2);
+      const { queryAllByTestId } = renderUserDetails(mockContextValue);
+      expect(queryAllByTestId(/tableHeaderCell_/).length).toBe(2);
     });
 
     it('should render empty table if no related host is returned', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/status_popover_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/status_popover_button.test.tsx
@@ -96,7 +96,7 @@ describe('StatusPopoverButton', () => {
 
   test('Status should be text when user does not have write priveleges', () => {
     (useAlertsPrivileges as jest.Mock<AlertsPriveleges>).mockReturnValue(readPriveleges);
-    const { getByText, queryByRole, container } = render(
+    const { getByText, container } = render(
       <TestProviders>
         <StatusPopoverButton {...props} />
       </TestProviders>
@@ -108,6 +108,6 @@ describe('StatusPopoverButton', () => {
     expect(container.querySelector('.euiBadge__icon')).toBeNull();
 
     // popover should not open when hence checking that popover is not open
-    expect(queryByRole('dialog')).not.toBeInTheDocument();
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_field_value_cell.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_field_value_cell.test.tsx
@@ -199,7 +199,9 @@ describe('TableFieldValueCell', () => {
     });
 
     it('should render link buttons for each of the host ip addresses', () => {
-      expect(screen.getAllByRole('button').length).toBe(hostIpValues.length);
+      expect(screen.getAllByTestId(/securitySolutionFlyoutTablePreviewLinkField-/).length).toBe(
+        hostIpValues.length
+      );
     });
 
     it('should render each of the expected values when `fieldFromBrowserField` is provided', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -100,17 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -192,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/.eslintrc.js
@@ -79,6 +79,25 @@ const RESTRICTED_IMPORTS_PATHS = [
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
 ];
 
 const ROOT_DIR = execSync('git rev-parse --show-toplevel', {

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/connector_cards.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/connector_cards.test.tsx
@@ -82,7 +82,7 @@ describe('ConnectorCards', () => {
   });
 
   it('renders a loading spinner when connectors are not provided', () => {
-    render(
+    const { container } = render(
       <ConnectorCards
         connectors={undefined}
         onNewConnectorSaved={jest.fn()}
@@ -90,7 +90,7 @@ describe('ConnectorCards', () => {
         onConnectorSelected={jest.fn()}
       />
     );
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(container.querySelector('[role="progressbar"]')).toBeInTheDocument();
   });
 
   it('calls onConnectorSelected when a connector is selected', async () => {
@@ -104,7 +104,7 @@ describe('ConnectorCards', () => {
       />
     );
 
-    await userEvent.click(screen.getByRole('button', { name: /Connector Selector/i }));
+    await userEvent.click(screen.getByTestId('connector-selector'));
     await userEvent.click(screen.getByText('Connector 1'));
     expect(onConnectorSelected).toHaveBeenCalledWith(mockConnectors[0]);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/connector_selector_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/connector_selector_panel.test.tsx
@@ -69,7 +69,7 @@ describe('ConnectorSelectorPanel', () => {
         onConnectorSelected={onConnectorSelected}
       />
     );
-    await userEvent.click(screen.getByRole('button', { name: /Connector Selector/i }));
+    await userEvent.click(screen.getByTestId('connector-selector'));
     await userEvent.click(screen.getByText('Connector 2'));
     expect(onConnectorSelected).toHaveBeenCalledWith(mockConnectors[1]);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/connector_setup.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/connector_setup.test.tsx
@@ -62,13 +62,13 @@ describe('ConnectorSetup', () => {
     expect(mockActionTypeRegistry.get).toHaveBeenCalledWith('testType1');
     expect(mockActionTypeRegistry.get).toHaveBeenCalledWith('testType2');
 
-    expect(screen.getByRole('button', { name: 'AI service provider' })).toBeInTheDocument();
+    expect(screen.getByTestId('createConnectorButton')).toBeInTheDocument();
   });
 
   it('opens the modal when the button is clicked', async () => {
     render(<ConnectorSetup actionTypes={mockActionTypes} onConnectorSaved={jest.fn()} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'AI service provider' }));
+    await userEvent.click(screen.getByTestId('createConnectorButton'));
 
     expect(screen.getByTestId('addConnectorModal')).toBeInTheDocument();
   });
@@ -78,7 +78,7 @@ describe('ConnectorSetup', () => {
     render(
       <ConnectorSetup actionTypes={mockActionTypes} onConnectorSaved={mockOnConnectorSaved} />
     );
-    await userEvent.click(screen.getByRole('button', { name: 'AI service provider' }));
+    await userEvent.click(screen.getByTestId('createConnectorButton'));
 
     mockOnConnectorSaved({ id: '1', name: 'New Connector' });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/onboarding_card_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/onboarding_card_panel.test.tsx
@@ -91,7 +91,7 @@ describe('OnboardingCardPanel Component', () => {
   });
 
   it('displays the correct button icon based on isExpanded prop', () => {
-    const { rerender } = render(
+    const { container, rerender } = render(
       <OnboardingCardPanel {...defaultProps} isExpanded={false}>
         <div>{'Test Card Content'}</div>
       </OnboardingCardPanel>,
@@ -99,7 +99,9 @@ describe('OnboardingCardPanel Component', () => {
     );
 
     // Check the button icon when card is not expanded
-    const buttonIcon = screen.getByLabelText(EXPAND_CARD_BUTTON_LABEL('Test Card'));
+    const buttonIcon = container.querySelector(
+      `[aria-label='${EXPAND_CARD_BUTTON_LABEL('Test Card')}']`
+    );
     expect(buttonIcon).toHaveAttribute('aria-expanded', 'false');
     expect(buttonIcon).toHaveClass('euiButtonIcon'); // EuiButtonIcon should be rendered
 

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/.eslintrc.js
@@ -68,8 +68,6 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
-// eslint-disable-next-line import/no-nodejs-modules
-const { execSync } = require('child_process');
 
 const minimatch = require('minimatch');
 
@@ -100,17 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
-  encoding: 'utf8',
-  cwd: __dirname,
-}).trim();
-
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -192,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/.eslintrc.js
@@ -79,6 +79,25 @@ const RESTRICTED_IMPORTS_PATHS = [
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
 ];
 
 const ROOT_DIR = execSync('git rev-parse --show-toplevel', {

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/cases_table/cases_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/cases_table/cases_table.test.tsx
@@ -81,9 +81,9 @@ describe('CasesTable', () => {
 
   it('should render the table columns', () => {
     mockUseCaseItemsReturn({ items: parsedCasesItems });
-    const { getAllByRole } = renderComponent();
+    const { getAllByTestId } = renderComponent();
 
-    const columnHeaders = getAllByRole('columnheader');
+    const columnHeaders = getAllByTestId(/tableHeaderCell_/);
     expect(columnHeaders.at(0)).toHaveTextContent('Name');
     expect(columnHeaders.at(1)).toHaveTextContent('Alerts');
     expect(columnHeaders.at(2)).toHaveTextContent('Time');

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/host_alerts_table/host_alerts_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/host_alerts_table/host_alerts_table.test.tsx
@@ -87,9 +87,9 @@ describe('HostAlertsTable', () => {
 
   it('should render the table columns', () => {
     mockUseHostAlertsItemsReturn({ items: parsedVulnerableHostsAlertsResult });
-    const { getAllByRole } = renderComponent();
+    const { getAllByTestId } = renderComponent();
 
-    const columnHeaders = getAllByRole('columnheader');
+    const columnHeaders = getAllByTestId(/tableHeaderCell_/);
     expect(columnHeaders.at(0)).toHaveTextContent('Host name');
     expect(columnHeaders.at(1)).toHaveTextContent('Alerts');
     expect(columnHeaders.at(2)).toHaveTextContent('Critical');

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/rule_alerts_table/rule_alerts_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/rule_alerts_table/rule_alerts_table.test.tsx
@@ -117,7 +117,7 @@ describe('RuleAlertsTable', () => {
       </TestProviders>
     );
 
-    const columnHeaders = result.getAllByRole('columnheader');
+    const columnHeaders = result.getAllByTestId(/tableHeaderCell_/);
     expect(columnHeaders.at(0)).toHaveTextContent('Rule name');
     expect(columnHeaders.at(1)).toHaveTextContent('Last alert');
     expect(columnHeaders.at(2)).toHaveTextContent('Alert count');

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/user_alerts_table/user_alerts_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/user_alerts_table/user_alerts_table.test.tsx
@@ -97,9 +97,9 @@ describe('UserAlertsTable', () => {
 
   it('should render the table columns', () => {
     mockUseUserAlertsItemsReturn({ items: parsedVulnerableUserAlertsResult });
-    const { getAllByRole } = renderComponent();
+    const { getAllByTestId } = renderComponent();
 
-    const columnHeaders = getAllByRole('columnheader');
+    const columnHeaders = getAllByTestId(/tableHeaderCell_/);
     expect(columnHeaders.at(0)).toHaveTextContent('User name');
     expect(columnHeaders.at(1)).toHaveTextContent('Alerts');
     expect(columnHeaders.at(2)).toHaveTextContent('Critical');

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/disabled_link_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/disabled_link_panel.test.tsx
@@ -35,7 +35,10 @@ describe('DisabledLinkPanel', () => {
     expect(screen.getByTestId('_test_prefix_-enable-module-button')).toHaveTextContent(
       defaultProps.buttonCopy
     );
-    expect(screen.getByRole('link')).toHaveAttribute('href', defaultProps.docLink);
+    expect(screen.getByTestId('_test_prefix_-enable-module-button')).toHaveAttribute(
+      'href',
+      defaultProps.docLink
+    );
   });
 
   it('renders more buttons', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/inner_link_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/inner_link_panel.test.tsx
@@ -20,14 +20,14 @@ describe('InnerLinkPanel', () => {
   };
 
   it('renders expected children', () => {
-    render(
+    const { container } = render(
       <TestProviders>
         <InnerLinkPanel color="warning" {...defaultProps} />
       </TestProviders>
     );
 
     expect(screen.getByTestId('custom_test_subj')).toBeInTheDocument();
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(container.querySelector('button')).toBeInTheDocument();
     expect(screen.getByTestId('inner-link-panel-title')).toHaveTextContent(defaultProps.title);
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/link.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/link.test.tsx
@@ -13,15 +13,15 @@ describe('Link', () => {
   it('renders <a> tag when there is a path', () => {
     render(<Link copy="test_copy" path="/test-path" />);
 
-    expect(screen.getByRole('link')).toBeInTheDocument();
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/test-path');
-    expect(screen.getByRole('link')).toHaveTextContent('test_copy');
+    expect(screen.getByTestId('panel-link')).toBeInTheDocument();
+    expect(screen.getByTestId('panel-link')).toHaveAttribute('href', '/test-path');
+    expect(screen.getByTestId('panel-link')).toHaveTextContent('test_copy');
   });
 
   it('does not render <a> tag when there is no path', () => {
     render(<Link copy="test_copy" />);
 
     expect(screen.getByText('test_copy')).toBeInTheDocument();
-    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByTestId('panel-link')).toBeNull();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/link_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/link_panel/link_panel.test.tsx
@@ -33,14 +33,14 @@ describe('LinkPanel', () => {
   };
 
   it('renders expected children', () => {
-    render(
+    const { container } = render(
       <TestProviders>
         <LinkPanel {...defaultProps} />
       </TestProviders>
     );
 
     expect(screen.getByTestId('_custom_test_subj_')).toBeInTheDocument();
-    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(container.querySelector('.euiTable')).toBeInTheDocument();
     expect(screen.getByTestId('_test_button_')).toBeInTheDocument();
     expect(screen.getByTestId('_split_panel_')).toBeInTheDocument();
     expect(screen.getByTestId('_subtitle_')).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/.eslintrc.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: 'enzyme',
+    message: 'Please use @testing-library/react instead',
+  },
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -97,14 +98,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -186,7 +184,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/barchart/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/barchart/wrapper.test.tsx
@@ -51,7 +51,7 @@ describe('<IndicatorsBarChartWrapper />', () => {
 
   describe('when loading for the first time', () => {
     it('should render progress indicator', () => {
-      const { queryByRole, getByTestId } = render(
+      const { container, getByTestId } = render(
         <TestProvidersComponent>
           <ScreenReaderAnnouncementsProvider>
             <IndicatorsBarChartWrapper
@@ -67,7 +67,7 @@ describe('<IndicatorsBarChartWrapper />', () => {
         </TestProvidersComponent>
       );
 
-      expect(queryByRole('progressbar')).toBeInTheDocument();
+      expect(container.querySelector('[role="progressbar"]')).toBeInTheDocument();
       expect(getByTestId(LOADING_TEST_ID)).toBeInTheDocument();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/table.test.tsx
@@ -61,15 +61,16 @@ const indicatorsFixture: Indicator[] = [
 
 describe('<IndicatorsTable />', () => {
   it('should render loading spinner when doing initial loading', async () => {
+    let container: HTMLElement;
     await act(async () => {
-      render(
+      container = render(
         <TestProvidersComponent>
           <IndicatorsTable {...tableProps} isLoading={true} />
         </TestProvidersComponent>
-      );
+      ).container;
     });
 
-    expect(screen.queryByRole('progressbar')).toBeInTheDocument();
+    expect(container!.querySelector('[role="progressbar"]')).toBeInTheDocument();
   });
 
   it('should render loading indicator when doing data update', async () => {
@@ -90,8 +91,9 @@ describe('<IndicatorsTable />', () => {
   });
 
   it('should render datagrid when loading is done', async () => {
+    let container: HTMLElement;
     await act(async () => {
-      render(
+      container = render(
         <TestProvidersComponent>
           <IndicatorsTable
             {...tableProps}
@@ -101,10 +103,10 @@ describe('<IndicatorsTable />', () => {
             indicators={indicatorsFixture}
           />
         </TestProvidersComponent>
-      );
+      ).container;
     });
 
-    expect(screen.queryByRole('grid')).toBeInTheDocument();
+    expect(screen.queryByTestId('euiDataGridBody')).toBeInTheDocument();
 
     // Two rows should be rendered
     expect(screen.queryAllByTestId(BUTTON_TEST_ID).length).toEqual(2);
@@ -115,7 +117,7 @@ describe('<IndicatorsTable />', () => {
 
     expect(screen.queryByTestId(INDICATORS_FLYOUT_TITLE_TEST_ID)).toBeInTheDocument();
 
-    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(container!.querySelector('[role="progressbar"]')).not.toBeInTheDocument();
     expect(screen.queryByTestId(TABLE_UPDATE_PROGRESS_TEST_ID)).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/.eslintrc.js
@@ -68,6 +68,7 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
@@ -93,14 +94,11 @@ const RESTRICTED_IMPORTS_PATHS = [
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
-
 /** @type {import('eslint').Linter.Config} */
-const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+const rootConfig = require('../../../../../../../.eslintrc');
 
-const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+const clonedRootConfig = structuredClone(rootConfig);
 
 const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
   (override) => override.rules && 'no-restricted-imports' in override.rules
@@ -182,7 +180,7 @@ function getAssignableDifference(inputPath, targetDir) {
 const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
   ...override,
   files: override.files.map((fileOrGlob) => {
-    return path.resolve(ROOT_DIR, fileOrGlob);
+    return path.resolve('../../../../../../../', fileOrGlob);
   }),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/.eslintrc.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @typedef {string} RestrictedImportString
+ * A string specifying a module name to restrict.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPath
+ * @property {string} name - The name of the module to restrict.
+ * @property {string} [message] - Custom message appended to the lint error.
+ * @property {string[]} [importNames] - Specific named imports to restrict.
+ * @property {string[]} [allowImportNames] - Named imports to allow (restricts all others).
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternGroup
+ * @property {string[]} group - Array of gitignore-style patterns to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the group.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the group.
+ * @property {boolean} [caseSensitive=false] - Whether the pattern is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportPatternRegex
+ * @property {string} regex - Regex pattern string to restrict.
+ * @property {string} [message] - Custom message.
+ * @property {string[]} [importNames] - Named imports to restrict within the regex.
+ * @property {string[]} [allowImportNames] - Named imports to allow within the regex.
+ * @property {boolean} [caseSensitive=false] - Whether the regex is case-sensitive.
+ */
+
+/**
+ * @typedef {Object} RestrictedImportOptions
+ * @property {Array.<string|RestrictedImportPath>} [paths]
+ *   - List of module names (as strings) or objects with `name`, `message`, `importNames`, or `allowImportNames`.
+ * @property {Array.<string|RestrictedImportPatternGroup|RestrictedImportPatternRegex>} [patterns]
+ *   - List of patterns (as strings), or objects with `group` or `regex`, plus optional `message`, `importNames`, `allowImportNames`, and `caseSensitive`.
+ */
+
+/**
+ * @typedef {(
+ *   'error'|'warn'|'off'|number |  // Simple severity
+ *   [  // Array format with mixed restrictions
+ *     'error'|'warn'|'off'|number,
+ *     ...(  // Restriction list can contain:
+ *       | RestrictedImportString
+ *       | RestrictedImportPath
+ *       | RestrictedImportPatternGroup
+ *       | RestrictedImportPatternRegex
+ *       | RestrictedImportOptions
+ *     )[]
+ *   ]
+ * )} NoRestrictedImportsRuleConfig
+ *
+ * Represents the complete ESLint rule configuration structure:
+ * - First element: severity (required)
+ * - Subsequent elements: restrictions in either:
+ *   a) Legacy format (strings/objects)
+ *   b) Modern format (configuration object with paths/patterns)
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+const path = require('path');
+const minimatch = require('minimatch');
+
+/** @type {Array.<RestrictedImportPath>} */
+const RESTRICTED_IMPORTS_PATHS = [
+  {
+    name: '@testing-library/react',
+    importNames: [
+      'getByRole',
+      'getAllByRole',
+      'queryByRole',
+      'queryAllByRole',
+      'findByRole',
+      'findAllByRole',
+      'getByLabelText',
+      'getAllByLabelText',
+      'queryByLabelText',
+      'queryAllByLabelText',
+      'findByLabelText',
+      'findAllByLabelText',
+    ],
+    message:
+      'ByRole and ByLabelText selectors are considered slow. Use lighter alternatives like ByText, ByTestId etc. instead.',
+  },
+];
+
+// root directory of the project dynamically calculated
+const ROOT_DIR = process.cwd();
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+
+/** @type {import('eslint').Linter.Config} */
+const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
+
+const clonedRootConfig = JSON.parse(JSON.stringify(rootConfig));
+
+const overridesWithNoRestrictedImportRule = clonedRootConfig.overrides.filter(
+  (override) => override.rules && 'no-restricted-imports' in override.rules
+);
+
+for (const override of overridesWithNoRestrictedImportRule) {
+  /** @type {NoRestrictedImportsRuleConfig} */
+  const rule = override.rules['no-restricted-imports'];
+
+  if (Array.isArray(rule) && rule.length >= 2) {
+    const [severity, ...rawOptions] = rule;
+
+    /** @type {RestrictedImportOptions} */
+    const modernConfig = { paths: [], patterns: [] };
+
+    // Normalize all inputs into modern config format
+    for (const opt of rawOptions) {
+      if (typeof opt === 'string' || 'name' in opt) {
+        modernConfig.paths.push(opt);
+      } else if ('paths' in opt || 'patterns' in opt) {
+        modernConfig.paths.push(...(opt.paths || []));
+        modernConfig.patterns.push(...(opt.patterns || []));
+      }
+    }
+
+    // Dynamic duplicates removal for all restricted imports
+    const existingPaths = modernConfig.paths.filter(
+      (existing) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
+          typeof existing === 'string'
+            ? existing === restriction.name
+            : existing.name === restriction.name
+        )
+    );
+
+    /** @type {NoRestrictedImportsRuleConfig} */
+    const newRuleConfig = [
+      severity,
+      {
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
+        patterns: modernConfig.patterns,
+      },
+    ];
+
+    override.rules['no-restricted-imports'] = newRuleConfig;
+  }
+}
+
+function getAssignableDifference(inputPath, targetDir) {
+  // Normalize to absolute paths
+  const absoluteTarget = path.resolve(targetDir);
+  const isGlob = inputPath.includes('**');
+
+  // Split into base path and remaining pattern
+  let base;
+  let remaining;
+  if (isGlob) {
+    const globIndex = inputPath.indexOf('**');
+    base = inputPath.slice(0, globIndex).replace(/[\\/]+$/, '');
+    remaining = inputPath.slice(globIndex);
+  } else {
+    base = inputPath;
+    remaining = '';
+  }
+
+  const absoluteBase = path.resolve(base);
+
+  // Check if target is within base path
+  if (!absoluteTarget.startsWith(absoluteBase)) return null;
+
+  if (isGlob) {
+    return remaining || path.normalize('**/*');
+  } else {
+    const relative = path.relative(absoluteBase, absoluteTarget);
+    return relative || '.';
+  }
+}
+
+const absOverrides = overridesWithNoRestrictedImportRule.map((override) => ({
+  ...override,
+  files: override.files.map((fileOrGlob) => {
+    return path.resolve(ROOT_DIR, fileOrGlob);
+  }),
+}));
+
+const inScopeOverrides = absOverrides.map((override) => ({
+  ...override,
+  files: override.files
+    .filter((absPath) => {
+      return minimatch(__dirname, path.dirname(absPath), {
+        matchBase: true,
+        dot: true,
+        nocase: true,
+      });
+    })
+    .map((absPath) => {
+      return getAssignableDifference(absPath, __dirname);
+    })
+    .filter(Boolean),
+}));
+
+const finalOverrides = inScopeOverrides.filter((override) => override.files.length > 0);
+
+module.exports = {
+  overrides: finalOverrides,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/default_renderer/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/default_renderer/index.test.tsx
@@ -108,7 +108,7 @@ describe('Field Renderers', () => {
     });
 
     test('it should render the items after overflowIndexStart in the popover', async () => {
-      render(
+      const { container } = render(
         <TestProviders>
           <DefaultFieldRendererOverflow
             idPrefix={idPrefix}
@@ -121,7 +121,7 @@ describe('Field Renderers', () => {
       );
 
       await userEvent.click(screen.getByTestId('DefaultFieldRendererOverflow-button'));
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(container.closest('body')!.querySelector('[role="dialog"]')).toBeInTheDocument();
       expect(screen.getByTestId('more-container').textContent).toEqual('item6item7');
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.test.tsx
@@ -48,22 +48,22 @@ describe('useCreateFieldButton', () => {
     const { result } = renderUseCreateFieldButton();
 
     const CreateFieldButton = result.current!;
-    const { getByRole } = render(<CreateFieldButton onHide={mockOnHide} />, {
+    const { getByTestId } = render(<CreateFieldButton onHide={mockOnHide} />, {
       wrapper: TestProviders,
     });
 
-    expect(getByRole('button')).toBeInTheDocument();
+    expect(getByTestId('create-field')).toBeInTheDocument();
   });
 
   it('should call openFieldEditor and hide the modal when button clicked', async () => {
     const { result } = renderUseCreateFieldButton();
 
     const CreateFieldButton = result.current!;
-    const { getByRole } = render(<CreateFieldButton onHide={mockOnHide} />, {
+    const { getByTestId } = render(<CreateFieldButton onHide={mockOnHide} />, {
       wrapper: TestProviders,
     });
 
-    getByRole('button').click();
+    getByTestId('create-field').click();
     expect(mockOpenFieldEditor).toHaveBeenCalled();
     expect(mockOnHide).toHaveBeenCalled();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/field_table_columns/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/field_table_columns/index.test.tsx
@@ -53,14 +53,14 @@ describe('useFieldTableColumns', () => {
       onHide: mockOnHide,
     });
 
-    const { getAllByRole, getByTestId } = render(
+    const { container, getByTestId } = render(
       <EuiInMemoryTable items={[fieldItem]} columns={columns} />,
       {
         wrapper: TestProviders,
       }
     );
 
-    expect(getAllByRole('columnheader').length).toBe(5);
+    expect(container.querySelectorAll('[role="columnheader"]').length).toBe(5);
     expect(getByTestId('actionEditRuntimeField')).toBeInTheDocument();
     expect(getByTestId('actionDeleteRuntimeField')).toBeInTheDocument();
   });
@@ -73,14 +73,14 @@ describe('useFieldTableColumns', () => {
       onHide: mockOnHide,
     });
 
-    const { getAllByRole, queryByTestId } = render(
+    const { container, queryByTestId } = render(
       <EuiInMemoryTable items={[fieldItem]} columns={columns} />,
       {
         wrapper: TestProviders,
       }
     );
 
-    expect(getAllByRole('columnheader').length).toBe(4);
+    expect(container.querySelectorAll('[role="columnheader"]').length).toBe(4);
     expect(queryByTestId('actionEditRuntimeField')).toBeNull();
     expect(queryByTestId('actionDeleteRuntimeField')).toBeNull();
   });
@@ -93,14 +93,14 @@ describe('useFieldTableColumns', () => {
       onHide: mockOnHide,
     });
 
-    const { getAllByRole, queryByTestId } = render(
+    const { container, queryByTestId } = render(
       <EuiInMemoryTable items={[{ ...fieldItem, isRuntime: false }]} columns={columns} />,
       {
         wrapper: TestProviders,
       }
     );
 
-    expect(getAllByRole('columnheader').length).toBe(5);
+    expect(container.querySelectorAll('[role="columnheader"]').length).toBe(5);
     expect(queryByTestId('actionEditRuntimeField')).toBeNull();
     expect(queryByTestId('actionDeleteRuntimeField')).toBeNull();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
@@ -132,12 +132,12 @@ describe('useFieldBrowserOptions', () => {
     const { result } = await renderUpdatedUseFieldBrowserOptions();
 
     const CreateFieldButton = result!.current.createFieldButton!;
-    const { getByRole } = render(<CreateFieldButton onHide={mockOnHide} />, {
+    const { getByTestId } = render(<CreateFieldButton onHide={mockOnHide} />, {
       wrapper: TestProviders,
     });
 
-    expect(getByRole('button')).toBeInTheDocument();
-    getByRole('button').click();
+    expect(getByTestId('create-field')).toBeInTheDocument();
+    getByTestId('create-field').click();
     expect(mockOnHide).toHaveBeenCalled();
   });
 
@@ -171,11 +171,11 @@ describe('useFieldBrowserOptions', () => {
     const { result } = await renderUpdatedUseFieldBrowserOptions();
 
     const CreateFieldButton = result.current.createFieldButton!;
-    const { getByRole } = render(<CreateFieldButton onHide={mockOnHide} />, {
+    const { getByTestId } = render(<CreateFieldButton onHide={mockOnHide} />, {
       wrapper: TestProviders,
     });
 
-    getByRole('button').click();
+    getByTestId('create-field').click();
     expect(onSave).toBeDefined();
 
     const savedField = [{ name: 'newField' }] as DataViewField[];
@@ -269,13 +269,13 @@ describe('useFieldBrowserOptions', () => {
     const { result } = await renderUpdatedUseFieldBrowserOptions({ editorActionsRef });
 
     const CreateFieldButton = result!.current.createFieldButton!;
-    const { getByRole } = render(<CreateFieldButton onHide={mockOnHide} />, {
+    const { getByTestId } = render(<CreateFieldButton onHide={mockOnHide} />, {
       wrapper: TestProviders,
     });
 
     expect(editorActionsRef?.current).toBeNull();
 
-    getByRole('button').click();
+    getByTestId('create-field').click();
     await runAllPromises();
 
     expect(mockCloseEditor).not.toHaveBeenCalled();

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -306,7 +306,7 @@ describe.skip('query tab with unified timeline', () => {
     it(
       'should hide row-renderers when disabled',
       async () => {
-        renderTestComponents();
+        const { container } = renderTestComponents();
         await waitFor(() => {
           expect(screen.getByTestId('discoverDocTable')).toBeVisible();
         });
@@ -317,12 +317,12 @@ describe.skip('query tab with unified timeline', () => {
         expect(screen.getByTestId('row-renderers-modal')).toBeVisible();
 
         fireEvent.click(screen.getByTestId('disable-all'));
-
         expect(
-          within(screen.getAllByTestId('renderer-checkbox')[0]).getByRole('checkbox')
+          screen.getAllByTestId('renderer-checkbox')[0].querySelector('[type="checkbox"]')
         ).not.toBeChecked();
-
-        fireEvent.click(screen.getByLabelText('Closes this modal window'));
+        fireEvent.click(
+          container.closest('body')!.querySelector('[aria-label="Closes this modal window"]')!
+        );
 
         expect(screen.queryByTestId('row-renderers-modal')).not.toBeInTheDocument();
 
@@ -781,7 +781,7 @@ describe.skip('query tab with unified timeline', () => {
 
         expect(screen.getByTestId('dataGridColumnSortingButton')).toBeVisible();
         expect(
-          within(screen.getByTestId('dataGridColumnSortingButton')).getByRole('marquee')
+          screen.getByTestId('dataGridColumnSortingButton').querySelector('[role="marquee"]')
         ).toHaveTextContent('1');
 
         fireEvent.click(screen.getByTestId('dataGridColumnSortingButton'));
@@ -810,7 +810,7 @@ describe.skip('query tab with unified timeline', () => {
 
         expect(screen.getByTestId('dataGridColumnSortingButton')).toBeVisible();
         expect(
-          within(screen.getByTestId('dataGridColumnSortingButton')).getByRole('marquee')
+          screen.getByTestId('dataGridColumnSortingButton').querySelector('[role="marquee"]')
         ).toHaveTextContent('1');
 
         fireEvent.click(screen.getByTestId('dataGridColumnSortingButton'));


### PR DESCRIPTION
addresses #223242

So for this specific PR the gains are almost invisible:

Before
[timing-results-before.csv](https://github.com/user-attachments/files/21034673/timing-results-before.csv)

After:
[timing-results-after.csv](https://github.com/user-attachments/files/21034675/timing-results-after.csv)

Because this PR tests are testing pretty shallow rendering trees or selectors are doing too little work to see the difference.

Whereas results from earlier [PR](https://github.com/elastic/kibana/pull/196591) rendering deep trees and involving some selector sweat shows convincing time savings.

Before:
[timing-results-before.csv](https://github.com/user-attachments/files/21034732/timing-results-before.csv)

After:
[timing-results-after.csv](https://github.com/user-attachments/files/21034733/timing-results-after.csv)

I have raised this issue last week on one of our team meetings and asked about this discrepancy and whether it's ok to still move on with banning heavy selectors for us as a team. And the team decided that it's ok as long as we potentially save time on complex trees.

To get an idea of the algorithmic scaling of the cost with deeper trees horizontally or vertically I have created a perf-test repo where I go over each selector in depth and test them out in various ways to try to highlight said difference and impact.

Please feel free to explore this if you are curious and when you have time: https://github.com/elastic/rtl-selectors-perf-test