### PR TITLE
[ES|QL] Add query description in the documentation prop

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/recommended_queries/suggestions.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/recommended_queries/suggestions.ts
@@ -51,7 +51,8 @@ export const mapRecommendedQueriesFromExtensions = (
     return {
       label: extension.name,
       text: extension.query,
-      detail: extension.description ?? '',
+      detail: extension.name ?? '',
+      ...(extension.description ? { documentation: { value: extension.description } } : {}),
       kind: 'Issue',
       sortText: 'D',
     };

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/recommended_queries/suggestions.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/recommended_queries/suggestions.ts
@@ -82,7 +82,10 @@ export const getRecommendedQueriesTemplatesFromExtensions = (
       return {
         label: recommendedQuery.name,
         text: `|${queryParts.slice(1).join('|')}`,
-        detail: recommendedQuery.description ?? '',
+        detail: recommendedQuery.name ?? '',
+        ...(recommendedQuery.description
+          ? { documentation: { value: recommendedQuery.description } }
+          : {}),
         kind: 'Issue',
         sortText: 'D',
       };


### PR DESCRIPTION
## Summary

Display the description on the documentation prop mostly for allowing markdown.

(There is also a [monaco bug](https://github.com/elastic/kibana/pull/224054#issuecomment-2976159805) that I cant replicate but I hope this is fixing it)

Update: It is not fixing it but is def better 

<img width="908" alt="image" src="https://github.com/user-attachments/assets/e843fc23-284b-436c-b199-c43510227cf0" />



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->