### PR TITLE
[Fleet] Add install retry to ensureInstalledPackage

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -100,6 +100,7 @@ import { removeInstallation } from './remove';
 export const UPLOAD_RETRY_AFTER_MS = 10000; // 10s
 const MAX_ENSURE_INSTALL_TIME = 60 * 1000;
 const MAX_INSTALL_RETRIES = 5;
+const BASE_RETRY_DELAY_MS = 1000; // 1s
 
 const PACKAGES_TO_INSTALL_WITH_STREAMING = [
   // The security_detection_engine package contains a large number of assets and
@@ -223,6 +224,8 @@ export async function ensureInstalledPackage(options: {
       attempt < MAX_INSTALL_RETRIES &&
       installResult.error?.message.includes('version_conflict_engine_exception')
     ) {
+      const delayMs = BASE_RETRY_DELAY_MS * 2 ** attempt; // Exponential backoff
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
       return await installPackageWithRetries(++attempt);
     } else {
       return installResult;

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -99,6 +99,7 @@ import { removeInstallation } from './remove';
 
 export const UPLOAD_RETRY_AFTER_MS = 10000; // 10s
 const MAX_ENSURE_INSTALL_TIME = 60 * 1000;
+const MAX_INSTALL_RETRIES = 5;
 
 const PACKAGES_TO_INSTALL_WITH_STREAMING = [
   // The security_detection_engine package contains a large number of assets and
@@ -205,16 +206,30 @@ export async function ensureInstalledPackage(options: {
     };
   }
   const pkgkey = Registry.pkgToPkgKey(pkgKeyProps);
-  const installResult = await installPackage({
-    installSource: 'registry',
-    savedObjectsClient,
-    pkgkey,
-    spaceId,
-    esClient,
-    neverIgnoreVerificationError: !force,
-    force: true, // Always force outdated packages to be installed if a later version isn't installed
-    authorizationHeader,
-  });
+
+  const installPackageWithRetries = async (attempt: number): Promise<InstallResult> => {
+    const installResult = await installPackage({
+      installSource: 'registry',
+      savedObjectsClient,
+      pkgkey,
+      spaceId,
+      esClient,
+      neverIgnoreVerificationError: !force,
+      force: true, // Always force outdated packages to be installed if a later version isn't installed
+      authorizationHeader,
+    });
+
+    if (
+      attempt < MAX_INSTALL_RETRIES &&
+      installResult.error?.message.includes('version_conflict_engine_exception')
+    ) {
+      return await installPackageWithRetries(++attempt);
+    } else {
+      return installResult;
+    }
+  };
+
+  const installResult = await installPackageWithRetries(0);
 
   if (installResult.error) {
     const errorPrefix =


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/213337

When requests to install a package as part of the logic ensuring that a package is installed are fired concurrently, the second request fails with a 409 `version_conflict_engine_exception`, which causes flakiness in tests. Ignoring these errors in transform installs was already attempted in https://github.com/elastic/kibana/pull/177380. This PR adds a retry mechanism directly into the package install to consolidate the flow.

### Identify risks

Low probability risk of slower package policy creation.





<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->