### PR TITLE
[Fleet] Encode kuery in Manage auto-upgrade agents Status link

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/manage_auto_upgrade_agents_modal/status_column.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/manage_auto_upgrade_agents_modal/status_column.tsx
@@ -31,7 +31,7 @@ export const StatusColumn: React.FunctionComponent<{
         ? `policy_id:"${agentPolicyId}" AND upgrade_details.state:"UPG_FAILED" AND upgrade_details.target_version:"${version}"`
         : `policy_id:"${agentPolicyId}" AND agent.version:"${version}"`;
       return getHref('agent_list', {
-        kuery,
+        kuery: encodeURIComponent(kuery),
       });
     },
     [getHref, agentPolicyId, version]


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/224351

To verify:
1. Navigate to Fleet > Agents Tab.
2. Select desired Agent Policy and click on "Manage" link under Auto-upgrade agents.
3. Choose the 8.14.3 beta agent version and click the Save button.
4. Wait for 5–10 minutes until the upgrade status is shown as Completed.
5. Click on the Completed status.
6. Beta agent version should be filtered correctly in the "Manage Auto-Upgrade Agents" popup.

<img width="1530" alt="image" src="https://github.com/user-attachments/assets/2682c789-f417-4058-b97c-65536444eba9" />
<img width="1538" alt="image" src="https://github.com/user-attachments/assets/2de8c1f9-af95-4826-9214-79973821dc72" />
