### PR TITLE
[8.19] [o11y Rules] Fetch dashboards only when combobox is focused (#223308)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_dashboards.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_dashboards.tsx
@@ -48,6 +48,8 @@ export const RuleDashboards = ({ contentManagement }: Props) => {
     Array<EuiComboBoxOptionOption<string>> | undefined
   >();
 
+  const [isComboBoxOpen, setIsComboBoxOpen] = useState(false);
+
   const fetchDashboardTitles = useCallback(async () => {
     if (!dashboardsFormData?.length || !contentManagement) {
       return;
@@ -146,8 +148,18 @@ export const RuleDashboards = ({ contentManagement }: Props) => {
   }, [contentManagement, searchValue]);
 
   useEffect(() => {
-    loadDashboards();
-  }, [loadDashboards]);
+    if (isComboBoxOpen) {
+      loadDashboards();
+    }
+  }, [isComboBoxOpen, loadDashboards]);
+
+  // Only load dashboards when ComboBox is focused/opened
+  const handleComboBoxFocus = useCallback(() => {
+    if (!isComboBoxOpen) {
+      setIsComboBoxOpen(true);
+      loadDashboards();
+    }
+  }, [isComboBoxOpen, loadDashboards]);
 
   return (
     <>
@@ -167,6 +179,7 @@ export const RuleDashboards = ({ contentManagement }: Props) => {
               selectedOptions={selectedDashboards}
               placeholder={ALERT_LINK_DASHBOARDS_PLACEHOLDER}
               onChange={onChange}
+              onFocus={handleComboBoxFocus}
               onSearchChange={onSearchChange}
               data-test-subj="ruleLinkedDashboards"
             />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[o11y Rules] Fetch dashboards only when combobox is focused (#223308)](https://github.com/elastic/kibana/pull/223308)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Panagiota Mitsopoulou","email":"panagiota.mitsopoulou@elastic.co"},"sourceCommit":{"committedDate":"2025-06-12T22:57:58Z","message":"[o11y Rules] Fetch dashboards only when combobox is focused (#223308)\n\nFollow up PR to this\n[comment](https://github.com/elastic/kibana/pull/221848#discussion_r2113901297)\n\n## Summary\n\nRight now we are pre-populating the combo box with all dashboards every\ntime the create rule or edit rule is opened\n\n## ACCs\n- fetch the dashboard list only if the combo box is focused\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"60a21fd9dc6e539aa73e8a9de9ea34b988783634","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[o11y Rules] Fetch dashboards only when combobox is focused","number":223308,"url":"https://github.com/elastic/kibana/pull/223308","mergeCommit":{"message":"[o11y Rules] Fetch dashboards only when combobox is focused (#223308)\n\nFollow up PR to this\n[comment](https://github.com/elastic/kibana/pull/221848#discussion_r2113901297)\n\n## Summary\n\nRight now we are pre-populating the combo box with all dashboards every\ntime the create rule or edit rule is opened\n\n## ACCs\n- fetch the dashboard list only if the combo box is focused\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"60a21fd9dc6e539aa73e8a9de9ea34b988783634"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223308","number":223308,"mergeCommit":{"message":"[o11y Rules] Fetch dashboards only when combobox is focused (#223308)\n\nFollow up PR to this\n[comment](https://github.com/elastic/kibana/pull/221848#discussion_r2113901297)\n\n## Summary\n\nRight now we are pre-populating the combo box with all dashboards every\ntime the create rule or edit rule is opened\n\n## ACCs\n- fetch the dashboard list only if the combo box is focused\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"60a21fd9dc6e539aa73e8a9de9ea34b988783634"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->