### PR TITLE
[Discover][Traces] Fix processed OTel waterfall flyout

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/helpers/is_span.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/helpers/is_span.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DataTableRecord, PARENT_ID_FIELD, TRANSACTION_NAME_FIELD } from '@kbn/discover-utils';
+
+export const isSpanHit = (hit: DataTableRecord | null): boolean => {
+  return !!hit?.flattened[PARENT_ID_FIELD] && !hit?.flattened[TRANSACTION_NAME_FIELD];
+};

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/index.ts
@@ -35,7 +35,12 @@ async function getSpanData({ spanId, indexPattern, data, signal }: GetTransactio
           size: 1,
           body: {
             timeout: '20s',
-            fields: ['*'],
+            fields: [
+              {
+                field: '*',
+                include_unmapped: true,
+              },
+            ],
             query: {
               match: {
                 [SPAN_ID_FIELD]: spanId,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/index.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/index.ts
@@ -35,6 +35,7 @@ async function getSpanData({ spanId, indexPattern, data, signal }: GetTransactio
           size: 1,
           body: {
             timeout: '20s',
+            fields: ['*'],
             query: {
               match: {
                 [SPAN_ID_FIELD]: spanId,
@@ -68,7 +69,7 @@ export const useSpan = ({ spanId, indexPattern }: UseSpanParams) => {
       try {
         setLoading(true);
         const result = await getSpanData({ spanId, indexPattern, data, signal });
-        setSpan(result.rawResponse.hits.hits[0]?._source);
+        setSpan(result.rawResponse.hits.hits[0]?.fields ?? null);
         setDocId(result.rawResponse.hits.hits[0]?._id ?? null);
       } catch (err) {
         if (!signal.aborted) {

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/use_span.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/hooks/use_span/use_span.test.ts
@@ -45,7 +45,7 @@ describe('useSpan', () => {
 
   describe('when parameters are NOT missing', () => {
     it('should fetch span data successfully', async () => {
-      const mockHit = { _source: { name: 'test-span' }, _id: 'test-id' };
+      const mockHit = { fields: { name: 'test-span' }, _id: 'test-id' };
 
       mockSearch.mockReturnValue(
         of({
@@ -61,7 +61,7 @@ describe('useSpan', () => {
       await waitFor(() => !result.current.loading);
 
       expect(result.current.loading).toBe(false);
-      expect(result.current.span).toEqual(mockHit._source);
+      expect(result.current.span).toEqual(mockHit.fields);
       expect(result.current.docId).toEqual(mockHit._id);
     });
   });

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/index.tsx
@@ -15,13 +15,14 @@ import {
   EuiFlyoutBody,
   EuiSkeletonTitle,
 } from '@elastic/eui';
-import { DataTableRecord, PARENT_ID_FIELD } from '@kbn/discover-utils';
+import { DataTableRecord } from '@kbn/discover-utils';
 import { flattenObject } from '@kbn/object-utils';
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import { useSpan } from '../hooks/use_span';
 import { SpanFlyoutBody } from './span_flyout_body';
+import { isSpanHit } from '../helpers/is_span';
 
 const flyoutId = 'spanDetailFlyout';
 
@@ -53,7 +54,8 @@ export const SpanFlyout = ({
       flattened: flattenObject(span),
     };
   }, [docId, span]);
-  const isSpan = !!documentAsHit?.flattened[PARENT_ID_FIELD];
+
+  const isSpan = isSpanHit(documentAsHit);
 
   return (
     <EuiFlyout

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
@@ -8,7 +8,7 @@
  */
 
 import { EuiSkeletonText, EuiTab, EuiTabs } from '@elastic/eui';
-import { DataTableRecord, PARENT_ID_FIELD } from '@kbn/discover-utils';
+import { DataTableRecord } from '@kbn/discover-utils';
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
@@ -17,6 +17,7 @@ import TransactionOverview from '../../../doc_viewer_transaction_overview';
 import DocViewerTable from '../../../../../doc_viewer_table';
 import DocViewerSource from '../../../../../doc_viewer_source';
 import { useDataSourcesContext } from '../../../hooks/use_data_sources';
+import { isSpanHit } from '../helpers/is_span';
 
 const tabIds = {
   OVERVIEW: 'unifiedDocViewerTracesSpanFlyoutOverview',
@@ -58,7 +59,7 @@ export interface SpanFlyoutProps {
 
 export const SpanFlyoutBody = ({ hit, loading, dataView }: SpanFlyoutProps) => {
   const [selectedTabId, setSelectedTabId] = useState(tabIds.OVERVIEW);
-  const isSpan = !!hit?.flattened[PARENT_ID_FIELD];
+  const isSpan = isSpanHit(hit);
   const { indexes } = useDataSourcesContext();
   const onSelectedTabChanged = (id: string) => setSelectedTabId(id);
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/208707


While reviewing the Traces in Discover feature, we noticed a couple of issues affecting processed OTel data in the waterfall flyout:

- The data wasn’t properly formatted because we were pulling it directly from `_source`, which meant the UI wasn’t receiving the processed version. Now we're using `fields` the same way it's used in Discover.
- The logic used to set the flyout title (to determine whether the document was a span or a transaction) relied entirely on the presence of `parent.id`. However, since transactions can also be children of other transactions, we’ve added an extra check using `transaction.name` (spans reference the parent transaction via `transaction.id`) to ensure we're correctly identifying spans.

||Discover|Transaction|Span|
|-|-|-|-|
|Before|![Screenshot 2025-06-19 at 12 48 32](https://github.com/user-attachments/assets/7a2f7db9-c348-40b7-a974-c57436db70f1)|![Screenshot 2025-06-19 at 12 50 02](https://github.com/user-attachments/assets/18098108-12e9-4ed0-8fae-f9653729272b)|![Screenshot 2025-06-19 at 12 49 47](https://github.com/user-attachments/assets/6aa120b8-ba0f-48e7-b775-ab8101849635)|
|After|Same than before.|![Screenshot 2025-06-19 at 12 51 11](https://github.com/user-attachments/assets/3e29bd8a-d803-4efd-8bde-7baa63f25067)|![Screenshot 2025-06-19 at 12 47 52](https://github.com/user-attachments/assets/f82bc2a9-02a8-4a98-94ba-1449e8588d78)|











<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->