### PR TITLE
[Obs AI Assistant] redact function arguments when anonymizing 

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/anonymization/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/anonymization/index.ts
@@ -234,6 +234,15 @@ export class AnonymizationService {
     }
     return { unredactedMessages: messages };
   }
+
+  /**
+   * Unredacts function arguments that may contain hashed values.
+   */
+  unhashFunctionArguments(args: string | undefined): string | undefined {
+    if (!args) return args;
+    return unhashString(args, this.currentHashMap);
+  }
+
   unredactChatCompletionEvent(): OperatorFunction<
     ChatCompletionEvent,
     ChatCompletionEvent | ChatCompletionUnredactedMessageEvent

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -292,6 +292,7 @@ export class ObservabilityAIAssistantClient {
                 disableFunctions,
                 connectorId,
                 simulateFunctionCalling,
+                anonymizationService: this.dependencies.anonymizationService,
               })
             )
           );
@@ -503,16 +504,11 @@ export class ObservabilityAIAssistantClient {
       return defer(() =>
         from(this.dependencies.anonymizationService.redactMessages(messages)).pipe(
           switchMap(({ redactedMessages }) => {
-            return (
-              this.dependencies.inferenceClient
-                .chatComplete({
-                  ...options,
-                  stream: true,
-                  messages: convertMessagesForInference(redactedMessages, this.dependencies.logger),
-                })
-                // unredact complete assistant response event
-                .pipe(this.dependencies.anonymizationService.unredactChatCompletionEvent())
-            );
+            return this.dependencies.inferenceClient.chatComplete({
+              ...options,
+              stream: true,
+              messages: convertMessagesForInference(redactedMessages, this.dependencies.logger),
+            });
           })
         )
       ).pipe(


### PR DESCRIPTION
This PR fixes a bug with function arguments containing anonymized values not being deanonymized/unredacted. This is due to `unredactChatCompletionEvent()` having no effect later because `continueConversation` which calls `chat`, filters out any non chunk events in `emitWithConcatenatedMessage`.  By the time the function is called, it has used the concatenated chunks instead which are not unredacted.  This results, for eg, in knowledge base entries being stored with hashes instead of being unredacted or unhashed before being saved.

This is a temporary solution until the upcoming refactor moves anonymization functionality to the inference plugin. 

The fix:

1. Adds a targeted `unhashFunctionArguments` method to the AnonymizationService
2. Updates `continueConversation` to unhash function arguments right before they're used in executeFunctionAndCatchError
3. Removes ineffective streaming event deanonymization that was getting filtered out in the pipeline

Trace showing anonymized arguments still being sent to LLM (correct behaviour) though we unredact after:
https://35-187-109-62.sslip.io/projects/UHJvamVjdDo2/spans/bc3d203e71fbba5d01055399389ec290?selectedSpanNodeId=U3BhbjoyNjMxODk%3D

This can be manually tested by trying to add some entity to the knowledge base, for eg "My name is charles, always address me by this name".  Looking at the knowledge base entry, one should not see hashes. 