### PR TITLE
[OAS] Improve spaces discoverability

### DIFF
--- a/temp.sh
+++ b/temp.sh
@@ -1,0 +1,3 @@
+yq '(.paths.*.* | .description | select(length > 0)) |= (. // "") + "<br /><br />[Learn](#topic-kibana-spaces) how to select a space for this request."' ./oas_docs/output/kibana.yaml \
+ | yq '(.paths.*.* | .description | select(length == 0)) |= (. // "") + "[Learn](#topic-kibana-spaces) how to select a space for this request."' \
+ | > temp.yaml


### PR DESCRIPTION
## Summary

Some bash commands to update our OAS op descriptions with the following text:

<img width="708" alt="Screenshot 2025-06-18 at 13 04 57" src="https://github.com/user-attachments/assets/1c14c4f8-28a8-43a4-bb67-d6ae11d3dbf6" />


## TODO

- [ ] write another command to strip `/s/{spacedId}` like prefixes to ensure paths are consistent.