### PR TITLE
[8.18] Remove unnecessary try catch in the APM user filters (#224014)

### DIFF
--- a/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.test.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isPlainObject } from 'lodash';
+import { piiFilter } from './pii_filter';
+
+interface Payload {
+  context?: {
+    user?: any;
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+const isPayload = (result: unknown): result is Payload => isPlainObject(result) && result !== null;
+
+describe('piiFilter', () => {
+  it('redacts all keys in a valid user object', () => {
+    const payload: Payload = {
+      context: {
+        user: {
+          id: '123',
+          username: 'alice',
+          email: 'alice@example.com',
+        },
+      },
+    };
+    const result = piiFilter({ ...payload });
+    expect(isPayload(result) && result.context?.user).toEqual({
+      id: '[REDACTED]',
+      username: '[REDACTED]',
+      email: '[REDACTED]',
+    });
+  });
+
+  it('replaces non-object user context with { id: "[INVALID]" }', () => {
+    const payloads: Payload[] = [
+      { context: { user: 'not-an-object' } },
+      { context: { user: 42 } },
+      { context: { user: null } },
+      { context: { user: undefined } },
+
+      { context: { user: [1, 2, 3] } },
+    ];
+    for (const payload of payloads) {
+      const result = piiFilter({ ...payload });
+      expect(isPayload(result) && result.context?.user).toEqual({ id: '[INVALID]' });
+    }
+  });
+
+  it('replaces user context with { id: "[INVALID]" } on any error', () => {
+    const payloads: Payload[] = [
+      // Proxy is not a valid user context
+      {
+        context: {
+          user: new Proxy(
+            { username: 'alice' },
+            {
+              set(target, prop) {
+                if (prop === 'username') {
+                  throw new Error('Access denied');
+                }
+                return true;
+              },
+            }
+          ),
+        },
+      },
+      // Object.freeze is not a valid user context
+      { context: { user: Object.freeze({ username: 'alice' }) } },
+    ];
+
+    for (const payload of payloads) {
+      const result = piiFilter({ ...payload });
+      expect(isPayload(result) && result.context?.user).toEqual({ id: '[INVALID]' });
+    }
+  });
+
+  it('does not modify payloads without user context', () => {
+    const payload: Payload = { context: {} };
+    const result = piiFilter({ ...payload });
+    expect(result).toEqual(payload);
+  });
+
+  it('does not throw if context is missing', () => {
+    const payload: Payload = {};
+    expect(() => piiFilter({ ...payload })).not.toThrow();
+    expect(piiFilter({ ...payload })).toEqual(payload);
+  });
+});

--- a/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/filters/pii_filter.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FilterFn } from 'elastic-apm-node';
+import { isPlainObject, has } from 'lodash';
+
+export const piiFilter: FilterFn = (payload) => {
+  try {
+    // if user context is defined, apply the pii filter
+    if (has(payload.context, 'user')) {
+      // if the user context has loopable properties, redact the values
+      if (payload.context.user != null && isPlainObject(payload.context.user)) {
+        const userContextKeys = Object.keys(payload.context.user);
+        for (const key of userContextKeys) {
+          payload.context.user[key] = '[REDACTED]';
+        }
+      } else {
+        // Replace with a known invalid object to avoid APM trace discards
+        payload.context.user = { id: '[INVALID]' };
+      }
+    }
+  } catch (error) {
+    // If there's an error for any reason in the context access, override the whole user context.
+    Object.assign(payload.context, { user: { id: '[INVALID]' } });
+  }
+
+  return payload;
+};

--- a/src/platform/packages/private/kbn-apm-config-loader/src/init_apm.ts
+++ b/src/platform/packages/private/kbn-apm-config-loader/src/init_apm.ts
@@ -8,6 +8,7 @@
  */
 
 import { loadConfiguration } from './config_loader';
+import { piiFilter } from './filters/pii_filter';
 
 export const initApm = (
   argv: string[],
@@ -25,18 +26,7 @@ export const initApm = (
 
   // Filter out all user PII
   if (shouldRedactUsers) {
-    apm.addFilter((payload: Record<string, any>) => {
-      try {
-        if (payload.context?.user && typeof payload.context.user === 'object') {
-          Object.keys(payload.context.user).forEach((key) => {
-            payload.context.user[key] = '[REDACTED]';
-          });
-        }
-      } catch (e) {
-        // just silently ignore the error
-      }
-      return payload;
-    });
+    apm.addFilter(piiFilter);
   }
 
   apm.start(apmConfig);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Remove unnecessary try catch in the APM user filters (#224014)](https://github.com/elastic/kibana/pull/224014)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ahmad Bamieh","email":"ahmad.bamyeh@elastic.co"},"sourceCommit":{"committedDate":"2025-06-16T10:28:40Z","message":"Remove unnecessary try catch in the APM user filters (#224014)\n\n## Summary\n\nImproves the IF statement to ensure that we are dealing with an object\nwith loopable keys and remove the try-catch. If not loopable, we might\nwant to remove the user context entirely (or replace it with a known\nobject { id: '[INVALID]' }) since it might lead to APM traces being\ndiscarded due to invalid user context.\n\ncloses https://github.com/elastic/kibana/issues/219095","sha":"a77f6f0cc93d147675113261354d445c7f85860e","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","v9.1.0","v9.0.3"],"title":"Remove unnecessary try catch in the APM user filters","number":224014,"url":"https://github.com/elastic/kibana/pull/224014","mergeCommit":{"message":"Remove unnecessary try catch in the APM user filters (#224014)\n\n## Summary\n\nImproves the IF statement to ensure that we are dealing with an object\nwith loopable keys and remove the try-catch. If not loopable, we might\nwant to remove the user context entirely (or replace it with a known\nobject { id: '[INVALID]' }) since it might lead to APM traces being\ndiscarded due to invalid user context.\n\ncloses https://github.com/elastic/kibana/issues/219095","sha":"a77f6f0cc93d147675113261354d445c7f85860e"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224014","number":224014,"mergeCommit":{"message":"Remove unnecessary try catch in the APM user filters (#224014)\n\n## Summary\n\nImproves the IF statement to ensure that we are dealing with an object\nwith loopable keys and remove the try-catch. If not loopable, we might\nwant to remove the user context entirely (or replace it with a known\nobject { id: '[INVALID]' }) since it might lead to APM traces being\ndiscarded due to invalid user context.\n\ncloses https://github.com/elastic/kibana/issues/219095","sha":"a77f6f0cc93d147675113261354d445c7f85860e"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->