### PR TITLE
[ES|QL] Small enhancements in controls flow

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.styles.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.styles.ts
@@ -77,6 +77,7 @@ export const esqlEditorStyles = (
       marginTop: 0,
       marginLeft: 0,
       marginBottom: 0,
+      border: hasOutline ? euiTheme.border.thin : 'none',
       borderBottomLeftRadius: 0,
       borderBottomRightRadius: 0,
     },

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -49,6 +49,10 @@ interface ValueControlFormProps {
 }
 
 const SUGGESTED_INTERVAL_VALUES = ['5 minutes', '1 hour', '1 day', '1 week', '1 month'];
+const INITIAL_EMPTY_STATE_QUERY = `/** Example
+To get the agent field values use: 
+FROM logs-* | STATS BY agent
+*/`;
 
 export function ValueControlForm({
   variableType,
@@ -87,7 +91,9 @@ export function ValueControlForm({
   );
 
   const [valuesQuery, setValuesQuery] = useState<string>(
-    variableType === ESQLVariableType.VALUES ? initialState?.esqlQuery ?? '' : ''
+    variableType === ESQLVariableType.VALUES
+      ? initialState?.esqlQuery ?? INITIAL_EMPTY_STATE_QUERY
+      : ''
   );
   const [esqlQueryErrors, setEsqlQueryErrors] = useState<Error[] | undefined>();
   const [queryColumns, setQueryColumns] = useState<string[]>(
@@ -270,6 +276,7 @@ export function ValueControlForm({
               }}
               isDisabled={false}
               isLoading={false}
+              hasOutline
             />
           </EuiFormRow>
           {queryColumns.length > 0 && (


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/223982

- Adds an initial query (comment)
- Adds the outline
- Fixes the outline in the editor footer

<img width="717" alt="image" src="https://github.com/user-attachments/assets/2a116cf4-5654-452d-82ae-f040dbe23da8" />



It doesnt add the border radius as we have the resizer in the bottom and it looks bad. Andrea will take a look in a follow up PR.



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->