### PR TITLE
[APM] Enable `logging_level` agent configuration for EDOT Python, PHP and .net

### DIFF
--- a/src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts
+++ b/src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts
@@ -77,6 +77,8 @@ export const EDOT_AGENT_NAMES: OpenTelemetryAgentName[] = [
   'opentelemetry/java/elastic',
   'opentelemetry/nodejs/elastic',
   'opentelemetry/python/elastic',
+  'opentelemetry/php/elastic',
+  'opentelemetry/dotnet/elastic',
 ];
 
 export type JavaAgentName = 'java' | 'opentelemetry/java' | 'otlp/java';

--- a/src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts
+++ b/src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts
@@ -76,6 +76,7 @@ export const OPEN_TELEMETRY_AGENT_NAMES: OpenTelemetryAgentName[] = [
 export const EDOT_AGENT_NAMES: OpenTelemetryAgentName[] = [
   'opentelemetry/java/elastic',
   'opentelemetry/nodejs/elastic',
+  'opentelemetry/python/elastic',
 ];
 
 export type JavaAgentName = 'java' | 'opentelemetry/java' | 'otlp/java';

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -66,7 +66,11 @@ export const edotSDKSettings: RawSettingDefinition[] = [
       { text: 'fatal', value: 'fatal' },
       { text: 'off', value: 'off' },
     ],
-    includeAgents: ['opentelemetry/java/elastic', 'opentelemetry/nodejs/elastic', 'opentelemetry/python/elastic'],
+    includeAgents: [
+	'opentelemetry/java/elastic',
+	'opentelemetry/nodejs/elastic',
+	'opentelemetry/python/elastic',
+    ],
   },
   {
     key: 'send_traces',

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -70,6 +70,8 @@ export const edotSDKSettings: RawSettingDefinition[] = [
       'opentelemetry/java/elastic',
       'opentelemetry/nodejs/elastic',
       'opentelemetry/python/elastic',
+      'opentelemetry/php/elastic',
+      'opentelemetry/dotnet/elastic',
     ],
   },
   {

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -67,9 +67,9 @@ export const edotSDKSettings: RawSettingDefinition[] = [
       { text: 'off', value: 'off' },
     ],
     includeAgents: [
-	'opentelemetry/java/elastic',
-	'opentelemetry/nodejs/elastic',
-	'opentelemetry/python/elastic',
+      'opentelemetry/java/elastic',
+      'opentelemetry/nodejs/elastic',
+      'opentelemetry/python/elastic',
     ],
   },
   {

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -66,7 +66,7 @@ export const edotSDKSettings: RawSettingDefinition[] = [
       { text: 'fatal', value: 'fatal' },
       { text: 'off', value: 'off' },
     ],
-    includeAgents: ['opentelemetry/java/elastic', 'opentelemetry/nodejs/elastic'],
+    includeAgents: ['opentelemetry/java/elastic', 'opentelemetry/nodejs/elastic', 'opentelemetry/python/elastic'],
   },
   {
     key: 'send_traces',

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -209,6 +209,12 @@ describe('filterByAgent', () => {
       );
     });
 
+    it('opentelemetry/python/elastic', () => {
+      expect(getSettingKeysForAgent('opentelemetry/python/elastic')).toEqual(
+        expect.arrayContaining(['logging_level'])
+      );
+    });
+
     it('"All" services (no agent name)', () => {
       expect(getSettingKeysForAgent(undefined)).toEqual(
         expect.arrayContaining(['transaction_max_spans', 'transaction_sample_rate'])

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -215,6 +215,18 @@ describe('filterByAgent', () => {
       );
     });
 
+    it('opentelemetry/php/elastic', () => {
+      expect(getSettingKeysForAgent('opentelemetry/php/elastic')).toEqual(
+        expect.arrayContaining(['logging_level'])
+      );
+    });
+
+    it('opentelemetry/dotnet/elastic', () => {
+      expect(getSettingKeysForAgent('opentelemetry/dotnet/elastic')).toEqual(
+        expect.arrayContaining(['logging_level'])
+      );
+    });
+
     it('"All" services (no agent name)', () => {
       expect(getSettingKeysForAgent(undefined)).toEqual(
         expect.arrayContaining(['transaction_max_spans', 'transaction_sample_rate'])

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
@@ -254,6 +254,29 @@ Object {
         },
       },
     },
+    "opentelemetry/dotnet/elastic": Object {
+      "agent": Object {
+        "activation_method": Array [],
+        "version": Array [],
+      },
+      "service": Object {
+        "framework": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "language": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "runtime": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+      },
+    },
     "opentelemetry/java": Object {
       "agent": Object {
         "activation_method": Array [
@@ -345,6 +368,29 @@ Object {
       },
     },
     "opentelemetry/nodejs/elastic": Object {
+      "agent": Object {
+        "activation_method": Array [],
+        "version": Array [],
+      },
+      "service": Object {
+        "framework": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "language": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "runtime": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+      },
+    },
+    "opentelemetry/php/elastic": Object {
       "agent": Object {
         "activation_method": Array [],
         "version": Array [],
@@ -1251,9 +1297,11 @@ Object {
     "js-base": 0,
     "nodejs": 0,
     "opentelemetry": 4,
+    "opentelemetry/dotnet/elastic": 10,
     "opentelemetry/java": 5,
     "opentelemetry/java/elastic": 6,
     "opentelemetry/nodejs/elastic": 7,
+    "opentelemetry/php/elastic": 9,
     "opentelemetry/python/elastic": 8,
     "otlp": 1,
     "otlp/java": 2,

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
@@ -367,6 +367,29 @@ Object {
         },
       },
     },
+    "opentelemetry/python/elastic": Object {
+      "agent": Object {
+        "activation_method": Array [],
+        "version": Array [],
+      },
+      "service": Object {
+        "framework": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "language": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+        "runtime": Object {
+          "composite": Array [],
+          "name": Array [],
+          "version": Array [],
+        },
+      },
+    },
     "otlp": Object {
       "agent": Object {
         "activation_method": Array [

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/__snapshots__/tasks.test.ts.snap
@@ -1254,6 +1254,7 @@ Object {
     "opentelemetry/java": 5,
     "opentelemetry/java/elastic": 6,
     "opentelemetry/nodejs/elastic": 7,
+    "opentelemetry/python/elastic": 8,
     "otlp": 1,
     "otlp/java": 2,
     "otlp/java/elastic": 3,

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -929,6 +929,14 @@ describe('data telemetry collection tasks', () => {
                     key: 'opentelemetry/python/elastic',
                     services: { value: 8 },
                   },
+                  {
+                    key: 'opentelemetry/php/elastic',
+                    services: { value: 9 },
+                  },
+                  {
+                    key: 'opentelemetry/dotnet/elastic',
+                    services: { value: 10 },
+                  },
                 ],
               },
             },

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -925,6 +925,10 @@ describe('data telemetry collection tasks', () => {
                     key: 'opentelemetry/nodejs/elastic',
                     services: { value: 7 },
                   },
+                  {
+                    key: 'opentelemetry/python/elastic',
+                    services: { value: 8 },
+                  },
                 ],
               },
             },


### PR DESCRIPTION
## Summary

Enable `logging_level` agent configuration options for EDOT Python (`opentelemetry/python/elastic`), PHP (`opentelemetry/php/elastic`) and .net (`opentelemetry/dotnet/elastic`).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] I don't think this introduces any risk



