### PR TITLE
[8.19] [APM] Unified trace waterfall fix error toggle (#224322)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -108,7 +108,7 @@ export async function getTraceItems({
     logger,
   });
 
-  const [errorResponse, traceResponse, spanLinksCountById] = await Promise.all([
+  const [errorDocs, traceResponse, spanLinksCountById] = await Promise.all([
     errorResponsePromise,
     traceResponsePromise,
     getSpanLinksCountById({ traceId, apmEventClient, start, end }),
@@ -119,7 +119,54 @@ export async function getTraceItems({
 
   const traceDocs = traceResponse.hits.map(({ hit }) => hit);
 
-  const errorDocs = errorResponse.hits.hits.map((hit) => {
+  return {
+    exceedsMax,
+    traceDocs,
+    errorDocs,
+    spanLinksCountById,
+    traceDocsTotal,
+    maxTraceItems,
+  };
+}
+
+export const MAX_ITEMS_PER_PAGE = 10000; // 10000 is the max allowed by ES
+const excludedLogLevels = ['debug', 'info', 'warning'];
+
+export async function getApmTraceError({
+  apmEventClient,
+  traceId,
+  start,
+  end,
+}: {
+  apmEventClient: APMEventClient;
+  traceId: string;
+  start: number;
+  end: number;
+}) {
+  const response = await apmEventClient.search('get_errors_docs', {
+    apm: {
+      sources: [
+        {
+          documentType: ApmDocumentType.ErrorEvent,
+          rollupInterval: RollupInterval.None,
+        },
+      ],
+    },
+    body: {
+      track_total_hits: false,
+      size: 1000,
+      query: {
+        bool: {
+          filter: [{ term: { [TRACE_ID]: traceId } }, ...rangeQuery(start, end)],
+          must_not: { terms: { [ERROR_LOG_LEVEL]: excludedLogLevels } },
+        },
+      },
+      fields: [...requiredFields, ...optionalFields],
+      _source: [ERROR_LOG_MESSAGE, ERROR_EXC_MESSAGE, ERROR_EXC_HANDLED, ERROR_EXC_TYPE],
+    },
+  });
+
+  return response.hits.hits.map((hit) => {
     const errorSource = 'error' in hit._source ? hit._source : undefined;
 
     const event = unflattenKnownApmEventFields(hit.fields, requiredFields);
@@ -141,53 +188,6 @@ export async function getTraceItems({
     };
 
     return waterfallErrorEvent;
-  });
-
-  return {
-    exceedsMax,
-    traceDocs,
-    errorDocs,
-    spanLinksCountById,
-    traceDocsTotal,
-    maxTraceItems,
-  };
-}
-
-export const MAX_ITEMS_PER_PAGE = 10000; // 10000 is the max allowed by ES
-const excludedLogLevels = ['debug', 'info', 'warning'];
-
-export function getApmTraceError({
-  apmEventClient,
-  traceId,
-  start,
-  end,
-}: {
-  apmEventClient: APMEventClient;
-  traceId: string;
-  start: number;
-  end: number;
-}) {
-  return apmEventClient.search('get_errors_docs', {
-    apm: {
-      sources: [
-        {
-          documentType: ApmDocumentType.ErrorEvent,
-          rollupInterval: RollupInterval.None,
-        },
-      ],
-    },
-    body: {
-      track_total_hits: false,
-      size: 1000,
-      query: {
-        bool: {
-          filter: [{ term: { [TRACE_ID]: traceId } }, ...rangeQuery(start, end)],
-          must_not: { terms: { [ERROR_LOG_LEVEL]: excludedLogLevels } },
-        },
-      },
-      fields: [...requiredFields, ...optionalFields],
-      _source: [ERROR_LOG_MESSAGE, ERROR_EXC_MESSAGE, ERROR_EXC_HANDLED, ERROR_EXC_TYPE],
-    },
   });
 }
 

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
@@ -94,8 +94,8 @@ async function getUnprocessedOtelErrors({
             ],
           },
         },
+        fields: optionalFields,
       },
-      fields: optionalFields,
     },
     { skipProcessorEventFilter: true }
   );

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
@@ -6,17 +6,26 @@
  */
 
 import type { APMEventClient } from '@kbn/apm-data-access-plugin/server';
+import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { existsQuery, rangeQuery, termQuery } from '@kbn/observability-plugin/server';
-import { getApmTraceError } from './get_trace_items';
 import {
-  PROCESSOR_EVENT,
-  TRACE_ID,
+  ERROR_MESSAGE,
   EXCEPTION_MESSAGE,
   EXCEPTION_TYPE,
-  ERROR_MESSAGE,
+  PROCESSOR_EVENT,
+  SPAN_ID,
   STATUS_CODE,
+  TRACE_ID,
 } from '../../../common/es_fields/apm';
+import { asMutableArray } from '../../../common/utils/as_mutable_array';
+import { getApmTraceError } from './get_trace_items';
+
+export interface UnifiedTraceErrors {
+  apmErrors: Awaited<ReturnType<typeof getApmTraceError>>;
+  unprocessedOtelErrors: Awaited<ReturnType<typeof getUnprocessedOtelErrors>>;
+  totalErrors: number;
+}
 
 export async function getUnifiedTraceErrors({
   apmEventClient,
@@ -28,20 +37,27 @@ export async function getUnifiedTraceErrors({
   traceId: string;
   start: number;
   end: number;
-}) {
+}): Promise<UnifiedTraceErrors> {
   const [apmErrors, unprocessedOtelError] = await Promise.all([
     getApmTraceError({ apmEventClient, traceId, start, end }),
     getUnprocessedOtelErrors({ apmEventClient, traceId, start, end }),
   ]);
 
   return {
-    apmErrors: apmErrors.hits.hits.map((hit) => hit._source),
-    unprocessedOtelErrors: unprocessedOtelError.hits.hits.map((hit) => hit._source),
-    totalErrors: apmErrors.hits.hits.length + unprocessedOtelError.hits.hits.length,
+    apmErrors,
+    unprocessedOtelErrors: unprocessedOtelError,
+    totalErrors: apmErrors.length + unprocessedOtelError.length,
   };
 }
 
-function getUnprocessedOtelErrors({
+export const optionalFields = asMutableArray([
+  SPAN_ID,
+  ERROR_MESSAGE,
+  EXCEPTION_TYPE,
+  EXCEPTION_MESSAGE,
+] as const);
+
+async function getUnprocessedOtelErrors({
   apmEventClient,
   end,
   start,
@@ -52,7 +68,7 @@ function getUnprocessedOtelErrors({
   start: number;
   end: number;
 }) {
-  return apmEventClient.search(
+  const response = await apmEventClient.search(
     'get_unprocessed_errors_docs',
     {
       apm: { events: [ProcessorEvent.span, ProcessorEvent.transaction, ProcessorEvent.error] },
@@ -79,7 +95,23 @@ function getUnprocessedOtelErrors({
           },
         },
       },
+      fields: optionalFields,
     },
     { skipProcessorEventFilter: true }
   );
+
+  return response.hits.hits.map((hit) => {
+    const event = unflattenKnownApmEventFields(hit.fields);
+
+    return {
+      id: event.span?.id,
+      error: {
+        message: event.error?.message,
+        exception: {
+          type: event.exception?.type,
+          message: event.exception?.message,
+        },
+      },
+    };
+  });
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UnifiedTraceErrors } from './get_unified_trace_errors';
+import { getErrorCountByDocId } from './get_unified_trace_items';
+
+describe('getErrorCountByDocId', () => {
+  it('counts errors grouped by doc id from apmErrors and unprocessedOtelErrors', () => {
+    const unifiedTraceErrors = {
+      apmErrors: [
+        { parent: { id: 'a' } },
+        { parent: { id: 'a' } },
+        { parent: { id: 'b' } },
+        { parent: { id: undefined } },
+      ],
+      unprocessedOtelErrors: [{ id: 'a' }, { id: 'c' }, { id: undefined }],
+      totalErrors: 5,
+    } as UnifiedTraceErrors;
+
+    const result = getErrorCountByDocId(unifiedTraceErrors);
+
+    expect(result).toEqual({
+      a: 3,
+      b: 1,
+      c: 1,
+    });
+  });
+
+  it('returns an empty object if there are no errors', () => {
+    const unifiedTraceErrors = {
+      apmErrors: [],
+      unprocessedOtelErrors: [],
+      totalErrors: 0,
+    } as UnifiedTraceErrors;
+
+    expect(getErrorCountByDocId(unifiedTraceErrors)).toEqual({});
+  });
+
+  it('ignores errors with undefined ids', () => {
+    const unifiedTraceErrors = {
+      apmErrors: [{ parent: { id: undefined } }],
+      unprocessedOtelErrors: [{ id: undefined }],
+      totalErrors: 0,
+    } as UnifiedTraceErrors;
+
+    expect(getErrorCountByDocId(unifiedTraceErrors)).toEqual({});
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import type { Sort } from '@elastic/elasticsearch/lib/api/types';
 import type { APMEventClient } from '@kbn/apm-data-access-plugin/server';
+import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
-import type { Sort } from '@elastic/elasticsearch/lib/api/types';
-import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import { MAX_ITEMS_PER_PAGE } from './get_trace_items';
+import type { APMConfig } from '../..';
 import {
   AT_TIMESTAMP,
   DURATION,
@@ -25,9 +25,10 @@ import {
   TRANSACTION_ID,
   TRANSACTION_NAME,
 } from '../../../common/es_fields/apm';
-import type { APMConfig } from '../..';
 import { asMutableArray } from '../../../common/utils/as_mutable_array';
 import type { TraceItem } from '../../../common/waterfall/unified_trace_item';
+import { MAX_ITEMS_PER_PAGE } from './get_trace_items';
+import type { UnifiedTraceErrors } from './get_unified_trace_errors';
 
 const fields = asMutableArray(['@timestamp', 'trace.id', 'service.name'] as const);
 
@@ -44,6 +45,26 @@ const optionalFields = asMutableArray([
   STATUS_CODE,
 ] as const);
 
+export function getErrorCountByDocId(unifiedTraceErrors: UnifiedTraceErrors) {
+  const groupedErrorCountByDocId: Record<string, number> = {};
+
+  function incrementErrorCount(id: string) {
+    if (!groupedErrorCountByDocId[id]) {
+      groupedErrorCountByDocId[id] = 0;
+    }
+    groupedErrorCountByDocId[id] += 1;
+  }
+
+  unifiedTraceErrors.apmErrors.forEach((doc) =>
+    doc.parent?.id ? incrementErrorCount(doc.parent.id) : undefined
+  );
+  unifiedTraceErrors.unprocessedOtelErrors.forEach((doc) =>
+    doc.id ? incrementErrorCount(doc.id) : undefined
+  );
+
+  return groupedErrorCountByDocId;
+}
+
 /**
  * Returns both APM documents and unprocessed OTEL spans
  */
@@ -54,6 +75,7 @@ export async function getUnifiedTraceItems({
   start,
   end,
   config,
+  unifiedTraceErrors,
 }: {
   apmEventClient: APMEventClient;
   maxTraceItemsFromUrlParam?: number;
@@ -61,6 +83,7 @@ export async function getUnifiedTraceItems({
   start: number;
   end: number;
   config: APMConfig;
+  unifiedTraceErrors: UnifiedTraceErrors;
 }): Promise<TraceItem[]> {
   const maxTraceItems = maxTraceItemsFromUrlParam ?? config.ui.maxTraceItems;
   const size = Math.min(maxTraceItems, MAX_ITEMS_PER_PAGE);
@@ -112,27 +135,37 @@ export async function getUnifiedTraceItems({
     { skipProcessorEventFilter: true }
   );
 
-  return response.hits.hits.map((hit) => {
-    const event = unflattenKnownApmEventFields(hit.fields, fields);
-    const apmDuration = event.span?.duration?.us || event.transaction?.duration?.us;
+  const errorCountByDocId = getErrorCountByDocId(unifiedTraceErrors);
 
-    return {
-      id: event.span?.id ?? event.transaction?.id,
-      timestamp: event[AT_TIMESTAMP],
-      name: event.span?.name ?? event.transaction?.name,
-      traceId: event.trace.id,
-      duration:
-        apmDuration !== undefined
-          ? apmDuration
-          : Array.isArray(event.duration)
-          ? (event.duration as number[])[0]
-          : event.duration ?? 0,
-      hasError:
-        event.status?.code && Array.isArray(event.status.code)
-          ? event.status.code[0] === 'Error'
-          : false,
-      parentId: event.parent?.id,
-      serviceName: event.service.name,
-    } as TraceItem;
-  });
+  return response.hits.hits
+    .map((hit) => {
+      const event = unflattenKnownApmEventFields(hit.fields, fields);
+      const apmDuration = event.span?.duration?.us || event.transaction?.duration?.us;
+      const id = event.span?.id || event.transaction?.id;
+      if (!id) {
+        return undefined;
+      }
+
+      const docErrorCount = errorCountByDocId[id] || 0;
+      return {
+        id: event.span?.id ?? event.transaction?.id,
+        timestamp: event[AT_TIMESTAMP],
+        name: event.span?.name ?? event.transaction?.name,
+        traceId: event.trace.id,
+        duration:
+          apmDuration !== undefined
+            ? apmDuration
+            : Array.isArray(event.duration)
+            ? (event.duration as number[])[0]
+            : event.duration ?? 0,
+        hasError:
+          docErrorCount > 0 ||
+          (event.status?.code && Array.isArray(event.status.code)
+            ? event.status.code[0] === 'Error'
+            : false),
+        parentId: event.parent?.id,
+        serviceName: event.service.name,
+      } as TraceItem;
+    })
+    .filter((_) => _) as TraceItem[];
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
@@ -142,7 +142,9 @@ const focusedTraceRoute = createApmServerRoute({
     const { traceId, docId } = params.path;
     const { start, end } = params.query;
 
-    const [traceItems, traceSummaryCount, unifiedErrors] = await Promise.all([
+    const unifiedTraceErrors = await getUnifiedTraceErrors({ apmEventClient, traceId, start, end });
+
+    const [traceItems, traceSummaryCount] = await Promise.all([
       getUnifiedTraceItems({
         apmEventClient,
         traceId,
@@ -150,16 +152,16 @@ const focusedTraceRoute = createApmServerRoute({
         end,
         maxTraceItemsFromUrlParam: params.query.maxTraceItems,
         config,
+        unifiedTraceErrors,
       }),
       getTraceSummaryCount({ apmEventClient, start, end, traceId }),
-      getUnifiedTraceErrors({ apmEventClient, traceId, start, end }),
     ]);
 
     const focusedTraceItems = buildFocusedTraceItems({ traceItems, docId });
 
     return {
       traceItems: focusedTraceItems,
-      summary: { ...traceSummaryCount, errors: unifiedErrors.totalErrors },
+      summary: { ...traceSummaryCount, errors: unifiedTraceErrors.totalErrors },
     };
   },
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Unified trace waterfall fix error toggle (#224322)](https://github.com/elastic/kibana/pull/224322)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cauê Marcondes","email":"55978943+cauemarcondes@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-18T13:19:19Z","message":"[APM] Unified trace waterfall fix error toggle (#224322)\n\nBefore:\n![image\n(3)](https://github.com/user-attachments/assets/3767b7e3-9612-46e9-a660-dc043af90cf2)\n\nAfter:\n<img width=\"1236\" alt=\"Screenshot 2025-06-17 at 15 25 35\"\nsrc=\"https://github.com/user-attachments/assets/279d5b77-a0cb-4100-9432-23425990ed75\"\n/>","sha":"5e28a4200f1449e97b00d873914328efdc970a82","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0"],"title":"[APM] Unified trace waterfall fix error toggle","number":224322,"url":"https://github.com/elastic/kibana/pull/224322","mergeCommit":{"message":"[APM] Unified trace waterfall fix error toggle (#224322)\n\nBefore:\n![image\n(3)](https://github.com/user-attachments/assets/3767b7e3-9612-46e9-a660-dc043af90cf2)\n\nAfter:\n<img width=\"1236\" alt=\"Screenshot 2025-06-17 at 15 25 35\"\nsrc=\"https://github.com/user-attachments/assets/279d5b77-a0cb-4100-9432-23425990ed75\"\n/>","sha":"5e28a4200f1449e97b00d873914328efdc970a82"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224322","number":224322,"mergeCommit":{"message":"[APM] Unified trace waterfall fix error toggle (#224322)\n\nBefore:\n![image\n(3)](https://github.com/user-attachments/assets/3767b7e3-9612-46e9-a660-dc043af90cf2)\n\nAfter:\n<img width=\"1236\" alt=\"Screenshot 2025-06-17 at 15 25 35\"\nsrc=\"https://github.com/user-attachments/assets/279d5b77-a0cb-4100-9432-23425990ed75\"\n/>","sha":"5e28a4200f1449e97b00d873914328efdc970a82"}}]}] BACKPORT-->