### PR TITLE
[8.19] [Console] Fix parsing requests with errors (#215568)

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/console/parser.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/parser.test.ts
@@ -94,4 +94,26 @@ describe('console parser', () => {
     expect(errors[0].offset).toBe(14);
     expect(errors[0].text).toBe('Bad string');
   });
+
+  it('parses requests with an error and a comment before the next request', () => {
+    const input =
+      'GET _search\n' +
+      '{ERROR\n' +
+      '  "query": {\n' +
+      '    "match_all": {}\n' +
+      '  }\n' +
+      '}\n\n' +
+      '# This is a comment\n' +
+      'POST _test_index\n' +
+      '// Another comment\n';
+    const { requests, errors } = parser(input) as ConsoleParserResult;
+    expect(requests.length).toBe(2);
+    expect(requests[0].startOffset).toBe(0);
+    expect(requests[0].endOffset).toBe(57);
+    expect(requests[1].startOffset).toBe(79); // The next request should start after the comment
+    expect(requests[1].endOffset).toBe(95);
+    expect(errors.length).toBe(1);
+    expect(errors[0].offset).toBe(14);
+    expect(errors[0].text).toBe('Bad string');
+  });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix parsing requests with errors (#215568)](https://github.com/elastic/kibana/pull/215568)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-01T17:28:24Z","message":"[Console] Fix parsing requests with errors (#215568)\n\nFixes https://github.com/elastic/kibana/issues/211031\n\n## Summary\n\nThis PR fixes the selection of requests in Console when a request\ncontains an error. It also adds an error toast when the user tries to\nsend a request containing an error, as the response from Elasticsearch\nis usually too long and not very helpful.\n\n\n\n\nhttps://github.com/user-attachments/assets/4de10953-9ee5-489b-94fb-fd8a772bd598","sha":"4557b7395940710e0ba2b9fde828d07aa30315e3","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:version","v9.1.0","v8.19.0"],"title":"[Console] Fix parsing requests with errors","number":215568,"url":"https://github.com/elastic/kibana/pull/215568","mergeCommit":{"message":"[Console] Fix parsing requests with errors (#215568)\n\nFixes https://github.com/elastic/kibana/issues/211031\n\n## Summary\n\nThis PR fixes the selection of requests in Console when a request\ncontains an error. It also adds an error toast when the user tries to\nsend a request containing an error, as the response from Elasticsearch\nis usually too long and not very helpful.\n\n\n\n\nhttps://github.com/user-attachments/assets/4de10953-9ee5-489b-94fb-fd8a772bd598","sha":"4557b7395940710e0ba2b9fde828d07aa30315e3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215568","number":215568,"mergeCommit":{"message":"[Console] Fix parsing requests with errors (#215568)\n\nFixes https://github.com/elastic/kibana/issues/211031\n\n## Summary\n\nThis PR fixes the selection of requests in Console when a request\ncontains an error. It also adds an error toast when the user tries to\nsend a request containing an error, as the response from Elasticsearch\nis usually too long and not very helpful.\n\n\n\n\nhttps://github.com/user-attachments/assets/4de10953-9ee5-489b-94fb-fd8a772bd598","sha":"4557b7395940710e0ba2b9fde828d07aa30315e3"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216713","number":216713,"state":"MERGED","mergeCommit":{"sha":"0b81bce71b737502ff351ab2d18f1a0adbd2e115","message":"[8.x] [Console] Fix parsing requests with errors (#215568) (#216713)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Console] Fix parsing requests with errors\n(#215568)](https://github.com/elastic/kibana/pull/215568)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}}]}] BACKPORT-->