### PR TITLE
[Discover][Trace waterfall] Update link to relate errors to use QSTR

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -73,7 +73,7 @@ export const FullScreenWaterfall = ({
         filters: [],
         query: {
           language: 'kuery',
-          esql: `FROM ${indexes.apm.errors},${indexes.logs} | WHERE trace.id == "${traceId}" AND span.id == "${docId}"`,
+          esql: `FROM ${indexes.apm.errors},${indexes.logs} | WHERE QSTR("trace.id:${traceId} AND span.id:${docId}")`,
         },
       });
 
@@ -152,14 +152,16 @@ export const FullScreenWaterfall = ({
       </EuiOverlayMask>
 
       {isFlyoutVisible && spanId && (
-        <SpanFlyout
-          tracesIndexPattern={tracesIndexPattern}
-          spanId={spanId}
-          dataView={dataView}
-          onCloseFlyout={() => {
-            setIsFlyoutVisible(false);
-          }}
-        />
+        <EuiFocusTrap>
+          <SpanFlyout
+            tracesIndexPattern={tracesIndexPattern}
+            spanId={spanId}
+            dataView={dataView}
+            onCloseFlyout={() => {
+              setIsFlyoutVisible(false);
+            }}
+          />
+        </EuiFocusTrap>
       )}
     </>
   );

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -152,16 +152,14 @@ export const FullScreenWaterfall = ({
       </EuiOverlayMask>
 
       {isFlyoutVisible && spanId && (
-        <EuiFocusTrap>
-          <SpanFlyout
-            tracesIndexPattern={tracesIndexPattern}
-            spanId={spanId}
-            dataView={dataView}
-            onCloseFlyout={() => {
-              setIsFlyoutVisible(false);
-            }}
-          />
-        </EuiFocusTrap>
+        <SpanFlyout
+          tracesIndexPattern={tracesIndexPattern}
+          spanId={spanId}
+          dataView={dataView}
+          onCloseFlyout={() => {
+            setIsFlyoutVisible(false);
+          }}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/224596

The “View related errors” link in the full-screen waterfall was resolving to an invalid ES|QL query in some specific scenarios (it worked fine in edge-oblt, for example).

To work around this and make the query less restrictive for ES|QL, we’ve updated it to use `QSTR` instead. It provides the same type of search and gives us the expected results without triggering errors.

**Before**
![Screen Recording 2025-06-20 at 09 46 13](https://github.com/user-attachments/assets/4d1c0c19-dbc0-42b2-aba9-194f121eb1c5)
**After**
![Screen Recording 2025-06-20 at 09 43 32](https://github.com/user-attachments/assets/69e0f580-84b8-4c0e-93e7-ebc907e975b0)


## How to test

- Enable the discover profiles by adding this to the` kibana.yml `file:
```discover.experimental.enabledProfiles:
  - observability-traces-data-source-profile
  - observability-traces-transaction-document-profile
  - observability-traces-span-document-profile
```
- Make sure your space has Observability as Solution View.
- Open Discover and query a trace with errors
- Open any flyout and go to the full screen waterfall
- Click on "View related links" on any of the nodes





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->