### PR TITLE
Bringing back error tab for android agent dashboard

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/errors_and_crashes_overview/tabs/tabs.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/errors_and_crashes_overview/tabs/tabs.tsx
@@ -10,8 +10,6 @@ import { EuiTab, EuiTabs, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { MobileErrorsOverview } from '../errors_overview';
 import { MobileCrashesOverview } from '../crashes_overview';
-import { isAndroidAgentName } from '../../../../../../common/agent_name';
-import { useApmServiceContext } from '../../../../../context/apm_service/use_apm_service_context';
 
 export enum MobileErrorTabIds {
   ERRORS = 'errors',
@@ -43,8 +41,6 @@ export function Tabs({
   mobileErrorTabId: MobileErrorTabIds;
   onTabClick: (nextTab: MobileErrorTabIds) => void;
 }) {
-  const { agentName } = useApmServiceContext();
-  const isAndroidAgent = isAndroidAgentName(agentName);
   const selectedTabId = mobileErrorTabId;
   const tabEntries = tabs.map((tab, index) => (
     <EuiTab
@@ -62,12 +58,8 @@ export function Tabs({
 
   return (
     <>
-      {!isAndroidAgent && (
-        <>
-          <EuiTabs>{tabEntries}</EuiTabs>
-          <EuiSpacer />
-        </>
-      )}
+      <EuiTabs>{tabEntries}</EuiTabs>
+      <EuiSpacer />
       {selectedTabId === MobileErrorTabIds.ERRORS && <MobileErrorsOverview />}
       {selectedTabId === MobileErrorTabIds.CRASHES && <MobileCrashesOverview />}
     </>


### PR DESCRIPTION
Resolves #218535 

Rolls back the errors tab changes previously made [here](https://github.com/elastic/kibana/pull/213734), as the crash support is being added to the EDOT collector.