### PR TITLE
[8.19] [Synthetics] Add monitor downtime alert on no data (#220127)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.ts
@@ -53,6 +53,7 @@ const StatusRuleConditionSchema = schema.object({
     NumberOfChecksSchema,
   ]),
   includeRetests: schema.maybe(schema.boolean()),
+  alertOnNoData: schema.maybe(schema.boolean()),
 });
 
 export const syntheticsMonitorStatusRuleParamsSchema = schema.object(

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/alert_rules/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/alert_rules/common.ts
@@ -31,52 +31,80 @@ export type SyntheticsMonitorStatusAlertState = t.TypeOf<
   typeof SyntheticsMonitorStatusAlertStateCodec
 >;
 
-export const AlertStatusMetaDataCodec = t.interface({
-  monitorQueryId: t.string,
-  configId: t.string,
-  status: t.string,
-  locationId: t.string,
-  timestamp: t.string,
-  ping: OverviewPingCodec,
-  checks: t.type({
-    downWithinXChecks: t.number,
-    down: t.number,
-  }),
-});
+export interface AlertStatusMetaData {
+  monitorQueryId: string;
+  configId: string;
+  status: string;
+  locationId: string;
+  timestamp: string;
+  ping: t.TypeOf<typeof OverviewPingCodec>;
+  checks: {
+    downWithinXChecks: number;
+    down: number;
+  };
+}
 
-export const StaleAlertStatusMetaDataCodec = t.intersection([
-  AlertStatusMetaDataCodec,
-  t.partial({
-    isDeleted: t.boolean,
-    isLocationRemoved: t.boolean,
-  }),
-]);
+// Interface for StaleMetaData
+export interface StaleAlertMetadata {
+  isDeleted?: boolean;
+  isLocationRemoved?: boolean;
+}
 
-export const AlertPendingStatusMetaDataCodec = t.intersection([
-  t.interface({
-    monitorQueryId: t.string,
-    configId: t.string,
-    status: t.string,
-    locationId: t.string,
-  }),
-  t.partial({
-    timestamp: t.string,
-    ping: OverviewPingCodec,
-  }),
-]);
+// Interface for MissingPingMonitorInfo
+export interface MissingPingMonitorInfo {
+  // Required fields
+  monitor: {
+    name: string;
+    id: string;
+    type: string;
+  };
+  observer: {
+    geo: {
+      name: string;
+    };
+  };
+  tags: string[];
 
-export const AlertStatusCodec = t.interface({
-  upConfigs: t.record(t.string, AlertStatusMetaDataCodec),
-  downConfigs: t.record(t.string, AlertStatusMetaDataCodec),
-  pendingConfigs: t.record(t.string, AlertPendingStatusMetaDataCodec),
-  enabledMonitorQueryIds: t.array(t.string),
-  staleDownConfigs: t.record(t.string, StaleAlertStatusMetaDataCodec),
-  maxPeriod: t.number,
-});
+  // Optional fields
+  labels?: Record<string, string>;
+  url?: {
+    full?: string;
+  };
+  error?: {
+    message: string;
+    stack_trace: string;
+  };
+  service?: {
+    name: string;
+  };
+  agent?: {
+    name: string;
+  };
+  state?: {
+    id: string;
+  };
+}
 
-export type StaleDownConfig = t.TypeOf<typeof StaleAlertStatusMetaDataCodec>;
-export type AlertStatusMetaData = t.TypeOf<typeof AlertStatusMetaDataCodec>;
-export type AlertOverviewStatus = t.TypeOf<typeof AlertStatusCodec>;
+export interface AlertPendingStatusMetaData {
+  monitorQueryId: string;
+  configId: string;
+  status: string;
+  locationId: string;
+  monitorInfo: MissingPingMonitorInfo;
+  timestamp?: string;
+  ping?: t.TypeOf<typeof OverviewPingCodec>;
+}
+
+export interface AlertOverviewStatus {
+  upConfigs: Record<string, AlertStatusMetaData>;
+  downConfigs: Record<string, AlertStatusMetaData>;
+  pendingConfigs: Record<string, AlertPendingStatusMetaData>;
+  enabledMonitorQueryIds: string[];
+  staleDownConfigs: Record<string, AlertStatusMetaData & StaleAlertMetadata>;
+  stalePendingConfigs: Record<string, AlertPendingStatusMetaData & StaleAlertMetadata>;
+  maxPeriod: number;
+}
+export type StaleDownConfig = AlertStatusMetaData & StaleAlertMetadata;
 export type StatusRuleInspect = AlertOverviewStatus & {
   monitors: Array<{
     id: string;
@@ -86,3 +114,4 @@ export type StatusRuleInspect = AlertOverviewStatus & {
 };
 export type TLSRuleInspect = StatusRuleInspect;
 export type AlertStatusConfigs = Record<string, AlertStatusMetaData>;
+export type AlertPendingStatusConfigs = Record<string, AlertPendingStatusMetaData>;

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/default_status_alert.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/default_status_alert.journey.ts
@@ -111,7 +111,7 @@ journey(`DefaultStatusAlert`, async ({ page, params }) => {
     const reasonMessage = getReasonMessage({
       name: 'Test Monitor',
       location: 'North America - US Central',
-      status: 'down',
+      reason: 'down',
       checks: {
         downWithinXChecks: 1,
         down: 1,
@@ -176,7 +176,7 @@ journey(`DefaultStatusAlert`, async ({ page, params }) => {
     const reasonMessage = getReasonMessage({
       name,
       location: 'North America - US Central',
-      status: 'down',
+      reason: 'down',
       checks: {
         downWithinXChecks: 1,
         down: 1,

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.test.ts
@@ -291,6 +291,7 @@ describe('setRecoveredAlertsContext', () => {
       dateFormat,
       tz: 'UTC',
       groupByLocation: true,
+      stalePendingConfigs: {},
     });
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       id: idWithLocation,
@@ -380,6 +381,7 @@ describe('setRecoveredAlertsContext', () => {
       dateFormat,
       tz: 'UTC',
       groupByLocation: true,
+      stalePendingConfigs: {},
     });
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       id: idWithLocation,
@@ -464,6 +466,7 @@ describe('setRecoveredAlertsContext', () => {
       dateFormat,
       tz: 'UTC',
       groupByLocation: true,
+      stalePendingConfigs: {},
     });
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       id: idWithLocation,
@@ -535,6 +538,7 @@ describe('setRecoveredAlertsContext', () => {
       dateFormat,
       tz: 'UTC',
       groupByLocation: true,
+      stalePendingConfigs: {},
     });
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       id: idWithLocation,
@@ -610,6 +614,7 @@ describe('setRecoveredAlertsContext', () => {
       dateFormat,
       tz: 'UTC',
       groupByLocation: true,
+      stalePendingConfigs: {},
     });
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       id: idWithLocation,
@@ -687,6 +692,7 @@ describe('setRecoveredAlertsContext', () => {
       dateFormat,
       tz: 'UTC',
       groupByLocation: false,
+      stalePendingConfigs: {},
     });
     expect(alertsClientMock.setAlertData).toBeCalledWith({
       id: idWithLocation,

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.ts
@@ -142,6 +142,7 @@ export const setRecoveredAlertsContext = ({
   basePath,
   spaceId,
   staleDownConfigs = {},
+  stalePendingConfigs = {},
   upConfigs,
   dateFormat,
   tz,
@@ -158,6 +159,7 @@ export const setRecoveredAlertsContext = ({
   spaceId?: string;
   params?: StatusRuleParams;
   staleDownConfigs: AlertOverviewStatus['staleDownConfigs'];
+  stalePendingConfigs: AlertOverviewStatus['stalePendingConfigs'];
   upConfigs: AlertOverviewStatus['upConfigs'];
   dateFormat: string;
   tz: string;
@@ -212,9 +214,13 @@ export const setRecoveredAlertsContext = ({
       monitorSummary.locationId = formattedLocationIds;
     }
 
-    if (recoveredAlertId && locationIds && staleDownConfigs[recoveredAlertId]) {
+    if (
+      recoveredAlertId &&
+      locationIds &&
+      (staleDownConfigs[recoveredAlertId] || stalePendingConfigs[recoveredAlertId])
+    ) {
       const summary = getDeletedMonitorOrLocationSummary({
-        staleDownConfigs,
+        staleConfigs: staleDownConfigs[recoveredAlertId] ? staleDownConfigs : stalePendingConfigs,
         recoveredAlertId,
         locationIds,
         dateFormat,
@@ -355,7 +361,7 @@ export const getDefaultRecoveredSummary = ({
       ...(hit['error.message'] ? { error: { message: hit['error.message'] } } : {}),
       ...(hit['url.full'] ? { url: { full: hit['url.full'] } } : {}),
     } as unknown as OverviewPing,
-    statusMessage: RECOVERED_LABEL,
+    reason: 'recovered',
     locationId,
     configId,
     dateFormat,
@@ -365,38 +371,40 @@ export const getDefaultRecoveredSummary = ({
 };
 
 export const getDeletedMonitorOrLocationSummary = ({
-  staleDownConfigs,
+  staleConfigs,
   recoveredAlertId,
   locationIds,
   dateFormat,
   tz,
   params,
 }: {
-  staleDownConfigs: AlertOverviewStatus['staleDownConfigs'];
+  staleConfigs:
+    | AlertOverviewStatus['staleDownConfigs']
+    | AlertOverviewStatus['stalePendingConfigs'];
   recoveredAlertId: string;
   locationIds: string[];
   dateFormat: string;
   tz: string;
   params?: StatusRuleParams;
 }) => {
-  const downConfig = staleDownConfigs[recoveredAlertId];
-  const { ping } = downConfig;
+  const config = staleConfigs[recoveredAlertId];
+  const monitorInfo = 'monitorInfo' in config ? config.monitorInfo : config.ping;
   const monitorSummary = getMonitorSummary({
-    monitorInfo: ping,
-    statusMessage: RECOVERED_LABEL,
+    monitorInfo,
+    reason: 'recovered',
     locationId: locationIds,
-    configId: downConfig.configId,
+    configId: config.configId,
     dateFormat,
     tz,
     params,
   });
   const lastErrorMessage = monitorSummary.lastErrorMessage;
 
-  if (downConfig.isDeleted) {
+  if (config.isDeleted) {
     return {
       lastErrorMessage,
       monitorSummary,
-      stateId: ping.state?.id,
+      stateId: monitorInfo?.state?.id,
       recoveryStatus: i18n.translate('xpack.synthetics.alerts.monitorStatus.deleteMonitor.status', {
         defaultMessage: `has been deleted`,
       }),
@@ -404,11 +412,11 @@ export const getDeletedMonitorOrLocationSummary = ({
         defaultMessage: `has been deleted`,
       }),
     };
-  } else if (downConfig.isLocationRemoved) {
+  } else if (config.isLocationRemoved) {
     return {
       monitorSummary,
       lastErrorMessage,
-      stateId: ping.state?.id,
+      stateId: monitorInfo?.state?.id,
       recoveryStatus: i18n.translate(
         'xpack.synthetics.alerts.monitorStatus.removedLocation.status',
         {
@@ -458,7 +466,7 @@ export const getUpMonitorRecoverySummary = ({
 
   const monitorSummary = getMonitorSummary({
     monitorInfo: ping,
-    statusMessage: RECOVERED_LABEL,
+    reason: 'recovered',
     locationId: locationIds,
     configId,
     dateFormat,
@@ -502,10 +510,6 @@ export const getUpMonitorRecoverySummary = ({
     stateId,
   };
 };
-
-export const RECOVERED_LABEL = i18n.translate('xpack.synthetics.monitorStatus.recoveredLabel', {
-  defaultMessage: 'recovered',
-});
 
 export const formatFilterString = async (
   syntheticsEsClient: SyntheticsEsClient,

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/message_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/message_utils.test.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import {
+  getMonitorSummary,
+  getReasonMessage,
+  getUngroupedReasonMessage,
+  getMonitorAlertDocument,
+} from './message_utils';
+import { MissingPingMonitorInfo } from '../../../common/runtime_types/alert_rules/common';
+import { OverviewPing } from '../../../common/runtime_types';
+
+describe('message_utils', () => {
+  const dateFormat = 'YYYY-MM-DD HH:mm:ss';
+  const tz = 'UTC';
+  const monitorId = 'test-monitor-id';
+  const locationId = 'test-location-id';
+  const monitorName = 'Test Monitor';
+  const locationName = 'Test Location';
+  const timestamp = '2025-05-27T12:00:00.000Z';
+  const monitorUrl = 'https://example.com';
+  const monitorAgentName = 'test-agent';
+
+  describe('getMonitorSummary', () => {
+    it('returns correct summary for a ping monitor', () => {
+      const monitorInfo = {
+        '@timestamp': timestamp,
+        monitor: {
+          id: monitorId,
+          name: monitorName,
+          type: 'http',
+        },
+        observer: {
+          geo: {
+            name: locationName,
+          },
+        },
+        url: {
+          full: monitorUrl,
+        },
+        agent: {
+          name: monitorAgentName,
+        },
+        summary: {
+          up: 1,
+          down: 0,
+        },
+      } as unknown as OverviewPing;
+
+      const result = getMonitorSummary({
+        monitorInfo,
+        locationId: [locationId],
+        configId: monitorId,
+        tz,
+        dateFormat,
+        reason: 'down' as any,
+        params: {
+          condition: {
+            downThreshold: 3,
+            locationsThreshold: 2,
+            window: { time: { unit: 'm', size: 10 } },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        monitorId,
+        monitorName,
+        monitorType: 'HTTP',
+        monitorUrl,
+        configId: monitorId,
+        locationId,
+        locationName,
+        hostName: monitorAgentName,
+        timestamp,
+        checkedAt: moment(timestamp).tz(tz).format(dateFormat),
+        downThreshold: 3,
+        reason:
+          'Monitor "Test Monitor" from Test Location is down. Alert when 3 checks are down within the last 10 minutes from at least 2 locations.',
+        locationNames: locationName,
+        status: 'down',
+        monitorUrlLabel: 'URL',
+      });
+    });
+
+    it('handles missing timestamp for pending monitors', () => {
+      const monitorInfo = {
+        monitor: {
+          id: monitorId,
+          name: monitorName,
+          type: 'http',
+        },
+        observer: {
+          geo: {
+            name: locationName,
+          },
+        },
+        url: {
+          full: monitorUrl,
+        },
+      } as MissingPingMonitorInfo;
+
+      const result = getMonitorSummary({
+        monitorInfo,
+        locationId: [locationId],
+        configId: monitorId,
+        tz,
+        dateFormat,
+        reason: 'pending',
+      });
+
+      expect(result).toEqual({
+        monitorId,
+        monitorName,
+        monitorType: 'HTTP',
+        monitorUrl,
+        configId: monitorId,
+        locationId,
+        locationName,
+        status: 'pending',
+        downThreshold: 1,
+        locationNames: locationName,
+        monitorUrlLabel: 'URL',
+        reason: 'Monitor "Test Monitor" from Test Location is pending.',
+      });
+    });
+  });
+
+  describe('getReasonMessage', () => {
+    it('returns correct message for down status with latest checks', () => {
+      const message = getReasonMessage({
+        name: monitorName,
+        location: locationName,
+        reason: 'down',
+        checks: {
+          downWithinXChecks: 2,
+          down: 2,
+        },
+        params: {
+          condition: {
+            latestChecks: {
+              count: 3,
+              threshold: 1,
+              locationsThreshold: 1,
+            },
+          },
+        } as any,
+      });
+
+      expect(message).toContain(`Monitor "${monitorName}" from ${locationName} is down`);
+      expect(message).toContain('Monitor is down 2 times within the last 1 checks');
+      expect(message).toContain('Alert when 1 out of the last 1 checks are down');
+    });
+  });
+
+  describe('getUngroupedReasonMessage', () => {
+    const secondLocationId = `${locationId}-2`;
+    const secondLocationName = `${locationName}-2`;
+    it('returns correct message for down status with latest checks', () => {
+      const statusConfigs = [
+        {
+          status: 'down',
+          configId: monitorId,
+          monitorQueryId: monitorId,
+          locationId,
+          ping: {
+            observer: {
+              geo: {
+                name: locationName,
+              },
+            },
+          },
+          checks: {
+            downWithinXChecks: 2,
+            down: 2,
+          },
+        },
+        {
+          status: 'down',
+          configId: monitorId,
+          monitorQueryId: monitorId,
+          locationId: secondLocationId,
+          ping: {
+            observer: {
+              geo: {
+                name: secondLocationName,
+              },
+            },
+          },
+          checks: {
+            downWithinXChecks: 1,
+            down: 1,
+          },
+        },
+      ] as any;
+
+      const message = getUngroupedReasonMessage({
+        statusConfigs,
+        monitorName,
+        reason: 'down',
+        params: {
+          condition: {
+            latestChecks: {
+              count: 3,
+              threshold: 1,
+              locationsThreshold: 1,
+            },
+          },
+        } as any,
+      });
+
+      expect(message).toContain(`Monitor "${monitorName}" is down`);
+      expect(message).toContain(`2 times from ${locationName}`);
+      expect(message).toContain(`1 time from ${secondLocationName}`);
+    });
+  });
+
+  describe('getMonitorAlertDocument', () => {
+    const monitorTags = ['tag1', 'tag2'];
+    it('correctly formats the alert document', () => {
+      const monitorSummary = {
+        monitorId,
+        monitorName,
+        monitorType: 'http',
+        monitorUrl,
+        configId: monitorId,
+        locationId,
+        locationName,
+        hostName: monitorAgentName,
+        status: 'down',
+        reason: 'Monitor is down',
+        checks: {
+          downWithinXChecks: 2,
+          down: 2,
+        },
+        monitorTags,
+      } as any;
+
+      const result = getMonitorAlertDocument(
+        monitorSummary,
+        [locationName],
+        [monitorSummary.locationId],
+        true,
+        1
+      );
+
+      expect(result).toEqual({
+        'monitor.id': monitorId,
+        'monitor.type': 'http',
+        'monitor.name': monitorName,
+        'url.full': monitorUrl,
+        'observer.geo.name': [locationName],
+        'observer.name': [monitorSummary.locationId],
+        'agent.name': monitorAgentName,
+        'kibana.alert.reason': 'Monitor is down',
+        'location.id': [monitorSummary.locationId],
+        'location.name': [locationName],
+        configId: monitorId,
+        'kibana.alert.evaluation.threshold': 1,
+        'kibana.alert.evaluation.value': 2,
+        'monitor.tags': monitorTags,
+      });
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/get_search_ping_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/get_search_ping_params.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  AggregationsTopHitsAggregation,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+import { createEsParams } from '../../../lib';
+import {
+  FINAL_SUMMARY_FILTER,
+  SUMMARY_FILTER,
+  getRangeFilter,
+} from '../../../../common/constants/client_defaults';
+
+export const getSearchPingsParams = ({
+  idsToQuery,
+  idSize,
+  monitorLocationIds,
+  range,
+  numberOfChecks,
+  includeRetests,
+}: {
+  idsToQuery: string[];
+  idSize: number;
+  monitorLocationIds: string[];
+  range: { from: string; to: string };
+  numberOfChecks: number;
+  includeRetests: boolean;
+}) => {
+  // Filters for pings
+  const queryFilters: QueryDslQueryContainer[] = [
+    ...(includeRetests ? [SUMMARY_FILTER] : [FINAL_SUMMARY_FILTER]),
+    getRangeFilter({ from: range.from, to: range.to }),
+    {
+      terms: {
+        'monitor.id': idsToQuery,
+      },
+    },
+  ];
+
+  // For each ping we want to get the monitor id as an aggregation and the location as a sub-aggregation
+  // The location aggregation will have a filter for down checks and a top hits aggregation to get the latest ping
+
+  // Total checks per location per monitor
+  const totalChecks: AggregationsTopHitsAggregation = {
+    size: numberOfChecks,
+    sort: [
+      {
+        '@timestamp': {
+          order: 'desc',
+        },
+      },
+    ],
+    _source: {
+      includes: [
+        '@timestamp',
+        'summary',
+        'monitor',
+        'observer',
+        'config_id',
+        'error',
+        'agent',
+        'url',
+        'state',
+        'tags',
+        'service',
+        'labels',
+      ],
+    },
+  };
+
+  // Down checks per location per monitor
+  const downChecks: QueryDslQueryContainer = {
+    range: {
+      'summary.down': {
+        gte: '1',
+      },
+    },
+  };
+
+  const locationAggs = {
+    downChecks: {
+      filter: downChecks,
+    },
+    totalChecks: {
+      top_hits: totalChecks,
+    },
+  };
+
+  const idAggs = {
+    location: {
+      terms: {
+        field: 'observer.name',
+        size: monitorLocationIds.length || 100,
+      },
+      aggs: locationAggs,
+    },
+  };
+
+  const pingAggs = {
+    id: {
+      terms: {
+        field: 'monitor.id',
+        size: idSize,
+      },
+      aggs: idAggs,
+    },
+  };
+
+  const params = createEsParams({
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: queryFilters,
+        },
+      },
+      aggs: pingAggs,
+    },
+  });
+
+  if (monitorLocationIds.length > 0) {
+    params.body.query.bool.filter.push({
+      terms: {
+        'observer.name': monitorLocationIds,
+      },
+    });
+  }
+
+  return params;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { calculateIsValidPing } from './helpers';
+
+describe('helpers', () => {
+  describe('calculateIsValidPing', () => {
+    // Store the original Date implementation
+    const originalDate = global.Date;
+
+    // Mock the current time to be fixed for tests
+    const mockCurrentTime = new Date('2025-06-09T10:00:00.000Z').getTime();
+
+    beforeEach(() => {
+      // Mock Date to return fixed time for Date.now() and new Date()
+      global.Date = class extends Date {
+        constructor(...args: Parameters<typeof Date>) {
+          if (args.length === 0) {
+            super(mockCurrentTime);
+          } else {
+            super(...args);
+          }
+        }
+
+        static now() {
+          return mockCurrentTime;
+        }
+      } as any;
+    });
+
+    afterEach(() => {
+      // Restore original Date implementation
+      global.Date = originalDate;
+    });
+
+    it('should return true when ping is within schedule + buffer time', () => {
+      // Ping was 2 minutes ago, schedule is 5 minutes, buffer is 1 minute (default)
+      // Total allowed time: 5 + 1 = 6 minutes
+      // 2 minutes < 6 minutes, so ping is valid
+      const twoMinutesAgo = new Date(mockCurrentTime - 2 * 60 * 1000).toISOString();
+
+      const result = calculateIsValidPing({
+        previousRunEndTimeISO: twoMinutesAgo,
+        scheduleInMs: 5 * 60 * 1000, // 5 minutes
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when ping is older than schedule + buffer time', () => {
+      // Ping was 7 minutes ago, schedule is 5 minutes, buffer is 1 minute (default)
+      // Total allowed time: 5 + 1 = 6 minutes
+      // 7 minutes > 6 minutes, so ping is invalid/stale
+      const sevenMinutesAgo = new Date(mockCurrentTime - 7 * 60 * 1000).toISOString();
+
+      const result = calculateIsValidPing({
+        previousRunEndTimeISO: sevenMinutesAgo,
+        scheduleInMs: 5 * 60 * 1000, // 5 minutes
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should respect custom buffer time', () => {
+      // Ping was 7 minutes ago, schedule is 5 minutes, custom buffer is 3 minutes
+      // Total allowed time: 5 + 3 = 8 minutes
+      // 7 minutes < 8 minutes, so ping is valid
+      const sevenMinutesAgo = new Date(mockCurrentTime - 7 * 60 * 1000).toISOString();
+
+      const result = calculateIsValidPing({
+        previousRunEndTimeISO: sevenMinutesAgo,
+        scheduleInMs: 5 * 60 * 1000, // 5 minutes
+        minimumTotalBufferMs: 3 * 60 * 1000, // 3 minutes
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should handle very long previousRunDurationUs', () => {
+      // Ping was 10 minutes ago, schedule is 5 minutes
+      // Previous run duration is 6 minutes (360,000,000 microseconds)
+      // Total allowed time: 5 + 6 = 11 minutes
+      // 10 minutes < 11 minutes, so ping is valid
+      const tenMinutesAgo = new Date(mockCurrentTime - 10 * 60 * 1000).toISOString();
+
+      const result = calculateIsValidPing({
+        previousRunEndTimeISO: tenMinutesAgo,
+        scheduleInMs: 5 * 60 * 1000, // 5 minutes
+        previousRunDurationUs: 6 * 60 * 1000 * 1000, // 6 minutes in microseconds
+      });
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import { SavedObjectsFindResult } from '@kbn/core/server';
+import { Logger } from '@kbn/core/server';
+import { MonitorData } from '../../../saved_objects/synthetics_monitor/get_all_monitors';
+import {
+  AlertStatusConfigs,
+  AlertPendingStatusConfigs,
+  MissingPingMonitorInfo,
+} from '../../../../common/runtime_types/alert_rules/common';
+import { EncryptedSyntheticsMonitorAttributes } from '../../../../common/runtime_types';
+
+export interface ConfigStats {
+  up: number;
+  down: number;
+  pending: number;
+}
+
+export const getMissingPingMonitorInfo = ({
+  monitors,
+  configId,
+  locationId,
+}: {
+  monitors: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>>;
+  configId: string;
+  locationId: string;
+}): (MissingPingMonitorInfo & { createdAt?: string }) | undefined => {
+  const monitor = monitors.find((m) => m.id === configId);
+  if (!monitor) {
+    // This should never happen
+    return;
+  }
+
+  // For some reason 'urls' is not considered a valid attribute in the monitor attributes, there's probably a problem with the EncryptedSyntheticsMonitorAttributes type
+  const fullUrl =
+    'urls' in monitor.attributes && typeof monitor.attributes.urls === 'string'
+      ? monitor.attributes.urls
+      : '';
+
+  return {
+    monitor: {
+      name: monitor.attributes.name,
+      id: configId,
+      type: monitor.attributes.type,
+    },
+    observer: {
+      geo: {
+        name: monitor.attributes.locations.find((l) => l.id === locationId)?.label || '',
+      },
+    },
+    labels: monitor.attributes.labels,
+    tags: monitor.attributes.tags,
+    url: { full: fullUrl },
+    createdAt: monitor.created_at,
+  };
+};
+
+const isMonitorReadyForData = ({
+  createdAt,
+  monitorType,
+}: {
+  createdAt?: string;
+  monitorType: string;
+}) => {
+  const waitMinutesBeforePending = monitorType === 'browser' ? 5 : 1;
+  return (
+    !createdAt ||
+    (createdAt &&
+      moment(createdAt).isBefore(moment().subtract(waitMinutesBeforePending, 'minutes')))
+  );
+};
+
+export const getPendingConfigs = ({
+  monitorQueryIds,
+  monitorLocationIds,
+  upConfigs,
+  downConfigs,
+  monitorsData,
+  monitors,
+  logger,
+}: {
+  monitorQueryIds: string[];
+  monitorLocationIds: string[];
+  upConfigs: AlertStatusConfigs;
+  downConfigs: AlertStatusConfigs;
+  monitorsData: Record<string, MonitorData>;
+  monitors: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>>;
+  logger: Logger;
+}) => {
+  // Check if a config is missing, if it is it means that the monitor is pending
+  const pendingConfigs: AlertPendingStatusConfigs = {};
+
+  for (const monitorQueryId of monitorQueryIds) {
+    for (const locationId of monitorLocationIds) {
+      const configWithLocationId = `${monitorQueryId}-${locationId}`;
+
+      const isConfigMissing =
+        !upConfigs[configWithLocationId] &&
+        !downConfigs[configWithLocationId] &&
+        monitorsData[monitorQueryId].locations.includes(locationId);
+
+      if (isConfigMissing) {
+        const res = getMissingPingMonitorInfo({
+          configId: monitorQueryId,
+          locationId,
+          monitors,
+        });
+        if (res) {
+          const { createdAt, ...monitorInfo } = res;
+          if (
+            isMonitorReadyForData({ monitorType: monitorsData[monitorQueryId].type, createdAt })
+          ) {
+            pendingConfigs[configWithLocationId] = {
+              status: 'pending',
+              configId: monitorQueryId,
+              monitorQueryId,
+              locationId,
+              monitorInfo,
+            };
+          }
+        } else {
+          logger.error(
+            `Config ${configWithLocationId} not added to pending configs because the monitor info is missing`
+          );
+        }
+      }
+    }
+  }
+
+  return pendingConfigs;
+};
+
+export const getConfigStats = ({
+  monitorQueryIds,
+  upConfigs,
+  downConfigs,
+  pendingConfigs,
+}: {
+  monitorQueryIds: string[];
+  upConfigs: AlertStatusConfigs;
+  downConfigs: AlertStatusConfigs;
+  pendingConfigs: AlertPendingStatusConfigs;
+}) => {
+  // Pre-organize configs by monitorId for faster lookup
+  const configsByMonitor = new Map<string, ConfigStats>();
+
+  // Initialize all monitors with zero counts
+  for (const monitorId of monitorQueryIds) {
+    configsByMonitor.set(monitorId, { up: 0, down: 0, pending: 0 });
+  }
+
+  // Count up configs
+  for (const configKey of Object.keys(upConfigs)) {
+    const monitorId = upConfigs[configKey].monitorQueryId;
+    const stats = configsByMonitor.get(monitorId);
+    if (stats) stats.up++;
+  }
+
+  // Count down configs
+  for (const configKey of Object.keys(downConfigs)) {
+    const monitorId = downConfigs[configKey].monitorQueryId;
+    const stats = configsByMonitor.get(monitorId);
+    if (stats) stats.down++;
+  }
+
+  // Count pending configs
+  for (const configKey of Object.keys(pendingConfigs)) {
+    const monitorId = pendingConfigs[configKey].monitorQueryId;
+    const stats = configsByMonitor.get(monitorId);
+    if (stats) stats.pending++;
+  }
+
+  // Convert Map to the expected Record structure
+  return Object.fromEntries(configsByMonitor.entries());
+};
+
+export const calculateIsValidPing = ({
+  previousRunEndTimeISO,
+  scheduleInMs,
+  previousRunDurationUs = 0,
+  minimumTotalBufferMs = 60 * 1000, // 60 seconds
+}: {
+  previousRunEndTimeISO: string;
+  scheduleInMs: number;
+  previousRunDurationUs?: number;
+  minimumTotalBufferMs?: number;
+}) => {
+  const msSincePreviousRunEnd = new Date().getTime() - new Date(previousRunEndTimeISO).getTime();
+  const stalenessThresholdMs =
+    scheduleInMs + Math.max(minimumTotalBufferMs, previousRunDurationUs / 1000);
+
+  // Example: if a monitor has a schedule of 5m the last valid ping can be at (5+1)m
+  // If it's greater than that it means the monitor is pending
+  return msSincePreviousRunEnd < stalenessThresholdMs;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/query_monitor_status_alert.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/query_monitor_status_alert.test.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsFindResult } from '@kbn/core/server';
+import { Logger } from '@kbn/core/server';
+import { queryMonitorStatusAlert } from './query_monitor_status_alert';
+import { EncryptedSyntheticsMonitorAttributes } from '../../../../common/runtime_types';
+import { SyntheticsEsClient } from '../../../lib';
+
+// Mock the logger
+const createLoggerMock = () => {
+  return {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as Logger;
+};
+
+// Mock the ES client
+const createEsClientMock = () => {
+  return {
+    search: jest.fn(),
+  } as unknown as SyntheticsEsClient;
+};
+
+describe('queryMonitorStatusAlert', () => {
+  const esClient = createEsClientMock();
+  const logger = createLoggerMock();
+
+  // Mock Date to return a fixed timestamp for 2025-05-27T14:25:00Z
+  const fixedDateString = '2025-05-27T14:25:00Z';
+  let originalDate: DateConstructor;
+
+  beforeEach(() => {
+    originalDate = global.Date;
+    // @ts-ignore - We need to mock the Date constructor
+    global.Date = class extends originalDate {
+      constructor(date?: string | number | Date) {
+        if (date !== undefined) {
+          // If a date is provided, use the original Date behavior
+          super(date);
+        } else {
+          // If no date is provided, return our fixed date
+          super(fixedDateString);
+        }
+      }
+    } as DateConstructor;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.Date = originalDate;
+  });
+
+  it('returns empty configs when no monitors are found', async () => {
+    // Mock ES client to return empty results
+    esClient.search = jest.fn().mockResolvedValue({
+      body: {
+        aggregations: {
+          id: {
+            buckets: [],
+          },
+        },
+      },
+    });
+
+    const result = await queryMonitorStatusAlert({
+      esClient,
+      monitorLocationIds: ['location1'],
+      range: { from: '2025-05-27T13:30:00Z', to: '2025-05-27T14:30:00Z' },
+      monitorQueryIds: ['monitor1'],
+      numberOfChecks: 3,
+      monitorsData: {
+        monitor1: { scheduleInMs: 60000, locations: ['location1'], type: 'http' },
+      },
+      monitors: [],
+      logger,
+    });
+
+    expect(result).toEqual({
+      upConfigs: {},
+      downConfigs: {},
+      pendingConfigs: {},
+      enabledMonitorQueryIds: ['monitor1'],
+      configStats: {
+        monitor1: { up: 0, down: 0, pending: 0 },
+      },
+    });
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      {
+        body: {
+          size: 0,
+          query: {
+            bool: {
+              filter: [
+                {
+                  exists: {
+                    field: 'summary',
+                  },
+                },
+                {
+                  range: {
+                    '@timestamp': { gte: expect.any(String), lte: expect.any(String) },
+                  },
+                },
+                {
+                  terms: {
+                    'monitor.id': ['monitor1'],
+                  },
+                },
+                {
+                  terms: {
+                    'observer.name': ['location1'],
+                  },
+                },
+              ],
+            },
+          },
+          aggs: {
+            id: {
+              terms: {
+                field: 'monitor.id',
+                size: 10000,
+              },
+              aggs: {
+                location: {
+                  terms: {
+                    field: 'observer.name',
+                    size: 1,
+                  },
+                  aggs: {
+                    downChecks: {
+                      filter: {
+                        range: {
+                          'summary.down': {
+                            gte: '1',
+                          },
+                        },
+                      },
+                    },
+                    totalChecks: {
+                      top_hits: {
+                        size: 3,
+                        sort: [
+                          {
+                            '@timestamp': {
+                              order: 'desc',
+                            },
+                          },
+                        ],
+                        _source: {
+                          includes: [
+                            '@timestamp',
+                            'summary',
+                            'monitor',
+                            'observer',
+                            'config_id',
+                            'error',
+                            'agent',
+                            'url',
+                            'state',
+                            'tags',
+                            'service',
+                            'labels',
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      'Monitors status rule query'
+    );
+  });
+
+  it('classifies monitors as up, down, or pending based on ping data', async () => {
+    // Mock ES client to return ping data
+    esClient.search = jest.fn().mockResolvedValue({
+      body: {
+        aggregations: {
+          id: {
+            buckets: [
+              {
+                key: 'monitor1',
+                location: {
+                  buckets: [
+                    {
+                      key: 'location1',
+                      totalChecks: {
+                        hits: {
+                          hits: [
+                            {
+                              _source: {
+                                '@timestamp': '2025-05-27T14:25:00Z',
+                                config_id: 'monitor1',
+                                monitor: { id: 'monitor1' },
+                                summary: { up: 1, down: 0 },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      downChecks: { doc_count: 0 },
+                    },
+                    {
+                      key: 'location2',
+                      totalChecks: {
+                        hits: {
+                          hits: [
+                            {
+                              _source: {
+                                '@timestamp': '2025-05-27T14:25:00Z',
+                                config_id: 'monitor1',
+                                monitor: { id: 'monitor1' },
+                                summary: { up: 0, down: 1 },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      downChecks: { doc_count: 1 },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    // Create monitor data
+    const monitors: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>> = [
+      {
+        id: 'monitor1',
+        type: 'synthetics-monitor',
+        attributes: {
+          name: 'Monitor 1',
+          type: 'http',
+          locations: [
+            { id: 'location1', label: 'Location 1' },
+            { id: 'location2', label: 'Location 2' },
+            { id: 'location3', label: 'Location 3' }, // This will be pending
+          ],
+        } as unknown as EncryptedSyntheticsMonitorAttributes,
+        references: [],
+        created_at: '2025-05-27T12:00:00.000Z',
+        updated_at: '2025-05-27T12:00:00.000Z',
+        version: '1',
+        score: 1,
+      },
+    ];
+
+    const result = await queryMonitorStatusAlert({
+      esClient,
+      monitorLocationIds: ['location1', 'location2', 'location3'],
+      range: { from: '2025-05-27T13:30:00Z', to: '2025-05-27T14:30:00Z' },
+      monitorQueryIds: ['monitor1'],
+      numberOfChecks: 3,
+      monitorsData: {
+        monitor1: {
+          scheduleInMs: 300000,
+          locations: ['location1', 'location2', 'location3'],
+          type: 'http',
+        },
+      },
+      monitors,
+      logger,
+    });
+
+    // Verify up configs
+    expect(Object.keys(result.upConfigs)).toContain('monitor1-location1');
+    expect(result.upConfigs['monitor1-location1'].status).toBe('up');
+
+    // Verify down configs
+    expect(Object.keys(result.downConfigs)).toContain('monitor1-location2');
+    expect(result.downConfigs['monitor1-location2'].status).toBe('down');
+
+    // Verify pending configs (location3 should be pending since it has no ping data)
+    expect(Object.keys(result.pendingConfigs)).toContain('monitor1-location3');
+    expect(result.pendingConfigs['monitor1-location3'].status).toBe('pending');
+
+    // Verify config stats
+    expect(result.configStats.monitor1).toEqual({
+      up: 1,
+      down: 1,
+      pending: 1,
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/query_monitor_status_alert.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/query_monitor_status_alert.ts
@@ -6,40 +6,32 @@
  */
 
 import pMap from 'p-map';
-import times from 'lodash/times';
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { times } from 'lodash';
 import { intersection } from 'lodash';
-import { AlertStatusMetaData } from '../../../../common/runtime_types/alert_rules/common';
+import { SavedObjectsFindResult } from '@kbn/core/server';
+import { Logger } from '@kbn/core/server';
+import { MonitorData } from '../../../saved_objects/synthetics_monitor/get_all_monitors';
 import {
-  FINAL_SUMMARY_FILTER,
-  getRangeFilter,
-  SUMMARY_FILTER,
-} from '../../../../common/constants/client_defaults';
-import { OverviewPing } from '../../../../common/runtime_types';
-import { createEsParams, SyntheticsEsClient } from '../../../lib';
+  AlertStatusConfigs,
+  AlertStatusMetaData,
+  AlertPendingStatusConfigs,
+} from '../../../../common/runtime_types/alert_rules/common';
+import {
+  EncryptedSyntheticsMonitorAttributes,
+  OverviewPing,
+} from '../../../../common/runtime_types';
+import { SyntheticsEsClient } from '../../../lib';
+import { getSearchPingsParams } from './get_search_ping_params';
+import { ConfigStats, calculateIsValidPing, getConfigStats, getPendingConfigs } from './helpers';
 
 const DEFAULT_MAX_ES_BUCKET_SIZE = 10000;
 
-const fields = [
-  '@timestamp',
-  'summary',
-  'monitor',
-  'observer',
-  'config_id',
-  'error',
-  'agent',
-  'url',
-  'state',
-  'tags',
-  'service',
-  'labels',
-];
-type StatusConfigs = Record<string, AlertStatusMetaData>;
-
 export interface AlertStatusResponse {
-  upConfigs: StatusConfigs;
-  downConfigs: StatusConfigs;
+  upConfigs: AlertStatusConfigs;
+  downConfigs: AlertStatusConfigs;
+  pendingConfigs: AlertPendingStatusConfigs;
   enabledMonitorQueryIds: string[];
+  configStats: Record<string, ConfigStats>;
 }
 
 export async function queryMonitorStatusAlert({
@@ -47,95 +39,50 @@ export async function queryMonitorStatusAlert({
   monitorLocationIds,
   range,
   monitorQueryIds,
-  monitorLocationsMap,
   numberOfChecks,
   includeRetests = true,
+  monitorsData,
+  monitors,
+  logger,
 }: {
   esClient: SyntheticsEsClient;
   monitorLocationIds: string[];
   range: { from: string; to: string };
   monitorQueryIds: string[];
-  monitorLocationsMap: Record<string, string[]>;
   numberOfChecks: number;
   includeRetests?: boolean;
+  monitorsData: Record<string, MonitorData>;
+  monitors: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>>;
+  logger: Logger;
 }): Promise<AlertStatusResponse> {
   const idSize = Math.trunc(DEFAULT_MAX_ES_BUCKET_SIZE / monitorLocationIds.length || 1);
   const pageCount = Math.ceil(monitorQueryIds.length / idSize);
-  const upConfigs: StatusConfigs = {};
-  const downConfigs: StatusConfigs = {};
+  const upConfigs: AlertStatusConfigs = {};
+  const downConfigs: AlertStatusConfigs = {};
+
+  for (let i = monitorQueryIds.length - 1; i >= 0; i--) {
+    const monitorQueryId = monitorQueryIds[i];
+    if (monitorsData[monitorQueryId] === undefined) {
+      logger.error(
+        `Monitor ${monitorQueryId} not found in monitorsData, removing from query. This should never happen.`
+      );
+      monitorQueryIds.splice(i, 1);
+    }
+  }
 
   await pMap(
     times(pageCount),
     async (i) => {
       const idsToQuery = (monitorQueryIds as string[]).slice(i * idSize, i * idSize + idSize);
-      const params = createEsParams({
-        body: {
-          size: 0,
-          query: {
-            bool: {
-              filter: [
-                ...(includeRetests ? [SUMMARY_FILTER] : [FINAL_SUMMARY_FILTER]),
-                getRangeFilter({ from: range.from, to: range.to }),
-                {
-                  terms: {
-                    'monitor.id': idsToQuery,
-                  },
-                },
-              ] as QueryDslQueryContainer[],
-            },
-          },
-          aggs: {
-            id: {
-              terms: {
-                field: 'monitor.id',
-                size: idSize,
-              },
-              aggs: {
-                location: {
-                  terms: {
-                    field: 'observer.name',
-                    size: monitorLocationIds.length || 100,
-                  },
-                  aggs: {
-                    downChecks: {
-                      filter: {
-                        range: {
-                          'summary.down': {
-                            gte: '1',
-                          },
-                        },
-                      },
-                    },
-                    totalChecks: {
-                      top_hits: {
-                        size: numberOfChecks,
-                        sort: [
-                          {
-                            '@timestamp': {
-                              order: 'desc',
-                            },
-                          },
-                        ],
-                        _source: {
-                          includes: fields,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      });
 
-      if (monitorLocationIds.length > 0) {
-        params.body.query.bool.filter.push({
-          terms: {
-            'observer.name': monitorLocationIds,
-          },
-        });
-      }
+      const params = getSearchPingsParams({
+        idSize,
+        idsToQuery,
+        monitorLocationIds,
+        range,
+        numberOfChecks,
+        includeRetests,
+      });
 
       const { body: result } = await esClient.search<OverviewPing, typeof params>(
         params,
@@ -151,7 +98,7 @@ export async function queryMonitorStatusAlert({
 
         // discard any locations that are not in the monitorLocationsMap for the given monitor as well as those which are
         // in monitorLocationsMap but not in listOfLocations
-        const monLocations = monitorLocationsMap?.[queryId];
+        const monLocations = monitorsData[queryId].locations;
         const monQueriedLocations = intersection(monLocations, monitorLocationIds);
         monQueriedLocations?.forEach((monLocationId) => {
           const locationSummary = locationSummaries.find(
@@ -165,6 +112,12 @@ export async function queryMonitorStatusAlert({
             const isLatestPingUp = (latestPing.summary?.up ?? 0) > 0;
             const configId = latestPing.config_id;
             const monitorQueryId = latestPing.monitor.id;
+
+            const isValidPing = calculateIsValidPing({
+              scheduleInMs: monitorsData[monitorQueryId].scheduleInMs,
+              previousRunEndTimeISO: latestPing['@timestamp'],
+              previousRunDurationUs: latestPing.monitor.duration?.us,
+            });
 
             const meta: AlertStatusMetaData = {
               ping: latestPing,
@@ -182,13 +135,13 @@ export async function queryMonitorStatusAlert({
               status: 'up',
             };
 
-            if (downCount > 0) {
+            if (isValidPing && downCount > 0) {
               downConfigs[`${configId}-${monLocationId}`] = {
                 ...meta,
                 status: 'down',
               };
             }
-            if (isLatestPingUp) {
+            if (isValidPing && isLatestPingUp) {
               upConfigs[`${configId}-${monLocationId}`] = {
                 ...meta,
                 status: 'up',
@@ -201,9 +154,23 @@ export async function queryMonitorStatusAlert({
     { concurrency: 5 }
   );
 
+  const pendingConfigs = getPendingConfigs({
+    monitorQueryIds,
+    monitorLocationIds,
+    upConfigs,
+    downConfigs,
+    monitorsData,
+    monitors,
+    logger,
+  });
+
+  const configStats = getConfigStats({ downConfigs, upConfigs, pendingConfigs, monitorQueryIds });
+
   return {
     upConfigs,
     downConfigs,
+    pendingConfigs,
     enabledMonitorQueryIds: monitorQueryIds,
+    configStats,
   };
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.test.ts
@@ -15,7 +15,10 @@ import { SyntheticsService } from '../../synthetics_service/synthetics_service';
 import * as locationsUtils from '../../synthetics_service/get_all_locations';
 import type { PublicLocation } from '../../../common/runtime_types';
 import { SyntheticsServerSetup } from '../../types';
-import { AlertStatusMetaData } from '../../../common/runtime_types/alert_rules/common';
+import {
+  AlertStatusMetaData,
+  AlertPendingStatusMetaData,
+} from '../../../common/runtime_types/alert_rules/common';
 import { SyntheticsEsClient } from '../../lib';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../common/constants';
 
@@ -87,7 +90,7 @@ describe('StatusRuleExecutor', () => {
     it('should only query enabled monitors', async () => {
       const spy = jest.spyOn(configRepo, 'getAll').mockResolvedValue([]);
 
-      const { downConfigs, staleDownConfigs } = await statusRule.getDownChecks({});
+      const { downConfigs, staleDownConfigs } = await statusRule.getConfigs({});
 
       expect(downConfigs).toEqual({});
       expect(staleDownConfigs).toEqual({});
@@ -106,6 +109,8 @@ describe('StatusRuleExecutor', () => {
           upConfigs: {},
           downConfigs: {},
           enabledMonitorQueryIds: [],
+          pendingConfigs: {},
+          configStats: {},
         });
 
       // Create a new instance with empty locations array
@@ -134,7 +139,7 @@ describe('StatusRuleExecutor', () => {
         .mockResolvedValue(testMonitors);
 
       // Execute
-      await statusRuleWithEmptyLocations.getDownChecks({});
+      await statusRuleWithEmptyLocations.getConfigs({});
 
       // Verify that queryMonitorStatusAlert was called passing the monitor location
       expect(spy).toHaveBeenCalledWith(
@@ -147,7 +152,7 @@ describe('StatusRuleExecutor', () => {
     it('marks deleted configs as expected', async () => {
       jest.spyOn(configRepo, 'getAll').mockResolvedValue(testMonitors);
 
-      const { downConfigs } = await statusRule.getDownChecks({});
+      const { downConfigs } = await statusRule.getConfigs({});
 
       expect(downConfigs).toEqual({});
 
@@ -237,7 +242,7 @@ describe('StatusRuleExecutor', () => {
         },
       ]);
 
-      const { downConfigs } = await statusRule.getDownChecks({});
+      const { downConfigs } = await statusRule.getConfigs({});
 
       expect(downConfigs).toEqual({});
 
@@ -570,6 +575,336 @@ describe('StatusRuleExecutor', () => {
         },
       });
       expect(spy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('handlePendingMonitorAlert', () => {
+    let schedulePendingAlertPerConfigIdSpy: jest.SpyInstance;
+    let schedulePendingAlertPerConfigIdPerLocationSpy: jest.SpyInstance;
+
+    const MOCK_FIRST_MONITOR = {
+      id: 'monitor-1',
+      name: 'Monitor 1',
+      type: 'browser',
+      url: 'http://monitor.1.com',
+    };
+    const MOCK_SECOND_MONITOR = {
+      id: 'monitor-2',
+      name: 'Monitor 2',
+      type: 'http',
+      url: 'http://monitor.2.com',
+    };
+    const MOCK_FIRST_LOCATION = { id: 'location-1', name: 'Test Location 1' };
+    const MOCK_SECOND_LOCATION = { id: 'location-2', name: 'Test Location 2' };
+    const FIRST_CONFIG_ID = `${MOCK_FIRST_MONITOR.id}${MOCK_FIRST_LOCATION.id}`;
+    const SECOND_CONFIG_ID = `${MOCK_SECOND_MONITOR.id}${MOCK_SECOND_LOCATION.id}`;
+
+    const mockPendingConfigs: Record<string, AlertPendingStatusMetaData> = {
+      [FIRST_CONFIG_ID]: {
+        configId: MOCK_FIRST_MONITOR.id,
+        locationId: MOCK_FIRST_LOCATION.id,
+        status: 'pending',
+        timestamp: '2025-05-15T10:00:00.000Z',
+        monitorQueryId: MOCK_FIRST_MONITOR.id,
+        ping: {
+          '@timestamp': '2025-05-15T10:00:00.000Z',
+          monitor: MOCK_FIRST_MONITOR,
+          url: { full: MOCK_FIRST_MONITOR.url },
+          observer: {
+            geo: { name: MOCK_FIRST_LOCATION.name },
+          },
+        } as any,
+        monitorInfo: {
+          monitor: MOCK_FIRST_MONITOR,
+          observer: { geo: { name: MOCK_FIRST_LOCATION.name } },
+          tags: ['test', 'monitor1'],
+          url: { full: MOCK_FIRST_MONITOR.url },
+        },
+      },
+      [SECOND_CONFIG_ID]: {
+        configId: MOCK_SECOND_MONITOR.id,
+        locationId: MOCK_SECOND_LOCATION.id,
+        status: 'pending',
+        timestamp: '2025-05-15T10:00:00.000Z',
+        monitorQueryId: MOCK_SECOND_MONITOR.id,
+        ping: {
+          '@timestamp': '2025-05-15T10:00:00.000Z',
+          monitor: MOCK_SECOND_MONITOR,
+          url: { full: MOCK_SECOND_MONITOR.url },
+          observer: {
+            geo: { name: MOCK_SECOND_LOCATION.name },
+          },
+        } as any,
+        monitorInfo: {
+          monitor: MOCK_SECOND_MONITOR,
+          observer: { geo: { name: MOCK_SECOND_LOCATION.name } },
+          tags: ['test', 'monitor2'],
+          url: { full: MOCK_SECOND_MONITOR.url },
+        },
+      },
+    };
+
+    beforeEach(() => {
+      schedulePendingAlertPerConfigIdSpy = jest.spyOn(
+        statusRule,
+        'schedulePendingAlertPerConfigId'
+      );
+      schedulePendingAlertPerConfigIdPerLocationSpy = jest.spyOn(
+        statusRule,
+        'schedulePendingAlertPerConfigIdPerLocation'
+      );
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call schedulePendingAlertPerConfigId when alertOnNoData is true and groupBy is not locationId', () => {
+      // Set up params with alertOnNoData=true and groupBy='monitor'
+      statusRule.params = {
+        condition: {
+          alertOnNoData: true,
+          groupBy: 'monitor',
+        } as any,
+      };
+
+      // Call the method
+      statusRule.handlePendingMonitorAlert({ pendingConfigs: mockPendingConfigs });
+
+      // Verify schedulePendingAlertPerConfigId was called with the correct arguments
+      expect(schedulePendingAlertPerConfigIdSpy).toHaveBeenCalledTimes(1);
+      expect(schedulePendingAlertPerConfigIdSpy).toHaveBeenCalledWith({
+        pendingConfigs: mockPendingConfigs,
+      });
+
+      // Verify schedulePendingAlertPerConfigIdPerLocation was not called
+      expect(schedulePendingAlertPerConfigIdPerLocationSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call schedulePendingAlertPerConfigIdPerLocation when alertOnNoData is true and groupBy is locationId', () => {
+      // Set up params with alertOnNoData=true and groupBy='locationId'
+      statusRule.params = {
+        condition: {
+          alertOnNoData: true,
+          groupBy: 'locationId',
+        } as any,
+      };
+
+      // Call the method
+      statusRule.handlePendingMonitorAlert({ pendingConfigs: mockPendingConfigs });
+
+      // Verify schedulePendingAlertPerConfigIdPerLocation was called with the correct arguments
+      expect(schedulePendingAlertPerConfigIdPerLocationSpy).toHaveBeenCalledTimes(1);
+      expect(schedulePendingAlertPerConfigIdPerLocationSpy).toHaveBeenCalledWith({
+        pendingConfigs: mockPendingConfigs,
+      });
+
+      // Verify schedulePendingAlertPerConfigId was not called
+      expect(schedulePendingAlertPerConfigIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call schedulePendingAlertPerConfigIdPerLocation when alertOnNoData is true and groupBy is undefined', () => {
+      // Set up params with alertOnNoData=true and groupBy undefined
+      statusRule.params = {
+        condition: {
+          alertOnNoData: true,
+        } as any,
+      };
+
+      // Call the method
+      statusRule.handlePendingMonitorAlert({ pendingConfigs: mockPendingConfigs });
+
+      // Verify schedulePendingAlertPerConfigIdPerLocation was called with the correct arguments
+      expect(schedulePendingAlertPerConfigIdPerLocationSpy).toHaveBeenCalledTimes(1);
+      expect(schedulePendingAlertPerConfigIdPerLocationSpy).toHaveBeenCalledWith({
+        pendingConfigs: mockPendingConfigs,
+      });
+
+      // Verify schedulePendingAlertPerConfigId was not called
+      expect(schedulePendingAlertPerConfigIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not call any scheduling methods when alertOnNoData is false', () => {
+      // Set up params with alertOnNoData=false
+      statusRule.params = {
+        condition: {
+          alertOnNoData: false,
+          groupBy: 'locationId', // This shouldn't matter since alertOnNoData is false
+        } as any,
+      };
+
+      // Call the method
+      statusRule.handlePendingMonitorAlert({ pendingConfigs: mockPendingConfigs });
+
+      // Verify neither method was called
+      expect(schedulePendingAlertPerConfigIdSpy).not.toHaveBeenCalled();
+      expect(schedulePendingAlertPerConfigIdPerLocationSpy).not.toHaveBeenCalled();
+    });
+
+    describe('schedulePendingAlertPerConfigIdPerLocation', () => {
+      let scheduleAlertSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        // Set up statusRule with necessary parameters for getMonitorPendingSummary
+        statusRule.dateFormat = 'Y-MM-DD HH:mm:ss';
+        statusRule.tz = 'UTC';
+        statusRule.params = {
+          condition: {
+            alertOnNoData: true,
+          } as any,
+        };
+
+        scheduleAlertSpy = jest.spyOn(statusRule, 'scheduleAlert');
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call scheduleAlert for each pending config with correct parameters', () => {
+        // Call the method
+        statusRule.schedulePendingAlertPerConfigIdPerLocation({
+          pendingConfigs: mockPendingConfigs,
+        });
+
+        // Verify scheduleAlert was called with the correct parameters for each config
+        expect(scheduleAlertSpy).toHaveBeenCalledTimes(2);
+
+        expect(scheduleAlertSpy).toHaveBeenNthCalledWith(1, {
+          alertId: FIRST_CONFIG_ID,
+          idWithLocation: FIRST_CONFIG_ID,
+          locationNames: [MOCK_FIRST_LOCATION.name],
+          locationIds: [MOCK_FIRST_LOCATION.id],
+          statusConfig: mockPendingConfigs[FIRST_CONFIG_ID],
+          monitorSummary: {
+            configId: MOCK_FIRST_MONITOR.id,
+            downThreshold: 1,
+            locationId: MOCK_FIRST_LOCATION.id,
+            locationName: MOCK_FIRST_LOCATION.name,
+            locationNames: MOCK_FIRST_LOCATION.name,
+            monitorId: MOCK_FIRST_MONITOR.id,
+            monitorName: MOCK_FIRST_MONITOR.name,
+            monitorTags: ['test', 'monitor1'],
+            monitorType: MOCK_FIRST_MONITOR.type,
+            monitorUrl: MOCK_FIRST_MONITOR.url,
+            monitorUrlLabel: 'URL',
+            reason: `Monitor "${MOCK_FIRST_MONITOR.name}" from ${MOCK_FIRST_LOCATION.name} is pending.`,
+            status: 'pending',
+          },
+        });
+        expect(scheduleAlertSpy).toHaveBeenNthCalledWith(2, {
+          alertId: SECOND_CONFIG_ID,
+          idWithLocation: SECOND_CONFIG_ID,
+          locationNames: [MOCK_SECOND_LOCATION.name],
+          locationIds: [MOCK_SECOND_LOCATION.id],
+          statusConfig: mockPendingConfigs[SECOND_CONFIG_ID],
+          monitorSummary: {
+            configId: MOCK_SECOND_MONITOR.id,
+            downThreshold: 1,
+            locationId: MOCK_SECOND_LOCATION.id,
+            locationName: MOCK_SECOND_LOCATION.name,
+            locationNames: MOCK_SECOND_LOCATION.name,
+            monitorId: MOCK_SECOND_MONITOR.id,
+            monitorName: MOCK_SECOND_MONITOR.name,
+            monitorTags: ['test', 'monitor2'],
+            monitorType: 'HTTP',
+            monitorUrl: MOCK_SECOND_MONITOR.url,
+            monitorUrlLabel: 'URL',
+            reason: `Monitor "${MOCK_SECOND_MONITOR.name}" from ${MOCK_SECOND_LOCATION.name} is pending.`,
+            status: 'pending',
+          },
+        });
+      });
+
+      it('should do nothing if pendingConfigs is empty', () => {
+        // Call the method with empty pendingConfigs
+        statusRule.schedulePendingAlertPerConfigIdPerLocation({ pendingConfigs: {} });
+
+        // Verify scheduleAlert was not called
+        expect(scheduleAlertSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('schedulePendingAlertPerConfigId', () => {
+      let scheduleAlertSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        // Set up statusRule with necessary parameters for getUngroupedPendingSummary
+        statusRule.dateFormat = 'Y-MM-DD HH:mm:ss';
+        statusRule.tz = 'UTC';
+        statusRule.params = {
+          condition: {
+            alertOnNoData: true,
+          } as any,
+        };
+
+        scheduleAlertSpy = jest.spyOn(statusRule, 'scheduleAlert');
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should group configs by configId and call scheduleAlert with combined location information', () => {
+        // Call the method
+        statusRule.schedulePendingAlertPerConfigId({ pendingConfigs: mockPendingConfigs });
+
+        // Verify scheduleAlert was called twice (once for each unique configId)
+        expect(scheduleAlertSpy).toHaveBeenCalledTimes(2);
+
+        expect(scheduleAlertSpy).toHaveBeenNthCalledWith(1, {
+          alertId: MOCK_FIRST_MONITOR.id,
+          idWithLocation: MOCK_FIRST_MONITOR.id,
+          locationNames: [MOCK_FIRST_LOCATION.name],
+          locationIds: [MOCK_FIRST_LOCATION.id],
+          statusConfig: mockPendingConfigs[FIRST_CONFIG_ID],
+          monitorSummary: {
+            configId: MOCK_FIRST_MONITOR.id,
+            downThreshold: 1,
+            locationId: MOCK_FIRST_LOCATION.id,
+            locationName: MOCK_FIRST_LOCATION.name,
+            locationNames: MOCK_FIRST_LOCATION.name,
+            monitorId: MOCK_FIRST_MONITOR.id,
+            monitorName: MOCK_FIRST_MONITOR.name,
+            monitorTags: ['test', 'monitor1'],
+            monitorType: MOCK_FIRST_MONITOR.type,
+            monitorUrl: MOCK_FIRST_MONITOR.url,
+            monitorUrlLabel: 'URL',
+            reason: `Monitor "${MOCK_FIRST_MONITOR.name}" is pending 1 time from ${MOCK_FIRST_LOCATION.name}.`,
+            status: 'pending',
+          },
+        });
+        expect(scheduleAlertSpy).toHaveBeenNthCalledWith(2, {
+          alertId: MOCK_SECOND_MONITOR.id,
+          idWithLocation: MOCK_SECOND_MONITOR.id,
+          locationNames: [MOCK_SECOND_LOCATION.name],
+          locationIds: [MOCK_SECOND_LOCATION.id],
+          statusConfig: mockPendingConfigs[SECOND_CONFIG_ID],
+          monitorSummary: {
+            configId: MOCK_SECOND_MONITOR.id,
+            downThreshold: 1,
+            locationId: MOCK_SECOND_LOCATION.id,
+            locationName: MOCK_SECOND_LOCATION.name,
+            locationNames: MOCK_SECOND_LOCATION.name,
+            monitorId: MOCK_SECOND_MONITOR.id,
+            monitorName: MOCK_SECOND_MONITOR.name,
+            monitorTags: ['test', 'monitor2'],
+            monitorType: 'HTTP',
+            monitorUrl: MOCK_SECOND_MONITOR.url,
+            monitorUrlLabel: 'URL',
+            reason: `Monitor "${MOCK_SECOND_MONITOR.name}" is pending 1 time from ${MOCK_SECOND_LOCATION.name}.`,
+            status: 'pending',
+          },
+        });
+      });
+
+      it('should do nothing if pendingConfigs is empty', () => {
+        // Call the method with empty pendingConfigs
+        statusRule.schedulePendingAlertPerConfigId({ pendingConfigs: {} });
+
+        // Verify scheduleAlert was not called
+        expect(scheduleAlertSpy).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -10,15 +10,17 @@ import {
   SavedObjectsFindResult,
 } from '@kbn/core-saved-objects-api-server';
 import { Logger } from '@kbn/core/server';
-import { intersection, isEmpty, uniq } from 'lodash';
+import { intersection, isEmpty } from 'lodash';
 import { getAlertDetailsUrl } from '@kbn/observability-plugin/common';
 import { SyntheticsMonitorStatusRuleParams as StatusRuleParams } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
 import { MonitorConfigRepository } from '../../services/monitor_config_repository';
 import {
   AlertOverviewStatus,
+  AlertPendingStatusConfigs,
+  AlertPendingStatusMetaData,
   AlertStatusConfigs,
   AlertStatusMetaData,
-  StaleDownConfig,
+  StaleAlertMetadata,
   StatusRuleInspect,
 } from '../../../common/runtime_types/alert_rules/common';
 import { queryFilterMonitors } from './queries/filter_monitors';
@@ -30,7 +32,6 @@ import {
   getViewInAppUrl,
 } from '../common';
 import {
-  DOWN_LABEL,
   getMonitorAlertDocument,
   getMonitorSummary,
   getUngroupedReasonMessage,
@@ -149,8 +150,14 @@ export class StatusRuleExecutor {
     return processMonitors(this.monitors);
   }
 
-  async getDownChecks(prevDownConfigs: AlertStatusConfigs = {}): Promise<AlertOverviewStatus> {
-    const { enabledMonitorQueryIds, maxPeriod, monitorLocationIds, monitorLocationsMap } =
+  async getConfigs({
+    prevDownConfigs = {},
+    prevPendingConfigs = {},
+  }: {
+    prevDownConfigs?: AlertStatusConfigs;
+    prevPendingConfigs?: AlertPendingStatusConfigs;
+  }): Promise<AlertOverviewStatus> {
+    const { enabledMonitorQueryIds, maxPeriod, monitorLocationIds, monitorsData } =
       await this.init();
 
     const range = this.getRange(maxPeriod);
@@ -159,12 +166,14 @@ export class StatusRuleExecutor {
 
     if (enabledMonitorQueryIds.length === 0) {
       const staleDownConfigs = this.markDeletedConfigs(prevDownConfigs);
+      const stalePendingConfigs = this.markDeletedConfigs(prevPendingConfigs);
       return {
         downConfigs: { ...prevDownConfigs },
         upConfigs: {},
         staleDownConfigs,
         enabledMonitorQueryIds,
-        pendingConfigs: {},
+        pendingConfigs: { ...prevPendingConfigs },
+        stalePendingConfigs,
         maxPeriod,
       };
     }
@@ -183,42 +192,48 @@ export class StatusRuleExecutor {
       range,
       monitorQueryIds: enabledMonitorQueryIds,
       numberOfChecks,
-      monitorLocationsMap,
       includeRetests: this.params.condition?.includeRetests,
+      monitorsData,
+      monitors: this.monitors,
+      logger: this.logger,
     });
 
-    const { downConfigs, upConfigs } = currentStatus;
+    const { downConfigs, upConfigs, pendingConfigs, configStats } = currentStatus;
 
     this.debug(
-      `Found ${Object.keys(downConfigs).length} down configs and ${
+      `Found ${Object.keys(downConfigs).length} down configs, ${
         Object.keys(upConfigs).length
-      } up configs`
+      } up configs and ${Object.keys(pendingConfigs).length} pending configs`
     );
 
-    const downConfigsById = getConfigsByIds(downConfigs);
-    const upConfigsById = getConfigsByIds(upConfigs);
-
-    uniq([...downConfigsById.keys(), ...upConfigsById.keys()]).forEach((configId) => {
-      const downCount = downConfigsById.get(configId)?.length ?? 0;
-      const upCount = upConfigsById.get(configId)?.length ?? 0;
+    Object.entries(configStats).forEach(([configId, configStat]) => {
       const name = this.monitors.find((m) => m.id === configId)?.attributes.name ?? configId;
       this.debug(
-        `Monitor: ${name} with id ${configId} has ${downCount} down check and ${upCount} up check`
+        `Monitor: ${name} with id ${configId} has ${configStat.down} down check, ${configStat.up} up check and ${configStat.pending} pending check`
       );
     });
 
-    Object.keys(prevDownConfigs).forEach((locId) => {
-      if (!downConfigs[locId] && !upConfigs[locId]) {
-        downConfigs[locId] = prevDownConfigs[locId];
+    const downConfigsToMarkAsStale = Object.keys(prevDownConfigs).reduce((acc, locId) => {
+      if (!pendingConfigs[locId] && !upConfigs[locId] && !downConfigs[locId]) {
+        acc[locId] = prevDownConfigs[locId];
       }
-    });
+      return acc;
+    }, {} as Record<string, AlertStatusMetaData>);
 
-    const staleDownConfigs = this.markDeletedConfigs(downConfigs);
+    const pendingConfigsToMarkAsStale = Object.keys(prevPendingConfigs).reduce((acc, locId) => {
+      if (!pendingConfigs[locId] && !upConfigs[locId] && !downConfigs[locId]) {
+        acc[locId] = prevPendingConfigs[locId];
+      }
+      return acc;
+    }, {} as Record<string, AlertPendingStatusMetaData>);
+
+    const staleDownConfigs = this.markDeletedConfigs(downConfigsToMarkAsStale);
+    const stalePendingConfigs = this.markDeletedConfigs(pendingConfigsToMarkAsStale);
 
     return {
       ...currentStatus,
       staleDownConfigs,
-      pendingConfigs: {},
+      stalePendingConfigs,
       maxPeriod,
     };
   }
@@ -249,32 +264,98 @@ export class StatusRuleExecutor {
     return { from, to: 'now' };
   };
 
-  markDeletedConfigs(downConfigs: AlertStatusConfigs): Record<string, StaleDownConfig> {
+  markDeletedConfigs<T extends AlertStatusMetaData | AlertPendingStatusMetaData>(
+    configs: Record<string, T>
+  ): Record<string, T & StaleAlertMetadata> {
     const monitors = this.monitors;
-    const staleDownConfigs: AlertOverviewStatus['staleDownConfigs'] = {};
-    Object.keys(downConfigs).forEach((locPlusId) => {
-      const downConfig = downConfigs[locPlusId];
+    const staleConfigs: Record<string, T & StaleAlertMetadata> = {};
+
+    Object.keys(configs).forEach((locPlusId) => {
+      const config = configs[locPlusId];
       const monitor = monitors.find((m) => {
         return (
-          m.id === downConfig.configId ||
-          m.attributes[ConfigKey.MONITOR_QUERY_ID] === downConfig.monitorQueryId
+          m.id === config.configId ||
+          m.attributes[ConfigKey.MONITOR_QUERY_ID] === config.monitorQueryId
         );
       });
       if (!monitor) {
-        staleDownConfigs[locPlusId] = { ...downConfig, isDeleted: true };
-        delete downConfigs[locPlusId];
+        staleConfigs[locPlusId] = { ...config, isDeleted: true };
+        delete configs[locPlusId];
       } else {
         const { locations } = monitor.attributes;
-        const isLocationRemoved = !locations.some((l) => l.id === downConfig.locationId);
+        const isLocationRemoved = !locations.some((l) => l.id === config.locationId);
         if (isLocationRemoved) {
-          staleDownConfigs[locPlusId] = { ...downConfig, isLocationRemoved: true };
-          delete downConfigs[locPlusId];
+          staleConfigs[locPlusId] = { ...config, isLocationRemoved: true };
+          delete configs[locPlusId];
         }
       }
     });
 
-    return staleDownConfigs;
+    return staleConfigs;
   }
+
+  schedulePendingAlertPerConfigIdPerLocation({
+    pendingConfigs,
+  }: {
+    pendingConfigs: AlertPendingStatusConfigs;
+  }) {
+    Object.entries(pendingConfigs).forEach(([idWithLocation, statusConfig]) => {
+      const alertId = idWithLocation;
+      const monitorSummary = this.getMonitorPendingSummary({
+        statusConfig,
+      });
+
+      this.scheduleAlert({
+        idWithLocation,
+        alertId,
+        monitorSummary,
+        statusConfig,
+        locationNames: [monitorSummary.locationName],
+        locationIds: [statusConfig.locationId],
+      });
+    });
+  }
+
+  schedulePendingAlertPerConfigId({
+    pendingConfigs,
+  }: {
+    pendingConfigs: AlertPendingStatusConfigs;
+  }) {
+    const pendingConfigsById = getConfigsByIds(pendingConfigs);
+
+    for (const [configId, configs] of pendingConfigsById) {
+      const alertId = configId;
+      const monitorSummary = this.getUngroupedPendingSummary({
+        statusConfigs: configs,
+      });
+      this.scheduleAlert({
+        idWithLocation: configId,
+        alertId,
+        monitorSummary,
+        statusConfig: configs[0],
+        locationNames: configs.map(({ locationId, ping }) => ping?.observer.geo.name || locationId),
+        locationIds: configs.map(({ locationId }) => locationId),
+      });
+    }
+  }
+
+  handlePendingMonitorAlert = ({
+    pendingConfigs,
+  }: {
+    pendingConfigs: AlertPendingStatusConfigs;
+  }) => {
+    if (this.params.condition?.alertOnNoData) {
+      if (this.params.condition?.groupBy && this.params.condition.groupBy !== 'locationId') {
+        this.schedulePendingAlertPerConfigId({
+          pendingConfigs,
+        });
+      } else {
+        this.schedulePendingAlertPerConfigIdPerLocation({
+          pendingConfigs,
+        });
+      }
+    }
+  };
 
   handleDownMonitorThresholdAlert = ({ downConfigs }: { downConfigs: AlertStatusConfigs }) => {
     const { useTimeWindow, useLatestChecks, downThreshold, locationsThreshold } = getConditionType(
@@ -344,7 +425,7 @@ export class StatusRuleExecutor {
 
     return getMonitorSummary({
       monitorInfo: ping,
-      statusMessage: DOWN_LABEL,
+      reason: 'down',
       locationId: [locationId],
       configId,
       dateFormat: this.dateFormat ?? 'Y-MM-DD HH:mm:ss',
@@ -354,12 +435,26 @@ export class StatusRuleExecutor {
     });
   }
 
+  getMonitorPendingSummary({ statusConfig }: { statusConfig: AlertPendingStatusMetaData }) {
+    const { monitorInfo } = statusConfig;
+
+    return getMonitorSummary({
+      monitorInfo,
+      reason: 'pending',
+      locationId: [statusConfig.locationId],
+      configId: statusConfig.configId,
+      dateFormat: this.dateFormat ?? 'Y-MM-DD HH:mm:ss',
+      tz: this.tz ?? 'UTC',
+      params: this.params,
+    });
+  }
+
   getUngroupedDownSummary({ statusConfigs }: { statusConfigs: AlertStatusMetaData[] }) {
     const sampleConfig = statusConfigs[0];
     const { ping, configId, checks } = sampleConfig;
     const baseSummary = getMonitorSummary({
       monitorInfo: ping,
-      statusMessage: DOWN_LABEL,
+      reason: 'down',
       locationId: statusConfigs.map((c) => c.ping.observer.name!),
       configId,
       dateFormat: this.dateFormat!,
@@ -371,6 +466,7 @@ export class StatusRuleExecutor {
       statusConfigs,
       monitorName: baseSummary.monitorName,
       params: this.params,
+      reason: 'down',
     });
     if (statusConfigs.length > 1) {
       baseSummary.locationNames = statusConfigs
@@ -381,26 +477,52 @@ export class StatusRuleExecutor {
     return baseSummary;
   }
 
-  scheduleAlert({
-    idWithLocation,
-    alertId,
-    monitorSummary,
-    statusConfig,
-    downThreshold,
-    useLatestChecks = false,
-    locationNames,
-    locationIds,
-  }: {
-    idWithLocation: string;
-    alertId: string;
-    monitorSummary: MonitorSummaryStatusRule;
-    statusConfig: AlertStatusMetaData;
-    downThreshold: number;
-    useLatestChecks?: boolean;
-    locationNames: string[];
-    locationIds: string[];
-  }) {
-    const { configId, locationId, checks } = statusConfig;
+  getUngroupedPendingSummary({ statusConfigs }: { statusConfigs: AlertPendingStatusMetaData[] }) {
+    const sampleConfig = statusConfigs[0];
+    const { configId, monitorInfo } = sampleConfig;
+
+    const baseSummary = getMonitorSummary({
+      monitorInfo,
+      reason: 'pending',
+      locationId: statusConfigs.map(({ locationId }) => locationId),
+      configId,
+      dateFormat: this.dateFormat!,
+      tz: this.tz!,
+      params: this.params,
+    });
+    baseSummary.reason = getUngroupedReasonMessage({
+      statusConfigs,
+      monitorName: baseSummary.monitorName,
+      params: this.params,
+      reason: 'pending',
+    });
+
+    return baseSummary;
+  }
+
+  scheduleAlert(
+    params: {
+      idWithLocation: string;
+      alertId: string;
+      monitorSummary: MonitorSummaryStatusRule;
+      useLatestChecks?: boolean;
+      locationNames: string[];
+      locationIds: string[];
+    } & (
+      | { statusConfig: AlertPendingStatusMetaData }
+      | { statusConfig: AlertStatusMetaData; downThreshold: number }
+    )
+  ) {
+    const {
+      idWithLocation,
+      alertId,
+      monitorSummary,
+      statusConfig,
+      useLatestChecks = false,
+      locationNames,
+      locationIds,
+    } = params;
+    const { configId, locationId } = statusConfig;
     const { spaceId, startedAt } = this.options;
     const { alertsClient } = this.options.services;
     const { basePath } = this.server;
@@ -424,8 +546,6 @@ export class StatusRuleExecutor {
     const context = {
       ...monitorSummary,
       idWithLocation,
-      checks,
-      downThreshold,
       errorStartedAt,
       linkMessage: monitorSummary.stateId
         ? getFullViewInAppMessage(basePath, spaceId, relativeViewInAppUrl)
@@ -434,11 +554,21 @@ export class StatusRuleExecutor {
       [ALERT_DETAILS_URL]: getAlertDetailsUrl(basePath, spaceId, alertUuid),
     };
 
+    // downThreshold and checks are only available for down alerts
+    if ('downThreshold' in params) {
+      context.downThreshold = params.downThreshold;
+    }
+
+    if ('checks' in statusConfig) {
+      context.checks = statusConfig.checks;
+    }
+
     const alertDocument = getMonitorAlertDocument(
       monitorSummary,
       locationNames,
       locationIds,
-      useLatestChecks
+      useLatestChecks,
+      'downThreshold' in params ? params.downThreshold : 1
     );
 
     alertsClient.setAlertData({
@@ -449,7 +579,7 @@ export class StatusRuleExecutor {
   }
 
   getRuleThresholdOverview = async (): Promise<StatusRuleInspect> => {
-    const data = await this.getDownChecks({});
+    const data = await this.getConfigs({});
     return {
       ...data,
       monitors: this.monitors.map((monitor) => ({
@@ -492,16 +622,20 @@ export const getDoesMonitorMeetLocationThreshold = ({
   }
 };
 
-export const getConfigsByIds = (
-  downConfigs: AlertStatusConfigs
-): Map<string, AlertStatusMetaData[]> => {
-  const downConfigsById = new Map<string, AlertStatusMetaData[]>();
-  Object.entries(downConfigs).forEach(([_, config]) => {
+export function getConfigsByIds(configs: AlertStatusConfigs): Map<string, AlertStatusMetaData[]>;
+export function getConfigsByIds(
+  configs: AlertPendingStatusConfigs
+): Map<string, AlertPendingStatusMetaData[]>;
+export function getConfigsByIds(
+  configs: AlertStatusConfigs | AlertPendingStatusConfigs
+): Map<string, Array<AlertStatusMetaData | AlertPendingStatusMetaData>> {
+  const configsById = new Map<string, Array<AlertStatusMetaData | AlertPendingStatusMetaData>>();
+  Object.entries(configs).forEach(([_, config]) => {
     const { configId } = config;
-    if (!downConfigsById.has(configId)) {
-      downConfigsById.set(configId, []);
+    if (!configsById.has(configId)) {
+      configsById.set(configId, []);
     }
-    downConfigsById.get(configId)?.push(config);
+    configsById.get(configId)?.push(config);
   });
-  return downConfigsById;
-};
+  return configsById;
+}

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/types.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/types.ts
@@ -52,7 +52,7 @@ export interface MonitorSummaryStatusRule {
   configId: string;
   hostName: string;
   monitorId: string;
-  checkedAt: string;
+  checkedAt?: string;
   monitorUrl: string;
   locationId: string;
   monitorType: string;
@@ -70,6 +70,6 @@ export interface MonitorSummaryStatusRule {
   stateId?: string;
   lastErrorMessage?: string;
   lastErrorStack?: string | null;
-  timestamp: string;
+  timestamp?: string;
   labels?: Record<string, string>;
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
@@ -125,22 +125,10 @@ export class TLSRuleExecutor {
       )} | parsed location filter is ${JSON.stringify(locationIds)} `
     );
 
-    const {
-      allIds,
-      enabledMonitorQueryIds,
-      monitorLocationIds,
-      monitorLocationsMap,
-      projectMonitorsCount,
-      monitorQueryIdToConfigIdMap,
-    } = processMonitors(this.monitors);
+    const { enabledMonitorQueryIds } = processMonitors(this.monitors);
 
     return {
       enabledMonitorQueryIds,
-      monitorLocationIds,
-      allIds,
-      monitorLocationsMap,
-      projectMonitorsCount,
-      monitorQueryIdToConfigIdMap,
     };
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.test.ts
@@ -27,18 +27,20 @@ describe('processMonitors', () => {
       disabledMonitorQueryIds: ['test-project-id-default'],
       monitorLocationIds: ['us_central_qa', 'us_central_staging', 'us_central'],
       maxPeriod: 600000,
-      monitorLocationsMap: {
-        '7f796001-a795-4c0b-afdb-3ce74edea775': [
-          'us_central_qa',
-          'us_central',
-          'us_central_staging',
-        ],
-        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['us_central_qa', 'us_central_staging'],
-      },
       monitorQueryIdToConfigIdMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': '7f796001-a795-4c0b-afdb-3ce74edea775',
         'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': 'aa925d91-40b0-4f8f-b695-bb9b53cd4e22',
         'test-project-id-default': '5e203f47-1261-4978-a915-cc3315d90fb1',
+      },
+      monitorsData: {
+        '7f796001-a795-4c0b-afdb-3ce74edea775': {
+          locations: ['us_central_qa', 'us_central', 'us_central_staging'],
+          scheduleInMs: 600000,
+        },
+        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': {
+          locations: ['us_central_qa', 'us_central_staging'],
+          scheduleInMs: 180000,
+        },
       },
     });
   });
@@ -63,18 +65,20 @@ describe('processMonitors', () => {
       disabledMonitorQueryIds: ['test-project-id-default'],
       monitorLocationIds: ['us_central_qa', 'us_central_staging', 'us_central'],
       maxPeriod: 600000,
-      monitorLocationsMap: {
-        '7f796001-a795-4c0b-afdb-3ce74edea775': [
-          'us_central_qa',
-          'us_central',
-          'us_central_staging',
-        ],
-        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['us_central_qa', 'us_central_staging'],
-      },
       monitorQueryIdToConfigIdMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': '7f796001-a795-4c0b-afdb-3ce74edea775',
         'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': 'aa925d91-40b0-4f8f-b695-bb9b53cd4e22',
         'test-project-id-default': '5e203f47-1261-4978-a915-cc3315d90fb1',
+      },
+      monitorsData: {
+        '7f796001-a795-4c0b-afdb-3ce74edea775': {
+          locations: ['us_central_qa', 'us_central', 'us_central_staging'],
+          scheduleInMs: 600000,
+        },
+        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': {
+          locations: ['us_central_qa', 'us_central_staging'],
+          scheduleInMs: 180000,
+        },
       },
     });
   });
@@ -137,18 +141,20 @@ describe('processMonitors', () => {
       disabledMonitorQueryIds: ['test-project-id-default'],
       monitorLocationIds: ['us_central_qa', 'us_central_staging', 'us_central'],
       maxPeriod: 600000,
-      monitorLocationsMap: {
-        '7f796001-a795-4c0b-afdb-3ce74edea775': [
-          'us_central_qa',
-          'us_central',
-          'us_central_staging',
-        ],
-        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['us_central_qa', 'us_central_staging'],
-      },
       monitorQueryIdToConfigIdMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': '7f796001-a795-4c0b-afdb-3ce74edea775',
         'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': 'aa925d91-40b0-4f8f-b695-bb9b53cd4e22',
         'test-project-id-default': '5e203f47-1261-4978-a915-cc3315d90fb1',
+      },
+      monitorsData: {
+        '7f796001-a795-4c0b-afdb-3ce74edea775': {
+          locations: ['us_central_qa', 'us_central', 'us_central_staging'],
+          scheduleInMs: 600000,
+        },
+        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': {
+          locations: ['us_central_qa', 'us_central_staging'],
+          scheduleInMs: 180000,
+        },
       },
     });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.ts
@@ -14,6 +14,12 @@ import {
   SourceType,
 } from '../../../common/runtime_types';
 
+export interface MonitorData {
+  scheduleInMs: number;
+  locations: string[];
+  type: string;
+}
+
 export const processMonitors = (
   allMonitors: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>>,
   queryLocations?: string[] | string
@@ -28,12 +34,11 @@ export const processMonitors = (
   const disabledMonitorQueryIds: string[] = [];
   let disabledCount = 0;
   let disabledMonitorsCount = 0;
-  let maxPeriod = 0;
   let projectMonitorsCount = 0;
   const allIds: string[] = [];
   let listOfLocationsSet = new Set<string>();
-  const monitorLocationsMap: Record<string, string[]> = {};
   const monitorQueryIdToConfigIdMap: Record<string, string> = {};
+  const monitorsData: Record<string, MonitorData> = {};
 
   for (const monitor of allMonitors) {
     const attrs = monitor.attributes;
@@ -58,25 +63,26 @@ export const processMonitors = (
     } else {
       enabledMonitorQueryIds.push(attrs[ConfigKey.MONITOR_QUERY_ID]);
 
-      monitorLocationsMap[attrs[ConfigKey.MONITOR_QUERY_ID]] = queryLocations
-        ? intersection(monitorLocIds, queryLocations)
-        : monitorLocIds;
-      listOfLocationsSet = new Set([...listOfLocationsSet, ...monitorLocIds]);
+      monitorsData[attrs[ConfigKey.MONITOR_QUERY_ID]] = {
+        scheduleInMs: periodToMs(attrs[ConfigKey.SCHEDULE]),
+        locations: queryLocations ? intersection(monitorLocIds, queryLocations) : monitorLocIds,
+        type: attrs[ConfigKey.MONITOR_TYPE],
+      };
 
-      maxPeriod = Math.max(maxPeriod, periodToMs(attrs[ConfigKey.SCHEDULE]));
+      listOfLocationsSet = new Set([...listOfLocationsSet, ...monitorLocIds]);
     }
   }
 
   return {
-    maxPeriod,
+    maxPeriod: Math.max(...Object.values(monitorsData).map(({ scheduleInMs }) => scheduleInMs)),
     allIds,
     enabledMonitorQueryIds,
     disabledMonitorQueryIds,
     disabledCount,
-    monitorLocationsMap,
     disabledMonitorsCount,
     projectMonitorsCount,
     monitorLocationIds: [...listOfLocationsSet],
     monitorQueryIdToConfigIdMap,
+    monitorsData,
   };
 };

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/index.ts
@@ -16,6 +16,7 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     describe('Synthetics Alerting', () => {
       loadTestFile(require.resolve('./synthetics/synthetics_default_rule'));
       loadTestFile(require.resolve('./synthetics/custom_status_rule'));
+      loadTestFile(require.resolve('./synthetics/alert_on_no_data'));
     });
   });
 }

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/alert_on_no_data.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/alert_on_no_data.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import expect from '@kbn/expect';
+import moment from 'moment';
+import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
+import { waitForDocumentInIndex } from '../../../../../../alerting_api_integration/observability/helpers/alerting_wait_for_helpers';
+import { RoleCredentials, SupertestWithRoleScopeType } from '../../../../services';
+import { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provider_context';
+import {
+  SyntheticsRuleHelper,
+  SYNTHETICS_ALERT_ACTION_INDEX,
+  SYNTHETICS_DOCS_INDEX,
+} from './synthetics_rule_helper';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const server = getService('kibanaServer');
+  const retryService = getService('retry');
+  let ruleHelper: SyntheticsRuleHelper;
+  const logger = getService('log');
+  const esClient = getService('es');
+  const esDeleteAllIndices = getService('esDeleteAllIndices');
+  const roleScopedSupertest = getService('roleScopedSupertest');
+  let supertestEditorWithApiKey: SupertestWithRoleScopeType;
+  let supertestAdminWithCookieHeader: SupertestWithRoleScopeType;
+  let adminRoleAuthc: RoleCredentials;
+  const samlAuth = getService('samlAuth');
+
+  describe('SyntheticsAlertOnNoData', function () {
+    // Test failing on MKI and ECH
+    this.tags(['skipCloud']);
+
+    const SYNTHETICS_RULE_ALERT_INDEX = '.alerts-observability.uptime.alerts-default';
+
+    before(async () => {
+      [supertestEditorWithApiKey, supertestAdminWithCookieHeader, adminRoleAuthc] =
+        await Promise.all([
+          roleScopedSupertest.getSupertestWithRoleScope('editor', {
+            withInternalHeaders: true,
+          }),
+          roleScopedSupertest.getSupertestWithRoleScope('admin', {
+            withInternalHeaders: true,
+            useCookieHeader: true,
+          }),
+          samlAuth.createM2mApiKeyWithRoleScope('admin'),
+        ]);
+
+      ruleHelper = new SyntheticsRuleHelper(getService, supertestEditorWithApiKey, adminRoleAuthc);
+      await ruleHelper.createIndexAction();
+      await supertestAdminWithCookieHeader
+        .put(SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT)
+        .expect(200);
+    });
+
+    after(async () => {
+      await supertestEditorWithApiKey.destroy();
+      await samlAuth.invalidateM2mApiKeyWithRoleScope(adminRoleAuthc);
+      await supertestAdminWithCookieHeader.destroy();
+      await server.savedObjects.cleanStandardList();
+      await esDeleteAllIndices([SYNTHETICS_ALERT_ACTION_INDEX]);
+      await esClient.indices
+        .deleteDataStream({
+          name: SYNTHETICS_DOCS_INDEX,
+        })
+        .catch();
+      await esClient.deleteByQuery({
+        index: SYNTHETICS_RULE_ALERT_INDEX,
+        query: { match_all: {} },
+        ignore_unavailable: true,
+      });
+      await server.savedObjects.clean({ types: ['rule'] });
+    });
+
+    let ruleId = '';
+    let monitor: any;
+
+    it('creates a monitor', async () => {
+      monitor = await ruleHelper.addMonitor('Monitor check based at ' + moment().format('LLL'));
+      expect(monitor).to.have.property('id');
+    });
+
+    it('creates a custom rule', async () => {
+      const params = {
+        condition: {
+          alertOnNoData: true,
+          locationsThreshold: 1,
+          window: {
+            numberOfChecks: 5,
+          },
+          groupBy: 'locationId',
+          downThreshold: 5,
+        },
+        monitorIds: [monitor.id],
+      };
+      const rule = await ruleHelper.createCustomStatusRule({
+        params,
+        name: 'When down 5 times from 1 location, alert on no data',
+      });
+      ruleId = rule.id;
+      expect(rule.params).to.eql(params, JSON.stringify(rule));
+    });
+
+    it('should trigger 1 pending alert per location', async function () {
+      const [dev1Alert, dev2Alert] = await Promise.all([
+        ruleHelper.waitForStatusAlert({
+          ruleId,
+          filters: [
+            { term: { 'kibana.alert.status': 'active' } },
+            { term: { 'location.id': 'dev' } },
+          ],
+        }),
+        ruleHelper.waitForStatusAlert({
+          ruleId,
+          filters: [
+            { term: { 'kibana.alert.status': 'active' } },
+            { term: { 'location.id': 'dev2' } },
+          ],
+        }),
+      ]);
+
+      expect(dev1Alert.hits.hits.length).to.eql(1);
+      expect(dev2Alert.hits.hits.length).to.eql(1);
+
+      const dev1AlertSource: any = dev1Alert.hits.hits[0]._source;
+      const dev2AlertSource: any = dev2Alert.hits.hits[0]._source;
+
+      expect(dev1AlertSource['kibana.alert.reason']).to.be(
+        `Monitor "${monitor.name}" from Dev Service is pending.`
+      );
+      expect(dev2AlertSource['kibana.alert.reason']).to.be(
+        `Monitor "${monitor.name}" from Dev Service 2 is pending.`
+      );
+
+      const [dev1AlertAction, dev2AlertAction] = await Promise.all([
+        waitForDocumentInIndex<{
+          ruleType: string;
+          alertDetailsUrl: string;
+          reason: string;
+        }>({
+          esClient,
+          indexName: SYNTHETICS_ALERT_ACTION_INDEX,
+          retryService,
+          logger,
+          filters: [
+            {
+              term: { 'monitor.id': monitor.id },
+            },
+            {
+              term: { locationId: 'dev' },
+            },
+          ],
+        }),
+        waitForDocumentInIndex<{
+          ruleType: string;
+          alertDetailsUrl: string;
+          reason: string;
+        }>({
+          esClient,
+          indexName: SYNTHETICS_ALERT_ACTION_INDEX,
+          retryService,
+          logger,
+          filters: [
+            {
+              term: { 'monitor.id': monitor.id },
+            },
+            {
+              term: { locationId: 'dev2' },
+            },
+          ],
+        }),
+      ]);
+
+      expect(dev1AlertAction.hits.hits.length).to.eql(1);
+      expect(dev2AlertAction.hits.hits.length).to.eql(1);
+
+      const dev1AlertActionSource: any = dev1AlertAction.hits.hits[0]._source;
+      const dev2AlertActionSource: any = dev2AlertAction.hits.hits[0]._source;
+
+      expect(dev1AlertActionSource.reason).to.be(
+        `Monitor "${monitor.name}" from Dev Service is pending.`
+      );
+      expect(dev2AlertActionSource.reason).to.be(
+        `Monitor "${monitor.name}" from Dev Service 2 is pending.`
+      );
+      expect(dev1AlertActionSource.linkMessage).to.be('');
+      expect(dev2AlertActionSource.linkMessage).to.be('');
+      expect(dev1AlertActionSource.locationNames).to.be('Dev Service');
+      expect(dev2AlertActionSource.locationNames).to.be('Dev Service 2');
+    });
+
+    it('should change the message if monitor goes from pending to down and recover the alert if monitor goes from pending to up', async () => {
+      const [_, recoveryDoc] = await Promise.all([
+        ruleHelper.makeSummaries({
+          monitor,
+          downChecks: 5,
+          location: { id: 'dev', label: 'Dev Service' },
+        }),
+        ruleHelper.makeSummaries({
+          monitor,
+          upChecks: 1,
+          location: { id: 'dev2', label: 'Dev Service 2' },
+        }),
+      ]);
+
+      const [dev1Alert, dev2AlertAction] = await Promise.all([
+        ruleHelper.waitForStatusAlert({
+          ruleId,
+          filters: [
+            { term: { 'kibana.alert.status': 'active' } },
+            { term: { 'location.id': 'dev' } },
+            { wildcard: { 'kibana.alert.reason': { value: '*down*' } } },
+          ],
+        }),
+        waitForDocumentInIndex<{
+          ruleType: string;
+          alertDetailsUrl: string;
+          reason: string;
+        }>({
+          esClient,
+          indexName: SYNTHETICS_ALERT_ACTION_INDEX,
+          retryService,
+          logger,
+          filters: [
+            {
+              term: { 'monitor.id': monitor.id },
+            },
+            {
+              term: { locationId: 'dev2' },
+            },
+            {
+              term: { status: 'recovered' },
+            },
+          ],
+        }),
+      ]);
+
+      const dev1AlertHits = dev1Alert.hits.hits;
+
+      expect(dev1AlertHits.length).to.eql(1);
+
+      const dev1AlertSource: any = dev1Alert.hits.hits[0]._source;
+
+      expect(dev1AlertSource['kibana.alert.reason']).to.be(
+        `Monitor "${monitor.name}" from Dev Service is down. Monitor is down 5 times within the last 5 checks. Alert when 5 out of the last 5 checks are down from at least 1 location.`
+      );
+
+      expect(dev2AlertAction.hits.hits.length).to.eql(1);
+
+      const dev2AlertActionSource: any = dev2AlertAction.hits.hits[0]._source;
+
+      expect(dev2AlertActionSource.recoveryStatus).to.be('is now up');
+      expect(dev2AlertActionSource.recoveryReason).to.be(
+        `the monitor is now up again. It ran successfully at ${moment(recoveryDoc[0]['@timestamp'])
+          .tz('UTC')
+          .format('MMM D, YYYY @ HH:mm:ss.SSS')}`
+      );
+    });
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/custom_status_rule.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/synthetics/custom_status_rule.ts
@@ -30,8 +30,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let adminRoleAuthc: RoleCredentials;
   const samlAuth = getService('samlAuth');
 
-  // Failing: See https://github.com/elastic/kibana/issues/202337
-  describe.skip('SyntheticsCustomStatusRule', function () {
+  describe('SyntheticsCustomStatusRule', function () {
     // Test failing on MKI and ECH
     this.tags(['skipCloud']);
 
@@ -616,21 +615,24 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             {
               term: { 'monitor.id': monitor.id },
             },
+            {
+              term: { status: 'recovered' },
+            },
           ],
         });
-        expect(recoveryResponse.hits.hits[1]._source).property(
+        expect(recoveryResponse.hits.hits[0]._source).property(
           'reason',
           `Monitor "${monitor.name}" from Dev Service and Dev Service 2 is recovered. Alert when 1 out of the last 1 checks are down from at least 2 locations.`
         );
-        expect(recoveryResponse.hits.hits[1]._source).property(
+        expect(recoveryResponse.hits.hits[0]._source).property(
           'locationNames',
           'Dev Service and Dev Service 2'
         );
-        expect(recoveryResponse.hits.hits[1]._source).property(
+        expect(recoveryResponse.hits.hits[0]._source).property(
           'linkMessage',
           `- Link: http://localhost:5620/app/synthetics/monitor/${monitor.id}/errors/Test%20private%20location-18524a3d9a7-0?locationId=dev`
         );
-        expect(recoveryResponse.hits.hits[1]._source).property('locationId', 'dev and dev2');
+        expect(recoveryResponse.hits.hits[0]._source).property('locationId', 'dev and dev2');
       });
 
       let downDocs: any[] = [];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Add monitor downtime alert on no data (#220127)](https://github.com/elastic/kibana/pull/220127)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-06-19T12:27:19Z","message":"[Synthetics] Add monitor downtime alert on no data (#220127)","sha":"9049e27f8a536fccca4438a3a2048228a6accb04","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","ci:project-deploy-observability","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Synthetics] Add monitor downtime alert on no data","number":220127,"url":"https://github.com/elastic/kibana/pull/220127","mergeCommit":{"message":"[Synthetics] Add monitor downtime alert on no data (#220127)","sha":"9049e27f8a536fccca4438a3a2048228a6accb04"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220127","number":220127,"mergeCommit":{"message":"[Synthetics] Add monitor downtime alert on no data (#220127)","sha":"9049e27f8a536fccca4438a3a2048228a6accb04"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->