### PR TITLE
[a11y][ml] Add visually hidden label for screenreader for select checkboxes in anomaly detection job selection flyout

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_selection_table/custom_selection_table.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_selection_table/custom_selection_table.js
@@ -195,6 +195,7 @@ export function CustomSelectionTable({
       <EuiCheckbox
         id={`${mobile ? `mobile-` : ''}${selectAllCheckboxId}`}
         label={mobile ? selectAll : null}
+        aria-label={selectAll}
         checked={areAllItemsSelected()}
         onChange={toggleAll}
       />
@@ -280,6 +281,10 @@ export function CustomSelectionTable({
                   }
                   id={`${item[tableItemId]}-checkbox`}
                   data-test-subj={`${item[tableItemId]}-checkbox`}
+                  aria-label={i18n.translate('xpack.ml.jobSelector.customTable.checkboxAriaLabel', {
+                    defaultMessage: 'Select job {itemId}',
+                    values: { itemId: item[tableItemId] },
+                  })}
                   checked={isItemSelected(item[tableItemId])}
                   onChange={() => toggleItem(item[tableItemId])}
                 />
@@ -289,6 +294,13 @@ export function CustomSelectionTable({
                   id={item[tableItemId]}
                   data-test-subj={`${item[tableItemId]}-radio-button`}
                   checked={isItemSelected(item[tableItemId])}
+                  aria-label={i18n.translate(
+                    'xpack.ml.jobSelector.customTable.singleSelectionRadioButtonAriaLabel',
+                    {
+                      defaultMessage: 'Select job {itemId}',
+                      values: { itemId: item[tableItemId] },
+                    }
+                  )}
                   onChange={() => toggleItem(item[tableItemId])}
                   disabled={radioDisabledCheck !== undefined ? radioDisabledCheck(item) : undefined}
                 />
@@ -369,7 +381,7 @@ export function CustomSelectionTable({
             fullWidth
             isInvalid={error !== null}
             error={getError(error)}
-            style={{ maxHeight: '0px' }}
+            css={{ maxHeight: '0px' }}
           >
             <Fragment />
           </EuiFormRow>


### PR DESCRIPTION
## Summary

This PR resolves [[ML] Anomaly Detection: Job selector flyout checkboxes in the first column missing title from announcement](https://github.com/elastic/kibana/issues/216802).

#### This is a follow up from https://github.com/elastic/kibana/pull/221865 pr. (Closed because of merge issues.)

https://github.com/user-attachments/assets/a6796576-cc46-4769-ab3d-c8f5dc37409e

Fixes https://github.com/elastic/kibana/issues/216802


<!--ONMERGE {"backportTargets":["7.17","8.17","8.18","8.19","9.0"]} ONMERGE-->