### PR TITLE
[Upgrade assistant] Unify read-only copies

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/data_streams_deprecation_flyout.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/data_streams_deprecation_flyout.test.ts
@@ -178,7 +178,7 @@ describe('Data streams deprecation flyout', () => {
       expect(find('dataStreamMigrationWarningsCallout').text()).toContain(
         `Indices created on or before ${moment(
           defaultMetaResponse.lastIndexRequiringUpgradeCreationDate
-        ).format(DATE_FORMAT)} need to be reindexed to a compatible format or marked as read-only.`
+        ).format(DATE_FORMAT)} need to be reindexed to a compatible format or set to read-only.`
       );
 
       expect(exists('reindexDsWarningCallout')).toBe(true);
@@ -486,7 +486,7 @@ describe('Data streams deprecation flyout', () => {
 
       expect(exists('readOnlyDsWarningCallout')).toBe(true);
       expect(find('readOnlyDsWarningCallout').text()).toContain(
-        'Marking this data read-only could affect some of the existing setups'
+        'Setting this data to read-only could affect some of the existing setups'
       );
 
       expect(exists('migrationWarningCheckbox')).toBe(true);

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/messages.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/messages.tsx
@@ -30,7 +30,7 @@ export const getPrimaryButtonLabel = (
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.reindexButton.reindexingLabel"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migrating}}…"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {Migrating}}…"
           values={{ resolutionType }}
         />
       );
@@ -38,7 +38,7 @@ export const getPrimaryButtonLabel = (
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.reindexButton.restartLabel"
-          defaultMessage="{resolutionType, select, reindex {Restart reindexing} readonly {Restart marking as read-only} other {Restart migration}}"
+          defaultMessage="{resolutionType, select, reindex {Restart reindexing} readonly {Restart setting to read-only} other {Restart migration}}"
           values={{ resolutionType }}
         />
       );
@@ -46,7 +46,7 @@ export const getPrimaryButtonLabel = (
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.reindexButton.runReindexLabel"
-          defaultMessage="{resolutionType, select, reindex {Start reindexing} readonly {Start marking as read-only} other {Start migration}}"
+          defaultMessage="{resolutionType, select, reindex {Start reindexing} readonly {Start setting to read-only} other {Start migration}}"
           values={{ resolutionType }}
         />
       );

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress_title.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress_title.tsx
@@ -49,7 +49,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.inProgress.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {}}"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {}}"
           values={{ resolutionType }}
         />
       );
@@ -58,7 +58,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.failed.reindexingDocumentsStepTitle"
-          defaultMessage="Failed to {resolutionType, select, reindex {reindex} readonly {mark as read-only} other {}}"
+          defaultMessage="Failed to {resolutionType, select, reindex {reindex} readonly {setting to read-only} other {}}"
           values={{ resolutionType }}
         />
       );
@@ -73,7 +73,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.cancelled.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {}} cancelled"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {}} cancelled"
           values={{ resolutionType }}
         />
       );
@@ -81,7 +81,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.completed.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {}} completed"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {}} completed"
           values={{ resolutionType }}
         />
       );
@@ -90,7 +90,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.inProgress.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindex data stream} readonly {Mark data stream as read-only} other {Unknown action}}"
+          defaultMessage="{resolutionType, select, reindex {Reindex data stream} readonly {Set data stream to read-only} other {Unknown action}}"
         />
       );
     }

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress_title.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress_title.tsx
@@ -58,7 +58,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.failed.reindexingDocumentsStepTitle"
-          defaultMessage="Failed to {resolutionType, select, reindex {reindex} readonly {setting to read-only} other {}}"
+          defaultMessage="Failed to {resolutionType, select, reindex {reindex} readonly {set to read-only} other {}}"
           values={{ resolutionType }}
         />
       );

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/callouts.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/callouts.tsx
@@ -38,7 +38,7 @@ export const ReadonlyWarningCallout: React.FunctionComponent<{}> = () => {
       title={
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.readonly.calloutTitle"
-          defaultMessage="Marking this data read-only could affect some of the existing setups"
+          defaultMessage="Setting this data to read-only could affect some of the existing setups"
         />
       }
       color="warning"

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/warnings/existing_setups.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/warnings/existing_setups.tsx
@@ -22,7 +22,7 @@ export const AffectExistingSetupsWarningCheckbox: React.FunctionComponent<Warnin
       label={
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.affectExistingSetupsWarningTitle"
-          defaultMessage="Mark as read-only all incompatible data for this data stream"
+          defaultMessage="Set to read-only all incompatible data for this data stream"
         />
       }
       description={null}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/warnings/warnings_callout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/warnings/warnings_callout.tsx
@@ -23,7 +23,7 @@ export const DurationClarificationCallOut: React.FunctionComponent<Props> = ({
       <p>
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.indicesNeedReindexing"
-          defaultMessage="Indices created on or before {formattedDate} need to be reindexed to a compatible format or marked as read-only."
+          defaultMessage="Indices created on or before {formattedDate} need to be reindexed to a compatible format or set to read-only."
           values={{ formattedDate }}
         />
         <br />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
@@ -37,7 +37,7 @@ const getI18nTexts = (resolutionType?: DataStreamResolutionType) => {
       'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionInProgressText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} in progress…',
+          '{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {Migration}} in progress…',
         values: { resolutionType },
       }
     ),
@@ -45,7 +45,7 @@ const getI18nTexts = (resolutionType?: DataStreamResolutionType) => {
       'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionCompleteText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} complete',
+          '{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {Migration}} complete',
         values: { resolutionType },
       }
     ),
@@ -53,7 +53,7 @@ const getI18nTexts = (resolutionType?: DataStreamResolutionType) => {
       'xpack.upgradeAssistant.esDeprecations.dataStream.resulutionFailedText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} failed',
+          '{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {Migration}} failed',
         values: { resolutionType },
       }
     ),
@@ -61,7 +61,7 @@ const getI18nTexts = (resolutionType?: DataStreamResolutionType) => {
       'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionFetchFailedText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} status not available',
+          '{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {Migration}} status not available',
         values: { resolutionType },
       }
     ),
@@ -69,7 +69,7 @@ const getI18nTexts = (resolutionType?: DataStreamResolutionType) => {
       'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionCanceledText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} cancelled',
+          '{resolutionType, select, reindex {Reindexing} readonly {Setting to read-only} other {Migration}} cancelled',
         values: { resolutionType },
       }
     ),

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/callouts/follower_index_callout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/callouts/follower_index_callout.tsx
@@ -26,7 +26,7 @@ export const FollowerIndexCallout: React.FunctionComponent = () => {
         <p>
           <FormattedMessage
             id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.followerIndexText"
-            defaultMessage="This index is a cross-cluster replication follower index, which should not be reindexed. You can mark it as read-only or terminate the replication and convert it to a standard index."
+            defaultMessage="This index is a cross-cluster replication follower index, which should not be reindexed. You can set it to read-only or terminate the replication and convert it to a standard index."
           />
         </p>
       </EuiCallOut>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/callouts/ml_anomaly_callout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/callouts/ml_anomaly_callout.tsx
@@ -28,7 +28,7 @@ export const MlAnomalyCallout: FunctionComponent = () => {
       >
         <FormattedMessage
           id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.notCompatibleMlAnomalyIndexText"
-          defaultMessage="Anomaly result indices that were created in 7.x must be either reindexed, marked as read-only, or deleted before upgrading to 9.x. {learnMore}."
+          defaultMessage="Anomaly result indices that were created in 7.x must be either reindexed, set to read-only, or deleted before upgrading to 9.x. {learnMore}."
           values={{
             learnMore: (
               <EuiLink target="_blank" href={docLinks.links.ml.anomalyMigrationGuide}>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
@@ -127,7 +127,7 @@ const i18nTexts = {
         'xpack.upgradeAssistant.esDeprecations.indices.recommendedActionReadonlyReasonIsLargeIndex',
         {
           defaultMessage:
-            'This index is larger than 1GB. Reindexing large indices can take a long time. If you no longer need to update documents in this index (or add new ones), you might want to set it to a read-only index.',
+            'This index is larger than 1GB. Reindexing large indices can take a long time. If you no longer need to update documents in this index (or add new ones), you might want to set it to read-only.',
         }
       ),
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
@@ -127,7 +127,7 @@ const i18nTexts = {
         'xpack.upgradeAssistant.esDeprecations.indices.recommendedActionReadonlyReasonIsLargeIndex',
         {
           defaultMessage:
-            'This index is larger than 1GB. Reindexing large indices can take a long time. If you no longer need to update documents in this index (or add new ones), you might want to convert it to a read-only index.',
+            'This index is larger than 1GB. Reindexing large indices can take a long time. If you no longer need to update documents in this index (or add new ones), you might want to set it to a read-only index.',
         }
       ),
     },
@@ -137,7 +137,7 @@ const i18nTexts = {
         'xpack.upgradeAssistant.esDeprecations.indices.recommendedActionReadonlyReasonIsFollowerIndex',
         {
           defaultMessage:
-            'This index is a cross-cluster replication follower index, which should not be reindexed. You can mark it as read-only or terminate the replication and convert it to a standard index.',
+            'This index is a cross-cluster replication follower index, which should not be reindexed. You can set it to read-only or terminate the replication and convert it to a standard index.',
         }
       ),
     },

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations.ts
@@ -102,7 +102,7 @@ export async function getEnterpriseSearchPre8IndexDeprecations(
         i18n.translate(
           'xpack.upgradeAssistant.deprecations.incompatibleEnterpriseSearchIndexes.deleteIndices',
           {
-            defaultMessage: 'Set all incompatible indices and data streams to read only, or',
+            defaultMessage: 'Set all incompatible indices and data streams to read-only, or',
           }
         ),
         i18n.translate(

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
@@ -241,7 +241,7 @@ export function registerMigrateDataStreamRoutes({
       },
       options: {
         access: 'public',
-        summary: `Mark Data Stream indices as read only`,
+        summary: `Set data stream indices as read-only`,
       },
       validate: {
         body: schema.object({


### PR DESCRIPTION
Part of: https://github.com/elastic/kibana/issues/222037

## Summary
This PR unifies the copies for the `Set to read-only` option. We had different copies option such as "Mark as read-only", "Flag as read-only" or "Make read-only".