### PR TITLE
[8.19] [ResponseOps][Alerting] assure grouping fields in alert match expected cardinality (#223409)

### DIFF
--- a/x-pack/platform/packages/shared/alerting-rule-utils/src/get_ecs_groups.test.ts
+++ b/x-pack/platform/packages/shared/alerting-rule-utils/src/get_ecs_groups.test.ts
@@ -51,4 +51,15 @@ describe('getEcsGroups', () => {
 
     expect(getEcsGroups(groups)).toEqual({});
   });
+
+  it('should handle array types assigned non-array values', () => {
+    const groups = [
+      {
+        field: 'tags',
+        value: 'abc',
+      },
+    ];
+
+    expect(getEcsGroups(groups)).toEqual({ tags: ['abc'] });
+  });
 });

--- a/x-pack/platform/packages/shared/alerting-rule-utils/src/get_ecs_groups.ts
+++ b/x-pack/platform/packages/shared/alerting-rule-utils/src/get_ecs_groups.ts
@@ -8,27 +8,24 @@
 import { ecsFieldMap } from '@kbn/alerts-as-data-utils';
 import { Group } from './types';
 
-export const getEcsGroups = (groups: Group[] = []): Record<string, string> => {
-  const ecsGroups = groups.filter((group) => {
-    const path = group.field;
-    const ecsField = ecsFieldMap[path as keyof typeof ecsFieldMap];
+export const getEcsGroups = (groups: Group[] = []): Record<string, string | string[]> => {
+  const ecsGroup: Record<string, string | string[]> = {};
 
-    if (!Boolean(!!ecsField)) {
-      return false;
-    }
+  groups.forEach((group) => {
+    const path = group.field;
+    const ecsField = ecsFieldMap[path];
+    if (!ecsField) return;
 
     // we only allow keyword group values
-    if (ecsField.type !== 'keyword') {
-      return false;
+    if (ecsField.type !== 'keyword') return;
+
+    if (!ecsField.array) {
+      // if the ecs type is not an array, assign the value
+      ecsGroup[path] = group.value;
+    } else {
+      // otherwise the ecs type is an array, create a 1-element array
+      ecsGroup[path] = [group.value];
     }
-
-    return true;
-  });
-
-  const ecsGroup: Record<string, string> = {};
-
-  ecsGroups.forEach((group) => {
-    ecsGroup[group.field] = group.value;
   });
 
   return ecsGroup;

--- a/x-pack/test/alerting_api_integration/packages/helpers/es_test_index_tool.ts
+++ b/x-pack/test/alerting_api_integration/packages/helpers/es_test_index_tool.ts
@@ -84,10 +84,10 @@ export class ESTestIndexTool {
                   },
                 },
               },
-            },
-            // store as array of strings
-            tags: {
-              type: 'keyword',
+              // store as array of strings
+              tags: {
+                type: 'keyword',
+              },
             },
           },
         },

--- a/x-pack/test/alerting_api_integration/packages/helpers/es_test_index_tool.ts
+++ b/x-pack/test/alerting_api_integration/packages/helpers/es_test_index_tool.ts
@@ -85,6 +85,10 @@ export class ESTestIndexTool {
                 },
               },
             },
+            // store as array of strings
+            tags: {
+              type: 'keyword',
+            },
           },
         },
       },

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/common.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/common.ts
@@ -68,6 +68,9 @@ export interface CreateRuleParams {
   indexName?: string;
   aggType?: string;
   groupBy?: string;
+  termField?: string;
+  termSize?: number;
+  sourceFields?: Array<{ label: string; searchPath: string }>;
 }
 
 export function getRuleServices(getService: FtrProviderContext['getService']) {
@@ -128,6 +131,20 @@ export function getRuleServices(getService: FtrProviderContext['getService']) {
     return await esTestIndexToolAAD.getAll(size, sort);
   }
 
+  async function waitForAADDocs(numDocs: number = 1) {
+    return await retry.try(async () => {
+      const searchResult = await getAllAADDocs(numDocs);
+      const value =
+        typeof searchResult.body.hits.total === 'number'
+          ? searchResult.body.hits.total
+          : searchResult.body.hits.total?.value;
+      if (value! < numDocs) {
+        throw new Error(`Expected ${numDocs} alert docs but received ${value}.`);
+      }
+      return searchResult.body.hits.hits;
+    });
+  }
+
   async function removeAllAADDocs(): Promise<any> {
     return await esTestIndexToolAAD.removeAll();
   }
@@ -142,6 +159,7 @@ export function getRuleServices(getService: FtrProviderContext['getService']) {
     createGroupedEsDocumentsInGroups,
     waitForDocs,
     getAllAADDocs,
+    waitForAADDocs,
     removeAllAADDocs,
   };
 }

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
@@ -207,16 +207,21 @@ export default function ruleTests({ getService }: FtrProviderContext) {
     });
 
     it('runs correctly: threshold on grouped hit with all columns', async () => {
+      // This test is sensitive to the fields in the index; when adding new fields,
+      // you should drop them here, as it has a limit of 10 or so for grouping,
+      // or otherwise change the grouping values that result.
+      const columnsToDrop = ['tags'];
+
       // write documents from now to the future end date in groups
       await createEsDocumentsInGroups(ES_GROUPS_TO_WRITE, endDate);
       await createRule({
         name: 'never fire',
-        esqlQuery: 'from .kibana-alerting-test-data | limit 0',
+        esqlQuery: `from kibana-alerting-test-data | drop ${columnsToDrop} | limit 0`,
         groupBy: 'row',
       });
       await createRule({
         name: 'always fire',
-        esqlQuery: 'from .kibana-alerting-test-data',
+        esqlQuery: `from kibana-alerting-test-data | drop ${columnsToDrop}`,
         groupBy: 'row',
       });
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
@@ -216,12 +216,12 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       await createEsDocumentsInGroups(ES_GROUPS_TO_WRITE, endDate);
       await createRule({
         name: 'never fire',
-        esqlQuery: `from kibana-alerting-test-data | drop ${columnsToDrop} | limit 0`,
+        esqlQuery: `from .kibana-alerting-test-data | drop ${columnsToDrop} | limit 0`,
         groupBy: 'row',
       });
       await createRule({
         name: 'always fire',
-        esqlQuery: `from kibana-alerting-test-data | drop ${columnsToDrop}`,
+        esqlQuery: `from .kibana-alerting-test-data | drop ${columnsToDrop}`,
         groupBy: 'row',
       });
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/query_dsl_only.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/query_dsl_only.ts
@@ -8,6 +8,8 @@
 import expect from '@kbn/expect';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { pull } from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
+
 import { Spaces } from '../../../../../scenarios';
 import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
@@ -27,11 +29,20 @@ import {
   RULE_TYPE_ID,
 } from './common';
 
+const TEST_HOSTNAME = 'test.alerting.example.com';
+
 // eslint-disable-next-line import/no-default-export
 export default function ruleTests({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
-  const { es, esTestIndexTool, esTestIndexToolOutput, createEsDocumentsInGroups, waitForDocs } =
-    getRuleServices(getService);
+  const {
+    es,
+    esTestIndexTool,
+    esTestIndexToolOutput,
+    createEsDocumentsInGroups,
+    waitForDocs,
+    waitForAADDocs,
+    removeAllAADDocs,
+  } = getRuleServices(getService);
 
   describe('Query DSL only', () => {
     let endDate: string;
@@ -52,6 +63,8 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       endDate = new Date(endDateMillis).toISOString();
 
       await createDataStream(es, ES_TEST_DATA_STREAM_NAME);
+
+      await removeAllAADDocs();
     });
 
     afterEach(async () => {
@@ -59,6 +72,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       await esTestIndexTool.destroy();
       await esTestIndexToolOutput.destroy();
       await deleteDataStream(es, ES_TEST_DATA_STREAM_NAME);
+      await removeAllAADDocs();
     });
 
     it(`runs correctly: runtime fields for esQuery search type`, async () => {
@@ -267,6 +281,41 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       }
     });
 
+    it(`runs correctly: copies fields from groups into alerts`, async () => {
+      const tag = 'example-tag-A';
+      const ruleName = 'group by tag';
+      await createDocWithTags([tag]);
+
+      await createRule({
+        name: ruleName,
+        esQuery: JSON.stringify({ query: { match_all: {} } }),
+        timeField: '@timestamp',
+        size: 100,
+        thresholdComparator: '>',
+        threshold: [0],
+        groupBy: 'top',
+        termField: 'tags',
+        termSize: 3,
+        sourceFields: [{ label: 'host.hostname', searchPath: 'host.hostname.keyword' }],
+      });
+
+      const docs = await waitForAADDocs(1);
+      const alert = docs[0]._source || {};
+      expect(alert['kibana.alert.rule.name']).to.be(ruleName);
+      expect(alert['kibana.alert.evaluation.value']).to.be('1');
+
+      // eslint-disable-next-line dot-notation
+      const tags = alert['tags'];
+      expect(Array.isArray(tags)).to.be(true);
+      expect(tags.length).to.be(1);
+      expect(tags[0]).to.be(tag);
+
+      const hostname = alert['host.hostname'];
+      expect(Array.isArray(hostname)).to.be(true);
+      expect(hostname.length).to.be(1);
+      expect(hostname[0]).to.be(TEST_HOSTNAME);
+    });
+
     async function createRule(params: CreateRuleParams): Promise<string> {
       const action = {
         id: connectorId,
@@ -324,7 +373,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
               esQuery: params.esQuery,
             };
 
-      const { body: createdRule } = await supertest
+      const response = await supertest
         .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
         .set('kbn-xsrf', 'foo')
         .send({
@@ -344,15 +393,42 @@ export default function ruleTests({ getService }: FtrProviderContext) {
             searchType: params.searchType,
             aggType: params.aggType || 'count',
             groupBy: params.groupBy || 'all',
+            termField: params.termField,
+            termSize: params.termSize,
+            sourceFields: params.sourceFields,
             ...ruleParams,
           },
-        })
-        .expect(200);
+        });
+
+      const { body: createdRule, statusCode } = response;
+      expect(statusCode).to.be(200);
 
       const ruleId = createdRule.id;
       objectRemover.add(Spaces.space1.id, ruleId, 'rule', 'alerting');
 
       return ruleId;
+    }
+
+    async function createDocWithTags(tags: string[]) {
+      const document = {
+        '@timestamp': new Date().toISOString(),
+        tags,
+        host: {
+          hostname: TEST_HOSTNAME,
+        },
+      };
+
+      const response = await es.index({
+        id: uuidv4(),
+        index: ES_TEST_INDEX_NAME,
+        refresh: 'wait_for',
+        op_type: 'create',
+        body: document,
+      });
+
+      if (response.result !== 'created') {
+        throw new Error(`document not created: ${JSON.stringify(response)}`);
+      }
     }
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Alerting] assure grouping fields in alert match expected cardinality (#223409)](https://github.com/elastic/kibana/pull/223409)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2025-06-17T16:47:31Z","message":"[ResponseOps][Alerting] assure grouping fields in alert match expected cardinality (#223409)\n\nresolves https://github.com/elastic/kibana/issues/221252\n\nEnsure alert field values added from grouping information are the right\ncardinality. Previously, array typed fields were assigned strings and\nthe string characters were split into an array by down-stream\nprocessing.","sha":"ac5c313c1d25ebb28bbd6a88915b789a5c4183c1","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","Feature:Alerting/RulesFramework","Feature:Alerting/Alerts-as-Data","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[ResponseOps][Alerting] assure grouping fields in alert match expected cardinality","number":223409,"url":"https://github.com/elastic/kibana/pull/223409","mergeCommit":{"message":"[ResponseOps][Alerting] assure grouping fields in alert match expected cardinality (#223409)\n\nresolves https://github.com/elastic/kibana/issues/221252\n\nEnsure alert field values added from grouping information are the right\ncardinality. Previously, array typed fields were assigned strings and\nthe string characters were split into an array by down-stream\nprocessing.","sha":"ac5c313c1d25ebb28bbd6a88915b789a5c4183c1"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223409","number":223409,"mergeCommit":{"message":"[ResponseOps][Alerting] assure grouping fields in alert match expected cardinality (#223409)\n\nresolves https://github.com/elastic/kibana/issues/221252\n\nEnsure alert field values added from grouping information are the right\ncardinality. Previously, array typed fields were assigned strings and\nthe string characters were split into an array by down-stream\nprocessing.","sha":"ac5c313c1d25ebb28bbd6a88915b789a5c4183c1"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->