### PR TITLE
[OBX-UX-MGTM][BUG] Log threshold rule preview chart doesn't work when groupBy is applied

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_chart_preview.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_chart_preview.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { addHistogramAggregationToQuery } from './log_threshold_chart_preview';
+
+describe('addHistogramAggregationToQuery', () => {
+  const rangeFilter = {
+    range: {
+      '@timestamp': {
+        gte: 'now-1h/h',
+        lte: 'now',
+      },
+    },
+  };
+
+  const interval = '1m';
+  const timestampField = '@timestamp';
+
+  it('should add histogram aggregation to a non-grouped query', () => {
+    const query = {
+      query: {
+        match_all: {},
+      },
+    };
+
+    const result = addHistogramAggregationToQuery(
+      query,
+      rangeFilter,
+      interval,
+      timestampField,
+      false
+    );
+
+    expect(result.aggregations).toHaveProperty('histogramBuckets');
+    expect(result.aggregations!.histogramBuckets).toEqual({
+      date_histogram: {
+        field: '@timestamp',
+        fixed_interval: '1m',
+        extended_bounds: {
+          min: 'now-1h/h',
+          max: 'now',
+        },
+      },
+    });
+  });
+
+  it('should add histogram inside grouped query (optimized case)', () => {
+    const query = {
+      aggregations: {
+        groups: {
+          terms: {
+            field: 'user.id',
+          },
+          aggregations: {},
+        },
+      },
+    };
+
+    const result = addHistogramAggregationToQuery(
+      query,
+      rangeFilter,
+      interval,
+      timestampField,
+      true
+    );
+
+    expect(result.aggregations!.groups.aggregations).toHaveProperty('histogramBuckets');
+    expect(result.aggregations!.groups.aggregations!.histogramBuckets).toEqual({
+      date_histogram: {
+        field: '@timestamp',
+        fixed_interval: '1m',
+        extended_bounds: {
+          min: 'now-1h/h',
+          max: 'now',
+        },
+      },
+    });
+  });
+
+  it('should add histogram inside filtered_results if it exists (non-optimized case)', () => {
+    const query = {
+      aggregations: {
+        groups: {
+          terms: {
+            field: 'user.id',
+          },
+          aggregations: {
+            filtered_results: {
+              filter: {
+                term: { status: 'ok' },
+              },
+              aggregations: {},
+            },
+          },
+        },
+      },
+    };
+
+    const result = addHistogramAggregationToQuery(
+      query,
+      rangeFilter,
+      interval,
+      timestampField,
+      true
+    );
+
+    expect(result.aggregations!.groups.aggregations!.filtered_results.aggregations).toHaveProperty(
+      'histogramBuckets'
+    );
+    expect(
+      result.aggregations!.groups.aggregations!.filtered_results.aggregations!.histogramBuckets
+    ).toEqual({
+      date_histogram: {
+        field: '@timestamp',
+        fixed_interval: '1m',
+        extended_bounds: {
+          min: 'now-1h/h',
+          max: 'now',
+        },
+      },
+    });
+  });
+
+  it('should return the original query if grouped but required structure is missing', () => {
+    const query = {
+      aggregations: {},
+    };
+
+    const result = addHistogramAggregationToQuery(
+      query,
+      rangeFilter,
+      interval,
+      timestampField,
+      true
+    );
+
+    expect(result).toEqual(query);
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.test.ts
@@ -221,37 +221,36 @@ describe('Log threshold executor', () => {
           index: 'filebeat-*',
           allow_no_indices: true,
           ignore_unavailable: true,
-          body: {
-            track_total_hits: true,
-            aggregations: {},
-            query: {
-              bool: {
-                filter: [
-                  {
-                    range: {
-                      '@timestamp': {
-                        gte: expect.any(Number),
-                        lte: expect.any(Number),
-                        format: 'epoch_millis',
-                      },
+
+          track_total_hits: true,
+          aggregations: {},
+          query: {
+            bool: {
+              filter: [
+                {
+                  range: {
+                    '@timestamp': {
+                      gte: expect.any(Number),
+                      lte: expect.any(Number),
+                      format: 'epoch_millis',
                     },
                   },
-                  ...expectedPositiveFilterClauses,
-                ],
-                must_not: [...expectedNegativeFilterClauses],
-              },
-            },
-            runtime_mappings: {
-              runtime_field: {
-                type: 'keyword',
-                script: {
-                  lang: 'painless',
-                  source: 'emit("a runtime value")',
                 },
+                ...expectedPositiveFilterClauses,
+              ],
+              must_not: [...expectedNegativeFilterClauses],
+            },
+          },
+          runtime_mappings: {
+            runtime_field: {
+              type: 'keyword',
+              script: {
+                lang: 'painless',
+                source: 'emit("a runtime value")',
               },
             },
-            size: 0,
           },
+          size: 0,
         });
       });
 

--- a/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
@@ -818,7 +818,7 @@ export const getUngroupedESQuery = (
   index: string,
   runtimeMappings: estypes.MappingRuntimeFields,
   executionTimeRange?: ExecutionTimeRange
-): object => {
+): estypes.SearchRequest => {
   const { rangeFilter, mustFilters, mustNotFilters } = buildFiltersFromCriteria(
     params,
     timestampField,
@@ -845,7 +845,7 @@ export const getUngroupedESQuery = (
     index,
     allow_no_indices: true,
     ignore_unavailable: true,
-    body,
+    ...body,
   };
 };
 


### PR DESCRIPTION
## Summary
Related to https://github.com/elastic/kibana/pull/208776
It fixes #220007 by applying the update of the ES client to 9.0.0-alpha.3. 
### Note
No backport to 9.0 as the issue was [introduced in 9.1 only](https://github.com/elastic/kibana/pull/208776#issuecomment-2682267017). 

<img width="1137" alt="Screenshot 2025-06-16 at 15 45 08" src="https://github.com/user-attachments/assets/9cffcc33-8b3d-422e-a34f-d380bd6446cd" />


