### PR TITLE
[9.0] [Security Solution] Fix "too many clauses" error on prebuilt rules installation page (#223240)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { uniqBy } from 'lodash';
+import { chunk, uniqBy } from 'lodash';
+import pMap from 'p-map';
 import type {
   AggregationsMultiBucketAggregateBase,
   AggregationsTopHitsAggregate,
@@ -18,7 +19,10 @@ import { validatePrebuiltRuleAssets } from './prebuilt_rule_assets_validation';
 import { PREBUILT_RULE_ASSETS_SO_TYPE } from './prebuilt_rule_assets_type';
 import type { RuleVersionSpecifier } from '../rule_versions/rule_version_specifier';
 
+const RULE_ASSET_ATTRIBUTES = `${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes`;
 const MAX_PREBUILT_RULES_COUNT = 10_000;
+const ES_MAX_CLAUSE_COUNT = 1024;
+const ES_MAX_CONCURRENT_REQUESTS = 2;
 
 export interface IPrebuiltRuleAssetsClient {
   fetchLatestAssets: () => Promise<PrebuiltRuleAsset[]>;
@@ -77,50 +81,64 @@ export const createPrebuiltRuleAssetsClient = (
 
     fetchLatestVersions: (ruleIds: string[] = []): Promise<RuleVersionSpecifier[]> => {
       return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchLatestVersions', async () => {
-        const filter = ruleIds
-          .map((ruleId) => `${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes.rule_id: ${ruleId}`)
-          .join(' OR ');
+        if (ruleIds && ruleIds.length === 0) {
+          return [];
+        }
 
-        const findResult = await savedObjectsClient.find<
-          PrebuiltRuleAsset,
-          {
-            rules: AggregationsMultiBucketAggregateBase<{
-              latest_version: AggregationsTopHitsAggregate;
-            }>;
-          }
-        >({
-          type: PREBUILT_RULE_ASSETS_SO_TYPE,
-          filter,
-          aggs: {
-            rules: {
-              terms: {
-                field: `${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes.rule_id`,
-                size: MAX_PREBUILT_RULES_COUNT,
-              },
-              aggs: {
-                latest_version: {
-                  top_hits: {
-                    size: 1,
-                    sort: [
-                      {
-                        [`${PREBUILT_RULE_ASSETS_SO_TYPE}.version`]: 'desc',
-                      },
-                    ],
-                    _source: [
-                      `${PREBUILT_RULE_ASSETS_SO_TYPE}.rule_id`,
-                      `${PREBUILT_RULE_ASSETS_SO_TYPE}.version`,
-                    ],
+        const fetchLatestVersionInfo = async (filter?: string) => {
+          const findResult = await savedObjectsClient.find<
+            PrebuiltRuleAsset,
+            {
+              rules: AggregationsMultiBucketAggregateBase<{
+                latest_version: AggregationsTopHitsAggregate;
+              }>;
+            }
+          >({
+            type: PREBUILT_RULE_ASSETS_SO_TYPE,
+            filter,
+            aggs: {
+              rules: {
+                terms: {
+                  field: `${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes.rule_id`,
+                  size: MAX_PREBUILT_RULES_COUNT,
+                },
+                aggs: {
+                  latest_version: {
+                    top_hits: {
+                      size: 1,
+                      sort: [
+                        {
+                          [`${PREBUILT_RULE_ASSETS_SO_TYPE}.version`]: 'desc',
+                        },
+                      ],
+                      _source: [
+                        `${PREBUILT_RULE_ASSETS_SO_TYPE}.rule_id`,
+                        `${PREBUILT_RULE_ASSETS_SO_TYPE}.version`,
+                      ],
+                    },
                   },
                 },
               },
             },
-          },
-        });
+          });
 
-        const buckets = findResult.aggregations?.rules?.buckets ?? [];
-        invariant(Array.isArray(buckets), 'Expected buckets to be an array');
+          const aggregatedBuckets = findResult.aggregations?.rules?.buckets ?? [];
+          invariant(Array.isArray(aggregatedBuckets), 'Expected buckets to be an array');
 
-        return buckets.map((bucket) => {
+          return aggregatedBuckets;
+        };
+
+        const filters = ruleIds
+          ? createChunkedFilters({
+              items: ruleIds,
+              mapperFn: (ruleId) => `${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes.rule_id: ${ruleId}`,
+              clausesPerItem: 2,
+            })
+          : undefined;
+
+        const buckets = await chunkedFetch(fetchLatestVersionInfo, filters);
+
+        const latestVersions = buckets.map((bucket) => {
           const hit = bucket.latest_version.hits.hits[0];
           const soAttributes = hit._source[PREBUILT_RULE_ASSETS_SO_TYPE];
           const versionInfo: RuleVersionSpecifier = {
@@ -129,6 +147,8 @@ export const createPrebuiltRuleAssetsClient = (
           };
           return versionInfo;
         });
+
+        return latestVersions;
       });
     },
 
@@ -139,21 +159,26 @@ export const createPrebuiltRuleAssetsClient = (
           return [];
         }
 
-        const attr = `${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes`;
-        const filter = versions
-          .map((v) => `(${attr}.rule_id: ${v.rule_id} AND ${attr}.version: ${v.version})`)
-          .join(' OR ');
-
-        // Usage of savedObjectsClient.bulkGet() is ~25% more performant and
-        // simplifies deduplication but too many tests get broken.
-        // See https://github.com/elastic/kibana/issues/218198
-        const findResult = await savedObjectsClient.find<PrebuiltRuleAsset>({
-          type: PREBUILT_RULE_ASSETS_SO_TYPE,
-          filter,
-          perPage: MAX_PREBUILT_RULES_COUNT,
+        const filters = createChunkedFilters({
+          items: versions,
+          mapperFn: (versionSpecifier) =>
+            `(${RULE_ASSET_ATTRIBUTES}.rule_id: ${versionSpecifier.rule_id} AND ${RULE_ASSET_ATTRIBUTES}.version: ${versionSpecifier.version})`,
+          clausesPerItem: 4,
         });
 
-        const ruleAssets = findResult.saved_objects.map((so) => so.attributes);
+        const ruleAssets = await chunkedFetch(async (filter) => {
+          // Usage of savedObjectsClient.bulkGet() is ~25% more performant and
+          // simplifies deduplication but too many tests get broken.
+          // See https://github.com/elastic/kibana/issues/218198
+          const findResult = await savedObjectsClient.find<PrebuiltRuleAsset>({
+            type: PREBUILT_RULE_ASSETS_SO_TYPE,
+            filter,
+            perPage: MAX_PREBUILT_RULES_COUNT,
+          });
+
+          return findResult.saved_objects.map((so) => so.attributes);
+        }, filters);
+
         // Rule assets may have duplicates we have to get rid of.
         // In particular prebuilt rule assets package v8.17.1 has duplicates.
         const uniqueRuleAssets = uniqBy(ruleAssets, 'rule_id');
@@ -163,3 +188,50 @@ export const createPrebuiltRuleAssetsClient = (
     },
   };
 };
+
+/**
+ * Creates an array of KQL filter strings for a collection of items.
+ * Uses chunking to ensure that the number of filter clauses does not exceed the ES "too_many_clauses" limit.
+ * See: https://github.com/elastic/kibana/pull/223240
+ *
+ * @param {object} options
+ * @param {T[]} options.items - Array of items to create filters for.
+ * @param {(item: T) => string} options.mapperFn - A function that maps an item to a filter string.
+ * @param {number} options.clausesPerItem - Number of Elasticsearch clauses generated per item. Determined empirically by converting a KQL filter into a Query DSL query.
+ * More complex filters will result in more clauses. Info about clauses in docs: https://www.elastic.co/docs/explore-analyze/query-filter/languages/querydsl#query-dsl
+ * @returns {string[]} An array of filter strings
+ */
+function createChunkedFilters<T>({
+  items,
+  mapperFn,
+  clausesPerItem,
+}: {
+  items: T[];
+  mapperFn: (item: T) => string;
+  clausesPerItem: number;
+}): string[] {
+  return chunk(items, ES_MAX_CLAUSE_COUNT / clausesPerItem).map((singleChunk) =>
+    singleChunk.map(mapperFn).join(' OR ')
+  );
+}
+
+/**
+ * Fetches objects using a provided function.
+ * If filters are provided fetches concurrently in chunks.
+ *
+ * @param {(filter?: string) => Promise<T[]>} chunkFetchFn - Function that fetches a chunk.
+ * @param {string[]} [filters] - An optional array of filter strings. If provided, `chunkFetchFn` will be called for each filter concurrently.
+ * @returns {Promise<T[]>} A promise that resolves to an array of fetched objects.
+ */
+function chunkedFetch<T>(
+  chunkFetchFn: (filter?: string) => Promise<T[]>,
+  filters?: string[]
+): Promise<T[]> {
+  if (filters?.length) {
+    return pMap(filters, chunkFetchFn, {
+      concurrency: ES_MAX_CONCURRENT_REQUESTS,
+    }).then((results) => results.flat());
+  }
+
+  return chunkFetchFn();
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client.ts
@@ -79,7 +79,7 @@ export const createPrebuiltRuleAssetsClient = (
       });
     },
 
-    fetchLatestVersions: (ruleIds: string[] = []): Promise<RuleVersionSpecifier[]> => {
+    fetchLatestVersions: (ruleIds?: string[]): Promise<RuleVersionSpecifier[]> => {
       return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchLatestVersions', async () => {
         if (ruleIds && ruleIds.length === 0) {
           return [];
@@ -154,6 +154,7 @@ export const createPrebuiltRuleAssetsClient = (
 
     fetchAssetsByVersion: (versions: RuleVersionSpecifier[]): Promise<PrebuiltRuleAsset[]> => {
       return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchAssetsByVersion', async () => {
+        // debugger;
         if (versions.length === 0) {
           // NOTE: without early return it would build incorrect filter and fetch all existing saved objects
           return [];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Fix "too many clauses" error on prebuilt rules installation page (#223240)](https://github.com/elastic/kibana/pull/223240)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nikita Indik","email":"nikita.indik@elastic.co"},"sourceCommit":{"committedDate":"2025-06-17T14:14:56Z","message":"[Security Solution] Fix \"too many clauses\" error on prebuilt rules installation page (#223240)\n\n**Resolves: https://github.com/elastic/kibana/issues/223399**\n\n## Summary\nThis PR fixes an error on the \"Add Elastic rules\" page. The error is\nshown when running a local dev environment from `main` branch and going\nto the \"Add Elastic rules\" page.\n\n<img width=\"1741\" alt=\"Screenshot 2025-06-10 at 11 28 19\"\nsrc=\"https://github.com/user-attachments/assets/f8f81f88-3749-491f-bcdb-cd51f465bda6\"\n/>\n\n## Changes\nPR updates methods of `PrebuiltRuleAssetsClient` to split requests to ES\ninto smaller chunks to avoid the error.\n\n## Cause\nKibana makes a search request to ES with a filter that has too many\nclauses, so ES rejects with an error.\n\nMore specifically, `/prebuilt_rules/installation/_review` route handler\ncalls `PrebuiltRuleAssetsClient.fetchAssetsByVersion` to fetch all\ninstallable rules. To do this, we construct a request with thousands of\nclauses in a filter. ES counts the number of clauses in a filter and\nrejects because it's bigger than `maxClauseCount`. `maxClauseCount`\nvalue is computed dynamically by ES and its size depends on hardware and\navailable resources\n([docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-settings.html),\n[code](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/search/SearchUtils.java)).\nThe minimum value for `maxClauseCount` is 1024.\n\n## Why it didn't fail before\nTwo reasons:\n1. ES changed how `maxClauseCount` is computed. They've recently merged\na [PR](https://github.com/elastic/elasticsearch/pull/128293) that made\nqueries against numeric types count three times towards the\n`maxClauseCount` limit. They plan to revert the change in [this\nPR](https://github.com/elastic/elasticsearch/pull/129206).\n2. Prebuilt rule packages are growing bigger with each version,\nresulting in a bigger number of clauses. I've tested behaviour with ES\nchange in place on different package versions:\n- 8.17.1 (contains 1262 rule versions) - no \"too many clauses\" error\n- 8.18.1 (contains 1356 rule versions) - causes \"too many clauses\" error\n- 9.0.1 (also contains 1356 rule versions) - causes \"too many clauses\"\nerror\nThe precise number of versions that start to cause errors is 1293 on my\nlaptop.\n\nSo even if ES team rolls back their change, we still need to make sure\nwe don't go over the limit with ever-growing prebuilt rule package\nsizes.","sha":"482953ddc5a9e1494a3182c9cedfa4214179a297","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[Security Solution] Fix \"too many clauses\" error on prebuilt rules installation page","number":223240,"url":"https://github.com/elastic/kibana/pull/223240","mergeCommit":{"message":"[Security Solution] Fix \"too many clauses\" error on prebuilt rules installation page (#223240)\n\n**Resolves: https://github.com/elastic/kibana/issues/223399**\n\n## Summary\nThis PR fixes an error on the \"Add Elastic rules\" page. The error is\nshown when running a local dev environment from `main` branch and going\nto the \"Add Elastic rules\" page.\n\n<img width=\"1741\" alt=\"Screenshot 2025-06-10 at 11 28 19\"\nsrc=\"https://github.com/user-attachments/assets/f8f81f88-3749-491f-bcdb-cd51f465bda6\"\n/>\n\n## Changes\nPR updates methods of `PrebuiltRuleAssetsClient` to split requests to ES\ninto smaller chunks to avoid the error.\n\n## Cause\nKibana makes a search request to ES with a filter that has too many\nclauses, so ES rejects with an error.\n\nMore specifically, `/prebuilt_rules/installation/_review` route handler\ncalls `PrebuiltRuleAssetsClient.fetchAssetsByVersion` to fetch all\ninstallable rules. To do this, we construct a request with thousands of\nclauses in a filter. ES counts the number of clauses in a filter and\nrejects because it's bigger than `maxClauseCount`. `maxClauseCount`\nvalue is computed dynamically by ES and its size depends on hardware and\navailable resources\n([docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-settings.html),\n[code](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/search/SearchUtils.java)).\nThe minimum value for `maxClauseCount` is 1024.\n\n## Why it didn't fail before\nTwo reasons:\n1. ES changed how `maxClauseCount` is computed. They've recently merged\na [PR](https://github.com/elastic/elasticsearch/pull/128293) that made\nqueries against numeric types count three times towards the\n`maxClauseCount` limit. They plan to revert the change in [this\nPR](https://github.com/elastic/elasticsearch/pull/129206).\n2. Prebuilt rule packages are growing bigger with each version,\nresulting in a bigger number of clauses. I've tested behaviour with ES\nchange in place on different package versions:\n- 8.17.1 (contains 1262 rule versions) - no \"too many clauses\" error\n- 8.18.1 (contains 1356 rule versions) - causes \"too many clauses\" error\n- 9.0.1 (also contains 1356 rule versions) - causes \"too many clauses\"\nerror\nThe precise number of versions that start to cause errors is 1293 on my\nlaptop.\n\nSo even if ES team rolls back their change, we still need to make sure\nwe don't go over the limit with ever-growing prebuilt rule package\nsizes.","sha":"482953ddc5a9e1494a3182c9cedfa4214179a297"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223240","number":223240,"mergeCommit":{"message":"[Security Solution] Fix \"too many clauses\" error on prebuilt rules installation page (#223240)\n\n**Resolves: https://github.com/elastic/kibana/issues/223399**\n\n## Summary\nThis PR fixes an error on the \"Add Elastic rules\" page. The error is\nshown when running a local dev environment from `main` branch and going\nto the \"Add Elastic rules\" page.\n\n<img width=\"1741\" alt=\"Screenshot 2025-06-10 at 11 28 19\"\nsrc=\"https://github.com/user-attachments/assets/f8f81f88-3749-491f-bcdb-cd51f465bda6\"\n/>\n\n## Changes\nPR updates methods of `PrebuiltRuleAssetsClient` to split requests to ES\ninto smaller chunks to avoid the error.\n\n## Cause\nKibana makes a search request to ES with a filter that has too many\nclauses, so ES rejects with an error.\n\nMore specifically, `/prebuilt_rules/installation/_review` route handler\ncalls `PrebuiltRuleAssetsClient.fetchAssetsByVersion` to fetch all\ninstallable rules. To do this, we construct a request with thousands of\nclauses in a filter. ES counts the number of clauses in a filter and\nrejects because it's bigger than `maxClauseCount`. `maxClauseCount`\nvalue is computed dynamically by ES and its size depends on hardware and\navailable resources\n([docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-settings.html),\n[code](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/search/SearchUtils.java)).\nThe minimum value for `maxClauseCount` is 1024.\n\n## Why it didn't fail before\nTwo reasons:\n1. ES changed how `maxClauseCount` is computed. They've recently merged\na [PR](https://github.com/elastic/elasticsearch/pull/128293) that made\nqueries against numeric types count three times towards the\n`maxClauseCount` limit. They plan to revert the change in [this\nPR](https://github.com/elastic/elasticsearch/pull/129206).\n2. Prebuilt rule packages are growing bigger with each version,\nresulting in a bigger number of clauses. I've tested behaviour with ES\nchange in place on different package versions:\n- 8.17.1 (contains 1262 rule versions) - no \"too many clauses\" error\n- 8.18.1 (contains 1356 rule versions) - causes \"too many clauses\" error\n- 9.0.1 (also contains 1356 rule versions) - causes \"too many clauses\"\nerror\nThe precise number of versions that start to cause errors is 1293 on my\nlaptop.\n\nSo even if ES team rolls back their change, we still need to make sure\nwe don't go over the limit with ever-growing prebuilt rule package\nsizes.","sha":"482953ddc5a9e1494a3182c9cedfa4214179a297"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224269","number":224269,"state":"OPEN"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->