### PR TITLE
[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_stream_details.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_stream_details.ts
@@ -36,6 +36,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   }
 
   describe('DataStream Details', function () {
+    // this mutes the forward-compatibility test with Elasticsearch, 8.19 kibana and 9.0 ES.
+    // There are not expected to work together.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     let synthtraceLogsEsClient: LogsSynthtraceEsClient;
 
     before(async () => {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_stream_total_docs.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_stream_total_docs.ts
@@ -48,6 +48,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   }
 
   describe('DataStream total docs', function () {
+    // this mutes the forward-compatibility test with Elasticsearch, 8.19 kibana and 9.0 ES.
+    // There are not expected to work together.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     let adminRoleAuthc: RoleCredentials;
     let supertestAdminWithCookieCredentials: SupertestWithRoleScopeType;
     let synthtraceLogsEsClient: LogsSynthtraceEsClient;

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/update_field_limit.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/update_field_limit.ts
@@ -49,6 +49,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   }
 
   describe('Update field limit', function () {
+    // this mutes the forward-compatibility test with Elasticsearch, 8.19 kibana and 9.0 ES.
+    // There are not expected to work together.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     let adminRoleAuthc: RoleCredentials;
     let supertestAdminWithCookieCredentials: SupertestWithRoleScopeType;
     let synthtraceLogsEsClient: LogsSynthtraceEsClient;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/222498
Fixes https://github.com/elastic/kibana/issues/222501

## Summary

The PR skips test suites for ES `9.0.*` which were failing when these tests ran in Kibana `8.19` branch against ES `9.0.*` in forward compatibility runs.

<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->