### PR TITLE
[8.16] Replace old Security API doc links with API ref links in doc link service (#224222)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -24,9 +24,12 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
   const ELASTIC_WEBSITE_URL = meta.elasticWebsiteUrl;
   const ELASTIC_GITHUB = meta.elasticGithubUrl;
   const SEARCH_LABS_URL = meta.searchLabsUrl;
+  const API_DOCS = meta.apiDocsUrl;
 
   const ELASTICSEARCH_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/reference/${DOC_LINK_VERSION}/`;
   const KIBANA_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/`;
+  const KIBANA_APIS = `${API_DOCS}doc/kibana/v8/`;
+  const KIBANA_SERVERLESS_APIS = `${API_DOCS}doc/serverless/`;
   const FLEET_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/fleet/${DOC_LINK_VERSION}/`;
   const INTEGRATIONS_DEV_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/integrations-developer/current/`;
   const PLUGIN_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/plugins/${DOC_LINK_VERSION}/`;
@@ -465,7 +468,9 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       detectionsReq: `${SECURITY_SOLUTION_DOCS}detections-permissions-section.html`,
       networkMap: `${SECURITY_SOLUTION_DOCS}conf-map-ui.html`,
       troubleshootGaps: `${SECURITY_SOLUTION_DOCS}alerts-ui-monitor.html#troubleshoot-gaps`,
-      ruleApiOverview: `${SECURITY_SOLUTION_DOCS}rule-api-overview.html`,
+      ruleApiOverview: isServerless
+        ? `${KIBANA_SERVERLESS_APIS}group/endpoint-security-detections-api`
+        : `${KIBANA_APIS}group/endpoint-security-detections-api`,
       configureAlertSuppression: `${SECURITY_SOLUTION_DOCS}alert-suppression.html#_configure_alert_suppression`,
     },
     securitySolution: {

--- a/packages/kbn-doc-links/src/get_doc_meta.ts
+++ b/packages/kbn-doc-links/src/get_doc_meta.ts
@@ -25,5 +25,6 @@ export const getDocLinksMeta = ({
     elasticGithubUrl: 'https://github.com/elastic/',
     docsWebsiteUrl: 'https://docs.elastic.co/',
     searchLabsUrl: 'https://search-labs.elastic.co/',
+    apiDocsUrl: 'https://www.elastic.co/docs/api/',
   };
 };

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -17,6 +17,7 @@ export interface DocLinksMeta {
   elasticGithubUrl: string;
   docsWebsiteUrl: string;
   searchLabsUrl: string;
+  apiDocsUrl: string;
 }
 
 /**

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules_bulk.ts
@@ -59,8 +59,10 @@ export default ({ getService }: FtrProviderContext): void => {
           .send([getSimpleRule()])
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_create API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_create API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
@@ -47,8 +47,10 @@ export default ({ getService }: FtrProviderContext): void => {
           .bulkDeleteRules({ body: [{ rule_id: 'rule-1' }] })
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_delete API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_delete API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/patch_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/patch_rules_bulk.ts
@@ -55,8 +55,10 @@ export default ({ getService }: FtrProviderContext) => {
           .bulkPatchRules({ body: [{ rule_id: 'rule-1', name: 'some other name' }] })
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules_bulk.ts
@@ -71,8 +71,10 @@ export default ({ getService }: FtrProviderContext) => {
           .bulkUpdateRules({ body: [updatedRule] })
           .expect(200);
 
-        expect(header.warning).to.be(
-          '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead. See https://www.elastic.co/guide/en/security/master/rule-api-overview.html for more detail."'
+        expect(
+          header.warning.includes(
+            '299 Kibana "Deprecated endpoint: /api/detection_engine/rules/_bulk_update API is deprecated since v8.2. Please use the /api/detection_engine/rules/_bulk_action API instead."'
+          )
         );
       });
     });


### PR DESCRIPTION
This will backport the following commits from 8.17 to 8.16:
* https://github.com/elastic/kibana/pull/224222
