### PR TITLE
Add upload Sourcemaps to APM to Kibana build script

### DIFF
--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -47,7 +47,7 @@ export function getWebpackConfig(
       [bundle.id]: ENTRY_CREATOR,
     },
 
-    devtool: worker.dist ? false : 'cheap-source-map',
+    devtool: 'cheap-source-map',
     profile: worker.profileWebpack,
 
     target: 'web',

--- a/src/dev/build/args.ts
+++ b/src/dev/build/args.ts
@@ -47,6 +47,7 @@ export function readCliArgs(argv: string[]) {
       'silent',
       'debug',
       'help',
+      'upload-sourcemaps-to-apm',
       'with-test-plugins',
       'with-example-plugins',
       'serverless',
@@ -154,6 +155,7 @@ export function readCliArgs(argv: string[]) {
     targetServerlessPlatforms: Boolean(flags.serverless),
     eprRegistry: flags['epr-registry'],
     buildCanvasShareableRuntime: !Boolean(flags['skip-canvas-shareable-runtime']),
+    uploadServiceMapsToApm: Boolean(flags['upload-sourcemaps-to-apm']),
     withExamplePlugins: Boolean(flags['with-example-plugins']),
     withTestPlugins: Boolean(flags['with-test-plugins']),
   };

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -40,6 +40,7 @@ export interface BuildOptions {
   versionQualifier: string | undefined;
   targetAllPlatforms: boolean;
   targetServerlessPlatforms: boolean;
+  uploadServiceMapsToApm: boolean;
   withExamplePlugins: boolean;
   withTestPlugins: boolean;
   eprRegistry: 'production' | 'snapshot';
@@ -91,6 +92,10 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
     // before DeletePackagesFromBuildRoot
     await globalRun(Tasks.CreateNoticeFile);
     await globalRun(Tasks.CreateXPackNoticeFile);
+
+    if (options.uploadServiceMapsToApm) {
+      await globalRun(Tasks.UploadSourcemapsToApm);
+    }
 
     await globalRun(Tasks.DeletePackagesFromBuildRoot);
     await globalRun(Tasks.UpdateLicenseFile);

--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -65,6 +65,7 @@ if (showHelp) {
         --skip-platform-folders              {dim Skip platform specific folder creation and operations}
         --skip-node-download                 {dim Reuse existing downloads of node.js}
         --skip-os-packages                   {dim Don't produce rpm/deb/docker packages}
+        --upload-sourcemaps-to-apm           {dim Upload sourcemaps to APM}
         --verbose,-v                         {dim Turn on verbose logging}
         --version-qualifier                  {dim Suffix version with a qualifier}
         --with-example-plugins               {dim Pass to include example plugins in the build output}

--- a/src/dev/build/tasks/index.ts
+++ b/src/dev/build/tasks/index.ts
@@ -33,5 +33,6 @@ export * from './replace_favicon';
 export * from './verify_env_task';
 export * from './write_sha_sums_task';
 export * from './fetch_agent_versions_list';
+export * from './upload_sourcemaps_to_apm';
 
 export { InstallChromium } from './install_chromium';

--- a/src/dev/build/tasks/upload_sourcemaps_to_apm.ts
+++ b/src/dev/build/tasks/upload_sourcemaps_to_apm.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+import globby from 'globby';
+import { readFileSync, existsSync } from 'fs';
+import { cwd } from 'process';
+import path from 'path';
+import { Task } from '../lib';
+
+const KIBANA_HOST = process.env.ES || 'http://localhost:5601';
+const KIBANA_API_KEY = process.env.API_KEY || 'YOUR_API_KEY';
+
+export const UploadSourcemapsToApm: Task = {
+  description: 'Uploading sourcemaps to APM',
+
+  async run(config, log, build) {
+    // /src/dev/build/cli.ts configures cwd to be the root of the Kibana repo
+    const root = cwd();
+
+    const version = config.getBuildVersion();
+
+    const sourceMaps = await globby(`${root}/src/**/*.map`, {
+      ignore: ['**/node_modules/**'],
+    });
+
+    if (sourceMaps.length === 0) {
+      log.info('No sourcemaps found to upload.');
+      return;
+    }
+
+    for (const sourceMap of sourceMaps) {
+      try {
+        log.info(`Processing sourcemap: ${sourceMap}`);
+
+        const metricsPath = `${path.dirname(sourceMap)}/metrics.json`;
+
+        if (!existsSync(metricsPath)) {
+          log.error(`No metrics.json found for ${sourceMap}. Skipping upload.`);
+          continue;
+        }
+
+        const metricsContent = readFileSync(metricsPath, 'utf8');
+        const metrics = JSON.parse(metricsContent);
+
+        const bundle = sourceMap.split('.map')[0];
+
+        const id = metrics[0]?.id || 'unknown-app';
+
+        const compressedSourceMap = `${sourceMap}.gz`;
+
+        // Compress the sourcemap using gzip
+        execa.sync('gzip', [`-c "${sourceMap}" > "${compressedSourceMap}"`]);
+
+        const formData = new FormData();
+        formData.append('service_name', id);
+        formData.append('service_version', version);
+        formData.append('bundle_filepath', bundle);
+        formData.append(
+          'sourcemap',
+          JSON.stringify({
+            version: 3,
+            file: bundle,
+            sources: [compressedSourceMap],
+            sourcesContent: ['content'],
+            mappings: 'mapping',
+            sourceRoot: '',
+          })
+        );
+
+        await fetch(`${KIBANA_HOST}/api/apm/sourcemaps`, {
+          method: 'POST',
+          headers: {
+            'kbn-xsrf': 'true',
+            Authorization: `ApiKey ${KIBANA_API_KEY}`,
+          },
+          body: formData,
+        });
+      } catch (error) {
+        log.error(`Failed to upload sourcemap ${sourceMap}: ${error}`);
+        throw error;
+      }
+    }
+  },
+};


### PR DESCRIPTION
## Summary

This adds an optional extra task to the Kibana Build script to upload generated sourcemaps to a configurable APM server via the [Upload Sourcemap API](https://www.elastic.co/docs/api/doc/kibana/operation/operation-uploadsourcemap). 

It compresses generated sourcemaps with gzip before uploading.

### How to use

`$ KIBANA_HOST=<ip_address> KIBANA_API_KEY=<api_key> node scripts/build --upload-to-apm`

