### PR TITLE
[8.18] [ResponseOps][Cases]Allow dashes in host names in Observables (#219038)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/observables/fields_config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/observables/fields_config.test.ts
@@ -75,6 +75,14 @@ describe('genericValidator', () => {
     } as Parameters<ValidationFunc>[0]);
     expect(result).toBeUndefined();
   });
+
+  it('should return undefined if the value contains dashes', () => {
+    const result = genericValidator({
+      value: 'valid-value',
+      path: 'generic',
+    } as Parameters<ValidationFunc>[0]);
+    expect(result).toBeUndefined();
+  });
 });
 
 describe('domainValidator', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/observables/fields_config.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/observables/fields_config.ts
@@ -28,7 +28,7 @@ export const normalizeValueType = (value: string): keyof typeof fieldsConfig.val
 };
 
 const DOMAIN_REGEX = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)\.[A-Za-z]{2,}$/;
-const GENERIC_REGEX = /^[a-zA-Z0-9._:/\\]+$/;
+const GENERIC_REGEX = /^[a-zA-Z0-9._:/\\-]+$/;
 
 const notStringError = (path: string) => ({
   code: 'ERR_NOT_STRING',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ResponseOps][Cases]Allow dashes in host names in Observables (#219038)](https://github.com/elastic/kibana/pull/219038)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2025-04-29T07:27:18Z","message":"[ResponseOps][Cases]Allow dashes in host names in Observables (#219038)\n\nCloses https://github.com/elastic/kibana/issues/218946\n\n## Summary\n\n- changed the GENERIC_REGEX to allow `-` \n\n<img width=\"488\" alt=\"Screenshot 2025-04-24 at 10 31 00\"\nsrc=\"https://github.com/user-attachments/assets/57841c74-9e6c-4600-81f4-8b454d1ddec1\"\n/>","sha":"d0d08b0bdb8f178e88063e0a05467f78d4d8b99f","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[ResponseOps][Cases]Allow dashes in host names in Observables","number":219038,"url":"https://github.com/elastic/kibana/pull/219038","mergeCommit":{"message":"[ResponseOps][Cases]Allow dashes in host names in Observables (#219038)\n\nCloses https://github.com/elastic/kibana/issues/218946\n\n## Summary\n\n- changed the GENERIC_REGEX to allow `-` \n\n<img width=\"488\" alt=\"Screenshot 2025-04-24 at 10 31 00\"\nsrc=\"https://github.com/user-attachments/assets/57841c74-9e6c-4600-81f4-8b454d1ddec1\"\n/>","sha":"d0d08b0bdb8f178e88063e0a05467f78d4d8b99f"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219038","number":219038,"mergeCommit":{"message":"[ResponseOps][Cases]Allow dashes in host names in Observables (#219038)\n\nCloses https://github.com/elastic/kibana/issues/218946\n\n## Summary\n\n- changed the GENERIC_REGEX to allow `-` \n\n<img width=\"488\" alt=\"Screenshot 2025-04-24 at 10 31 00\"\nsrc=\"https://github.com/user-attachments/assets/57841c74-9e6c-4600-81f4-8b454d1ddec1\"\n/>","sha":"d0d08b0bdb8f178e88063e0a05467f78d4d8b99f"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219489","number":219489,"state":"MERGED","mergeCommit":{"sha":"078e45f32cc56d76fbeb5ecffbf46d8262cc23bb","message":"[8.19] [ResponseOps][Cases]Allow dashes in host names in Observables (#219038) (#219489)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[ResponseOps][Cases]Allow dashes in host names in Observables\n(#219038)](https://github.com/elastic/kibana/pull/219038)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Georgiana-Andreea Onoleață <georgiana.onoleata@elastic.co>"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->