### PR TITLE
[8.19] [Discover][APM] Add link to view related errors in Discover from the full-screen waterfall  (#224033)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/index.ts
@@ -36,6 +36,7 @@ export {
   convertValueToString,
   createLogsContextService,
   createTracesContextService,
+  createApmErrorsContextService,
   createDegradedDocsControl,
   createStacktraceControl,
   fieldConstants,
@@ -66,7 +67,7 @@ export {
   LogLevelBadge,
 } from './src';
 
-export type { LogsContextService, TracesContextService } from './src';
+export type { LogsContextService, TracesContextService, ApmErrorsContextService } from './src';
 
 export * from './src/types';
 

--- a/src/platform/packages/shared/kbn-discover-utils/src/__mocks__/apm_errors_context_service.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/__mocks__/apm_errors_context_service.ts
@@ -7,6 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './logs';
-export * from './traces';
-export * from './apm';
+import { getApmErrorsContextService } from '../data_types';
+
+export const createApmErrorsContextServiceMock = () => getApmErrorsContextService('errors-*');

--- a/src/platform/packages/shared/kbn-discover-utils/src/__mocks__/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/__mocks__/index.ts
@@ -12,3 +12,4 @@ export * from './es_hits';
 export * from './additional_field_groups';
 export * from './logs_context_service';
 export * from './traces_context_service';
+export * from './apm_errors_context_service';

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/apm/errors/errors_context_service.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/apm/errors/errors_context_service.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ApmSourceAccessPluginStart } from '@kbn/apm-sources-access-plugin/public';
+
+export interface ApmErrorsContextService {
+  getErrorsIndexPattern(): string;
+}
+
+export interface ApmErrorsContextServiceDeps {
+  apmSourcesAccess?: ApmSourceAccessPluginStart;
+}
+
+// should we have defaults here?
+export const DEFAULT_ALLOWED_APM_ERRORS_BASE_PATTERNS = [];
+
+export const createApmErrorsContextService = async ({
+  apmSourcesAccess,
+}: ApmErrorsContextServiceDeps): Promise<ApmErrorsContextService> => {
+  if (!apmSourcesAccess) {
+    return defaultApmErrorsContextService;
+  }
+
+  try {
+    const indices = await apmSourcesAccess.getApmIndices();
+
+    if (!indices) {
+      return defaultApmErrorsContextService;
+    }
+
+    const { error } = indices;
+    return getApmErrorsContextService(error);
+  } catch (error) {
+    return defaultApmErrorsContextService;
+  }
+};
+
+export const getApmErrorsContextService = (error: string) => ({
+  getErrorsIndexPattern: () => error,
+});
+
+const defaultApmErrorsContextService = getApmErrorsContextService(
+  DEFAULT_ALLOWED_APM_ERRORS_BASE_PATTERNS.join()
+);

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/apm/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/apm/index.ts
@@ -7,6 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './logs';
-export * from './traces';
-export * from './apm';
+export * from './errors/errors_context_service';

--- a/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
@@ -27,6 +27,7 @@ import type { ProfileProviderServices } from '../profile_providers/profile_provi
 import { ProfilesManager } from '../profiles_manager';
 import { DiscoverEBTManager } from '../../plugin_imports/discover_ebt_manager';
 import {
+  createApmErrorsContextServiceMock,
   createLogsContextServiceMock,
   createTracesContextServiceMock,
 } from '@kbn/discover-utils/src/__mocks__';
@@ -198,6 +199,7 @@ const createProfileProviderServicesMock = () => {
     logsContextService: createLogsContextServiceMock(),
     discoverShared: discoverSharedPluginMock.createStartContract(),
     tracesContextService: createTracesContextServiceMock(),
+    apmErrorsContextService: createApmErrorsContextServiceMock(),
     core: {
       pricing: pricingServiceMock.createStartContract() as ReturnType<
         typeof pricingServiceMock.createStartContract

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
@@ -15,7 +15,10 @@ import type { DocumentProfileProvider } from '../../../../../profiles';
 import type { DocViewerExtensionParams, DocViewerExtension } from '../../../../../types';
 
 export const createGetDocViewer =
-  (tracesIndexPattern: string): DocumentProfileProvider['profile']['getDocViewer'] =>
+  (indexes: {
+    apm: { errors: string; traces: string };
+    logs: string;
+  }): DocumentProfileProvider['profile']['getDocViewer'] =>
   (prev: (params: DocViewerExtensionParams) => DocViewerExtension) =>
   (params: DocViewerExtensionParams) => {
     const prevDocViewer = prev(params);
@@ -30,12 +33,7 @@ export const createGetDocViewer =
           }),
           order: 0,
           component: (props) => {
-            return (
-              <UnifiedDocViewerObservabilityTracesSpanOverview
-                {...props}
-                tracesIndexPattern={tracesIndexPattern}
-              />
-            );
+            return <UnifiedDocViewerObservabilityTracesSpanOverview {...props} indexes={indexes} />;
           },
         });
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.ts
@@ -19,12 +19,20 @@ const OBSERVABILITY_TRACES_SPAN_DOCUMENT_PROFILE_ID = 'observability-traces-span
 
 export const createObservabilityTracesSpanDocumentProfileProvider = ({
   tracesContextService,
+  apmErrorsContextService,
+  logsContextService,
 }: ProfileProviderServices): DocumentProfileProvider => ({
   isExperimental: true,
   profileId: OBSERVABILITY_TRACES_SPAN_DOCUMENT_PROFILE_ID,
   restrictedToProductFeature: TRACES_PRODUCT_FEATURE_ID,
   profile: {
-    getDocViewer: createGetDocViewer(tracesContextService.getAllTracesIndexPattern()),
+    getDocViewer: createGetDocViewer({
+      apm: {
+        errors: apmErrorsContextService.getErrorsIndexPattern(),
+        traces: tracesContextService.getAllTracesIndexPattern(),
+      },
+      logs: logsContextService.getAllLogsIndexPattern() ?? '',
+    }),
   },
   resolve: ({ record, rootContext }) => {
     const isObservabilitySolutionView = rootContext.solutionType === SolutionType.Observability;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/accessors/doc_viewer.tsx
@@ -15,7 +15,10 @@ import type { DocumentProfileProvider } from '../../../../..';
 import type { DocViewerExtensionParams, DocViewerExtension } from '../../../../../types';
 
 export const createGetDocViewer =
-  (tracesIndexPattern: string): DocumentProfileProvider['profile']['getDocViewer'] =>
+  (indexes: {
+    apm: { errors: string; traces: string };
+    logs: string;
+  }): DocumentProfileProvider['profile']['getDocViewer'] =>
   (prev: (params: DocViewerExtensionParams) => DocViewerExtension) =>
   (params: DocViewerExtensionParams) => {
     const prevDocViewer = prev(params);
@@ -36,7 +39,7 @@ export const createGetDocViewer =
             return (
               <UnifiedDocViewerObservabilityTracesTransactionOverview
                 {...props}
-                tracesIndexPattern={tracesIndexPattern}
+                indexes={indexes}
               />
             );
           },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.ts
@@ -20,12 +20,20 @@ const OBSERVABILITY_TRACES_TRANSACTION_DOCUMENT_PROFILE_ID =
 
 export const createObservabilityTracesTransactionDocumentProfileProvider = ({
   tracesContextService,
+  apmErrorsContextService,
+  logsContextService,
 }: ProfileProviderServices): DocumentProfileProvider => ({
   isExperimental: true,
   profileId: OBSERVABILITY_TRACES_TRANSACTION_DOCUMENT_PROFILE_ID,
   restrictedToProductFeature: TRACES_PRODUCT_FEATURE_ID,
   profile: {
-    getDocViewer: createGetDocViewer(tracesContextService.getAllTracesIndexPattern() || ''),
+    getDocViewer: createGetDocViewer({
+      apm: {
+        errors: apmErrorsContextService.getErrorsIndexPattern(),
+        traces: tracesContextService.getAllTracesIndexPattern(),
+      },
+      logs: logsContextService.getAllLogsIndexPattern() ?? '',
+    }),
   },
   resolve: ({ record, rootContext }) => {
     const isObservabilitySolutionView = rootContext.solutionType === SolutionType.Observability;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/profile_provider_services.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/profile_provider_services.ts
@@ -12,6 +12,8 @@ import {
   type LogsContextService,
   createTracesContextService,
   type TracesContextService,
+  createApmErrorsContextService,
+  type ApmErrorsContextService,
 } from '@kbn/discover-utils';
 
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
@@ -35,6 +37,7 @@ export interface ProfileProviderServices extends DiscoverServices {
    */
   logsContextService: LogsContextService;
   tracesContextService: TracesContextService;
+  apmErrorsContextService: ApmErrorsContextService;
 }
 
 /**
@@ -51,6 +54,9 @@ export const createProfileProviderServices = async (
       logsDataAccess: discoverServices.logsDataAccess,
     }),
     tracesContextService: await createTracesContextService({
+      apmSourcesAccess: discoverServices.apmSourcesAccess,
+    }),
+    apmErrorsContextService: await createApmErrorsContextService({
       apmSourcesAccess: discoverServices.apmSourcesAccess,
     }),
   };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/exit_full_screen_button/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/exit_full_screen_button/index.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { EuiButtonIcon, EuiWindowEvent } from '@elastic/eui';
+export interface ExitFullScreenButtonProps {
+  ariaLabel: string;
+  dataTestSubj: string;
+  onExitFullScreen: () => void;
+}
+
+export const ExitFullScreenButton = ({
+  ariaLabel,
+  dataTestSubj,
+  onExitFullScreen,
+}: ExitFullScreenButtonProps) => {
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+
+        onExitFullScreen();
+      }
+    },
+    [onExitFullScreen]
+  );
+  return (
+    <>
+      <EuiWindowEvent event="keydown" handler={onKeyDown} />
+      <EuiButtonIcon
+        data-test-subj={dataTestSubj}
+        display="base"
+        iconSize="m"
+        iconType="fullScreenExit"
+        aria-label={ariaLabel}
+        onClick={onExitFullScreen}
+      />
+    </>
+  );
+};

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -7,10 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
 import {
-  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFocusTrap,
@@ -22,8 +21,11 @@ import {
 import { SERVICE_NAME_FIELD, SPAN_ID_FIELD, TRANSACTION_ID_FIELD } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import { useRootTransactionContext } from '../../doc_viewer_transaction_overview/hooks/use_root_transaction';
+import { getUnifiedDocViewerServices } from '../../../../../plugin';
 import { SpanFlyout } from './span_flyout';
+import { useRootTransactionContext } from '../../doc_viewer_transaction_overview/hooks/use_root_transaction';
+import { useDataSourcesContext } from '../../hooks/use_data_sources';
+import { ExitFullScreenButton } from './exit_full_screen_button';
 
 export interface FullScreenWaterfallProps {
   traceId: string;
@@ -31,7 +33,7 @@ export interface FullScreenWaterfallProps {
   rangeTo: string;
   dataView: DocViewRenderProps['dataView'];
   tracesIndexPattern: string;
-  onCloseFullScreen: () => void;
+  onExitFullScreen: () => void;
 }
 
 export const FullScreenWaterfall = ({
@@ -40,12 +42,45 @@ export const FullScreenWaterfall = ({
   rangeTo,
   dataView,
   tracesIndexPattern,
-  onCloseFullScreen,
+  onExitFullScreen,
 }: FullScreenWaterfallProps) => {
   const { transaction } = useRootTransactionContext();
   const [spanId, setSpanId] = useState<string | null>(null);
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const overlayMaskRef = useRef<HTMLDivElement>(null);
+  const {
+    share: {
+      url: { locators },
+    },
+    data: {
+      query: {
+        timefilter: { timefilter },
+      },
+    },
+  } = getUnifiedDocViewerServices();
+  const { indexes } = useDataSourcesContext();
+
+  const discoverLocator = useMemo(() => locators.get('DISCOVER_APP_LOCATOR'), [locators]);
+
+  const generateRelatedErrorsDiscoverUrl = useCallback(
+    (docId: string) => {
+      if (!discoverLocator) {
+        return null;
+      }
+
+      const url = discoverLocator.getRedirectUrl({
+        timeRange: timefilter.getAbsoluteTime(),
+        filters: [],
+        query: {
+          language: 'kuery',
+          esql: `FROM ${indexes.apm.errors},${indexes.logs} | WHERE trace.id == "${traceId}" AND span.id == "${docId}"`,
+        },
+      });
+
+      return url;
+    },
+    [discoverLocator, timefilter, indexes.apm.errors, indexes.logs, traceId]
+  );
 
   const getParentApi = useCallback(
     () => ({
@@ -57,6 +92,7 @@ export const FullScreenWaterfall = ({
           serviceName: transaction?.[SERVICE_NAME_FIELD],
           entryTransactionId: transaction?.[TRANSACTION_ID_FIELD] || transaction?.[SPAN_ID_FIELD],
           scrollElement: overlayMaskRef.current,
+          getRelatedErrorsHref: generateRelatedErrorsDiscoverUrl,
           onNodeClick: (nodeSpanId: string) => {
             setSpanId(nodeSpanId);
             setIsFlyoutVisible(true);
@@ -64,7 +100,7 @@ export const FullScreenWaterfall = ({
         },
       }),
     }),
-    [traceId, rangeFrom, rangeTo, transaction]
+    [traceId, rangeFrom, rangeTo, transaction, generateRelatedErrorsDiscoverUrl]
   );
 
   return (
@@ -89,18 +125,15 @@ export const FullScreenWaterfall = ({
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem grow={1} css={{ alignItems: 'end' }}>
-                <EuiButtonIcon
-                  data-test-subj="unifiedDocViewerObservabilityTracesFullScreenWaterfallExitFullScreenButton"
-                  display="base"
-                  iconSize="m"
-                  iconType="fullScreenExit"
-                  aria-label={i18n.translate(
+                <ExitFullScreenButton
+                  onExitFullScreen={onExitFullScreen}
+                  dataTestSubj="unifiedDocViewerObservabilityTracesFullScreenWaterfallExitFullScreenButton"
+                  ariaLabel={i18n.translate(
                     'unifiedDocViewer.observability.traces.fullScreenWaterfall.exitFullScreen.button',
                     {
                       defaultMessage: 'Exit full screen waterfall',
                     }
                   )}
-                  onClick={onCloseFullScreen}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
@@ -16,6 +16,7 @@ import SpanOverview from '../../../doc_viewer_span_overview';
 import TransactionOverview from '../../../doc_viewer_transaction_overview';
 import DocViewerTable from '../../../../../doc_viewer_table';
 import DocViewerSource from '../../../../../doc_viewer_source';
+import { useDataSourcesContext } from '../../../hooks/use_data_sources';
 
 const tabIds = {
   OVERVIEW: 'unifiedDocViewerTracesSpanFlyoutOverview',
@@ -55,9 +56,10 @@ export interface SpanFlyoutProps {
   onCloseFlyout: () => void;
 }
 
-export const SpanFlyoutBody = ({ tracesIndexPattern, hit, loading, dataView }: SpanFlyoutProps) => {
+export const SpanFlyoutBody = ({ hit, loading, dataView }: SpanFlyoutProps) => {
   const [selectedTabId, setSelectedTabId] = useState(tabIds.OVERVIEW);
   const isSpan = !!hit?.flattened[PARENT_ID_FIELD];
+  const { indexes } = useDataSourcesContext();
   const onSelectedTabChanged = (id: string) => setSelectedTabId(id);
 
   const renderTabs = () => {
@@ -84,7 +86,7 @@ export const SpanFlyoutBody = ({ tracesIndexPattern, hit, loading, dataView }: S
               (isSpan ? (
                 <SpanOverview
                   hit={hit}
-                  tracesIndexPattern={tracesIndexPattern}
+                  indexes={indexes}
                   showWaterfall={false}
                   showActions={false}
                   dataView={dataView}
@@ -92,7 +94,7 @@ export const SpanFlyoutBody = ({ tracesIndexPattern, hit, loading, dataView }: S
               ) : (
                 <TransactionOverview
                   hit={hit}
-                  tracesIndexPattern={tracesIndexPattern}
+                  indexes={indexes}
                   showWaterfall={false}
                   showActions={false}
                   dataView={dataView}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
@@ -88,7 +88,7 @@ export const Trace = ({
           rangeTo={rangeTo}
           dataView={dataView}
           tracesIndexPattern={tracesIndexPattern}
-          onCloseFullScreen={() => {
+          onExitFullScreen={() => {
             setShowFullScreenWaterfall(false);
           }}
         />

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
@@ -30,9 +30,16 @@ import { SpanDurationSummary } from './sub_components/span_duration_summary';
 import { SpanSummaryField } from './sub_components/span_summary_field';
 import { SpanSummaryTitle } from './sub_components/span_summary_title';
 import { RootTransactionProvider } from '../doc_viewer_transaction_overview/hooks/use_root_transaction';
+import { DataSourcesProvider } from '../hooks/use_data_sources';
 
 export type SpanOverviewProps = DocViewRenderProps & {
-  tracesIndexPattern: string;
+  indexes: {
+    apm: {
+      traces: string;
+      errors: string;
+    };
+    logs: string;
+  };
   showWaterfall?: boolean;
   showActions?: boolean;
 };
@@ -43,7 +50,7 @@ export function SpanOverview({
   filter,
   onAddColumn,
   onRemoveColumn,
-  tracesIndexPattern,
+  indexes,
   showWaterfall = true,
   showActions = true,
   dataView,
@@ -65,66 +72,68 @@ export function SpanOverview({
   const transactionId = flattenedDoc[TRANSACTION_ID_FIELD];
 
   return (
-    <RootTransactionProvider
-      traceId={flattenedDoc[TRACE_ID_FIELD]}
-      indexPattern={tracesIndexPattern}
-    >
-      <TransactionProvider transactionId={transactionId} indexPattern={tracesIndexPattern}>
-        <FieldActionsProvider
-          columns={columns}
-          filter={filter}
-          onAddColumn={onAddColumn}
-          onRemoveColumn={onRemoveColumn}
-        >
-          <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
-            <EuiSpacer size="m" />
-            <EuiFlexGroup direction="column" gutterSize="m">
-              <EuiFlexItem>
-                <SpanSummaryTitle
-                  spanName={flattenedDoc[SPAN_NAME_FIELD]}
-                  formattedSpanName={formattedDoc[SPAN_NAME_FIELD]}
-                  spanId={flattenedDoc[SPAN_ID_FIELD]}
-                  formattedSpanId={formattedDoc[SPAN_ID_FIELD]}
-                  showActions={showActions}
-                />
-              </EuiFlexItem>
-              <EuiFlexItem>
-                {spanFields.map((fieldId) => (
-                  <SpanSummaryField
-                    key={fieldId}
-                    fieldId={fieldId}
-                    fieldConfiguration={fieldConfigurations[fieldId]}
+    <DataSourcesProvider indexes={indexes}>
+      <RootTransactionProvider
+        traceId={flattenedDoc[TRACE_ID_FIELD]}
+        indexPattern={indexes.apm.traces}
+      >
+        <TransactionProvider transactionId={transactionId} indexPattern={indexes.apm.traces}>
+          <FieldActionsProvider
+            columns={columns}
+            filter={filter}
+            onAddColumn={onAddColumn}
+            onRemoveColumn={onRemoveColumn}
+          >
+            <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
+              <EuiSpacer size="m" />
+              <EuiFlexGroup direction="column" gutterSize="m">
+                <EuiFlexItem>
+                  <SpanSummaryTitle
+                    spanName={flattenedDoc[SPAN_NAME_FIELD]}
+                    formattedSpanName={formattedDoc[SPAN_NAME_FIELD]}
+                    spanId={flattenedDoc[SPAN_ID_FIELD]}
+                    formattedSpanId={formattedDoc[SPAN_ID_FIELD]}
                     showActions={showActions}
                   />
-                ))}
-              </EuiFlexItem>
-
-              {spanDuration && (
+                </EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiSpacer size="m" />
-                  <SpanDurationSummary
-                    spanDuration={spanDuration}
-                    spanName={flattenedDoc[SPAN_NAME_FIELD]}
-                    serviceName={flattenedDoc[SERVICE_NAME_FIELD]}
+                  {spanFields.map((fieldId) => (
+                    <SpanSummaryField
+                      key={fieldId}
+                      fieldId={fieldId}
+                      fieldConfiguration={fieldConfigurations[fieldId]}
+                      showActions={showActions}
+                    />
+                  ))}
+                </EuiFlexItem>
+
+                {spanDuration && (
+                  <EuiFlexItem>
+                    <EuiSpacer size="m" />
+                    <SpanDurationSummary
+                      spanDuration={spanDuration}
+                      spanName={flattenedDoc[SPAN_NAME_FIELD]}
+                      serviceName={flattenedDoc[SERVICE_NAME_FIELD]}
+                    />
+                  </EuiFlexItem>
+                )}
+                <EuiFlexItem>
+                  <Trace
+                    fields={fieldConfigurations}
+                    traceId={flattenedDoc[TRACE_ID_FIELD]}
+                    docId={flattenedDoc[SPAN_ID_FIELD]}
+                    displayType="span"
+                    dataView={dataView}
+                    tracesIndexPattern={indexes.apm.traces}
+                    showWaterfall={showWaterfall}
+                    showActions={showActions}
                   />
                 </EuiFlexItem>
-              )}
-              <EuiFlexItem>
-                <Trace
-                  fields={fieldConfigurations}
-                  traceId={flattenedDoc[TRACE_ID_FIELD]}
-                  docId={flattenedDoc[SPAN_ID_FIELD]}
-                  displayType="span"
-                  dataView={dataView}
-                  tracesIndexPattern={tracesIndexPattern}
-                  showWaterfall={showWaterfall}
-                  showActions={showActions}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPanel>
-        </FieldActionsProvider>
-      </TransactionProvider>
-    </RootTransactionProvider>
+              </EuiFlexGroup>
+            </EuiPanel>
+          </FieldActionsProvider>
+        </TransactionProvider>
+      </RootTransactionProvider>
+    </DataSourcesProvider>
   );
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
@@ -29,9 +29,16 @@ import { RootTransactionProvider } from './hooks/use_root_transaction';
 import { Trace } from '../components/trace';
 import { TransactionSummaryTitle } from './sub_components/transaction_summary_title';
 import { getUnifiedDocViewerServices } from '../../../../plugin';
+import { DataSourcesProvider } from '../hooks/use_data_sources';
 
 export type TransactionOverviewProps = DocViewRenderProps & {
-  tracesIndexPattern: string;
+  indexes: {
+    apm: {
+      traces: string;
+      errors: string;
+    };
+    logs: string;
+  };
   showWaterfall?: boolean;
   showActions?: boolean;
 };
@@ -42,7 +49,7 @@ export function TransactionOverview({
   filter,
   onAddColumn,
   onRemoveColumn,
-  tracesIndexPattern,
+  indexes,
   showWaterfall = true,
   showActions = true,
   dataView,
@@ -65,63 +72,65 @@ export function TransactionOverview({
   const transactionId = flattenedDoc[TRANSACTION_ID_FIELD];
 
   return (
-    <RootTransactionProvider traceId={traceId} indexPattern={tracesIndexPattern}>
-      <FieldActionsProvider
-        columns={columns}
-        filter={filter}
-        onAddColumn={onAddColumn}
-        onRemoveColumn={onRemoveColumn}
-      >
-        <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
-          <EuiSpacer size="m" />
-          <EuiFlexGroup direction="column" gutterSize="m">
-            <EuiFlexItem>
-              <TransactionSummaryTitle
-                serviceName={flattenedDoc[SERVICE_NAME_FIELD]}
-                transactionName={flattenedDoc[TRANSACTION_NAME_FIELD]}
-                formattedTransactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
-                id={transactionId}
-                formattedId={formattedDoc[TRANSACTION_ID_FIELD]}
-                showActions={showActions}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              {transactionFields.map((fieldId) => (
-                <TransactionSummaryField
-                  key={fieldId}
-                  fieldId={fieldId}
-                  fieldConfiguration={fieldConfigurations[fieldId]}
-                  showActions={showActions}
-                />
-              ))}
-            </EuiFlexItem>
-            {transactionDuration !== undefined && (
+    <DataSourcesProvider indexes={indexes}>
+      <RootTransactionProvider traceId={traceId} indexPattern={indexes.apm.traces}>
+        <FieldActionsProvider
+          columns={columns}
+          filter={filter}
+          onAddColumn={onAddColumn}
+          onRemoveColumn={onRemoveColumn}
+        >
+          <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
+            <EuiSpacer size="m" />
+            <EuiFlexGroup direction="column" gutterSize="m">
               <EuiFlexItem>
-                <TransactionDurationSummary
-                  transactionDuration={transactionDuration}
-                  transactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
-                  transactionType={formattedDoc[TRANSACTION_TYPE_FIELD]}
-                  serviceName={formattedDoc[SERVICE_NAME_FIELD]}
+                <TransactionSummaryTitle
+                  serviceName={flattenedDoc[SERVICE_NAME_FIELD]}
+                  transactionName={flattenedDoc[TRANSACTION_NAME_FIELD]}
+                  formattedTransactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
+                  id={transactionId}
+                  formattedId={formattedDoc[TRANSACTION_ID_FIELD]}
+                  showActions={showActions}
                 />
               </EuiFlexItem>
-            )}
-            <EuiFlexItem>
-              {traceId && transactionId && (
-                <Trace
-                  fields={fieldConfigurations}
-                  traceId={traceId}
-                  docId={transactionId}
-                  displayType="transaction"
-                  dataView={dataView}
-                  tracesIndexPattern={tracesIndexPattern}
-                  showWaterfall={showWaterfall}
-                  showActions={showActions}
-                />
+              <EuiFlexItem>
+                {transactionFields.map((fieldId) => (
+                  <TransactionSummaryField
+                    key={fieldId}
+                    fieldId={fieldId}
+                    fieldConfiguration={fieldConfigurations[fieldId]}
+                    showActions={showActions}
+                  />
+                ))}
+              </EuiFlexItem>
+              {transactionDuration !== undefined && (
+                <EuiFlexItem>
+                  <TransactionDurationSummary
+                    transactionDuration={transactionDuration}
+                    transactionName={formattedDoc[TRANSACTION_NAME_FIELD]}
+                    transactionType={formattedDoc[TRANSACTION_TYPE_FIELD]}
+                    serviceName={formattedDoc[SERVICE_NAME_FIELD]}
+                  />
+                </EuiFlexItem>
               )}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiPanel>
-      </FieldActionsProvider>
-    </RootTransactionProvider>
+              <EuiFlexItem>
+                {traceId && transactionId && (
+                  <Trace
+                    fields={fieldConfigurations}
+                    traceId={traceId}
+                    docId={transactionId}
+                    displayType="transaction"
+                    dataView={dataView}
+                    tracesIndexPattern={indexes.apm.traces}
+                    showWaterfall={showWaterfall}
+                    showActions={showActions}
+                  />
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+        </FieldActionsProvider>
+      </RootTransactionProvider>
+    </DataSourcesProvider>
   );
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_data_sources/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_data_sources/index.ts
@@ -7,6 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './logs';
-export * from './traces';
-export * from './apm';
+import createContainer from 'constate';
+
+type UseDataSourcesParams = DataSources;
+
+export interface DataSources {
+  indexes: {
+    logs: string;
+    apm: {
+      errors: string;
+      traces: string;
+    };
+  };
+}
+
+const useDataSources = ({ indexes }: UseDataSourcesParams) => {
+  return { indexes };
+};
+
+export const [DataSourcesProvider, useDataSourcesContext] = createContainer(useDataSources);

--- a/src/platform/plugins/shared/unified_doc_viewer/tsconfig.json
+++ b/src/platform/plugins/shared/unified_doc_viewer/tsconfig.json
@@ -47,7 +47,7 @@
     "@kbn/embeddable-plugin",
     "@kbn/apm-types-shared",
     "@kbn/object-utils",
-    "@kbn/es-query",
+    "@kbn/es-query"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
@@ -27,6 +27,7 @@ import type {
   IWaterfallNodeFlatten,
   IWaterfall,
   IWaterfallSpanOrTransaction,
+  IWaterfallGetRelatedErrorsHref,
 } from './waterfall_helpers/waterfall_helpers';
 import { WaterfallItem } from './waterfall_item';
 import { WaterfallContextProvider } from './context/waterfall_context';
@@ -44,6 +45,7 @@ interface AccordionWaterfallProps {
   displayLimit?: number;
   isEmbeddable?: boolean;
   scrollElement?: Element;
+  getRelatedErrorsHref?: IWaterfallGetRelatedErrorsHref;
 }
 
 type WaterfallProps = Omit<
@@ -185,7 +187,14 @@ const VirtualRow = React.memo(
 
 const WaterfallNode = React.memo((props: WaterfallNodeProps) => {
   const theme = useTheme();
-  const { duration, waterfallItemId, onClickWaterfallItem, timelineMargins, node } = props;
+  const {
+    duration,
+    waterfallItemId,
+    onClickWaterfallItem,
+    getRelatedErrorsHref,
+    timelineMargins,
+    node,
+  } = props;
   const {
     criticalPathSegmentsById,
     getErrorCount,
@@ -251,6 +260,7 @@ const WaterfallNode = React.memo((props: WaterfallNodeProps) => {
               onClick={onWaterfallItemClick}
               segments={segments}
               isEmbeddable={isEmbeddable}
+              getRelatedErrorsHref={getRelatedErrorsHref}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -21,6 +21,7 @@ import { getErrorMarks } from '../marks/get_error_marks';
 import { AccordionWaterfall } from './accordion_waterfall';
 import type {
   IWaterfall,
+  IWaterfallGetRelatedErrorsHref,
   IWaterfallSpanOrTransaction,
 } from './waterfall_helpers/waterfall_helpers';
 
@@ -41,6 +42,7 @@ interface Props {
   displayLimit?: number;
   isEmbeddable?: boolean;
   scrollElement?: Element;
+  getRelatedErrorsHref?: IWaterfallGetRelatedErrorsHref;
 }
 
 function getWaterfallMaxLevel(waterfall: IWaterfall) {
@@ -81,6 +83,7 @@ export function Waterfall({
   displayLimit,
   isEmbeddable,
   scrollElement,
+  getRelatedErrorsHref,
 }: Props) {
   const theme = useTheme();
   const [isAccordionOpen, setIsAccordionOpen] = useState(true);
@@ -185,6 +188,7 @@ export function Waterfall({
             displayLimit={displayLimit}
             isEmbeddable={isEmbeddable}
             scrollElement={scrollElement}
+            getRelatedErrorsHref={getRelatedErrorsHref}
           />
         )}
       </WaterfallItemsContainer>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -91,6 +91,8 @@ export type IWaterfallSpan = IWaterfallItemBase<WaterfallSpan, 'span'>;
 
 export type IWaterfallSpanOrTransaction = IWaterfallTransaction | IWaterfallSpan;
 
+export type IWaterfallGetRelatedErrorsHref = (docId: string) => string;
+
 export type IWaterfallItem = IWaterfallSpanOrTransaction;
 
 export interface IWaterfallLegend {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
@@ -24,7 +24,10 @@ import { SyncBadge } from './badge/sync_badge';
 import { FailureBadge } from './failure_badge';
 import { OrphanItemTooltipIcon } from './orphan_item_tooltip_icon';
 import { SpanMissingDestinationTooltip } from './span_missing_destination_tooltip';
-import type { IWaterfallSpanOrTransaction } from './waterfall_helpers/waterfall_helpers';
+import type {
+  IWaterfallGetRelatedErrorsHref,
+  IWaterfallSpanOrTransaction,
+} from './waterfall_helpers/waterfall_helpers';
 
 type ItemType = 'transaction' | 'span' | 'error';
 
@@ -126,6 +129,7 @@ interface IWaterfallItemProps {
     color: string;
   }>;
   onClick?: (flyoutDetailTab: string) => unknown;
+  getRelatedErrorsHref?: IWaterfallGetRelatedErrorsHref;
   isEmbeddable?: boolean;
 }
 
@@ -226,6 +230,7 @@ export function WaterfallItem({
   color,
   isSelected,
   errorCount,
+  getRelatedErrorsHref,
   marginLeftLevel,
   onClick,
   segments,
@@ -300,7 +305,11 @@ export function WaterfallItem({
 
         <Duration item={item} />
         {isEmbeddable ? (
-          <EmbeddableErrorIcon errorCount={errorCount} />
+          <EmbeddableRelatedErrors
+            item={item}
+            errorCount={errorCount}
+            getRelatedErrorsHref={getRelatedErrorsHref}
+          />
         ) : (
           <RelatedErrors item={item} errorCount={errorCount} />
         )}
@@ -320,12 +329,47 @@ export function WaterfallItem({
   );
 }
 
-function EmbeddableErrorIcon({ errorCount }: { errorCount: number }) {
-  const theme = useEuiTheme();
-  if (errorCount <= 0) {
-    return null;
+function EmbeddableRelatedErrors({
+  item,
+  errorCount,
+  getRelatedErrorsHref,
+}: {
+  item: IWaterfallSpanOrTransaction;
+  errorCount: number;
+  getRelatedErrorsHref?: IWaterfallGetRelatedErrorsHref;
+}) {
+  const { euiTheme } = useEuiTheme();
+
+  const viewRelatedErrorsLabel = i18n.translate(
+    'xpack.apm.waterfall.embeddableRelatedErrors.errorCount',
+    {
+      defaultMessage:
+        '{errorCount, plural, one {View related error} other {View # related errors}}',
+      values: { errorCount },
+    }
+  );
+
+  if (errorCount > 0 && getRelatedErrorsHref) {
+    return (
+      // eslint-disable-next-line @elastic/eui/href-or-on-click
+      <EuiBadge
+        color={euiTheme.colors.danger}
+        iconType="arrowRight"
+        href={getRelatedErrorsHref(item.id) as any}
+        onClick={(e: React.MouseEvent | React.KeyboardEvent) => {
+          e.stopPropagation();
+        }}
+        tabIndex={0}
+        role="button"
+        aria-label={viewRelatedErrorsLabel}
+        onClickAriaLabel={viewRelatedErrorsLabel}
+      >
+        {viewRelatedErrorsLabel}
+      </EuiBadge>
+    );
   }
-  return <EuiIcon type="errorFilled" color={theme.euiTheme.colors.danger} size="s" />;
+
+  return <FailureBadge outcome={item.doc.event?.outcome} />;
 }
 
 function RelatedErrors({

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
@@ -351,7 +351,6 @@ function EmbeddableRelatedErrors({
 
   if (errorCount > 0 && getRelatedErrorsHref) {
     return (
-      // eslint-disable-next-line @elastic/eui/href-or-on-click
       <EuiBadge
         color={euiTheme.colors.danger}
         iconType="arrowRight"

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
@@ -20,6 +20,7 @@ import type { EmbeddableDeps } from '../types';
 import { APM_TRACE_WATERFALL_EMBEDDABLE } from './constant';
 import { TraceWaterfallEmbeddable } from './trace_waterfall_embeddable';
 import { FocusedTraceWaterfallEmbeddable } from './focused_trace_waterfall_embeddable';
+import type { IWaterfallGetRelatedErrorsHref } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
 
 interface BaseProps {
   traceId: string;
@@ -37,6 +38,7 @@ export interface ApmTraceWaterfallEmbeddableEntryProps extends BaseProps, Serial
   displayLimit?: number;
   scrollElement?: Element;
   onNodeClick?: (nodeSpanId: string) => void;
+  getRelatedErrorsHref?: IWaterfallGetRelatedErrorsHref;
 }
 
 export type ApmTraceWaterfallEmbeddableProps =
@@ -67,6 +69,9 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
       const onNodeClick$ = new BehaviorSubject(
         'onNodeClick' in state ? state.onNodeClick : undefined
       );
+      const getRelatedErrorsHref$ = new BehaviorSubject(
+        'getRelatedErrorsHref' in state ? state.getRelatedErrorsHref : undefined
+      );
 
       function serializeState() {
         return {
@@ -81,6 +86,7 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             docId: docId$.getValue(),
             scrollElement: scrollElement$.getValue(),
             onNodeClick: onNodeClick$.getValue(),
+            getRelatedErrorsHref: getRelatedErrorsHref$.getValue(),
           },
         };
       }
@@ -99,7 +105,8 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
           displayLimit$,
           docId$,
           scrollElement$,
-          onNodeClick$
+          onNodeClick$,
+          getRelatedErrorsHref$
         ).pipe(map(() => undefined)),
         getComparators: () => {
           return {
@@ -113,6 +120,7 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             docId: 'referenceEquality',
             scrollElement: 'referenceEquality',
             onNodeClick: 'referenceEquality',
+            getRelatedErrorsHref: 'referenceEquality',
           };
         },
         onReset: (lastSaved) => {
@@ -130,6 +138,7 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
           displayLimit$.next(entryState?.displayLimit ?? 0);
           scrollElement$.next(entryState?.scrollElement ?? undefined);
           onNodeClick$.next(entryState?.onNodeClick ?? undefined);
+          getRelatedErrorsHref$.next(entryState?.getRelatedErrorsHref ?? undefined);
 
           // reset focused state
           const focusedState = lastSaved?.rawState as ApmTraceWaterfallEmbeddableFocusedProps;
@@ -156,6 +165,7 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             docId,
             scrollElement,
             onNodeClick,
+            getRelatedErrorsHref,
           ] = useBatchedPublishingSubjects(
             serviceName$,
             traceId$,
@@ -165,7 +175,8 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
             displayLimit$,
             docId$,
             scrollElement$,
-            onNodeClick$
+            onNodeClick$,
+            getRelatedErrorsHref$
           );
           const content = isEmpty(docId) ? (
             <TraceWaterfallEmbeddable
@@ -177,6 +188,7 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
               displayLimit={displayLimit}
               onNodeClick={onNodeClick}
               scrollElement={scrollElement}
+              getRelatedErrorsHref={getRelatedErrorsHref}
             />
           ) : (
             <FocusedTraceWaterfallEmbeddable

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
@@ -22,6 +22,7 @@ export function TraceWaterfallEmbeddable({
   displayLimit,
   scrollElement,
   onNodeClick,
+  getRelatedErrorsHref,
 }: ApmTraceWaterfallEmbeddableEntryProps) {
   const waterfallFetchResult = useWaterfallFetcher({
     traceId,
@@ -49,6 +50,7 @@ export function TraceWaterfallEmbeddable({
           onNodeClick={(node) => onNodeClick?.(node.id)}
           isEmbeddable
           scrollElement={scrollElement}
+          getRelatedErrorsHref={getRelatedErrorsHref}
         />
       </EuiFlexItem>
     </EuiFlexGroup>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][APM] Add link to view related errors in Discover from the full-screen waterfall  (#224033)](https://github.com/elastic/kibana/pull/224033)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2025-06-18T11:02:04Z","message":"[Discover][APM] Add link to view related errors in Discover from the full-screen waterfall  (#224033)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/222591\n\nThis PR adds the link to the “View related error” / \"View X related\nerrors\" badge in the full-screen waterfall.\n\nUnlike the same badge in APM, here it’s handled as a native `href`, so\nthe user keeps the option to open it in a new tab—avoiding loss of\ncontext from Discover if they prefer.\n\n **Highlights**\n\n* Created `ApmErrorsContextService` to access the configured APM error\nindices.\n\n* I had considered merging this with `TracesContextService` into a\nshared `ApmContextService` (for both traces and errors), but decided to\nkeep them separate to avoid mixing methods and logic. Totally open to\nrevisit this if anyone feels that a shared service would make things\ncleaner or more maintainable.\n\n* Created `DataSourcesProvider` to easily access the relevant indices\nwithin our flyouts.\n\n* Built the Discover URL using the locator, preparing an ESQL query to\nfilter by `span.id` and `trace.id` across both error and log indices.\n\n* Added `getRelatedErrorsHref` as a prop to `TraceWaterfallEmbeddable`,\nallowing us to pass the errors URL directly.\n\n* Why this approach instead of triggering a callback to the parent? We\nwanted to preserve native link behavior (e.g., open in new tab), which\nwouldn't work if navigation was handled via `navigateTo` from the\nparent.\n\n* Created `EmbeddableRelatedErrors` to handle the badge link.\n\n* Agreed with the EUI team to cast the `href` as `any`, since due to the\ncomponent nesting in the waterfall, it was the cleanest way to make the\nnative link behavior work in this context.\n\n* Created `ExitFullScreenButton` wrapper to enable exiting full-screen\nmode with the `ESC` key.\n\n\n\nhttps://github.com/user-attachments/assets/d3e476ae-ee10-410f-b003-02521dc35e13\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: Milosz Marcinkowski <38698566+miloszmarcinkowski@users.noreply.github.com>","sha":"87cb7685888f21b0f9d2a2467f47701364535b44","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0"],"title":"[Discover][APM] Add link to view related errors in Discover from the full-screen waterfall ","number":224033,"url":"https://github.com/elastic/kibana/pull/224033","mergeCommit":{"message":"[Discover][APM] Add link to view related errors in Discover from the full-screen waterfall  (#224033)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/222591\n\nThis PR adds the link to the “View related error” / \"View X related\nerrors\" badge in the full-screen waterfall.\n\nUnlike the same badge in APM, here it’s handled as a native `href`, so\nthe user keeps the option to open it in a new tab—avoiding loss of\ncontext from Discover if they prefer.\n\n **Highlights**\n\n* Created `ApmErrorsContextService` to access the configured APM error\nindices.\n\n* I had considered merging this with `TracesContextService` into a\nshared `ApmContextService` (for both traces and errors), but decided to\nkeep them separate to avoid mixing methods and logic. Totally open to\nrevisit this if anyone feels that a shared service would make things\ncleaner or more maintainable.\n\n* Created `DataSourcesProvider` to easily access the relevant indices\nwithin our flyouts.\n\n* Built the Discover URL using the locator, preparing an ESQL query to\nfilter by `span.id` and `trace.id` across both error and log indices.\n\n* Added `getRelatedErrorsHref` as a prop to `TraceWaterfallEmbeddable`,\nallowing us to pass the errors URL directly.\n\n* Why this approach instead of triggering a callback to the parent? We\nwanted to preserve native link behavior (e.g., open in new tab), which\nwouldn't work if navigation was handled via `navigateTo` from the\nparent.\n\n* Created `EmbeddableRelatedErrors` to handle the badge link.\n\n* Agreed with the EUI team to cast the `href` as `any`, since due to the\ncomponent nesting in the waterfall, it was the cleanest way to make the\nnative link behavior work in this context.\n\n* Created `ExitFullScreenButton` wrapper to enable exiting full-screen\nmode with the `ESC` key.\n\n\n\nhttps://github.com/user-attachments/assets/d3e476ae-ee10-410f-b003-02521dc35e13\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: Milosz Marcinkowski <38698566+miloszmarcinkowski@users.noreply.github.com>","sha":"87cb7685888f21b0f9d2a2467f47701364535b44"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224033","number":224033,"mergeCommit":{"message":"[Discover][APM] Add link to view related errors in Discover from the full-screen waterfall  (#224033)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/222591\n\nThis PR adds the link to the “View related error” / \"View X related\nerrors\" badge in the full-screen waterfall.\n\nUnlike the same badge in APM, here it’s handled as a native `href`, so\nthe user keeps the option to open it in a new tab—avoiding loss of\ncontext from Discover if they prefer.\n\n **Highlights**\n\n* Created `ApmErrorsContextService` to access the configured APM error\nindices.\n\n* I had considered merging this with `TracesContextService` into a\nshared `ApmContextService` (for both traces and errors), but decided to\nkeep them separate to avoid mixing methods and logic. Totally open to\nrevisit this if anyone feels that a shared service would make things\ncleaner or more maintainable.\n\n* Created `DataSourcesProvider` to easily access the relevant indices\nwithin our flyouts.\n\n* Built the Discover URL using the locator, preparing an ESQL query to\nfilter by `span.id` and `trace.id` across both error and log indices.\n\n* Added `getRelatedErrorsHref` as a prop to `TraceWaterfallEmbeddable`,\nallowing us to pass the errors URL directly.\n\n* Why this approach instead of triggering a callback to the parent? We\nwanted to preserve native link behavior (e.g., open in new tab), which\nwouldn't work if navigation was handled via `navigateTo` from the\nparent.\n\n* Created `EmbeddableRelatedErrors` to handle the badge link.\n\n* Agreed with the EUI team to cast the `href` as `any`, since due to the\ncomponent nesting in the waterfall, it was the cleanest way to make the\nnative link behavior work in this context.\n\n* Created `ExitFullScreenButton` wrapper to enable exiting full-screen\nmode with the `ESC` key.\n\n\n\nhttps://github.com/user-attachments/assets/d3e476ae-ee10-410f-b003-02521dc35e13\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: Milosz Marcinkowski <38698566+miloszmarcinkowski@users.noreply.github.com>","sha":"87cb7685888f21b0f9d2a2467f47701364535b44"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->