### PR TITLE
[Renovate] Restrict updates for selected shared-ux deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -298,6 +298,9 @@
       "matchBaseBranches": [
         "main"
       ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "labels": [
         "Team:SharedUX",
         "release_note:skip",
@@ -458,6 +461,10 @@
       "reviewers": [
         "team:appex-sharedux"
       ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "matchBaseBranches": [
         "main"
       ],
@@ -508,6 +515,10 @@
       ],
       "matchBaseBranches": [
         "main"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
       ],
       "labels": [
         "Team:SharedUX",
@@ -562,6 +573,10 @@
         "@types/react-router-dom",
         "history",
         "@types/history"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
       ],
       "reviewers": [
         "team:appex-sharedux"


### PR DESCRIPTION
## Summary

another attempt of https://github.com/elastic/kibana/pull/224432

@elastic/appex-sharedux Has a couple of dependency groups that need a lot of manual intervention or are being phased out. We want to reduce the noise from automatic updates and decided to pin automatic updates to some of those to minor/patch version

- React - team is working on it manually https://github.com/elastic/kibana-team/issues/1564
- React-Router - will be huge manual phased dependency upgrade when we get to it
- Enzyme - Deprecated and teams are migrating away https://github.com/elastic/kibana/issues/222949, Let's not spend time upgrading related dependencies since the pull request for the upgrade to newer versions is failing.https://github.com/elastic/kibana/pull/219581
- Styled Components - Deprecated and teams are moving away from it. https://github.com/elastic/kibana-team/issues/1417 .I suggest we don't upgrade and avoid spending time on visual regression testing.


