### PR TITLE
[ResponseOps] Include time metrics and totals in the cases analytics index.

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/mappings.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/mappings.ts
@@ -107,15 +107,12 @@ export const CAI_CASES_INDEX_MAPPINGS: MappingTypeMapping = {
       type: 'keyword',
     },
     time_to_resolve: {
-      // in seconds, calculated by case.closed_at - case.created_at
       type: 'long',
     },
     time_to_acknowledge: {
-      // in seconds, calculated by case.in_progress_at - case.created_at
       type: 'long',
     },
-    time_to_investigaste: {
-      // in seconds, calculated by case.closed_at - case.in_progress_at
+    time_to_investigate: {
       type: 'long',
     },
     custom_fields: {
@@ -150,6 +147,12 @@ export const CAI_CASES_INDEX_MAPPINGS: MappingTypeMapping = {
     },
     space_ids: {
       type: 'keyword',
+    },
+    total_alerts: {
+      type: 'integer',
+    },
+    total_comments: {
+      type: 'integer',
     },
   },
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/painless_scripts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/cases_index/painless_scripts.ts
@@ -134,8 +134,24 @@ export const CAI_CASES_INDEX_SCRIPT: StoredScript = {
     ctx._source.owner = source.cases.owner;
     ctx._source.space_ids = source.namespaces;
 
-    if (ctx._source.created_at_ms != null && ctx._source.closed_at_ms != null){
-      ctx._source.time_to_resolve = (ctx._source.closed_at_ms - ctx._source.created_at_ms) / 1000;
+    if (source.cases.time_to_acknowledge != null){
+      ctx._source.time_to_acknowledge = source.cases.time_to_acknowledge;
+    }
+
+    if (source.cases.time_to_investigate != null){
+      ctx._source.time_to_investigate = source.cases.time_to_investigate;
+    }
+
+    if (source.cases.time_to_resolve != null){
+      ctx._source.time_to_resolve = source.cases.time_to_resolve;
+    }
+
+    if (source.cases.total_alerts != null && source.cases.total_alerts >= 0){
+      ctx._source.total_alerts = source.cases.total_alerts;
+    }
+
+    if (source.cases.total_comments != null && source.cases.total_comments >= 0){
+      ctx._source.total_comments = source.cases.total_comments;
     }
   `,
 };


### PR DESCRIPTION
## Summary

This PR adds some recently added fields to the cases analytics index.

The fields are:
- `time_to_resolve`
- `time_to_acknowledge`
- `time_to_investigate`
- `total_alerts`
- `total_comments`