### PR TITLE
[Discover] Update aria tags in patterns selected field (#217562)

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/log_categorization_for_embeddable/field_selector.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/log_categorization_for_embeddable/field_selector.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiToken,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { DataViewField } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
@@ -36,6 +37,24 @@ export const SelectedField: FC<Props> = ({ fields, selectedField, setSelectedFie
     <EuiDataGridToolbarControl
       data-test-subj="aiopsEmbeddableSelectFieldButton"
       onClick={() => togglePopover()}
+      aria-haspopup="dialog"
+      aria-expanded={showPopover}
+      aria-label={
+        selectedField
+          ? i18n.translate(
+              'xpack.aiops.logCategorization.embeddableMenu.selectedFieldButtonAriaLabel',
+              {
+                defaultMessage: 'Selected field: {fieldName}',
+                values: { fieldName: selectedField?.name },
+              }
+            )
+          : i18n.translate(
+              'xpack.aiops.logCategorization.embeddableMenu.noSelectedFieldButtonAriaLabel',
+              {
+                defaultMessage: 'Select field',
+              }
+            )
+      }
     >
       <EuiFlexGroup gutterSize="s" responsive={false}>
         <EuiFlexItem>
@@ -72,23 +91,26 @@ export const FieldSelector: FC<Props> = ({
     () => fields.map((field) => ({ inputDisplay: field.name, value: field })),
     [fields]
   );
-
-  const label = i18n.translate(
-    'xpack.aiops.logCategorization.embeddableMenu.selectedFieldRowLabel',
-    {
-      defaultMessage: 'Selected field',
-    }
-  );
+  const fieldId = useGeneratedHtmlId({ prefix: 'fieldSelector', suffix: 'select' });
 
   return (
     <>
       {WarningComponent !== undefined ? <WarningComponent /> : null}
 
-      <EuiFormRow fullWidth data-test-subj="aiopsEmbeddableMenuSelectedFieldFormRow" label={label}>
+      <EuiFormRow
+        fullWidth
+        data-test-subj="aiopsEmbeddableMenuSelectedFieldFormRow"
+        label={i18n.translate(
+          'xpack.aiops.logCategorization.embeddableMenu.selectedFieldRowLabel',
+          {
+            defaultMessage: 'Selected field',
+          }
+        )}
+        id={fieldId}
+      >
         <EuiSuperSelect
           fullWidth
           compressed
-          aria-label={label}
           options={fieldOptions}
           disabled={fields.length === 0}
           valueOfSelected={selectedField ?? undefined}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/217562

Updates some aria tags to try to improve the accessibility of the "Selected field" part of patterns:
- Added `aria-haspopup` and `aria-expanded` to toggle button
- Added `aria-label` to have a more understandable name
- Added `id` to the form so the label has a for

| Before | After |
|--------|------|
| ![image (9)](https://github.com/user-attachments/assets/03b8f443-0d67-4103-a338-de1108b1eb6f) | ![image (8)](https://github.com/user-attachments/assets/42e06aa6-3e4d-4fa0-9740-d664a3350f80) |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->