### PR TITLE
[8.19] [ska] relocate guided_onboarding tests that import search solution src code (#224390)

### DIFF
--- a/.buildkite/ftr_search_stateful_configs.yml
+++ b/.buildkite/ftr_search_stateful_configs.yml
@@ -12,3 +12,5 @@ defaultQueue: 'n2-4-spot'
 enabled:
   - x-pack/test/functional_search/config.ts
   - x-pack/test/functional/apps/search_playground/config.ts
+  - x-pack/solutions/search/test/api_integration/apis/guided_onboarding/config.ts
+

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2137,9 +2137,6 @@ module.exports = {
         'x-pack/platform/plugins/shared/osquery/**',
         // FIXME PhilippeOberti @kbn/timelines-plugin depends on security-solution-plugin (security/private) (timelines is going to disappear)
         'x-pack/platform/plugins/shared/timelines/**',
-        // FIXME @dmlemeshko
-        `src/platform/test/api_integration/apis/guided_onboarding/get_guides.ts`,
-        `src/platform/test/api_integration/apis/guided_onboarding/put_state.ts`,
 
         // For now, we keep the exception to let tests depend on anythying.
         // Ideally, we need to classify the solution specific ones to reduce CI times

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2719,6 +2719,7 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 ^/src/platform/test/examples/error_boundary/index.ts @elastic/appex-sharedux
 ^/src/platform/test/examples/content_management/*.ts @elastic/appex-sharedux
 ^/src/platform/test/api_integration/apis/guided_onboarding @elastic/appex-sharedux
+/x-pack/solutions/search/test/api_integration/apis/guided_onboarding @elastic/appex-sharedux
 /x-pack/test/banners_functional @elastic/appex-sharedux
 /x-pack/test/custom_branding @elastic/appex-sharedux
 /x-pack/platform/test/api_integration/apis/content_management @elastic/appex-sharedux

--- a/src/platform/test/api_integration/apis/guided_onboarding/index.ts
+++ b/src/platform/test/api_integration/apis/guided_onboarding/index.ts
@@ -12,8 +12,6 @@ import type { FtrProviderContext } from '../../ftr_provider_context';
 export default function apiIntegrationTests({ loadTestFile }: FtrProviderContext) {
   describe('guided onboarding', () => {
     loadTestFile(require.resolve('./get_state'));
-    loadTestFile(require.resolve('./put_state'));
-    loadTestFile(require.resolve('./get_guides'));
     loadTestFile(require.resolve('./get_config'));
   });
 }

--- a/src/platform/test/tsconfig.json
+++ b/src/platform/test/tsconfig.json
@@ -61,7 +61,6 @@
     "@kbn/dev-utils",
     "@kbn/utility-types",
     "@kbn/dev-proc-runner",
-    "@kbn/enterprise-search-plugin",
     "@kbn/core-saved-objects-server",
     "@kbn/core-http-common",
     "@kbn/event-annotation-plugin",

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/config.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseIntegrationTestsConfig = await readConfigFile(require.resolve('../../config.ts'));
+
+  return {
+    ...baseIntegrationTestsConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/get_guides.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/get_guides.ts
@@ -1,10 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 import expect from '@kbn/expect';
@@ -16,8 +14,8 @@ import {
 import { appSearchGuideId } from '@kbn/enterprise-search-plugin/common/guided_onboarding/search_guide_config';
 import { API_BASE_PATH } from '@kbn/guided-onboarding-plugin/common';
 import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
+import { createGuides } from '@kbn/test-suites-src/api_integration/apis/guided_onboarding/helpers';
 import type { FtrProviderContext } from '../../ftr_provider_context';
-import { createGuides } from './helpers';
 
 const getGuidesPath = `${API_BASE_PATH}/guides`;
 export default function testGetGuidesState({ getService }: FtrProviderContext) {

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/index.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function apiIntegrationTests({ loadTestFile }: FtrProviderContext) {
+  describe('guided onboarding', () => {
+    loadTestFile(require.resolve('./get_guides'));
+    loadTestFile(require.resolve('./put_state'));
+  });
+}

--- a/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/put_state.ts
+++ b/x-pack/solutions/search/test/api_integration/apis/guided_onboarding/put_state.ts
@@ -1,10 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 import expect from '@kbn/expect';
@@ -24,8 +22,11 @@ import { testGuideId } from '@kbn/guided-onboarding';
 import { appSearchGuideId } from '@kbn/enterprise-search-plugin/common/guided_onboarding/search_guide_config';
 import { API_BASE_PATH } from '@kbn/guided-onboarding-plugin/common';
 import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
+import {
+  createGuides,
+  createPluginState,
+} from '@kbn/test-suites-src/api_integration/apis/guided_onboarding/helpers';
 import type { FtrProviderContext } from '../../ftr_provider_context';
-import { createGuides, createPluginState } from './helpers';
 
 const putStatePath = `${API_BASE_PATH}/state`;
 export default function testPutState({ getService }: FtrProviderContext) {

--- a/x-pack/solutions/search/test/tsconfig.json
+++ b/x-pack/solutions/search/test/tsconfig.json
@@ -21,5 +21,10 @@
     "@kbn/test",
     "@kbn/scout-info",
     "@kbn/test-suites-xpack-platform",
+    "@kbn/expect",
+    "@kbn/guided-onboarding-plugin",
+    "@kbn/enterprise-search-plugin",
+    "@kbn/test-suites-src",
+    "@kbn/guided-onboarding",
   ]
 }

--- a/x-pack/solutions/search/test/tsconfig.json
+++ b/x-pack/solutions/search/test/tsconfig.json
@@ -26,5 +26,6 @@
     "@kbn/enterprise-search-plugin",
     "@kbn/test-suites-src",
     "@kbn/guided-onboarding",
+    "@kbn/core-http-common",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ska] relocate guided_onboarding tests that import search solution src code (#224390)](https://github.com/elastic/kibana/pull/224390)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-06-18T14:01:56Z","message":"[ska] relocate guided_onboarding tests that import search solution src code (#224390)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR relocates few test files from `/src/platform/test` dir that\nimports from `@kbn/enterprise-search-plugin`, which is Search solution\nplugin.\n\nBefore:\n\n```\n/src/platform/test/api_integration/guided_onboarding\n     | - get_guides.ts\n     | - put_state.ts\n```\n\nAfter: \n```\n/x-pack/solutions/search/test/api_integration/guided_onboarding\n     | - get_guides.ts\n     | - put_state.ts\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"995153f45fd9d2e459822b8d39edfeec2a00efd5","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.1.0","v8.19.0"],"title":"[ska] relocate guided_onboarding tests that import search solution src code","number":224390,"url":"https://github.com/elastic/kibana/pull/224390","mergeCommit":{"message":"[ska] relocate guided_onboarding tests that import search solution src code (#224390)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR relocates few test files from `/src/platform/test` dir that\nimports from `@kbn/enterprise-search-plugin`, which is Search solution\nplugin.\n\nBefore:\n\n```\n/src/platform/test/api_integration/guided_onboarding\n     | - get_guides.ts\n     | - put_state.ts\n```\n\nAfter: \n```\n/x-pack/solutions/search/test/api_integration/guided_onboarding\n     | - get_guides.ts\n     | - put_state.ts\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"995153f45fd9d2e459822b8d39edfeec2a00efd5"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224390","number":224390,"mergeCommit":{"message":"[ska] relocate guided_onboarding tests that import search solution src code (#224390)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR relocates few test files from `/src/platform/test` dir that\nimports from `@kbn/enterprise-search-plugin`, which is Search solution\nplugin.\n\nBefore:\n\n```\n/src/platform/test/api_integration/guided_onboarding\n     | - get_guides.ts\n     | - put_state.ts\n```\n\nAfter: \n```\n/x-pack/solutions/search/test/api_integration/guided_onboarding\n     | - get_guides.ts\n     | - put_state.ts\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"995153f45fd9d2e459822b8d39edfeec2a00efd5"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->