### PR TITLE
[Entiyt Analytics] Do not run migration tests in MKI

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/migrations.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/migrations.ts
@@ -41,7 +41,7 @@ export default ({ getService }: FtrProviderContext) => {
 
   const SPACE_TEST_SPACES = ['space1', 'space2', 'space3'];
 
-  describe('@ess @serverless @serverlessQA Entity Analytics Migrations', () => {
+  describe('@ess @serverless @skipInServerlessMKI Entity Analytics Migrations', () => {
     beforeEach(async () => {
       for (const space of ['default', ...SPACE_TEST_SPACES]) {
         await cleanAssetCriticality({


### PR DESCRIPTION
## Summary

These tests rely on having system indices superuser permissions to run, causing them to break in MKI. 