### PR TITLE
[8.19] [Response Ops][Connectors] New `xpack.actions.webhook.ssl.pfx.enabled` config (#222507)

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -196,6 +196,7 @@ enabled:
   - x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/config.ts
   - x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/with_aws_ses_kibana_config/config.ts
   - x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/shared/config.ts
+  - x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/config.ts
   - x-pack/test/functional/apps/advanced_settings/config.ts
   - x-pack/test/functional/apps/aiops/config.ts
   - x-pack/test/functional/apps/api_keys/config.ts

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -605,6 +605,9 @@ Sets the number of actions that will run ephemerally. To use this, enable
 ephemeral tasks in task manager first with
 <<task-manager-settings,`xpack.task_manager.ephemeral_tasks.enabled`>>
 
+`xpack.actions.webhook.ssl.pfx.enabled` {ess-icon}::
+Disable PFX file support for SSL client authentication. When set to `false`, the application will not accept PFX certificate files and will require separate certificate and private key files instead. Only applies to the [Webhook connector](/reference/connectors-kibana/webhook-action-type.md).
+
 `xpack.alerting.cancelAlertsOnRuleTimeout` {ess-icon}::
 Specifies whether to skip writing alerts and scheduling actions if rule
 processing was cancelled due to a timeout. Default: `true`. This setting can be

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -232,6 +232,7 @@ kibana_vars=(
     xpack.actions.responseTimeout
     xpack.actions.ssl.proxyVerificationMode
     xpack.actions.ssl.verificationMode
+    xpack.actions.webhook.ssl.pfx.enabled
     xpack.alerting.healthCheck.interval
     xpack.alerting.invalidateApiKeysTask.interval
     xpack.alerting.invalidateApiKeysTask.removalDelay

--- a/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -205,6 +205,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'vis_type_xy.readOnly (boolean?|never)',
         'vis_type_vega.enableExternalUrls (boolean?)',
         'xpack.actions.email.domain_allowlist (array?)',
+        'xpack.actions.webhook.ssl.pfx.enabled (boolean?)',
         'xpack.apm.serviceMapEnabled (boolean?)',
         'xpack.apm.ui.enabled (boolean?)',
         'xpack.apm.ui.maxTraceItems (number?)',

--- a/x-pack/platform/plugins/shared/actions/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/actions/public/plugin.test.ts
@@ -62,5 +62,20 @@ describe('Actions Plugin', () => {
         ]
       `);
     });
+
+    it('returns isWebhookSslWithPfxEnabled if set in kibana config', async () => {
+      const context = coreMock.createPluginInitializerContext({
+        webhook: {
+          ssl: {
+            pfx: {
+              enabled: false,
+            },
+          },
+        },
+      });
+      const plugin = new Plugin(context);
+      const pluginSetup = plugin.setup();
+      expect(pluginSetup.isWebhookSslWithPfxEnabled).toBe(false);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/actions/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/public/plugin.ts
@@ -14,26 +14,37 @@ export interface ActionsPublicPluginSetup {
     emails: string[],
     options?: ValidateEmailAddressesOptions
   ): ValidatedEmail[];
+  isWebhookSslWithPfxEnabled?: boolean;
 }
 
 export interface Config {
   email: {
     domain_allowlist: string[];
   };
+  webhook: {
+    ssl: {
+      pfx: {
+        enabled: boolean;
+      };
+    };
+  };
 }
 
 export class Plugin implements CorePlugin<ActionsPublicPluginSetup> {
   private readonly allowedEmailDomains: string[] | null = null;
+  private readonly webhookSslWithPfxEnabled: boolean;
 
   constructor(ctx: PluginInitializerContext<Config>) {
     const config = ctx.config.get();
     this.allowedEmailDomains = config.email?.domain_allowlist || null;
+    this.webhookSslWithPfxEnabled = config.webhook?.ssl.pfx.enabled ?? true;
   }
 
   public setup(): ActionsPublicPluginSetup {
     return {
       validateEmailAddresses: (emails: string[], options: ValidateEmailAddressesOptions) =>
         validateEmails(this.allowedEmailDomains, emails, options),
+      isWebhookSslWithPfxEnabled: this.webhookSslWithPfxEnabled,
     };
   }
 

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
@@ -36,6 +36,13 @@ const createActionsConfigMock = () => {
     getMaxAttempts: jest.fn().mockReturnValue(3),
     enableFooterInEmail: jest.fn().mockReturnValue(true),
     getMaxQueued: jest.fn().mockReturnValue(1000),
+    getWebhookSettings: jest.fn().mockReturnValue({
+      ssl: {
+        pfx: {
+          enabled: true,
+        },
+      },
+    }),
     getAwsSesConfig: jest.fn().mockReturnValue(null),
   };
   return mocked;

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
@@ -593,6 +593,56 @@ describe('getMaxQueued()', () => {
   });
 });
 
+describe('getWebhookSettings()', () => {
+  test('returns the webhook settings from config', () => {
+    const config: ActionsConfig = {
+      ...defaultActionsConfig,
+      webhook: {
+        ssl: {
+          pfx: {
+            enabled: true,
+          },
+        },
+      },
+    };
+    const webhookSettings = getActionsConfigurationUtilities(config).getWebhookSettings();
+    expect(webhookSettings).toEqual({
+      ssl: {
+        pfx: {
+          enabled: true,
+        },
+      },
+    });
+  });
+
+  test('returns the webhook settings from config when pfx is false', () => {
+    const config: ActionsConfig = {
+      ...defaultActionsConfig,
+      webhook: {
+        ssl: {
+          pfx: {
+            enabled: false,
+          },
+        },
+      },
+    };
+    const webhookSettings = getActionsConfigurationUtilities(config).getWebhookSettings();
+    expect(webhookSettings).toEqual({
+      ssl: {
+        pfx: {
+          enabled: false,
+        },
+      },
+    });
+  });
+
+  test('returns true when no webhook settings are defined', () => {
+    const config: ActionsConfig = defaultActionsConfig;
+    const webhookSettings = getActionsConfigurationUtilities(config).getWebhookSettings();
+    expect(webhookSettings).toEqual({ ssl: { pfx: { enabled: true } } });
+  });
+});
+
 describe('getAwsSesConfig()', () => {
   test('returns null when no email config set', () => {
     const acu = getActionsConfigurationUtilities(defaultActionsConfig);

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.ts
@@ -55,6 +55,13 @@ export interface ActionsConfigurationUtilities {
   ): string | undefined;
   enableFooterInEmail: () => boolean;
   getMaxQueued: () => number;
+  getWebhookSettings(): {
+    ssl: {
+      pfx: {
+        enabled: boolean;
+      };
+    };
+  };
   getAwsSesConfig: () => AwsSesConfig;
 }
 
@@ -230,6 +237,15 @@ export function getActionsConfigurationUtilities(
     },
     enableFooterInEmail: () => config.enableFooterInEmail,
     getMaxQueued: () => config.queued?.max || DEFAULT_QUEUED_MAX,
+    getWebhookSettings: () => {
+      return {
+        ssl: {
+          pfx: {
+            enabled: config.webhook?.ssl.pfx.enabled ?? true,
+          },
+        },
+      };
+    },
     getAwsSesConfig: () => {
       if (config.email?.services?.ses.host && config.email?.services?.ses.port) {
         return {

--- a/x-pack/platform/plugins/shared/actions/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.test.ts
@@ -258,6 +258,32 @@ describe('config validation', () => {
     expect(result.email?.domain_allowlist).toEqual(['a.com', 'b.c.com', 'd.e.f.com']);
   });
 
+  test('validates xpack.actions.webhook', () => {
+    const config: Record<string, unknown> = {};
+    let result = configSchema.validate(config);
+    expect(result.webhook === undefined);
+
+    config.webhook = {};
+    result = configSchema.validate(config);
+    expect(result.webhook?.ssl.pfx.enabled).toEqual(true);
+
+    config.webhook = { ssl: {} };
+    result = configSchema.validate(config);
+    expect(result.webhook?.ssl.pfx.enabled).toEqual(true);
+
+    config.webhook = { ssl: { pfx: {} } };
+    result = configSchema.validate(config);
+    expect(result.webhook?.ssl.pfx.enabled).toEqual(true);
+
+    config.webhook = { ssl: { pfx: { enabled: false } } };
+    result = configSchema.validate(config);
+    expect(result.webhook?.ssl.pfx.enabled).toEqual(false);
+
+    config.webhook = { ssl: { pfx: { enabled: true } } };
+    result = configSchema.validate(config);
+    expect(result.webhook?.ssl.pfx.enabled).toEqual(true);
+  });
+
   describe('email.services.ses', () => {
     const config: Record<string, unknown> = {};
     test('validates no email config at all', () => {

--- a/x-pack/platform/plugins/shared/actions/server/config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.ts
@@ -179,6 +179,15 @@ export const configSchema = schema.object({
       })
     ),
   }),
+  webhook: schema.maybe(
+    schema.object({
+      ssl: schema.object({
+        pfx: schema.object({
+          enabled: schema.boolean({ defaultValue: true }),
+        }),
+      }),
+    })
+  ),
 });
 
 export type ActionsConfig = TypeOf<typeof configSchema>;

--- a/x-pack/platform/plugins/shared/actions/server/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/index.ts
@@ -51,6 +51,7 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
   schema: configSchema,
   exposeToBrowser: {
     email: { domain_allowlist: true },
+    webhook: { ssl: { pfx: { enabled: true } } },
   },
   deprecations: ({ renameFromRoot, unused }) => [
     renameFromRoot('xpack.actions.whitelistedHosts', 'xpack.actions.allowedHosts', {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/auth_config.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/auth_config.tsx
@@ -39,13 +39,14 @@ import * as i18n from './translations';
 
 interface Props {
   readOnly: boolean;
+  isPfxEnabled?: boolean;
 }
 
 const { emptyField } = fieldValidators;
 
 const VERIFICATION_MODE_DEFAULT = 'full';
 
-export const AuthConfig: FunctionComponent<Props> = ({ readOnly }) => {
+export const AuthConfig: FunctionComponent<Props> = ({ readOnly, isPfxEnabled = true }) => {
   const { setFieldValue, getFieldDefaultValue } = useFormContext();
   const [{ config, __internal__ }] = useFormData({
     watch: [
@@ -112,6 +113,7 @@ export const AuthConfig: FunctionComponent<Props> = ({ readOnly }) => {
                   readOnly={readOnly}
                   certTypeDefaultValue={certTypeDefaultValue}
                   certType={certType}
+                  isPfxEnabled={isPfxEnabled}
                 />
               ),
               'data-test-subj': 'authSSL',
@@ -180,7 +182,7 @@ export const AuthConfig: FunctionComponent<Props> = ({ readOnly }) => {
                         onClick={() => removeItem(item.id)}
                         iconType="minusInCircle"
                         aria-label={i18n.DELETE_BUTTON}
-                        style={{ marginTop: '28px' }}
+                        css={{ marginTop: '28px' }}
                       />
                     </EuiFlexItem>
                   </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/ssl_cert_fields.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/ssl_cert_fields.tsx
@@ -22,12 +22,14 @@ interface BasicAuthProps {
   readOnly: boolean;
   certTypeDefaultValue: SSLCertType;
   certType: SSLCertType;
+  isPfxEnabled?: boolean;
 }
 
 export const SSLCertFields: React.FC<BasicAuthProps> = ({
   readOnly,
   certTypeDefaultValue,
   certType,
+  isPfxEnabled = true,
 }) => (
   <EuiFlexGroup justifyContent="spaceBetween" data-test-subj="sslCertFields">
     <EuiFlexItem>
@@ -52,21 +54,25 @@ export const SSLCertFields: React.FC<BasicAuthProps> = ({
           <EuiTabs size="s" data-test-subj="webhookCertTypeTabs">
             <EuiTab
               onClick={() => field.setValue(SSLCertType.CRT)}
-              isSelected={field.value === SSLCertType.CRT}
+              isSelected={field.value === SSLCertType.CRT || !isPfxEnabled}
+              data-test-subj="webhookCertTypeCRTab"
             >
               {i18n.CERT_TYPE_CRT_KEY}
             </EuiTab>
-            <EuiTab
-              onClick={() => field.setValue(SSLCertType.PFX)}
-              isSelected={field.value === SSLCertType.PFX}
-            >
-              {i18n.CERT_TYPE_PFX}
-            </EuiTab>
+            {isPfxEnabled && (
+              <EuiTab
+                onClick={() => field.setValue(SSLCertType.PFX)}
+                isSelected={field.value === SSLCertType.PFX}
+                data-test-subj="webhookCertTypePFXTab"
+              >
+                {i18n.CERT_TYPE_PFX}
+              </EuiTab>
+            )}
           </EuiTabs>
         )}
       />
       <EuiSpacer size="s" />
-      {certType === SSLCertType.CRT && (
+      {(!isPfxEnabled || certType === SSLCertType.CRT) && (
         <EuiFlexGroup wrap>
           <EuiFlexItem css={{ minWidth: 200 }}>
             <UseField
@@ -112,7 +118,7 @@ export const SSLCertFields: React.FC<BasicAuthProps> = ({
           </EuiFlexItem>
         </EuiFlexGroup>
       )}
-      {certType === SSLCertType.PFX && (
+      {isPfxEnabled && certType === SSLCertType.PFX && (
         <UseField
           path="secrets.pfx"
           config={{

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.tsx
@@ -177,7 +177,7 @@ const CasesWebhookActionConnectorFields: React.FunctionComponent<ActionConnector
       <UpdateStep readOnly={readOnly} display={currentStep === 4} />
       <EuiFlexGroup alignItems="flexStart" justifyContent="flexStart" direction="rowReverse">
         {currentStep < 4 && (
-          <EuiFlexItem grow={false} style={{ minWidth: 160 }}>
+          <EuiFlexItem grow={false} css={{ minWidth: 160 }}>
             <EuiButton
               data-test-subj="casesWebhookNext"
               fill
@@ -190,7 +190,7 @@ const CasesWebhookActionConnectorFields: React.FunctionComponent<ActionConnector
           </EuiFlexItem>
         )}
         {currentStep > 1 && (
-          <EuiFlexItem grow={false} style={{ minWidth: 160 }}>
+          <EuiFlexItem grow={false} css={{ minWidth: 160 }}>
             <EuiButton
               data-test-subj="casesWebhookBack"
               iconSide="left"

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/test_utils.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/test_utils.tsx
@@ -71,7 +71,10 @@ const FormTestProviderComponent: React.FC<FormTestProviderProps> = ({
   children,
   defaultValue,
   onSubmit,
-  connectorServices = { validateEmailAddresses: jest.fn() },
+  connectorServices = {
+    validateEmailAddresses: jest.fn(),
+    isWebhookSslWithPfxEnabled: true,
+  },
 }) => {
   const { form } = useForm({ defaultValue });
   const { submit } = form;

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook_connectors.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook_connectors.tsx
@@ -11,7 +11,10 @@ import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { Field, SelectField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
-import type { ActionConnectorFieldsProps } from '@kbn/triggers-actions-ui-plugin/public';
+import {
+  useConnectorContext,
+  type ActionConnectorFieldsProps,
+} from '@kbn/triggers-actions-ui-plugin/public';
 
 import * as i18n from './translations';
 import { AuthConfig } from '../../common/auth/auth_config';
@@ -22,6 +25,10 @@ const { emptyField, urlField } = fieldValidators;
 const WebhookActionConnectorFields: React.FunctionComponent<ActionConnectorFieldsProps> = ({
   readOnly,
 }) => {
+  const {
+    services: { isWebhookSslWithPfxEnabled: isPfxEnabled },
+  } = useConnectorContext();
+
   return (
     <>
       <EuiFlexGroup justifyContent="spaceBetween">
@@ -67,7 +74,7 @@ const WebhookActionConnectorFields: React.FunctionComponent<ActionConnectorField
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />
-      <AuthConfig readOnly={readOnly} />
+      <AuthConfig readOnly={readOnly} isPfxEnabled={isPfxEnabled} />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
@@ -222,7 +222,7 @@ describe('config validation', () => {
     expect(() => {
       validateConfig(connectorType, config, { configurationUtilities });
     }).toThrowErrorMatchingInlineSnapshot(
-      '"error validating action type config: error configuring webhook action: unable to parse url: TypeError: Invalid URL: example.com/do-something"'
+      `"error validating action type config: error validation webhook action config: unable to parse url: TypeError: Invalid URL: example.com/do-something"`
     );
   });
 
@@ -295,7 +295,25 @@ describe('config validation', () => {
     expect(() => {
       validateConfig(connectorType, config, { configurationUtilities: configUtils });
     }).toThrowErrorMatchingInlineSnapshot(
-      `"error validating action type config: error configuring webhook action: target url is not present in allowedHosts"`
+      `"error validating action type config: error validation webhook action config: target url is not present in allowedHosts"`
+    );
+  });
+
+  test('config validation fails when using disabled pfx certType', () => {
+    const config: Record<string, string | boolean> = {
+      url: 'https://mylisteningserver:9200/endpoint',
+      method: WebhookMethods.POST,
+      authType: AuthType.SSL,
+      certType: SSLCertType.PFX,
+      hasAuth: true,
+    };
+    configurationUtilities.getWebhookSettings = jest.fn(() => ({
+      ssl: { pfx: { enabled: false } },
+    }));
+    expect(() => {
+      validateConfig(connectorType, config, { configurationUtilities });
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"error validating action type config: error validation webhook action config: certType \\"ssl-pfx\\" is disabled"`
     );
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.ts
@@ -26,6 +26,7 @@ import {
 import { renderMustacheString } from '@kbn/actions-plugin/server/lib/mustache_renderer';
 import { combineHeadersWithBasicAuthHeader } from '@kbn/actions-plugin/server/lib';
 
+import { SSLCertType } from '../../../common/auth/constants';
 import type {
   WebhookConnectorType,
   ActionParamsType,
@@ -95,7 +96,7 @@ function validateConnectorTypeConfig(
   } catch (err) {
     throw new Error(
       i18n.translate('xpack.stackConnectors.webhook.configurationErrorNoHostname', {
-        defaultMessage: 'error configuring webhook action: unable to parse url: {err}',
+        defaultMessage: 'error validation webhook action config: unable to parse url: {err}',
         values: {
           err: err.toString(),
         },
@@ -108,7 +109,7 @@ function validateConnectorTypeConfig(
   } catch (allowListError) {
     throw new Error(
       i18n.translate('xpack.stackConnectors.webhook.configurationError', {
-        defaultMessage: 'error configuring webhook action: {message}',
+        defaultMessage: 'error validation webhook action config: {message}',
         values: {
           message: allowListError.message,
         },
@@ -120,9 +121,24 @@ function validateConnectorTypeConfig(
     throw new Error(
       i18n.translate('xpack.stackConnectors.webhook.authConfigurationError', {
         defaultMessage:
-          'error configuring webhook action: authType must be null or undefined if hasAuth is false',
+          'error validation webhook action config: authType must be null or undefined if hasAuth is false',
       })
     );
+  }
+
+  if (configObject.certType === SSLCertType.PFX) {
+    const webhookSettings = configurationUtilities.getWebhookSettings();
+    if (!webhookSettings.ssl.pfx.enabled) {
+      throw new Error(
+        i18n.translate('xpack.stackConnectors.webhook.pfxConfigurationError', {
+          defaultMessage:
+            'error validation webhook action config: certType "{certType}" is disabled',
+          values: {
+            certType: SSLCertType.PFX,
+          },
+        })
+      );
+    }
   }
 }
 

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/connectors_app.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/connectors_app.tsx
@@ -90,11 +90,11 @@ export const App = ({ deps }: { deps: TriggersAndActionsUiServices }) => {
 
 export const AppWithoutRouter = ({ sectionsRegex }: { sectionsRegex: string }) => {
   const {
-    actions: { validateEmailAddresses },
+    actions: { validateEmailAddresses, isWebhookSslWithPfxEnabled },
   } = useKibana().services;
 
   return (
-    <ConnectorProvider value={{ services: { validateEmailAddresses } }}>
+    <ConnectorProvider value={{ services: { validateEmailAddresses, isWebhookSslWithPfxEnabled } }}>
       <Routes>
         <Route
           path={`/:section(${sectionsRegex})`}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/types.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/types.ts
@@ -400,6 +400,7 @@ export interface SnoozeSchedule {
 
 export interface ConnectorServices {
   validateEmailAddresses: ActionsPublicPluginSetup['validateEmailAddresses'];
+  isWebhookSslWithPfxEnabled?: ActionsPublicPluginSetup['isWebhookSslWithPfxEnabled'];
 }
 
 export interface RulesListFilters {

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const testSubjects = getService('testSubjects');
+  const find = getService('find');
+  const pageObjects = getPageObjects(['common', 'triggersActionsUI', 'header']);
+
+  describe('webhook', () => {
+    beforeEach(async () => {
+      await pageObjects.common.navigateToApp('triggersActionsConnectors');
+    });
+
+    it('should render the cr and pfx tab for ssl auth', async () => {
+      await pageObjects.triggersActionsUI.clickCreateConnectorButton();
+      await testSubjects.click('.webhook-card');
+      await testSubjects.click('authSSL');
+
+      const certTypeTabs = await find.allByCssSelector(
+        '[data-test-subj="webhookCertTypeTabs"] > .euiTab'
+      );
+      expect(certTypeTabs.length).to.be(2);
+      expect(await certTypeTabs[0].getAttribute('data-test-subj')).to.be('webhookCertTypeCRTab');
+      expect(await certTypeTabs[1].getAttribute('data-test-subj')).to.be('webhookCertTypePFXTab');
+    });
+  });
+};

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/config.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/config.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseConfig = await readConfigFile(require.resolve('../../../../config.base.ts'));
+
+  return {
+    ...baseConfig.getAll(),
+    testFiles: [require.resolve('.')],
+    junit: {
+      reportName: 'Chrome X-Pack UI Functional Tests with ES SSL - Disabled Webhook SSL PFX',
+    },
+    kbnTestServer: {
+      ...baseConfig.getAll().kbnTestServer,
+      serverArgs: [
+        ...baseConfig.getAll().kbnTestServer.serverArgs,
+        `--xpack.actions.webhook.ssl.pfx.enabled=false`,
+      ],
+    },
+  };
+}

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/index.ts
@@ -5,14 +5,10 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default ({ loadTestFile }: FtrProviderContext) => {
-  describe('Connectors', function () {
-    loadTestFile(require.resolve('./general'));
-    loadTestFile(require.resolve('./opsgenie'));
-    loadTestFile(require.resolve('./tines'));
-    loadTestFile(require.resolve('./slack'));
+  describe('Webhook - disabled ssl pfx', function () {
     loadTestFile(require.resolve('./webhook'));
   });
 };

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/webhook.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/webhook.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const testSubjects = getService('testSubjects');
+  const find = getService('find');
+  const pageObjects = getPageObjects(['common', 'triggersActionsUI', 'header']);
+
+  describe('webhook', () => {
+    beforeEach(async () => {
+      await pageObjects.common.navigateToApp('triggersActionsConnectors');
+    });
+
+    it('should not render the pfx tab for ssl auth', async () => {
+      await pageObjects.triggersActionsUI.clickCreateConnectorButton();
+      await testSubjects.click('.webhook-card');
+      await testSubjects.click('authSSL');
+
+      const certTypeTabs = await find.allByCssSelector(
+        '[data-test-subj="webhookCertTypeTabs"] > .euiTab'
+      );
+      expect(certTypeTabs.length).to.be(1);
+      expect(await certTypeTabs[0].getAttribute('data-test-subj')).to.be('webhookCertTypeCRTab');
+    });
+  });
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Connectors] New `xpack.actions.webhook.ssl.pfx.enabled` config (#222507)](https://github.com/elastic/kibana/pull/222507)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-17T07:31:17Z","message":"[Response Ops][Connectors] New `xpack.actions.webhook.ssl.pfx.enabled` config (#222507)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/220416\n\n## Release note\nNew `xpack.actions.webhook.ssl.pfx.enabled` Kibana setting to disable\nWebhook connector PFX file support for SSL client authentication\n\n---------\n\nCo-authored-by: Nastasha Solomon <79124755+nastasha-solomon@users.noreply.github.com>","sha":"25b4f507e22869a87cbf43b04b1f0c20fc242789","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:ResponseOps","release_note:feature","backport:version","v9.1.0","v8.19.0"],"title":"[Response Ops][Connectors] New `xpack.actions.webhook.ssl.pfx.enabled` config","number":222507,"url":"https://github.com/elastic/kibana/pull/222507","mergeCommit":{"message":"[Response Ops][Connectors] New `xpack.actions.webhook.ssl.pfx.enabled` config (#222507)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/220416\n\n## Release note\nNew `xpack.actions.webhook.ssl.pfx.enabled` Kibana setting to disable\nWebhook connector PFX file support for SSL client authentication\n\n---------\n\nCo-authored-by: Nastasha Solomon <79124755+nastasha-solomon@users.noreply.github.com>","sha":"25b4f507e22869a87cbf43b04b1f0c20fc242789"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222507","number":222507,"mergeCommit":{"message":"[Response Ops][Connectors] New `xpack.actions.webhook.ssl.pfx.enabled` config (#222507)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/220416\n\n## Release note\nNew `xpack.actions.webhook.ssl.pfx.enabled` Kibana setting to disable\nWebhook connector PFX file support for SSL client authentication\n\n---------\n\nCo-authored-by: Nastasha Solomon <79124755+nastasha-solomon@users.noreply.github.com>","sha":"25b4f507e22869a87cbf43b04b1f0c20fc242789"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->