### PR TITLE
[8.19] Audit Synthetics plugin log levels (#218399)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/default_alerts/default_alert_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/default_alerts/default_alert_service.ts
@@ -259,8 +259,8 @@ export class DefaultAlertService {
     let actionConnectors: FindActionResult[] = [];
     try {
       actionConnectors = await actionsClient.getAll();
-    } catch (e) {
-      this.server.logger.error(e);
+    } catch (error) {
+      this.server.logger.error(`Error getting connectors, Error: ${error.message}`, { error });
     }
     return { actionConnectors, settings: this.settings };
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/default_alerts/update_default_alert.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/default_alerts/update_default_alert.ts
@@ -37,8 +37,10 @@ export const updateDefaultAlertingRoute: SyntheticsRestApiRouteFactory = () => (
         statusRule: statusRule || null,
         tlsRule: tlsRule || null,
       };
-    } catch (e) {
-      server.logger.error(`Error updating default alerting rules: ${e}`);
+    } catch (error) {
+      server.logger.error(`Error updating default alerting rules, Error: ${error.message}`, {
+        error,
+      });
       return {
         statusRule: null,
         tlsRule: null,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -122,17 +122,17 @@ export const addSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
       addMonitorAPI.setupGettingStarted(newMonitor.id);
 
       return mapSavedObjectToMonitor({ monitor: newMonitor, internal });
-    } catch (getErr) {
-      server.logger.error(getErr);
-      if (getErr instanceof InvalidLocationError || getErr instanceof InvalidScheduleError) {
-        return response.badRequest({ body: { message: getErr.message } });
+    } catch (error) {
+      if (error instanceof InvalidLocationError || error instanceof InvalidScheduleError) {
+        return response.badRequest({ body: { message: error.message } });
       }
-      if (SavedObjectsErrorHelpers.isForbiddenError(getErr)) {
-        return response.forbidden({ body: getErr });
+      if (SavedObjectsErrorHelpers.isForbiddenError(error)) {
+        return response.forbidden({ body: error });
       }
 
+      server.logger.error('Unable to create synthetics monitor', { error });
       return response.customError({
-        body: { message: getErr.message },
+        body: { message: error.message },
         statusCode: 500,
       });
     }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts
@@ -88,10 +88,7 @@ export class AddEditMonitorAPI {
       const [monitorSavedObjectN, [packagePolicyResult, syncErrors]] = await Promise.all([
         newMonitorPromise,
         syncErrorsPromise,
-      ]).catch((e) => {
-        server.logger.error(e);
-        throw e;
-      });
+      ]);
 
       if (packagePolicyResult && (packagePolicyResult?.failed?.length ?? []) > 0) {
         const failed = packagePolicyResult.failed.map((f) => f.error);
@@ -119,14 +116,10 @@ export class AddEditMonitorAPI {
         },
       };
     } catch (e) {
-      server.logger.error(
-        `Unable to create Synthetics monitor ${monitorWithNamespace[ConfigKey.NAME]}`
-      );
+      e.message = `${e.message}, monitor name: ${monitorWithNamespace[ConfigKey.NAME]}`;
       await this.revertMonitorIfCreated({
         newMonitorId,
       });
-
-      server.logger.error(e);
 
       throw e;
     }
@@ -264,10 +257,12 @@ export class AddEditMonitorAPI {
           server.logger.debug(`Successfully created default alert for monitor: ${name}`);
         })
         .catch((error) => {
-          server.logger.error(`Error creating default alert: ${error} for monitor: ${name}`);
+          server.logger.error(`Error creating default alert: ${error} for monitor: ${name}`, {
+            error,
+          });
         });
-    } catch (e) {
-      server.logger.error(`Error creating default alert: ${e} for monitor: ${name}`);
+    } catch (error) {
+      server.logger.error(`Error creating default alert: ${error} for monitor: ${name}`, { error });
     }
   }
 
@@ -283,13 +278,19 @@ export class AddEditMonitorAPI {
           .then(() => {
             server.logger.debug(`Successfully triggered test for monitor: ${configId}`);
           })
-          .catch((e) => {
-            server.logger.error(`Error triggering test for monitor: ${configId}: ${e}`);
+          .catch((error) => {
+            server.logger.error(
+              `Error triggering test for monitor: ${configId}, Error: ${error.message}`,
+              {
+                error,
+              }
+            );
           });
       }
-    } catch (e) {
-      server.logger.info(`Error triggering test for getting started monitor: ${configId}`);
-      server.logger.error(e);
+    } catch (error) {
+      server.logger.error(`Error triggering test for getting started monitor: ${configId}`, {
+        error,
+      });
     }
   };
 
@@ -344,9 +345,14 @@ export class AddEditMonitorAPI {
           monitorIds: [newMonitorId],
         });
       }
-    } catch (e) {
+    } catch (error) {
       // ignore errors here
-      server.logger.error(e);
+      server.logger.error(
+        `Unable to revert monitor with id ${newMonitorId}, Error: ${error.message}`,
+        {
+          error,
+        }
+      );
     }
   }
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/add_monitor_bulk.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/add_monitor_bulk.ts
@@ -150,9 +150,9 @@ const rollBackNewMonitorBulk = async (
     await deleteMonitorAPI.execute({
       monitorIds: monitorsToCreate.map(({ id }) => id),
     });
-  } catch (e) {
+  } catch (error) {
     // ignore errors here
-    server.logger.error(e);
+    server.logger.error(`Unable to rollback new monitors, Error: ${error.message}`, { error });
   }
 };
 
@@ -197,6 +197,6 @@ export const deleteMonitorIfCreated = async ({
     }
   } catch (e) {
     // ignore errors here
-    server.logger.error(e);
+    server.logger.error(`Unable to delete monitor with id ${newMonitorId}`, { error: e });
   }
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/edit_monitor_bulk.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/edit_monitor_bulk.ts
@@ -132,7 +132,6 @@ export const syncEditedMonitorBulk = async ({
       editedMonitors: editedMonitorSavedObjects?.saved_objects,
     };
   } catch (e) {
-    server.logger.error(`Unable to update Synthetics monitors, ${e.message}`);
     await rollbackCompletely({ routeContext, monitorsToUpdate });
     throw e;
   }
@@ -154,8 +153,8 @@ export const rollbackCompletely = async ({
         attributes: decryptedPreviousMonitor.attributes,
       }))
     );
-  } catch (e) {
-    server.logger.error(`Unable to rollback Synthetics monitors edit ${e.message} `);
+  } catch (error) {
+    server.logger.error(`Unable to rollback Synthetics monitors edit ${error.message} `, { error });
   }
 };
 
@@ -204,7 +203,10 @@ export const rollbackFailedUpdates = async ({
       await savedObjectsClient.bulkUpdate<MonitorFields>(monitorsToRevert);
     }
     return failedConfigs;
-  } catch (e) {
-    server.logger.error(`Unable to rollback Synthetics monitor failed updates, ${e.message} `);
+  } catch (error) {
+    server.logger.error(
+      `Unable to rollback Synthetics monitor failed updates, Error: ${error.message}`,
+      { error }
+    );
   }
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
@@ -91,14 +91,14 @@ export const inspectSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () =
       }
 
       return response.ok({ body: { result, decodedCode: formatCode(decodedCode) } });
-    } catch (getErr) {
+    } catch (error) {
       server.logger.error(
-        `Unable to inspect Synthetics monitor ${monitorWithDefaults[ConfigKey.NAME]}`
+        `Unable to inspect Synthetics monitor ${monitorWithDefaults[ConfigKey.NAME]}`,
+        { error }
       );
-      server.logger.error(getErr);
 
       return response.customError({
-        body: { message: getErr.message },
+        body: { message: error.message },
         statusCode: 500,
       });
     }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
@@ -83,12 +83,12 @@ export const addSyntheticsProjectMonitorRoute: SyntheticsRestApiRouteFactory = (
         failedMonitors: pushMonitorFormatter.failedMonitors,
       };
     } catch (error) {
-      server.logger.error(`Error adding monitors to project ${decodedProjectName}`);
       if (error.output?.statusCode === 404) {
         const spaceId = server.spaces?.spacesService.getSpaceId(request) ?? DEFAULT_SPACE_ID;
         return response.notFound({ body: { message: `Kibana space '${spaceId}' does not exist` } });
       }
 
+      server.logger.error(`Error adding monitors to project ${decodedProjectName}`, { error });
       throw error;
     }
   },

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/get_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/get_monitor_project.ts
@@ -67,7 +67,7 @@ export const getSyntheticsProjectMonitorsRoute: SyntheticsRestApiRouteFactory = 
         monitors: projectMonitors,
       };
     } catch (error) {
-      logger.error(error);
+      logger.error(`Error getting Synthetics monitors, Error: ${error.message}`, { error });
     }
   },
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.ts
@@ -71,7 +71,9 @@ export class DeleteMonitorAPI {
           error: `Monitor id ${monitorId} not found!`,
         });
       } else {
-        server.logger.error(`Failed to decrypt monitor to delete ${monitorId}${e}`);
+        server.logger.error(`Failed to decrypt monitor to delete, monitor id: ${monitorId}`, {
+          error: e,
+        });
         sendErrorTelemetryEvents(server.logger, server.telemetry, {
           reason: `Failed to decrypt monitor to delete ${monitorId}`,
           message: e?.message,
@@ -118,10 +120,11 @@ export class DeleteMonitorAPI {
       });
 
       return { errors, result: this.result };
-    } catch (e) {
-      server.logger.error(`Unable to delete Synthetics monitor with error ${e.message}`);
-      server.logger.error(e);
-      throw e;
+    } catch (error) {
+      server.logger.error(`Unable to delete Synthetics monitor with error ${error.message}`, {
+        error,
+      });
+      throw error;
     }
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/migrate_legacy_private_locations.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/migrate_legacy_private_locations.test.ts
@@ -43,7 +43,8 @@ describe('migrateLegacyPrivateLocations', () => {
     await migrateLegacyPrivateLocations(repositoryMock, loggerMockVal);
 
     expect(loggerMockVal.error).toHaveBeenCalledWith(
-      'Error migrating legacy private locations: Error: Get error'
+      'Error migrating legacy private locations: Get error',
+      { error }
     );
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/migrate_legacy_private_locations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/migrate_legacy_private_locations.ts
@@ -64,7 +64,7 @@ export const migrateLegacyPrivateLocations = async (
         {}
       );
     }
-  } catch (e) {
-    logger.error(`Error migrating legacy private locations: ${e}`);
+  } catch (error) {
+    logger.error(`Error migrating legacy private locations: ${error.message}`, { error });
   }
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/suggestions/route.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/suggestions/route.ts
@@ -69,54 +69,50 @@ export const getSyntheticsSuggestionsRoute: SyntheticsRestApiRouteFactory<
 
     const { filtersStr } = await getMonitorFilters(route);
     const { allLocations = [] } = await getAllLocations(route);
-    try {
-      const data = await savedObjectsClient.find<EncryptedSyntheticsMonitorAttributes>({
-        type: syntheticsMonitorType,
-        perPage: 0,
-        filter: filtersStr ? `${filtersStr}` : undefined,
-        aggs,
-        search: query ? `${query}*` : undefined,
-        searchFields: SEARCH_FIELDS,
-      });
+    const data = await savedObjectsClient.find<EncryptedSyntheticsMonitorAttributes>({
+      type: syntheticsMonitorType,
+      perPage: 0,
+      filter: filtersStr ? `${filtersStr}` : undefined,
+      aggs,
+      search: query ? `${query}*` : undefined,
+      searchFields: SEARCH_FIELDS,
+    });
 
-      const { monitorTypesAggs, tagsAggs, locationsAggs, projectsAggs, monitorIdsAggs } =
-        (data?.aggregations as AggsResponse) ?? {};
-      const allLocationsMap = new Map(allLocations.map((obj) => [obj.id, obj.label]));
+    const { monitorTypesAggs, tagsAggs, locationsAggs, projectsAggs, monitorIdsAggs } =
+      (data?.aggregations as AggsResponse) ?? {};
+    const allLocationsMap = new Map(allLocations.map((obj) => [obj.id, obj.label]));
 
-      return {
-        monitorIds: monitorIdsAggs?.buckets?.map(({ key, doc_count: count, name }) => ({
-          label: name?.hits?.hits[0]?._source?.[syntheticsMonitorType]?.[ConfigKey.NAME] || key,
+    return {
+      monitorIds: monitorIdsAggs?.buckets?.map(({ key, doc_count: count, name }) => ({
+        label: name?.hits?.hits[0]?._source?.[syntheticsMonitorType]?.[ConfigKey.NAME] || key,
+        value: key,
+        count,
+      })),
+      tags:
+        tagsAggs?.buckets?.map(({ key, doc_count: count }) => ({
+          label: key,
           value: key,
           count,
-        })),
-        tags:
-          tagsAggs?.buckets?.map(({ key, doc_count: count }) => ({
-            label: key,
-            value: key,
-            count,
-          })) ?? [],
-        locations:
-          locationsAggs?.buckets?.map(({ key, doc_count: count }) => ({
-            label: allLocationsMap.get(key) || key,
-            value: key,
-            count,
-          })) ?? [],
-        projects:
-          projectsAggs?.buckets?.map(({ key, doc_count: count }) => ({
-            label: key,
-            value: key,
-            count,
-          })) ?? [],
-        monitorTypes:
-          monitorTypesAggs?.buckets?.map(({ key, doc_count: count }) => ({
-            label: key,
-            value: key,
-            count,
-          })) ?? [],
-      };
-    } catch (error) {
-      logger.error(`Failed to fetch synthetics suggestions: ${error}`);
-    }
+        })) ?? [],
+      locations:
+        locationsAggs?.buckets?.map(({ key, doc_count: count }) => ({
+          label: allLocationsMap.get(key) || key,
+          value: key,
+          count,
+        })) ?? [],
+      projects:
+        projectsAggs?.buckets?.map(({ key, doc_count: count }) => ({
+          label: key,
+          value: key,
+          count,
+        })) ?? [],
+      monitorTypes:
+        monitorTypesAggs?.buckets?.map(({ key, doc_count: count }) => ({
+          label: key,
+          value: key,
+          count,
+        })) ?? [],
+    };
   },
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/suggestions/route.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/suggestions/route.ts
@@ -61,10 +61,7 @@ export const getSyntheticsSuggestionsRoute: SyntheticsRestApiRouteFactory<
     query: QuerySchema,
   },
   handler: async (route): Promise<any> => {
-    const {
-      savedObjectsClient,
-      server: { logger },
-    } = route;
+    const { savedObjectsClient } = route;
     const { query } = route.request.query;
 
     const { filtersStr } = await getMonitorFilters(route);

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.ts
@@ -37,8 +37,8 @@ export function sendTelemetryEvents(
   try {
     eventsTelemetry.queueTelemetryEvents(MONITOR_UPDATE_CHANNEL, [updateEvent]);
     eventsTelemetry.queueTelemetryEvents(MONITOR_CURRENT_CHANNEL, [updateEvent]);
-  } catch (exc) {
-    logger.error(`queuing telemetry events failed ${exc}`);
+  } catch (error) {
+    logger.error(`queuing telemetry events failed ${error.message}`, { error });
   }
 }
 
@@ -53,8 +53,8 @@ export function sendErrorTelemetryEvents(
 
   try {
     eventsTelemetry.queueTelemetryEvents(MONITOR_ERROR_EVENTS_CHANNEL, [updateEvent]);
-  } catch (exc) {
-    logger.error(`queuing telemetry events failed ${exc}`);
+  } catch (error) {
+    logger.error(`queuing telemetry events failed ${error.message}`, { error });
   }
 }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_route_wrapper.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_route_wrapper.ts
@@ -115,8 +115,11 @@ export const syntheticsRouteWrapper: SyntheticsRouteWrapper = (
               },
             });
           }
+        } else if (e.statusCode >= 500) {
+          server.logger.error(e);
+        } else {
+          server.logger.debug(e);
         }
-        server.logger.error(e);
         throw e;
       }
     });

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_all_locations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_all_locations.ts
@@ -44,8 +44,8 @@ export async function getAllLocations({
       throttling,
       allLocations: [...publicLocations, ...pvtLocations],
     };
-  } catch (e) {
-    server.logger.error(e);
+  } catch (error) {
+    server.logger.error(`Error getting Synthetics locations, Error: ${error.message}`, { error });
     return { publicLocations: [], privateLocations: [], allLocations: [] };
   }
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_api_key.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_api_key.ts
@@ -68,14 +68,10 @@ export const getAPIKeyForSyntheticsService = async ({
         return { isValid: false, apiKey };
       }
 
-      if (!isValid) {
-        server.logger.info('Synthetics api is no longer valid');
-      }
-
       return { apiKey, isValid };
     }
-  } catch (err) {
-    server.logger.error(err);
+  } catch (error) {
+    server.logger.error(`API key is invalid, ${error.message}`, { error });
   }
 
   return { isValid: false };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_service_locations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/get_service_locations.ts
@@ -77,8 +77,10 @@ export async function getServiceLocations(server: SyntheticsServerSetup) {
     ) as ThrottlingOptions;
 
     return { throttling, locations };
-  } catch (e) {
-    server.logger.error(e);
+  } catch (error) {
+    server.logger.error(`Error getting available Synthetics locations, Error: ${error.message}`, {
+      error,
+    });
     return { locations: [] };
   }
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/clean_up_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/clean_up_task.ts
@@ -37,7 +37,7 @@ export const registerCleanUpTask = (
         return {
           // Perform the work of the task. The return value should fit the TaskResult interface.
           async run() {
-            logger.info(
+            logger.debug(
               `Executing synthetics clean up task: ${SYNTHETICS_SERVICE_CLEAN_UP_TASK_ID}`
             );
             const { state } = taskInstance;

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/service_api_client.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/service_api_client.ts
@@ -111,8 +111,8 @@ export class ServiceAPIClient {
 
           const { allowed, signupUrl } = data;
           return { allowed, signupUrl };
-        } catch (e) {
-          this.logger.error(e);
+        } catch (error) {
+          this.logger.error(`Error getting isAllowed status, Error: ${error.message}`, { error });
         }
       }
     } else {
@@ -177,8 +177,8 @@ export class ServiceAPIClient {
   async syncMonitors(data: ServiceData) {
     try {
       return (await this.callAPI('PUT', { ...data, endpoint: 'sync' })).pushErrors;
-    } catch (e) {
-      this.logger.error(e);
+    } catch (error) {
+      this.logger.error(`Error syncing Synthetics monitors, Error: ${error.message}`, { error });
     }
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -126,20 +126,20 @@ export class SyntheticsService {
           installedPackage.name === 'synthetics' &&
           installedPackage.install_status === 'installed'
         ) {
-          this.logger.info('Installed synthetics index templates');
+          this.logger.debug('Installed synthetics index templates');
           this.indexTemplateExists = true;
         } else if (
           installedPackage.name === 'synthetics' &&
           installedPackage.install_status === 'install_failed'
         ) {
-          this.logger.warn(new IndexTemplateInstallationError());
+          const e = new IndexTemplateInstallationError();
+          this.logger.error(e.message, { error: e });
           this.indexTemplateExists = false;
         }
       }
     } catch (e) {
-      this.logger.error(e);
+      this.logger.error(new IndexTemplateInstallationError().message, { error: e });
       this.indexTemplateInstalling = false;
-      this.logger.warn(new IndexTemplateInstallationError());
     }
   }
 
@@ -156,8 +156,8 @@ export class SyntheticsService {
           .map((loc) => loc.id)
           .join(',')} Synthetics service locations from manifest: ${this.config.manifestUrl}`
       );
-    } catch (e) {
-      this.logger.error(e);
+    } catch (error) {
+      this.logger.error(`Error registering service locations, Error: ${error.message}`, { error });
     }
   }
 
@@ -477,16 +477,17 @@ export class SyntheticsService {
           });
 
           await syncAllLocations(PER_PAGE);
-        } catch (e) {
-          this.logger.error(`Failed to run Synthetics sync task with error: ${e.message}`);
-          this.logger.error(e);
+        } catch (error) {
+          this.logger.error(`Failed to run Synthetics sync task, Error: ${error.message}`, {
+            error,
+          });
 
           sendErrorTelemetryEvents(service.logger, service.server.telemetry, {
             reason: 'Failed to push configs to service',
-            message: e?.message,
+            message: error?.message,
             type: 'pushConfigsError',
-            code: e?.code,
-            status: e.status,
+            code: error?.code,
+            status: error.status,
             stackVersion: service.server.stackVersion,
           });
         }

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -291,7 +291,8 @@ export const runSynPrivateLocationMonitorsTaskSoon = async ({
     logger.debug(`Synthetics sync private location task scheduled successfully`);
   } catch (error) {
     logger.error(
-      `Error scheduling Synthetics sync private location monitors task: ${error.message}`
+      `Error scheduling Synthetics sync private location monitors task: ${error.message}`,
+      { error }
     );
   }
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Audit Synthetics plugin log levels (#218399)](https://github.com/elastic/kibana/pull/218399)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2025-06-12T13:55:03Z","message":"Audit Synthetics plugin log levels (#218399)\n\nCloses https://github.com/elastic/observability-dev/issues/4432\n\n## Summary\n\nAuditing [log\nlevels](https://docs.elastic.dev/kibana-dev-docs/services/logging#log-level)\nin the Synthetics plugin.\n\n### Example\nThrowing error when creating a new monitor:\n<img\nsrc=\"https://github.com/user-attachments/assets/7cead63b-c209-4174-a4f7-7dfad40aa34d\"\nwidth=500 />\n\n#### Before\n```\n1.\n[2025-04-23T12:29:37.594+02:00][ERROR][plugins.synthetics] Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n\n2.\n[2025-04-23T12:29:37.595+02:00][ERROR][plugins.synthetics] Unable to create Synthetics monitor https://www.elastic.co/\n\n3.\n[2025-04-23T12:29:38.758+02:00][ERROR][plugins.synthetics] Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n\n4.\n[2025-04-23T12:29:38.760+02:00][ERROR][plugins.synthetics] Unable to create synthetics monitor\n```\n\n#### After\n```\n[2025-05-12T16:06:23.160+02:00][ERROR][plugins.synthetics] Unable to create Synthetics monitor with name https://www.elastic.co/ Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n```\n##### ⚠️ Note\nAfter merging this [PR](https://github.com/elastic/kibana/pull/219940),\nwe will also have stacktrace locally.\n\n### ❓ Questions\n1. When calling `synthetics/params` API with wrong parameters, we get\n`[2025-05-13T11:05:52.401+02:00][ERROR][http] 400 Bad Request`, which\npath is responsible for this error? (Since it is from `http`, so it is\nnot logged in synthetics. I am wondering where the validation is\nhappening in this case)\n**Answer**: It was here:\nhttps://github.com/elastic/kibana/blob/main/src/core/packages/http/router-server-internal/src/route.ts#L124","sha":"327979743e08a9ae5433b3f2359817eacbfffb3d","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"Audit Synthetics plugin log levels","number":218399,"url":"https://github.com/elastic/kibana/pull/218399","mergeCommit":{"message":"Audit Synthetics plugin log levels (#218399)\n\nCloses https://github.com/elastic/observability-dev/issues/4432\n\n## Summary\n\nAuditing [log\nlevels](https://docs.elastic.dev/kibana-dev-docs/services/logging#log-level)\nin the Synthetics plugin.\n\n### Example\nThrowing error when creating a new monitor:\n<img\nsrc=\"https://github.com/user-attachments/assets/7cead63b-c209-4174-a4f7-7dfad40aa34d\"\nwidth=500 />\n\n#### Before\n```\n1.\n[2025-04-23T12:29:37.594+02:00][ERROR][plugins.synthetics] Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n\n2.\n[2025-04-23T12:29:37.595+02:00][ERROR][plugins.synthetics] Unable to create Synthetics monitor https://www.elastic.co/\n\n3.\n[2025-04-23T12:29:38.758+02:00][ERROR][plugins.synthetics] Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n\n4.\n[2025-04-23T12:29:38.760+02:00][ERROR][plugins.synthetics] Unable to create synthetics monitor\n```\n\n#### After\n```\n[2025-05-12T16:06:23.160+02:00][ERROR][plugins.synthetics] Unable to create Synthetics monitor with name https://www.elastic.co/ Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n```\n##### ⚠️ Note\nAfter merging this [PR](https://github.com/elastic/kibana/pull/219940),\nwe will also have stacktrace locally.\n\n### ❓ Questions\n1. When calling `synthetics/params` API with wrong parameters, we get\n`[2025-05-13T11:05:52.401+02:00][ERROR][http] 400 Bad Request`, which\npath is responsible for this error? (Since it is from `http`, so it is\nnot logged in synthetics. I am wondering where the validation is\nhappening in this case)\n**Answer**: It was here:\nhttps://github.com/elastic/kibana/blob/main/src/core/packages/http/router-server-internal/src/route.ts#L124","sha":"327979743e08a9ae5433b3f2359817eacbfffb3d"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218399","number":218399,"mergeCommit":{"message":"Audit Synthetics plugin log levels (#218399)\n\nCloses https://github.com/elastic/observability-dev/issues/4432\n\n## Summary\n\nAuditing [log\nlevels](https://docs.elastic.dev/kibana-dev-docs/services/logging#log-level)\nin the Synthetics plugin.\n\n### Example\nThrowing error when creating a new monitor:\n<img\nsrc=\"https://github.com/user-attachments/assets/7cead63b-c209-4174-a4f7-7dfad40aa34d\"\nwidth=500 />\n\n#### Before\n```\n1.\n[2025-04-23T12:29:37.594+02:00][ERROR][plugins.synthetics] Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n\n2.\n[2025-04-23T12:29:37.595+02:00][ERROR][plugins.synthetics] Unable to create Synthetics monitor https://www.elastic.co/\n\n3.\n[2025-04-23T12:29:38.758+02:00][ERROR][plugins.synthetics] Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n\n4.\n[2025-04-23T12:29:38.760+02:00][ERROR][plugins.synthetics] Unable to create synthetics monitor\n```\n\n#### After\n```\n[2025-05-12T16:06:23.160+02:00][ERROR][plugins.synthetics] Unable to create Synthetics monitor with name https://www.elastic.co/ Error: newMonitorPromise failed!\n    at /Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:82:15\n    at async AddEditMonitorAPI.syncNewMonitor (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts:88:72)\n    at async handler (/Users/maryam.saeidi/WebstormProjects/kibana-mary/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts:123:11)\n```\n##### ⚠️ Note\nAfter merging this [PR](https://github.com/elastic/kibana/pull/219940),\nwe will also have stacktrace locally.\n\n### ❓ Questions\n1. When calling `synthetics/params` API with wrong parameters, we get\n`[2025-05-13T11:05:52.401+02:00][ERROR][http] 400 Bad Request`, which\npath is responsible for this error? (Since it is from `http`, so it is\nnot logged in synthetics. I am wondering where the validation is\nhappening in this case)\n**Answer**: It was here:\nhttps://github.com/elastic/kibana/blob/main/src/core/packages/http/router-server-internal/src/route.ts#L124","sha":"327979743e08a9ae5433b3f2359817eacbfffb3d"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->