### PR TITLE
fix(slo): use wildcard remote when useAllRemoteClusters is true

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/common/get_slo_summary_indices.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/get_slo_summary_indices.test.ts
@@ -9,7 +9,7 @@ import { getSLOSummaryIndices } from './get_slo_summary_indices';
 import { DEFAULT_STALE_SLO_THRESHOLD_HOURS, SUMMARY_DESTINATION_INDEX_PATTERN } from './constants';
 
 describe('getSLOSummaryIndices', () => {
-  it('should return default local index if disabled', function () {
+  it('returns the local index if disabled', function () {
     const settings = {
       useAllRemoteClusters: false,
       selectedRemoteClusters: [],
@@ -19,7 +19,7 @@ describe('getSLOSummaryIndices', () => {
     expect(result).toStrictEqual([SUMMARY_DESTINATION_INDEX_PATTERN]);
   });
 
-  it('should return all remote clusters when enabled', function () {
+  it('returns a wildcard remote and the local index when useAllRemoteClusters is true', function () {
     const settings = {
       useAllRemoteClusters: true,
       selectedRemoteClusters: [],
@@ -32,20 +32,20 @@ describe('getSLOSummaryIndices', () => {
     const result = getSLOSummaryIndices(settings, clustersByName);
     expect(result).toStrictEqual([
       SUMMARY_DESTINATION_INDEX_PATTERN,
-      `cluster1:${SUMMARY_DESTINATION_INDEX_PATTERN}`,
-      `cluster2:${SUMMARY_DESTINATION_INDEX_PATTERN}`,
+      `*:${SUMMARY_DESTINATION_INDEX_PATTERN}`,
     ]);
   });
 
-  it('should return selected when enabled', function () {
+  it('returns only the connected clusters from the selected list when useAllRemoteClusters is false', function () {
     const settings = {
       useAllRemoteClusters: false,
-      selectedRemoteClusters: ['cluster1'],
+      selectedRemoteClusters: ['cluster1', 'cluster3'],
       staleThresholdInHours: DEFAULT_STALE_SLO_THRESHOLD_HOURS,
     };
     const clustersByName = [
       { name: 'cluster1', isConnected: true },
       { name: 'cluster2', isConnected: true },
+      { name: 'cluster3', isConnected: false },
     ];
     const result = getSLOSummaryIndices(settings, clustersByName);
     expect(result).toStrictEqual([

--- a/x-pack/solutions/observability/plugins/slo/common/get_slo_summary_indices.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/get_slo_summary_indices.ts
@@ -8,18 +8,28 @@
 import { GetSLOSettingsResponse } from '@kbn/slo-schema';
 import { SUMMARY_DESTINATION_INDEX_PATTERN } from './constants';
 
+/**
+ * @returns the local SLO summary index or the remote cluster indices based on the settings.
+ * If `useAllRemoteClusters` is false and no remote clusters are selected it returns only the local index.
+ * If `useAllRemoteClusters` is true, it returns both the local index and a wildcard remote index.
+ * If `useAllRemoteClusters` is false, it returns the local index and only the indices of the selected remote clusters that are connected.
+ */
 export const getSLOSummaryIndices = (
   settings: GetSLOSettingsResponse,
-  remoteClusters: Array<{ name: string; isConnected: boolean }>
+  remoteClusters: Array<{ name: string; isConnected: boolean }> = []
 ): string[] => {
   const { useAllRemoteClusters, selectedRemoteClusters } = settings;
   if (!useAllRemoteClusters && selectedRemoteClusters.length === 0) {
     return [SUMMARY_DESTINATION_INDEX_PATTERN];
   }
 
+  if (useAllRemoteClusters) {
+    return [SUMMARY_DESTINATION_INDEX_PATTERN, `*:${SUMMARY_DESTINATION_INDEX_PATTERN}`];
+  }
+
   return remoteClusters.reduce(
     (acc, { name, isConnected }) => {
-      if (isConnected && (useAllRemoteClusters || selectedRemoteClusters.includes(name))) {
+      if (isConnected && selectedRemoteClusters.includes(name)) {
         acc.push(`${name}:${SUMMARY_DESTINATION_INDEX_PATTERN}`);
       }
       return acc;

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_settings.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_settings.ts
@@ -9,10 +9,7 @@ import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { PutSLOSettingsParams, sloSettingsSchema } from '@kbn/slo-schema';
-import {
-  DEFAULT_STALE_SLO_THRESHOLD_HOURS,
-  SUMMARY_DESTINATION_INDEX_PATTERN,
-} from '../../common/constants';
+import { DEFAULT_STALE_SLO_THRESHOLD_HOURS } from '../../common/constants';
 import { getSLOSummaryIndices } from '../../common/get_slo_summary_indices';
 import { SLOSettings, StoredSLOSettings } from '../domain/models';
 import { SO_SLO_SETTINGS_TYPE, sloSettingsObjectId } from '../saved_objects/slo_settings';
@@ -61,8 +58,11 @@ export const getSummaryIndices = async (
   settings: StoredSLOSettings
 ): Promise<{ indices: string[] }> => {
   const { useAllRemoteClusters, selectedRemoteClusters } = settings;
-  if (!useAllRemoteClusters && selectedRemoteClusters.length === 0) {
-    return { indices: [SUMMARY_DESTINATION_INDEX_PATTERN] };
+  // If remote clusters are not used, we don't need to fetch the remote cluster info
+  if (useAllRemoteClusters || (!useAllRemoteClusters && selectedRemoteClusters.length === 0)) {
+    return {
+      indices: getSLOSummaryIndices(settings),
+    };
   }
 
   const clustersByName = await esClient.cluster.remoteInfo();


### PR DESCRIPTION
### 🍒 Summary

resolves https://github.com/elastic/kibana/issues/224476

This PR changes how the summary indices are constructed when remote clusters is enabled. 

When `useAllRemoteCluster` is true, we simply use `*:summary-index` instead of listing each remote individually.
We also removed the need to fetch the remote clusters info when we use `useAllRemoteCluster`.

### Release notes

Fix SLO federated view bug when remote clusters and index name listed exceeded 4096 bytes.



<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->