### PR TITLE
[8.18] Replace old Security API doc links with API ref links in doc link service (#223388)

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -492,7 +492,9 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       detectionsReq: `${SECURITY_SOLUTION_DOCS}detections-permissions-section.html`,
       networkMap: `${SECURITY_SOLUTION_DOCS}conf-map-ui.html`,
       troubleshootGaps: `${SECURITY_SOLUTION_DOCS}alerts-ui-monitor.html#troubleshoot-gaps`,
-      ruleApiOverview: `${SECURITY_SOLUTION_DOCS}rule-api-overview.html`,
+      ruleApiOverview: isServerless
+        ? `${KIBANA_SERVERLESS_APIS}group/endpoint-security-detections-api`
+        : `${KIBANA_APIS}group/endpoint-security-detections-api`,
       configureAlertSuppression: `${SECURITY_SOLUTION_DOCS}alert-suppression.html#_configure_alert_suppression`,
     },
     logging: {
@@ -539,7 +541,9 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       },
       detectionEngineOverview: `${SECURITY_SOLUTION_DOCS}detection-engine-overview.html`,
       aiAssistant: `${SECURITY_SOLUTION_DOCS}security-assistant.html`,
-      signalsMigrationApi: `${SECURITY_SOLUTION_DOCS}signals-migration-api.html`,
+      signalsMigrationApi: isServerless
+        ? `${KIBANA_SERVERLESS_APIS}group/endpoint-security-detections-api`
+        : `${KIBANA_APIS}group/endpoint-security-detections-api`,
       legacyEndpointManagementApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-199598`,
       legacyRuleManagementBulkApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-207091`,
       siemMigrations: `${SECURITY_SOLUTION_DOCS}siem-migration.html`,

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules_bulk.ts
@@ -59,8 +59,10 @@ export default ({ getService }: FtrProviderContext): void => {
           .send([getSimpleRule()])
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_create API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_create API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
@@ -47,8 +47,10 @@ export default ({ getService }: FtrProviderContext): void => {
           .bulkDeleteRules({ body: [{ rule_id: 'rule-1' }] })
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_delete API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_delete API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/patch_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/patch_rules_bulk.ts
@@ -55,8 +55,10 @@ export default ({ getService }: FtrProviderContext) => {
           .bulkPatchRules({ body: [{ rule_id: 'rule-1', name: 'some other name' }] })
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules_bulk.ts
@@ -71,8 +71,10 @@ export default ({ getService }: FtrProviderContext) => {
           .bulkUpdateRules({ body: [updatedRule] })
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });


### PR DESCRIPTION
This will backport the following commits from `8.19` to `8.18`:
* https://github.com/elastic/kibana/pull/223388
