### PR TITLE
[Fleet] Add in-product description to remote outputs hosts

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_remote_es.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_remote_es.tsx
@@ -17,6 +17,8 @@ import {
   EuiLink,
   EuiCode,
   EuiFieldPassword,
+  EuiToolTip,
+  EuiIcon,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -133,6 +135,25 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
         )}
         {...inputs.elasticsearchUrlInput.props}
         isUrl
+        helpText={
+          <>
+            <FormattedMessage
+              id="xpack.fleet.settings.editOutputFlyout.remoteEsHostsInputHelpText"
+              defaultMessage="Specify the URL that your agents will use to access the remote Elasticsearch cluster"
+            />
+            <EuiToolTip
+              content={i18n.translate(
+                'xpack.fleet.settings.editOutputFlyout.remoteEsHostsInputTooltip',
+                {
+                  defaultMessage:
+                    'To find the remote host address, in the remote cluster open Kibana and go to Management → Fleet → Settings',
+                }
+              )}
+            >
+              <EuiIcon type="questionInCircle" />
+            </EuiToolTip>
+          </>
+        }
       />
       <EuiSpacer size="m" />
       {!useSecretsStorage ? (


### PR DESCRIPTION
## Summary

Add in-product description to remote outputs hosts - based on the [docs](https://www.elastic.co/docs/reference/fleet/remote-elasticsearch-output)

<img width="799" alt="Screenshot 2025-06-18 at 10 39 12" src="https://github.com/user-attachments/assets/a646314d-3bb5-44d3-b313-299bd4ac36b9" />
<img width="794" alt="Screenshot 2025-06-18 at 10 39 18" src="https://github.com/user-attachments/assets/3d62be98-711d-411d-8d97-63876ed7f81c" />


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)

