### PR TITLE
[8.19] [Discover][APM] Expanded waterfall for spans and transactions (#222214)

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
@@ -15,7 +15,7 @@ import type { DocumentProfileProvider } from '../../../../../profiles';
 import type { DocViewerExtensionParams, DocViewerExtension } from '../../../../../types';
 
 export const createGetDocViewer =
-  (transactionIndexPattern: string): DocumentProfileProvider['profile']['getDocViewer'] =>
+  (tracesIndexPattern: string): DocumentProfileProvider['profile']['getDocViewer'] =>
   (prev: (params: DocViewerExtensionParams) => DocViewerExtension) =>
   (params: DocViewerExtensionParams) => {
     const prevDocViewer = prev(params);
@@ -33,7 +33,7 @@ export const createGetDocViewer =
             return (
               <UnifiedDocViewerObservabilityTracesSpanOverview
                 {...props}
-                transactionIndexPattern={transactionIndexPattern}
+                tracesIndexPattern={tracesIndexPattern}
               />
             );
           },

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/field_with_actions/field_with_actions.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/field_with_actions/field_with_actions.tsx
@@ -20,6 +20,7 @@ export interface FieldWithActionsProps {
   value: string;
   children: React.ReactNode;
   loading?: boolean;
+  showActions?: boolean;
 }
 
 export function FieldWithActions({
@@ -30,6 +31,7 @@ export function FieldWithActions({
   value,
   loading,
   children,
+  showActions = true,
   ...props
 }: FieldWithActionsProps) {
   const hasFieldDescription = !!fieldMetadata?.flat_name;
@@ -37,6 +39,13 @@ export function FieldWithActions({
   if (!label) {
     return null;
   }
+
+  const fieldContent = (
+    <div className="eui-textBreakWord">
+      {loading && <EuiLoadingSpinner size="m" />}
+      {children}
+    </div>
+  );
 
   return (
     <div {...props}>
@@ -50,19 +59,25 @@ export function FieldWithActions({
             </EuiFlexItem>
             {hasFieldDescription && (
               <EuiFlexItem grow={false}>
-                <EuiIconTip content={fieldMetadata.flat_name} color="subdued" />
+                <EuiIconTip
+                  title={fieldMetadata.flat_name}
+                  content={fieldMetadata.short}
+                  color="subdued"
+                  aria-label={`${fieldMetadata.flat_name}: ${fieldMetadata.short}`}
+                />
               </EuiFlexItem>
             )}
           </EuiFlexGroup>
         </EuiFlexItem>
 
         <EuiFlexItem grow={2}>
-          <FieldHoverActionPopover title={value} value={value} field={field}>
-            <div className="eui-textBreakWord">
-              {loading && <EuiLoadingSpinner size="m" />}
-              {children}
-            </div>
-          </FieldHoverActionPopover>
+          {showActions ? (
+            <FieldHoverActionPopover title={value} value={value} field={field}>
+              {fieldContent}
+            </FieldHoverActionPopover>
+          ) : (
+            fieldContent
+          )}
         </EuiFlexItem>
       </EuiFlexGroup>
     </div>

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/index.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { lastValueFrom } from 'rxjs';
+import { SPAN_ID_FIELD } from '@kbn/discover-utils';
+import { useState, useEffect } from 'react';
+import { getUnifiedDocViewerServices } from '../../../../../../../plugin';
+
+interface UseSpanParams {
+  spanId?: string;
+  indexPattern: string;
+}
+
+interface GetTransactionParams {
+  spanId: string;
+  indexPattern: string;
+  data: DataPublicPluginStart;
+  signal: AbortSignal;
+}
+
+async function getSpanData({ spanId, indexPattern, data, signal }: GetTransactionParams) {
+  return lastValueFrom(
+    data.search.search(
+      {
+        params: {
+          index: indexPattern,
+          size: 1,
+          body: {
+            timeout: '20s',
+            query: {
+              match: {
+                [SPAN_ID_FIELD]: spanId,
+              },
+            },
+          },
+        },
+      },
+      { abortSignal: signal }
+    )
+  );
+}
+
+export const useSpan = ({ spanId, indexPattern }: UseSpanParams) => {
+  const { data, core } = getUnifiedDocViewerServices();
+  const [span, setSpan] = useState<Record<PropertyKey, any> | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [docId, setDocId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!spanId) {
+      setSpan(null);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const result = await getSpanData({ spanId, indexPattern, data, signal });
+        setSpan(result.rawResponse.hits.hits[0]?._source);
+        setDocId(result.rawResponse.hits.hits[0]?._id ?? null);
+      } catch (err) {
+        if (!signal.aborted) {
+          const error = err as Error;
+          core.notifications.toasts.addDanger({
+            title: i18n.translate('unifiedDocViewer.fullScreenWaterfall.useSpan.error', {
+              defaultMessage: 'An error occurred while fetching the span',
+            }),
+            text: error.message,
+          });
+          setSpan(null);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
+    return function onUnmount() {
+      controller.abort();
+    };
+  }, [core.notifications.toasts, data, indexPattern, spanId]);
+
+  return { loading, span, docId };
+};

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/use_span.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/use_span.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSpan } from '.';
+import { getUnifiedDocViewerServices } from '../../../../../../../plugin';
+import { of, throwError } from 'rxjs';
+
+jest.mock('../../../../../../../plugin', () => ({
+  getUnifiedDocViewerServices: jest.fn(),
+}));
+
+const mockSearch = jest.fn();
+const mockAddDanger = jest.fn();
+
+const mockServices = {
+  data: {
+    search: {
+      search: mockSearch,
+    },
+  },
+  core: {
+    notifications: {
+      toasts: {
+        addDanger: mockAddDanger,
+      },
+    },
+  },
+};
+
+describe('useSpan', () => {
+  const spanId = 'test-span-id';
+  const indexPattern = 'test-index';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getUnifiedDocViewerServices as jest.Mock).mockReturnValue(mockServices);
+  });
+
+  describe('when parameters are NOT missing', () => {
+    it('should fetch span data successfully', async () => {
+      const mockHit = { _source: { name: 'test-span' }, _id: 'test-id' };
+
+      mockSearch.mockReturnValue(
+        of({
+          rawResponse: {
+            hits: {
+              hits: [mockHit],
+            },
+          },
+        })
+      );
+
+      const { result } = renderHook(() => useSpan({ spanId, indexPattern }));
+      await waitFor(() => !result.current.loading);
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.span).toEqual(mockHit._source);
+      expect(result.current.docId).toEqual(mockHit._id);
+    });
+  });
+
+  describe('when parameters are missing', () => {
+    it('should set span to null and loading to false', () => {
+      const { result } = renderHook(() => useSpan({ spanId: undefined, indexPattern }));
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.span).toBe(null);
+      expect(result.current.docId).toBe(null);
+    });
+  });
+
+  describe('when there is an error', () => {
+    it('should show an error toast and set span to null', async () => {
+      const error = new Error('something went wrong');
+      mockSearch.mockReturnValue(throwError(() => error));
+
+      const { result } = renderHook(() => useSpan({ spanId, indexPattern }));
+      await waitFor(() => !result.current.loading);
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.span).toBe(null);
+      expect(result.current.docId).toBe(null);
+      expect(mockAddDanger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'something went wrong',
+        })
+      );
+    });
+  });
+});

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFocusTrap,
+  EuiOverlayMask,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { SERVICE_NAME_FIELD, SPAN_ID_FIELD, TRANSACTION_ID_FIELD } from '@kbn/discover-utils';
+import { i18n } from '@kbn/i18n';
+import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import { useRootTransactionContext } from '../../doc_viewer_transaction_overview/hooks/use_root_transaction';
+import { SpanFlyout } from './span_flyout';
+
+export interface FullScreenWaterfallProps {
+  traceId: string;
+  rangeFrom: string;
+  rangeTo: string;
+  dataView: DocViewRenderProps['dataView'];
+  tracesIndexPattern: string;
+  onCloseFullScreen: () => void;
+}
+
+export const FullScreenWaterfall = ({
+  traceId,
+  rangeFrom,
+  rangeTo,
+  dataView,
+  tracesIndexPattern,
+  onCloseFullScreen,
+}: FullScreenWaterfallProps) => {
+  const { transaction } = useRootTransactionContext();
+  const [spanId, setSpanId] = useState<string | null>(null);
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const overlayMaskRef = useRef<HTMLDivElement>(null);
+
+  const getParentApi = useCallback(
+    () => ({
+      getSerializedStateForChild: () => ({
+        rawState: {
+          traceId,
+          rangeFrom,
+          rangeTo,
+          serviceName: transaction?.[SERVICE_NAME_FIELD],
+          entryTransactionId: transaction?.[TRANSACTION_ID_FIELD] || transaction?.[SPAN_ID_FIELD],
+          scrollElement: overlayMaskRef.current,
+          onNodeClick: (nodeSpanId: string) => {
+            setSpanId(nodeSpanId);
+            setIsFlyoutVisible(true);
+          },
+        },
+      }),
+    }),
+    [traceId, rangeFrom, rangeTo, transaction]
+  );
+
+  return (
+    <>
+      <EuiOverlayMask
+        maskRef={overlayMaskRef}
+        css={{ paddingBlockEnd: '0 !important', overflowY: 'scroll' }}
+      >
+        <EuiFocusTrap css={{ height: '100%', width: '100%' }}>
+          <EuiPanel hasShadow={false} css={{ minHeight: '100%', width: '100%' }}>
+            <EuiFlexGroup alignItems="center">
+              <EuiFlexItem grow={1}>
+                <EuiTitle size="l">
+                  <h2>
+                    {i18n.translate(
+                      'unifiedDocViewer.observability.traces.fullScreenWaterfall.title',
+                      {
+                        defaultMessage: 'Trace timeline',
+                      }
+                    )}
+                  </h2>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem grow={1} css={{ alignItems: 'end' }}>
+                <EuiButtonIcon
+                  data-test-subj="unifiedDocViewerObservabilityTracesFullScreenWaterfallExitFullScreenButton"
+                  display="base"
+                  iconSize="m"
+                  iconType="fullScreenExit"
+                  aria-label={i18n.translate(
+                    'unifiedDocViewer.observability.traces.fullScreenWaterfall.exitFullScreen.button',
+                    {
+                      defaultMessage: 'Exit full screen waterfall',
+                    }
+                  )}
+                  onClick={onCloseFullScreen}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EmbeddableRenderer
+                  type="APM_TRACE_WATERFALL_EMBEDDABLE"
+                  getParentApi={getParentApi}
+                  hidePanelChrome
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+        </EuiFocusTrap>
+      </EuiOverlayMask>
+
+      {isFlyoutVisible && spanId && (
+        <SpanFlyout
+          tracesIndexPattern={tracesIndexPattern}
+          spanId={spanId}
+          dataView={dataView}
+          onCloseFlyout={() => {
+            setIsFlyoutVisible(false);
+          }}
+        />
+      )}
+    </>
+  );
+};

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/index.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  useEuiTheme,
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlyoutBody,
+  EuiSkeletonTitle,
+} from '@elastic/eui';
+import { DataTableRecord, PARENT_ID_FIELD } from '@kbn/discover-utils';
+import { flattenObject } from '@kbn/object-utils';
+import React, { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import { useSpan } from '../hooks/use_span';
+import { SpanFlyoutBody } from './span_flyout_body';
+
+const flyoutId = 'spanDetailFlyout';
+
+export interface SpanFlyoutProps {
+  tracesIndexPattern: string;
+  spanId: string;
+  dataView: DocViewRenderProps['dataView'];
+  onCloseFlyout: () => void;
+}
+
+export const SpanFlyout = ({
+  tracesIndexPattern,
+  spanId,
+  dataView,
+  onCloseFlyout,
+}: SpanFlyoutProps) => {
+  const { span, docId, loading } = useSpan({ indexPattern: tracesIndexPattern, spanId });
+  const { euiTheme } = useEuiTheme();
+  const documentAsHit = useMemo<DataTableRecord | null>(() => {
+    if (!span || !docId) return null;
+
+    return {
+      id: docId,
+      raw: {
+        _index: span._index,
+        _id: docId,
+        _source: span,
+      },
+      flattened: flattenObject(span),
+    };
+  }, [docId, span]);
+  const isSpan = !!documentAsHit?.flattened[PARENT_ID_FIELD];
+
+  return (
+    <EuiFlyout
+      includeFixedHeadersInFocusTrap={false}
+      ownFocus={false}
+      css={{ zIndex: (euiTheme.levels.mask as number) + 1, top: '0' }}
+      onClose={onCloseFlyout}
+      aria-labelledby={flyoutId}
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiSkeletonTitle isLoading={loading}>
+          <EuiTitle size="m">
+            <h2 id={flyoutId}>
+              {i18n.translate(
+                'unifiedDocViewer.observability.traces.fullScreenWaterfall.spanFlyout.title',
+                {
+                  defaultMessage: '{docType} document',
+                  values: {
+                    docType: isSpan
+                      ? i18n.translate(
+                          'unifiedDocViewer.observability.traces.fullScreenWaterfall.spanFlyout.title.span',
+                          { defaultMessage: 'Span' }
+                        )
+                      : i18n.translate(
+                          'unifiedDocViewer.observability.traces.fullScreenWaterfall.spanFlyout.title.transction',
+                          { defaultMessage: 'Transaction' }
+                        ),
+                  },
+                }
+              )}
+            </h2>
+          </EuiTitle>
+        </EuiSkeletonTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <SpanFlyoutBody
+          tracesIndexPattern={tracesIndexPattern}
+          hit={documentAsHit}
+          dataView={dataView}
+          loading={loading}
+          onCloseFlyout={onCloseFlyout}
+        />
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiSkeletonText, EuiTab, EuiTabs } from '@elastic/eui';
+import { DataTableRecord, PARENT_ID_FIELD } from '@kbn/discover-utils';
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import SpanOverview from '../../../doc_viewer_span_overview';
+import TransactionOverview from '../../../doc_viewer_transaction_overview';
+import DocViewerTable from '../../../../../doc_viewer_table';
+import DocViewerSource from '../../../../../doc_viewer_source';
+
+const tabIds = {
+  OVERVIEW: 'unifiedDocViewerTracesSpanFlyoutOverview',
+  TABLE: 'unifiedDocViewerTracesSpanFlyoutTable',
+  JSON: 'unifiedDocViewerTracesSpanFlyoutJson',
+};
+
+const tabs = [
+  {
+    id: tabIds.OVERVIEW,
+    name: i18n.translate(
+      'unifiedDocViewer.observability.traces.fullScreenWaterfall.tabs.overview',
+      {
+        defaultMessage: 'Overview',
+      }
+    ),
+  },
+  {
+    id: tabIds.TABLE,
+    name: i18n.translate('unifiedDocViewer.observability.traces.fullScreenWaterfall.tabs.table', {
+      defaultMessage: 'Table',
+    }),
+  },
+  {
+    id: tabIds.JSON,
+    name: i18n.translate('unifiedDocViewer.observability.traces.fullScreenWaterfall.tabs.json', {
+      defaultMessage: 'JSON',
+    }),
+  },
+];
+
+export interface SpanFlyoutProps {
+  tracesIndexPattern: string;
+  hit: DataTableRecord | null;
+  loading: boolean;
+  dataView: DocViewRenderProps['dataView'];
+  onCloseFlyout: () => void;
+}
+
+export const SpanFlyoutBody = ({ tracesIndexPattern, hit, loading, dataView }: SpanFlyoutProps) => {
+  const [selectedTabId, setSelectedTabId] = useState(tabIds.OVERVIEW);
+  const isSpan = !!hit?.flattened[PARENT_ID_FIELD];
+  const onSelectedTabChanged = (id: string) => setSelectedTabId(id);
+
+  const renderTabs = () => {
+    return tabs.map((tab) => (
+      <EuiTab
+        key={tab.id}
+        onClick={() => onSelectedTabChanged(tab.id)}
+        isSelected={tab.id === selectedTabId}
+      >
+        {tab.name}
+      </EuiTab>
+    ));
+  };
+
+  return (
+    <>
+      {loading || !hit ? (
+        <EuiSkeletonText lines={5} />
+      ) : (
+        <>
+          <EuiTabs size="s">{renderTabs()}</EuiTabs>
+          <EuiSkeletonText isLoading={loading}>
+            {selectedTabId === tabIds.OVERVIEW &&
+              (isSpan ? (
+                <SpanOverview
+                  hit={hit}
+                  tracesIndexPattern={tracesIndexPattern}
+                  showWaterfall={false}
+                  showActions={false}
+                  dataView={dataView}
+                />
+              ) : (
+                <TransactionOverview
+                  hit={hit}
+                  tracesIndexPattern={tracesIndexPattern}
+                  showWaterfall={false}
+                  showActions={false}
+                  dataView={dataView}
+                />
+              ))}
+
+            {selectedTabId === tabIds.TABLE && <DocViewerTable hit={hit} dataView={dataView} />}
+
+            {selectedTabId === tabIds.JSON && (
+              <DocViewerSource
+                id={hit.id}
+                index={hit.raw._index}
+                dataView={dataView}
+                esqlHit={hit}
+                onRefresh={() => {}}
+                /* We're already passing the document in this case, so this refresh won't have a chance to run.
+            It's handled the same way in src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx */
+              />
+            )}
+          </EuiSkeletonText>
+        </>
+      )}
+    </>
+  );
+};

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
@@ -7,26 +7,42 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import { spanTraceFields } from '../doc_viewer_span_overview/resources/fields';
 import { transactionTraceFields } from '../doc_viewer_transaction_overview/resources/fields';
 import { SpanSummaryField } from '../doc_viewer_span_overview/sub_components/span_summary_field';
 import { TransactionSummaryField } from '../doc_viewer_transaction_overview/sub_components/transaction_summary_field';
 import { getUnifiedDocViewerServices } from '../../../../plugin';
 import { FieldConfiguration } from '../resources/get_field_configuration';
+import { FullScreenWaterfall } from './full_screen_waterfall';
 
 export interface TraceProps {
   fields: Record<string, FieldConfiguration>;
   traceId: string;
   displayType: 'span' | 'transaction';
   docId: string;
+  dataView: DocViewRenderProps['dataView'];
+  tracesIndexPattern: string;
+  showWaterfall?: boolean;
+  showActions?: boolean;
 }
 
-export const Trace = ({ traceId, fields, displayType, docId }: TraceProps) => {
+export const Trace = ({
+  traceId,
+  fields,
+  displayType,
+  docId,
+  dataView,
+  tracesIndexPattern,
+  showWaterfall = true,
+  showActions = true,
+}: TraceProps) => {
   const { data } = getUnifiedDocViewerServices();
+  const [showFullScreenWaterfall, setShowFullScreenWaterfall] = useState(false);
 
   const { from: rangeFrom, to: rangeTo } = data.query.timefilter.timefilter.getAbsoluteTime();
 
@@ -47,35 +63,81 @@ export const Trace = ({ traceId, fields, displayType, docId }: TraceProps) => {
   const fieldRows =
     displayType === 'span'
       ? spanTraceFields.map((fieldId: string) => (
-          <SpanSummaryField key={fieldId} fieldId={fieldId} fieldConfiguration={fields[fieldId]} />
+          <SpanSummaryField
+            key={fieldId}
+            fieldId={fieldId}
+            fieldConfiguration={fields[fieldId]}
+            showActions={showActions}
+          />
         ))
       : transactionTraceFields.map((fieldId: string) => (
           <TransactionSummaryField
             key={fieldId}
             fieldId={fieldId}
             fieldConfiguration={fields[fieldId]}
+            showActions={showActions}
           />
         ));
 
   return (
     <>
-      <EuiTitle size="s">
-        <h2>
-          {i18n.translate('unifiedDocViewer.observability.traces.trace.title', {
-            defaultMessage: 'Trace',
-          })}
-        </h2>
-      </EuiTitle>
+      {showFullScreenWaterfall && (
+        <FullScreenWaterfall
+          traceId={traceId}
+          rangeFrom={rangeFrom}
+          rangeTo={rangeTo}
+          dataView={dataView}
+          tracesIndexPattern={tracesIndexPattern}
+          onCloseFullScreen={() => {
+            setShowFullScreenWaterfall(false);
+          }}
+        />
+      )}
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h2>
+              {i18n.translate('unifiedDocViewer.observability.traces.trace.title', {
+                defaultMessage: 'Trace',
+              })}
+            </h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        {showWaterfall && (
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              data-test-subj="unifiedDocViewerObservabilityTracesTraceFullScreenButton"
+              iconSize="m"
+              iconType="fullScreen"
+              color="text"
+              aria-label={i18n.translate(
+                'unifiedDocViewer.observability.traces.trace.fullScreen.button',
+                {
+                  defaultMessage: 'Open full screen waterfall',
+                }
+              )}
+              onClick={() => {
+                setShowFullScreenWaterfall(true);
+              }}
+            />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
       <EuiSpacer size="m" />
       <EuiFlexGroup direction="column">
         <EuiFlexItem>{fieldRows}</EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <EmbeddableRenderer
-        type="APM_TRACE_WATERFALL_EMBEDDABLE"
-        getParentApi={getParentApi}
-        hidePanelChrome={true}
-      />
+
+      {showWaterfall && (
+        <>
+          <EuiSpacer size="m" />
+          <EmbeddableRenderer
+            type="APM_TRACE_WATERFALL_EMBEDDABLE"
+            getParentApi={getParentApi}
+            hidePanelChrome
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/resources/get_span_field_configuration.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/resources/get_span_field_configuration.tsx
@@ -66,6 +66,12 @@ export const getSpanFieldConfiguration = ({
       formattedValue: attributes[SPAN_DESTINATION_SERVICE_RESOURCE_FIELD],
       fieldMetadata: {
         flat_name: 'span.destination.service.resource',
+        short: i18n.translate(
+          'unifiedDocViewer.observability.traces.details.spanDestinationServiceResource.description',
+          {
+            defaultMessage: 'Identifier for the destination service resource being operated on.',
+          }
+        ),
       },
     },
     [SPAN_TYPE_FIELD]: {

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiPanel, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer } from '@elastic/eui';
 import {
   SPAN_DURATION_FIELD,
   SPAN_ID_FIELD,
@@ -29,9 +29,12 @@ import { getSpanFieldConfiguration } from './resources/get_span_field_configurat
 import { SpanDurationSummary } from './sub_components/span_duration_summary';
 import { SpanSummaryField } from './sub_components/span_summary_field';
 import { SpanSummaryTitle } from './sub_components/span_summary_title';
+import { RootTransactionProvider } from '../doc_viewer_transaction_overview/hooks/use_root_transaction';
 
 export type SpanOverviewProps = DocViewRenderProps & {
-  transactionIndexPattern: string;
+  tracesIndexPattern: string;
+  showWaterfall?: boolean;
+  showActions?: boolean;
 };
 
 export function SpanOverview({
@@ -40,7 +43,9 @@ export function SpanOverview({
   filter,
   onAddColumn,
   onRemoveColumn,
-  transactionIndexPattern,
+  tracesIndexPattern,
+  showWaterfall = true,
+  showActions = true,
   dataView,
 }: SpanOverviewProps) {
   const { fieldFormats } = getUnifiedDocViewerServices();
@@ -60,49 +65,66 @@ export function SpanOverview({
   const transactionId = flattenedDoc[TRANSACTION_ID_FIELD];
 
   return (
-    <TransactionProvider transactionId={transactionId} indexPattern={transactionIndexPattern}>
-      <FieldActionsProvider
-        columns={columns}
-        filter={filter}
-        onAddColumn={onAddColumn}
-        onRemoveColumn={onRemoveColumn}
-      >
-        <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
-          <EuiSpacer size="m" />
-          <SpanSummaryTitle
-            spanName={flattenedDoc[SPAN_NAME_FIELD]}
-            formattedSpanName={formattedDoc[SPAN_NAME_FIELD]}
-            spanId={flattenedDoc[SPAN_ID_FIELD]}
-            formattedSpanId={formattedDoc[SPAN_ID_FIELD]}
-          />
-          <EuiSpacer size="m" />
-          {spanFields.map((fieldId) => (
-            <SpanSummaryField
-              key={fieldId}
-              fieldId={fieldId}
-              fieldConfiguration={fieldConfigurations[fieldId]}
-            />
-          ))}
+    <RootTransactionProvider
+      traceId={flattenedDoc[TRACE_ID_FIELD]}
+      indexPattern={tracesIndexPattern}
+    >
+      <TransactionProvider transactionId={transactionId} indexPattern={tracesIndexPattern}>
+        <FieldActionsProvider
+          columns={columns}
+          filter={filter}
+          onAddColumn={onAddColumn}
+          onRemoveColumn={onRemoveColumn}
+        >
+          <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
+            <EuiSpacer size="m" />
+            <EuiFlexGroup direction="column" gutterSize="m">
+              <EuiFlexItem>
+                <SpanSummaryTitle
+                  spanName={flattenedDoc[SPAN_NAME_FIELD]}
+                  formattedSpanName={formattedDoc[SPAN_NAME_FIELD]}
+                  spanId={flattenedDoc[SPAN_ID_FIELD]}
+                  formattedSpanId={formattedDoc[SPAN_ID_FIELD]}
+                  showActions={showActions}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                {spanFields.map((fieldId) => (
+                  <SpanSummaryField
+                    key={fieldId}
+                    fieldId={fieldId}
+                    fieldConfiguration={fieldConfigurations[fieldId]}
+                    showActions={showActions}
+                  />
+                ))}
+              </EuiFlexItem>
 
-          {spanDuration && (
-            <>
-              <EuiSpacer size="m" />
-              <SpanDurationSummary
-                spanDuration={spanDuration}
-                spanName={formattedDoc[SPAN_NAME_FIELD]}
-                serviceName={formattedDoc[SERVICE_NAME_FIELD]}
-              />
-            </>
-          )}
-          <EuiSpacer size="m" />
-          <Trace
-            fields={fieldConfigurations}
-            traceId={flattenedDoc[TRACE_ID_FIELD]}
-            docId={flattenedDoc[SPAN_ID_FIELD]}
-            displayType="span"
-          />
-        </EuiPanel>
-      </FieldActionsProvider>
-    </TransactionProvider>
+              {spanDuration && (
+                <EuiFlexItem>
+                  <EuiSpacer size="m" />
+                  <SpanDurationSummary
+                    spanDuration={spanDuration}
+                    spanName={flattenedDoc[SPAN_NAME_FIELD]}
+                    serviceName={flattenedDoc[SERVICE_NAME_FIELD]}
+                  />
+                </EuiFlexItem>
+              )}
+              <EuiFlexItem>
+                <Trace
+                  fields={fieldConfigurations}
+                  traceId={flattenedDoc[TRACE_ID_FIELD]}
+                  docId={flattenedDoc[SPAN_ID_FIELD]}
+                  displayType="span"
+                  dataView={dataView}
+                  tracesIndexPattern={tracesIndexPattern}
+                  showWaterfall={showWaterfall}
+                  showActions={showActions}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+        </FieldActionsProvider>
+      </TransactionProvider>
+    </RootTransactionProvider>
   );
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_field.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_field.tsx
@@ -16,9 +16,14 @@ import { FieldConfiguration } from '../../resources/get_field_configuration';
 export interface SpanSummaryFieldProps {
   fieldId: string;
   fieldConfiguration: FieldConfiguration;
+  showActions?: boolean;
 }
 
-export function SpanSummaryField({ fieldConfiguration, fieldId }: SpanSummaryFieldProps) {
+export function SpanSummaryField({
+  fieldConfiguration,
+  fieldId,
+  showActions = true,
+}: SpanSummaryFieldProps) {
   const { transaction, loading } = useTransactionContext();
   const [fieldValue, setFieldValue] = useState(fieldConfiguration.value);
   const isTransactionNameField = fieldId === TRANSACTION_NAME_FIELD;
@@ -47,6 +52,7 @@ export function SpanSummaryField({ fieldConfiguration, fieldId }: SpanSummaryFie
         formattedValue={fieldValue as string}
         fieldMetadata={fieldConfiguration.fieldMetadata}
         loading={isTransactionNameFieldWithoutValue && loading}
+        showActions={showActions}
       >
         <div>{fieldConfiguration.content(fieldValue, fieldConfiguration.formattedValue)}</div>
       </FieldWithActions>

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.test.tsx
@@ -10,8 +10,12 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { SpanSummaryTitle } from './span_summary_title';
 
+const fieldHoverActionPopoverDataTestSubj = 'FieldHoverActionPopover';
+
 jest.mock('../../components/field_with_actions/field_hover_popover_action', () => ({
-  FieldHoverActionPopover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FieldHoverActionPopover: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj={fieldHoverActionPopoverDataTestSubj}>{children}</div>
+  ),
 }));
 
 jest.mock('../../components/highlight_field.tsx', () => ({
@@ -71,5 +75,35 @@ describe('SpanSummaryTitle', () => {
 
     expect(getByText('Test Span')).toBeInTheDocument();
     expect(getByText('123')).toBeInTheDocument();
+  });
+
+  it('renders FieldHoverActionPopover if showActions is undefined', () => {
+    const { container } = render(
+      <SpanSummaryTitle spanId="123" formattedSpanId="<mark>123</mark>" />
+    );
+
+    expect(
+      container.querySelector(`[data-test-subj="${fieldHoverActionPopoverDataTestSubj}"]`)
+    ).not.toBeNull();
+  });
+
+  it('renders FieldHoverActionPopover if showActions is true', () => {
+    const { container } = render(
+      <SpanSummaryTitle spanId="123" formattedSpanId="<mark>123</mark>" showActions={true} />
+    );
+
+    expect(
+      container.querySelector(`[data-test-subj="${fieldHoverActionPopoverDataTestSubj}"]`)
+    ).not.toBeNull();
+  });
+
+  it('does not render FieldHoverActionPopover if showActions is false', () => {
+    const { container } = render(
+      <SpanSummaryTitle spanId="123" formattedSpanId="<mark>123</mark>" showActions={false} />
+    );
+
+    expect(
+      container.querySelector(`[data-test-subj="${fieldHoverActionPopoverDataTestSubj}"]`)
+    ).toBeNull();
   });
 });

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.tsx
@@ -18,6 +18,7 @@ export interface SpanSummaryTitleProps {
   formattedSpanName?: string;
   spanId: string;
   formattedSpanId: string;
+  showActions?: boolean;
 }
 
 export const SpanSummaryTitle = ({
@@ -25,11 +26,38 @@ export const SpanSummaryTitle = ({
   spanId,
   formattedSpanId,
   formattedSpanName,
+  showActions = true,
 }: SpanSummaryTitleProps) => {
+  const FieldContent = ({
+    children,
+    field,
+    title,
+    value,
+  }: {
+    children: React.ReactNode;
+    field: string;
+    title: string;
+    value: string;
+    showActions: boolean;
+  }) => {
+    return showActions ? (
+      <FieldHoverActionPopover title={title} value={value} field={field}>
+        <>{children}</>
+      </FieldHoverActionPopover>
+    ) : (
+      <>{children}</>
+    );
+  };
+
   return spanName ? (
     <>
       <div>
-        <FieldHoverActionPopover title={spanName} value={spanName} field={SPAN_NAME_FIELD}>
+        <FieldContent
+          title={spanName}
+          value={spanName}
+          field={SPAN_NAME_FIELD}
+          showActions={showActions}
+        >
           <EuiTitle size="xs">
             <h2>
               <HighlightField
@@ -40,17 +68,17 @@ export const SpanSummaryTitle = ({
               />
             </h2>
           </EuiTitle>
-        </FieldHoverActionPopover>
+        </FieldContent>
       </div>
-      <FieldHoverActionPopover title={spanId} value={spanId} field={SPAN_ID_FIELD}>
+      <FieldContent title={spanId} value={spanId} field={SPAN_ID_FIELD} showActions={showActions}>
         <HighlightField value={spanId} formattedValue={formattedSpanId} />
-      </FieldHoverActionPopover>
+      </FieldContent>
     </>
   ) : (
-    <FieldHoverActionPopover title={spanId} value={spanId} field={SPAN_ID_FIELD}>
+    <FieldContent title={spanId} value={spanId} field={SPAN_ID_FIELD} showActions={showActions}>
       <EuiTitle size="xs">
         <HighlightField value={spanId} formattedValue={formattedSpanId} as="h2" />
       </EuiTitle>
-    </FieldHoverActionPopover>
+    </FieldContent>
   );
 };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/hooks/use_root_transaction/use_root_transaction.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/hooks/use_root_transaction/use_root_transaction.test.tsx
@@ -12,7 +12,13 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { lastValueFrom } from 'rxjs';
 import { getUnifiedDocViewerServices } from '../../../../../../plugin';
 import { RootTransactionProvider, useRootTransactionContext } from '.';
-import { TRANSACTION_DURATION_FIELD, TRANSACTION_NAME_FIELD } from '@kbn/discover-utils';
+import {
+  SERVICE_NAME_FIELD,
+  SPAN_ID_FIELD,
+  TRANSACTION_DURATION_FIELD,
+  TRANSACTION_ID_FIELD,
+  TRANSACTION_NAME_FIELD,
+} from '@kbn/discover-utils';
 
 jest.mock('../../../../../../plugin', () => ({
   getUnifiedDocViewerServices: jest.fn(),
@@ -69,6 +75,9 @@ describe('useRootTransaction hook', () => {
   it('should update transaction when data is fetched successfully', async () => {
     const transactionName = 'Test Transaction';
     const transactionDuration = 1;
+    const spanId = 'spanId';
+    const transactionId = 'transactionId';
+    const serviceName = 'serviceName';
     lastValueFromMock.mockResolvedValue({
       rawResponse: {
         hits: {
@@ -77,6 +86,9 @@ describe('useRootTransaction hook', () => {
               fields: {
                 [TRANSACTION_NAME_FIELD]: transactionName,
                 [TRANSACTION_DURATION_FIELD]: transactionDuration,
+                [SPAN_ID_FIELD]: spanId,
+                [TRANSACTION_ID_FIELD]: transactionId,
+                [SERVICE_NAME_FIELD]: serviceName,
               },
             },
           ],
@@ -90,6 +102,9 @@ describe('useRootTransaction hook', () => {
 
     expect(result.current.loading).toBe(false);
     expect(result.current.transaction?.duration).toBe(transactionDuration);
+    expect(result.current.transaction?.[SPAN_ID_FIELD]).toBe(spanId);
+    expect(result.current.transaction?.[TRANSACTION_ID_FIELD]).toBe(transactionId);
+    expect(result.current.transaction?.[SERVICE_NAME_FIELD]).toBe(serviceName);
     expect(lastValueFrom).toHaveBeenCalledTimes(1);
   });
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_field.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_field.tsx
@@ -15,11 +15,13 @@ import { FieldWithActions } from '../../components/field_with_actions/field_with
 export interface TransactionSummaryFieldProps {
   fieldId: string;
   fieldConfiguration: FieldConfiguration;
+  showActions?: boolean;
 }
 
 export function TransactionSummaryField({
   fieldConfiguration,
   fieldId,
+  showActions = true,
 }: TransactionSummaryFieldProps) {
   if (!fieldConfiguration.value) {
     return null;
@@ -34,6 +36,7 @@ export function TransactionSummaryField({
         value={fieldConfiguration.value as string}
         formattedValue={fieldConfiguration.value as string}
         fieldMetadata={fieldConfiguration.fieldMetadata}
+        showActions={showActions}
       >
         <div>
           {fieldConfiguration.content(fieldConfiguration.value, fieldConfiguration.formattedValue)}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.test.tsx
@@ -10,8 +10,12 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { TransactionSummaryTitle } from './transaction_summary_title';
 
+const fieldHoverActionPopoverDataTestSubj = 'FieldHoverActionPopover';
+
 jest.mock('../../components/field_with_actions/field_hover_popover_action', () => ({
-  FieldHoverActionPopover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FieldHoverActionPopover: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj={fieldHoverActionPopoverDataTestSubj}>{children}</div>
+  ),
 }));
 
 jest.mock('../../components/highlight_field.tsx', () => ({
@@ -83,7 +87,6 @@ describe('TransactionSummaryTitle', () => {
     );
 
     expect(getByText('Test Transaction')).toBeInTheDocument();
-
     expect(getByText('123')).toBeInTheDocument();
   });
 
@@ -107,5 +110,33 @@ describe('TransactionSummaryTitle', () => {
 
     expect(getByText('123')).toBeInTheDocument();
     expect(container.querySelector('span')?.innerHTML).toBe('<mark>123</mark>');
+  });
+
+  it('renders FieldHoverActionPopover if showActions is undefined', () => {
+    const { container } = render(<TransactionSummaryTitle serviceName="Test Service" />);
+
+    expect(
+      container.querySelector(`[data-test-subj="${fieldHoverActionPopoverDataTestSubj}"]`)
+    ).not.toBeNull();
+  });
+
+  it('renders FieldHoverActionPopover if showActions is true', () => {
+    const { container } = render(
+      <TransactionSummaryTitle serviceName="Test Service" showActions={true} />
+    );
+
+    expect(
+      container.querySelector(`[data-test-subj="${fieldHoverActionPopoverDataTestSubj}"]`)
+    ).not.toBeNull();
+  });
+
+  it('does not render FieldHoverActionPopover if showActions is false', () => {
+    const { container } = render(
+      <TransactionSummaryTitle serviceName="Test Service" showActions={false} />
+    );
+
+    expect(
+      container.querySelector(`[data-test-subj="${fieldHoverActionPopoverDataTestSubj}"]`)
+    ).toBeNull();
   });
 });

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.tsx
@@ -24,6 +24,7 @@ export interface TransactionSummaryTitleProps {
   formattedTransactionName?: string;
   id?: string;
   formattedId?: string;
+  showActions?: boolean;
 }
 
 export const TransactionSummaryTitle = ({
@@ -32,16 +33,39 @@ export const TransactionSummaryTitle = ({
   id,
   formattedId,
   formattedTransactionName,
+  showActions = true,
 }: TransactionSummaryTitleProps) => {
+  const FieldContent = ({
+    children,
+    field,
+    title,
+    value,
+  }: {
+    children: React.ReactNode;
+    field: string;
+    title: string;
+    value: string;
+    showActions: boolean;
+  }) => {
+    return showActions ? (
+      <FieldHoverActionPopover title={title} value={value} field={field}>
+        <>{children}</>
+      </FieldHoverActionPopover>
+    ) : (
+      <>{children}</>
+    );
+  };
+
   return (
     <>
       <EuiTitle size="xs">
         <h2>
           {transactionName ? (
-            <FieldHoverActionPopover
+            <FieldContent
               title={transactionName}
               value={transactionName}
               field={TRANSACTION_NAME_FIELD}
+              showActions={showActions}
             >
               <HighlightField
                 value={transactionName}
@@ -56,23 +80,24 @@ export const TransactionSummaryTitle = ({
                   />
                 )}
               </HighlightField>
-            </FieldHoverActionPopover>
+            </FieldContent>
           ) : (
-            <FieldHoverActionPopover
+            <FieldContent
               title={serviceName}
               value={serviceName}
               field={SERVICE_NAME_FIELD}
+              showActions={showActions}
             >
               {serviceName}
-            </FieldHoverActionPopover>
+            </FieldContent>
           )}
         </h2>
       </EuiTitle>
 
       {id && (
-        <FieldHoverActionPopover title={id} value={id} field={TRANSACTION_ID_FIELD}>
+        <FieldContent title={id} value={id} field={TRANSACTION_ID_FIELD} showActions={showActions}>
           <HighlightField value={id} formattedValue={formattedId} textSize="xs" />
-        </FieldHoverActionPopover>
+        </FieldContent>
       )}
     </>
   );

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
@@ -9,7 +9,7 @@
 
 import React, { useMemo } from 'react';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import { EuiPanel, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer } from '@elastic/eui';
 import {
   SERVICE_NAME_FIELD,
   TRACE_ID_FIELD,
@@ -27,11 +27,13 @@ import { TransactionSummaryField } from './sub_components/transaction_summary_fi
 import { TransactionDurationSummary } from './sub_components/transaction_duration_summary';
 import { RootTransactionProvider } from './hooks/use_root_transaction';
 import { Trace } from '../components/trace';
-
 import { TransactionSummaryTitle } from './sub_components/transaction_summary_title';
 import { getUnifiedDocViewerServices } from '../../../../plugin';
+
 export type TransactionOverviewProps = DocViewRenderProps & {
   tracesIndexPattern: string;
+  showWaterfall?: boolean;
+  showActions?: boolean;
 };
 
 export function TransactionOverview({
@@ -41,6 +43,8 @@ export function TransactionOverview({
   onAddColumn,
   onRemoveColumn,
   tracesIndexPattern,
+  showWaterfall = true,
+  showActions = true,
   dataView,
 }: TransactionOverviewProps) {
   const { fieldFormats } = getUnifiedDocViewerServices();
@@ -70,44 +74,52 @@ export function TransactionOverview({
       >
         <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
           <EuiSpacer size="m" />
-          <TransactionSummaryTitle
-            serviceName={flattenedDoc[SERVICE_NAME_FIELD]}
-            transactionName={flattenedDoc[TRANSACTION_NAME_FIELD]}
-            formattedTransactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
-            id={transactionId}
-            formattedId={formattedDoc[TRANSACTION_ID_FIELD]}
-          />
-          <EuiSpacer size="m" />
-          {transactionFields.map((fieldId) => (
-            <TransactionSummaryField
-              key={fieldId}
-              fieldId={fieldId}
-              fieldConfiguration={fieldConfigurations[fieldId]}
-            />
-          ))}
-
-          {transactionDuration !== undefined && (
-            <>
-              <EuiSpacer size="m" />
-              <TransactionDurationSummary
-                transactionDuration={transactionDuration}
-                transactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
-                transactionType={formattedDoc[TRANSACTION_TYPE_FIELD]}
-                serviceName={formattedDoc[SERVICE_NAME_FIELD]}
+          <EuiFlexGroup direction="column" gutterSize="m">
+            <EuiFlexItem>
+              <TransactionSummaryTitle
+                serviceName={flattenedDoc[SERVICE_NAME_FIELD]}
+                transactionName={flattenedDoc[TRANSACTION_NAME_FIELD]}
+                formattedTransactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
+                id={transactionId}
+                formattedId={formattedDoc[TRANSACTION_ID_FIELD]}
+                showActions={showActions}
               />
-            </>
-          )}
-          {traceId && transactionId ? (
-            <>
-              <EuiSpacer size="m" />
-              <Trace
-                fields={fieldConfigurations}
-                traceId={traceId}
-                docId={transactionId}
-                displayType="transaction"
-              />
-            </>
-          ) : null}
+            </EuiFlexItem>
+            <EuiFlexItem>
+              {transactionFields.map((fieldId) => (
+                <TransactionSummaryField
+                  key={fieldId}
+                  fieldId={fieldId}
+                  fieldConfiguration={fieldConfigurations[fieldId]}
+                  showActions={showActions}
+                />
+              ))}
+            </EuiFlexItem>
+            {transactionDuration !== undefined && (
+              <EuiFlexItem>
+                <TransactionDurationSummary
+                  transactionDuration={transactionDuration}
+                  transactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
+                  transactionType={formattedDoc[TRANSACTION_TYPE_FIELD]}
+                  serviceName={formattedDoc[SERVICE_NAME_FIELD]}
+                />
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem>
+              {traceId && transactionId && (
+                <Trace
+                  fields={fieldConfigurations}
+                  traceId={traceId}
+                  docId={transactionId}
+                  displayType="transaction"
+                  dataView={dataView}
+                  tracesIndexPattern={tracesIndexPattern}
+                  showWaterfall={showWaterfall}
+                  showActions={showActions}
+                />
+              )}
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiPanel>
       </FieldActionsProvider>
     </RootTransactionProvider>

--- a/src/platform/plugins/shared/unified_doc_viewer/tsconfig.json
+++ b/src/platform/plugins/shared/unified_doc_viewer/tsconfig.json
@@ -46,7 +46,8 @@
     "@kbn/react-hooks",
     "@kbn/embeddable-plugin",
     "@kbn/apm-types-shared",
-    "@kbn/es-query"
+    "@kbn/object-utils",
+    "@kbn/es-query",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
@@ -43,6 +43,7 @@ interface AccordionWaterfallProps {
   maxLevelOpen: number;
   displayLimit?: number;
   isEmbeddable?: boolean;
+  scrollElement?: Element;
 }
 
 type WaterfallProps = Omit<
@@ -94,6 +95,7 @@ export function AccordionWaterfall({
   waterfall,
   isOpen,
   isEmbeddable = false,
+  scrollElement,
   ...props
 }: AccordionWaterfallProps) {
   return (
@@ -104,7 +106,7 @@ export function AccordionWaterfall({
       isOpen={isOpen}
       isEmbeddable={isEmbeddable}
     >
-      <Waterfall {...props} />
+      <Waterfall {...props} scrollElement={scrollElement} />
     </WaterfallContextProvider>
   );
 }
@@ -129,7 +131,7 @@ function Waterfall(props: WaterfallProps) {
   };
 
   return (
-    <WindowScroller onScroll={onScroll}>
+    <WindowScroller onScroll={onScroll} scrollElement={props.scrollElement}>
       {({ registerChild }) => (
         <AutoSizer disableHeight>
           {({ width }) => (

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -40,6 +40,7 @@ interface Props {
   onNodeClick?: (item: IWaterfallSpanOrTransaction, flyoutDetailTab: string) => void;
   displayLimit?: number;
   isEmbeddable?: boolean;
+  scrollElement?: Element;
 }
 
 function getWaterfallMaxLevel(waterfall: IWaterfall) {
@@ -79,6 +80,7 @@ export function Waterfall({
   onNodeClick,
   displayLimit,
   isEmbeddable,
+  scrollElement,
 }: Props) {
   const theme = useTheme();
   const [isAccordionOpen, setIsAccordionOpen] = useState(true);
@@ -122,8 +124,11 @@ export function Waterfall({
       <div
         css={css`
           display: flex;
-          position: sticky;
-          top: var(--euiFixedHeadersOffset, 0);
+          ${isEmbeddable
+            ? 'position: relative;'
+            : `
+            position: sticky;
+            top: var(--euiFixedHeadersOffset, 0);`}
           z-index: ${theme.eui.euiZLevel2};
           background-color: ${theme.eui.euiColorEmptyShade};
           border-bottom: 1px solid ${theme.eui.euiColorMediumShade};
@@ -153,7 +158,7 @@ export function Waterfall({
           }}
         />
         <TimelineAxisContainer
-          marks={[...agentMarks, ...errorMarks]}
+          marks={[...agentMarks, ...(isEmbeddable ? [] : errorMarks)]}
           xMax={duration}
           margins={timelineMargins}
         />
@@ -179,6 +184,7 @@ export function Waterfall({
             }
             displayLimit={displayLimit}
             isEmbeddable={isEmbeddable}
+            scrollElement={scrollElement}
           />
         )}
       </WaterfallItemsContainer>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/timeline/vertical_lines.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/timeline/vertical_lines.tsx
@@ -46,9 +46,9 @@ export function VerticalLines({ topTraceDuration, plotValues, marks = [] }: Vert
       }}
     >
       <g transform={`translate(0 ${margins.top})`}>
-        {tickPositions.map((position) => (
+        {tickPositions.map((position, index) => (
           <line
-            key={`tick-${position}`}
+            key={`tick-${position}-${index}`}
             x1={position}
             x2={position}
             y1={0}
@@ -56,9 +56,9 @@ export function VerticalLines({ topTraceDuration, plotValues, marks = [] }: Vert
             stroke={theme.eui.euiColorLightestShade}
           />
         ))}
-        {markPositions.map((position) => (
+        {markPositions.map((position, index) => (
           <line
-            key={`mark-${position}`}
+            key={`mark-${position}-${index}`}
             x1={position}
             x2={position}
             y1={0}

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
@@ -35,6 +35,8 @@ export interface ApmTraceWaterfallEmbeddableEntryProps extends BaseProps, Serial
   serviceName: string;
   entryTransactionId: string;
   displayLimit?: number;
+  scrollElement?: Element;
+  onNodeClick?: (nodeSpanId: string) => void;
 }
 
 export type ApmTraceWaterfallEmbeddableProps =
@@ -59,6 +61,12 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
       const rangeTo$ = new BehaviorSubject(state.rangeTo);
       const displayLimit$ = new BehaviorSubject('displayLimit' in state ? state.displayLimit : 0);
       const docId$ = new BehaviorSubject('docId' in state ? state.docId : '');
+      const scrollElement$ = new BehaviorSubject(
+        'scrollElement' in state ? state.scrollElement : undefined
+      );
+      const onNodeClick$ = new BehaviorSubject(
+        'onNodeClick' in state ? state.onNodeClick : undefined
+      );
 
       function serializeState() {
         return {
@@ -71,6 +79,8 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             rangeTo: rangeTo$.getValue(),
             displayLimit: displayLimit$.getValue(),
             docId: docId$.getValue(),
+            scrollElement: scrollElement$.getValue(),
+            onNodeClick: onNodeClick$.getValue(),
           },
         };
       }
@@ -87,7 +97,9 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
           rangeFrom$,
           rangeTo$,
           displayLimit$,
-          docId$
+          docId$,
+          scrollElement$,
+          onNodeClick$
         ).pipe(map(() => undefined)),
         getComparators: () => {
           return {
@@ -99,6 +111,8 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             rangeTo: 'referenceEquality',
             displayLimit: 'referenceEquality',
             docId: 'referenceEquality',
+            scrollElement: 'referenceEquality',
+            onNodeClick: 'referenceEquality',
           };
         },
         onReset: (lastSaved) => {
@@ -114,6 +128,8 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
           serviceName$.next(entryState?.serviceName ?? '');
           entryTransactionId$.next(entryState?.entryTransactionId ?? '');
           displayLimit$.next(entryState?.displayLimit ?? 0);
+          scrollElement$.next(entryState?.scrollElement ?? undefined);
+          onNodeClick$.next(entryState?.onNodeClick ?? undefined);
 
           // reset focused state
           const focusedState = lastSaved?.rawState as ApmTraceWaterfallEmbeddableFocusedProps;
@@ -138,6 +154,8 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             rangeTo,
             displayLimit,
             docId,
+            scrollElement,
+            onNodeClick,
           ] = useBatchedPublishingSubjects(
             serviceName$,
             traceId$,
@@ -145,7 +163,9 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             rangeFrom$,
             rangeTo$,
             displayLimit$,
-            docId$
+            docId$,
+            scrollElement$,
+            onNodeClick$
           );
           const content = isEmpty(docId) ? (
             <TraceWaterfallEmbeddable
@@ -155,6 +175,8 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
               rangeFrom={rangeFrom}
               rangeTo={rangeTo}
               displayLimit={displayLimit}
+              onNodeClick={onNodeClick}
+              scrollElement={scrollElement}
             />
           ) : (
             <FocusedTraceWaterfallEmbeddable

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
@@ -20,6 +20,8 @@ export function TraceWaterfallEmbeddable({
   rangeTo,
   traceId,
   displayLimit,
+  scrollElement,
+  onNodeClick,
 }: ApmTraceWaterfallEmbeddableEntryProps) {
   const waterfallFetchResult = useWaterfallFetcher({
     traceId,
@@ -44,7 +46,9 @@ export function TraceWaterfallEmbeddable({
           showCriticalPath={false}
           waterfall={waterfallFetchResult.waterfall}
           displayLimit={displayLimit}
+          onNodeClick={(node) => onNodeClick?.(node.id)}
           isEmbeddable
+          scrollElement={scrollElement}
         />
       </EuiFlexItem>
     </EuiFlexGroup>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][APM] Expanded waterfall for spans and transactions (#222214)](https://github.com/elastic/kibana/pull/222214)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2025-06-12T12:18:52Z","message":"[Discover][APM] Expanded waterfall for spans and transactions (#222214)\n\n## Summary\n\nCloses\nhttps://github.com/elastic/kibana/issues/208707?issue=elastic%7Ckibana%7C217068\n\nThis PR adds the full-screen version of the waterfall preview shown in\nthe span and transaction flyouts in Discover.\n\n\nhttps://github.com/user-attachments/assets/a042dcff-ee31-473d-8a9c-34f3fd00e1a1\n\n\n**Here’s a summary of the main changes introduced:**\n- Set up a custom full-screen waterfall component.\n- There’s currently no unified way to do this, but there’s an [open\nissue for sharedUX](https://github.com/elastic/kibana/issues/220610)\nrequesting it, I believe it could be useful across Kibana.\n- Created a hook to retrieve span information for the flyout (since the\nnode click event only provides limited span details).\n- Created a `SpanFlyout` component, which opens when clicking on a node\nin the waterfall.\n  - All 3 tabs are the same ones as we have in Discove.\n- Booleans were added in the Overview tab components to show/hide the\nfull-screen button, the waterfall preview, and the field actions.\n- Added span and transaction ids to `useRootTransaction` to use them as\n`entryTransactionId` for the waterfall. This isn’t fully OTel-compatible\nyet, that will be handled in a [separate\nissue](https://github.com/elastic/kibana/issues/221521), but I wanted to\nget ahead by including both IDs now, using `span.id` as a fallback when\n`transaction.id` isn’t available.\n \n**Applied some updates to the waterfall component itself:**\n- The `onNodeClick` event is now propagated so the flyout can be\ntriggered.\n- Error markers in the embedded waterfall timeline have been temporarily\nremoved.\n- Error markers depended on APM routing, which we’re avoiding in\nembedded mode.\n- They’re now disabled when embedded, and we’ll revisit this to improve\nthe experience.\n- Added `scrollElement` to properly handle the virtual rendering of the\nwaterfall nodes\n\n>[!WARNING]\nThe changes on the APM waterfall will be removed soon in favor of a [new\nversion](https://github.com/elastic/kibana/issues/214795) of it, there\nis [a separate issue](https://github.com/elastic/kibana/issues/222590)\nto handle the migration.\n\n**Additional improvements that were out of the full-screen scope:**\n- A short description was added for the \"Destination\" field in spans.\n- Renamed `transactionIndexPattern` to `tracesIndexPattern` for\nconsistency.\n\n---------\n>[!NOTE]\n> The error details feature will be handled in a [separate\nissue](https://github.com/elastic/kibana/issues/219780). We’ll implement\n[an intermediate\nsolution](https://github.com/elastic/kibana/issues/222591) before\ntackling the final one.\n\n>[!WARNING]\n~This needs to be backported to 8.19, but before that, we need to merge\n[this](https://github.com/elastic/kibana/pull/221950#issuecomment-2929778812)\nother backport PR containing the whole feature.~ It has been merged.\n\n## How to test  \n- Enable the discover profiles by adding this to the` kibana.yml `file: \n``` \ndiscover.experimental.enabledProfiles:\n  - observability-traces-data-source-profile\n  - observability-traces-transaction-document-profile\n  - observability-traces-span-document-profile\n```\n\n- Make sure your space has Observability as Solution View. \n- Open Discover and select or create a data view that includes any APM\ntraces index (`traces-*`), or query them using ES|QL.\n- Open the flyout for a span or transaction document.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: Milosz Marcinkowski <38698566+miloszmarcinkowski@users.noreply.github.com>","sha":"fd367a0bfdfe7fc727968134b7f14242e9ce3a2f","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0"],"title":"[Discover][APM] Expanded waterfall for spans and transactions","number":222214,"url":"https://github.com/elastic/kibana/pull/222214","mergeCommit":{"message":"[Discover][APM] Expanded waterfall for spans and transactions (#222214)\n\n## Summary\n\nCloses\nhttps://github.com/elastic/kibana/issues/208707?issue=elastic%7Ckibana%7C217068\n\nThis PR adds the full-screen version of the waterfall preview shown in\nthe span and transaction flyouts in Discover.\n\n\nhttps://github.com/user-attachments/assets/a042dcff-ee31-473d-8a9c-34f3fd00e1a1\n\n\n**Here’s a summary of the main changes introduced:**\n- Set up a custom full-screen waterfall component.\n- There’s currently no unified way to do this, but there’s an [open\nissue for sharedUX](https://github.com/elastic/kibana/issues/220610)\nrequesting it, I believe it could be useful across Kibana.\n- Created a hook to retrieve span information for the flyout (since the\nnode click event only provides limited span details).\n- Created a `SpanFlyout` component, which opens when clicking on a node\nin the waterfall.\n  - All 3 tabs are the same ones as we have in Discove.\n- Booleans were added in the Overview tab components to show/hide the\nfull-screen button, the waterfall preview, and the field actions.\n- Added span and transaction ids to `useRootTransaction` to use them as\n`entryTransactionId` for the waterfall. This isn’t fully OTel-compatible\nyet, that will be handled in a [separate\nissue](https://github.com/elastic/kibana/issues/221521), but I wanted to\nget ahead by including both IDs now, using `span.id` as a fallback when\n`transaction.id` isn’t available.\n \n**Applied some updates to the waterfall component itself:**\n- The `onNodeClick` event is now propagated so the flyout can be\ntriggered.\n- Error markers in the embedded waterfall timeline have been temporarily\nremoved.\n- Error markers depended on APM routing, which we’re avoiding in\nembedded mode.\n- They’re now disabled when embedded, and we’ll revisit this to improve\nthe experience.\n- Added `scrollElement` to properly handle the virtual rendering of the\nwaterfall nodes\n\n>[!WARNING]\nThe changes on the APM waterfall will be removed soon in favor of a [new\nversion](https://github.com/elastic/kibana/issues/214795) of it, there\nis [a separate issue](https://github.com/elastic/kibana/issues/222590)\nto handle the migration.\n\n**Additional improvements that were out of the full-screen scope:**\n- A short description was added for the \"Destination\" field in spans.\n- Renamed `transactionIndexPattern` to `tracesIndexPattern` for\nconsistency.\n\n---------\n>[!NOTE]\n> The error details feature will be handled in a [separate\nissue](https://github.com/elastic/kibana/issues/219780). We’ll implement\n[an intermediate\nsolution](https://github.com/elastic/kibana/issues/222591) before\ntackling the final one.\n\n>[!WARNING]\n~This needs to be backported to 8.19, but before that, we need to merge\n[this](https://github.com/elastic/kibana/pull/221950#issuecomment-2929778812)\nother backport PR containing the whole feature.~ It has been merged.\n\n## How to test  \n- Enable the discover profiles by adding this to the` kibana.yml `file: \n``` \ndiscover.experimental.enabledProfiles:\n  - observability-traces-data-source-profile\n  - observability-traces-transaction-document-profile\n  - observability-traces-span-document-profile\n```\n\n- Make sure your space has Observability as Solution View. \n- Open Discover and select or create a data view that includes any APM\ntraces index (`traces-*`), or query them using ES|QL.\n- Open the flyout for a span or transaction document.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: Milosz Marcinkowski <38698566+miloszmarcinkowski@users.noreply.github.com>","sha":"fd367a0bfdfe7fc727968134b7f14242e9ce3a2f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222214","number":222214,"mergeCommit":{"message":"[Discover][APM] Expanded waterfall for spans and transactions (#222214)\n\n## Summary\n\nCloses\nhttps://github.com/elastic/kibana/issues/208707?issue=elastic%7Ckibana%7C217068\n\nThis PR adds the full-screen version of the waterfall preview shown in\nthe span and transaction flyouts in Discover.\n\n\nhttps://github.com/user-attachments/assets/a042dcff-ee31-473d-8a9c-34f3fd00e1a1\n\n\n**Here’s a summary of the main changes introduced:**\n- Set up a custom full-screen waterfall component.\n- There’s currently no unified way to do this, but there’s an [open\nissue for sharedUX](https://github.com/elastic/kibana/issues/220610)\nrequesting it, I believe it could be useful across Kibana.\n- Created a hook to retrieve span information for the flyout (since the\nnode click event only provides limited span details).\n- Created a `SpanFlyout` component, which opens when clicking on a node\nin the waterfall.\n  - All 3 tabs are the same ones as we have in Discove.\n- Booleans were added in the Overview tab components to show/hide the\nfull-screen button, the waterfall preview, and the field actions.\n- Added span and transaction ids to `useRootTransaction` to use them as\n`entryTransactionId` for the waterfall. This isn’t fully OTel-compatible\nyet, that will be handled in a [separate\nissue](https://github.com/elastic/kibana/issues/221521), but I wanted to\nget ahead by including both IDs now, using `span.id` as a fallback when\n`transaction.id` isn’t available.\n \n**Applied some updates to the waterfall component itself:**\n- The `onNodeClick` event is now propagated so the flyout can be\ntriggered.\n- Error markers in the embedded waterfall timeline have been temporarily\nremoved.\n- Error markers depended on APM routing, which we’re avoiding in\nembedded mode.\n- They’re now disabled when embedded, and we’ll revisit this to improve\nthe experience.\n- Added `scrollElement` to properly handle the virtual rendering of the\nwaterfall nodes\n\n>[!WARNING]\nThe changes on the APM waterfall will be removed soon in favor of a [new\nversion](https://github.com/elastic/kibana/issues/214795) of it, there\nis [a separate issue](https://github.com/elastic/kibana/issues/222590)\nto handle the migration.\n\n**Additional improvements that were out of the full-screen scope:**\n- A short description was added for the \"Destination\" field in spans.\n- Renamed `transactionIndexPattern` to `tracesIndexPattern` for\nconsistency.\n\n---------\n>[!NOTE]\n> The error details feature will be handled in a [separate\nissue](https://github.com/elastic/kibana/issues/219780). We’ll implement\n[an intermediate\nsolution](https://github.com/elastic/kibana/issues/222591) before\ntackling the final one.\n\n>[!WARNING]\n~This needs to be backported to 8.19, but before that, we need to merge\n[this](https://github.com/elastic/kibana/pull/221950#issuecomment-2929778812)\nother backport PR containing the whole feature.~ It has been merged.\n\n## How to test  \n- Enable the discover profiles by adding this to the` kibana.yml `file: \n``` \ndiscover.experimental.enabledProfiles:\n  - observability-traces-data-source-profile\n  - observability-traces-transaction-document-profile\n  - observability-traces-span-document-profile\n```\n\n- Make sure your space has Observability as Solution View. \n- Open Discover and select or create a data view that includes any APM\ntraces index (`traces-*`), or query them using ES|QL.\n- Open the flyout for a span or transaction document.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: Milosz Marcinkowski <38698566+miloszmarcinkowski@users.noreply.github.com>","sha":"fd367a0bfdfe7fc727968134b7f14242e9ce3a2f"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->