### PR TITLE
[ResponseOps] Aliases for the cases analytics indexes

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
@@ -11,6 +11,8 @@ import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-serve
 
 export const CAI_ACTIVITY_INDEX_NAME = '.internal.cases-activity';
 
+export const CAI_ACTIVITY_INDEX_ALIAS = '.cases-activity';
+
 export const CAI_ACTIVITY_INDEX_VERSION = 1;
 
 export const CAI_ACTIVITY_SOURCE_QUERY: QueryDslQueryContainer = {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/index.ts
@@ -10,6 +10,7 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { AnalyticsIndex } from '../analytics_index';
 import {
   CAI_ACTIVITY_INDEX_NAME,
+  CAI_ACTIVITY_INDEX_ALIAS,
   CAI_ACTIVITY_INDEX_VERSION,
   CAI_ACTIVITY_SOURCE_INDEX,
   CAI_ACTIVITY_SOURCE_QUERY,
@@ -37,6 +38,7 @@ export const createActivityAnalyticsIndex = ({
     isServerless,
     taskManager,
     indexName: CAI_ACTIVITY_INDEX_NAME,
+    indexAlias: CAI_ACTIVITY_INDEX_ALIAS,
     indexVersion: CAI_ACTIVITY_INDEX_VERSION,
     mappings: CAI_ACTIVITY_INDEX_MAPPINGS,
     painlessScriptId: CAI_ACTIVITY_INDEX_SCRIPT_ID,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.test.ts
@@ -32,6 +32,7 @@ describe('AnalyticsIndex', () => {
   const taskManager = taskManagerMock.createStart();
   const isServerless = false;
   const indexName = '.test-index-name';
+  const indexAlias = '.index-name';
   const indexVersion = 1;
   const painlessScriptId = 'painless_script_id';
   const taskId = 'foobar_task_id';
@@ -77,6 +78,7 @@ describe('AnalyticsIndex', () => {
       esClient,
       logger,
       indexName,
+      indexAlias,
       indexVersion,
       isServerless,
       mappings,
@@ -108,6 +110,11 @@ describe('AnalyticsIndex', () => {
       mappings: {
         ...mappings,
         _meta: mappingsMeta,
+      },
+      aliases: {
+        [indexAlias]: {
+          is_write_index: true,
+        },
       },
       settings: {
         index: {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.ts
@@ -29,6 +29,7 @@ interface AnalyticsIndexParams {
   esClient: ElasticsearchClient;
   logger: Logger;
   indexName: string;
+  indexAlias: string;
   indexVersion: number;
   isServerless: boolean;
   mappings: MappingTypeMapping;
@@ -48,6 +49,7 @@ interface MappingMeta {
 export class AnalyticsIndex {
   private readonly logger: Logger;
   private readonly indexName: string;
+  private readonly indexAlias: string;
   private readonly indexVersion: number;
   private readonly esClient: ElasticsearchClient;
   private readonly mappings: MappingTypeMapping;
@@ -65,6 +67,7 @@ export class AnalyticsIndex {
     esClient,
     isServerless,
     indexName,
+    indexAlias,
     indexVersion,
     mappings,
     painlessScriptId,
@@ -77,6 +80,7 @@ export class AnalyticsIndex {
     this.logger = logger;
     this.esClient = esClient;
     this.indexName = indexName;
+    this.indexAlias = indexAlias;
     this.indexVersion = indexVersion;
 
     this.mappings = mappings;
@@ -178,6 +182,11 @@ export class AnalyticsIndex {
       mappings: this.mappings,
       settings: {
         index: this.indexSettings,
+      },
+      aliases: {
+        [this.indexAlias]: {
+          is_write_index: true,
+        },
       },
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/constants.ts
@@ -11,6 +11,8 @@ import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-serve
 
 export const CAI_ATTACHMENTS_INDEX_NAME = '.internal.cases-attachments';
 
+export const CAI_ATTACHMENTS_INDEX_ALIAS = '.cases-attachments';
+
 export const CAI_ATTACHMENTS_INDEX_VERSION = 1;
 
 export const CAI_ATTACHMENTS_SOURCE_QUERY: QueryDslQueryContainer = {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/attachments_index/index.ts
@@ -10,6 +10,7 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { AnalyticsIndex } from '../analytics_index';
 import {
   CAI_ATTACHMENTS_INDEX_NAME,
+  CAI_ATTACHMENTS_INDEX_ALIAS,
   CAI_ATTACHMENTS_INDEX_VERSION,
   CAI_ATTACHMENTS_SOURCE_INDEX,
   CAI_ATTACHMENTS_SOURCE_QUERY,
@@ -37,6 +38,7 @@ export const createAttachmentsAnalyticsIndex = ({
     isServerless,
     taskManager,
     indexName: CAI_ATTACHMENTS_INDEX_NAME,
+    indexAlias: CAI_ATTACHMENTS_INDEX_ALIAS,
     indexVersion: CAI_ATTACHMENTS_INDEX_VERSION,
     mappings: CAI_ATTACHMENTS_INDEX_MAPPINGS,
     painlessScriptId: CAI_ATTACHMENTS_INDEX_SCRIPT_ID,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/constants.ts
@@ -11,6 +11,8 @@ import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-serve
 
 export const CAI_CASES_INDEX_NAME = '.internal.cases';
 
+export const CAI_CASES_INDEX_ALIAS = '.cases';
+
 export const CAI_CASES_INDEX_VERSION = 1;
 
 export const CAI_CASES_SOURCE_QUERY: QueryDslQueryContainer = {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/index.ts
@@ -10,6 +10,7 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { AnalyticsIndex } from '../analytics_index';
 import {
   CAI_CASES_INDEX_NAME,
+  CAI_CASES_INDEX_ALIAS,
   CAI_CASES_INDEX_VERSION,
   CAI_CASES_SOURCE_INDEX,
   CAI_CASES_SOURCE_QUERY,
@@ -37,6 +38,7 @@ export const createCasesAnalyticsIndex = ({
     isServerless,
     taskManager,
     indexName: CAI_CASES_INDEX_NAME,
+    indexAlias: CAI_CASES_INDEX_ALIAS,
     indexVersion: CAI_CASES_INDEX_VERSION,
     mappings: CAI_CASES_INDEX_MAPPINGS,
     painlessScriptId: CAI_CASES_INDEX_SCRIPT_ID,

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/constants.ts
@@ -11,6 +11,8 @@ import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-serve
 
 export const CAI_COMMENTS_INDEX_NAME = '.internal.cases-comments';
 
+export const CAI_COMMENTS_INDEX_ALIAS = '.cases-comments';
+
 export const CAI_COMMENTS_INDEX_VERSION = 1;
 
 export const CAI_COMMENTS_SOURCE_QUERY: QueryDslQueryContainer = {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/comments_index/index.ts
@@ -10,6 +10,7 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { AnalyticsIndex } from '../analytics_index';
 import {
   CAI_COMMENTS_INDEX_NAME,
+  CAI_COMMENTS_INDEX_ALIAS,
   CAI_COMMENTS_INDEX_VERSION,
   CAI_COMMENTS_SOURCE_INDEX,
   CAI_COMMENTS_SOURCE_QUERY,
@@ -37,6 +38,7 @@ export const createCommentsAnalyticsIndex = ({
     isServerless,
     taskManager,
     indexName: CAI_COMMENTS_INDEX_NAME,
+    indexAlias: CAI_COMMENTS_INDEX_ALIAS,
     indexVersion: CAI_COMMENTS_INDEX_VERSION,
     mappings: CAI_COMMENTS_INDEX_MAPPINGS,
     painlessScriptId: CAI_COMMENTS_INDEX_SCRIPT_ID,


### PR DESCRIPTION
**Merging into a feature branch.**

## Summary

This PR adds the following aliases when creating the cases analytics indexes:
- `.internal.cases` -> `.cases`
- `.internal.cases-activity` -> `.cases-activity`
- `.internal.cases-attachments` -> `.cases-attachments`
- `.internal.cases-comments` -> `.cases-comments`


