### PR TITLE
[8.17] fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)

### DIFF
--- a/x-pack/plugins/observability_solution/slo/common/summary_indices.test.ts
+++ b/x-pack/plugins/observability_solution/slo/common/summary_indices.test.ts
@@ -12,17 +12,17 @@ import {
 } from './constants';
 
 describe('getListOfSloSummaryIndices', () => {
-  it('should return default index if disabled', function () {
+  it('returns the local index if disabled', function () {
     const settings = {
       useAllRemoteClusters: false,
       selectedRemoteClusters: [],
       staleThresholdInHours: DEFAULT_STALE_SLO_THRESHOLD_HOURS,
     };
     const result = getListOfSloSummaryIndices(settings, []);
-    expect(result).toBe(SLO_SUMMARY_DESTINATION_INDEX_PATTERN);
+    expect(result).toStrictEqual([SLO_SUMMARY_DESTINATION_INDEX_PATTERN]);
   });
 
-  it('should return all remote clusters when enabled', function () {
+  it('returns a wildcard remote and the local index when useAllRemoteClusters is true', function () {
     const settings = {
       useAllRemoteClusters: true,
       selectedRemoteClusters: [],
@@ -33,24 +33,27 @@ describe('getListOfSloSummaryIndices', () => {
       { name: 'cluster2', isConnected: true },
     ];
     const result = getListOfSloSummaryIndices(settings, clustersByName);
-    expect(result).toBe(
-      `${SLO_SUMMARY_DESTINATION_INDEX_PATTERN},cluster1:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN},cluster2:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN}`
-    );
+    expect(result).toStrictEqual([
+      SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
+      `*:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN}`,
+    ]);
   });
 
-  it('should return selected when enabled', function () {
+  it('returns only the connected clusters from the selected list when useAllRemoteClusters is false', function () {
     const settings = {
       useAllRemoteClusters: false,
-      selectedRemoteClusters: ['cluster1'],
+      selectedRemoteClusters: ['cluster1', 'cluster3'],
       staleThresholdInHours: DEFAULT_STALE_SLO_THRESHOLD_HOURS,
     };
     const clustersByName = [
       { name: 'cluster1', isConnected: true },
       { name: 'cluster2', isConnected: true },
+      { name: 'cluster3', isConnected: false },
     ];
     const result = getListOfSloSummaryIndices(settings, clustersByName);
-    expect(result).toBe(
-      `${SLO_SUMMARY_DESTINATION_INDEX_PATTERN},cluster1:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN}`
-    );
+    expect(result).toStrictEqual([
+      SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
+      `cluster1:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN}`,
+    ]);
   });
 });

--- a/x-pack/plugins/observability_solution/slo/common/summary_indices.ts
+++ b/x-pack/plugins/observability_solution/slo/common/summary_indices.ts
@@ -10,19 +10,24 @@ import { SLO_SUMMARY_DESTINATION_INDEX_PATTERN } from './constants';
 
 export const getListOfSloSummaryIndices = (
   settings: GetSLOSettingsResponse,
-  clustersByName: Array<{ name: string; isConnected: boolean }>
-) => {
+  clustersByName: Array<{ name: string; isConnected: boolean }> = []
+): string[] => {
   const { useAllRemoteClusters, selectedRemoteClusters } = settings;
   if (!useAllRemoteClusters && selectedRemoteClusters.length === 0) {
-    return SLO_SUMMARY_DESTINATION_INDEX_PATTERN;
+    return [SLO_SUMMARY_DESTINATION_INDEX_PATTERN];
   }
 
-  const indices: string[] = [SLO_SUMMARY_DESTINATION_INDEX_PATTERN];
-  clustersByName.forEach(({ name, isConnected }) => {
-    if (isConnected && (useAllRemoteClusters || selectedRemoteClusters.includes(name))) {
-      indices.push(`${name}:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN}`);
-    }
-  });
+  if (useAllRemoteClusters) {
+    return [SLO_SUMMARY_DESTINATION_INDEX_PATTERN, `*:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN}`];
+  }
 
-  return indices.join(',');
+  return clustersByName.reduce(
+    (acc, { name, isConnected }) => {
+      if (isConnected && selectedRemoteClusters.includes(name)) {
+        acc.push(`${name}:${SLO_SUMMARY_DESTINATION_INDEX_PATTERN}`);
+      }
+      return acc;
+    },
+    [SLO_SUMMARY_DESTINATION_INDEX_PATTERN]
+  );
 };

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/hooks/use_summary_dataview.ts
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/hooks/use_summary_dataview.ts
@@ -24,7 +24,7 @@ export const useSloSummaryDataView = () => {
   useEffect(() => {
     if (settings && remoteClusters) {
       const summaryIndices = getListOfSloSummaryIndices(settings, remoteClusters);
-      setIndexPattern(summaryIndices);
+      setIndexPattern(summaryIndices.join(','));
     }
   }, [settings, remoteClusters]);
 

--- a/x-pack/plugins/observability_solution/slo/server/services/slo_settings.ts
+++ b/x-pack/plugins/observability_solution/slo/server/services/slo_settings.ts
@@ -9,10 +9,7 @@ import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { PutSLOSettingsParams, sloSettingsSchema } from '@kbn/slo-schema';
-import {
-  DEFAULT_STALE_SLO_THRESHOLD_HOURS,
-  SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
-} from '../../common/constants';
+import { DEFAULT_STALE_SLO_THRESHOLD_HOURS } from '../../common/constants';
 import { getListOfSloSummaryIndices } from '../../common/summary_indices';
 import { StoredSLOSettings } from '../domain/models';
 import { sloSettingsObjectId, SO_SLO_SETTINGS_TYPE } from '../saved_objects/slo_settings';
@@ -59,8 +56,11 @@ export const getListOfSummaryIndices = async (
   settings: StoredSLOSettings
 ) => {
   const { useAllRemoteClusters, selectedRemoteClusters } = settings;
-  if (!useAllRemoteClusters && selectedRemoteClusters.length === 0) {
-    return { indices: [SLO_SUMMARY_DESTINATION_INDEX_PATTERN], settings };
+  // If remote clusters are not used, we don't need to fetch the remote cluster info
+  if (useAllRemoteClusters || (!useAllRemoteClusters && selectedRemoteClusters.length === 0)) {
+    return {
+      indices: getListOfSloSummaryIndices(settings),
+    };
   }
 
   const clustersByName = await esClient.cluster.remoteInfo();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)](https://github.com/elastic/kibana/pull/224478)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Delemme","email":"kevin.delemme@elastic.co"},"sourceCommit":{"committedDate":"2025-06-19T09:04:15Z","message":"fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)\n\n### 🍒 Summary\n\nresolves https://github.com/elastic/kibana/issues/224476\n\nThis PR changes how the summary indices are constructed when remote\nclusters is enabled.\n\nWhen `useAllRemoteCluster` is true, we simply use `*:summary-index`\ninstead of listing each remote individually.\nWe also removed the need to fetch the remote clusters info when we use\n`useAllRemoteCluster`.\n\n### Release notes\n\nFix SLO federated view bug when remote clusters and index name listed\nexceeded 4096 bytes.","sha":"aac08931d165e89b40832eac06fbb1ff19a1eecf","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management","v9.0.3","v8.18.3","v8.17.8"],"title":"fix(slo): use wildcard remote when useAllRemoteClusters is true","number":224478,"url":"https://github.com/elastic/kibana/pull/224478","mergeCommit":{"message":"fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)\n\n### 🍒 Summary\n\nresolves https://github.com/elastic/kibana/issues/224476\n\nThis PR changes how the summary indices are constructed when remote\nclusters is enabled.\n\nWhen `useAllRemoteCluster` is true, we simply use `*:summary-index`\ninstead of listing each remote individually.\nWe also removed the need to fetch the remote clusters info when we use\n`useAllRemoteCluster`.\n\n### Release notes\n\nFix SLO federated view bug when remote clusters and index name listed\nexceeded 4096 bytes.","sha":"aac08931d165e89b40832eac06fbb1ff19a1eecf"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224478","number":224478,"mergeCommit":{"message":"fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478)\n\n### 🍒 Summary\n\nresolves https://github.com/elastic/kibana/issues/224476\n\nThis PR changes how the summary indices are constructed when remote\nclusters is enabled.\n\nWhen `useAllRemoteCluster` is true, we simply use `*:summary-index`\ninstead of listing each remote individually.\nWe also removed the need to fetch the remote clusters info when we use\n`useAllRemoteCluster`.\n\n### Release notes\n\nFix SLO federated view bug when remote clusters and index name listed\nexceeded 4096 bytes.","sha":"aac08931d165e89b40832eac06fbb1ff19a1eecf"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224531","number":224531,"state":"MERGED","mergeCommit":{"sha":"3590e18388bfe075c6158c8873e3c2f2be63a91f","message":"[8.19] fix(slo): use wildcard remote when useAllRemoteClusters is true (#224478) (#224531)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [fix(slo): use wildcard remote when useAllRemoteClusters is true\n(#224478)](https://github.com/elastic/kibana/pull/224478)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Kevin Delemme <kevin.delemme@elastic.co>"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->