### PR TITLE
[9.0] Fix for the discard button state change for the toggle (#223493)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useReducer } from 'react';
 import {
   EuiSuperDatePicker,
   EuiButton,
@@ -23,6 +23,58 @@ import * as i18n from '../translations';
 import { useConfigureSORiskEngineMutation } from '../api/hooks/use_configure_risk_engine_saved_object';
 import { getEntityAnalyticsRiskScorePageStyles } from './risk_score_page_styles';
 
+interface RiskScoreConfigurationState {
+  saved: {
+    includeClosedAlerts: boolean;
+    start: string;
+    end: string;
+  };
+  draft: {
+    includeClosedAlerts: boolean;
+    start: string;
+    end: string;
+  };
+  showBar: boolean;
+}
+
+type RiskScoreConfigurationAction =
+  | { type: 'updateField'; field: 'includeClosedAlerts' | 'start' | 'end'; value: boolean | string }
+  | { type: 'saveChanges' }
+  | { type: 'discardChanges' };
+
+function riskScoreConfigurationReducer(
+  state: RiskScoreConfigurationState,
+  action: RiskScoreConfigurationAction
+): RiskScoreConfigurationState {
+  switch (action.type) {
+    case 'updateField': {
+      const draft = { ...state.draft, [action.field]: action.value };
+      const showBar =
+        draft.includeClosedAlerts !== state.saved.includeClosedAlerts ||
+        draft.start !== state.saved.start ||
+        draft.end !== state.saved.end;
+
+      return { ...state, draft, showBar };
+    }
+    case 'saveChanges': {
+      return {
+        saved: { ...state.draft },
+        draft: { ...state.draft },
+        showBar: false,
+      };
+    }
+    case 'discardChanges': {
+      return {
+        saved: { ...state.saved },
+        draft: { ...state.saved },
+        showBar: false,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
 export const RiskScoreConfigurationSection = ({
   includeClosedAlerts,
   from,
@@ -34,49 +86,54 @@ export const RiskScoreConfigurationSection = ({
 }) => {
   const { euiTheme } = useEuiTheme();
   const styles = getEntityAnalyticsRiskScorePageStyles(euiTheme);
-  const [checked, setChecked] = useState(includeClosedAlerts);
-  const [isLoading, setIsLoading] = useState(false);
-  const [showBar, setShowBar] = useState(false);
   const { addSuccess } = useAppToasts();
-  const [start, setStart] = useState(from);
-  const [end, setEnd] = useState(to);
-
-  useEffect(() => {
-    setChecked(includeClosedAlerts);
-    setStart(from);
-    setEnd(to);
-  }, [includeClosedAlerts, from, to]);
-
-  const handleDateChange = ({ start: newStart, end: newEnd }: { start: string; end: string }) => {
-    setShowBar(true);
-    setStart(newStart);
-    setEnd(newEnd);
-  };
-
-  const onChange = () => {
-    setChecked((prev) => !prev);
-    setShowBar(true);
-  };
   const { mutate } = useConfigureSORiskEngineMutation();
+
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const [state, dispatch] = useReducer(riskScoreConfigurationReducer, {
+    saved: {
+      includeClosedAlerts,
+      start: from,
+      end: to,
+    },
+    draft: {
+      includeClosedAlerts,
+      start: from,
+      end: to,
+    },
+    showBar: false,
+  });
+
+  const handleDateChange = ({ start, end }: { start: string; end: string }) => {
+    dispatch({ type: 'updateField', field: 'start', value: start });
+    dispatch({ type: 'updateField', field: 'end', value: end });
+  };
+
+  const handleToggle = () => {
+    dispatch({
+      type: 'updateField',
+      field: 'includeClosedAlerts',
+      value: !state.draft.includeClosedAlerts,
+    });
+  };
 
   const handleSave = () => {
     setIsLoading(true);
     mutate(
       {
-        includeClosedAlerts: checked,
-        range: { start, end },
+        includeClosedAlerts: state.draft.includeClosedAlerts,
+        range: { start: state.draft.start, end: state.draft.end },
       },
       {
         onSuccess: () => {
-          setShowBar(false);
+          setIsLoading(false);
           addSuccess(i18n.RISK_ENGINE_SAVED_OBJECT_CONFIGURATION_SUCCESS, {
             toastLifeTimeMs: 5000,
           });
-          setIsLoading(false);
+          dispatch({ type: 'saveChanges' });
         },
-        onError: () => {
-          setIsLoading(false);
-        },
+        onError: () => setIsLoading(false),
       }
     );
   };
@@ -87,28 +144,31 @@ export const RiskScoreConfigurationSection = ({
         <div>
           <EuiSwitch
             label={i18n.INCLUDE_CLOSED_ALERTS_LABEL}
-            checked={checked}
-            onChange={onChange}
+            checked={state.draft.includeClosedAlerts}
+            onChange={handleToggle}
             data-test-subj="includeClosedAlertsSwitch"
           />
         </div>
         <styles.VerticalSeparator />
         <div>
           <EuiSuperDatePicker
-            start={start}
-            end={end}
+            start={state.draft.start}
+            end={state.draft.end}
             onTimeChange={handleDateChange}
-            width={'auto'}
+            width="auto"
             compressed={false}
             showUpdateButton={false}
           />
         </div>
       </EuiFlexGroup>
+
       <EuiSpacer size="m" />
+
       <EuiText size="s">
         <p>{i18n.RISK_ENGINE_INCLUDE_CLOSED_ALERTS_DESCRIPTION}</p>
       </EuiText>
-      {showBar && (
+
+      {state.showBar && (
         <EuiBottomBar paddingSize="s" position="fixed">
           <EuiFlexGroup justifyContent="spaceBetween">
             <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
@@ -117,12 +177,7 @@ export const RiskScoreConfigurationSection = ({
                   color="text"
                   size="s"
                   iconType="cross"
-                  onClick={() => {
-                    setShowBar(false);
-                    setStart(start);
-                    setEnd(end);
-                    setChecked(includeClosedAlerts);
-                  }}
+                  onClick={() => dispatch({ type: 'discardChanges' })}
                 >
                   {i18n.DISCARD_CHANGES}
                 </EuiButtonEmpty>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Fix for the discard button state change for the toggle (#223493)](https://github.com/elastic/kibana/pull/223493)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abhishek Bhatia","email":"117628830+abhishekbhatia1710@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-17T12:38:50Z","message":"Fix for the discard button state change for the toggle (#223493)\n\n## Summary\n\nThis PR addresses a UI inconsistency in the Risk Score Configuration\nsection where clicking the \"Discard\" button after toggling\nincludeClosedAlerts or changing the date range did not correctly reset\nthe UI state to the last saved values.\n\nThe core issue was due to relying on React state and useEffect to track\nand restore the saved state, which failed when parent props did not\nchange. The changes resolves the issue by:\n\n- Introducing a useRef (savedStateRef) to persist the last saved\nconfiguration.\n- Updating savedStateRef only on successful \"Save\".\n- Using savedStateRef to restore toggle and date range when \"Discard\" is\nclicked.\n- This ensures consistent behavior whether or not the parent component\nre-renders.\n\n\nScreen recording for ref : \n\n\n\nhttps://github.com/user-attachments/assets/1bb59df6-35c0-4cbc-a7b0-a29affdf7327\n\n\n\n### Testing Steps\n\n#### Initial Load:\nOpen the Risk Score Configuration section.\nVerify that the includeClosedAlerts toggle and date range are\ninitialized correctly.\n\n#### Toggle & Discard:\nClick the toggle to change its state.\nVerify that the bottom bar (\"Save\" / \"Discard\") appears.\nClick Discard.\nConfirm that the toggle resets to its original state.\n\n#### Toggle & Save:\nClick the toggle to change its state.\nClick Save.\nConfirm success toast appears.\nRefresh the page or revisit the config — the toggle should reflect the\nnewly saved state.\nChange Date Range & Discard:\nChange the date range via the super date picker.\n\n#### Click Discard.\nConfirm the date range resets to the last saved value.\nChange Both & Save:\nChange both toggle and date range.\nClick Save.\nConfirm the new configuration is persisted correctly.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"f0b8e0da903cb204309ca8363e86ced5ea3b79e6","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"Fix for the discard button state change for the toggle","number":223493,"url":"https://github.com/elastic/kibana/pull/223493","mergeCommit":{"message":"Fix for the discard button state change for the toggle (#223493)\n\n## Summary\n\nThis PR addresses a UI inconsistency in the Risk Score Configuration\nsection where clicking the \"Discard\" button after toggling\nincludeClosedAlerts or changing the date range did not correctly reset\nthe UI state to the last saved values.\n\nThe core issue was due to relying on React state and useEffect to track\nand restore the saved state, which failed when parent props did not\nchange. The changes resolves the issue by:\n\n- Introducing a useRef (savedStateRef) to persist the last saved\nconfiguration.\n- Updating savedStateRef only on successful \"Save\".\n- Using savedStateRef to restore toggle and date range when \"Discard\" is\nclicked.\n- This ensures consistent behavior whether or not the parent component\nre-renders.\n\n\nScreen recording for ref : \n\n\n\nhttps://github.com/user-attachments/assets/1bb59df6-35c0-4cbc-a7b0-a29affdf7327\n\n\n\n### Testing Steps\n\n#### Initial Load:\nOpen the Risk Score Configuration section.\nVerify that the includeClosedAlerts toggle and date range are\ninitialized correctly.\n\n#### Toggle & Discard:\nClick the toggle to change its state.\nVerify that the bottom bar (\"Save\" / \"Discard\") appears.\nClick Discard.\nConfirm that the toggle resets to its original state.\n\n#### Toggle & Save:\nClick the toggle to change its state.\nClick Save.\nConfirm success toast appears.\nRefresh the page or revisit the config — the toggle should reflect the\nnewly saved state.\nChange Date Range & Discard:\nChange the date range via the super date picker.\n\n#### Click Discard.\nConfirm the date range resets to the last saved value.\nChange Both & Save:\nChange both toggle and date range.\nClick Save.\nConfirm the new configuration is persisted correctly.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"f0b8e0da903cb204309ca8363e86ced5ea3b79e6"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.19"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223493","number":223493,"mergeCommit":{"message":"Fix for the discard button state change for the toggle (#223493)\n\n## Summary\n\nThis PR addresses a UI inconsistency in the Risk Score Configuration\nsection where clicking the \"Discard\" button after toggling\nincludeClosedAlerts or changing the date range did not correctly reset\nthe UI state to the last saved values.\n\nThe core issue was due to relying on React state and useEffect to track\nand restore the saved state, which failed when parent props did not\nchange. The changes resolves the issue by:\n\n- Introducing a useRef (savedStateRef) to persist the last saved\nconfiguration.\n- Updating savedStateRef only on successful \"Save\".\n- Using savedStateRef to restore toggle and date range when \"Discard\" is\nclicked.\n- This ensures consistent behavior whether or not the parent component\nre-renders.\n\n\nScreen recording for ref : \n\n\n\nhttps://github.com/user-attachments/assets/1bb59df6-35c0-4cbc-a7b0-a29affdf7327\n\n\n\n### Testing Steps\n\n#### Initial Load:\nOpen the Risk Score Configuration section.\nVerify that the includeClosedAlerts toggle and date range are\ninitialized correctly.\n\n#### Toggle & Discard:\nClick the toggle to change its state.\nVerify that the bottom bar (\"Save\" / \"Discard\") appears.\nClick Discard.\nConfirm that the toggle resets to its original state.\n\n#### Toggle & Save:\nClick the toggle to change its state.\nClick Save.\nConfirm success toast appears.\nRefresh the page or revisit the config — the toggle should reflect the\nnewly saved state.\nChange Date Range & Discard:\nChange the date range via the super date picker.\n\n#### Click Discard.\nConfirm the date range resets to the last saved value.\nChange Both & Save:\nChange both toggle and date range.\nClick Save.\nConfirm the new configuration is persisted correctly.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"f0b8e0da903cb204309ca8363e86ced5ea3b79e6"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->