### PR TITLE
[Fleet] Update Remote ES Kibana API key placeholder

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_remote_es.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_remote_es.tsx
@@ -415,7 +415,7 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
                   placeholder={i18n.translate(
                     'xpack.fleet.settings.editOutputFlyout.kibanaAPIKeyPlaceholder',
                     {
-                      defaultMessage: 'Specify Kibana API Key',
+                      defaultMessage: 'Specify encoded Kibana API Key',
                     }
                   )}
                 />


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/222025

Renamed placeholder to make it clearer that the encoded value is needed.

<img width="771" alt="image" src="https://github.com/user-attachments/assets/5cff4c94-2ba2-47dd-83c3-9ea8370fc9b3" />
