### PR TITLE
[Search] fix: move app menu z index down

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/project/app_menu.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/app_menu.tsx
@@ -20,7 +20,7 @@ export const AppMenuBar = ({ headerActionMenuMounter }: AppMenuBarProps) => {
   const { euiTheme } = useEuiTheme();
   const zIndex =
     typeof euiTheme.levels.header === 'number'
-      ? euiTheme.levels.header - 1 // We want it to appear right below the header
+      ? euiTheme.levels.header - 10 // We want it to appear right below the header
       : euiTheme.levels.header;
 
   return (


### PR DESCRIPTION
## Summary

Currently the app menu z index is header - 1, which makes it below the header and standard flyout, but it is then above the embeddable dev console which is level1 - 2 to not conflict with flyouts.

Updating the AppMenuBar to be header - 10 (990) here to give more flexibility for other layers specifically the embeddable dev console to have a z index between the AppMenuBar and flyouts.

This is fixing an issue seen when using the search solution navigation where the header actions are put into an additional header that is not accounted for in the fixed header offset. Which then causes the embedded dev console to render below the AppMenu bar and be more difficult to close:

![image](https://github.com/user-attachments/assets/cb57314a-ca84-4998-b7dd-47a8b1808d14)

With this change the `AppMenuBar` is moved down to allow the embedded dev console room to open above. The other option would be to introduce a CSS variable for the height of the `AppMenuBar` when it's rendered and update the embedded dev console to account for that height as well as the `--euiFixedHeadersOffset` with it's total maximum height.

After fix:
![image](https://github.com/user-attachments/assets/6762eb99-1a7b-4dbf-a5f4-b34363a3bd0e)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->

## Release note

Adjusted `z-index` of app menu header to not conflict with the portable dev console.