### PR TITLE
[9.0] [StdPerf][Synthetics-SLO-Alerts] Added onPageRefreshStart when refreshing data  (#223900)

### DIFF
--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/use_page_ready.test.tsx
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/use_page_ready.test.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V.
+ * Licensed under the Elastic License 2.0 and other licenses.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePageReady } from './use_page_ready';
+
+// We need to mock the PerformanceContext that the hook relies on so that we can
+// verify that its callbacks are invoked.
+const mockOnPageReady = jest.fn();
+const mockOnPageRefreshStart = jest.fn();
+
+jest.mock('../../..', () => ({
+  usePerformanceContext: () => ({
+    onPageReady: mockOnPageReady,
+    onPageRefreshStart: mockOnPageRefreshStart,
+  }),
+}));
+
+describe('usePageReady', () => {
+  beforeEach(() => {
+    mockOnPageReady.mockClear();
+    mockOnPageRefreshStart.mockClear();
+  });
+  it('calls onPageReady on initial render when isReady is true', async () => {
+    renderHook(() =>
+      usePageReady({
+        isReady: true,
+        isRefreshing: false,
+      })
+    );
+
+    await waitFor(() => expect(mockOnPageReady).toHaveBeenCalledTimes(1));
+    expect(mockOnPageReady).toHaveBeenCalledWith({ customMetrics: undefined, meta: undefined });
+  });
+
+  it('passes customMetrics and meta to onPageReady', async () => {
+    const customMetrics = { key1: 'counter', value1: 42 } as any;
+    const meta = { rangeFrom: 'now-1h', rangeTo: 'now' } as any;
+
+    renderHook(() =>
+      usePageReady({
+        isReady: true,
+        isRefreshing: false,
+        customMetrics,
+        meta,
+      })
+    );
+
+    await waitFor(() => expect(mockOnPageReady).toHaveBeenCalledTimes(1));
+    expect(mockOnPageReady).toHaveBeenCalledWith({ customMetrics, meta });
+  });
+
+  it('does nothing when not ready', () => {
+    renderHook(() =>
+      usePageReady({
+        isReady: false,
+        isRefreshing: false,
+      })
+    );
+
+    expect(mockOnPageReady).not.toHaveBeenCalled();
+    expect(mockOnPageRefreshStart).not.toHaveBeenCalled();
+  });
+
+  it('triggers refresh start and ready events correctly', async () => {
+    const { rerender } = renderHook(
+      ({ ready, refreshing }) =>
+        usePageReady({
+          isReady: ready,
+          isRefreshing: refreshing,
+        }),
+      { initialProps: { ready: true, refreshing: false } }
+    );
+
+    // initial ready
+    await waitFor(() => expect(mockOnPageReady).toHaveBeenCalledTimes(1));
+
+    // begin refresh
+    rerender({ ready: true, refreshing: true });
+    await waitFor(() => expect(mockOnPageRefreshStart).toHaveBeenCalledTimes(1));
+
+    // end refresh
+    rerender({ ready: true, refreshing: false });
+    await waitFor(() => expect(mockOnPageReady).toHaveBeenCalledTimes(2));
+  });
+
+  it('uses external customInitialLoad flag', async () => {
+    const external = { value: true, onInitialLoadReported: jest.fn() };
+
+    const { rerender } = renderHook(
+      ({ ready }) =>
+        usePageReady({
+          isReady: ready,
+          isRefreshing: false,
+          customInitialLoad: external,
+        }),
+      { initialProps: { ready: false } }
+    );
+
+    // still not ready
+    expect(mockOnPageReady).not.toHaveBeenCalled();
+
+    // turn ready true
+    rerender({ ready: true });
+    await waitFor(() => expect(mockOnPageReady).toHaveBeenCalledTimes(1));
+    expect(external.onInitialLoadReported).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -7,7 +7,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { usePerformanceContext } from '@kbn/ebt-tools';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -34,6 +33,7 @@ import dedent from 'dedent';
 import { AlertFieldsTable } from '@kbn/alerts-ui-shared';
 import { css } from '@emotion/react';
 import { omit } from 'lodash';
+import { usePageReady } from '@kbn/ebt-tools';
 import { BetaBadge } from '../../components/experimental_badge';
 import { RelatedAlerts } from './components/related_alerts';
 import { AlertDetailsSource } from './types';
@@ -96,7 +96,6 @@ export function AlertDetails() {
     uiSettings,
     serverless,
   } = useKibana().services;
-  const { onPageReady } = usePerformanceContext();
 
   const { search } = useLocation();
   const history = useHistory();
@@ -183,11 +182,10 @@ export function AlertDetails() {
     setAlertStatus(ALERT_STATUS_UNTRACKED);
   };
 
-  useEffect(() => {
-    if (!isLoading && !!alertDetail && activeTabId === OVERVIEW_TAB_ID) {
-      onPageReady();
-    }
-  }, [onPageReady, alertDetail, isLoading, activeTabId]);
+  usePageReady({
+    isRefreshing: isLoading,
+    isReady: !isLoading && !!alertDetail && activeTabId === 'overview',
+  });
 
   if (isLoading) {
     return <CenterJustifiedSpinner />;

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
@@ -6,12 +6,12 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { usePerformanceContext } from '@kbn/ebt-tools';
 import { SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { useIsMutating } from '@tanstack/react-query';
 import dedent from 'dedent';
 import { groupBy as _groupBy, mapValues } from 'lodash';
 import React, { useEffect } from 'react';
+import { usePageReady } from '@kbn/ebt-tools';
 import { useFetchSloList } from '../../../hooks/use_fetch_slo_list';
 import { useKibana } from '../../../hooks/use_kibana';
 import { useUrlSearchState } from '../hooks/use_url_search_state';
@@ -20,7 +20,6 @@ import { ToggleSLOView } from './toggle_slo_view';
 import { UngroupedView } from './ungrouped_slos/ungrouped_view';
 
 export function SloList() {
-  const { onPageReady } = usePerformanceContext();
   const { observabilityAIAssistant } = useKibana().services;
   const { state, onStateChange } = useUrlSearchState();
   const { view, page, perPage, kqlQuery, filters, tagsFilter, statusFilter, groupBy } = state;
@@ -80,11 +79,10 @@ export function SloList() {
     });
   }, [sloList, observabilityAIAssistant]);
 
-  useEffect(() => {
-    if (!isLoading && sloList !== undefined) {
-      onPageReady();
-    }
-  }, [isLoading, sloList, onPageReady]);
+  usePageReady({
+    isReady: !isLoading && sloList !== undefined,
+    isRefreshing: isLoading,
+  });
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m" data-test-subj="sloList">

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
@@ -16,6 +16,7 @@ import { ListFilters } from '../common/monitor_filters/list_filters';
 import { MonitorList } from './monitor_list_table/monitor_list';
 import { MonitorStats } from './monitor_stats/monitor_stats';
 import { AlertingCallout } from '../../common/alerting_callout/alerting_callout';
+import { useSyntheticsPageReady } from '../../../hooks/use_synthetics_page_ready';
 
 export const MonitorListContainer = ({
   isEnabled,
@@ -37,6 +38,8 @@ export const MonitorListContainer = ({
   } = monitorListProps;
 
   const { status: overviewStatus } = useSelector(selectOverviewStatus);
+
+  useSyntheticsPageReady();
 
   // TODO: Display inline errors in the management table
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -9,7 +9,6 @@ import { EuiFlexGroup, EuiSpacer, EuiFlexItem } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTrackPageview } from '@kbn/observability-shared-plugin/public';
 import { Redirect, useLocation } from 'react-router-dom';
-import { usePageReady } from '@kbn/ebt-tools';
 import { selectOverviewStatus } from '../../../state/overview_status';
 import { DisabledCallout } from '../management/disabled_callout';
 import { FilterGroup } from '../common/monitor_filters/filter_group';
@@ -28,6 +27,7 @@ import { SearchField } from '../common/search_field';
 import { NoMonitorsFound } from '../common/no_monitors_found';
 import { OverviewErrors } from './overview/overview_errors/overview_errors';
 import { AlertingCallout } from '../../common/alerting_callout/alerting_callout';
+import { useSyntheticsPageReady } from '../../../hooks/use_synthetics_page_ready';
 
 export const OverviewPage: React.FC = () => {
   useTrackPageview({ app: 'synthetics', path: 'overview' });
@@ -39,9 +39,8 @@ export const OverviewPage: React.FC = () => {
   const { search } = useLocation();
 
   const { loading: locationsLoading, locationsLoaded } = useSelector(selectServiceLocationsState);
-  const { loaded } = useSelector(selectOverviewStatus);
 
-  usePageReady({ isReady: loaded });
+  useSyntheticsPageReady();
 
   useEffect(() => {
     if (!locationsLoading && !locationsLoaded) {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_page_ready.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_page_ready.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useDispatch, useSelector } from 'react-redux';
+import { usePageReady } from '@kbn/ebt-tools';
+import { initialLoadReported, selectOverviewStatus } from '../state/overview_status';
+
+export const useSyntheticsPageReady = () => {
+  const {
+    loaded,
+    isInitialLoad,
+    loading: isLoadingOverviewStatus,
+  } = useSelector(selectOverviewStatus);
+
+  const dispatch = useDispatch();
+
+  usePageReady({
+    isReady: loaded,
+    customInitialLoad: {
+      value: isInitialLoad,
+      onInitialLoadReported: () => {
+        dispatch(initialLoadReported());
+      },
+    },
+    // This will collect the metric even when we are periodically refreshing the data in the background
+    // and not only when the user decides to refresh the data, the action is the same
+    isRefreshing: loaded && isLoadingOverviewStatus,
+  });
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/actions.ts
@@ -22,3 +22,4 @@ export const quietFetchOverviewStatusAction = createAsyncAction<
 
 export const clearOverviewStatusErrorAction = createAction<void>('clearOverviewStatusErrorAction');
 export const clearOverviewStatusState = createAction<void>('clearOverviewStatusState');
+export const initialLoadReported = createAction<void>('initialLoadReported');

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/index.ts
@@ -14,6 +14,7 @@ import {
   clearOverviewStatusState,
   fetchOverviewStatusAction,
   quietFetchOverviewStatusAction,
+  initialLoadReported,
 } from './actions';
 
 export interface OverviewStatusStateReducer {
@@ -23,6 +24,7 @@ export interface OverviewStatusStateReducer {
   allConfigs?: OverviewStatusMetaData[];
   disabledConfigs?: OverviewStatusMetaData[];
   error: IHttpSerializedFetchError | null;
+  isInitialLoad: boolean;
 }
 
 const initialState: OverviewStatusStateReducer = {
@@ -30,6 +32,7 @@ const initialState: OverviewStatusStateReducer = {
   loaded: false,
   status: null,
   error: null,
+  isInitialLoad: true,
 };
 
 export const overviewStatusReducer = createReducer(initialState, (builder) => {
@@ -65,6 +68,9 @@ export const overviewStatusReducer = createReducer(initialState, (builder) => {
     })
     .addCase(clearOverviewStatusErrorAction, (state) => {
       state.error = null;
+    })
+    .addCase(initialLoadReported, (state) => {
+      state.isInitialLoad = false;
     });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -141,6 +141,7 @@ export const mockState: SyntheticsAppState = {
     loading: false,
     status: null,
     error: null,
+    isInitialLoad: true,
   },
   globalParams: {
     addError: null,

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/monitor_list_container.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/monitor_list_container.tsx
@@ -47,7 +47,10 @@ export const MonitorList: React.FC<MonitorListProps> = (props) => {
   const monitorList = useSelector(monitorListSelector);
   useMappingCheck(monitorList.error);
 
-  usePageReady({ isReady: Boolean(monitorList.isLoaded) });
+  usePageReady({
+    isReady: Boolean(monitorList.isLoaded),
+    isRefreshing: false,
+  });
 
   useEffect(() => {
     filterCheck(() =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[StdPerf][Synthetics-SLO-Alerts] Added onPageRefreshStart when refreshing data  (#223900)](https://github.com/elastic/kibana/pull/223900)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-06-19T10:05:02Z","message":"[StdPerf][Synthetics-SLO-Alerts] Added onPageRefreshStart when refreshing data  (#223900)\n\nThis PR closes [this\nissue](https://github.com/elastic/observability-dev/issues/4565).\n\nWhile working on it I identified a problem with the collection of the\nTTFMP metric in Synthetics. Currently, the `onPageReady` method is\ninvoked only on the overview page, not on the management page. As a\nresult, if users switch between the management and overview tabs, the\nmetric data collected is incorrect.\n\nI fixed this and I have also implemented a call to `onPageRefreshStart`\nwhen data is being refetched, either through user-initiated refresh\nactions or automatic background updates.\n\nBefore\n\n\nhttps://github.com/user-attachments/assets/1408761d-024a-4373-8173-00bcf8fac1d7\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/a7396c06-4648-4c42-a8e4-6bd48ef5cc88\n\nAlerts and SLO:\n\n\nhttps://github.com/user-attachments/assets/b8d2b6ad-3d84-40d7-a9d9-6e771c2375c3","sha":"8d2b552b9b2b722ee522a287f5406b798d5fd89a","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management","v9.0.3"],"title":"[StdPerf][Synthetics-SLO-Alerts] Added onPageRefreshStart when refreshing data ","number":223900,"url":"https://github.com/elastic/kibana/pull/223900","mergeCommit":{"message":"[StdPerf][Synthetics-SLO-Alerts] Added onPageRefreshStart when refreshing data  (#223900)\n\nThis PR closes [this\nissue](https://github.com/elastic/observability-dev/issues/4565).\n\nWhile working on it I identified a problem with the collection of the\nTTFMP metric in Synthetics. Currently, the `onPageReady` method is\ninvoked only on the overview page, not on the management page. As a\nresult, if users switch between the management and overview tabs, the\nmetric data collected is incorrect.\n\nI fixed this and I have also implemented a call to `onPageRefreshStart`\nwhen data is being refetched, either through user-initiated refresh\nactions or automatic background updates.\n\nBefore\n\n\nhttps://github.com/user-attachments/assets/1408761d-024a-4373-8173-00bcf8fac1d7\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/a7396c06-4648-4c42-a8e4-6bd48ef5cc88\n\nAlerts and SLO:\n\n\nhttps://github.com/user-attachments/assets/b8d2b6ad-3d84-40d7-a9d9-6e771c2375c3","sha":"8d2b552b9b2b722ee522a287f5406b798d5fd89a"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223900","number":223900,"mergeCommit":{"message":"[StdPerf][Synthetics-SLO-Alerts] Added onPageRefreshStart when refreshing data  (#223900)\n\nThis PR closes [this\nissue](https://github.com/elastic/observability-dev/issues/4565).\n\nWhile working on it I identified a problem with the collection of the\nTTFMP metric in Synthetics. Currently, the `onPageReady` method is\ninvoked only on the overview page, not on the management page. As a\nresult, if users switch between the management and overview tabs, the\nmetric data collected is incorrect.\n\nI fixed this and I have also implemented a call to `onPageRefreshStart`\nwhen data is being refetched, either through user-initiated refresh\nactions or automatic background updates.\n\nBefore\n\n\nhttps://github.com/user-attachments/assets/1408761d-024a-4373-8173-00bcf8fac1d7\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/a7396c06-4648-4c42-a8e4-6bd48ef5cc88\n\nAlerts and SLO:\n\n\nhttps://github.com/user-attachments/assets/b8d2b6ad-3d84-40d7-a9d9-6e771c2375c3","sha":"8d2b552b9b2b722ee522a287f5406b798d5fd89a"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224541","number":224541,"state":"OPEN"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->