### PR TITLE
[Synthetics] Last Successful screenshots match the step

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details_successful.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details_successful.tsx
@@ -59,7 +59,7 @@ export const ResultDetailsSuccessful = ({
           <EuiSpacer size="m" />
           <JourneyStepScreenshotContainer
             checkGroup={data?.monitor.check_group}
-            initialStepNumber={data?.synthetics?.step?.index}
+            initialStepNumber={stepIndex}
             stepStatus={data?.synthetics?.payload?.status}
             allStepsLoaded={!loading}
             retryFetchOnRevisit={false}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_failed_tests.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_failed_tests.tsx
@@ -45,8 +45,8 @@ export function useErrorFailedTests() {
             },
           ],
         },
-        sort: [{ '@timestamp': 'desc' }],
       },
+      sort: [{ '@timestamp': 'desc' }],
     },
     [lastRefresh, monitorId, dateRangeStart, dateRangeEnd],
     { name: 'getMonitorErrorFailedTests' }


### PR DESCRIPTION
This PR closes #209844 . It also fixes a bug introduces in [this PR](https://github.com/elastic/kibana/pull/208776) that was preventing the Error details page from loading.

**Before**
![Screenshot 2025-06-17 at 12 22 06](https://github.com/user-attachments/assets/8b22426b-8ca5-468c-a635-3b165dc95813)

**After**
![Screenshot 2025-06-17 at 12 19 33](https://github.com/user-attachments/assets/34f13487-d07b-4cfe-9223-39b00e06a812)






<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->