### PR TITLE
[8.19] [Console] Fix autocomplete insertText (#215911)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -305,9 +305,10 @@ const getSuggestions = (
     endLineNumber: position.lineNumber,
     endColumn: model.getLineMaxColumn(position.lineNumber),
   });
-  // if the rest of the line is empty or there is only "
+  // if the rest of the line is empty or there is only " or ends with closing parentheses
   // then template can be inserted, otherwise only name
-  context.addTemplate = isEmptyOrDoubleQuote(lineContentAfterPosition);
+  context.addTemplate =
+    isEmptyOrDoubleQuote(lineContentAfterPosition) || /^}*$/.test(lineContentAfterPosition);
 
   // if there is " after the cursor, include it in the insert range
   let endColumn = position.column;
@@ -340,7 +341,7 @@ const getSuggestions = (
       })
   );
 };
-const getInsertText = (
+export const getInsertText = (
   { name, insertValue, template, value }: ResultTerm,
   bodyContent: string,
   context: AutoCompleteContext
@@ -348,12 +349,12 @@ const getInsertText = (
   if (name === undefined) {
     return '';
   }
+
   let insertText = '';
   if (typeof name === 'string') {
     const bodyContentLines = bodyContent.split('\n');
-    const currentContentLine = bodyContentLines[bodyContentLines.length - 1];
-    const incompleteFieldRegex = /.*"[^"]*$/;
-    if (incompleteFieldRegex.test(currentContentLine)) {
+    const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
+    if (hasUnclosedQuote(currentContentLine)) {
       // The cursor is after an unmatched quote (e.g. '..."abc', '..."')
       insertText = '';
     } else {
@@ -374,7 +375,8 @@ const getInsertText = (
   if (conditionalTemplate) {
     template = conditionalTemplate;
   }
-  if (template !== undefined && context.addTemplate) {
+
+  if (template && context.addTemplate) {
     let templateLines;
     const { __raw, value: templateValue } = template;
     if (__raw && templateValue) {
@@ -384,9 +386,9 @@ const getInsertText = (
     }
     insertText += ': ' + templateLines.join('\n');
   } else if (value === '{') {
-    insertText += '{}';
+    insertText += ': {}';
   } else if (value === '[') {
-    insertText += '[]';
+    insertText += ': []';
   }
   // the string $0 is used to move the cursor between empty curly/square brackets
   if (insertText.endsWith('{}')) {
@@ -448,4 +450,22 @@ export const shouldTriggerSuggestions = (lineContent: string): boolean => {
 export const isEmptyOrDoubleQuote = (lineContent: string): boolean => {
   lineContent = lineContent.trim();
   return !lineContent || lineContent === '"';
+};
+
+export const hasUnclosedQuote = (lineContent: string): boolean => {
+  let insideString = false;
+  let prevChar = '';
+  for (let i = 0; i < lineContent.length; i++) {
+    const char = lineContent[i];
+
+    if (!insideString && char === '"') {
+      insideString = true;
+    } else if (insideString && char === '"' && prevChar !== '\\') {
+      insideString = false;
+    }
+
+    prevChar = char;
+  }
+
+  return insideString;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix autocomplete insertText (#215911)](https://github.com/elastic/kibana/pull/215911)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-28T12:17:15Z","message":"[Console] Fix autocomplete insertText (#215911)\n\nFixes https://github.com/elastic/kibana/issues/212851\n\n## Summary\n\nThis PR fixes the autocomplete insert text, which was incorrectly always\nadding a template due to the changes made in\nhttps://github.com/elastic/kibana/pull/210187. This PR reverts most of\nthese changes and instead fixes\nhttps://github.com/elastic/kibana/issues/208862 by fixing the value of\n`context.addTemplate`. It also adds unit tests for the `getInsertText`\nfunction.\n\n\nRequests to test:\n\n**Test 1:**\n\n```\nGET index/_search\n{\"query\": {te}} \n```\n\nshould autocomplete to \n\n\n```GET index/_search\n{\n  \"query\": {\n    \"term\": {\n      \"FIELD\": {\n        \"value\": \"VALUE\"\n      }\n    }\n  }\n}\n```\n\nSame for the request below:\n\n```\nGET index/_search\n{\n  \"query\": {\n    te\n}\n```\n\n**Test 2:**\nIn the following request, deleting `AGG_TYPE` and replacing it with\n`terms` is correctly autocompleted:\n\n\n```\nGET /_search\n{\n  \"aggs\": {\n    \"NAME\": {\n      \"AGG_TYPE\": {}\n    }\n  }\n}\n```\n\nautocomplete to:\n\n```\nGET /_search\n{\n  \"aggs\": {\n    \"NAME\": {\n      \"terms\": {}\n    }\n  }\n}\n```\n\n**Test 3:**\n\nInsert the following request\n```\nGET /_search\n{\n    \"query\": {\n      \"match_all\": {}\n    }\n}\n```\nPut the cursor at the end of the `match_all` field (right before the\nclosing quote) and then delete a few of the last characters. Retype one\ncharacter in order to get the suggestions popup displayed. Then press\nEnter to add a suggestion.\nVerify that the suggestion is added with no extra quote in the\nbeginning.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f1c61e43b07ab3730284d2fbdaad97c892a32fab","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","v9.0.0","backport:prev-minor","v9.1.0","v8.19.0"],"title":"[Console] Fix autocomplete insertText","number":215911,"url":"https://github.com/elastic/kibana/pull/215911","mergeCommit":{"message":"[Console] Fix autocomplete insertText (#215911)\n\nFixes https://github.com/elastic/kibana/issues/212851\n\n## Summary\n\nThis PR fixes the autocomplete insert text, which was incorrectly always\nadding a template due to the changes made in\nhttps://github.com/elastic/kibana/pull/210187. This PR reverts most of\nthese changes and instead fixes\nhttps://github.com/elastic/kibana/issues/208862 by fixing the value of\n`context.addTemplate`. It also adds unit tests for the `getInsertText`\nfunction.\n\n\nRequests to test:\n\n**Test 1:**\n\n```\nGET index/_search\n{\"query\": {te}} \n```\n\nshould autocomplete to \n\n\n```GET index/_search\n{\n  \"query\": {\n    \"term\": {\n      \"FIELD\": {\n        \"value\": \"VALUE\"\n      }\n    }\n  }\n}\n```\n\nSame for the request below:\n\n```\nGET index/_search\n{\n  \"query\": {\n    te\n}\n```\n\n**Test 2:**\nIn the following request, deleting `AGG_TYPE` and replacing it with\n`terms` is correctly autocompleted:\n\n\n```\nGET /_search\n{\n  \"aggs\": {\n    \"NAME\": {\n      \"AGG_TYPE\": {}\n    }\n  }\n}\n```\n\nautocomplete to:\n\n```\nGET /_search\n{\n  \"aggs\": {\n    \"NAME\": {\n      \"terms\": {}\n    }\n  }\n}\n```\n\n**Test 3:**\n\nInsert the following request\n```\nGET /_search\n{\n    \"query\": {\n      \"match_all\": {}\n    }\n}\n```\nPut the cursor at the end of the `match_all` field (right before the\nclosing quote) and then delete a few of the last characters. Retype one\ncharacter in order to get the suggestions popup displayed. Then press\nEnter to add a suggestion.\nVerify that the suggestion is added with no extra quote in the\nbeginning.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f1c61e43b07ab3730284d2fbdaad97c892a32fab"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216288","number":216288,"state":"MERGED","mergeCommit":{"sha":"51c01bf91989a0ab2f67225a9d06372e848fd735","message":"[9.0] [Console] Fix autocomplete insertText (#215911) (#216288)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Console] Fix autocomplete insertText\n(#215911)](https://github.com/elastic/kibana/pull/215911)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Elena Stoeva <59341489+ElenaStoeva@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215911","number":215911,"mergeCommit":{"message":"[Console] Fix autocomplete insertText (#215911)\n\nFixes https://github.com/elastic/kibana/issues/212851\n\n## Summary\n\nThis PR fixes the autocomplete insert text, which was incorrectly always\nadding a template due to the changes made in\nhttps://github.com/elastic/kibana/pull/210187. This PR reverts most of\nthese changes and instead fixes\nhttps://github.com/elastic/kibana/issues/208862 by fixing the value of\n`context.addTemplate`. It also adds unit tests for the `getInsertText`\nfunction.\n\n\nRequests to test:\n\n**Test 1:**\n\n```\nGET index/_search\n{\"query\": {te}} \n```\n\nshould autocomplete to \n\n\n```GET index/_search\n{\n  \"query\": {\n    \"term\": {\n      \"FIELD\": {\n        \"value\": \"VALUE\"\n      }\n    }\n  }\n}\n```\n\nSame for the request below:\n\n```\nGET index/_search\n{\n  \"query\": {\n    te\n}\n```\n\n**Test 2:**\nIn the following request, deleting `AGG_TYPE` and replacing it with\n`terms` is correctly autocompleted:\n\n\n```\nGET /_search\n{\n  \"aggs\": {\n    \"NAME\": {\n      \"AGG_TYPE\": {}\n    }\n  }\n}\n```\n\nautocomplete to:\n\n```\nGET /_search\n{\n  \"aggs\": {\n    \"NAME\": {\n      \"terms\": {}\n    }\n  }\n}\n```\n\n**Test 3:**\n\nInsert the following request\n```\nGET /_search\n{\n    \"query\": {\n      \"match_all\": {}\n    }\n}\n```\nPut the cursor at the end of the `match_all` field (right before the\nclosing quote) and then delete a few of the last characters. Retype one\ncharacter in order to get the suggestions popup displayed. Then press\nEnter to add a suggestion.\nVerify that the suggestion is added with no extra quote in the\nbeginning.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f1c61e43b07ab3730284d2fbdaad97c892a32fab"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->