### PR TITLE
Remove tech preview designation from session invalidation API

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -46955,7 +46955,6 @@ paths:
       summary: Invalidate user sessions
       tags:
         - user session
-      x-state: Technical Preview
   /api/short_url:
     post:
       description: |

--- a/x-pack/platform/plugins/shared/security/docs/openapi/user_session_apis.yaml
+++ b/x-pack/platform/plugins/shared/security/docs/openapi/user_session_apis.yaml
@@ -17,7 +17,6 @@ paths:
       summary: Invalidate user sessions
       tags:
         - user session
-      x-state: Technical Preview
       description: >
         Invalidate user sessions that match a query.
         To use this API, you must be a superuser.
@@ -82,7 +81,7 @@ paths:
               invalidateRequestExample2:
                 summary: Invalidate all SAML sessions
                 description: Run `POST api/security/session/_invalidate` to invalidate sessions that were created by any SAML authentication provider.
-                value: |-              
+                value: |-
                   {
                     "match" : "query",
                     "query": {


### PR DESCRIPTION
## Summary

Removes the tech preview designation from the session invalidation API.

Resolves https://github.com/elastic/kibana/issues/224070

## Release Note
The Session Invalidation API is now marked as Stable.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->