### PR TITLE
[8.19] [ResponseOps] Check if we override EuiButton & EuiFilter styles (#222528)

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
@@ -16,7 +16,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import { CustomFieldPanel } from './custom_field_panel';
 import * as i18n from '../translations';
-import { StyledContextMenu, StyledEuiButtonEmpty } from '../styles';
+import { StyledContextMenu } from '../styles';
 
 export interface GroupSelectorProps {
   'data-test-subj'?: string;
@@ -120,7 +120,7 @@ const GroupSelectorComponent = ({
           return optionsTitle ? [optionsTitle, selection.label].join(', ') : selection.label;
         }, '');
     return (
-      <StyledEuiButtonEmpty
+      <EuiButtonEmpty
         data-test-subj="group-selector-dropdown"
         flush="both"
         iconSide="right"
@@ -131,7 +131,7 @@ const GroupSelectorComponent = ({
         size="xs"
       >
         {`${title}: ${buttonLabel}`}
-      </StyledEuiButtonEmpty>
+      </EuiButtonEmpty>
     );
   }, [groupsSelected, isGroupSelected, onButtonClick, selectedOptions, title]);
 

--- a/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
@@ -10,9 +10,8 @@
 import type {
   EuiContextMenuPanelDescriptor,
   EuiContextMenuPanelItemDescriptor,
-  EuiButtonEmpty,
 } from '@elastic/eui';
-import { EuiPopover } from '@elastic/eui';
+import { EuiPopover, EuiButtonEmpty } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import { CustomFieldPanel } from './custom_field_panel';

--- a/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
@@ -10,6 +10,7 @@
 import type {
   EuiContextMenuPanelDescriptor,
   EuiContextMenuPanelItemDescriptor,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import { EuiPopover } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';

--- a/src/platform/packages/shared/kbn-grouping/src/components/styles.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/styles.tsx
@@ -110,14 +110,3 @@ export const StyledContextMenu = euiStyled(EuiContextMenu)`
     border: none;
   }
 `;
-
-export const StyledEuiButtonEmpty = euiStyled(EuiButtonEmpty)`
-  font-weight: 'normal';
-
-  .euiButtonEmpty__text {
-    max-width: 300px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-`;

--- a/src/platform/packages/shared/kbn-grouping/src/components/styles.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/styles.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiButtonEmpty, EuiContextMenu } from '@elastic/eui';
+import { EuiContextMenu } from '@elastic/eui';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { css } from '@emotion/react';
 import { euiThemeVars } from '@kbn/ui-theme';

--- a/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
+++ b/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
@@ -18,7 +18,6 @@ import {
   EuiIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import { CoreStart } from '@kbn/core/public';
 import { useFetchStream } from '@kbn/ml-response-stream/client';
 
@@ -148,11 +147,6 @@ export const StreamingResponse = ({
     <EuiPanel color="primary">
       <EuiAccordion
         id={`streamingResponse`}
-        css={css`
-          .euiButtonIcon {
-            color: ${euiTheme.colors.primaryText};
-          }
-        `}
         buttonContent={
           <EuiFlexGroup direction="row" alignItems="center">
             <EuiFlexItem grow>

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/filter_activity.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/filter_activity.tsx
@@ -8,7 +8,6 @@
 import React, { useCallback } from 'react';
 import { EuiFilterGroup, EuiFilterButton } from '@elastic/eui';
 
-import { css } from '@emotion/react';
 import type { CaseUserActionsStats } from '../../containers/types';
 import * as i18n from './translations';
 import type { UserActivityFilter } from './types';
@@ -32,22 +31,9 @@ export const FilterActivity = React.memo<FilterActivityProps>(
     );
 
     return (
-      <EuiFilterGroup
-        data-test-subj="user-actions-filter-activity-group"
-        css={css`
-          > .euiFilterButton-hasNotification {
-            min-width: 68px;
-          }
-        `}
-      >
+      <EuiFilterGroup data-test-subj="user-actions-filter-activity-group">
         <EuiFilterButton
           withNext
-          css={css`
-            &,
-            & .euiFilterButton__text {
-              min-width: 28px;
-            }
-          `}
           grow={false}
           onClick={() => handleFilterChange('all')}
           isToggle

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/rule_quick_edit_buttons.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/rule_quick_edit_buttons.tsx
@@ -8,9 +8,8 @@
 import { i18n } from '@kbn/i18n';
 import { KueryNode } from '@kbn/es-query';
 import React, { useMemo, useCallback, useState } from 'react';
-import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiButtonEmpty, EuiFlexItem, EuiFlexGroup, useEuiTheme } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 
 import { RuleTableItem, BulkEditActions, UpdateRulesToBulkEditProps } from '../../../../types';
 import {
@@ -54,13 +53,6 @@ export const RuleQuickEditButtons: React.FunctionComponent<ComponentOpts> = ({
     notifications: { toasts },
   } = useKibana().services;
 
-  const { euiTheme } = useEuiTheme();
-
-  const bulkDeleteButtonCss = css`
-    .euiButtonEmpty__text {
-      padding-top: ${euiTheme.size.xs};
-    }
-  `;
   const [isUntrackAlertsModalOpen, setIsUntrackAlertsModalOpen] = useState<boolean>(false);
 
   const isPerformingAction = isEnablingRules || isDisablingRules || isBulkEditing;
@@ -367,7 +359,6 @@ export const RuleQuickEditButtons: React.FunctionComponent<ComponentOpts> = ({
             color="danger"
             isDisabled={isPerformingAction || hasDisabledByLicenseRuleTypes}
             data-test-subj="bulkDelete"
-            css={bulkDeleteButtonCss}
             className="actBulkActionPopover__deleteAll"
           >
             <FormattedMessage


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps] Check if we override EuiButton & EuiFilter styles (#222528)](https://github.com/elastic/kibana/pull/222528)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2025-06-16T08:35:15Z","message":"[ResponseOps] Check if we override EuiButton & EuiFilter styles (#222528)\n\nCloses https://github.com/elastic/kibana/issues/220464\n\n## Summary\n\nAs part of the EUI button style updates, I reviewed the RO files for any\nCSS class overrides affecting `euiButton` and `euiFilter` components. I\nfound some custom CSS overrides and I was able to safely remove them.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e987cdbb55b68f7477ae727e37968e9c334a8ffa","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0"],"title":"[ResponseOps] Check if we override EuiButton & EuiFilter styles","number":222528,"url":"https://github.com/elastic/kibana/pull/222528","mergeCommit":{"message":"[ResponseOps] Check if we override EuiButton & EuiFilter styles (#222528)\n\nCloses https://github.com/elastic/kibana/issues/220464\n\n## Summary\n\nAs part of the EUI button style updates, I reviewed the RO files for any\nCSS class overrides affecting `euiButton` and `euiFilter` components. I\nfound some custom CSS overrides and I was able to safely remove them.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e987cdbb55b68f7477ae727e37968e9c334a8ffa"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222528","number":222528,"mergeCommit":{"message":"[ResponseOps] Check if we override EuiButton & EuiFilter styles (#222528)\n\nCloses https://github.com/elastic/kibana/issues/220464\n\n## Summary\n\nAs part of the EUI button style updates, I reviewed the RO files for any\nCSS class overrides affecting `euiButton` and `euiFilter` components. I\nfound some custom CSS overrides and I was able to safely remove them.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e987cdbb55b68f7477ae727e37968e9c334a8ffa"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->