### PR TITLE
[8.19] [Discover] Register traces recommended ES|QL queries in Observability (#224614)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/kibana.jsonc
@@ -1,9 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/apm-plugin",
-  "owner": [
-    "@elastic/obs-ux-infra_services-team"
-  ],
+  "owner": ["@elastic/obs-ux-infra_services-team"],
   "group": "observability",
   "visibility": "private",
   "description": "The user interface for Elastic APM",
@@ -11,10 +9,7 @@
     "id": "apm",
     "browser": true,
     "server": true,
-    "configPath": [
-      "xpack",
-      "apm"
-    ],
+    "configPath": ["xpack", "apm"],
     "requiredPlugins": [
       "apmSourcesAccess",
       "apmDataAccess",
@@ -65,13 +60,6 @@
       "observabilityAIAssistant",
       "share"
     ],
-    "requiredBundles": [
-      "fleet",
-      "kibanaReact",
-      "kibanaUtils",
-      "ml",
-      "observability",
-      "maps"
-    ]
+    "requiredBundles": ["fleet", "kibanaReact", "kibanaUtils", "ml", "observability", "maps"]
   }
 }

--- a/x-pack/solutions/observability/plugins/observability/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability/kibana.jsonc
@@ -46,7 +46,8 @@
       "logsShared",
       "licensing",
       "navigation",
-      "fieldsMetadata"
+      "fieldsMetadata",
+      "esql"
     ],
     "optionalPlugins": [
       "discover",

--- a/x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions/set_esql_recommended_queries.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions/set_esql_recommended_queries.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { i18n } from '@kbn/i18n';
+
+import { PluginSetup as ESQLSetup } from '@kbn/esql/server';
+
+const TRACES_INDEX_PATTERN = 'traces-*';
+const LOGS_INDEX_PATTERN = 'logs-*';
+
+const TRACES_ESQL_RECOMMENDED_QUERIES = [
+  {
+    name: i18n.translate('xpack.observability.recommendedQueries.findRootTraces.name', {
+      defaultMessage: 'Root traces',
+    }),
+    query: `FROM ${TRACES_INDEX_PATTERN} | WHERE parent.id IS NULL`,
+    description: i18n.translate(
+      'xpack.observability.recommendedQueries.findRootTraces.description',
+      {
+        defaultMessage:
+          'Display all root spans, which represent the start of a request or transaction. This is useful for getting a high-level overview of all operations in your system.',
+      }
+    ),
+  },
+  {
+    name: i18n.translate('xpack.observability.recommendedQueries.slowDatabaseQueries.name', {
+      defaultMessage: 'Database queries',
+    }),
+    query: `FROM ${TRACES_INDEX_PATTERN} | WHERE QSTR("span.type:db OR db.system:*")`,
+    description: i18n.translate(
+      'xpack.observability.recommendedQueries.slowDatabaseQueries.description',
+      {
+        defaultMessage: 'Pinpoint performance bottlenecks by finding all database (db) spans.',
+      }
+    ),
+  },
+  {
+    name: i18n.translate('xpack.observability.recommendedQueries.allApplicationErrors.name', {
+      defaultMessage: 'All application errors',
+    }),
+    query: `FROM ${LOGS_INDEX_PATTERN} | WHERE QSTR("processor.event:error OR event_name:exception")`,
+    description: i18n.translate(
+      'xpack.observability.recommendedQueries.allApplicationErrors.description',
+      {
+        defaultMessage:
+          'Scan logs to find all documents marked as an error or exception, which is essential for monitoring and troubleshooting application failures.',
+      }
+    ),
+  },
+  {
+    name: i18n.translate('xpack.observability.recommendedQueries.matchingUrlPattern.name', {
+      defaultMessage: 'Spans matching URL pattern',
+    }),
+    query: `FROM ${TRACES_INDEX_PATTERN} | WHERE QSTR("""url.path: \\/api\\/*""")`,
+    description: i18n.translate(
+      'xpack.observability.recommendedQueries.matchingUrlPattern.description',
+      {
+        defaultMessage:
+          'Find all spans which have url.path attribute matching a specified condition.',
+      }
+    ),
+  },
+];
+
+const OBS_ESQL_RECOMMENDED_QUERIES = [...TRACES_ESQL_RECOMMENDED_QUERIES];
+
+export function setEsqlRecommendedQueries(esqlPlugin: ESQLSetup) {
+  const esqlExtensionsRegistry = esqlPlugin.getExtensionsRegistry();
+  esqlExtensionsRegistry.setRecommendedQueries(OBS_ESQL_RECOMMENDED_QUERIES, 'oblt');
+}

--- a/x-pack/solutions/observability/plugins/observability/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/plugin.ts
@@ -35,6 +35,7 @@ import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
+import { PluginSetup as ESQLSetup } from '@kbn/esql/server';
 import { ObservabilityConfig } from '.';
 import { observabilityFeatureId } from '../common';
 import {
@@ -57,6 +58,7 @@ import { OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES } from '../
 import { getCasesFeature } from './features/cases_v1';
 import { getCasesFeatureV2 } from './features/cases_v2';
 import { getCasesFeatureV3 } from './features/cases_v3';
+import { setEsqlRecommendedQueries } from './lib/esql_extensions/set_esql_recommended_queries';
 
 export type ObservabilityPluginSetup = ReturnType<ObservabilityPlugin['setup']>;
 
@@ -70,6 +72,7 @@ interface PluginSetup {
   usageCollection?: UsageCollectionSetup;
   cloud?: CloudSetup;
   contentManagement: ContentManagementServerSetup;
+  esql: ESQLSetup;
 }
 
 interface PluginStart {
@@ -218,6 +221,8 @@ export class ObservabilityPlugin
      * Register a config for the observability guide
      */
     plugins.guidedOnboarding?.registerGuideConfig(kubernetesGuideId, kubernetesGuideConfig);
+
+    setEsqlRecommendedQueries(plugins.esql);
 
     return {
       getAlertDetailsConfig() {

--- a/x-pack/solutions/observability/plugins/observability/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability/tsconfig.json
@@ -121,7 +121,8 @@
     "@kbn/core-saved-objects-server",
     "@kbn/response-ops-rule-params",
     "@kbn/controls-plugin",
-    "@kbn/core-http-browser"
+    "@kbn/core-http-browser",
+    "@kbn/esql"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover] Register traces recommended ES|QL queries in Observability (#224614)](https://github.com/elastic/kibana/pull/224614)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2025-06-20T14:38:51Z","message":"[Discover] Register traces recommended ES|QL queries in Observability (#224614)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/222908\n\nIn this PR, we're using the new feature that allows us to register\nrecommended queries by plugin.\n\nI’ve followed the [same approach as the logs\nteam](https://github.com/elastic/kibana/pull/224054/files), so the\nimplementation should be easy to merge.\n\nThe reasoning behind the query format is explained in [this\ncomment](https://github.com/elastic/kibana/issues/222908#issuecomment-2984919662),\nbut in short, we had to adapt and limit our queries to ensure they work\nwell across multiple data sources like ECS and OTel indexes.\n\n|Index|Editor|ES\\|QL help menu|\n|-|-|-|\n|**traces-***|![Screenshot 2025-06-19 at 19 24\n54](https://github.com/user-attachments/assets/5abd272f-c4fb-4b17-9c8b-243cdcf7f486)|![Screenshot\n2025-06-19 at 19 26\n53](https://github.com/user-attachments/assets/4404b728-164a-4cc7-93c3-366a688f8bc5)|\n|**logs-***|![Screenshot 2025-06-19 at 19 27\n11](https://github.com/user-attachments/assets/3e939d81-16c7-4c13-9f0b-800560abf328)|![Screenshot\n2025-06-19 at 19 27\n32](https://github.com/user-attachments/assets/a190ac64-0c56-4368-be36-fa1ab81043a6)|\n\nThere's also a description for each of the queries that looks like this:\n![Screenshot 2025-06-19 at 19 25\n11](https://github.com/user-attachments/assets/639a4e7f-3807-45fa-8b8c-bc30b0db1296)\n\n\nThis is just the first batch of recommended queries, we’re definitely\nplanning to keep improving them and add more over time.\n\n## How to test\n- Access any Observability solution space\n- Go to Discover in ES|QL mode\n- Type `FROM logs-*` or `FROM traces-*` and hit space, the recommended\nqueries should appear\n- Or go to ES|QL help > Recommended queries","sha":"92ed032ee2f5646575f6443de1906f1fcfb01dda","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Discover] Register traces recommended ES|QL queries in Observability","number":224614,"url":"https://github.com/elastic/kibana/pull/224614","mergeCommit":{"message":"[Discover] Register traces recommended ES|QL queries in Observability (#224614)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/222908\n\nIn this PR, we're using the new feature that allows us to register\nrecommended queries by plugin.\n\nI’ve followed the [same approach as the logs\nteam](https://github.com/elastic/kibana/pull/224054/files), so the\nimplementation should be easy to merge.\n\nThe reasoning behind the query format is explained in [this\ncomment](https://github.com/elastic/kibana/issues/222908#issuecomment-2984919662),\nbut in short, we had to adapt and limit our queries to ensure they work\nwell across multiple data sources like ECS and OTel indexes.\n\n|Index|Editor|ES\\|QL help menu|\n|-|-|-|\n|**traces-***|![Screenshot 2025-06-19 at 19 24\n54](https://github.com/user-attachments/assets/5abd272f-c4fb-4b17-9c8b-243cdcf7f486)|![Screenshot\n2025-06-19 at 19 26\n53](https://github.com/user-attachments/assets/4404b728-164a-4cc7-93c3-366a688f8bc5)|\n|**logs-***|![Screenshot 2025-06-19 at 19 27\n11](https://github.com/user-attachments/assets/3e939d81-16c7-4c13-9f0b-800560abf328)|![Screenshot\n2025-06-19 at 19 27\n32](https://github.com/user-attachments/assets/a190ac64-0c56-4368-be36-fa1ab81043a6)|\n\nThere's also a description for each of the queries that looks like this:\n![Screenshot 2025-06-19 at 19 25\n11](https://github.com/user-attachments/assets/639a4e7f-3807-45fa-8b8c-bc30b0db1296)\n\n\nThis is just the first batch of recommended queries, we’re definitely\nplanning to keep improving them and add more over time.\n\n## How to test\n- Access any Observability solution space\n- Go to Discover in ES|QL mode\n- Type `FROM logs-*` or `FROM traces-*` and hit space, the recommended\nqueries should appear\n- Or go to ES|QL help > Recommended queries","sha":"92ed032ee2f5646575f6443de1906f1fcfb01dda"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224614","number":224614,"mergeCommit":{"message":"[Discover] Register traces recommended ES|QL queries in Observability (#224614)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/222908\n\nIn this PR, we're using the new feature that allows us to register\nrecommended queries by plugin.\n\nI’ve followed the [same approach as the logs\nteam](https://github.com/elastic/kibana/pull/224054/files), so the\nimplementation should be easy to merge.\n\nThe reasoning behind the query format is explained in [this\ncomment](https://github.com/elastic/kibana/issues/222908#issuecomment-2984919662),\nbut in short, we had to adapt and limit our queries to ensure they work\nwell across multiple data sources like ECS and OTel indexes.\n\n|Index|Editor|ES\\|QL help menu|\n|-|-|-|\n|**traces-***|![Screenshot 2025-06-19 at 19 24\n54](https://github.com/user-attachments/assets/5abd272f-c4fb-4b17-9c8b-243cdcf7f486)|![Screenshot\n2025-06-19 at 19 26\n53](https://github.com/user-attachments/assets/4404b728-164a-4cc7-93c3-366a688f8bc5)|\n|**logs-***|![Screenshot 2025-06-19 at 19 27\n11](https://github.com/user-attachments/assets/3e939d81-16c7-4c13-9f0b-800560abf328)|![Screenshot\n2025-06-19 at 19 27\n32](https://github.com/user-attachments/assets/a190ac64-0c56-4368-be36-fa1ab81043a6)|\n\nThere's also a description for each of the queries that looks like this:\n![Screenshot 2025-06-19 at 19 25\n11](https://github.com/user-attachments/assets/639a4e7f-3807-45fa-8b8c-bc30b0db1296)\n\n\nThis is just the first batch of recommended queries, we’re definitely\nplanning to keep improving them and add more over time.\n\n## How to test\n- Access any Observability solution space\n- Go to Discover in ES|QL mode\n- Type `FROM logs-*` or `FROM traces-*` and hit space, the recommended\nqueries should appear\n- Or go to ES|QL help > Recommended queries","sha":"92ed032ee2f5646575f6443de1906f1fcfb01dda"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->