### PR TITLE
[OAS] Test options for Kibana API path variations

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -777,6 +777,9 @@ paths:
       summary: Delete a rule
       tags:
         - alerting
+      x-path-variations:
+        - POST `/s/{space_id}/api/alerting/rule/`
+        - POST `/api/alerting/rule/{id}`
     get:
       operationId: get-alerting-rule-id
       parameters:
@@ -2862,6 +2865,11 @@ paths:
       summary: Create a rule
       tags:
         - alerting
+      description: |
+        **All methods and paths for this operation:**
+
+        - `POST /s/{space_id}/api/alerting/rule/`
+        - `POST /api/alerting/rule/{id}`
     put:
       operationId: put-alerting-rule-id
       parameters:
@@ -3897,6 +3905,8 @@ paths:
       summary: Update a rule
       tags:
         - alerting
+      description: |
+        [Learn](../topic/topic-kibana-spaces) how to select a space for this request.
   /api/alerting/rule/{id}/_disable:
     post:
       operationId: post-alerting-rule-id-disable

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -1171,6 +1171,9 @@ paths:
       summary: Delete a rule
       tags:
         - alerting
+      x-path-variations:
+        - POST `/s/{space_id}/api/alerting/rule/`
+        - POST `/api/alerting/rule/{id}`
     get:
       operationId: get-alerting-rule-id
       parameters:
@@ -3256,6 +3259,11 @@ paths:
       summary: Create a rule
       tags:
         - alerting
+      description: |
+        **All methods and paths for this operation:**
+
+        - `POST /s/{space_id}/api/alerting/rule/`
+        - `POST /api/alerting/rule/{id}`
     put:
       operationId: put-alerting-rule-id
       parameters:
@@ -4291,6 +4299,8 @@ paths:
       summary: Update a rule
       tags:
         - alerting
+      description: |
+        [Learn](../topic/topic-kibana-spaces) how to select a space for this request.
   /api/alerting/rule/{id}/_disable:
     post:
       operationId: post-alerting-rule-id-disable

--- a/oas_docs/overlays/kibana.overlays.shared.yaml
+++ b/oas_docs/overlays/kibana.overlays.shared.yaml
@@ -88,3 +88,25 @@ actions:
                   $ref: '../examples/get_spaces_response1.yaml'
                 getSpacesResponseExample2:
                   $ref: '../examples/get_spaces_response2.yaml'
+# Test addition of space variations
+  - target: "$.paths['/api/alerting/rule/{id}']['post']"
+    description: 'Add description to create rule API'
+    update:
+      description: |
+        **All methods and paths for this operation:**
+
+        - `POST /s/{space_id}/api/alerting/rule/`
+        - `POST /api/alerting/rule/{id}`
+  - target: "$.paths['/api/alerting/rule/{id}']['put']"
+    description: 'Add description to update rule API'
+    update:
+      description: >
+        [Learn](../topic/topic-kibana-spaces) how to select a space for this request.
+  - target: "$.paths['/api/alerting/rule/{id}']['delete']"
+    description: 'Add extension to delete rule API'
+    update:
+      x-path-variations:
+        - POST `/s/{space_id}/api/alerting/rule/`
+        - POST `/api/alerting/rule/{id}`
+      
+      


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/elasticsearch-specification/pull/4415

This PR tests some possible options for drawing attention to the fact that you can specify Kibana APIs either with or without the space identifier.

## Option 1: Bulleted list in description

Add a bulleted list to each operation's description, for example:

```
      description: |
        **All methods and paths for this operation:**

        - `POST /s/{space_id}/api/alerting/rule/`
        - `POST /api/alerting/rule/{id}`
```  

... which would be displayed like this:

![image](https://github.com/user-attachments/assets/30cdbff9-05c4-4eff-a11f-081042fa981c)

Pros:

- Most detailed information
- Aligns with what's being implemented in Elasticsearch APIs

Cons:

- Cannot be accomplished via overlays since overlays can't append info to existing descriptions; therefore would require updating every operation's description in the appropriate source file or else automatically appending this information as part of the generator

## Option 2: Link in description 

Add a link to the extra "Kibana spaces" page from each operation's description. For example:

```
      description: |
        [Learn](../topic/topic-kibana-spaces) how to select a space for this request.
``` 

... which would be displayed like this:

![image](https://github.com/user-attachments/assets/46f00511-ff4c-4ab0-ba80-8d1ea961940b)

Pros:

- Same text and link can be applied to every operation.

Cons:

- Cannot be accomplished via overlays since overlays can't append info to existing descriptions; therefore would require updating every operation's description in the appropriate source file or else automatically appending this information as part of the generator
- Relative markdown links seem to work in my test, but probably the better solution would be to have the full URL (which would then need to vary by branch so the right URL is used in each case).

## Option 3: Extension with array

Add a new [specification extension](https://spec.openapis.org/oas/latest#specification-extensions) that contains an array of strings. For example:

```
      x-path-variations:
        - POST `/s/{space_id}/api/alerting/rule/`
        - POST `/api/alerting/rule/{id}`
``` 

Pros:

- Have the most control over how it's ultimately displayed
- Could be accomplished via overlays, though given we'd need one for every single operation that would be fragile and time-intensive to maintain. Therefore having it part of the automated output would be preferrable where applicable.

Cons:

- Requires work on the publishing site to render this information.

## Option 4 Extension with string

Add a new [specification extension](https://spec.openapis.org/oas/latest#specification-extensions) that contains a single string and is rendered as markdown. For example:

```
      x-path-variation-string: |
        [Learn](https://www.elastic.co/docs/api/doc/kibana/topic/topic-kibana-spaces) how to select a space for this request. 
``` 

Pros:

- Seems like it could support both the simple sentence in Kibana and the fancier bulleted list in Elasticsearch.
- Could be accomplished via overlays, since it could be applied identically to all operations.

Cons:

- Requires work on the publishing site to support this new extension.