### PR TITLE
[Renovate] Disable updates for selected shared-ux dependencies

### DIFF
--- a/packages/kbn-dependency-ownership/src/rule.ts
+++ b/packages/kbn-dependency-ownership/src/rule.ts
@@ -25,6 +25,10 @@ export function ruleFilter(rule: RenovatePackageRule) {
     'bazel', // Per operations team. This is slated for removal, and does not make sense to track.
     'typescript', // These updates are always handled manually
     'webpack', // While we are in the middle of a webpack upgrade. TODO: Remove this once we are done.
+    'enzyme', // Per sharedux team. This is deprecated and in process of removal.
+    'styled-components', // Per sharedux team. This is deprecated and in process of removal.
+    'react', // Per sharedux team. Always handled manually, and not covered by renovate.
+    'react-router', // Per sharedux team. Always handled manually, and not covered by renovate.
   ];
   return (
     // Only include rules that are enabled or explicitly allowed to be disabled

--- a/renovate.json
+++ b/renovate.json
@@ -285,7 +285,7 @@
       "enabled": true
     },
     {
-      "groupName": "Enzyme dependencies",
+      "groupName": "enzyme",
       "matchDepNames": [
         "@wojtekmaj/enzyme-adapter-react-17",
         "enzyme",
@@ -450,7 +450,7 @@
       "enabled": true
     },
     {
-      "groupName": "styled-components dependencies",
+      "groupName": "styled-components",
       "matchDepNames": [
         "styled-components",
         "@types/styled-components"
@@ -492,7 +492,7 @@
       "enabled": true
     },
     {
-      "groupName": "React dependencies",
+      "groupName": "react",
       "matchDepNames": [
         "prop-types",
         "react",
@@ -551,7 +551,7 @@
       "enabled": true
     },
     {
-      "groupName": "react-router dependencies",
+      "groupName": "react-router",
       "matchDepNames": [
         "react-router",
         "react-router-config",

--- a/renovate.json
+++ b/renovate.json
@@ -320,7 +320,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": false
     },
     {
       "matchDepNames": [
@@ -466,7 +466,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": false
     },
     {
       "groupName": "Emotion dependencies",
@@ -514,7 +514,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": false
     },
     {
       "matchDepNames": [
@@ -574,7 +574,7 @@
         "release_note:skip",
         "backport:all-open"
       ],
-      "enabled": true
+      "enabled": false
     },
     {
       "groupName": "react-markdown",


### PR DESCRIPTION
## Summary

@elastic/appex-sharedux Has a couple of dependency groups that need a lot of manual intervention or are being phased out. We want to reduce the noise from automatic updates. I couldn't figure out how to disable branch updates in Renovate PRs, so I'm updating the config:

- **React** - team is working on it manually https://github.com/elastic/kibana-team/issues/1564
- **React-Router** - will be huge manual phased dependency upgrade when we get to it
- **Enzyme** - Deprecated and teams are migrating away https://github.com/elastic/kibana/issues/222949, Let's not spend time upgrading related dependencies since the pull request for the upgrade to newer versions is failing.https://github.com/elastic/kibana/pull/219581
- **Styled Components** - Deprecated and teams are moving away from it. https://github.com/elastic/kibana-team/issues/1417 .I suggest we don't upgrade and avoid spending time on visual regression testing.

