### PR TITLE
[Upgrade Assistant] Add manually resolve for follower readonly

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/deprecations_list.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/deprecations_list.test.ts
@@ -489,6 +489,28 @@ describe('ES deprecations table', () => {
       expect(find('reindexTableCell-correctiveAction').text()).toContain('Recommended: reindex');
     });
 
+    it('recommends manual fix if follower index and already read-only', async () => {
+      await setupRecommendedActionTest({
+        correctiveAction: {
+          type: 'reindex',
+          index: 'large_and_readonly_index',
+          metadata: {
+            isClosedIndex: false,
+            isFrozenIndex: false,
+            isInDataStream: false,
+          },
+        },
+        reindexMeta: {
+          isFollowerIndex: true,
+          isReadonly: true,
+          indexName: 'large_and_readonly_index',
+          reindexName: 'reindexed-large_and_readonly_index',
+        },
+      });
+      const { find } = testBed;
+      expect(find('reindexTableCell-correctiveAction').length).toBe(1);
+      expect(find('reindexTableCell-correctiveAction').text()).toContain('Resolve manually');
+    });
     it('recommends reindexing by default', async () => {
       await setupRecommendedActionTest({
         correctiveAction: {

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
@@ -32,7 +32,8 @@ type RecommendedActionType =
   | 'isFollowerIndex'
   | 'isReadonly'
   | 'readonly'
-  | 'reindex';
+  | 'reindex'
+  | 'terminateReplication';
 
 const recommendedReadOnlyText = i18n.translate(
   'xpack.upgradeAssistant.esDeprecations.indices.recommendedActionReadonlyText',
@@ -185,6 +186,21 @@ const i18nTexts = {
         }
       ),
     },
+    terminateReplication: {
+      text: i18n.translate(
+        'xpack.upgradeAssistant.esDeprecations.indices.recommendedOptionTerminateReplicationText',
+        {
+          defaultMessage: 'Resolve manually',
+        }
+      ),
+      tooltipText: i18n.translate(
+        'xpack.upgradeAssistant.esDeprecations.indices.recommendedOptionTerminateReplicationReason',
+        {
+          defaultMessage:
+            'This index is a follower index that has already been set to read-only. You can terminate the replication and convert it to a standard index.',
+        }
+      ),
+    },
   },
 };
 
@@ -212,22 +228,28 @@ export const ReindexResolutionCell: React.FunctionComponent<{
     const readOnlyExcluded = excludedActions.includes('readOnly');
     const reindexExcluded = excludedActions.includes('reindex');
 
-    if (isFollowerIndex && !readOnlyExcluded) {
-      // If the index is a follower index, recommend setting it to read-only
+    // Follower index can only be reindexed
+    if (isFollowerIndex && !readOnlyExcluded && !isReadonly) {
       return 'isFollowerIndex';
-    } else if (isLargeIndex && !readOnlyExcluded) {
-      // If the index is larger than 1GB, recommend setting it to read-only
-      return 'isLargeIndex';
-    } else if (isReadonly) {
-      // If the index is already read-only, recommend reindexing
-      return 'isReadonly';
-    } else if (reindexExcluded) {
-      // If reindexing is excluded, recommend setting it to read-only
-      return 'readonly';
-    } else {
-      // Reindex is the default recommended action unless other conditions apply
-      return 'reindex';
     }
+    // Large index is always recommended to be set to read-only unless excluded or already read-only
+    if (isLargeIndex && !readOnlyExcluded && !isReadonly) {
+      return 'isLargeIndex';
+    }
+    // Follower index but already read-only, manual fix
+    if (isFollowerIndex && isReadonly) {
+      return 'terminateReplication';
+    }
+    // If it's already read-only and not excluded from reindexing, recommend reindexing unless it's a follower index
+    if (isReadonly && !reindexExcluded && !isFollowerIndex) {
+      return 'isReadonly';
+    }
+    // If reindexing is excluded and read-only is not, recommend setting it to read-only
+    if (reindexExcluded && !readOnlyExcluded && !isReadonly) {
+      return 'readonly';
+    }
+    // Default: reindex
+    return 'reindex';
   };
 
   const recommendedAction =


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/221977

## Summary
When testing all my changes I realized I missed a case for sugestions: when an index is a follower index and is set to read-only it still appears in the table with a warning but we suggested to set to read-only (what already was).

This PR improves the verification for the suggestions and now, for a follower that is already read-only, it display `Resolve manually` and indicates the termination of replication in the tooltip.
<img width="628" alt="Screenshot 2025-06-19 at 17 12 07" src="https://github.com/user-attachments/assets/4a29b641-181e-4881-a008-5ccc80681376" />


### How to test
* Follow the instructions in https://github.com/elastic/kibana-team/issues/1521. Use the data folder named `data_most_types.zip`.
* Set to read-only the index called `follower-index`
* Refresh the page
* Verify that know it displays the `Resolve manually` suggestion and the tooltip explains that replication can be terminated.