### PR TITLE
[Upgrade Assistant] Small cosmetic fixes

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
@@ -199,6 +199,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent<{
                 <EuiIcon
                   type="iInCircle"
                   aria-label={i18nTexts.recommendedActionTexts[recommendedAction].tooltipText}
+                  size="s"
                 />
               </EuiToolTip>
             </em>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/callouts/es_transform_target_callout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/callouts/es_transform_target_callout.tsx
@@ -27,7 +27,6 @@ export const ESTransformsTargetCallout = ({ deprecation }: Props) => {
           { defaultMessage: 'Transforms detected' }
         )}
         data-test-subj="esTransformsGuidance"
-        color="warning"
       >
         {deprecation.details}
       </EuiCallOut>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
@@ -366,6 +366,7 @@ export const ReindexResolutionCell: React.FunctionComponent<{
             <EuiIcon
               type="iInCircle"
               aria-label={i18nTexts.recommendedActionTexts[recommendedAction].tooltipText}
+              size="s"
             />
           </EuiToolTip>
         </em>


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/221977

## Summary
This PR introduces two small cosmetic fixes:
* Change Transforms callout color to primary (not warning) to use the same as other of the same characteristics (ML, frozen, follower...) 
<img width="499" alt="Screenshot 2025-06-19 at 11 14 55" src="https://github.com/user-attachments/assets/b04be621-15e4-4069-a7e8-4fc5755c72ea" />

* Modifies the size of the size of the info icon in the ES deprecations table so it doesn't compete visually with the Action icons
<img width="388" alt="Screenshot 2025-06-19 at 11 33 00" src="https://github.com/user-attachments/assets/df33fc14-1c96-437c-b19d-8729e0d974d9" />
