### PR TITLE
Add export derivative integration type 

### DIFF
--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
@@ -132,6 +132,7 @@ export const reportingCsvExportProvider = ({
       name: panelTitle,
       exportType: reportType,
       label: 'CSV',
+      icon: 'documents',
       generateAssetExport: generateReportingJobCSV,
       helpText: (
         <FormattedMessage

--- a/src/platform/plugins/shared/share/public/components/context/index.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useShareTabsContext, useShareContext } from '.';
+import { useShareTypeContext, useShareContext } from '.';
 
 describe('share menu context', () => {
   describe('useShareContext', () => {
@@ -21,7 +21,7 @@ describe('share menu context', () => {
 
   describe('useShareTabsContext', () => {
     it('throws an error if used outside of ShareMenuProvider tree', () => {
-      expect(() => renderHook(() => useShareTabsContext('embed'))).toThrow(
+      expect(() => renderHook(() => useShareTypeContext('embed'))).toThrow(
         /^Failed to call `useShareContext` because the context from ShareMenuProvider is missing./
       );
     });

--- a/src/platform/plugins/shared/share/public/components/context/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.tsx
@@ -16,17 +16,17 @@ export interface IShareContext extends Omit<ShowShareMenuOptions, 'onClose'> {
   shareMenuItems: ShareConfigs[];
 }
 
-const ShareTabsContext = createContext<IShareContext | null>(null);
+const ShareContext = createContext<IShareContext | null>(null);
 
-export const ShareMenuProvider = ({
+export const ShareProvider = ({
   shareContext,
   children,
 }: PropsWithChildren<{ shareContext: IShareContext }>) => {
-  return <ShareTabsContext.Provider value={shareContext}>{children}</ShareTabsContext.Provider>;
+  return <ShareContext.Provider value={shareContext}>{children}</ShareContext.Provider>;
 };
 
 export const useShareContext = () => {
-  const context = useContext(ShareTabsContext);
+  const context = useContext(ShareContext);
 
   if (!context) {
     throw new Error(
@@ -37,7 +37,7 @@ export const useShareContext = () => {
   return context;
 };
 
-export const useShareTabsContext = <
+export const useShareTypeContext = <
   T extends Exclude<ShareTypes, 'legacy'>,
   G extends T extends 'integration' ? string : never
 >(

--- a/src/platform/plugins/shared/share/public/components/context/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.tsx
@@ -53,7 +53,10 @@ export const useShareTypeContext = <
     ? Array<Extract<ShareConfigs, { shareType: T; groupId?: G }>>
     : Extract<ShareConfigs, { shareType: T }> = (
     shareType === 'integration' ? Array.prototype.filter : Array.prototype.find
-  ).call(shareMenuItems, (item) => item.shareType === shareType && item?.groupId === groupId);
+  ).call(
+    shareMenuItems,
+    (item) => item.shareType === shareType && item?.groupId === (groupId ?? item?.groupId)
+  );
 
   type ObjectTypeMetaConfig = IShareContext['objectTypeMeta']['config'];
 

--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -303,6 +303,8 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
       : setIsFlyoutVisible(false);
   }, [exportDerivatives.length, exportIntegrations.length, onClose]);
 
+  const flyoutRef = useRef<HTMLDivElement | null>(null);
+
   return (
     <Fragment>
       <EuiWrappingPopover
@@ -360,6 +362,10 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
           maskProps={{
             headerZindexLocation: 'above',
           }}
+          ref={flyoutRef}
+          {...(selectedMenuItem?.groupId === 'exportDerivatives'
+            ? selectedMenuItem.config.flyoutSizing || {}
+            : {})}
         >
           {selectedMenuItemMeta!.group === 'export' ? (
             <ManagedFlyout
@@ -374,6 +380,7 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
             />
           ) : (
             (selectedMenuItem as ExportShareDerivativesConfig)?.config.flyoutContent({
+              flyoutRef,
               closeFlyout: flyoutOnCloseHandler,
             })
           )}

--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -27,6 +27,7 @@ import {
   EuiToolTip,
   type EuiSwitchEvent,
   EuiSwitch,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, InjectedIntl, injectI18n } from '@kbn/i18n-react';
@@ -112,6 +113,10 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
     objectTypeAlias,
     objectTypeMeta,
   } = useShareTypeContext('integration', 'export');
+  const { shareMenuItems: exportDerivatives } = useShareTypeContext(
+    'integration',
+    'exportDerivatives'
+  );
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [isCreatingExport, setIsCreatingExport] = useState<boolean>(false);
   const [selectedMenuItemId, setSelectedMenuItemId] = useState<string>();
@@ -155,9 +160,9 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
         data-test-subj="exportPopover"
         button={anchorElement!}
         closePopover={onClose}
-        panelPaddingSize="none"
+        panelPaddingSize="s"
       >
-        <EuiListGroup>
+        <EuiListGroup flush>
           {shareMenuItems.map((menuItem) => (
             <EuiToolTip
               position="left"
@@ -178,6 +183,16 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
             </EuiToolTip>
           ))}
         </EuiListGroup>
+        {Boolean(exportDerivatives.length) && (
+          <React.Fragment>
+            <EuiHorizontalRule margin="xs" />
+            {exportDerivatives.map((exportDerivative) => {
+              return (
+                <EuiButton key={exportDerivative.id} iconType={exportDerivative.config.icon} />
+              );
+            })}
+          </React.Fragment>
+        )}
       </EuiWrappingPopover>
       {isFlyoutVisible && (
         <EuiFlyout

--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type FC, useState, Fragment, useMemo, useCallback, useEffect } from 'react';
+import React, { type FC, useState, Fragment, useMemo, useCallback, useRef, useEffect } from 'react';
 import {
   EuiWrappingPopover,
   EuiListGroup,
@@ -32,7 +32,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, InjectedIntl, injectI18n } from '@kbn/i18n-react';
 import { ShareProvider, type IShareContext, useShareTypeContext } from '../context';
-import { ExportShareConfig } from '../../types';
+import { ExportShareConfig, ExportShareDerivativesConfig } from '../../types';
 
 export const ExportMenu: FC<{ shareContext: IShareContext }> = ({ shareContext }) => {
   return (
@@ -102,11 +102,152 @@ function LayoutOptionsSwitch({ usePrintLayout, printLayoutChange }: LayoutOption
   );
 }
 
+function ManagedFlyout({
+  exportIntegration,
+  intl,
+  isDirty,
+  onCloseFlyout,
+  publicAPIEnabled,
+  shareObjectTypeMeta,
+  shareObjectType,
+  shareObjectTypeAlias,
+}: {
+  exportIntegration: ExportShareConfig;
+  intl: InjectedIntl;
+  isDirty: boolean;
+  onCloseFlyout: () => void;
+  publicAPIEnabled?: boolean;
+  shareObjectType: string;
+  shareObjectTypeAlias?: string;
+  shareObjectTypeMeta: ReturnType<
+    typeof useShareTypeContext<'integration', 'export'>
+  >['objectTypeMeta'];
+}) {
+  const [usePrintLayout, setPrintLayout] = useState(false);
+  const [isCreatingExport, setIsCreatingExport] = useState<boolean>(false);
+  const getReport = useCallback(async () => {
+    try {
+      setIsCreatingExport(true);
+      await exportIntegration.config.generateAssetExport({
+        intl,
+        optimizedForPrinting: usePrintLayout,
+      });
+    } finally {
+      setIsCreatingExport(false);
+      onCloseFlyout();
+    }
+  }, [exportIntegration.config, intl, onCloseFlyout, usePrintLayout]);
+
+  const DraftModeCallout = shareObjectTypeMeta.config?.[exportIntegration.id]?.draftModeCallOut;
+
+  return (
+    <React.Fragment>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle>
+          <h2>
+            <FormattedMessage
+              id="share.export.flyoutTitle"
+              defaultMessage="Export {objectType} as {type}"
+              values={{
+                objectType: shareObjectTypeAlias ?? shareObjectType.toLocaleLowerCase(),
+                type: exportIntegration.config.label,
+              }}
+            />
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiFlexGroup direction="column">
+          <Fragment>
+            {exportIntegration.config.renderLayoutOptionSwitch && (
+              <EuiFlexItem>
+                <LayoutOptionsSwitch
+                  usePrintLayout={usePrintLayout}
+                  printLayoutChange={(evt) => setPrintLayout(evt.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+          </Fragment>
+          <Fragment>
+            {exportIntegration?.config.copyAssetURIConfig && publicAPIEnabled && (
+              <EuiFlexItem>
+                <EuiFormRow
+                  label={
+                    <EuiText size="s">
+                      <h4>{exportIntegration.config.copyAssetURIConfig.headingText}</h4>
+                    </EuiText>
+                  }
+                  fullWidth
+                >
+                  <EuiFlexGroup direction="column">
+                    <EuiFlexItem>
+                      <EuiText size="s" color="subdued">
+                        {exportIntegration.config.copyAssetURIConfig.helpText}
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiCodeBlock
+                        data-test-subj="exportAssetValue"
+                        css={{ overflowWrap: 'break-word' }}
+                        language={exportIntegration.config.copyAssetURIConfig.contentType}
+                        isCopyable
+                        copyAriaLabel={i18n.translate('share.export.copyPostURLAriaLabel', {
+                          defaultMessage: 'Copy export asset value',
+                        })}
+                      >
+                        {exportIntegration.config.copyAssetURIConfig.generateAssetURIValue({
+                          intl,
+                          optimizedForPrinting: usePrintLayout,
+                        })}
+                      </EuiCodeBlock>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFormRow>
+              </EuiFlexItem>
+            )}
+          </Fragment>
+          <Fragment>{exportIntegration.config.generateAssetComponent}</Fragment>
+          <Fragment>
+            {publicAPIEnabled && isDirty && DraftModeCallout && (
+              <EuiFlexItem>{DraftModeCallout}</EuiFlexItem>
+            )}
+          </Fragment>
+        </EuiFlexGroup>
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty data-test-subj="exportFlyoutCloseButton" onClick={onCloseFlyout}>
+              <FormattedMessage id="share.export.closeFlyoutButtonLabel" defaultMessage="Close" />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              onClick={getReport}
+              data-test-subj="generateReportButton"
+              isLoading={isCreatingExport}
+            >
+              {exportIntegration.config.generateExportButtonLabel ?? (
+                <FormattedMessage
+                  id="share.export.generateButtonLabel"
+                  defaultMessage="Export {type}"
+                  values={{ type: exportIntegration.config.label }}
+                />
+              )}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </React.Fragment>
+  );
+}
+
 function ExportMenuPopover({ intl }: ExportMenuProps) {
   const {
     onClose,
     anchorElement,
-    shareMenuItems,
+    shareMenuItems: exportIntegrations,
     isDirty,
     publicAPIEnabled,
     objectType,
@@ -118,40 +259,49 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
     'exportDerivatives'
   );
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
-  const [isCreatingExport, setIsCreatingExport] = useState<boolean>(false);
-  const [selectedMenuItemId, setSelectedMenuItemId] = useState<string>();
-  const selectedMenuItem = useMemo<ExportShareConfig | null>(() => {
-    return shareMenuItems.find((item) => item.id === selectedMenuItemId) ?? null;
-  }, [shareMenuItems, selectedMenuItemId]);
-  const [usePrintLayout, setPrintLayout] = useState(false);
+  const selectionOptions = useRef({ export: exportIntegrations, exportDerivatives });
+  const [selectedMenuItemMeta, setSelectedMenuItemMeta] = useState<{
+    id: string;
+    group: keyof typeof selectionOptions.current;
+  }>();
+  const selectedMenuItem = useMemo<ExportShareConfig | ExportShareDerivativesConfig | null>(() => {
+    let result: ExportShareConfig | ExportShareDerivativesConfig | null = null;
 
-  const getReport = useCallback(async () => {
-    try {
-      setIsCreatingExport(true);
-      await selectedMenuItem?.config.generateAssetExport({
-        intl,
-        optimizedForPrinting: usePrintLayout,
-      });
-    } finally {
-      setIsCreatingExport(false);
-      onClose?.();
+    if (!selectedMenuItemMeta) {
+      return result;
     }
-  }, [intl, onClose, selectedMenuItem?.config, usePrintLayout]);
+
+    selectionOptions.current[selectedMenuItemMeta.group].forEach((item) => {
+      if (item.id === selectedMenuItemMeta.id) {
+        result = item;
+      }
+    });
+
+    return result;
+  }, [selectedMenuItemMeta]);
+
+  const openFlyout = useCallback((menuItem: ExportShareConfig | ExportShareDerivativesConfig) => {
+    setSelectedMenuItemMeta({ id: menuItem.id, group: menuItem.groupId });
+    setIsFlyoutVisible(true);
+  }, []);
 
   useEffect(() => {
-    // when there is only one share menu item,
+    // when there is only one share menu item, and no export derivatives registered,
     // we want to open the flyout and not the popover
-    if (shareMenuItems.length === 1) {
-      setSelectedMenuItemId(shareMenuItems[0].id);
-      setIsFlyoutVisible(true);
+    if (
+      exportIntegrations.length === 1 &&
+      exportDerivatives.length === 0 &&
+      !selectedMenuItemMeta
+    ) {
+      openFlyout(exportIntegrations[0]);
     }
-  }, [shareMenuItems]);
+  }, [exportIntegrations, exportDerivatives, openFlyout, selectedMenuItemMeta]);
 
   const flyoutOnCloseHandler = useCallback(() => {
-    return shareMenuItems.length === 1 ? onClose() : setIsFlyoutVisible(false);
-  }, [onClose, shareMenuItems.length]);
-
-  const DraftModeCallout = objectTypeMeta.config?.[selectedMenuItemId!]?.draftModeCallOut;
+    return exportIntegrations.length === 1 && exportDerivatives.length === 0
+      ? onClose()
+      : setIsFlyoutVisible(false);
+  }, [exportDerivatives.length, exportIntegrations.length, onClose]);
 
   return (
     <Fragment>
@@ -163,7 +313,7 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
         panelPaddingSize="s"
       >
         <EuiListGroup flush>
-          {shareMenuItems.map((menuItem) => (
+          {exportIntegrations.map((menuItem) => (
             <EuiToolTip
               position="left"
               content={selectedMenuItem?.config.toolTipContent}
@@ -175,10 +325,7 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
                 label={menuItem.config.label}
                 data-test-subj={`exportMenuItem-${menuItem.config.label}`}
                 isDisabled={menuItem.config.disabled}
-                onClick={() => {
-                  setSelectedMenuItemId(menuItem.id);
-                  setIsFlyoutVisible(true);
-                }}
+                onClick={() => openFlyout(menuItem)}
               />
             </EuiToolTip>
           ))}
@@ -186,11 +333,19 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
         {Boolean(exportDerivatives.length) && (
           <React.Fragment>
             <EuiHorizontalRule margin="xs" />
-            {exportDerivatives.map((exportDerivative) => {
-              return (
-                <EuiButton key={exportDerivative.id} iconType={exportDerivative.config.icon} />
-              );
-            })}
+            <EuiFlexGroup direction="column" gutterSize="s">
+              {exportDerivatives.map((exportDerivative) => {
+                return (
+                  <EuiFlexItem key={exportDerivative.id}>
+                    {React.cloneElement(exportDerivative.config.label, {
+                      onClick: () => {
+                        openFlyout(exportDerivative);
+                      },
+                    })}
+                  </EuiFlexItem>
+                );
+              })}
+            </EuiFlexGroup>
           </React.Fragment>
         )}
       </EuiWrappingPopover>
@@ -207,109 +362,25 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
             headerZindexLocation: 'above',
           }}
         >
-          <EuiFlyoutHeader hasBorder>
-            <EuiTitle>
-              <h2>
-                <FormattedMessage
-                  id="share.export.flyoutTitle"
-                  defaultMessage="Export {objectType} as {type}"
-                  values={{
-                    objectType: objectTypeAlias ?? objectType.toLocaleLowerCase(),
-                    type: selectedMenuItem?.config.label,
-                  }}
-                />
-              </h2>
-            </EuiTitle>
-          </EuiFlyoutHeader>
-          <EuiFlyoutBody>
-            <EuiFlexGroup direction="column">
-              <Fragment>
-                {selectedMenuItem?.config.renderLayoutOptionSwitch && (
-                  <EuiFlexItem>
-                    <LayoutOptionsSwitch
-                      usePrintLayout={usePrintLayout}
-                      printLayoutChange={(evt) => setPrintLayout(evt.target.checked)}
-                    />
-                  </EuiFlexItem>
-                )}
-              </Fragment>
-              <Fragment>
-                {selectedMenuItem?.config.copyAssetURIConfig && publicAPIEnabled && (
-                  <EuiFlexItem>
-                    <EuiFormRow
-                      label={
-                        <EuiText size="s">
-                          <h4>{selectedMenuItem?.config.copyAssetURIConfig.headingText}</h4>
-                        </EuiText>
-                      }
-                      fullWidth
-                    >
-                      <EuiFlexGroup direction="column">
-                        <EuiFlexItem>
-                          <EuiText size="s" color="subdued">
-                            {selectedMenuItem?.config.copyAssetURIConfig.helpText}
-                          </EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem>
-                          <EuiCodeBlock
-                            data-test-subj="exportAssetValue"
-                            css={{ overflowWrap: 'break-word' }}
-                            language={selectedMenuItem?.config.copyAssetURIConfig.contentType}
-                            isCopyable
-                            copyAriaLabel={i18n.translate('share.export.copyPostURLAriaLabel', {
-                              defaultMessage: 'Copy export asset value',
-                            })}
-                          >
-                            {selectedMenuItem?.config.copyAssetURIConfig.generateAssetURIValue({
-                              intl,
-                              optimizedForPrinting: usePrintLayout,
-                            })}
-                          </EuiCodeBlock>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiFormRow>
-                  </EuiFlexItem>
-                )}
-              </Fragment>
-              <Fragment>{selectedMenuItem?.config.generateAssetComponent}</Fragment>
-              <Fragment>
-                {publicAPIEnabled && isDirty && DraftModeCallout && (
-                  <EuiFlexItem>{DraftModeCallout}</EuiFlexItem>
-                )}
-              </Fragment>
-            </EuiFlexGroup>
-          </EuiFlyoutBody>
-          <EuiFlyoutFooter>
-            <EuiFlexGroup justifyContent="spaceBetween">
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  data-test-subj="exportFlyoutCloseButton"
-                  onClick={flyoutOnCloseHandler}
-                >
-                  <FormattedMessage
-                    id="share.export.closeFlyoutButtonLabel"
-                    defaultMessage="Close"
-                  />
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  fill
-                  onClick={getReport}
-                  data-test-subj="generateReportButton"
-                  isLoading={isCreatingExport}
-                >
-                  {selectedMenuItem?.config.generateExportButtonLabel ?? (
-                    <FormattedMessage
-                      id="share.export.generateButtonLabel"
-                      defaultMessage="Export {type}"
-                      values={{ type: selectedMenuItem?.config.label }}
-                    />
-                  )}
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlyoutFooter>
+          {selectedMenuItemMeta!.group === 'export' ? (
+            <ManagedFlyout
+              exportIntegration={selectedMenuItem as ExportShareConfig}
+              shareObjectType={objectType}
+              shareObjectTypeAlias={objectTypeAlias}
+              shareObjectTypeMeta={objectTypeMeta}
+              isDirty={isDirty}
+              publicAPIEnabled={publicAPIEnabled}
+              intl={intl}
+              onCloseFlyout={flyoutOnCloseHandler}
+            />
+          ) : (
+            React.createElement(
+              (selectedMenuItem as ExportShareDerivativesConfig)?.config.flyoutContent,
+              {
+                closeFlyout: flyoutOnCloseHandler,
+              }
+            )
+          )}
         </EuiFlyout>
       )}
     </Fragment>

--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { type FC, useState, Fragment, useMemo, useCallback, useRef, useEffect } from 'react';
+import { Global } from '@emotion/react';
 import {
   EuiWrappingPopover,
   EuiListGroup,
@@ -367,6 +368,15 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
             ? selectedMenuItem.config.flyoutSizing || {}
             : {})}
         >
+          <Global
+            // @ts-expect-error -- we pass a z-index specifying important so we override the default z-index, so solve a known bug,
+            // where when `headerZindexLocation` is set to `above`, the popover panel z-index is not high enough
+            styles={{
+              '.euiPopover__panel[data-popover-open="true"]': {
+                zIndex: '7000 !important',
+              },
+            }}
+          />
           {selectedMenuItemMeta!.group === 'export' ? (
             <ManagedFlyout
               exportIntegration={selectedMenuItem as ExportShareConfig}

--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -356,6 +356,7 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
           onClose={flyoutOnCloseHandler}
           css={() => ({
             ['--euiFixedHeadersOffset']: 0,
+            isolation: 'isolate', // ensures that tooltips within this flyout render as should
           })}
           ownFocus
           maskProps={{

--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -30,14 +30,14 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, InjectedIntl, injectI18n } from '@kbn/i18n-react';
-import { ShareMenuProvider, type IShareContext, useShareTabsContext } from '../context';
+import { ShareProvider, type IShareContext, useShareTypeContext } from '../context';
 import { ExportShareConfig } from '../../types';
 
 export const ExportMenu: FC<{ shareContext: IShareContext }> = ({ shareContext }) => {
   return (
-    <ShareMenuProvider {...{ shareContext }}>
+    <ShareProvider {...{ shareContext }}>
       <Fragment>{React.createElement(injectI18n(ExportMenuPopover))}</Fragment>
-    </ShareMenuProvider>
+    </ShareProvider>
   );
 };
 
@@ -111,7 +111,7 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
     objectType,
     objectTypeAlias,
     objectTypeMeta,
-  } = useShareTabsContext('integration', 'export');
+  } = useShareTypeContext('integration', 'export');
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [isCreatingExport, setIsCreatingExport] = useState<boolean>(false);
   const [selectedMenuItemId, setSelectedMenuItemId] = useState<string>();

--- a/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_popover/export_popover.tsx
@@ -337,10 +337,8 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
               {exportDerivatives.map((exportDerivative) => {
                 return (
                   <EuiFlexItem key={exportDerivative.id}>
-                    {React.cloneElement(exportDerivative.config.label, {
-                      onClick: () => {
-                        openFlyout(exportDerivative);
-                      },
+                    {exportDerivative.config.label({
+                      openFlyout: openFlyout.bind(null, exportDerivative),
                     })}
                   </EuiFlexItem>
                 );
@@ -375,12 +373,9 @@ function ExportMenuPopover({ intl }: ExportMenuProps) {
               onCloseFlyout={flyoutOnCloseHandler}
             />
           ) : (
-            React.createElement(
-              (selectedMenuItem as ExportShareDerivativesConfig)?.config.flyoutContent,
-              {
-                closeFlyout: flyoutOnCloseHandler,
-              }
-            )
+            (selectedMenuItem as ExportShareDerivativesConfig)?.config.flyoutContent({
+              closeFlyout: flyoutOnCloseHandler,
+            })
           )}
         </EuiFlyout>
       )}

--- a/src/platform/plugins/shared/share/public/components/share_tabs.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { ShareMenuTabs } from './share_tabs';
-import { ShareMenuProvider, type IShareContext } from './context';
+import { ShareProvider, type IShareContext } from './context';
 import { screen, render } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { KibanaLocation, LocatorGetUrlParams, UrlService } from '../../common/url_service';
@@ -91,9 +91,9 @@ describe('Share modal tabs', () => {
   it('does not render an export tab', () => {
     render(
       <IntlProvider locale="en">
-        <ShareMenuProvider shareContext={{ ...mockShareContext }}>
+        <ShareProvider shareContext={{ ...mockShareContext }}>
           <ShareMenuTabs />
-        </ShareMenuProvider>
+        </ShareProvider>
       </IntlProvider>
     );
     expect(screen.queryByTestId('export')).not.toBeInTheDocument();
@@ -116,9 +116,9 @@ describe('Share modal tabs', () => {
 
       render(
         <IntlProvider locale="en">
-          <ShareMenuProvider shareContext={{ ...disabledLinkShareContext }}>
+          <ShareProvider shareContext={{ ...disabledLinkShareContext }}>
             <ShareMenuTabs />
-          </ShareMenuProvider>
+          </ShareProvider>
         </IntlProvider>
       );
       expect(screen.queryByTestId('link')).not.toBeInTheDocument();

--- a/src/platform/plugins/shared/share/public/components/share_tabs.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.tsx
@@ -10,14 +10,14 @@
 import React, { type FC } from 'react';
 import { TabbedModal, type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
 
-import { ShareMenuProvider, useShareContext, type IShareContext } from './context';
+import { ShareProvider, useShareContext, type IShareContext } from './context';
 import { linkTab, embedTab } from './tabs';
 
 export const ShareMenu: FC<{ shareContext: IShareContext }> = ({ shareContext }) => {
   return (
-    <ShareMenuProvider {...{ shareContext }}>
+    <ShareProvider {...{ shareContext }}>
       <ShareMenuTabs />
-    </ShareMenuProvider>
+    </ShareProvider>
   );
 };
 

--- a/src/platform/plugins/shared/share/public/components/tabs/embed/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/embed/index.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
 import { EmbedContent } from './embed_content';
-import { useShareTabsContext } from '../../context';
+import { useShareTypeContext } from '../../context';
 
 type IEmbedTab = IModalTabDeclaration<{ url: string; isNotSaved: boolean }>;
 
@@ -25,7 +25,7 @@ const EmbedTabContent: NonNullable<IEmbedTab['content']> = ({ state, dispatch })
     allowShortUrl,
     shareableUrlLocatorParams,
     shareMenuItems,
-  } = useShareTabsContext('embed');
+  } = useShareTypeContext('embed');
 
   return (
     <EmbedContent

--- a/src/platform/plugins/shared/share/public/components/tabs/link/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/index.tsx
@@ -10,7 +10,7 @@
 import React, { useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
-import { useShareTabsContext } from '../../context';
+import { useShareTypeContext } from '../../context';
 import { LinkContent } from './link_content';
 
 type ILinkTab = IModalTabDeclaration<{
@@ -58,7 +58,7 @@ const LinkTabContent: ILinkTab['content'] = ({ state, dispatch }) => {
     shareableUrlLocatorParams,
     allowShortUrl,
     shareMenuItems,
-  } = useShareTabsContext('link');
+  } = useShareTypeContext('link');
 
   const setDashboardLink = useCallback(
     (url: string) => {

--- a/src/platform/plugins/shared/share/public/index.ts
+++ b/src/platform/plugins/shared/share/public/index.ts
@@ -27,6 +27,7 @@ export type {
   ShareContextMenuPanelItem,
   BrowserUrlService,
   ExportShare,
+  ExportShareDerivatives,
 } from './types';
 
 export type { RedirectOptions } from '../common/url_service';

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -167,11 +167,23 @@ export interface ExportShare
   groupId: 'export';
 }
 
+/**
+ * @description Special Share integration implementation definition that build off exports within kibana
+ */
+export interface ExportShareDerivatives
+  extends ShareIntegration<{
+    label: ReactNode;
+    icon?: EuiIconProps['type'];
+  }> {
+  groupId: 'exportDerivatives';
+}
+
 export type ShareActionIntents = LinkShare | EmbedShare | ShareLegacy | ShareIntegration;
 
 export type LinkShareConfig = ShareImplementation<LinkShare>;
 export type EmbedShareConfig = ShareImplementation<EmbedShare>;
 export type ExportShareConfig = ShareImplementation<ExportShare>;
+export type ExportShareDerivativesConfig = ShareImplementation<ExportShareDerivatives>;
 export type ShareIntegrationConfig = ShareImplementation<ShareIntegration>;
 
 export type LegacyIntegrationConfig = Omit<ShareLegacy, 'config'> & {
@@ -181,9 +193,10 @@ export type LegacyIntegrationConfig = Omit<ShareLegacy, 'config'> & {
 export type ShareConfigs =
   | LinkShareConfig
   | EmbedShareConfig
+  | ShareIntegrationConfig
   | ExportShareConfig
-  | LegacyIntegrationConfig
-  | ShareIntegrationConfig;
+  | ExportShareDerivativesConfig
+  | LegacyIntegrationConfig;
 
 export type LinkShareUIConfig = ShareActionUserInputBase<{
   /**

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ComponentType, ReactNode } from 'react';
+import type { ComponentType, ReactNode, ReactElement } from 'react';
 import type { InjectedIntl } from '@kbn/i18n-react';
 import { EuiContextMenuPanelDescriptor, type EuiCodeProps, type EuiIconProps } from '@elastic/eui';
 import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
@@ -168,12 +168,14 @@ export interface ExportShare
 }
 
 /**
- * @description Special Share integration implementation definition that build off exports within kibana
+ * @description Share integration implementation definition that build off exports within kibana,
+ * reach out to the shared ux team before settling on using this interface
  */
 export interface ExportShareDerivatives
   extends ShareIntegration<{
-    label: ReactNode;
-    icon?: EuiIconProps['type'];
+    label: ReactElement;
+    toolTipContent?: ReactNode;
+    flyoutContent: React.FC<{ closeFlyout: () => void }>;
   }> {
   groupId: 'exportDerivatives';
 }

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ComponentType, ReactNode, ReactElement } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import type { InjectedIntl } from '@kbn/i18n-react';
 import { EuiContextMenuPanelDescriptor, type EuiCodeProps, type EuiIconProps } from '@elastic/eui';
 import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
@@ -173,7 +173,7 @@ export interface ExportShare
  */
 export interface ExportShareDerivatives
   extends ShareIntegration<{
-    label: ReactElement;
+    label: React.FC<{ openFlyout: () => void }>;
     toolTipContent?: ReactNode;
     flyoutContent: React.FC<{ closeFlyout: () => void }>;
   }> {

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -9,7 +9,12 @@
 
 import type { ComponentType, ReactNode } from 'react';
 import type { InjectedIntl } from '@kbn/i18n-react';
-import { EuiContextMenuPanelDescriptor, type EuiCodeProps, type EuiIconProps } from '@elastic/eui';
+import {
+  EuiContextMenuPanelDescriptor,
+  type EuiCodeProps,
+  type EuiIconProps,
+  type EuiFlyoutProps,
+} from '@elastic/eui';
 import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
 import type { ILicense } from '@kbn/licensing-plugin/public';
 import type { Capabilities } from '@kbn/core/public';
@@ -175,7 +180,11 @@ export interface ExportShareDerivatives
   extends ShareIntegration<{
     label: React.FC<{ openFlyout: () => void }>;
     toolTipContent?: ReactNode;
-    flyoutContent: React.FC<{ closeFlyout: () => void }>;
+    flyoutContent: React.FC<{
+      closeFlyout: () => void;
+      flyoutRef: React.RefObject<HTMLDivElement>;
+    }>;
+    flyoutSizing?: Pick<EuiFlyoutProps, 'size' | 'maxWidth'>;
   }> {
   groupId: 'exportDerivatives';
 }

--- a/src/platform/test/functional/page_objects/export_page.ts
+++ b/src/platform/test/functional/page_objects/export_page.ts
@@ -35,14 +35,20 @@ export class ExportPageObject extends FtrService {
     return isEnabled;
   }
 
-  async clickPopoverItem(label: string) {
+  async clickPopoverItem(
+    label: string,
+    exportPopoverOpener: () => Promise<void> = this.clickExportTopNavButton.bind(this)
+  ) {
     this.log.debug(`clickPopoverItem label: ${label}`);
 
     await this.retry.waitFor('ascertain that export popover is open', async () => {
-      const isExportPopoverOpen = await this.isExportPopoverOpen();
+      let isExportPopoverOpen = await this.isExportPopoverOpen();
+
       if (!isExportPopoverOpen) {
-        await this.clickExportTopNavButton();
+        await exportPopoverOpener();
+        isExportPopoverOpen = await this.isExportPopoverOpen();
       }
+
       return isExportPopoverOpen;
     });
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -2007,7 +2007,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
 
     async openCSVDownloadExport() {
       await this.clickExportButton();
-      await exports.clickPopoverItem('CSV');
+      await exports.clickPopoverItem('CSV', this.clickExportButton);
     },
 
     async setCSVDownloadDebugFlag(value: boolean = true) {


### PR DESCRIPTION
This PR adds a new share integration type (i.e. the `exportDerivative`).  This integration is a special one that is only to be used in a scenario where a team would like to offer some extra functionality that depends on the availability of some `export` integration. Specifically because of the way this has been coupled to be presented to the user the `exportDerivative` type integration would only be displayed to the user when at least one export integration exists. 

This particular  integration is also much more flexible, in that it only accepts a label to denote what should be rendered to the user, and a freeform component that will be rendered into the flyout that will in turn open when the provided label is clicked.

One might configure an integration for this like so;

```ts
      share.registerShareIntegration<ExportShareDerivatives>({
        id: 'scheduledReporting',
        groupId: 'exportDerivatives',
        config: () => ({
          label: ({ openFlyout }) =>
            React.createElement(
              EuiButton,
              { iconType: 'calendar', onClick: openFlyout },
              'schedule report'
            ),
          flyoutContent: ({ closeFlyout , flyoutRef }) => {
            return React.createElement(
              EuiButton,
              {
                iconType: 'calendar',
              },
              'Click me'
            );
          },
        }),
      });
```
 
 The following config would produce the following experience;
 
 
![ScreenRecording2025-06-14at15 04 54-ezgif com-optimize](https://github.com/user-attachments/assets/52a232b3-7ce9-491b-8913-a8e3cd91e207)


<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->

