### PR TITLE
[Share] Convert Share registry to async registry

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 import useMountedState from 'react-use/lib/useMountedState';
@@ -259,10 +259,22 @@ export const useDashboardMenuItems = ({
    */
   const isLabsEnabled = useMemo(() => coreServices.uiSettings.get(UI_SETTINGS.ENABLE_LABS_UI), []);
 
-  const hasExportIntegration = Boolean(
-    shareService?.availableIntegrations('dashboard', 'export')?.length
-  );
+  const [hasExportIntegration, setHasExportIntegration] = useState(false);
+  useEffect(() => {
+    let canceled = false;
+    const checkExportIntegration = async () => {
+      if (shareService) {
+        const integrations = await shareService.availableIntegrations('dashboard', 'export');
+        if (canceled) return;
 
+        setHasExportIntegration(integrations.length > 0);
+      }
+    };
+    checkExportIntegration();
+    return () => {
+      canceled = true;
+    };
+  }, []);
   const viewModeTopNavConfig = useMemo(() => {
     const { showWriteControls } = getDashboardCapabilities();
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
@@ -24,10 +24,12 @@ export const getShareAppMenuItem = ({
   discoverParams,
   services,
   stateContainer,
+  hasIntegrations,
 }: {
   discoverParams: AppMenuDiscoverParams;
   services: DiscoverServices;
   stateContainer: DiscoverStateContainer;
+  hasIntegrations: boolean;
 }): AppMenuActionPrimary[] => {
   if (!services.share) {
     return [];
@@ -170,7 +172,7 @@ export const getShareAppMenuItem = ({
     },
   ];
 
-  if (Boolean(services.share?.availableIntegrations('search', 'export')?.length)) {
+  if (hasIntegrations) {
     menuItems.unshift({
       id: AppMenuActionId.export,
       type: AppMenuActionType.primary,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -21,6 +21,7 @@ import type { DiscoverStateContainer } from '../../state_management/discover_sta
 import { getTopNavBadges } from './get_top_nav_badges';
 import { useTopNavLinks } from './use_top_nav_links';
 import { useAdHocDataViews, useCurrentDataView } from '../../state_management/redux';
+import { useHasShareIntegration } from '../../hooks/use_has_share_integration';
 
 export const useDiscoverTopNav = ({
   stateContainer,
@@ -54,6 +55,7 @@ export const useDiscoverTopNav = ({
     inspector: services.inspector,
     stateContainer,
   });
+  const hasShareIntegration = useHasShareIntegration(services);
 
   const topNavMenu = useTopNavLinks({
     dataView,
@@ -64,6 +66,7 @@ export const useDiscoverTopNav = ({
     adHocDataViews,
     topNavCustomization,
     shouldShowESQLToDataViewTransitionModal,
+    hasShareIntegration,
   });
 
   return {

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -59,6 +59,7 @@ export const useTopNavLinks = ({
   adHocDataViews,
   topNavCustomization,
   shouldShowESQLToDataViewTransitionModal,
+  hasShareIntegration,
 }: {
   dataView: DataView | undefined;
   services: DiscoverServices;
@@ -68,6 +69,7 @@ export const useTopNavLinks = ({
   adHocDataViews: DataView[];
   topNavCustomization: TopNavCustomization | undefined;
   shouldShowESQLToDataViewTransitionModal: boolean;
+  hasShareIntegration: boolean;
 }): TopNavMenuData[] => {
   const dispatch = useInternalStateDispatch();
   const currentDataView = useCurrentDataView();
@@ -158,6 +160,7 @@ export const useTopNavLinks = ({
           discoverParams,
           services,
           stateContainer: state,
+          hasIntegrations: hasShareIntegration,
         });
         items.push(...shareAppMenuItem);
       }
@@ -171,6 +174,7 @@ export const useTopNavLinks = ({
       state,
       isEsqlMode,
       currentDataView,
+      hasShareIntegration,
     ]);
 
   const getAppMenuAccessor = useProfileAccessor('getAppMenu');

--- a/src/platform/plugins/shared/discover/public/application/main/hooks/use_has_share_integration.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/hooks/use_has_share_integration.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEffect, useState } from 'react';
+import type { DiscoverServices } from '../../../build_services';
+
+export function useHasShareIntegration({ share }: DiscoverServices) {
+  const [hasShareIntegration, setHasShareIntegration] = useState<boolean>(false);
+
+  useEffect(() => {
+    let canceled = false;
+    if (!share) return;
+    const checkShareIntegration = async () => {
+      const integrations = await share.availableIntegrations('search', 'export');
+      if (!canceled) {
+        setHasShareIntegration(integrations.length > 0);
+      }
+    };
+
+    checkShareIntegration();
+
+    return () => {
+      canceled = true;
+    };
+  }, [share]);
+
+  return hasShareIntegration;
+}

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -225,11 +225,15 @@ export interface SharingData {
   };
 }
 
-interface ShareRegistryInternalApi {
-  registerShareIntegration<I extends ShareIntegration>(shareObject: string, arg: I): void;
-  registerShareIntegration<I extends ShareIntegration>(arg: I): void;
+export type ShareIntegrationMapKey = `integration-${string}`;
+export interface ShareRegistryInternalApi {
+  registerShareIntegration<I extends ShareIntegration>(
+    shareObject: string,
+    key: ShareIntegrationMapKey,
+    getShareActionIntent: () => Promise<I>
+  ): void;
 
-  resolveShareItemsForShareContext(args: ShareContext): ShareConfigs[];
+  resolveShareItemsForShareContext(args: ShareContext): Promise<ShareConfigs[]>;
 }
 
 export abstract class ShareRegistryPublicApi {

--- a/x-pack/platform/plugins/private/reporting/public/plugin.ts
+++ b/x-pack/platform/plugins/private/reporting/public/plugin.ts
@@ -22,12 +22,7 @@ import { durationToNumber } from '@kbn/reporting-common';
 import type { ClientConfigType } from '@kbn/reporting-public';
 import { ReportingAPIClient } from '@kbn/reporting-public';
 
-import {
-  getSharedComponents,
-  reportingCsvExportProvider,
-  reportingPDFExportProvider,
-  reportingPNGExportProvider,
-} from '@kbn/reporting-public/share';
+import { getSharedComponents } from '@kbn/reporting-public/share/shared';
 import { ReportingCsvPanelAction } from '@kbn/reporting-csv-share-panel';
 import { InjectedIntl } from '@kbn/i18n-react';
 import type { ReportingSetup, ReportingStart } from '.';
@@ -209,28 +204,42 @@ export class ReportingPublicPlugin
 
     shareSetup.registerShareIntegration<ExportShare>(
       'search',
-      // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
-      reportingCsvExportProvider({
-        apiClient,
-        startServices$,
-      })
+      'integration-export-csvReports',
+      async () => {
+        // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
+        const { reportingCsvExportProvider } = await import('@kbn/reporting-public/share');
+        return reportingCsvExportProvider({
+          apiClient,
+          startServices$,
+        });
+      }
     );
 
     if (this.config.export_types.pdf.enabled || this.config.export_types.png.enabled) {
       shareSetup.registerShareIntegration<ExportShare>(
-        // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
-        reportingPDFExportProvider({
-          apiClient,
-          startServices$,
-        })
+        'search',
+        'integration-export-pdfReports',
+        async () => {
+          // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
+          const { reportingPDFExportProvider } = await import('@kbn/reporting-public/share');
+          return reportingPDFExportProvider({
+            apiClient,
+            startServices$,
+          });
+        }
       );
 
       shareSetup.registerShareIntegration<ExportShare>(
-        // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
-        reportingPNGExportProvider({
-          apiClient,
-          startServices$,
-        })
+        'search',
+        'integration-export-imageReports',
+        async () => {
+          // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
+          const { reportingPNGExportProvider } = await import('@kbn/reporting-public/share');
+          return reportingPNGExportProvider({
+            apiClient,
+            startServices$,
+          });
+        }
       );
     }
 

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
@@ -483,12 +483,29 @@ export const LensTopNavMenu = ({
     isOnTextBasedMode,
   ]);
 
+  const [hasShareIntegration, setHasShareIntegration] = useState(false);
+
   useEffect(() => {
+    let canceled = false;
+    if (!share) return;
+    const checkShareIntegration = async () => {
+      if (canceled) {
+        return;
+      }
+      const integrations = await share.availableIntegrations('lens', 'export');
+      if (canceled) return;
+
+      setHasShareIntegration(integrations.length > 0);
+    };
+
+    checkShareIntegration();
     return () => {
+      canceled = true;
       // Make sure to close the editors when unmounting
       closeFieldEditor.current?.();
       closeDataViewEditor.current?.();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const { AggregateQueryTopNavMenu } = navigation.ui;
@@ -785,7 +802,7 @@ export const LensTopNavMenu = ({
         inspect: { visible: true, execute: () => lensInspector.inspect({ title }) },
         export: {
           // Only show the export button if the current user meets the requirements for at least one registered export integration
-          visible: Boolean(share?.availableIntegrations('lens', 'export')?.length),
+          visible: hasShareIntegration,
           enabled: showShareMenu,
           tooltip: () => {
             if (!showShareMenu) {
@@ -917,7 +934,7 @@ export const LensTopNavMenu = ({
     return [...(additionalMenuEntries || []), ...baseMenuEntries];
   }, [
     initialContext,
-    initialInput,
+    initialInput?.savedObjectId,
     isLinkedToOriginatingApp,
     initialContextIsEmbedded,
     activeData,
@@ -927,15 +944,12 @@ export const LensTopNavMenu = ({
     savingToLibraryPermitted,
     savingToDashboardPermitted,
     contextOriginatingApp,
+    hasShareIntegration,
     layerMetaInfo,
     additionalMenuEntries,
-    lensInspector,
-    title,
     share,
     visualization,
     visualizationMap,
-    shortUrlService,
-    data,
     filters,
     query,
     activeDatasourceId,
@@ -943,9 +957,13 @@ export const LensTopNavMenu = ({
     datasourceMap,
     currentDoc,
     adHocDataViews,
+    data,
     isCurrentStateDirty,
     dataViews.indexPatterns,
+    title,
     defaultLensTitle,
+    shortUrlService,
+    lensInspector,
     onAppLeave,
     runSave,
     setIsSaveModalVisible,

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -135,7 +135,6 @@ import { setupExpressions } from './expressions';
 import { OpenInDiscoverDrilldown } from './trigger_actions/open_in_discover_drilldown';
 import { ChartInfoApi } from './chart_info_api';
 import { type LensAppLocator, LensAppLocatorDefinition } from '../common/locator/locator';
-import { downloadCsvLensShareProvider } from './app_plugin/csv_download_provider/csv_download_provider';
 import { LensDocument } from './persistence/saved_object_store';
 import {
   CONTENT_ID,
@@ -428,19 +427,25 @@ export class LensPlugin {
 
       share.registerShareIntegration<ExportShare>(
         'lens',
-        downloadCsvLensShareProvider({
-          uiSettings: core.uiSettings,
-          formatFactoryFn: () => startServices().plugins.fieldFormats.deserialize,
-          atLeastGold: () => {
-            let isGold = false;
-            startServices()
-              .plugins.licensing?.license$.pipe()
-              .subscribe((license) => {
-                isGold = license.hasAtLeast('gold');
-              });
-            return isGold;
-          },
-        })
+        'integration-export-csvDownloadLens',
+        async () => {
+          const { downloadCsvLensShareProvider } = await import(
+            './app_plugin/csv_download_provider/csv_download_provider'
+          );
+          return downloadCsvLensShareProvider({
+            uiSettings: core.uiSettings,
+            formatFactoryFn: () => startServices().plugins.fieldFormats.deserialize,
+            atLeastGold: () => {
+              let isGold = false;
+              startServices()
+                .plugins.licensing?.license$.pipe()
+                .subscribe((license) => {
+                  isGold = license.hasAtLeast('gold');
+                });
+              return isGold;
+            },
+          });
+        }
       );
     }
 


### PR DESCRIPTION
WIP Currently not wired up to internal share contexts, but I've hit a wall trying to asynchronously load the menu items. Feel free to pick up where I left off or I can continue to work on it as I have time.

## Summary

Changes the Share registry in the share plugin to an async registry. 

### With this PR:
* The arguments to the `registerShareIntegration` method on `ShareRegistry` require a `shareObject`, `key`, and a function returning a Promise that returns the `ShareIntegration`. 
* `availableIntegrations` and `resolveShareItemsForShareContext` now return promises.
* Plugins register their integrations with a function returning a Promise. This allows lazy imports of modules which decreases the initial page load.

### TODO

- [ ] Update the `ShareContext` to asynchronously get the menuItems from the `resolveShareItemsForShareContext` promise.
- [ ] Update plugin usage of `availableIntegrations` to support promises.


### Preliminary initial page load decreases

I used `node scripts/build_kibana_platform_plugins --profile --no-cache --dist` to generate `metrics.json` files for all plugins in this branch and the main branch. And then manually compared the sizes in `metrics.json` for each plugin against the other branch.

| plugin | main | this branch |
|---|---|---|
| reporting | 52KB | 44KB |
| lens | 61KB | 59KB | 

### Reference

* [[uiActions] make trigger action registry async ](https://github.com/elastic/kibana/pull/205512)
* [[controls] lazy load control actions](https://github.com/elastic/kibana/pull/206876)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



