### PR TITLE
[9.0] UI bug when editing Elasticsearch query alert rule "GROUPED OVER" a runtime_mapping field (#223975)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/es_query_expression.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/es_query_expression.test.tsx
@@ -226,7 +226,7 @@ describe('EsQueryRuleTypeExpression', () => {
   });
 
   test('should render EsQueryRuleTypeExpression with chosen runtime group field', async () => {
-    const result = await setup({
+    const wrapper = await setup({
       ...defaultEsQueryExpressionParams,
       esQuery:
         '{\n    "query":{\n      "match_all" : {}\n    },\n    "runtime_mappings": {\n      "day_of_week": {\n        "type": "keyword",\n        "script": {\n          "source": "emit(doc[\'@timestamp\'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))"\n        }\n      }\n    }\n  }',
@@ -235,10 +235,17 @@ describe('EsQueryRuleTypeExpression', () => {
       termSize: 3,
     } as unknown as EsQueryRuleParams<SearchType.esQuery>);
 
-    fireEvent.click(screen.getByTestId('groupByExpression'));
-    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    const groupByButton = wrapper.find('button[data-test-subj="groupByExpression"]');
+    groupByButton.simulate('click');
 
-    expect(result.getByTestId('fieldsExpressionSelect')).toHaveTextContent('day_of_week');
+    await act(async () => {
+      await nextTick();
+      wrapper.update();
+    });
+
+    expect(wrapper.find('EuiComboBox[data-test-subj="fieldsExpressionSelect"]').text()).toEqual(
+      'day_of_week'
+    );
   });
 
   test('should show success message if ungrouped Test Query is successful', async () => {

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/es_query_expression.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/es_query_expression.test.tsx
@@ -149,6 +149,8 @@ describe('EsQueryRuleTypeExpression', () => {
       size: [],
       timeField: [],
       timeWindowSize: [],
+      termSize: [],
+      termField: [],
     };
 
     const wrapper = mountWithIntl(
@@ -221,6 +223,22 @@ describe('EsQueryRuleTypeExpression', () => {
     );
     expect(excludeMatchesCheckBox.exists()).toBeTruthy();
     expect(excludeMatchesCheckBox.prop('checked')).toBe(false);
+  });
+
+  test('should render EsQueryRuleTypeExpression with chosen runtime group field', async () => {
+    const result = await setup({
+      ...defaultEsQueryExpressionParams,
+      esQuery:
+        '{\n    "query":{\n      "match_all" : {}\n    },\n    "runtime_mappings": {\n      "day_of_week": {\n        "type": "keyword",\n        "script": {\n          "source": "emit(doc[\'@timestamp\'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))"\n        }\n      }\n    }\n  }',
+      groupBy: 'top',
+      termField: 'day_of_week',
+      termSize: 3,
+    } as unknown as EsQueryRuleParams<SearchType.esQuery>);
+
+    fireEvent.click(screen.getByTestId('groupByExpression'));
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+    expect(result.getByTestId('fieldsExpressionSelect')).toHaveTextContent('day_of_week');
   });
 
   test('should show success message if ungrouped Test Query is successful', async () => {

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/es_query_expression.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/es_query_expression.tsx
@@ -98,10 +98,12 @@ export const EsQueryExpression: React.FC<
 
   const setDefaultExpressionValues = async () => {
     setRuleProperty('params', currentRuleParams);
-    setXJson(esQuery ?? DEFAULT_VALUES.QUERY);
+    const query = esQuery ?? DEFAULT_VALUES.QUERY;
+    setXJson(query);
 
     if (index && index.length > 0) {
-      await refreshEsFields(index);
+      const initialRuntimeFields = getRuntimeFields(query);
+      await refreshEsFields(index, initialRuntimeFields);
     }
   };
 
@@ -110,10 +112,14 @@ export const EsQueryExpression: React.FC<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const refreshEsFields = async (indices: string[]) => {
+  const refreshEsFields = async (indices: string[], initialRuntimeFields?: FieldOption[]) => {
     const currentEsFields = await getFields(http, indices);
     setEsFields(currentEsFields);
-    setCombinedFields(sortBy(currentEsFields.concat(runtimeFields), 'name'));
+
+    const combined = currentEsFields.concat(
+      initialRuntimeFields !== undefined ? initialRuntimeFields : runtimeFields
+    );
+    setCombinedFields(sortBy(combined, 'name'));
   };
 
   const getRuntimeFields = (xjson: string) => {
@@ -127,6 +133,7 @@ export const EsQueryExpression: React.FC<
       const currentRuntimeFields = convertRawRuntimeFieldtoFieldOption(runtimeMappings);
       setRuntimeFields(currentRuntimeFields);
       setCombinedFields(sortBy(esFields.concat(currentRuntimeFields), 'name'));
+      return currentRuntimeFields;
     }
   };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [UI bug when editing Elasticsearch query alert rule "GROUPED OVER" a runtime_mapping field (#223975)](https://github.com/elastic/kibana/pull/223975)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-17T18:19:28Z","message":"UI bug when editing Elasticsearch query alert rule \"GROUPED OVER\" a runtime_mapping field (#223975)\n\nResolves https://github.com/elastic/kibana/issues/221447\n\n## Summary\n\nThis PR fixes a UI bug when editing an ES query rule that's grouping\nover a runtime field.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Create a DSL ES Query rule and include a runtime field. Here is an\nexample that I like to use\n```\n  \"runtime_mappings\": {\n    \"day_of_week\": {\n      \"type\": \"keyword\",\n      \"script\": {\n        \"source\": \"emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))\"\n      }\n    }\n  },\n\n```\n2. Select that field to groupover and save your rule\n3. Edit your rule and click on `GROUPED OVER`, verify that there is no\nerror and the runtime field is selected","sha":"0a5df0462d75b23fc2088957eeca28d46c1ed8d8","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport missing","v9.0.0","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"UI bug when editing Elasticsearch query alert rule \"GROUPED OVER\" a runtime_mapping field","number":223975,"url":"https://github.com/elastic/kibana/pull/223975","mergeCommit":{"message":"UI bug when editing Elasticsearch query alert rule \"GROUPED OVER\" a runtime_mapping field (#223975)\n\nResolves https://github.com/elastic/kibana/issues/221447\n\n## Summary\n\nThis PR fixes a UI bug when editing an ES query rule that's grouping\nover a runtime field.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Create a DSL ES Query rule and include a runtime field. Here is an\nexample that I like to use\n```\n  \"runtime_mappings\": {\n    \"day_of_week\": {\n      \"type\": \"keyword\",\n      \"script\": {\n        \"source\": \"emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))\"\n      }\n    }\n  },\n\n```\n2. Select that field to groupover and save your rule\n3. Edit your rule and click on `GROUPED OVER`, verify that there is no\nerror and the runtime field is selected","sha":"0a5df0462d75b23fc2088957eeca28d46c1ed8d8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224320","number":224320,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224318","number":224318,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223975","number":223975,"mergeCommit":{"message":"UI bug when editing Elasticsearch query alert rule \"GROUPED OVER\" a runtime_mapping field (#223975)\n\nResolves https://github.com/elastic/kibana/issues/221447\n\n## Summary\n\nThis PR fixes a UI bug when editing an ES query rule that's grouping\nover a runtime field.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Create a DSL ES Query rule and include a runtime field. Here is an\nexample that I like to use\n```\n  \"runtime_mappings\": {\n    \"day_of_week\": {\n      \"type\": \"keyword\",\n      \"script\": {\n        \"source\": \"emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))\"\n      }\n    }\n  },\n\n```\n2. Select that field to groupover and save your rule\n3. Edit your rule and click on `GROUPED OVER`, verify that there is no\nerror and the runtime field is selected","sha":"0a5df0462d75b23fc2088957eeca28d46c1ed8d8"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224319","number":224319,"state":"OPEN"}]}] BACKPORT-->