### PR TITLE
fix(): inconsistent page_url between refresh and navigations

### DIFF
--- a/src/core/packages/application/browser-internal/src/utils/get_location_observable.test.ts
+++ b/src/core/packages/application/browser-internal/src/utils/get_location_observable.test.ts
@@ -18,6 +18,14 @@ describe('getLocationObservable', () => {
 
   beforeEach(() => {
     history = createBrowserHistory();
+    history.push('/foo'); // Set an initial location
+  });
+
+  it('falls back to window.location if history.location does not exist', async () => {
+    // Hard-mocking because history.location is always present. But our logic has the fallback just in case.
+    history.location = undefined as any;
+    const location$ = getLocationObservable({ pathname: '/window-foo', hash: '' }, history);
+    expect(await firstValueFrom(location$)).toEqual('/window-foo');
   });
 
   it('emits with the initial location', async () => {
@@ -53,6 +61,7 @@ describe('getLocationObservable', () => {
   });
 
   it('includes the hash when present', async () => {
+    history.push({ pathname: '/foo', hash: '#/index' }); // Set an initial location with hash
     const location$ = getLocationObservable({ pathname: '/foo', hash: '#/index' }, history);
     const locations: string[] = [];
     location$.subscribe((location) => locations.push(location));

--- a/src/core/packages/application/browser-internal/src/utils/get_location_observable.ts
+++ b/src/core/packages/application/browser-internal/src/utils/get_location_observable.ts
@@ -25,7 +25,7 @@ export const getLocationObservable = (
     subject.next(locationToUrl(location));
   });
   return subject.pipe(
-    startWith(locationToUrl(initialLocation)),
+    startWith(locationToUrl(history.location ?? initialLocation)),
     distinctUntilChanged(),
     shareReplay(1)
   );


### PR DESCRIPTION
## Summary

Resolves #205382

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->