### PR TITLE
Deprecate Cloud Security Transform

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -37,36 +37,41 @@ interface IndexTemplateSettings {
 export const initializeCspIndices = async (
   esClient: ElasticsearchClient,
   cloudSecurityPostureConfig: CloudSecurityPostureConfig,
+  latestFindingsIndexAutoCreated: boolean,
   logger: Logger
 ) => {
-  await Promise.allSettled([
-    createPipelineIfNotExists(esClient, scorePipelineIngestConfig, logger),
-    createPipelineIfNotExists(esClient, latestFindingsPipelineIngestConfig, logger),
-  ]);
+  await createPipelineIfNotExists(esClient, scorePipelineIngestConfig, logger);
 
-  const [
-    createFindingsLatestIndexPromise,
-    createVulnerabilitiesLatestIndexPromise,
-    createBenchmarkScoreIndexPromise,
-  ] = await Promise.allSettled([
-    createLatestIndex(esClient, latestIndexConfigs.findings, cloudSecurityPostureConfig, logger),
-    createLatestIndex(
-      esClient,
-      latestIndexConfigs.vulnerabilities,
-      cloudSecurityPostureConfig,
-      logger
-    ),
-    createBenchmarkScoreIndex(esClient, cloudSecurityPostureConfig, logger),
-  ]);
+  const [createVulnerabilitiesLatestIndexPromise, createBenchmarkScoreIndexPromise] =
+    await Promise.allSettled([
+      createLatestIndex(
+        esClient,
+        latestIndexConfigs.vulnerabilities,
+        cloudSecurityPostureConfig,
+        logger
+      ),
+      createBenchmarkScoreIndex(esClient, cloudSecurityPostureConfig, logger),
+    ]);
 
-  if (createFindingsLatestIndexPromise.status === 'rejected') {
-    logger.error(createFindingsLatestIndexPromise.reason);
-  }
   if (createVulnerabilitiesLatestIndexPromise.status === 'rejected') {
     logger.error(createVulnerabilitiesLatestIndexPromise.reason);
   }
   if (createBenchmarkScoreIndexPromise.status === 'rejected') {
     logger.error(createBenchmarkScoreIndexPromise.reason);
+  }
+
+  if (!latestFindingsIndexAutoCreated) {
+    try {
+      await createPipelineIfNotExists(esClient, latestFindingsPipelineIngestConfig, logger);
+      await createLatestIndex(
+        esClient,
+        latestIndexConfigs.findings,
+        cloudSecurityPostureConfig,
+        logger
+      );
+    } catch (e) {
+      logger.error(`Failed to create latest findings index: ${e}`);
+    }
   }
 };
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
@@ -18,7 +18,8 @@ const LATEST_FINDINGS_TRANSFORM_V830 = 'cloud_security_posture.findings_latest-d
 const LATEST_FINDINGS_TRANSFORM_V840 = 'cloud_security_posture.findings_latest-default-8.4.0';
 const LATEST_FINDINGS_TRANSFORM_V880 = 'cloud_security_posture.findings_latest-default-8.8.0';
 
-const CURRENT_FINDINGS_TRANSFORM_VERSION = 'cloud_security_posture.findings_latest-default-8.15.0';
+export const CURRENT_FINDINGS_TRANSFORM_VERSION =
+  'cloud_security_posture.findings_latest-default-8.15.0';
 
 export const DEPRECATED_FINDINGS_TRANSFORMS_VERSION = [
   LATEST_FINDINGS_TRANSFORM_V830,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
@@ -161,7 +161,7 @@ export class CspPlugin
           ): Promise<UpdatePackagePolicy> => {
             if (isCspPackage(packagePolicy.package?.name)) {
               const isIntegrationVersionIncludesTransformAsset = isTransformAssetIncluded(
-                packagePolicy.package?.version
+                packagePolicy.package!.version
               );
               await deletePreviousTransformsVersions(
                 esClient,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
@@ -180,7 +180,7 @@ export class CspPlugin
             soClient: SavedObjectsClientContract
           ): Promise<PackagePolicy> => {
             if (isCspPackage(packagePolicy.package?.name)) {
-              await this.initialize(core, plugins.taskManager, packagePolicy.package?.version);
+              await this.initialize(core, plugins.taskManager, packagePolicy.package!.version);
               return packagePolicy;
             }
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
@@ -160,7 +160,7 @@ export class CspPlugin
           ): Promise<UpdatePackagePolicy> => {
             if (isCspPackage(packagePolicy.package?.name)) {
               const isIntegrationVersionIncludesTransformAsset =
-                parseInt(packagePolicy.package.version.split('.')[0], 10) >= 2;
+                parseInt(packagePolicy.package!.version.split('.')[0], 10) >= 2;
               await deletePreviousTransformsVersions(
                 esClient,
                 isIntegrationVersionIncludesTransformAsset,


### PR DESCRIPTION
solves:
- https://github.com/elastic/security-team/issues/12757

## Summary
With the upcoming release of the Cloud Security Posture integration, we are introducing a new “Latest” Transform.
This PR aims to disable the Transform installation through the Kibana plugin.

Below is a table outlining the different scenarios for each use case:

_ | Create Index | Create Transform | Stop Transform | Remove Old Data
-- | -- | -- | -- | --
Install integration < 2.00 | ✅ | ✅ | ❌ | ❌
Install integration ≥ 2.00 | ❌ | ❌ | ✅ | ❌
Upgrade integration | ❌ | ❌ | ✅ | ❌

