### PR TITLE
[Security Solution] Fix default data view name mismatch

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -21,7 +21,7 @@ import { useSelectDataView } from '../../hooks/use_select_data_view';
 import { DataViewManagerScopeName } from '../../constants';
 import { useManagedDataViews } from '../../hooks/use_managed_data_views';
 import { useSavedDataViews } from '../../hooks/use_saved_data_views';
-import { DEFAULT_SECURITY_DATA_VIEW, LOADING } from './translations';
+import { LOADING } from './translations';
 import { DATA_VIEW_PICKER_TEST_ID } from './constants';
 
 interface DataViewPickerProps {
@@ -154,16 +154,10 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
       return { label: LOADING };
     }
 
-    if (dataViewSpec.id === defaultDataViewId) {
-      return {
-        label: DEFAULT_SECURITY_DATA_VIEW,
-      };
-    }
-
     return {
       label: dataViewSpec?.name || dataViewSpec?.id || 'Data view',
     };
-  }, [dataViewSpec.id, dataViewSpec?.name, defaultDataViewId, status]);
+  }, [dataViewSpec?.name, dataViewSpec?.id, status]);
 
   return (
     <div data-test-subj={DATA_VIEW_PICKER_TEST_ID}>

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
@@ -11,7 +11,7 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 import { ensurePatternFormat } from '../../../common/utils/sourcerer';
 import type { KibanaDataView } from '../store/model';
 import { DEFAULT_TIME_FIELD } from '../../../common/constants';
-import { DEFAULT_SECURITY_ALERT_DATA_VIEW } from '../../data_view_manager/components/data_view_picker/translations';
+import { DEFAULT_SECURITY_DATA_VIEW, DEFAULT_SECURITY_ALERT_DATA_VIEW } from '../../data_view_manager/components/data_view_picker/translations';
 
 export interface GetSourcererDataView {
   signal?: AbortSignal;
@@ -59,6 +59,7 @@ export const createSourcererDataView = async ({
           id: dataViewId,
           title: patternListAsTitle,
           timeFieldName: DEFAULT_TIME_FIELD,
+          name: DEFAULT_SECURITY_DATA_VIEW,
         },
         // Override property - if a data view exists with the security solution pattern
         // delete it and replace it with our data view

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/create_sourcerer_data_view.ts
@@ -11,7 +11,10 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 import { ensurePatternFormat } from '../../../common/utils/sourcerer';
 import type { KibanaDataView } from '../store/model';
 import { DEFAULT_TIME_FIELD } from '../../../common/constants';
-import { DEFAULT_SECURITY_DATA_VIEW, DEFAULT_SECURITY_ALERT_DATA_VIEW } from '../../data_view_manager/components/data_view_picker/translations';
+import {
+  DEFAULT_SECURITY_DATA_VIEW,
+  DEFAULT_SECURITY_ALERT_DATA_VIEW,
+} from '../../data_view_manager/components/data_view_picker/translations';
 
 export interface GetSourcererDataView {
   signal?: AbortSignal;

--- a/x-pack/test_serverless/functional/test_suites/security/constants.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/constants.ts
@@ -6,7 +6,8 @@
  */
 
 export const SECURITY_ES_ARCHIVES_DIR = 'x-pack/test/security_solution_cypress/es_archives';
-export const SECURITY_SOLUTION_DATA_VIEW =
+export const SECURITY_SOLUTION_DATA_VIEW = 'Default security data view';
+export const SECURITY_SOLUTION_INDEX_PATTERN =
   '.alerts-security.alerts-default,apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-*';
 
 export const CLOUD_SECURITY_POSTURE_PACKAGE_VERSION = '1.13.0';

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/discover/context_awareness/cell_renderer.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/discover/context_awareness/cell_renderer.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { ServerlessRoleName } from '../../../../../../shared/lib';
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
 import { getDiscoverESQLState } from './utils';
-import { SECURITY_SOLUTION_DATA_VIEW } from '../../../constants';
+import { SECURITY_SOLUTION_DATA_VIEW, SECURITY_SOLUTION_INDEX_PATTERN } from '../../../constants';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'timePicker', 'discover', 'svlCommonPage']);
@@ -27,7 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('ES|QL mode', () => {
       it('should render alert workflow status badge', async () => {
         const state = getDiscoverESQLState(
-          `from ${SECURITY_SOLUTION_DATA_VIEW} | WHERE host.name == "siem-kibana" and event.kind != "signal"`
+          `from ${SECURITY_SOLUTION_INDEX_PATTERN} | WHERE host.name == "siem-kibana" and event.kind != "signal"`
         );
         await PageObjects.common.navigateToActualUrl('discover', `?_a=${state}`, {
           ensureCurrentUrl: false,

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/discover/context_awareness/utils.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/discover/context_awareness/utils.ts
@@ -6,13 +6,13 @@
  */
 
 import kbnRison from '@kbn/rison';
-import { SECURITY_SOLUTION_DATA_VIEW } from '../../../constants';
+import { SECURITY_SOLUTION_INDEX_PATTERN } from '../../../constants';
 
 export const getDiscoverESQLState = (query?: string) => {
   return kbnRison.encode({
     dataSource: { type: 'esql' },
     query: {
-      esql: query ?? `FROM ${SECURITY_SOLUTION_DATA_VIEW} | WHERE host.name == "siem-kibana"`,
+      esql: query ?? `FROM ${SECURITY_SOLUTION_INDEX_PATTERN} | WHERE host.name == "siem-kibana"`,
     },
   });
 };


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/security-team/issues/12791

Enable `newDataViewPickerEnabled` and fresh kibana build

### Before
![image](https://github.com/user-attachments/assets/f0047b00-ce26-49f9-827c-44a07538a12a)


### After

Label is cut off in security pages because of the `Managed` label, will address this in a separate PR (likely in https://github.com/elastic/kibana/pull/223451)

![image](https://github.com/user-attachments/assets/f79615aa-05be-4d9a-8e33-4eca5c82591c)

![image](https://github.com/user-attachments/assets/dc7a4c23-c17c-4bb6-b1ca-d778900e5265)


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->