### PR TITLE
[9.0] fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/common/summary_indices.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/summary_indices.test.ts
@@ -48,8 +48,9 @@ describe('getListOfSloSummaryIndices', () => {
       { name: 'cluster3', isConnected: false },
     ];
     const result = getListOfSloSummaryIndices(settings, clustersByName);
-    expect(result).toStrictEqual(
-      `${SUMMARY_DESTINATION_INDEX_PATTERN},cluster1:${SUMMARY_DESTINATION_INDEX_PATTERN}`
-    );
+    expect(result).toStrictEqual([
+      SUMMARY_DESTINATION_INDEX_PATTERN,
+      `cluster1:${SUMMARY_DESTINATION_INDEX_PATTERN}`,
+    ]);
   });
 });

--- a/x-pack/solutions/observability/plugins/slo/common/summary_indices.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/summary_indices.test.ts
@@ -9,17 +9,17 @@ import { getListOfSloSummaryIndices } from './summary_indices';
 import { DEFAULT_STALE_SLO_THRESHOLD_HOURS, SUMMARY_DESTINATION_INDEX_PATTERN } from './constants';
 
 describe('getListOfSloSummaryIndices', () => {
-  it('should return default index if disabled', function () {
+  it('returns the local index if disabled', function () {
     const settings = {
       useAllRemoteClusters: false,
       selectedRemoteClusters: [],
       staleThresholdInHours: DEFAULT_STALE_SLO_THRESHOLD_HOURS,
     };
     const result = getListOfSloSummaryIndices(settings, []);
-    expect(result).toBe(SUMMARY_DESTINATION_INDEX_PATTERN);
+    expect(result).toStrictEqual([SUMMARY_DESTINATION_INDEX_PATTERN]);
   });
 
-  it('should return all remote clusters when enabled', function () {
+  it('returns a wildcard remote and the local index when useAllRemoteClusters is true', function () {
     const settings = {
       useAllRemoteClusters: true,
       selectedRemoteClusters: [],
@@ -30,23 +30,25 @@ describe('getListOfSloSummaryIndices', () => {
       { name: 'cluster2', isConnected: true },
     ];
     const result = getListOfSloSummaryIndices(settings, clustersByName);
-    expect(result).toBe(
-      `${SUMMARY_DESTINATION_INDEX_PATTERN},cluster1:${SUMMARY_DESTINATION_INDEX_PATTERN},cluster2:${SUMMARY_DESTINATION_INDEX_PATTERN}`
-    );
+    expect(result).toStrictEqual([
+      SUMMARY_DESTINATION_INDEX_PATTERN,
+      `*:${SUMMARY_DESTINATION_INDEX_PATTERN}`,
+    ]);
   });
 
-  it('should return selected when enabled', function () {
+  it('returns only the connected clusters from the selected list when useAllRemoteClusters is false', function () {
     const settings = {
       useAllRemoteClusters: false,
-      selectedRemoteClusters: ['cluster1'],
+      selectedRemoteClusters: ['cluster1', 'cluster3'],
       staleThresholdInHours: DEFAULT_STALE_SLO_THRESHOLD_HOURS,
     };
     const clustersByName = [
       { name: 'cluster1', isConnected: true },
       { name: 'cluster2', isConnected: true },
+      { name: 'cluster3', isConnected: false },
     ];
     const result = getListOfSloSummaryIndices(settings, clustersByName);
-    expect(result).toBe(
+    expect(result).toStrictEqual(
       `${SUMMARY_DESTINATION_INDEX_PATTERN},cluster1:${SUMMARY_DESTINATION_INDEX_PATTERN}`
     );
   });

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/hooks/use_summary_dataview.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/hooks/use_summary_dataview.ts
@@ -24,7 +24,7 @@ export const useSloSummaryDataView = () => {
   useEffect(() => {
     if (settings && remoteClusters) {
       const summaryIndices = getListOfSloSummaryIndices(settings, remoteClusters);
-      setIndexPattern(summaryIndices);
+      setIndexPattern(summaryIndices.join(','));
     }
   }, [settings, remoteClusters]);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)](https://github.com/elastic/kibana/pull/224478)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Delemme","email":"kevin.delemme@elastic.co"},"sourceCommit":{"committedDate":"2025-06-19T09:04:15Z","message":"fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)\n\n### 🍒 Summary\n\nresolves https://github.com/elastic/kibana/issues/224476\n\nThis PR changes how the summary indices are constructed when remote\nclusters is enabled.\n\nWhen `useAllRemoteCluster` is true, we simply use `*:summary-index`\ninstead of listing each remote individually.\nWe also removed the need to fetch the remote clusters info when we use\n`useAllRemoteCluster`.\n\n### Release notes\n\nFix SLO federated view bug when remote clusters and index name listed\nexceeded 4096 bytes.","sha":"aac08931d165e89b40832eac06fbb1ff19a1eecf","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management","v9.0.3","v8.18.3","v8.17.8"],"title":"fix(slo): use wildcard remote when useAllRemoteClusters is true","number":224478,"url":"https://github.com/elastic/kibana/pull/224478","mergeCommit":{"message":"fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)\n\n### 🍒 Summary\n\nresolves https://github.com/elastic/kibana/issues/224476\n\nThis PR changes how the summary indices are constructed when remote\nclusters is enabled.\n\nWhen `useAllRemoteCluster` is true, we simply use `*:summary-index`\ninstead of listing each remote individually.\nWe also removed the need to fetch the remote clusters info when we use\n`useAllRemoteCluster`.\n\n### Release notes\n\nFix SLO federated view bug when remote clusters and index name listed\nexceeded 4096 bytes.","sha":"aac08931d165e89b40832eac06fbb1ff19a1eecf"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224478","number":224478,"mergeCommit":{"message":"fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)\n\n### 🍒 Summary\n\nresolves https://github.com/elastic/kibana/issues/224476\n\nThis PR changes how the summary indices are constructed when remote\nclusters is enabled.\n\nWhen `useAllRemoteCluster` is true, we simply use `*:summary-index`\ninstead of listing each remote individually.\nWe also removed the need to fetch the remote clusters info when we use\n`useAllRemoteCluster`.\n\n### Release notes\n\nFix SLO federated view bug when remote clusters and index name listed\nexceeded 4096 bytes.","sha":"aac08931d165e89b40832eac06fbb1ff19a1eecf"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224531","number":224531,"state":"MERGED","mergeCommit":{"sha":"3590e18388bfe075c6158c8873e3c2f2be63a91f","message":"[8.19] fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478) (#224531)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [fix(slo): use wildcard remote when useAllRemoteClusters is true\n(#224478)](https://github.com/elastic/kibana/pull/224478)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Kevin Delemme <kevin.delemme@elastic.co>"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->