### PR TITLE
[Cloud Security] Fix elastic resource id to use kibana component id instead of deployment id

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -1640,6 +1640,8 @@ describe('<CspPolicyTemplateForm />', () => {
       jest.spyOn(KibanaHook, 'useKibana').mockReturnValue({
         services: {
           cloud: {
+            cloudId:
+              'cloud_connector_cspm:dXMtZWFzdC0xLmF3cy5zdGFnaW5nLmZvdW5kaXQubm86NDQzJDYyMjExNzI5MDhjZTQ0YmE5YWNkOGFmN2NlYmUyYmVjJGZmYmUyNDc2NGFkNTQwODJhZTkyYjU1NDQ0ZDI3NzA5',
             deploymentUrl: 'https://cloud.elastic.co/deployments/bfdad4ef99a24212a06d387593686d63',
             isCloudEnabled: true,
             isServerlessEnabled: false,
@@ -1687,6 +1689,8 @@ describe('<CspPolicyTemplateForm />', () => {
       jest.spyOn(KibanaHook, 'useKibana').mockReturnValue({
         services: {
           cloud: {
+            cloudId:
+              'cloud_connector_cspm:dXMtZWFzdC0xLmF3cy5zdGFnaW5nLmZvdW5kaXQubm86NDQzJDYyMjExNzI5MDhjZTQ0YmE5YWNkOGFmN2NlYmUyYmVjJGZmYmUyNDc2NGFkNTQwODJhZTkyYjU1NDQ0ZDI3NzA5',
             deploymentUrl: 'https://cloud.elastic.co/deployments/bfdad4ef99a24212a06d387593686d63',
             isCloudEnabled: true,
             isServerlessEnabled: false,
@@ -1733,6 +1737,8 @@ describe('<CspPolicyTemplateForm />', () => {
       jest.spyOn(KibanaHook, 'useKibana').mockReturnValue({
         services: {
           cloud: {
+            cloudId:
+              'cloud_connector_cspm:dXMtZWFzdC0xLmF3cy5zdGFnaW5nLmZvdW5kaXQubm86NDQzJDYyMjExNzI5MDhjZTQ0YmE5YWNkOGFmN2NlYmUyYmVjJGZmYmUyNDc2NGFkNTQwODJhZTkyYjU1NDQ0ZDI3NzA5',
             deploymentUrl: 'https://cloud.elastic.co/deployments/bfdad4ef99a24212a06d387593686d63',
             isCloudEnabled: true,
             isServerlessEnabled: false,
@@ -1780,6 +1786,7 @@ describe('<CspPolicyTemplateForm />', () => {
       jest.spyOn(KibanaHook, 'useKibana').mockReturnValue({
         services: {
           cloud: {
+            cloudId: undefined,
             deploymentUrl: undefined,
             isCloudEnabled: true,
             isServerlessEnabled: true,
@@ -1831,6 +1838,7 @@ describe('<CspPolicyTemplateForm />', () => {
       jest.spyOn(KibanaHook, 'useKibana').mockReturnValue({
         services: {
           cloud: {
+            cloudId: undefined,
             deploymentUrl: undefined,
             isCloudEnabled: true,
             isServerlessEnabled: true,
@@ -1882,6 +1890,7 @@ describe('<CspPolicyTemplateForm />', () => {
       jest.spyOn(KibanaHook, 'useKibana').mockReturnValue({
         services: {
           cloud: {
+            cloudId: undefined,
             deploymentUrl: undefined,
             isCloudEnabled: true,
             isServerlessEnabled: true,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -75,7 +75,12 @@ export interface GetCloudConnectorRemoteRoleTemplateParams {
   input: NewPackagePolicyPostureInput;
   cloud: Pick<
     CloudSetup,
-    'isCloudEnabled' | 'cloudHost' | 'deploymentUrl' | 'serverless' | 'isServerlessEnabled'
+    | 'isCloudEnabled'
+    | 'cloudId'
+    | 'cloudHost'
+    | 'deploymentUrl'
+    | 'serverless'
+    | 'isServerlessEnabled'
   >;
   packageInfo: PackageInfo;
 }
@@ -505,25 +510,38 @@ export const getDeploymentIdFromUrl = (url: string | undefined): string | undefi
   return match?.[1];
 };
 
+export const getKibanaComponentId = (cloudId: string | undefined): string | undefined => {
+  if (!cloudId) return undefined;
+
+  const base64Part = cloudId.split(':')[1];
+  const decoded = atob(base64Part);
+  const [, , kibanaComponentId] = decoded.split('$');
+
+  return kibanaComponentId || undefined;
+};
+
 export const getCloudConnectorRemoteRoleTemplate = ({
   input,
   cloud,
   packageInfo,
 }: GetCloudConnectorRemoteRoleTemplateParams): string | undefined => {
+  let elasticResourceId: string | undefined;
   const accountType = input?.streams?.[0]?.vars?.['aws.account_type']?.value ?? AWS_SINGLE_ACCOUNT;
 
   const provider = getCloudProviderFromCloudHost(cloud?.cloudHost);
+
   if (!provider || provider !== 'aws') return undefined;
 
   const deploymentId = getDeploymentIdFromUrl(cloud?.deploymentUrl);
-  let elasticResourceId: string | undefined;
+
+  const kibanaComponentId = getKibanaComponentId(cloud?.cloudId);
 
   if (cloud?.isServerlessEnabled && cloud?.serverless?.projectId) {
     elasticResourceId = cloud.serverless.projectId;
   }
 
-  if (cloud?.isCloudEnabled && deploymentId) {
-    elasticResourceId = deploymentId;
+  if (cloud?.isCloudEnabled && deploymentId && kibanaComponentId) {
+    elasticResourceId = kibanaComponentId;
   }
 
   if (!elasticResourceId) return undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/policy_template_form.test.tsx
@@ -948,11 +948,13 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       });
     });
 
-    it('should render setup technology selector for AWS and allow to select cloud connector in ess environnement', async () => {
+    it('should render setup technology selector for AWS and allow to select cloud connector in ess  aws environnement', async () => {
       const newPackagePolicy = getMockPolicyAWS();
       (useKibana as jest.Mock).mockReturnValue({
         services: {
           cloud: {
+            cloudId:
+              'cloud_connector_cspm:dXMtZWFzdC0xLmF3cy5zdGFnaW5nLmZvdW5kaXQubm86NDQzJDYyMjExNzI5MDhjZTQ0YmE5YWNkOGFmN2NlYmUyYmVjJGZmYmUyNDc2NGFkNTQwODJhZTkyYjU1NDQ0ZDI3NzA5',
             deploymentUrl: 'https://cloud.elastic.co/deployments/bfdad4ef99a24212a06d387593686d63',
             isCloudEnabled: true,
             isServerlessEnabled: false,
@@ -1008,6 +1010,8 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       (useKibana as jest.Mock).mockReturnValue({
         services: {
           cloud: {
+            cloudId:
+              'cloud_connector_cspm:dXMtZWFzdC0xLmF3cy5zdGFnaW5nLmZvdW5kaXQubm86NDQzJDYyMjExNzI5MDhjZTQ0YmE5YWNkOGFmN2NlYmUyYmVjJGZmYmUyNDc2NGFkNTQwODJhZTkyYjU1NDQ0ZDI3NzA5',
             deploymentUrl: 'https://cloud.elastic.co/deployments/bfdad4ef99a24212a06d387593686d63',
             isCloudEnabled: true,
             isServerlessEnabled: false,
@@ -1062,6 +1066,7 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       (useKibana as jest.Mock).mockReturnValue({
         services: {
           cloud: {
+            cloudId: undefined,
             cloudHost: 'eu-west-1.aws.qa.elastic.cloud',
             deploymentUrl: undefined,
             isCloudEnabled: true,
@@ -1122,6 +1127,7 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       (useKibana as jest.Mock).mockReturnValue({
         services: {
           cloud: {
+            cloudId: undefined,
             cloudHost: 'eu-west-1.gcp.qa.elastic.cloud',
             deploymentUrl: undefined,
             isCloudEnabled: true,
@@ -1182,6 +1188,7 @@ describe('<CloudAssetinventoryPolicyTemplateForm />', () => {
       (useKibana as jest.Mock).mockReturnValue({
         services: {
           cloud: {
+            cloudId: undefined,
             cloudHost: 'eu-west-1.azure.qa.elastic.cloud',
             deploymentUrl: undefined,
             isCloudEnabled: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/fleet_extensions/utils.ts
@@ -87,7 +87,12 @@ export interface GetCloudConnectorRemoteRoleTemplateParams {
   input: NewPackagePolicyAssetInput;
   cloud: Pick<
     CloudSetup,
-    'isCloudEnabled' | 'cloudHost' | 'deploymentUrl' | 'serverless' | 'isServerlessEnabled'
+    | 'isCloudEnabled'
+    | 'cloudId'
+    | 'cloudHost'
+    | 'deploymentUrl'
+    | 'serverless'
+    | 'isServerlessEnabled'
   >;
   packageInfo: PackageInfo;
 }
@@ -561,25 +566,38 @@ export const getDeploymentIdFromUrl = (url: string | undefined): string | undefi
   return match?.[1];
 };
 
+export const getKibanaComponentId = (cloudId: string | undefined): string | undefined => {
+  if (!cloudId) return undefined;
+
+  const base64Part = cloudId.split(':')[1];
+  const decoded = atob(base64Part);
+  const [, , kibanaComponentId] = decoded.split('$');
+
+  return kibanaComponentId || undefined;
+};
+
 export const getCloudConnectorRemoteRoleTemplate = ({
   input,
   cloud,
   packageInfo,
 }: GetCloudConnectorRemoteRoleTemplateParams): string | undefined => {
+  let elasticResourceId: string | undefined;
   const accountType = input?.streams?.[0]?.vars?.['aws.account_type']?.value ?? AWS_SINGLE_ACCOUNT;
 
   const provider = getCloudProviderFromCloudHost(cloud?.cloudHost);
+
   if (!provider || provider !== 'aws') return undefined;
 
   const deploymentId = getDeploymentIdFromUrl(cloud?.deploymentUrl);
-  let elasticResourceId: string | undefined;
+
+  const kibanaComponentId = getKibanaComponentId(cloud?.cloudId);
 
   if (cloud?.isServerlessEnabled && cloud?.serverless?.projectId) {
     elasticResourceId = cloud.serverless.projectId;
   }
 
-  if (cloud?.isCloudEnabled && deploymentId) {
-    elasticResourceId = deploymentId;
+  if (cloud?.isCloudEnabled && deploymentId && kibanaComponentId) {
+    elasticResourceId = kibanaComponentId;
   }
 
   if (!elasticResourceId) return undefined;


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

On cloud connector, cloud formation redirection kibana replaces the value of the parameter param_ElasticResourceId=RESOURCE_ID with:

We used the deployment ID for hosted. While in ESS, we need to replace with Kibana Component ID for hosted, instead of Deployment ID. We extract `cloud.cloudId`  base64 and decode `cloudId` in the following format `deployment_name:base64(<host>$<es_cluster_id>$<kibana_component_id>)` and get the Kibana Component ID
