### PR TITLE
[Entity Analytics][Privmon] swap `labels.monitoring.privileged_users` (string) to `user.is_privileged` (boolean)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -66877,14 +66877,6 @@ components:
         labels:
           type: object
           properties:
-            monitoring:
-              type: object
-              properties:
-                privileged_users:
-                  enum:
-                    - monitored
-                    - deleted
-                  type: string
             source_indices:
               items:
                 type: string
@@ -66905,6 +66897,8 @@ components:
           properties:
             name:
               type: string
+            is_privileged:
+              type: boolean
     Security_Entity_Analytics_API_MonitoringEngineDescriptor:
       type: object
       properties:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -66895,10 +66895,11 @@ components:
         user:
           type: object
           properties:
+            is_privileged:
+              description: Indicates if the user is privileged.
+              type: boolean
             name:
               type: string
-            is_privileged:
-              type: boolean
     Security_Entity_Analytics_API_MonitoringEngineDescriptor:
       type: object
       properties:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -76377,14 +76377,6 @@ components:
         labels:
           type: object
           properties:
-            monitoring:
-              type: object
-              properties:
-                privileged_users:
-                  enum:
-                    - monitored
-                    - deleted
-                  type: string
             source_indices:
               items:
                 type: string
@@ -76403,6 +76395,9 @@ components:
         user:
           type: object
           properties:
+            is_privileged:
+              description: Indicates if the user is privileged.
+              type: boolean
             name:
               type: string
     Security_Entity_Analytics_API_MonitoringEngineDescriptor:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/users/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/users/common.gen.ts
@@ -40,15 +40,14 @@ export const MonitoredUserDoc = z.object({
   user: z
     .object({
       name: z.string().optional(),
+      /**
+       * Indicates if the user is privileged.
+       */
+      is_privileged: z.boolean().optional(),
     })
     .optional(),
   labels: z
     .object({
-      monitoring: z
-        .object({
-          privileged_users: z.enum(['monitored', 'deleted']).optional(),
-        })
-        .optional(),
       sources: z.array(z.unknown()).optional(),
       source_indices: z.array(z.string()).optional(),
       source_integrations: z.array(z.string()).optional(),

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/users/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/users/common.schema.yaml
@@ -38,19 +38,12 @@ components:
           properties:
             name:
               type: string
-
+            is_privileged:
+              type: boolean
+              description: Indicates if the user is privileged.
         labels:
           type: object
           properties:
-            monitoring:
-              type: object
-              properties:
-                privileged_users:
-                  type: string
-                  enum:
-                    - monitored
-                    - deleted
-
             sources:
               type: array
               items:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1642,11 +1642,11 @@ components:
         user:
           type: object
           properties:
+            is_privileged:
+              description: Indicates if the user is privileged.
+              type: boolean
             name:
               type: string
-            is_privileged:
-              type: boolean
-              description: Indicates if the user is privileged.
     MonitoringEngineDescriptor:
       type: object
       properties:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1624,14 +1624,6 @@ components:
         labels:
           type: object
           properties:
-            monitoring:
-              type: object
-              properties:
-                privileged_users:
-                  enum:
-                    - monitored
-                    - deleted
-                  type: string
             source_indices:
               items:
                 type: string
@@ -1652,6 +1644,9 @@ components:
           properties:
             name:
               type: string
+            is_privileged:
+              type: boolean
+              description: Indicates if the user is privileged.
     MonitoringEngineDescriptor:
       type: object
       properties:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1624,14 +1624,6 @@ components:
         labels:
           type: object
           properties:
-            monitoring:
-              type: object
-              properties:
-                privileged_users:
-                  enum:
-                    - monitored
-                    - deleted
-                  type: string
             source_indices:
               items:
                 type: string
@@ -1650,6 +1642,9 @@ components:
         user:
           type: object
           properties:
+            is_privileged:
+              description: Indicates if the user is privileged.
+              type: boolean
             name:
               type: string
     MonitoringEngineDescriptor:

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/helpers.ts
@@ -12,5 +12,4 @@ export const getPrivilegedMonitorUsersJoin = (
 ) => `| RENAME @timestamp AS event_timestamp
   | LOOKUP JOIN ${getPrivilegedMonitorUsersIndex(namespace)} ON user.name
   | RENAME event_timestamp AS @timestamp
-  | EVAL is_privileged = labels.monitoring.privileged_users == "monitored"
-  | WHERE is_privileged == true`;
+  | WHERE user.is_privileged == true`;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
@@ -211,8 +211,10 @@ export class PrivilegeMonitoringDataClient {
     source: PrivMonUserSource
   ): Promise<CreatePrivMonUserResponse> {
     const doc = merge(user, {
+      user: {
+        is_privileged: true,
+      },
       labels: {
-        monitoring: { privileged_users: 'monitored' },
         sources: [source],
       },
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/soft_delete_omitted_usrs.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/soft_delete_omitted_usrs.ts
@@ -34,10 +34,7 @@ export const softDeleteOmittedUsers =
       index,
       query: {
         bool: {
-          must: [
-            { term: { 'labels.monitoring.privileged_users': 'monitored' } },
-            { term: { 'labels.sources': 'csv' } },
-          ],
+          must: [{ term: { 'user.is_privileged': true } }, { term: { 'labels.sources': 'csv' } }],
           must_not: [{ terms: { 'user.name': uploaded } }],
         },
       },
@@ -57,7 +54,9 @@ export const softDeleteOmittedUsers =
           { update: { _id: id } },
           {
             doc: {
-              labels: { monitoring: { privileged_users: 'deleted' } },
+              user: {
+                is_privileged: false,
+              },
             },
           },
         ];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/update_from_csv.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/update_from_csv.ts
@@ -49,14 +49,13 @@ export const bulkBatchUpsertFromCSV =
       onDocument: (row) => {
         const id = batch.existingUsers[row.username];
         const labels = {
-          monitoring: { privileged_users: 'monitored' },
           sources: ['csv'],
         };
         if (!id) {
           return [
             { create: {} },
             {
-              user: { name: row.username },
+              user: { name: row.username, is_privileged: true },
               labels,
             },
           ];


### PR DESCRIPTION
## Summary

We have [this RFC](https://github.com/elastic/ecs/pull/2493) in, I think this is a safer bet and might save us a migration in the future:

