### PR TITLE
[a11y][ml] Add visually hidden label for screenreader for open documentation button

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
@@ -272,6 +272,9 @@ export const EditorFooter = memo(function EditorFooter({
                     data-test-subj="ESQLEditor-documentation"
                     size="m"
                     onClick={() => toggleLanguageComponent()}
+                    aria-label={i18n.translate('esqlEditor.query.documentationAriaLabel', {
+                      defaultMessage: 'Open documentation',
+                    })}
                     css={css`
                       cursor: pointer;
                     `}


### PR DESCRIPTION
This PR resolves [[ML] ES|QL Data Visualizer: The button to access es|ql quick reference is missing discernible text](https://github.com/elastic/kibana/issues/217094) issue.

https://github.com/user-attachments/assets/09e18f9f-eb06-4468-bc72-c0c4e46a642e



<!--ONMERGE {"backportTargets":["7.17","8.17","8.18","8.19","9.0"]} ONMERGE-->