### PR TITLE
[Obs AI Assistant] [Anonymization] Update system prompt to inform about anonymization

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/common/utils/anonymization/redaction.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/common/utils/anonymization/redaction.ts
@@ -8,7 +8,7 @@
 import { DetectedEntity } from '../../types';
 
 /** Regex matching object‑hash placeholders (40 hex chars) */
-export const HASH_REGEX = /[0-9a-f]{40}/g;
+export const HASH_REGEX = /\b[A-Z]+_[0-9a-f]{40}\b/g;
 
 /** Default model ID for named entity recognition */
 export const NER_MODEL_ID = 'elastic__distilbert-base-uncased-finetuned-conll03-english';
@@ -22,7 +22,8 @@ export function redactEntities(original: string, entities: DetectedEntity[]): st
     .slice()
     .sort((a, b) => b.start_pos - a.start_pos)
     .forEach((e) => {
-      redacted = redacted.slice(0, e.start_pos) + e.hash + redacted.slice(e.end_pos);
+      redacted =
+        redacted.slice(0, e.start_pos) + e.class_name + '_' + e.hash + redacted.slice(e.end_pos);
     });
 
   return redacted;

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/functions/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/functions/route.ts
@@ -67,6 +67,8 @@ const getFunctionsRoute = createObservabilityAIAssistantServerRoute({
 
     const availableFunctionNames = functionDefinitions.map((def) => def.name);
 
+    const anonymizationService = client.getAnonymizationService();
+
     return {
       functionDefinitions,
       systemMessage: getSystemMessageFromInstructions({
@@ -74,6 +76,7 @@ const getFunctionsRoute = createObservabilityAIAssistantServerRoute({
         kbUserInstructions,
         apiUserInstructions: [],
         availableFunctionNames,
+        anonymizationInstruction: anonymizationService.getAnonymizationInstruction(),
       }),
     };
   },

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/anonymization/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/anonymization/index.ts
@@ -110,7 +110,7 @@ export class AnonymizationService {
 
         // Update hashMap
         entities.forEach((e) => {
-          this.currentHashMap.set(e.hash, {
+          this.currentHashMap.set(e.class_name + '_' + e.hash, {
             value: e.entity,
             class_name: e.class_name,
             type: e.type,
@@ -217,5 +217,14 @@ export class AnonymizationService {
         })
       );
     };
+  }
+  isEnabled(): boolean {
+    return this.rules.some((rule) => rule.enabled);
+  }
+  getAnonymizationInstruction(): string {
+    if (!this.isEnabled()) {
+      return '';
+    }
+    return 'Some entities in this conversation (like names, locations, or IDs) have been anonymized using placeholder hashes (e.g., `PER_123`, `LOC_abcd1234`). These tokens should be treated as distinct but semantically unknown entities. Do not try to infer their meaning. Refer to them as-is unless explicitly provided with a description.';
   }
 }

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -249,6 +249,8 @@ export class ObservabilityAIAssistantClient {
             availableFunctionNames: disableFunctions
               ? []
               : functionClient.getFunctions().map((fn) => fn.definition.name),
+            anonymizationInstruction:
+              this.dependencies.anonymizationService.getAnonymizationInstruction(),
           })
         ),
         shareReplay()
@@ -875,5 +877,9 @@ export class ObservabilityAIAssistantClient {
       this.dependencies.namespace,
       this.dependencies.user
     );
+  };
+
+  getAnonymizationService = () => {
+    return this.dependencies.anonymizationService;
   };
 }

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/util/get_system_message_from_instructions.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/util/get_system_message_from_instructions.test.ts
@@ -17,6 +17,7 @@ describe('getSystemMessageFromInstructions', () => {
         kbUserInstructions: [],
         apiUserInstructions: [],
         availableFunctionNames: [],
+        anonymizationInstruction: '',
       })
     ).toEqual(`first\n\nsecond`);
   });
@@ -33,6 +34,7 @@ describe('getSystemMessageFromInstructions', () => {
         kbUserInstructions: [],
         apiUserInstructions: [],
         availableFunctionNames: ['myFunction'],
+        anonymizationInstruction: '',
       })
     ).toEqual(`first\n\nmyFunction`);
   });
@@ -49,6 +51,7 @@ describe('getSystemMessageFromInstructions', () => {
           },
         ],
         availableFunctionNames: [],
+        anonymizationInstruction: '',
       })
     ).toEqual(`first\n\n${USER_INSTRUCTIONS_HEADER}\n\nsecond from adhoc instruction`);
   });
@@ -60,6 +63,7 @@ describe('getSystemMessageFromInstructions', () => {
         kbUserInstructions: [{ id: 'second', text: 'second_kb' }],
         apiUserInstructions: [],
         availableFunctionNames: [],
+        anonymizationInstruction: '',
       })
     ).toEqual(`first\n\n${USER_INSTRUCTIONS_HEADER}\n\nsecond_kb`);
   });
@@ -76,6 +80,7 @@ describe('getSystemMessageFromInstructions', () => {
         kbUserInstructions: [],
         apiUserInstructions: [],
         availableFunctionNames: [],
+        anonymizationInstruction: '',
       })
     ).toEqual(`first`);
   });

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/util/get_system_message_from_instructions.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/util/get_system_message_from_instructions.ts
@@ -60,7 +60,7 @@ export function getSystemMessageFromInstructions({
     ...(allUserInstructions.length ? [USER_INSTRUCTIONS_HEADER, ...allUserInstructions] : []),
 
     // anonymization instructions
-    anonymizationInstruction,
+    ...(anonymizationInstruction ? [anonymizationInstruction] : []),
   ]
     .map((instruction) => {
       return typeof instruction === 'string' ? instruction : instruction.text;

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/util/get_system_message_from_instructions.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/util/get_system_message_from_instructions.ts
@@ -27,11 +27,14 @@ export function getSystemMessageFromInstructions({
   // instructions provided by the user via the API. These will be displayed after the application instructions and only if they fit within the token budget
   apiUserInstructions,
   availableFunctionNames,
+  // instructions for anonymization
+  anonymizationInstruction,
 }: {
   applicationInstructions: InstructionOrCallback[];
   kbUserInstructions: Instruction[];
   apiUserInstructions: Instruction[];
   availableFunctionNames: string[];
+  anonymizationInstruction: string;
 }): string {
   const allApplicationInstructions = compact(
     applicationInstructions.flatMap((instruction) => {
@@ -55,6 +58,9 @@ export function getSystemMessageFromInstructions({
 
     // user instructions
     ...(allUserInstructions.length ? [USER_INSTRUCTIONS_HEADER, ...allUserInstructions] : []),
+
+    // anonymization instructions
+    anonymizationInstruction,
   ]
     .map((instruction) => {
       return typeof instruction === 'string' ? instruction : instruction.text;


### PR DESCRIPTION
Closes https://github.com/elastic/observability-dev/issues/4563
## Summary

This PR updates the Obs AI Assistant system prompt to explicitly inform the LLM about the presence of anonymized entities (e.g., hashes or placeholder tokens). The goal is to prevent the LLM from attempting to interpret or hallucinate the meaning of these anonymized tokens.

What Changed
- Modified the system prompt to include a new instruction:
```txt
Some entities in this conversation (like names, locations, or IDs) have been anonymized using placeholder hashes (e.g., `PER_123`, `LOC_abcd1234`). These tokens should be treated as distinct but semantically unknown entities. Do not try to infer their meaning. Refer to them as-is unless explicitly provided with a description.
```
- This instruction is now included in all prompts sent to the LLM as part of the chat completion setup when there are anonymization rules.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->