### PR TITLE
[Discover] Update "isSpan" logic in span waterfall flyout

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/helpers/is_span.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/helpers/is_span.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { OTEL_SPAN_KIND, PROCESSOR_EVENT_FIELD, DataTableRecord } from '@kbn/discover-utils';
+import { isSpanHit } from './is_span';
+
+describe('isSpanHit', () => {
+  it('returns false when hit.flattened is null', () => {
+    const hit = {
+      flattened: null,
+    } as unknown as DataTableRecord;
+
+    expect(isSpanHit(hit)).toBe(false);
+  });
+
+  it('returns true for an OTEL span (spanKind is present)', () => {
+    const hit = {
+      flattened: {
+        [OTEL_SPAN_KIND]: 'client',
+        [PROCESSOR_EVENT_FIELD]: 'span',
+      },
+    } as unknown as DataTableRecord;
+
+    expect(isSpanHit(hit)).toBe(true);
+  });
+
+  it('returns true when processorEvent is null (OTEL fallback)', () => {
+    const hit = {
+      flattened: {
+        [PROCESSOR_EVENT_FIELD]: null,
+      },
+    } as unknown as DataTableRecord;
+
+    expect(isSpanHit(hit)).toBe(true);
+  });
+
+  it('returns true for an APM span (processorEvent === "span")', () => {
+    const hit = {
+      flattened: {
+        [PROCESSOR_EVENT_FIELD]: 'span',
+      },
+    } as unknown as DataTableRecord;
+
+    expect(isSpanHit(hit)).toBe(true);
+  });
+
+  it('returns false when processorEvent is not "span" and spanKind is null', () => {
+    const hit = {
+      flattened: {
+        [PROCESSOR_EVENT_FIELD]: 'transaction',
+        [OTEL_SPAN_KIND]: null,
+      },
+    } as unknown as DataTableRecord;
+
+    expect(isSpanHit(hit)).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/helpers/is_span.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/helpers/is_span.ts
@@ -7,8 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { DataTableRecord, PARENT_ID_FIELD, TRANSACTION_NAME_FIELD } from '@kbn/discover-utils';
+import { DataTableRecord, OTEL_SPAN_KIND, PROCESSOR_EVENT_FIELD } from '@kbn/discover-utils';
 
 export const isSpanHit = (hit: DataTableRecord | null): boolean => {
-  return !!hit?.flattened[PARENT_ID_FIELD] && !hit?.flattened[TRANSACTION_NAME_FIELD];
+  if (!hit?.flattened) {
+    return false;
+  }
+
+  const processorEvent = hit.flattened[PROCESSOR_EVENT_FIELD];
+  const spanKind = hit.flattened[OTEL_SPAN_KIND];
+
+  const isOtelSpan = spanKind != null || processorEvent == null;
+  const isApmSpan = processorEvent === 'span';
+
+  return isApmSpan || isOtelSpan;
 };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -152,14 +152,16 @@ export const FullScreenWaterfall = ({
       </EuiOverlayMask>
 
       {isFlyoutVisible && spanId && (
-        <SpanFlyout
-          tracesIndexPattern={tracesIndexPattern}
-          spanId={spanId}
-          dataView={dataView}
-          onCloseFlyout={() => {
-            setIsFlyoutVisible(false);
-          }}
-        />
+        <EuiFocusTrap>
+          <SpanFlyout
+            tracesIndexPattern={tracesIndexPattern}
+            spanId={spanId}
+            dataView={dataView}
+            onCloseFlyout={() => {
+              setIsFlyoutVisible(false);
+            }}
+          />
+        </EuiFocusTrap>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/221521

This PR updates the logic that determines whether a clicked node in the waterfall is a span or a transaction, making it compatible with non-processed OTel traces data.

The approach used is the same as in the document profile enablement:

https://github.com/elastic/kibana/blob/d80885a45475d7f8d2f83c6181f66257cb6752f2/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.ts#L70-L79

**Extra fix**
- Added a focus trap to the flyout because without it, focus sometimes stayed on the waterfall behind, causing unexpected behavior when trying to filter in the "Table" tab.

## How to test

- Enable the discover profiles by adding this to the` kibana.yml `file:
```discover.experimental.enabledProfiles:
  - observability-traces-data-source-profile
  - observability-traces-transaction-document-profile
  - observability-traces-span-document-profile
```
- Make sure your space has Observability as Solution View.
- Open Discover and query non-processed OTel traces
- Open any flyout and go to the full screen waterfall
- Click on any node of the trace, it should be opened as "Span document"

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->