### PR TITLE
Revert "Fixes the zindex of the resizable flyout over the editor"

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -366,7 +366,7 @@ export function LensEditConfigurationFlyout({
           direction="column"
           gutterSize="none"
         >
-          <div ref={editorContainer} style={{ zIndex: 0 }} />
+          <div ref={editorContainer} />
           <EuiFlexItem
             grow={isLayerAccordionOpen ? 1 : false}
             css={css`


### PR DESCRIPTION
Reverts elastic/kibana#222925

Closes https://github.com/elastic/kibana/issues/223979


Unfortunately it created a bad UI bug so I will revert it and reopen the issue with the resizing which is lower impact than the current one

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->