### PR TITLE
Security dv cache improvements

### DIFF
--- a/src/platform/plugins/shared/data_views/common/types.ts
+++ b/src/platform/plugins/shared/data_views/common/types.ts
@@ -559,6 +559,8 @@ export type DataViewSpec = {
   allowHidden?: boolean;
 };
 
+export type DataViewMinimalSpec = Omit<DataViewSpec, 'fields'>;
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SourceFilter = {
   value: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
@@ -39,7 +39,7 @@ import { useSourcererDataView } from '../../sourcerer/containers';
 import { useDiscoverState } from '../../timelines/components/timeline/tabs/esql/use_discover_state';
 import { useKibana } from '../../common/lib/kibana';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
-import { useDataViewSpec } from '../../data_view_manager/hooks/use_data_view_spec';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 
 export interface SendToTimelineButtonProps {
   asEmptyButton: boolean;
@@ -67,10 +67,10 @@ export const SendToTimelineButton: FC<PropsWithChildren<SendToTimelineButtonProp
   const { dataViewId: oldTimelineDataViewId } = useSourcererDataView(SourcererScopeName.timeline);
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataViewSpec } = useDataViewSpec(SourcererScopeName.timeline);
+  const { dataView } = useDataView(SourcererScopeName.timeline);
 
   const timelineDataViewId = newDataViewPickerEnabled
-    ? dataViewSpec?.id ?? null
+    ? dataView?.id ?? null
     : oldTimelineDataViewId;
 
   const { setDiscoverAppState } = useDiscoverState();

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
@@ -61,7 +61,6 @@ import { useLicense } from '../../../../hooks/use_license';
 import { isProviderValid } from './helpers';
 import * as i18n from './translations';
 import { useGetScopedSourcererDataView } from '../../../../../sourcerer/components/use_get_sourcerer_data_view';
-import { useDataViewSpec } from '../../../../../data_view_manager/hooks/use_data_view_spec';
 
 interface InsightComponentProps {
   label?: string;
@@ -291,8 +290,8 @@ const InsightEditorComponent = ({
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataViewSpec } = useDataViewSpec();
-  const sourcererDataView = newDataViewPickerEnabled ? dataViewSpec : oldSourcererDataView;
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.default);
+  const sourcererDataView = newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView;
 
   const {
     unifiedSearch: {
@@ -304,8 +303,6 @@ const InsightEditorComponent = ({
   const oldDataView = useGetScopedSourcererDataView({
     sourcererScope: SourcererScopeName.default,
   });
-
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.default);
 
   const dataView = newDataViewPickerEnabled ? experimentalDataView : oldDataView;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/use_data_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/use_data_view.tsx
@@ -9,6 +9,7 @@ import { useCallback, useRef } from 'react';
 import type { Subscription } from 'rxjs';
 import { useDispatch } from 'react-redux';
 import memoizeOne from 'memoize-one';
+import deepEqual from 'fast-deep-equal';
 import type { BrowserFields } from '@kbn/timelines-plugin/common';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { FieldCategory } from '@kbn/timelines-plugin/common/search_strategy';
@@ -66,8 +67,13 @@ export const getDataViewStateFromIndexFields = memoizeOne(
       return { browserFields: browserFields as DangerCastForBrowserFieldsMutation };
     }
   },
-  (newArgs, lastArgs) => newArgs[0] === lastArgs[0] && newArgs[1]?.length === lastArgs[1]?.length
+  (newArgs, lastArgs) => deepEqual(newArgs, lastArgs)
 );
+
+// This is a utility function to get an instance of the getDataViewStateFromIndexFields function
+// If the original function is called in a hook called in different places, the memoization becomes potential useless
+// as each call overrides the previous one. This hook is used to ensure that the memoization is preserved for each hook instance.
+export const getMemoizedGetDataViewStateFromIndexFields = () => getDataViewStateFromIndexFields;
 
 export const useDataView = (): {
   indexFieldsSearch: IndexFieldSearch;

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -14,7 +14,7 @@ import type { SourcererUrlState } from '../../../sourcerer/store/model';
 import { useUpdateUrlParam } from '../../../common/utils/global_query_string';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { useKibana } from '../../../common/lib/kibana';
-import { useDataViewSpec } from '../../hooks/use_data_view_spec';
+import { useDataView } from '../../hooks/use_data_view';
 import { sharedStateSelector } from '../../redux/selectors';
 import { sharedDataViewManagerSlice } from '../../redux/slices';
 import { useSelectDataView } from '../../hooks/use_select_data_view';
@@ -55,12 +55,12 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
   const closeDataViewEditor = useRef<() => void | undefined>();
   const closeFieldEditor = useRef<() => void | undefined>();
 
-  const { dataViewSpec, status } = useDataViewSpec(scope);
+  const { dataView, status } = useDataView(scope);
 
   const isDefaultSourcerer = scope === DataViewManagerScopeName.default;
   const updateUrlParam = useUpdateUrlParam<SourcererUrlState>(URL_PARAM_KEY.sourcerer);
 
-  const dataViewId = dataViewSpec?.id;
+  const dataViewId = dataView?.id;
 
   // NOTE: this function is called in response to user interaction with the picker,
   // hence - it is the only place where we should update the url param for the data view selection.
@@ -145,16 +145,16 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
       return { label: LOADING };
     }
 
-    if (dataViewSpec.id === DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID) {
+    if (dataView?.id === DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID) {
       return {
         label: DEFAULT_SECURITY_DATA_VIEW,
       };
     }
 
     return {
-      label: dataViewSpec?.name || dataViewSpec?.id || 'Data view',
+      label: dataView?.name || dataView?.id || 'Data view',
     };
-  }, [dataViewSpec.id, dataViewSpec?.name, status]);
+  }, [dataView?.id, dataView?.name, status]);
 
   const { adhocDataViews: adhocDataViewSpecs } = useSelector(sharedStateSelector);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
@@ -9,7 +9,7 @@ import { useMemo } from 'react';
 import type { BrowserFields } from '@kbn/timelines-plugin/common';
 import { DataViewManagerScopeName } from '../constants';
 import { useDataViewSpec } from './use_data_view_spec';
-import { getDataViewStateFromIndexFields } from '../../common/containers/source/use_data_view';
+import { getMemoizedGetDataViewStateFromIndexFields } from '../../common/containers/source/use_data_view';
 
 export const useBrowserFields = (
   scope: DataViewManagerScopeName = DataViewManagerScopeName.default
@@ -21,6 +21,7 @@ export const useBrowserFields = (
       return {};
     }
 
+    const getDataViewStateFromIndexFields = getMemoizedGetDataViewStateFromIndexFields();
     const { browserFields } = getDataViewStateFromIndexFields(
       dataViewSpec?.title ?? '',
       dataViewSpec.fields

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
@@ -25,7 +25,8 @@ export interface UseDataViewSpecResult {
  * Returns an object with the dataViewSpec and status values for the given scopeName.
  */
 export const useDataViewSpec = (
-  scopeName: DataViewManagerScopeName = DataViewManagerScopeName.default
+  scopeName: DataViewManagerScopeName = DataViewManagerScopeName.default,
+  includeFields: boolean = true
 ): UseDataViewSpecResult => {
   const { dataView, status } = useDataView(scopeName);
 
@@ -42,6 +43,6 @@ export const useDataViewSpec = (
       };
     }
 
-    return { dataViewSpec: dataView?.toSpec?.(), status };
-  }, [dataView, status]);
+    return { dataViewSpec: dataView?.toSpec?.(includeFields), status };
+  }, [dataView, status, includeFields]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -164,7 +164,10 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
       useSourcererDataView(SourcererScopeName.timeline);
     const { newDataViewPickerEnabled } = useEnableExperimental();
 
-    const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(SourcererScopeName.timeline);
+    const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(
+      SourcererScopeName.timeline,
+      false
+    );
     const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
 
     const dataViewId = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -102,7 +102,10 @@ const StatefulTimelineComponent: React.FC<Props> = ({
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(SourcererScopeName.timeline);
+  const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(
+    SourcererScopeName.timeline,
+    false
+  );
 
   const selectedDataViewId = useMemo(
     () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -94,7 +94,10 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   } = useSourcererDataView(SourcererScopeName.timeline);
 
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(SourcererScopeName.timeline);
+  const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(
+    SourcererScopeName.timeline,
+    false
+  );
 
   const selectedPatterns = useMemo(
     () => (newDataViewPickerEnabled ? experimentalSelectedPatterns : oldSelectedPatterns),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
@@ -21,7 +21,7 @@ import { defaultUdtHeaders } from '../components/timeline/body/column_headers/de
 import { timelineDefaults } from '../store/defaults';
 import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
 import { DataViewManagerScopeName } from '../../data_view_manager/constants';
-import { useDataViewSpec } from '../../data_view_manager/hooks/use_data_view_spec';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 import { sourcererActions, sourcererSelectors } from '../../sourcerer/store';
 import { SourcererScopeName } from '../../sourcerer/store/model';
@@ -59,14 +59,12 @@ export const useCreateTimeline = ({
   ) ?? { id: '', patternList: [] };
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
-  const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(
-    DataViewManagerScopeName.default
-  );
+  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.default);
   const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.default);
 
   const dataViewId = useMemo(
-    () => (newDataViewPickerEnabled ? experimentalDataViewSpec.id ?? '' : oldDataViewId),
-    [experimentalDataViewSpec.id, newDataViewPickerEnabled, oldDataViewId]
+    () => (newDataViewPickerEnabled ? experimentalDataView?.id ?? '' : oldDataViewId),
+    [newDataViewPickerEnabled, experimentalDataView, oldDataViewId]
   );
   const selectedPatterns = useMemo(
     () => (newDataViewPickerEnabled ? experimentalSelectedPatterns : oldSelectedPatterns),


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



