### PR TITLE
[8.19] [One Discover] Fix Alerting menu visibility issue (#223054)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/app_menu_registry.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/app_menu_registry.ts
@@ -125,7 +125,9 @@ export class AppMenuRegistry {
     const secondaryItems = this.getSortedItemsForType(AppMenuActionType.secondary);
     const customItems = this.getSortedItemsForType(AppMenuActionType.custom);
 
-    return [...customItems, ...secondaryItems, ...primaryItems];
+    return [...customItems, ...secondaryItems, ...primaryItems].filter(
+      (item) => !isAppMenuActionSubmenu(item) || item.actions.length > 0
+    );
   }
 }
 

--- a/src/platform/plugins/shared/discover/public/__mocks__/services.ts
+++ b/src/platform/plugins/shared/discover/public/__mocks__/services.ts
@@ -184,6 +184,14 @@ export function createDiscoverServicesMock(): DiscoverServices {
       advancedSettings: {
         save: true,
       },
+      management: {
+        insightsAndAlerting: {
+          triggersActions: true,
+        },
+      },
+      indexPatterns: {
+        save: true,
+      },
     },
     fieldFormats: fieldFormatsMock,
     filterManager: dataPlugin.query.filterManager,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { findTestSubject } from '@elastic/eui/lib/test';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { ES_QUERY_ID } from '@kbn/rule-data-utils';
 import { AppMenuActionsMenuPopover } from './run_app_menu_action';
 import { getAlertsAppMenuItem } from './get_alerts';
 import { discoverServiceMock } from '../../../../../__mocks__/services';
@@ -18,7 +19,11 @@ import { dataViewWithTimefieldMock } from '../../../../../__mocks__/data_view_wi
 import { dataViewWithNoTimefieldMock } from '../../../../../__mocks__/data_view_no_timefield';
 import { getDiscoverStateMock } from '../../../../../__mocks__/discover_state.mock';
 
-const mount = (dataView = dataViewMock, isEsqlMode = false) => {
+const mount = (
+  dataView = dataViewMock,
+  isEsqlMode = false,
+  authorizedRuleTypeIds = [ES_QUERY_ID]
+) => {
   const stateContainer = getDiscoverStateMock({ isTimeBased: true });
   stateContainer.actions.setDataView(dataView);
 
@@ -26,7 +31,7 @@ const mount = (dataView = dataViewMock, isEsqlMode = false) => {
     dataView,
     adHocDataViews: [],
     isEsqlMode,
-    authorizedRuleTypeIds: [],
+    authorizedRuleTypeIds,
     onNewSearch: jest.fn(),
     onOpenSavedSearch: jest.fn(),
     onUpdateAdHocDataViews: jest.fn(),
@@ -49,6 +54,22 @@ const mount = (dataView = dataViewMock, isEsqlMode = false) => {
 };
 
 describe('OpenAlertsPopover', () => {
+  describe('Authorized Rule Types', () => {
+    it('should render the manage alerts button if there is any authorized rule type', () => {
+      const component = mount(dataViewMock, false, ['anyAuthorizedRule']);
+      expect(findTestSubject(component, 'discoverManageAlertsButton').exists()).toBeTruthy();
+    });
+
+    it('should render the create search threshold rule button if it is authorized', () => {
+      const component = mount();
+      expect(findTestSubject(component, 'discoverCreateAlertButton').exists()).toBeTruthy();
+    });
+
+    it('should not render the create search threshold rule button if it is not authorized', () => {
+      const component = mount(dataViewMock, false, []);
+      expect(findTestSubject(component, 'discoverCreateAlertButton').exists()).toBeFalsy();
+    });
+  });
   describe('Dataview mode', () => {
     it('should render with the create search threshold rule button disabled if the data view has no time field', () => {
       const component = mount();

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
@@ -10,7 +10,10 @@
 import React, { useCallback, useMemo } from 'react';
 import type { DataView } from '@kbn/data-plugin/common';
 import { i18n } from '@kbn/i18n';
-import type { AppMenuActionSubmenuSecondary } from '@kbn/discover-utils';
+import type {
+  AppMenuActionSubmenuSecondary,
+  AppMenuSubmenuActionSecondary,
+} from '@kbn/discover-utils';
 import { AppMenuActionId, AppMenuActionType } from '@kbn/discover-utils';
 import type { RuleCreationValidConsumer } from '@kbn/rule-data-utils';
 import { AlertConsumers, ES_QUERY_ID, STACK_ALERTS_FEATURE_ID } from '@kbn/rule-data-utils';
@@ -130,54 +133,62 @@ export const getAlertsAppMenuItem = ({
       defaultMessage: 'Alerts',
     }),
     testId: 'discoverAlertsButton',
-    actions: [
-      {
-        id: AppMenuActionId.createRule,
-        type: AppMenuActionType.secondary,
-        controlProps: {
-          label: i18n.translate('discover.alerts.createSearchThreshold', {
-            defaultMessage: 'Create search threshold rule',
-          }),
-          iconType: 'bell',
-          testId: 'discoverCreateAlertButton',
-          disableButton: !hasTimeFieldName,
-          tooltip: hasTimeFieldName
-            ? undefined
-            : i18n.translate('discover.alerts.missedTimeFieldToolTip', {
-                defaultMessage: 'Data view does not have a time field.',
-              }),
-          onClick: async (params) => {
-            return (
-              <CreateAlertFlyout
-                {...params}
-                discoverParams={discoverParams}
-                services={services}
-                stateContainer={stateContainer}
-              />
-            );
+    actions: services.capabilities.management?.insightsAndAlerting?.triggersActions
+      ? [
+          ...((discoverParams.authorizedRuleTypeIds.includes(ES_QUERY_ID)
+            ? [
+                {
+                  id: AppMenuActionId.createRule,
+                  type: AppMenuActionType.secondary,
+                  controlProps: {
+                    label: i18n.translate('discover.alerts.createSearchThreshold', {
+                      defaultMessage: 'Create search threshold rule',
+                    }),
+                    iconType: 'bell',
+                    testId: 'discoverCreateAlertButton',
+                    disableButton: !hasTimeFieldName,
+                    tooltip: hasTimeFieldName
+                      ? undefined
+                      : i18n.translate('discover.alerts.missedTimeFieldToolTip', {
+                          defaultMessage: 'Data view does not have a time field.',
+                        }),
+                    onClick: async (params) => {
+                      return (
+                        <CreateAlertFlyout
+                          {...params}
+                          discoverParams={discoverParams}
+                          services={services}
+                          stateContainer={stateContainer}
+                        />
+                      );
+                    },
+                  },
+                },
+              ]
+            : []) as AppMenuSubmenuActionSecondary[]),
+          {
+            id: 'alertsDivider',
+            type: AppMenuActionType.submenuHorizontalRule,
+            order: 109,
           },
-        },
-      },
-      {
-        id: 'alertsDivider',
-        type: AppMenuActionType.submenuHorizontalRule,
-      },
-      {
-        id: AppMenuActionId.manageRulesAndConnectors,
-        type: AppMenuActionType.secondary,
-        controlProps: {
-          label: i18n.translate('discover.alerts.manageRulesAndConnectors', {
-            defaultMessage: 'Manage rules and connectors',
-          }),
-          iconType: 'tableOfContents',
-          testId: 'discoverManageAlertsButton',
-          href: services.application.getUrlForApp(
-            'management/insightsAndAlerting/triggersActions/rules'
-          ),
-          onClick: undefined,
-        },
-      },
-    ],
+          {
+            id: AppMenuActionId.manageRulesAndConnectors,
+            type: AppMenuActionType.secondary,
+            order: 110,
+            controlProps: {
+              label: i18n.translate('discover.alerts.manageRulesAndConnectors', {
+                defaultMessage: 'Manage rules and connectors',
+              }),
+              iconType: 'tableOfContents',
+              testId: 'discoverManageAlertsButton',
+              href: services.application.getUrlForApp(
+                'management/insightsAndAlerting/triggersActions/rules'
+              ),
+              onClick: undefined,
+            },
+          },
+        ]
+      : [],
   };
 };
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/run_app_menu_action.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/run_app_menu_action.tsx
@@ -58,9 +58,13 @@ export const AppMenuActionsMenuPopover: React.FC<AppMenuActionsMenuPopoverProps>
     anchorElement?.focus();
   }, [anchorElement, originalOnClose]);
 
-  const items = appMenuItem.actions.map((action) => {
+  const items = appMenuItem.actions.map((action, i) => {
     if (action.type === AppMenuActionType.submenuHorizontalRule) {
-      return <EuiHorizontalRule key={action.id} data-test-subj={action.testId} margin="none" />;
+      if (i === 0 || i === appMenuItem.actions.length - 1) {
+        return <></>;
+      } else {
+        return <EuiHorizontalRule key={action.id} data-test-subj={action.testId} margin="none" />;
+      }
     }
 
     const controlProps = action.controlProps;

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -20,7 +20,6 @@ import {
 } from '@kbn/discover-utils';
 import type { RuleTypeWithDescription } from '@kbn/alerts-ui-shared';
 import { useGetRuleTypesPermissions } from '@kbn/alerts-ui-shared';
-import { ES_QUERY_ID } from '@kbn/rule-data-utils';
 import { ESQL_TRANSITION_MODAL_KEY } from '../../../../../common/constants';
 import type { DiscoverServices } from '../../../../build_services';
 import { onSaveSearch } from './on_save_search';
@@ -109,9 +108,8 @@ export const useTopNavLinks = ({
 
       if (
         services.triggersActionsUi &&
-        services.capabilities.management?.insightsAndAlerting?.triggersActions &&
         !defaultMenu?.alertsItem?.disabled &&
-        discoverParams.authorizedRuleTypeIds.includes(ES_QUERY_ID)
+        discoverParams.authorizedRuleTypeIds.length
       ) {
         const alertsAppMenuItem = getAlertsAppMenuItem({
           discoverParams,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_app_menu.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_app_menu.tsx
@@ -117,9 +117,10 @@ const registerCustomThresholdRuleAction = (
             }}
             consumer={AlertConsumers.LOGS}
             validConsumers={[
-              AlertConsumers.INFRASTRUCTURE,
               AlertConsumers.LOGS,
+              AlertConsumers.INFRASTRUCTURE,
               AlertConsumers.OBSERVABILITY,
+              AlertConsumers.STACK_ALERTS,
             ]}
             ruleTypeId={OBSERVABILITY_THRESHOLD_RULE_TYPE_ID}
             initialValues={{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[One Discover] Fix Alerting menu visibility issue (#223054)](https://github.com/elastic/kibana/pull/223054)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"mohamedhamed-ahmed","email":"mohamed.ahmed@elastic.co"},"sourceCommit":{"committedDate":"2025-06-16T08:45:24Z","message":"[One Discover] Fix Alerting menu visibility issue (#223054)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/223007\n\n### This PR fixes a couple of bugs in the visibility of the Alert Top\nNave menu item:\n\n**1. When the user is in Classic space with <ins> no rule type\nprivileges </ins> the `Alert` top nav menu item should be hidden**\n\n- Only `Discover` _**All**_ Feature Privilege\n\n<img width=\"465\" alt=\"Screenshot 2025-06-11 at 11 01 03\"\nsrc=\"https://github.com/user-attachments/assets/063a01b1-16a5-4ee1-b981-a2d4b93c08ac\"\n/></br></br>\n\n\n**2. When a user has <ins> only `SLO` </ins> privilege the menu should\nbe shown with only SLO entry.**\n- `Discover` & Observability `SLO` _**All**_ Feature Privilege\n<img width=\"532\" alt=\"Screenshot 2025-06-11 at 11 00 31\"\nsrc=\"https://github.com/user-attachments/assets/91f48791-28b0-48ce-b7fa-f1c8139556dd\"\n/></br></br>\n\n**3. When the user has <ins> no `SLO` </ins> privilege, the `SLO` entry\nshould be hidden**\n- `Discover` & Observability `Logs` _**All**_ Feature Privilege\n<img width=\"518\" alt=\"Screenshot 2025-06-11 at 11 01 34\"\nsrc=\"https://github.com/user-attachments/assets/c6df8a7d-c35b-43f0-be81-84ca3ef0b2e4\"\n/></br></br>\n\n4. **When the user has access to <ins> only manage alerts </ins> without\nspecific rule type, the `Manage alerts` entry should be shown.**\n- `Discover` & Security `Security` _**All**_ Feature Privilege in\n**_Classic_** navigation\n<img width=\"509\" alt=\"Screenshot 2025-06-11 at 11 02 59\"\nsrc=\"https://github.com/user-attachments/assets/b5c370a6-f346-4bad-a8bd-d19fa6c95c76\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7a473cb4e0f3ec69b29ba35d906b6c05e1e7f188","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:DataDiscovery","Team:obs-ux-logs","backport:version","v9.1.0","v8.19.0"],"title":"[One Discover] Fix Alerting menu visibility issue","number":223054,"url":"https://github.com/elastic/kibana/pull/223054","mergeCommit":{"message":"[One Discover] Fix Alerting menu visibility issue (#223054)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/223007\n\n### This PR fixes a couple of bugs in the visibility of the Alert Top\nNave menu item:\n\n**1. When the user is in Classic space with <ins> no rule type\nprivileges </ins> the `Alert` top nav menu item should be hidden**\n\n- Only `Discover` _**All**_ Feature Privilege\n\n<img width=\"465\" alt=\"Screenshot 2025-06-11 at 11 01 03\"\nsrc=\"https://github.com/user-attachments/assets/063a01b1-16a5-4ee1-b981-a2d4b93c08ac\"\n/></br></br>\n\n\n**2. When a user has <ins> only `SLO` </ins> privilege the menu should\nbe shown with only SLO entry.**\n- `Discover` & Observability `SLO` _**All**_ Feature Privilege\n<img width=\"532\" alt=\"Screenshot 2025-06-11 at 11 00 31\"\nsrc=\"https://github.com/user-attachments/assets/91f48791-28b0-48ce-b7fa-f1c8139556dd\"\n/></br></br>\n\n**3. When the user has <ins> no `SLO` </ins> privilege, the `SLO` entry\nshould be hidden**\n- `Discover` & Observability `Logs` _**All**_ Feature Privilege\n<img width=\"518\" alt=\"Screenshot 2025-06-11 at 11 01 34\"\nsrc=\"https://github.com/user-attachments/assets/c6df8a7d-c35b-43f0-be81-84ca3ef0b2e4\"\n/></br></br>\n\n4. **When the user has access to <ins> only manage alerts </ins> without\nspecific rule type, the `Manage alerts` entry should be shown.**\n- `Discover` & Security `Security` _**All**_ Feature Privilege in\n**_Classic_** navigation\n<img width=\"509\" alt=\"Screenshot 2025-06-11 at 11 02 59\"\nsrc=\"https://github.com/user-attachments/assets/b5c370a6-f346-4bad-a8bd-d19fa6c95c76\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7a473cb4e0f3ec69b29ba35d906b6c05e1e7f188"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223054","number":223054,"mergeCommit":{"message":"[One Discover] Fix Alerting menu visibility issue (#223054)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/223007\n\n### This PR fixes a couple of bugs in the visibility of the Alert Top\nNave menu item:\n\n**1. When the user is in Classic space with <ins> no rule type\nprivileges </ins> the `Alert` top nav menu item should be hidden**\n\n- Only `Discover` _**All**_ Feature Privilege\n\n<img width=\"465\" alt=\"Screenshot 2025-06-11 at 11 01 03\"\nsrc=\"https://github.com/user-attachments/assets/063a01b1-16a5-4ee1-b981-a2d4b93c08ac\"\n/></br></br>\n\n\n**2. When a user has <ins> only `SLO` </ins> privilege the menu should\nbe shown with only SLO entry.**\n- `Discover` & Observability `SLO` _**All**_ Feature Privilege\n<img width=\"532\" alt=\"Screenshot 2025-06-11 at 11 00 31\"\nsrc=\"https://github.com/user-attachments/assets/91f48791-28b0-48ce-b7fa-f1c8139556dd\"\n/></br></br>\n\n**3. When the user has <ins> no `SLO` </ins> privilege, the `SLO` entry\nshould be hidden**\n- `Discover` & Observability `Logs` _**All**_ Feature Privilege\n<img width=\"518\" alt=\"Screenshot 2025-06-11 at 11 01 34\"\nsrc=\"https://github.com/user-attachments/assets/c6df8a7d-c35b-43f0-be81-84ca3ef0b2e4\"\n/></br></br>\n\n4. **When the user has access to <ins> only manage alerts </ins> without\nspecific rule type, the `Manage alerts` entry should be shown.**\n- `Discover` & Security `Security` _**All**_ Feature Privilege in\n**_Classic_** navigation\n<img width=\"509\" alt=\"Screenshot 2025-06-11 at 11 02 59\"\nsrc=\"https://github.com/user-attachments/assets/b5c370a6-f346-4bad-a8bd-d19fa6c95c76\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7a473cb4e0f3ec69b29ba35d906b6c05e1e7f188"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->