### PR TITLE
[8.19] [Unified search] Display the solutions recommended queries in the help menu (#223602)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-types/index.ts
+++ b/src/platform/packages/shared/kbn-esql-types/index.ts
@@ -34,3 +34,5 @@ export {
   type InferenceEndpointsAutocompleteResult,
   type InferenceEndpointAutocompleteItem,
 } from './src/inference_endpoint_autocomplete_types';
+
+export { REGISTRY_EXTENSIONS_ROUTE } from './src/constants';

--- a/src/platform/packages/shared/kbn-esql-types/src/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const REGISTRY_EXTENSIONS_ROUTE = '/internal/esql_registry/extensions/';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/index.ts
@@ -63,4 +63,6 @@ export {
 
 export { getRecommendedQueries } from './src/autocomplete/recommended_queries/templates';
 
+export { getRecommendedQueriesTemplatesFromExtensions } from './src/autocomplete/recommended_queries/suggestions';
+
 export { esqlFunctionNames } from './src/definitions/generated/function_names';

--- a/src/platform/plugins/shared/esql/public/plugin.ts
+++ b/src/platform/plugins/shared/esql/public/plugin.ts
@@ -16,7 +16,7 @@ import type { IndexManagementPluginSetup } from '@kbn/index-management-shared-ty
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
-import type { IndicesAutocompleteResult } from '@kbn/esql-types';
+import { type IndicesAutocompleteResult, REGISTRY_EXTENSIONS_ROUTE } from '@kbn/esql-types';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { InferenceEndpointsAutocompleteResult } from '@kbn/esql-types';
 import { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
@@ -137,7 +137,7 @@ export class EsqlPlugin implements Plugin<{}, EsqlPluginStart> {
       activeSolutionId: SolutionId
     ) => {
       const result = await core.http.get(
-        `/internal/esql_registry/extensions/${activeSolutionId}/${queryString}`
+        `${REGISTRY_EXTENSIONS_ROUTE}${activeSolutionId}/${queryString}`
       );
       return result;
     };

--- a/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
@@ -8,7 +8,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
-import type { ResolveIndexResponse } from '@kbn/esql-types';
+import { type ResolveIndexResponse, REGISTRY_EXTENSIONS_ROUTE } from '@kbn/esql-types';
 import type { ESQLExtensionsRegistry } from '../extensions_registry';
 
 type SolutionId = 'es' | 'oblt' | 'security';
@@ -37,7 +37,7 @@ export const registerESQLExtensionsRoute = (
 ) => {
   router.get(
     {
-      path: '/internal/esql_registry/extensions/{solutionId}/{query}',
+      path: `${REGISTRY_EXTENSIONS_ROUTE}{solutionId}/{query}`,
       security: {
         authz: {
           enabled: false,

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/esql_menu_popover.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/esql_menu_popover.test.tsx
@@ -8,7 +8,8 @@
  */
 
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import { screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { stubIndexPattern } from '@kbn/data-plugin/public/stubs';
@@ -16,18 +17,33 @@ import { coreMock } from '@kbn/core/public/mocks';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { ESQLMenuPopover } from './esql_menu_popover';
 
+const startMock = coreMock.createStart();
+// Mock the necessary services
+startMock.chrome.getActiveSolutionNavId$.mockReturnValue(new BehaviorSubject('oblt'));
+const httpModule = {
+  http: {
+    get: jest.fn().mockResolvedValue({ recommendedQueries: [] }), // Mock the HTTP GET request
+  },
+};
+const services = {
+  docLinks: startMock.docLinks,
+  http: httpModule.http,
+  chrome: startMock.chrome,
+};
+
 describe('ESQLMenuPopover', () => {
   const renderESQLPopover = (adHocDataview?: DataView) => {
-    const startMock = coreMock.createStart();
-    const services = {
-      docLinks: startMock.docLinks,
-    };
     return render(
       <KibanaContextProvider services={services}>
         <ESQLMenuPopover adHocDataview={adHocDataview} />
       </KibanaContextProvider>
     );
   };
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    httpModule.http.get.mockClear();
+  });
 
   it('should render a button', () => {
     renderESQLPopover();
@@ -46,6 +62,54 @@ describe('ESQLMenuPopover', () => {
 
   it('should have recommended queries if a dataview is passed', async () => {
     renderESQLPopover(stubIndexPattern);
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.queryByTestId('esql-recommended-queries')).toBeInTheDocument();
+  });
+
+  it('should fetch ESQL extensions when activeSolutionId and queryForRecommendedQueries are present and the popover is open', async () => {
+    const mockQueries = [
+      { name: 'Count of logs', query: 'FROM logstash1 | STATS COUNT()' },
+      { name: 'Average bytes', query: 'FROM logstash2 | STATS AVG(bytes) BY log.level' },
+    ];
+
+    // Configure the mock to resolve with mockQueries
+    httpModule.http.get.mockResolvedValueOnce({ recommendedQueries: mockQueries });
+
+    renderESQLPopover(stubIndexPattern);
+    const esqlQuery = `FROM ${stubIndexPattern.name}`;
+
+    // Assert that http.get was called with the correct URL
+    await waitFor(() => {
+      expect(httpModule.http.get).toHaveBeenCalledTimes(1);
+      expect(httpModule.http.get).toHaveBeenCalledWith(
+        `/internal/esql_registry/extensions/oblt/${esqlQuery}`
+      );
+    });
+
+    // open the popover and check for recommended queries
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.queryByTestId('esql-recommended-queries')).toBeInTheDocument();
+    // Open the nested section to see the recommended queries
+    await waitFor(() => userEvent.click(screen.getByTestId('esql-recommended-queries')));
+
+    await waitFor(() => {
+      expect(screen.getByText('Count of logs')).toBeInTheDocument();
+      expect(screen.getByText('Average bytes')).toBeInTheDocument();
+    });
+  });
+
+  it('should handle API call failure gracefully', async () => {
+    // Configure the mock to reject with an error
+    httpModule.http.get.mockRejectedValueOnce(new Error('Network error'));
+
+    renderESQLPopover(stubIndexPattern);
+    // Assert that http.get was called (even if it failed)
+    await waitFor(() => {
+      expect(httpModule.http.get).toHaveBeenCalledTimes(1);
+    });
+
+    // The catch block does nothing, so we assert that no error is thrown
+    // and that the static recommended queries are still shown.
     await userEvent.click(screen.getByRole('button'));
     expect(screen.queryByTestId('esql-recommended-queries')).toBeInTheDocument();
   });

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/esql_menu_popover.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/esql_menu_popover.tsx
@@ -6,20 +6,27 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import {
   EuiPopover,
   EuiButton,
   type EuiContextMenuPanelDescriptor,
   EuiContextMenuItem,
   EuiContextMenu,
+  useEuiScrollBar,
 } from '@elastic/eui';
+import { isEqual } from 'lodash';
+import { css } from '@emotion/react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { FEEDBACK_LINK } from '@kbn/esql-utils';
-import { getRecommendedQueries } from '@kbn/esql-validation-autocomplete';
+import { type RecommendedQuery, REGISTRY_EXTENSIONS_ROUTE } from '@kbn/esql-types';
+import {
+  getRecommendedQueries,
+  getRecommendedQueriesTemplatesFromExtensions,
+} from '@kbn/esql-validation-autocomplete';
 import { LanguageDocumentationFlyout } from '@kbn/language-documentation';
 import type { IUnifiedSearchPluginServices } from '../types';
 
@@ -35,12 +42,65 @@ export const ESQLMenuPopover: React.FC<ESQLMenuPopoverProps> = ({
   onESQLQuerySubmit,
 }) => {
   const kibana = useKibana<IUnifiedSearchPluginServices>();
+  const { docLinks, http, chrome } = kibana.services;
 
-  const { docLinks } = kibana.services;
+  const activeSolutionId = useObservable(chrome.getActiveSolutionNavId$());
   const [isESQLMenuPopoverOpen, setIsESQLMenuPopoverOpen] = useState(false);
   const [isLanguageComponentOpen, setIsLanguageComponentOpen] = useState(false);
 
-  const toggleLanguageComponent = useCallback(async () => {
+  const [solutionsRecommendedQueries, setSolutionsRecommendedQueries] = useState<
+    RecommendedQuery[]
+  >([]);
+
+  const { queryForRecommendedQueries, timeFieldName } = useMemo(() => {
+    if (adHocDataview && typeof adHocDataview !== 'string') {
+      return {
+        queryForRecommendedQueries: `FROM ${adHocDataview.name}`,
+        timeFieldName:
+          adHocDataview.timeFieldName ?? adHocDataview.fields?.getByType('date')?.[0]?.name,
+      };
+    }
+    return {
+      queryForRecommendedQueries: '',
+      timeFieldName: undefined,
+    };
+  }, [adHocDataview]);
+
+  // Use a ref to store the *previous* fetched recommended queries
+  const lastFetchedQueries = useRef<RecommendedQuery[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const getESQLExtensions = async () => {
+      if (!activeSolutionId || !queryForRecommendedQueries) {
+        return; // Don't fetch if we don't have the active solution or query
+      }
+
+      try {
+        const extensions: { recommendedQueries: RecommendedQuery[] } = await http.get(
+          `${REGISTRY_EXTENSIONS_ROUTE}${activeSolutionId}/${queryForRecommendedQueries}`
+        );
+
+        if (cancelled) return;
+
+        // Only update state if the new data is actually different from the *last successfully set* data
+        if (!isEqual(extensions.recommendedQueries, lastFetchedQueries.current)) {
+          setSolutionsRecommendedQueries(extensions.recommendedQueries);
+          lastFetchedQueries.current = extensions.recommendedQueries; // Update the ref with the new data
+        }
+      } catch (error) {
+        // Do nothing if the extensions are not available
+      }
+    };
+
+    getESQLExtensions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSolutionId, http, queryForRecommendedQueries]);
+
+  const toggleLanguageComponent = useCallback(() => {
     setIsLanguageComponentOpen(!isLanguageComponentOpen);
     setIsESQLMenuPopoverOpen(false);
   }, [isLanguageComponentOpen]);
@@ -55,17 +115,29 @@ export const ESQLMenuPopover: React.FC<ESQLMenuPopoverProps> = ({
 
   const esqlContextMenuPanels = useMemo(() => {
     const recommendedQueries = [];
-    if (adHocDataview && typeof adHocDataview !== 'string') {
-      const queryString = `FROM ${adHocDataview.name}`;
-      const timeFieldName =
-        adHocDataview.timeFieldName ?? adHocDataview.fields?.getByType('date')?.[0]?.name;
+    // If there are specific recommended queries for the current solution, process them.
+    if (solutionsRecommendedQueries.length) {
+      // Extract the core query templates by removing the 'FROM' clause.
+      const recommendedQueriesTemplatesFromExtensions =
+        getRecommendedQueriesTemplatesFromExtensions(solutionsRecommendedQueries);
 
+      // Construct the full recommended queries by prepending the base 'FROM' command
+      // and add them to the main list of recommended queries.
       recommendedQueries.push(
-        ...getRecommendedQueries({
-          fromCommand: queryString,
-          timeField: timeFieldName,
-        })
+        ...recommendedQueriesTemplatesFromExtensions.map((template) => ({
+          label: template.label,
+          queryString: `${queryForRecommendedQueries}${template.text}`,
+        }))
       );
+    }
+    // Handle the static recommended queries, no solutions specific
+    if (queryForRecommendedQueries && timeFieldName) {
+      const recommendedQueriesFromStaticTemplates = getRecommendedQueries({
+        fromCommand: queryForRecommendedQueries,
+        timeField: timeFieldName,
+      });
+
+      recommendedQueries.push(...recommendedQueriesFromStaticTemplates);
     }
     const panels = [
       {
@@ -75,7 +147,7 @@ export const ESQLMenuPopover: React.FC<ESQLMenuPopoverProps> = ({
             name: i18n.translate('unifiedSearch.query.queryBar.esqlMenu.quickReference', {
               defaultMessage: 'Quick Reference',
             }),
-            icon: 'nedocumentationsted',
+            icon: 'nedocumentationsted', // Typo: Should be 'documentation'
             renderItem: () => (
               <EuiContextMenuItem
                 key="quickReference"
@@ -160,7 +232,21 @@ export const ESQLMenuPopover: React.FC<ESQLMenuPopoverProps> = ({
       },
     ];
     return panels as EuiContextMenuPanelDescriptor[];
-  }, [adHocDataview, docLinks.links.query.queryESQL, onESQLQuerySubmit, toggleLanguageComponent]);
+  }, [
+    docLinks.links.query.queryESQL,
+    onESQLQuerySubmit,
+    queryForRecommendedQueries,
+    timeFieldName,
+    toggleLanguageComponent,
+    solutionsRecommendedQueries, // This dependency is fine here, as it *uses* the state
+  ]);
+
+  const esqlMenuPopoverStyles = css`
+    width: 240px;
+    max-height: 350px;
+    overflow-y: auto;
+    ${useEuiScrollBar()};
+  `;
 
   return (
     <>
@@ -179,7 +265,7 @@ export const ESQLMenuPopover: React.FC<ESQLMenuPopoverProps> = ({
         }
         panelProps={{
           ['data-test-subj']: 'esql-menu-popover',
-          css: { width: 240 },
+          css: esqlMenuPopoverStyles,
         }}
         isOpen={isESQLMenuPopoverOpen}
         closePopover={() => setIsESQLMenuPopoverOpen(false)}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -11,6 +11,7 @@ import { mockPersistedLogFactory } from './query_string_input.test.mocks';
 
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { BehaviorSubject } from 'rxjs';
 import { render } from '@testing-library/react';
 import { EMPTY } from 'rxjs';
 
@@ -24,6 +25,7 @@ import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import { unifiedSearchPluginMock } from '../mocks';
 
 const startMock = coreMock.createStart();
+startMock.chrome.getActiveSolutionNavId$.mockReturnValue(new BehaviorSubject('oblt'));
 
 const mockTimeHistory = {
   get: () => {

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import SearchBar from './search_bar';
-
+import { BehaviorSubject } from 'rxjs';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { indexPatternEditorPluginMock as dataViewEditorPluginMock } from '@kbn/data-view-editor-plugin/public/mocks';
 import { I18nProvider } from '@kbn/i18n-react';
@@ -74,6 +74,10 @@ function wrapSearchBarInContext(testProps: any) {
   (dataViewEditorMock.userPermissions.editDataView as jest.Mock).mockReturnValue(true);
 
   const services = {
+    chrome: {
+      ...startMock.chrome,
+      getActiveSolutionNavId$: jest.fn().mockReturnValue(new BehaviorSubject('oblt')),
+    },
     uiSettings: startMock.uiSettings,
     settings: startMock.settings,
     savedObjects: startMock.savedObjects,

--- a/src/platform/plugins/shared/unified_search/public/types.ts
+++ b/src/platform/plugins/shared/unified_search/public/types.ts
@@ -88,6 +88,7 @@ export interface IUnifiedSearchPluginServices extends Partial<CoreStart> {
     autocomplete: AutocompleteStart;
   };
   appName: string;
+  chrome: CoreStart['chrome'];
   uiSettings: CoreStart['uiSettings'];
   savedObjects: CoreStart['savedObjects'];
   notifications: CoreStart['notifications'];

--- a/src/platform/plugins/shared/unified_search/tsconfig.json
+++ b/src/platform/plugins/shared/unified_search/tsconfig.json
@@ -48,7 +48,8 @@
     "@kbn/esql-validation-autocomplete",
     "@kbn/react-kibana-mount",
     "@kbn/field-utils",
-    "@kbn/language-documentation"
+    "@kbn/language-documentation",
+    "@kbn/esql-types"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Unified search] Display the solutions recommended queries in the help menu (#223602)](https://github.com/elastic/kibana/pull/223602)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-06-13T04:22:45Z","message":"[Unified search] Display the solutions recommended queries in the help menu (#223602)\n\n## Summary\n\nReopening of https://github.com/elastic/kibana/pull/223362\n\nIn https://github.com/elastic/kibana/pull/221474 we introduced the\nmechanism to register queries per solution at the editor.\n\nThis PR displays these queries in the unified search menu too. In the\nfollowing screenshot the 2 first queries are the oblt solution\nregistered queries. I also have a max-height just to be sure that this\nlist doesnt get too long now that the solutions can register queries.\n\n<img width=\"439\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8ca48b8a-1880-42f3-944f-dd1fb012661f\"\n/>\n\n### Note\n\nThis change won't display anything in the popover as no solution has\nregistered any queries yet. This PR sets the mechanism though on when\nthey will do so.\n\n### How to test\nIf you want to test it the fastest way is to go to the esql plugin\n(server side) and add (change the examples as you wish):\n\n```\nthis.extensionsRegistry.setRecommendedQueries(\n      [\n        {\n          name: 'Logs count by log level',\n          query: 'from logs* | STATS count(*) by log_level',\n        },\n        {\n          name: 'Apache logs counts',\n          query: 'from logs-apache_error | STATS count(*)',\n        },\n        {\n          name: 'Another index, not logs',\n          query: 'from movies | STATS count(*)',\n        },\n      ],\n      'oblt'\n    );\n\n```\nThen go to Discover (solutions mode) and type `from logs*` and hit the\nquery. Open the popover and check the 2 first recommendations are been\nsuggested.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"563abe2cac151f59162639658ba4a3017d15cfb1","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[Unified search] Display the solutions recommended queries in the help menu","number":223602,"url":"https://github.com/elastic/kibana/pull/223602","mergeCommit":{"message":"[Unified search] Display the solutions recommended queries in the help menu (#223602)\n\n## Summary\n\nReopening of https://github.com/elastic/kibana/pull/223362\n\nIn https://github.com/elastic/kibana/pull/221474 we introduced the\nmechanism to register queries per solution at the editor.\n\nThis PR displays these queries in the unified search menu too. In the\nfollowing screenshot the 2 first queries are the oblt solution\nregistered queries. I also have a max-height just to be sure that this\nlist doesnt get too long now that the solutions can register queries.\n\n<img width=\"439\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8ca48b8a-1880-42f3-944f-dd1fb012661f\"\n/>\n\n### Note\n\nThis change won't display anything in the popover as no solution has\nregistered any queries yet. This PR sets the mechanism though on when\nthey will do so.\n\n### How to test\nIf you want to test it the fastest way is to go to the esql plugin\n(server side) and add (change the examples as you wish):\n\n```\nthis.extensionsRegistry.setRecommendedQueries(\n      [\n        {\n          name: 'Logs count by log level',\n          query: 'from logs* | STATS count(*) by log_level',\n        },\n        {\n          name: 'Apache logs counts',\n          query: 'from logs-apache_error | STATS count(*)',\n        },\n        {\n          name: 'Another index, not logs',\n          query: 'from movies | STATS count(*)',\n        },\n      ],\n      'oblt'\n    );\n\n```\nThen go to Discover (solutions mode) and type `from logs*` and hit the\nquery. Open the popover and check the 2 first recommendations are been\nsuggested.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"563abe2cac151f59162639658ba4a3017d15cfb1"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223602","number":223602,"mergeCommit":{"message":"[Unified search] Display the solutions recommended queries in the help menu (#223602)\n\n## Summary\n\nReopening of https://github.com/elastic/kibana/pull/223362\n\nIn https://github.com/elastic/kibana/pull/221474 we introduced the\nmechanism to register queries per solution at the editor.\n\nThis PR displays these queries in the unified search menu too. In the\nfollowing screenshot the 2 first queries are the oblt solution\nregistered queries. I also have a max-height just to be sure that this\nlist doesnt get too long now that the solutions can register queries.\n\n<img width=\"439\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8ca48b8a-1880-42f3-944f-dd1fb012661f\"\n/>\n\n### Note\n\nThis change won't display anything in the popover as no solution has\nregistered any queries yet. This PR sets the mechanism though on when\nthey will do so.\n\n### How to test\nIf you want to test it the fastest way is to go to the esql plugin\n(server side) and add (change the examples as you wish):\n\n```\nthis.extensionsRegistry.setRecommendedQueries(\n      [\n        {\n          name: 'Logs count by log level',\n          query: 'from logs* | STATS count(*) by log_level',\n        },\n        {\n          name: 'Apache logs counts',\n          query: 'from logs-apache_error | STATS count(*)',\n        },\n        {\n          name: 'Another index, not logs',\n          query: 'from movies | STATS count(*)',\n        },\n      ],\n      'oblt'\n    );\n\n```\nThen go to Discover (solutions mode) and type `from logs*` and hit the\nquery. Open the popover and check the 2 first recommendations are been\nsuggested.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n\n\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"563abe2cac151f59162639658ba4a3017d15cfb1"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->