### PR TITLE
[8.19] [Discover] Highlight filtered values in badges for custom cell renderers (#213941)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1142,8 +1142,9 @@ src/platform/plugins/shared/discover/public/context_awareness/profile_providers/
 # TODO: this deprecation_logs folder should be owned by kibana management team after 9.0
 src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs @elastic/kibana-data-discovery @elastic/kibana-core
 src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability @elastic/kibana-data-discovery @elastic/obs-ux-logs-team
-src/platform/plugins/shared/discover/public/context_awareness/profile_providers/traces_document_profile @elastic/obs-ux-infra_services-team
-src/platform/plugins/shared/discover/public/context_awareness/profile_providers/traces_data_source_profile @elastic/obs-ux-infra_services-team
+src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile @elastic/obs-ux-infra_services-team
+src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile @elastic/obs-ux-infra_services-team
+src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile @elastic/obs-ux-logs-team @elastic/obs-ux-infra_services-team
 
 # Platform Docs
 /x-pack/test_serverless/functional/test_suites/security/screenshot_creation/index.ts @elastic/platform-docs

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
@@ -36,6 +36,7 @@ import {
   filterOutText,
   openCellActionPopoverAriaText,
 } from './translations';
+import { truncateAndPreserveHighlightTags } from './utils';
 
 interface CellActionsPopoverProps {
   onFilter?: DocViewFilterFn;
@@ -192,6 +193,8 @@ export function FieldBadgeWithActions({
   rawValue,
   color = 'hollow',
 }: FieldBadgeWithActionsPropsAndDependencies) {
+  const MAX_LENGTH = 20;
+
   return (
     <CellActionsPopover
       onFilter={onFilter}
@@ -201,19 +204,14 @@ export function FieldBadgeWithActions({
       renderValue={renderValue}
       renderPopoverTrigger={({ popoverTriggerProps }) => (
         <EuiBadge {...popoverTriggerProps} color={color} iconType={icon} iconSide="left">
-          {truncateMiddle(value)}
+          <span
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html: truncateAndPreserveHighlightTags(value, MAX_LENGTH),
+            }}
+          />
         </EuiBadge>
       )}
     />
   );
-}
-
-const MAX_LENGTH = 20;
-
-function truncateMiddle(value: string): string {
-  if (value.length < MAX_LENGTH) {
-    return value;
-  }
-  const halfLength = MAX_LENGTH / 2;
-  return `${value.slice(0, halfLength)}...${value.slice(-halfLength)}`;
 }

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/index.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export * from './truncate_preserve_highlight_tags';

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { truncateAndPreserveHighlightTags } from '.';
+
+describe('truncateAndPreserveHighlightTags', () => {
+  const MAX_LENGTH = 10;
+  const SHORT_TEXT = 'short';
+  const LONG_TEXT = 'Long text that needs truncation';
+
+  describe("when there aren't <mark> tags", () => {
+    describe('and text is shorter than maxLength', () => {
+      const result = truncateAndPreserveHighlightTags(SHORT_TEXT, MAX_LENGTH);
+
+      it('should return the original string', () => {
+        expect(result).toBe(SHORT_TEXT);
+      });
+    });
+
+    describe('and text is longer than or equal to maxLength', () => {
+      const result = truncateAndPreserveHighlightTags(LONG_TEXT, MAX_LENGTH);
+
+      it('should truncate the middle of a long string ', () => {
+        expect(result).toBe('Long ...ation');
+      });
+    });
+  });
+
+  describe('when there are <mark> tags', () => {
+    describe('and text is shorter than maxLength', () => {
+      const result = truncateAndPreserveHighlightTags(`<mark>${SHORT_TEXT}</mark>`, MAX_LENGTH);
+
+      it('should return the original string with the tags', () => {
+        expect(result).toBe(`<mark>${SHORT_TEXT}</mark>`);
+      });
+    });
+
+    describe('and text is longer than or equal to maxLength', () => {
+      const result = truncateAndPreserveHighlightTags(`<mark>${LONG_TEXT}</mark>`, MAX_LENGTH);
+
+      it('should truncate the middle of a long string and add the tags ', () => {
+        expect(result).toBe('<mark>Long ...ation</mark>');
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+function extractTextAndMarkTags(html: string) {
+  const markTags: string[] = [];
+  const cleanText = html.replace(/<\/?mark>/g, (match) => {
+    markTags.push(match);
+    return '';
+  });
+
+  return { cleanText, markTags };
+}
+export function truncateAndPreserveHighlightTags(value: string, maxLength: number): string {
+  const { cleanText, markTags } = extractTextAndMarkTags(value);
+
+  if (cleanText.length < maxLength) {
+    return value;
+  }
+
+  const halfLength = maxLength / 2;
+  const truncatedText = `${cleanText.slice(0, halfLength)}...${cleanText.slice(-halfLength)}`;
+
+  if (markTags.length === 2) {
+    return `${markTags[0]}${truncatedText}${markTags[1]}`;
+  }
+
+  return truncatedText;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover] Highlight filtered values in badges for custom cell renderers (#213941)](https://github.com/elastic/kibana/pull/213941)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2025-03-17T15:18:36Z","message":"[Discover] Highlight filtered values in badges for custom cell renderers (#213941)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/213216\n\nThis PR adds the functionality to properly highlight filtered values\nwithin badges.\n\nPreviously, the content was treated as `text` instead of `html`, which\nprevented the highlighted values from being displayed correctly.\n\nThe content is now rendered with the `<mark>` tag, allowing matching\nvalues to be properly highlighted within the badges.\n\n>[!NOTE]\n>By looking at the code I assumed the `<mark>` tag is the only one we\nintroduce, so the proposed solution only handles that.\n\n\n|Before|After|\n|-|-|\n|![Screenshot 2025-03-11 at 15 02\n02](https://github.com/user-attachments/assets/779a860e-52c1-446a-b23a-09432ec01132)|![Screenshot\n2025-03-11 at 15 02\n31](https://github.com/user-attachments/assets/1e4d4a97-fc06-4302-88fe-d6060b6f99bf)|\n\n### How to test\n\n- Make sure you are in a space with Observability as solution view\n- Select the \"All logs\" data view\n- Add any filter that matches the displayed badges value","sha":"44d49a950108e7350b18e69301409deb6d5ba0ed","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-infra_services","v9.1.0"],"title":"[Discover] Highlight filtered values in badges for custom cell renderers","number":213941,"url":"https://github.com/elastic/kibana/pull/213941","mergeCommit":{"message":"[Discover] Highlight filtered values in badges for custom cell renderers (#213941)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/213216\n\nThis PR adds the functionality to properly highlight filtered values\nwithin badges.\n\nPreviously, the content was treated as `text` instead of `html`, which\nprevented the highlighted values from being displayed correctly.\n\nThe content is now rendered with the `<mark>` tag, allowing matching\nvalues to be properly highlighted within the badges.\n\n>[!NOTE]\n>By looking at the code I assumed the `<mark>` tag is the only one we\nintroduce, so the proposed solution only handles that.\n\n\n|Before|After|\n|-|-|\n|![Screenshot 2025-03-11 at 15 02\n02](https://github.com/user-attachments/assets/779a860e-52c1-446a-b23a-09432ec01132)|![Screenshot\n2025-03-11 at 15 02\n31](https://github.com/user-attachments/assets/1e4d4a97-fc06-4302-88fe-d6060b6f99bf)|\n\n### How to test\n\n- Make sure you are in a space with Observability as solution view\n- Select the \"All logs\" data view\n- Add any filter that matches the displayed badges value","sha":"44d49a950108e7350b18e69301409deb6d5ba0ed"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213941","number":213941,"mergeCommit":{"message":"[Discover] Highlight filtered values in badges for custom cell renderers (#213941)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/213216\n\nThis PR adds the functionality to properly highlight filtered values\nwithin badges.\n\nPreviously, the content was treated as `text` instead of `html`, which\nprevented the highlighted values from being displayed correctly.\n\nThe content is now rendered with the `<mark>` tag, allowing matching\nvalues to be properly highlighted within the badges.\n\n>[!NOTE]\n>By looking at the code I assumed the `<mark>` tag is the only one we\nintroduce, so the proposed solution only handles that.\n\n\n|Before|After|\n|-|-|\n|![Screenshot 2025-03-11 at 15 02\n02](https://github.com/user-attachments/assets/779a860e-52c1-446a-b23a-09432ec01132)|![Screenshot\n2025-03-11 at 15 02\n31](https://github.com/user-attachments/assets/1e4d4a97-fc06-4302-88fe-d6060b6f99bf)|\n\n### How to test\n\n- Make sure you are in a space with Observability as solution view\n- Select the \"All logs\" data view\n- Add any filter that matches the displayed badges value","sha":"44d49a950108e7350b18e69301409deb6d5ba0ed"}}]}] BACKPORT-->