### PR TITLE
[ska] relocate guided_onboarding tests that import search solution src code

### DIFF
--- a/.buildkite/ftr_search_stateful_configs.yml
+++ b/.buildkite/ftr_search_stateful_configs.yml
@@ -7,4 +7,5 @@ enabled:
   - x-pack/test/functional_search/config.ts
   - x-pack/test/functional/apps/search_playground/config.ts
   - x-pack/solutions/search/test/api_integration/apis/search_playground/config.ts
+  - x-pack/solutions/search/test/api_integration/apis/guided_onboarding/config.ts
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2272,9 +2272,6 @@ module.exports = {
         'x-pack/platform/plugins/shared/osquery/**',
         // FIXME PhilippeOberti @kbn/timelines-plugin depends on security-solution-plugin (security/private) (timelines is going to disappear)
         'x-pack/platform/plugins/shared/timelines/**',
-        // FIXME @dmlemeshko
-        `src/platform/test/api_integration/apis/guided_onboarding/get_guides.ts`,
-        `src/platform/test/api_integration/apis/guided_onboarding/put_state.ts`,
 
         // For now, we keep the exception to let tests depend on anythying.
         // Ideally, we need to classify the solution specific ones to reduce CI times

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2819,6 +2819,7 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /src/platform/test/examples/error_boundary/index.ts @elastic/appex-sharedux
 /src/platform/test/examples/content_management/*.ts @elastic/appex-sharedux
 /src/platform/test/api_integration/apis/guided_onboarding @elastic/appex-sharedux
+/x-pack/solutions/search/test/api_integration/apis/guided_onboarding @elastic/appex-sharedux
 /x-pack/test/banners_functional @elastic/appex-sharedux
 /x-pack/test/custom_branding @elastic/appex-sharedux
 /x-pack/platform/test/api_integration/apis/content_management @elastic/appex-sharedux

--- a/src/platform/test/api_integration/apis/guided_onboarding/index.ts
+++ b/src/platform/test/api_integration/apis/guided_onboarding/index.ts
@@ -12,8 +12,6 @@ import type { FtrProviderContext } from '../../ftr_provider_context';
 export default function apiIntegrationTests({ loadTestFile }: FtrProviderContext) {
   describe('guided onboarding', () => {
     loadTestFile(require.resolve('./get_state'));
-    loadTestFile(require.resolve('./put_state'));
-    loadTestFile(require.resolve('./get_guides'));
     loadTestFile(require.resolve('./get_config'));
   });
 }

--- a/src/platform/test/tsconfig.json
+++ b/src/platform/test/tsconfig.json
@@ -60,7 +60,6 @@
     "@kbn/dev-utils",
     "@kbn/utility-types",
     "@kbn/dev-proc-runner",
-    "@kbn/enterprise-search-plugin",
     "@kbn/core-saved-objects-server",
     "@kbn/core-http-common",
     "@kbn/event-annotation-plugin",

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/config.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseIntegrationTestsConfig = await readConfigFile(require.resolve('../../config.ts'));
+
+  return {
+    ...baseIntegrationTestsConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/get_guides.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/get_guides.ts
@@ -1,10 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 import expect from '@kbn/expect';
@@ -16,8 +14,8 @@ import {
 import { websiteSearchGuideId } from '@kbn/enterprise-search-plugin/common/guided_onboarding/search_guide_config';
 import { API_BASE_PATH } from '@kbn/guided-onboarding-plugin/common';
 import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
+import { createGuides } from '@kbn/test-suites-src/api_integration/apis/guided_onboarding/helpers';
 import type { FtrProviderContext } from '../../ftr_provider_context';
-import { createGuides } from './helpers';
 
 const getGuidesPath = `${API_BASE_PATH}/guides`;
 export default function testGetGuidesState({ getService }: FtrProviderContext) {

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/index.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function apiIntegrationTests({ loadTestFile }: FtrProviderContext) {
+  describe('guided onboarding', () => {
+    loadTestFile(require.resolve('./get_guides'));
+    loadTestFile(require.resolve('./put_state'));
+  });
+}

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/put_state.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/put_state.ts
@@ -1,10 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 import expect from '@kbn/expect';
@@ -24,8 +22,11 @@ import { testGuideId } from '@kbn/guided-onboarding';
 import { websiteSearchGuideId } from '@kbn/enterprise-search-plugin/common/guided_onboarding/search_guide_config';
 import { API_BASE_PATH } from '@kbn/guided-onboarding-plugin/common';
 import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
+import {
+  createGuides,
+  createPluginState,
+} from '@kbn/test-suites-src/api_integration/apis/guided_onboarding/helpers';
 import type { FtrProviderContext } from '../../ftr_provider_context';
-import { createGuides, createPluginState } from './helpers';
 
 const putStatePath = `${API_BASE_PATH}/state`;
 export default function testPutState({ getService }: FtrProviderContext) {

--- a/x-pack/solutions/search/test/tsconfig.json
+++ b/x-pack/solutions/search/test/tsconfig.json
@@ -22,5 +22,10 @@
     "@kbn/core-http-common",
     "@kbn/scout-info",
     "@kbn/test-suites-xpack-platform",
+    "@kbn/expect",
+    "@kbn/guided-onboarding-plugin",
+    "@kbn/enterprise-search-plugin",
+    "@kbn/test-suites-src",
+    "@kbn/guided-onboarding",
   ]
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana-team/issues/1503

This PR relocates few test files from `/src/platform/test` dir that imports from `@kbn/enterprise-search-plugin`, which is Search solution plugin.

Before:

```
/src/platform/test/api_integration/guided_onboarding
     | - get_guides.ts
     | - put_state.ts
```

After: 
```
/x-pack/solutions/search/test/api_integration/guided_onboarding
     | - get_guides.ts
     | - put_state.ts
```