### PR TITLE
[Response Ops][Reports] Updating list scheduled report API response

### DIFF
--- a/x-pack/platform/plugins/private/reporting/server/routes/internal/management/scheduled.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/internal/management/scheduled.ts
@@ -76,7 +76,7 @@ export function registerScheduledRoutesInternal(reporting: ReportingCore, logger
             MAX_SCHEDULED_REPORT_LIST_SIZE,
             parseInt(querySize, 10) || DEFAULT_SCHEDULED_REPORT_LIST_SIZE
           );
-          const results = await scheduledQuery.list(req, res, user, page, size);
+          const results = await scheduledQuery.list(logger, req, res, user, page, size);
 
           counters.usageCounter();
 

--- a/x-pack/platform/plugins/private/reporting/server/types.ts
+++ b/x-pack/platform/plugins/private/reporting/server/types.ts
@@ -129,11 +129,12 @@ export interface ListScheduledReportApiJSON {
   created_by: RawScheduledReport['createdBy'];
   enabled: RawScheduledReport['enabled'];
   jobtype: RawScheduledReport['jobType'];
-  object_type: RawScheduledReport['meta']['objectType'];
   last_run: string | undefined;
   next_run: string | undefined;
   notification: RawScheduledReport['notification'];
+  payload?: ReportApiJSON['payload'];
   schedule: RruleSchedule;
+  space_id: string;
   title: RawScheduledReport['title'];
 }
 

--- a/x-pack/test/reporting_api_integration/services/scenarios.ts
+++ b/x-pack/test/reporting_api_integration/services/scenarios.ts
@@ -277,7 +277,6 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
       .auth(username, password)
       .set('kbn-xsrf', 'xxx');
 
-    log.info(`listScheduledReports: ${JSON.stringify(res)}`);
     return res.body;
   };
 


### PR DESCRIPTION
> [!Note]
> This PR will be merged into a [feature branch](https://github.com/elastic/kibana/pull/221028)

## Summary

Updating the list scheduled report API response to return `payload` and `space_id`. This allows generating links for the reporting UI.