### PR TITLE
[Logs UX] Replace enzyme with React Testing Library

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/dataset_quality_details_link.test.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/dataset_quality_details_link.test.tsx
@@ -7,9 +7,9 @@
 
 import { DATA_QUALITY_DETAILS_LOCATOR_ID } from '@kbn/deeplinks-observability';
 import { BrowserUrlService } from '@kbn/share-plugin/public';
-import { shallow } from 'enzyme';
 import React from 'react';
 import { DatasetQualityDetailsLink } from './dataset_quality_details_link';
+import { screen, render } from '@testing-library/react';
 
 const createMockLocator = (id: string) => ({
   navigate: jest.fn(),
@@ -51,7 +51,7 @@ describe('DatasetQualityDetailsLink', () => {
   });
 
   it('renders a link to dataset quality details', () => {
-    const wrapper = shallow(
+    render(
       <DatasetQualityDetailsLink
         urlService={urlServiceMock}
         dataStream={dataStream.rawName}
@@ -65,6 +65,8 @@ describe('DatasetQualityDetailsLink', () => {
       dataStream: dataStream.rawName,
       timeRange,
     });
-    expect(wrapper.prop('href')).toBe(DATA_QUALITY_DETAILS_LOCATOR_ID);
+
+    const link = screen.getByTestId(`datasetQualityTableDetailsLink-${dataStream.rawName}`);
+    expect(link).toHaveAttribute('href', DATA_QUALITY_DETAILS_LOCATOR_ID);
   });
 });


### PR DESCRIPTION
## Summary
Replaces enzyme with React Testing Library in a Data Set Quality test.

### Test instructions
It can be validated through CI but you can run it manually through:
```
npx jest --config=x-pack/platform/plugins/shared/dataset_quality/jest.config.js ----testPathPattern=dataset_quality_details_link.test
```

Closes https://github.com/elastic/kibana/issues/223020



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->