### PR TITLE
Remove unnecessary try catch in the APM user filters

### DIFF
--- a/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.test.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { piiFilter } from './pii_filter';
+
+interface Payload {
+  context?: {
+    user?: any;
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+const isPayload = (result: any): result is Payload => typeof result === 'object' && result !== null;
+
+describe('piiFilter', () => {
+  it('redacts all keys in a valid user object', () => {
+    const payload: Payload = {
+      context: {
+        user: {
+          id: '123',
+          username: 'alice',
+          email: 'alice@example.com',
+        },
+      },
+    };
+    const result = piiFilter({ ...payload });
+    expect(isPayload(result) && result.context?.user).toEqual({
+      id: '[REDACTED]',
+      username: '[REDACTED]',
+      email: '[REDACTED]',
+    });
+  });
+
+  it('replaces non-object user context with { id: "[INVALID]" }', () => {
+    const payloads: Payload[] = [
+      { context: { user: 'not-an-object' } },
+      { context: { user: 42 } },
+      { context: { user: null } },
+      { context: { user: undefined } },
+      { context: { user: [1, 2, 3] } },
+    ];
+    for (const payload of payloads) {
+      const result = piiFilter({ ...payload });
+      expect(isPayload(result) && result.context?.user).toEqual({ id: '[INVALID]' });
+    }
+  });
+
+  it('does not modify payloads without user context', () => {
+    const payload: Payload = { context: {} };
+    const result = piiFilter({ ...payload });
+    expect(result).toEqual(payload);
+  });
+
+  it('does not throw if context is missing', () => {
+    const payload: Payload = {};
+    expect(() => piiFilter({ ...payload })).not.toThrow();
+    expect(piiFilter({ ...payload })).toEqual(payload);
+  });
+});

--- a/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.test.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.test.ts
@@ -7,17 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { isPlainObject } from 'lodash';
 import { piiFilter } from './pii_filter';
+import { Payload as ApmPayload } from 'elastic-apm-node';
 
-interface Payload {
+interface Payload extends ApmPayload {
   context?: {
-    user?: any;
+    user?: unknown;
     [key: string]: any;
   };
   [key: string]: any;
 }
 
-const isPayload = (result: any): result is Payload => typeof result === 'object' && result !== null;
+const isPayload = (result: unknown): result is Payload => isPlainObject(result) && result !== null;
 
 describe('piiFilter', () => {
   it('redacts all keys in a valid user object', () => {

--- a/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FilterFn } from 'elastic-apm-node';
+import { isPlainObject, has } from 'lodash';
+
+export const piiFilter: FilterFn = (payload) => {
+  // if user context is defined, apply the pii filter
+  if (has(payload.context, 'user')) {
+    // if the user context has loopable properties, redact the values
+    if (payload.context.user != null && isPlainObject(payload.context.user)) {
+      const userContextKeys = Object.keys(payload.context.user);
+      for (const key of userContextKeys) {
+        payload.context.user[key] = '[REDACTED]';
+      }
+    } else {
+      // Replace with a known invalid object to avoid APM trace discards
+      payload.context.user = { id: '[INVALID]' };
+    }
+  }
+  return payload;
+};

--- a/src/platform/packages/private/kbn-apm-config-loader/src/init_apm.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/init_apm.ts
@@ -8,6 +8,7 @@
  */
 
 import { loadConfiguration } from './config_loader';
+import { piiFilter } from './filters/pii_filter';
 
 export const initApm = (
   argv: string[],
@@ -26,18 +27,7 @@ export const initApm = (
 
   // Filter out all user PII
   if (shouldRedactUsers) {
-    apm.addFilter((payload) => {
-      try {
-        if (payload.context?.user && typeof payload.context.user === 'object') {
-          Object.keys(payload.context.user).forEach((key) => {
-            payload.context.user[key] = '[REDACTED]';
-          });
-        }
-      } catch (e) {
-        // just silently ignore the error
-      }
-      return payload;
-    });
+    apm.addFilter(piiFilter);
   }
 
   apm.start(apmConfig);


### PR DESCRIPTION
## Summary

Improves the IF statement to ensure that we are dealing with an object with loopable keys and remove the try-catch. If not loopable, we might want to remove the user context entirely (or replace it with a known object { id: '[INVALID]' }) since it might lead to APM traces being discarded due to invalid user context.

closes https://github.com/elastic/kibana/issues/219095

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->