### PR TITLE
[Synthetics] Error details - Improved network error handling

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/elasticsearch/effects.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/elasticsearch/effects.ts
@@ -8,6 +8,8 @@
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { Action } from 'redux-actions';
+import { i18n } from '@kbn/i18n';
+import { kibanaService } from '../../../../utils/kibana_service';
 import { serializeHttpFetchError } from '../utils/http_error';
 import { EsActionPayload, EsActionResponse, executeEsQueryAction } from './actions';
 import { executeEsQueryAPI } from './api';
@@ -30,8 +32,19 @@ export function* executeEsQueryEffect() {
         }
       } catch (e) {
         inProgressRequests.delete(action.payload.name);
-        yield put(executeEsQueryAction.fail(serializeHttpFetchError(e, action.payload)));
+        const serializedError = serializeHttpFetchError(e, action.payload);
+        kibanaService.coreSetup.notifications.toasts.addError(
+          { ...e, message: serializedError.body?.message ?? e.message },
+          {
+            title: ES_QUERY_FAIL_MESSAGE,
+          }
+        );
+        yield put(executeEsQueryAction.fail(serializedError));
       }
     }
   );
 }
+
+const ES_QUERY_FAIL_MESSAGE = i18n.translate('xpack.synthetics.esQuery.failed', {
+  defaultMessage: 'ES query failed.',
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/elasticsearch/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/elasticsearch/index.ts
@@ -35,7 +35,7 @@ export const elasticsearchReducer = createReducer(initialState, (builder) => {
       state.results = { ...state.results, [name]: action.payload.result };
     })
     .addCase(executeEsQueryAction.fail, (state, action) => {
-      const name = action.payload.name;
+      const name = action.payload.getPayload?.name!;
       state.loading = { ...state.loading, [name]: false };
       state.error = { ...state.error, [name]: action.payload };
     });


### PR DESCRIPTION
This PR improves how we handle network errors in the Error details page in Synthetics.

**Before**

https://github.com/user-attachments/assets/8052cd19-28e9-4683-a218-1bfdf4c642dc

**After**

https://github.com/user-attachments/assets/f187e9cf-2f5b-4322-b433-6be267f44893



<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->