### PR TITLE
[Custom threshold] Add grouping information for no data alerts

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/lib/get_data.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/lib/get_data.ts
@@ -141,20 +141,21 @@ export const getData = async (
         const bucketHits = additionalContext?.hits?.hits;
         const additionalContextSource =
           bucketHits && bucketHits.length > 0 ? bucketHits[0]._source : null;
+        const flattenGrouping: Record<string, string> = {};
+        const groups: string[] = typeof groupBy === 'string' ? [groupBy] : groupBy ?? [];
+        groups.map((group: string, groupIndex) => {
+          flattenGrouping[group] = bucket.key[`groupBy${groupIndex}`];
+        });
 
         if (missingGroup && missingGroup.value > 0) {
           previous[key] = {
             trigger: false,
             value: null,
             bucketKey: bucket.key,
+            flattenGrouping,
           };
         } else {
           const value = aggregatedValue ? aggregatedValue.value : null;
-          const flattenGrouping: Record<string, string> = {};
-          const groups: string[] = typeof groupBy === 'string' ? [groupBy] : groupBy ?? [];
-          groups.map((group: string, groupIndex) => {
-            flattenGrouping[group] = bucket.key[`groupBy${groupIndex}`];
-          });
 
           previous[key] = {
             trigger: (shouldTrigger && shouldTrigger.value > 0) || false,


### PR DESCRIPTION
## Summary

This PR includes grouping information in the alert document for no data alerts.

![image](https://github.com/user-attachments/assets/ce037531-be0e-43a8-a855-3bb7b71fb976)

### 🧪 How to test
- Trigger a no data alert for the custom threshold rule which has a group by field
- Check the alert document, you should see a `kibana.alert.grouping` + grouping field name for the related group value



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->