### PR TITLE
[8.19] [Incident Management] Add primary Add to case button (#223184)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.test.tsx
@@ -87,6 +87,53 @@ describe('Header Actions', () => {
       mockKibana();
       mockUseFetchRuleWithData();
     });
+    it('should offer an "Add to case" button which opens the add to case modal', async () => {
+      let attachments: any[] = [];
+
+      const useCasesAddToExistingCaseModalMock: any = jest.fn().mockImplementation(() => ({
+        open: ({ getAttachments }: { getAttachments: () => any[] }) => {
+          attachments = getAttachments();
+        },
+      })) as CasesPublicStart['hooks']['useCasesAddToExistingCaseModal'];
+
+      mockCases.hooks.useCasesAddToExistingCaseModal = useCasesAddToExistingCaseModalMock;
+
+      const { getByTestId } = render(
+        <HeaderActions
+          alert={alertWithGroupsAndTags}
+          alertIndex={'alert-index'}
+          alertStatus={alertWithGroupsAndTags.fields[ALERT_STATUS] as AlertStatus}
+          onUntrackAlert={mockOnUntrackAlert}
+        />
+      );
+
+      fireEvent.click(getByTestId('add-to-case-button'));
+
+      expect(attachments).toEqual([
+        {
+          alertId: mockAlertUuid,
+          index: 'alert-index',
+          rule: {
+            id: mockRuleId,
+            name: mockRuleName,
+          },
+          type: 'alert',
+        },
+      ]);
+    });
+
+    it('should not offer a "Snooze the rule" button', async () => {
+      const { queryByTestId } = render(
+        <HeaderActions
+          alert={alertWithGroupsAndTags}
+          alertIndex={'alert-index'}
+          alertStatus={alertWithGroupsAndTags.fields[ALERT_STATUS] as AlertStatus}
+          onUntrackAlert={mockOnUntrackAlert}
+        />
+      );
+
+      expect(queryByTestId('snooze-rule-button')).toBeFalsy();
+    });
 
     it('should display an actions button', () => {
       const { queryByTestId } = render(
@@ -100,41 +147,17 @@ describe('Header Actions', () => {
     });
 
     describe('when clicking the actions button', () => {
-      it('should offer an "Add to case" button which opens the add to case modal', async () => {
-        let attachments: any[] = [];
-
-        const useCasesAddToExistingCaseModalMock: any = jest.fn().mockImplementation(() => ({
-          open: ({ getAttachments }: { getAttachments: () => any[] }) => {
-            attachments = getAttachments();
-          },
-        })) as CasesPublicStart['hooks']['useCasesAddToExistingCaseModal'];
-
-        mockCases.hooks.useCasesAddToExistingCaseModal = useCasesAddToExistingCaseModalMock;
-
+      it('should offer a "Snooze the rule" button', async () => {
         const { getByTestId, findByTestId } = render(
           <HeaderActions
             alert={alertWithGroupsAndTags}
-            alertIndex={'alert-index'}
             alertStatus={alertWithGroupsAndTags.fields[ALERT_STATUS] as AlertStatus}
             onUntrackAlert={mockOnUntrackAlert}
           />
         );
 
         fireEvent.click(await findByTestId('alert-details-header-actions-menu-button'));
-
-        fireEvent.click(getByTestId('add-to-case-button'));
-
-        expect(attachments).toEqual([
-          {
-            alertId: mockAlertUuid,
-            index: 'alert-index',
-            rule: {
-              id: mockRuleId,
-              name: mockRuleName,
-            },
-            type: 'alert',
-          },
-        ]);
+        expect(getByTestId('snooze-rule-button')).toBeDefined();
       });
 
       it('should offer a "Edit rule" button which opens the edit rule flyout', async () => {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
@@ -213,25 +213,25 @@ export function HeaderActions({
             <EuiButtonIcon
               display="empty"
               size="m"
-              iconType="bellSlash"
-              data-test-subj="snooze-rule-button"
-              onClick={handleOpenSnoozeModal}
+              iconType="plus"
+              data-test-subj="add-to-case-button"
+              onClick={handleAddToCase}
               disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
-              aria-label={i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
-                defaultMessage: 'Snooze the rule',
+              aria-label={i18n.translate('xpack.observability.alertDetails.addToCase', {
+                defaultMessage: 'Add to case',
               })}
             />
           ) : (
             <EuiButton
               fill
-              iconType="bellSlash"
-              onClick={handleOpenSnoozeModal}
+              iconType="plus"
+              onClick={handleAddToCase}
               disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
-              data-test-subj="snooze-rule-button"
+              data-test-subj="add-to-case-button"
             >
               <EuiText size="s">
-                {i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
-                  defaultMessage: 'Snooze the rule',
+                {i18n.translate('xpack.observability.alertDetails.addToCase', {
+                  defaultMessage: 'Add to case',
                 })}
               </EuiText>
             </EuiButton>
@@ -283,13 +283,14 @@ export function HeaderActions({
                 <EuiButtonEmpty
                   size="s"
                   color="text"
-                  iconType="plus"
-                  onClick={handleAddToCase}
-                  data-test-subj="add-to-case-button"
+                  iconType="bellSlash"
+                  onClick={handleOpenSnoozeModal}
+                  disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
+                  data-test-subj="snooze-rule-button"
                 >
                   <EuiText size="s">
-                    {i18n.translate('xpack.observability.alertDetails.addToCase', {
-                      defaultMessage: 'Add to case',
+                    {i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
+                      defaultMessage: 'Snooze the rule',
                     })}
                   </EuiText>
                 </EuiButtonEmpty>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Incident Management] Add primary Add to case button (#223184)](https://github.com/elastic/kibana/pull/223184)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-06-13T12:39:22Z","message":"[Incident Management] Add primary Add to case button (#223184)\n\nThis PR closes #216235 by swapping the primary `Snooze the rule` button\nwith the `Add to case` acton.\n\n\n\nhttps://github.com/user-attachments/assets/7b59fae0-9d16-4a31-95dc-a3890ab6632d\n\n**Acceptance criteria:**\n- This primary action for all alert details pages in observability\nshould be \"Add to case\" ✅\n- The snooze rule action can be moved to the sub actions menu ✅\n- The existing \"Add to case\" action present in the sub menu (see below)\nshould be removed (replaced by the primary button) ✅\n- The button should allow the user to add this current alert to a new or\nexisting case ✅","sha":"31e5f46308bb3db3addee58ad87119f3035d73cf","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management"],"title":"[Incident Management] Add primary Add to case button","number":223184,"url":"https://github.com/elastic/kibana/pull/223184","mergeCommit":{"message":"[Incident Management] Add primary Add to case button (#223184)\n\nThis PR closes #216235 by swapping the primary `Snooze the rule` button\nwith the `Add to case` acton.\n\n\n\nhttps://github.com/user-attachments/assets/7b59fae0-9d16-4a31-95dc-a3890ab6632d\n\n**Acceptance criteria:**\n- This primary action for all alert details pages in observability\nshould be \"Add to case\" ✅\n- The snooze rule action can be moved to the sub actions menu ✅\n- The existing \"Add to case\" action present in the sub menu (see below)\nshould be removed (replaced by the primary button) ✅\n- The button should allow the user to add this current alert to a new or\nexisting case ✅","sha":"31e5f46308bb3db3addee58ad87119f3035d73cf"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223184","number":223184,"mergeCommit":{"message":"[Incident Management] Add primary Add to case button (#223184)\n\nThis PR closes #216235 by swapping the primary `Snooze the rule` button\nwith the `Add to case` acton.\n\n\n\nhttps://github.com/user-attachments/assets/7b59fae0-9d16-4a31-95dc-a3890ab6632d\n\n**Acceptance criteria:**\n- This primary action for all alert details pages in observability\nshould be \"Add to case\" ✅\n- The snooze rule action can be moved to the sub actions menu ✅\n- The existing \"Add to case\" action present in the sub menu (see below)\nshould be removed (replaced by the primary button) ✅\n- The button should allow the user to add this current alert to a new or\nexisting case ✅","sha":"31e5f46308bb3db3addee58ad87119f3035d73cf"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->