### PR TITLE
[8.19] [Discover][Oblt] Display Attributes doc viewer tab for Observability (#222391)

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/profile.tsx
@@ -10,10 +10,9 @@
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { BehaviorSubject } from 'rxjs';
 import type { DocumentProfileProvider } from '../../../profiles';
-import { DocumentType } from '../../../profiles';
+import { DocumentType, SolutionType } from '../../../profiles';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 import { createGetDocViewer } from './accessors';
-import { OBSERVABILITY_ROOT_PROFILE_ID } from '../consts';
 import type { LogOverviewContext } from '../logs_data_source_profile/profile';
 import { isLogsDataSourceContext } from '../logs_data_source_profile/profile';
 
@@ -29,7 +28,7 @@ export const createObservabilityLogDocumentProfileProvider = (
     getDocViewer: createGetDocViewer(services),
   },
   resolve: ({ record, rootContext, dataSourceContext }) => {
-    if (rootContext.profileId !== OBSERVABILITY_ROOT_PROFILE_ID) {
+    if (rootContext.solutionType !== SolutionType.Observability) {
       return { isMatch: false };
     }
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.ts
@@ -9,7 +9,7 @@
 
 import { BehaviorSubject } from 'rxjs';
 import type { DataSourceContext, DataSourceProfileProvider } from '../../../profiles';
-import { DataSourceCategory } from '../../../profiles';
+import { DataSourceCategory, SolutionType } from '../../../profiles';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 import {
   getCellRenderers,
@@ -19,7 +19,6 @@ import {
   getPaginationConfig,
 } from './accessors';
 import { extractIndexPatternFrom } from '../../extract_index_pattern_from';
-import { OBSERVABILITY_ROOT_PROFILE_ID } from '../consts';
 import type { ContextWithProfileId } from '../../../profile_service';
 
 export type LogOverViewAccordionExpandedValue = 'stacktrace' | 'quality_issues' | undefined;
@@ -54,7 +53,7 @@ export const createLogsDataSourceProfileProvider = (
     getPaginationConfig,
   },
   resolve: (params) => {
-    if (params.rootContext.profileId !== OBSERVABILITY_ROOT_PROFILE_ID) {
+    if (params.rootContext.solutionType !== SolutionType.Observability) {
       return { isMatch: false };
     }
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/create_resolve.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/create_resolve.ts
@@ -9,9 +9,8 @@
 
 import { createRegExpPatternFrom, testPatternAgainstAllowedList } from '@kbn/data-view-utils';
 import { BehaviorSubject } from 'rxjs';
-import { DataSourceCategory } from '../../../../profiles';
+import { DataSourceCategory, SolutionType } from '../../../../profiles';
 import { extractIndexPatternFrom } from '../../../extract_index_pattern_from';
-import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
 import type { LogOverviewContext, LogsDataSourceProfileProvider } from '../profile';
 
 export const createResolve = (
@@ -22,7 +21,7 @@ export const createResolve = (
   ]);
 
   return (params) => {
-    if (params.rootContext.profileId !== OBSERVABILITY_ROOT_PROFILE_ID) {
+    if (params.rootContext.solutionType !== SolutionType.Observability) {
       return { isMatch: false };
     }
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_profile_providers.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ProfileProviderServices } from '../profile_provider_services';
+import { createObservabilityLogDocumentProfileProvider } from './log_document_profile';
+import { createObservabilityTracesSpanDocumentProfileProvider } from './traces_document_profile/span_document_profile';
+import { createObservabilityTracesTransactionDocumentProfileProvider } from './traces_document_profile/transaction_document_profile';
+
+export const createObservabilityDocumentProfileProviders = (
+  providerServices: ProfileProviderServices
+) => {
+  return [
+    createObservabilityLogDocumentProfileProvider(providerServices),
+    createObservabilityTracesSpanDocumentProfileProvider(providerServices),
+    createObservabilityTracesTransactionDocumentProfileProvider(providerServices),
+  ];
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_doc_viewer.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_doc_viewer.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { hasAnyFieldWithPrefixes } from '../../utils/has_any_field_with_prefixes';
+import type { ObservabilityRootProfileProvider } from '../types';
+
+const attributesPrefixes = ['attributes.', 'scope.attributes.', 'resource.attributes.'];
+const hasAnyAttributesField = hasAnyFieldWithPrefixes(attributesPrefixes);
+
+export const getDocViewer: ObservabilityRootProfileProvider['profile']['getDocViewer'] =
+  (prev) => (params) => {
+    const prevDocViewer = prev(params);
+
+    return {
+      ...prevDocViewer,
+      docViewsRegistry: (registry) => {
+        if (hasAnyAttributesField(params.record)) {
+          registry.add({
+            id: 'doc_view_obs_attributes_overview',
+            title: i18n.translate('discover.docViews.observability.attributesOverview.title', {
+              defaultMessage: 'Attributes',
+            }),
+            order: 9,
+            component: (props) => {
+              return 'Attributes Overview';
+            },
+          });
+        }
+
+        return prevDocViewer.docViewsRegistry(registry);
+      },
+    };
+  };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/index.ts
@@ -7,4 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { createObservabilityRootProfileProvider } from './profile';
+import type { ProfileProviderServices } from '../../profile_provider_services';
+import { createObservabilityRootProfileProvider } from './profile';
+import { createObservabilityRootProfileProviderWithAttributesTab } from './sub_profiles/observability_root_profile_with_attributes_tab';
+
+export const createObservabilityRootProfileProviders = (
+  providerServices: ProfileProviderServices
+) => {
+  const observabilityRootProfileProvider = createObservabilityRootProfileProvider(providerServices);
+
+  return [
+    createObservabilityRootProfileProviderWithAttributesTab(observabilityRootProfileProvider),
+    observabilityRootProfileProvider,
+  ];
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/sub_profiles/observability_root_profile_with_attributes_tab.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/sub_profiles/observability_root_profile_with_attributes_tab.test.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import { createContextAwarenessMocks } from '../../../../__mocks__';
+import { SolutionType } from '../../../../profiles';
+import { createObservabilityRootProfileProvider } from '../profile';
+import { createObservabilityRootProfileProviderWithAttributesTab } from './observability_root_profile_with_attributes_tab';
+import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+
+const mockServices = createContextAwarenessMocks().profileProviderServices;
+
+describe('createObservabilityRootProfileProviderWithAttributesTab', () => {
+  const observabilityRootProfileProvider = createObservabilityRootProfileProvider(mockServices);
+  const observabilityRootProfileProviderWithAttributes =
+    createObservabilityRootProfileProviderWithAttributesTab(observabilityRootProfileProvider);
+
+  describe('getDocViewer', () => {
+    it('does NOT add attributes doc viewer tab to the registry when the record has no attributes fields', () => {
+      const getDocViewer = observabilityRootProfileProviderWithAttributes.profile.getDocViewer!(
+        () => ({
+          title: 'test title',
+          docViewsRegistry: (registry) => registry,
+        }),
+        {
+          context: {
+            solutionType: SolutionType.Observability,
+            allLogsIndexPattern: mockServices.logsContextService.getAllLogsIndexPattern(),
+          },
+        }
+      );
+
+      const docViewer = getDocViewer({
+        record: buildMockRecord('test-index', {
+          foo: 'bar',
+        }),
+      });
+
+      const registry = new DocViewsRegistry();
+
+      expect(docViewer.title).toBe('test title');
+      expect(registry.getAll()).toHaveLength(0);
+
+      docViewer.docViewsRegistry(registry);
+
+      expect(registry.getAll()).toHaveLength(0);
+    });
+    it('adds attributes doc viwer tab to the registry when the record has any attributes. field', () => {
+      const getDocViewer = observabilityRootProfileProviderWithAttributes.profile.getDocViewer!(
+        () => ({
+          title: 'test title',
+          docViewsRegistry: (registry) => registry,
+        }),
+        {
+          context: {
+            solutionType: SolutionType.Observability,
+            allLogsIndexPattern: mockServices.logsContextService.getAllLogsIndexPattern(),
+          },
+        }
+      );
+
+      const docViewer = getDocViewer({
+        record: buildMockRecord('test-index', {
+          'attributes.foo': 'bar',
+        }),
+      });
+
+      const registry = new DocViewsRegistry();
+
+      expect(docViewer.title).toBe('test title');
+      expect(registry.getAll()).toHaveLength(0);
+      docViewer.docViewsRegistry(registry);
+
+      expect(registry.getAll()).toHaveLength(1);
+
+      expect(registry.getAll()[0]).toEqual(
+        expect.objectContaining({
+          id: 'doc_view_obs_attributes_overview',
+          title: 'Attributes',
+          order: 9,
+          component: expect.any(Function),
+        })
+      );
+    });
+    it('adds attributes doc viwer tab to the registry when the record has any scope.attributes. field', () => {
+      const getDocViewer = observabilityRootProfileProviderWithAttributes.profile.getDocViewer!(
+        () => ({
+          title: 'test title',
+          docViewsRegistry: (registry) => registry,
+        }),
+        {
+          context: {
+            solutionType: SolutionType.Observability,
+            allLogsIndexPattern: mockServices.logsContextService.getAllLogsIndexPattern(),
+          },
+        }
+      );
+
+      const docViewer = getDocViewer({
+        record: buildMockRecord('test-index', {
+          'scope.attributes.foo': 'bar',
+        }),
+      });
+
+      const registry = new DocViewsRegistry();
+
+      expect(docViewer.title).toBe('test title');
+      expect(registry.getAll()).toHaveLength(0);
+      docViewer.docViewsRegistry(registry);
+
+      expect(registry.getAll()).toHaveLength(1);
+
+      expect(registry.getAll()[0]).toEqual(
+        expect.objectContaining({
+          id: 'doc_view_obs_attributes_overview',
+          title: 'Attributes',
+          order: 9,
+          component: expect.any(Function),
+        })
+      );
+    });
+    it('adds attributes doc viwer tab to the registry when the record has any resource.attributes. field', () => {
+      const getDocViewer = observabilityRootProfileProviderWithAttributes.profile.getDocViewer!(
+        () => ({
+          title: 'test title',
+          docViewsRegistry: (registry) => registry,
+        }),
+        {
+          context: {
+            solutionType: SolutionType.Observability,
+            allLogsIndexPattern: mockServices.logsContextService.getAllLogsIndexPattern(),
+          },
+        }
+      );
+
+      const docViewer = getDocViewer({
+        record: buildMockRecord('test-index', {
+          'resource.attributes.foo': 'bar',
+        }),
+      });
+
+      const registry = new DocViewsRegistry();
+
+      expect(docViewer.title).toBe('test title');
+      expect(registry.getAll()).toHaveLength(0);
+      docViewer.docViewsRegistry(registry);
+
+      expect(registry.getAll()).toHaveLength(1);
+
+      expect(registry.getAll()[0]).toEqual(
+        expect.objectContaining({
+          id: 'doc_view_obs_attributes_overview',
+          title: 'Attributes',
+          order: 9,
+          component: expect.any(Function),
+        })
+      );
+    });
+  });
+});
+
+const buildMockRecord = (index: string, fields: Record<string, unknown> = {}) =>
+  buildDataTableRecord({
+    _id: '',
+    _index: index,
+    fields: {
+      _index: index,
+      ...fields,
+    },
+  });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/sub_profiles/observability_root_profile_with_attributes_tab.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/sub_profiles/observability_root_profile_with_attributes_tab.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { extendProfileProvider } from '../../../extend_profile_provider';
+import { getDocViewer } from '../accessors/get_doc_viewer';
+import type { ObservabilityRootProfileProvider } from '../types';
+
+export const createObservabilityRootProfileProviderWithAttributesTab = (
+  observabilityRootProfileProvider: ObservabilityRootProfileProvider
+) =>
+  extendProfileProvider(observabilityRootProfileProvider, {
+    profileId: 'observability-root-profile-with-attributes-tab',
+    isExperimental: true,
+    profile: {
+      getDocViewer,
+    },
+  });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/types.ts
@@ -7,10 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { RootProfileProvider } from '../../..';
+import type { RootProfileProvider, SolutionType } from '../../..';
 
 export interface ObservabilityRootProfileContext {
   allLogsIndexPattern: string | undefined;
+  solutionType: SolutionType.Observability;
 }
 
 export type ObservabilityRootProfileProvider = RootProfileProvider<ObservabilityRootProfileContext>;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.test.ts
@@ -95,7 +95,7 @@ describe('tracesDataSourceProfileProvider', () => {
     ).toEqual(RESOLUTION_MISMATCH);
   });
 
-  it("should NOT match when the root context isn't Observability", () => {
+  it('should NOT match when the solutionType is NOT Observability', () => {
     expect(
       tracesDataSourceProfileProvider.resolve({
         rootContext: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.ts
@@ -8,11 +8,14 @@
  */
 
 import { TRACES_PRODUCT_FEATURE_ID } from '../../../../../common/constants';
-import { DataSourceCategory, type DataSourceProfileProvider } from '../../../profiles';
+import {
+  SolutionType,
+  DataSourceCategory,
+  type DataSourceProfileProvider,
+} from '../../../profiles';
 import { extractIndexPatternFrom } from '../../extract_index_pattern_from';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 import { getCellRenderers } from './accessors';
-import { OBSERVABILITY_ROOT_PROFILE_ID } from '../consts';
 
 const OBSERVABILITY_TRACES_DATA_SOURCE_PROFILE_ID = 'observability-traces-data-source-profile';
 
@@ -40,7 +43,7 @@ export const createTracesDataSourceProfileProvider = ({
   },
   resolve: (params) => {
     if (
-      params.rootContext.profileId === OBSERVABILITY_ROOT_PROFILE_ID &&
+      params.rootContext.solutionType === SolutionType.Observability &&
       tracesContextService.containsTracesIndexPattern(extractIndexPatternFrom(params))
     ) {
       return {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.test.ts
@@ -19,12 +19,14 @@ import type { ProfileProviderServices } from '../../../profile_provider_services
 describe('spanDocumentProfileProvider', () => {
   const getRootContext = ({
     profileId,
+    solutionType,
   }: {
     profileId: string;
+    solutionType?: SolutionType;
   }): ContextWithProfileId<RootContext> => {
     return {
       profileId,
-      solutionType: SolutionType.Observability,
+      solutionType: solutionType ?? SolutionType.Observability,
     };
   };
 
@@ -78,14 +80,14 @@ describe('spanDocumentProfileProvider', () => {
 
   describe('when root profile is NOT observability', () => {
     const profileId = 'another-profile';
-
+    const solutionType = SolutionType.Security;
     const spanDocumentProfileProvider =
       createObservabilityTracesSpanDocumentProfileProvider(mockServices);
 
     it('does not match records with the correct data stream type and the correct processor event', () => {
       expect(
         spanDocumentProfileProvider.resolve({
-          rootContext: getRootContext({ profileId }),
+          rootContext: getRootContext({ profileId, solutionType }),
           dataSourceContext: DATA_SOURCE_CONTEXT,
           record: buildMockRecord('index', {
             'data_stream.type': ['traces'],

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.ts
@@ -11,10 +11,9 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { DATASTREAM_TYPE_FIELD, getFieldValue, PROCESSOR_EVENT_FIELD } from '@kbn/discover-utils';
 import { TRACES_PRODUCT_FEATURE_ID } from '../../../../../../common/constants';
 import type { DocumentProfileProvider } from '../../../../profiles';
-import { DocumentType } from '../../../../profiles';
+import { DocumentType, SolutionType } from '../../../../profiles';
 import type { ProfileProviderServices } from '../../../profile_provider_services';
 import { createGetDocViewer } from './accessors';
-import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
 
 const OBSERVABILITY_TRACES_SPAN_DOCUMENT_PROFILE_ID = 'observability-traces-span-document-profile';
 
@@ -28,7 +27,7 @@ export const createObservabilityTracesSpanDocumentProfileProvider = ({
     getDocViewer: createGetDocViewer(tracesContextService.getAllTracesIndexPattern()),
   },
   resolve: ({ record, rootContext }) => {
-    const isObservabilitySolutionView = rootContext.profileId === OBSERVABILITY_ROOT_PROFILE_ID;
+    const isObservabilitySolutionView = rootContext.solutionType === SolutionType.Observability;
 
     if (!isObservabilitySolutionView) {
       return { isMatch: false };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.test.ts
@@ -19,12 +19,14 @@ import type { ProfileProviderServices } from '../../../profile_provider_services
 describe('transactionDocumentProfileProvider', () => {
   const getRootContext = ({
     profileId,
+    solutionType,
   }: {
     profileId: string;
+    solutionType?: SolutionType;
   }): ContextWithProfileId<RootContext> => {
     return {
       profileId,
-      solutionType: SolutionType.Observability,
+      solutionType: solutionType ?? SolutionType.Observability,
     };
   };
 
@@ -75,15 +77,16 @@ describe('transactionDocumentProfileProvider', () => {
     });
   });
 
-  describe('when root profile is NOT observability', () => {
-    const profileId = 'another-profile';
+  describe('when solutionType is NOT observability', () => {
+    const profileId = OBSERVABILITY_ROOT_PROFILE_ID;
+    const solutionType = SolutionType.Default;
     const transactionDocumentProfileProvider =
       createObservabilityTracesTransactionDocumentProfileProvider(mockServices);
 
     it('does not match records with the correct data stream type and the correct processor event', () => {
       expect(
         transactionDocumentProfileProvider.resolve({
-          rootContext: getRootContext({ profileId }),
+          rootContext: getRootContext({ profileId, solutionType }),
           dataSourceContext: DATA_SOURCE_CONTEXT,
           record: buildMockRecord('index', {
             'data_stream.type': ['traces'],

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.ts
@@ -11,9 +11,8 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { DATASTREAM_TYPE_FIELD, getFieldValue, PROCESSOR_EVENT_FIELD } from '@kbn/discover-utils';
 import { TRACES_PRODUCT_FEATURE_ID } from '../../../../../../common/constants';
 import type { DocumentProfileProvider } from '../../../../profiles';
-import { DocumentType } from '../../../../profiles';
+import { DocumentType, SolutionType } from '../../../../profiles';
 import { createGetDocViewer } from './accessors';
-import { OBSERVABILITY_ROOT_PROFILE_ID } from '../../consts';
 import type { ProfileProviderServices } from '../../../profile_provider_services';
 
 const OBSERVABILITY_TRACES_TRANSACTION_DOCUMENT_PROFILE_ID =
@@ -29,7 +28,7 @@ export const createObservabilityTracesTransactionDocumentProfileProvider = ({
     getDocViewer: createGetDocViewer(tracesContextService.getAllTracesIndexPattern() || ''),
   },
   resolve: ({ record, rootContext }) => {
-    const isObservabilitySolutionView = rootContext.profileId === OBSERVABILITY_ROOT_PROFILE_ID;
+    const isObservabilitySolutionView = rootContext.solutionType === SolutionType.Observability;
 
     if (!isObservabilitySolutionView) {
       return { isMatch: false };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/utils/has_any_field_with_prefixes.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/utils/has_any_field_with_prefixes.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { hasAnyFieldWithPrefixes } from './has_any_field_with_prefixes';
+import type { DataTableRecord } from '@kbn/discover-utils';
+
+describe('hasAnyFieldWithPrefixes', () => {
+  const makeRecord = (flattened: Record<string, unknown>): DataTableRecord =>
+    ({ flattened } as DataTableRecord);
+
+  it('returns true if any prefix matches a non-null field', () => {
+    const record = makeRecord({
+      'foo.bar': null,
+      'baz.qux': 42,
+      other: 'value',
+    });
+    const fn = hasAnyFieldWithPrefixes(['foo.', 'other']);
+    expect(fn(record)).toBe(true);
+  });
+
+  it('returns false if any suffix matches a non-null field', () => {
+    const record = makeRecord({
+      'foo.bar.qux': null,
+      'baz.bar.qux.': 42,
+      other: 'value',
+    });
+    const fn = hasAnyFieldWithPrefixes(['bar.quax']);
+    expect(fn(record)).toBe(false);
+  });
+
+  it('returns false if no keys in flattened object', () => {
+    const record = makeRecord({});
+    const fn = hasAnyFieldWithPrefixes(['foo.', 'bar.']);
+    expect(fn(record)).toBe(false);
+  });
+
+  it('returns false if prefixes array is empty', () => {
+    const record = makeRecord({
+      'foo.bar': 1,
+      'baz.qux': 2,
+    });
+    const fn = hasAnyFieldWithPrefixes([]);
+    expect(fn(record)).toBe(false);
+  });
+
+  it('returns false if prefix is an empty string and all fields are null/undefined', () => {
+    const record = makeRecord({
+      'foo.bar': null,
+      'baz.qux': undefined,
+    });
+    const fn = hasAnyFieldWithPrefixes(['']);
+    expect(fn(record)).toBe(false);
+  });
+
+  it('returns true if prefix is an empty string and any field is non-null', () => {
+    const record = makeRecord({
+      'foo.bar': 1,
+      'baz.qux': null,
+    });
+    const fn = hasAnyFieldWithPrefixes(['']);
+    expect(fn(record)).toBe(true);
+  });
+  it('returns true if a field with a prefix exists and its value is 0', () => {
+    const record = makeRecord({
+      'foo.bar': 0,
+      'baz.qux': null,
+    });
+    const fn = hasAnyFieldWithPrefixes(['foo.']);
+    expect(fn(record)).toBe(true);
+  });
+
+  it('returns true if a field with a prefix  exists and its value is false', () => {
+    const record = makeRecord({
+      'foo.bar': false,
+      'baz.qux': null,
+    });
+    const fn = hasAnyFieldWithPrefixes(['foo.']);
+    expect(fn(record)).toBe(true);
+  });
+
+  it('returns true if a field with a prefix exists and its value is an empty string', () => {
+    const record = makeRecord({
+      'foo.bar': '',
+      'baz.qux': null,
+    });
+    const fn = hasAnyFieldWithPrefixes(['foo.']);
+    expect(fn(record)).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/utils/has_any_field_with_prefixes.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/utils/has_any_field_with_prefixes.ts
@@ -7,6 +7,20 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { createGetAppMenu } from './get_app_menu';
-export { getDefaultAdHocDataViews } from './get_default_ad_hoc_data_views';
-export { getDocViewer } from './get_doc_viewer';
+import type { DataTableRecord } from '@kbn/discover-utils';
+
+export const hasAnyFieldWithPrefixes = (prefixes: string[]) => {
+  return (record: DataTableRecord): boolean => {
+    const data = record.flattened;
+
+    for (const prefix of prefixes) {
+      for (const key in data) {
+        if (key.startsWith(prefix) && data[key] != null) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -20,17 +20,15 @@ import {
   createExampleRootProfileProvider,
 } from './example/example_root_profile';
 import { createObservabilityLogsDataSourceProfileProviders } from './observability/logs_data_source_profile';
-import { createObservabilityLogDocumentProfileProvider } from './observability/log_document_profile';
 import { createSecurityRootProfileProvider } from './security/security_root_profile';
 import type { ProfileProviderServices } from './profile_provider_services';
 import { createProfileProviderServices } from './profile_provider_services';
 import type { DiscoverServices } from '../../build_services';
-import { createObservabilityRootProfileProvider } from './observability/observability_root_profile';
+import { createObservabilityRootProfileProviders } from './observability/observability_root_profile';
 import { createTracesDataSourceProfileProvider } from './observability/traces_data_source_profile';
 import { createDeprecationLogsDataSourceProfileProvider } from './common/deprecation_logs';
 import { createClassicNavRootProfileProvider } from './common/classic_nav_root_profile';
-import { createObservabilityTracesSpanDocumentProfileProvider } from './observability/traces_document_profile/span_document_profile';
-import { createObservabilityTracesTransactionDocumentProfileProvider } from './observability/traces_document_profile/transaction_document_profile';
+import { createObservabilityDocumentProfileProviders } from './observability/observability_profile_providers';
 
 /**
  * Register profile providers for root, data source, and document contexts to the profile profile services
@@ -138,7 +136,7 @@ const createRootProfileProviders = (providerServices: ProfileProviderServices) =
   createExampleSolutionViewRootProfileProvider(),
   createClassicNavRootProfileProvider(providerServices),
   createSecurityRootProfileProvider(providerServices),
-  createObservabilityRootProfileProvider(providerServices),
+  ...createObservabilityRootProfileProviders(providerServices),
 ];
 
 /**
@@ -160,7 +158,5 @@ const createDataSourceProfileProviders = (providerServices: ProfileProviderServi
  */
 const createDocumentProfileProviders = (providerServices: ProfileProviderServices) => [
   createExampleDocumentProfileProvider(),
-  createObservabilityLogDocumentProfileProvider(providerServices),
-  createObservabilityTracesSpanDocumentProfileProvider(providerServices),
-  createObservabilityTracesTransactionDocumentProfileProvider(providerServices),
+  ...createObservabilityDocumentProfileProviders(providerServices),
 ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][Oblt] Display Attributes doc viewer tab for Observability (#222391)](https://github.com/elastic/kibana/pull/222391)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Katerina","email":"aikaterini.patticha@elastic.co"},"sourceCommit":{"committedDate":"2025-06-13T12:16:11Z","message":"[Discover][Oblt] Display Attributes doc viewer tab for Observability (#222391)\n\nClosing https://github.com/elastic/kibana/issues/221919 \n\n\n## Summary\n\n\nIn this PR, I'm adding the Attributes doc viwer tab for the\n**Observability solution view.**\nThe tab should be visible for all discover documents that have any of\nthe following prefixes\n\n```\nconst attributesPrefixes = ['attributes.', 'scope.attributes.', 'resource.attributes.'];\n```\n\nAlso, \n- Group the observability document profile providers into one file\n\n> [!IMPORTANT]  \n> The content of the tab is not inlcuded in this PR. it will be part of\nthis [ticket](https://github.com/elastic/kibana/issues/221927)\n\n## Additional changes\n\n\nFor the existing profiles, logs, traces I updated the condition to check\nthe solution\n\nFrom `params.rootContext.profileId === OBSERVABILITY_ROOT_PROFILE_ID` to\n`params.rootContext.solutionType === SolutionType.Observability`\n \n \nIMO both are  prone to errors. \n\n- As I'm extending the root profile, the above statement is not true. it\nreturns the new extended profile ID\n- Also, if we add more extensions to the root profile and we add another\nsolutionType by mistake the profiles won't work\n\nI updated the type\nhttps://github.com/elastic/kibana/pull/222391/files#diff-ff7a53f0c234902226be3e34978326985dfffadabb8ae722b6c3fc2115085d11R14\nbut it might not be enough.\n\n\n## Test \n#### How to generate OTel data\n- Follow\nhttps://github.com/smith/elastic-stack-docker-compose?tab=readme-ov-file#elastic-stack-docker-compose\n\n#### How to test\n- Make sure your solution view is Observability\n- update your `kibana.yaml` \n\n```\ndiscover.experimental.enabledProfiles:\n   - observability-root-profile-with-attributes-tab\n   #  if you want to test it with the additional profiles add the following to your `kibana.yaml` \n   - observability-traces-data-source-profile\n   - observability-traces-transaction-document-profile\n   - observability-traces-span-document-profile\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cf57a85869bec73f71978fc367b783e168f5cce4","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","backport:version","v9.1.0","v8.19.0"],"title":"[Discover][Oblt] Display Attributes doc viewer tab for Observability","number":222391,"url":"https://github.com/elastic/kibana/pull/222391","mergeCommit":{"message":"[Discover][Oblt] Display Attributes doc viewer tab for Observability (#222391)\n\nClosing https://github.com/elastic/kibana/issues/221919 \n\n\n## Summary\n\n\nIn this PR, I'm adding the Attributes doc viwer tab for the\n**Observability solution view.**\nThe tab should be visible for all discover documents that have any of\nthe following prefixes\n\n```\nconst attributesPrefixes = ['attributes.', 'scope.attributes.', 'resource.attributes.'];\n```\n\nAlso, \n- Group the observability document profile providers into one file\n\n> [!IMPORTANT]  \n> The content of the tab is not inlcuded in this PR. it will be part of\nthis [ticket](https://github.com/elastic/kibana/issues/221927)\n\n## Additional changes\n\n\nFor the existing profiles, logs, traces I updated the condition to check\nthe solution\n\nFrom `params.rootContext.profileId === OBSERVABILITY_ROOT_PROFILE_ID` to\n`params.rootContext.solutionType === SolutionType.Observability`\n \n \nIMO both are  prone to errors. \n\n- As I'm extending the root profile, the above statement is not true. it\nreturns the new extended profile ID\n- Also, if we add more extensions to the root profile and we add another\nsolutionType by mistake the profiles won't work\n\nI updated the type\nhttps://github.com/elastic/kibana/pull/222391/files#diff-ff7a53f0c234902226be3e34978326985dfffadabb8ae722b6c3fc2115085d11R14\nbut it might not be enough.\n\n\n## Test \n#### How to generate OTel data\n- Follow\nhttps://github.com/smith/elastic-stack-docker-compose?tab=readme-ov-file#elastic-stack-docker-compose\n\n#### How to test\n- Make sure your solution view is Observability\n- update your `kibana.yaml` \n\n```\ndiscover.experimental.enabledProfiles:\n   - observability-root-profile-with-attributes-tab\n   #  if you want to test it with the additional profiles add the following to your `kibana.yaml` \n   - observability-traces-data-source-profile\n   - observability-traces-transaction-document-profile\n   - observability-traces-span-document-profile\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cf57a85869bec73f71978fc367b783e168f5cce4"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222391","number":222391,"mergeCommit":{"message":"[Discover][Oblt] Display Attributes doc viewer tab for Observability (#222391)\n\nClosing https://github.com/elastic/kibana/issues/221919 \n\n\n## Summary\n\n\nIn this PR, I'm adding the Attributes doc viwer tab for the\n**Observability solution view.**\nThe tab should be visible for all discover documents that have any of\nthe following prefixes\n\n```\nconst attributesPrefixes = ['attributes.', 'scope.attributes.', 'resource.attributes.'];\n```\n\nAlso, \n- Group the observability document profile providers into one file\n\n> [!IMPORTANT]  \n> The content of the tab is not inlcuded in this PR. it will be part of\nthis [ticket](https://github.com/elastic/kibana/issues/221927)\n\n## Additional changes\n\n\nFor the existing profiles, logs, traces I updated the condition to check\nthe solution\n\nFrom `params.rootContext.profileId === OBSERVABILITY_ROOT_PROFILE_ID` to\n`params.rootContext.solutionType === SolutionType.Observability`\n \n \nIMO both are  prone to errors. \n\n- As I'm extending the root profile, the above statement is not true. it\nreturns the new extended profile ID\n- Also, if we add more extensions to the root profile and we add another\nsolutionType by mistake the profiles won't work\n\nI updated the type\nhttps://github.com/elastic/kibana/pull/222391/files#diff-ff7a53f0c234902226be3e34978326985dfffadabb8ae722b6c3fc2115085d11R14\nbut it might not be enough.\n\n\n## Test \n#### How to generate OTel data\n- Follow\nhttps://github.com/smith/elastic-stack-docker-compose?tab=readme-ov-file#elastic-stack-docker-compose\n\n#### How to test\n- Make sure your solution view is Observability\n- update your `kibana.yaml` \n\n```\ndiscover.experimental.enabledProfiles:\n   - observability-root-profile-with-attributes-tab\n   #  if you want to test it with the additional profiles add the following to your `kibana.yaml` \n   - observability-traces-data-source-profile\n   - observability-traces-transaction-document-profile\n   - observability-traces-span-document-profile\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cf57a85869bec73f71978fc367b783e168f5cce4"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->