### PR TITLE
[8.19] [Incident Management] [Related dashboards api] Handle missing lens attributes gracefully  (#223619)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.test.ts
@@ -123,6 +123,7 @@ describe('RelatedDashboardsClient', () => {
                             },
                           },
                         },
+                        type: 'lens',
                       },
                     },
                   },
@@ -149,6 +150,7 @@ describe('RelatedDashboardsClient', () => {
                             },
                           },
                         },
+                        type: 'lens',
                       },
                     },
                   },
@@ -182,6 +184,7 @@ describe('RelatedDashboardsClient', () => {
                         formBased: { layers: [{ columns: [{ sourceField: 'field2' }] }] },
                       },
                     },
+                    type: 'lens',
                   },
                 },
                 panelIndex: expect.any(String),
@@ -212,6 +215,7 @@ describe('RelatedDashboardsClient', () => {
                         formBased: { layers: [{ columns: [{ sourceField: 'field1' }] }] },
                       },
                     },
+                    type: 'lens',
                   },
                 },
                 panelIndex: expect.any(String),
@@ -233,6 +237,7 @@ describe('RelatedDashboardsClient', () => {
                         formBased: { layers: [{ columns: [{ sourceField: 'field1' }] }] },
                       },
                     },
+                    type: 'lens',
                   },
                 },
                 panelIndex: expect.any(String),
@@ -277,6 +282,7 @@ describe('RelatedDashboardsClient', () => {
                           formBased: { layers: [{ columns: [{ sourceField: 'field1' }] }] },
                         },
                       },
+                      type: 'lens',
                     },
                   },
                 },
@@ -324,6 +330,7 @@ describe('RelatedDashboardsClient', () => {
                             formBased: { layers: [{ columns: [{ sourceField: 'field1' }] }] }, // matches by field which is handled by getDashboardsByField
                           },
                         },
+                        type: 'lens',
                       },
                     },
                   },
@@ -357,6 +364,7 @@ describe('RelatedDashboardsClient', () => {
                         formBased: { layers: [{ columns: [{ sourceField: 'field1' }] }] },
                       },
                     },
+                    type: 'lens',
                   },
                 },
                 panelIndex: '123',
@@ -407,6 +415,7 @@ describe('RelatedDashboardsClient', () => {
               type: 'lens',
               panelConfig: {
                 attributes: {
+                  type: 'lens',
                   references: [
                     { name: 'indexpattern', id: 'index2' },
                     { name: 'irrelevant', id: 'index1' },
@@ -429,6 +438,50 @@ describe('RelatedDashboardsClient', () => {
       expect(resultWithMatch.dashboards[0].matchedBy).toEqual({
         index: ['index2'],
       });
+    });
+
+    it('should return an empty set when lens attributes are not available', () => {
+      client.dashboardsById.set('dashboard1', {
+        id: 'dashboard1',
+        attributes: {
+          title: 'Dashboard 1',
+          panels: [
+            {
+              type: 'lens',
+              panelConfig: {
+                attributes: null, // Lens attributes are not available
+              },
+            },
+          ],
+        },
+      } as any);
+
+      // @ts-ignore next-line
+      const result = client.getDashboardsByIndex('index1');
+      expect(result.dashboards).toEqual([]);
+    });
+  });
+
+  describe('getPanelsByField', () => {
+    it('should return an empty set when lens attributes are not available', () => {
+      client.dashboardsById.set('dashboard1', {
+        id: 'dashboard1',
+        attributes: {
+          title: 'Dashboard 1',
+          panels: [
+            {
+              type: 'lens',
+              panelConfig: {
+                attributes: null, // Lens attributes are not available
+              },
+            },
+          ],
+        },
+      } as any);
+
+      // @ts-ignore next-line
+      const result = client.getDashboardsByField(['field1']);
+      expect(result.dashboards).toEqual([]);
     });
   });
 
@@ -669,6 +722,7 @@ describe('RelatedDashboardsClient', () => {
                             formBased: { layers: [{ columns: [{ sourceField: 'field1' }] }] }, // matches by field which is handled by getDashboardsByField
                           },
                         },
+                        type: 'lens',
                       },
                     },
                   },
@@ -691,6 +745,7 @@ describe('RelatedDashboardsClient', () => {
                             formBased: { layers: [{ columns: [{ sourceField: 'field2' }] }] },
                           },
                         },
+                        type: 'lens',
                       },
                     },
                   },
@@ -732,6 +787,7 @@ describe('RelatedDashboardsClient', () => {
                         formBased: { layers: [{ columns: [{ sourceField: 'field1' }] }] },
                       },
                     },
+                    type: 'lens',
                   },
                 },
                 panelIndex: '123',

--- a/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.ts
@@ -224,7 +224,7 @@ export class RelatedDashboardsClient {
     return { dashboards: relevantDashboards };
   }
 
-  getPanelsByIndex(index: string, panels: DashboardAttributes['panels']): DashboardPanel[] {
+  private getPanelsByIndex(index: string, panels: DashboardAttributes['panels']): DashboardPanel[] {
     const panelsByIndex = panels.filter((p) => {
       if (isDashboardSection(p)) return false; // filter out sections
       const panelIndices = this.getPanelIndices(p);
@@ -233,7 +233,7 @@ export class RelatedDashboardsClient {
     return panelsByIndex;
   }
 
-  getPanelsByField(
+  private getPanelsByField(
     fields: string[],
     panels: DashboardAttributes['panels']
   ): Array<{ matchingFields: Set<string>; panel: DashboardPanel }> {
@@ -249,31 +249,46 @@ export class RelatedDashboardsClient {
     return panelsByField;
   }
 
-  getPanelIndices(panel: DashboardPanel): Set<string> {
-    const indices = new Set<string>();
+  private getPanelIndices(panel: DashboardPanel): Set<string> {
+    const emptyIndicesSet = new Set<string>();
     switch (panel.type) {
       case 'lens':
-        const lensAttr = panel.panelConfig.attributes as unknown as LensAttributes;
-        if (!lensAttr) {
-          return indices;
+        const maybeLensAttr = panel.panelConfig.attributes;
+        if (this.isLensVizAttributes(maybeLensAttr)) {
+          const lensIndices = this.getLensVizIndices(maybeLensAttr);
+          return lensIndices;
         }
-        const lensIndices = this.getLensVizIndices(lensAttr);
-        return lensIndices;
+        return emptyIndicesSet;
       default:
-        return indices;
+        return emptyIndicesSet;
     }
   }
 
-  getPanelFields(panel: DashboardPanel): Set<string> {
-    const fields = new Set<string>();
+  private getPanelFields(panel: DashboardPanel): Set<string> {
+    const emptyFieldsSet = new Set<string>();
     switch (panel.type) {
       case 'lens':
-        const lensAttr = panel.panelConfig.attributes as unknown as LensAttributes;
-        const lensFields = this.getLensVizFields(lensAttr);
-        return lensFields;
+        const maybeLensAttr = panel.panelConfig.attributes;
+        if (this.isLensVizAttributes(maybeLensAttr)) {
+          const lensFields = this.getLensVizFields(maybeLensAttr);
+          return lensFields;
+        }
+        return emptyFieldsSet;
       default:
-        return fields;
+        return emptyFieldsSet;
     }
+  }
+
+  private isLensVizAttributes(attributes: unknown): attributes is LensAttributes {
+    if (!attributes) {
+      return false;
+    }
+    return (
+      Boolean(attributes) &&
+      typeof attributes === 'object' &&
+      'type' in attributes &&
+      attributes.type === 'lens'
+    );
   }
 
   private getRuleQueryIndex(): string | null {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Incident Management] [Related dashboards api] Handle missing lens attributes gracefully  (#223619)](https://github.com/elastic/kibana/pull/223619)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dominique Clarke","email":"dominique.clarke@elastic.co"},"sourceCommit":{"committedDate":"2025-06-12T23:32:34Z","message":"[Incident Management] [Related dashboards api] Handle missing lens attributes gracefully  (#223619)\n\n## Summary\n\nRelates to https://github.com/elastic/kibana/issues/212125\n\nWhen a Lens panel is saved to a dashboards, it is either saved by value\nor by reference. If it's saved by reference, the attributes will not be\navailable. This was creating a reference error when attempting to\ninspect the lens configuration to make suggestions.\n\nThis PR confirms that the attributes are available. \n\nA follow up PR will fetch the values for the references to include them\nin the evaluation.","sha":"f6da3f2cbc604c73b9d756306cf0226865b544d8","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management"],"title":"[Incident Management] [Related dashboards api] Handle missing lens attributes gracefully ","number":223619,"url":"https://github.com/elastic/kibana/pull/223619","mergeCommit":{"message":"[Incident Management] [Related dashboards api] Handle missing lens attributes gracefully  (#223619)\n\n## Summary\n\nRelates to https://github.com/elastic/kibana/issues/212125\n\nWhen a Lens panel is saved to a dashboards, it is either saved by value\nor by reference. If it's saved by reference, the attributes will not be\navailable. This was creating a reference error when attempting to\ninspect the lens configuration to make suggestions.\n\nThis PR confirms that the attributes are available. \n\nA follow up PR will fetch the values for the references to include them\nin the evaluation.","sha":"f6da3f2cbc604c73b9d756306cf0226865b544d8"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223619","number":223619,"mergeCommit":{"message":"[Incident Management] [Related dashboards api] Handle missing lens attributes gracefully  (#223619)\n\n## Summary\n\nRelates to https://github.com/elastic/kibana/issues/212125\n\nWhen a Lens panel is saved to a dashboards, it is either saved by value\nor by reference. If it's saved by reference, the attributes will not be\navailable. This was creating a reference error when attempting to\ninspect the lens configuration to make suggestions.\n\nThis PR confirms that the attributes are available. \n\nA follow up PR will fetch the values for the references to include them\nin the evaluation.","sha":"f6da3f2cbc604c73b9d756306cf0226865b544d8"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->