### PR TITLE
[APM] Add 'deactivate_...' agent configuration settings for EDOT Node.js

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -21,15 +21,13 @@ export const edotSDKSettings: RawSettingDefinition[] = [
       'xpack.apm.agentConfig.edot.deactivate_instrumentations.description',
       {
         defaultMessage:
-          'Comma-separated list of modules to disable instrumentation for.\n' +
-          'When instrumentation is disabled for a module, no spans will be collected for that module.\n' +
-          '\n' +
-          'The up-to-date list of modules for which instrumentation can be disabled is language specific ' +
-          'and can be found under the following links: ' +
-          '[opentelemetry/java/elastic](https://ela.st/otel-agent-instructions)',
+          'Comma-separated list of instrumentation names to disable. When an instrumentation is disabled, no telemetry will be collected for the library/module it instruments. ' +
+          'The list of supported instrumentation names is language specific:\n' +
+          '- [EDOT Java](https://ela.st/otel-agent-instructions): for example "akka-http,grpc"\n' +
+          '- [EDOT Node.js](https://ela.st/edot-node-disable-instrs): for example "net,dns,http"',
       }
     ),
-    includeAgents: ['opentelemetry/java/elastic'],
+    includeAgents: ['opentelemetry/java/elastic', 'opentelemetry/nodejs/elastic'],
   },
   {
     key: 'deactivate_all_instrumentations',
@@ -41,10 +39,10 @@ export const edotSDKSettings: RawSettingDefinition[] = [
     description: i18n.translate(
       'xpack.apm.agentConfig.edot.deactivate_all_instrumentations.description',
       {
-        defaultMessage: 'No spans will be collected for any instrumentation modules.\n' + '\n',
+        defaultMessage: 'No spans will be collected for any instrumentation modules.',
       }
     ),
-    includeAgents: ['opentelemetry/java/elastic'],
+    includeAgents: ['opentelemetry/java/elastic', 'opentelemetry/nodejs/elastic'],
   },
   {
     key: 'logging_level',
@@ -55,7 +53,7 @@ export const edotSDKSettings: RawSettingDefinition[] = [
       defaultMessage: 'Logging level',
     }),
     description: i18n.translate('xpack.apm.agentConfig.loggingLevel.description', {
-      defaultMessage: 'Sets the logging level for the agent',
+      defaultMessage: 'Sets the logging level for the agent.',
     }),
     options: [
       { text: 'trace', value: 'trace' },


### PR DESCRIPTION
## Summary

This makes the existing 'deactivate_all_instrumentations' and 'deactivate_instrumentations' agent configuration settings
available to EDOT Node.js agents (`agent.name: opentelemetry/nodejs/elastic`). (This follows on the recent https://github.com/elastic/kibana/pull/222883 that did the same for another config setting.)

This makes use of the newly added `https://ela.st/edot-node-disable-instrs` short URL that points to the current relevant anchor in the EDOT Node.js docs.

Screenshot of Agent Configuration section in Kibana showing to two newly available settings for an EDOT Node.js SDK configuration:

<img width="981" alt="Screenshot 2025-06-18 at 3 29 34 PM" src="https://github.com/user-attachments/assets/b4a11dd1-91c1-47c5-bf6e-6e20c420e1ab" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



