### PR TITLE
chore(slo): improve slo client

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/client/slo_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/client/slo_client.ts
@@ -4,20 +4,25 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { KibanaRequest } from '@kbn/core/server';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
 import { once } from 'lodash';
+import { GetSLOParams } from '@kbn/slo-schema';
 import { GetScopedClients } from '../routes/types';
 import { getSloSettings, getSummaryIndices } from '../services/slo_settings';
 import { SLOClient } from './types';
+import { DefaultBurnRatesClient, DefaultSummaryClient, GetSLO } from '../services';
+import { SloDefinitionClient } from '../services/slo_definition_client';
 
 export async function sloClientFactory({
   request,
   getScopedClients,
+  logger,
 }: {
   request: KibanaRequest;
   getScopedClients: GetScopedClients;
+  logger: Logger;
 }): Promise<SLOClient> {
-  const { scopedClusterClient, soClient } = await getScopedClients(request);
+  const { scopedClusterClient, spaceId, soClient, repository } = await getScopedClients(request);
 
   const getSummaryIndicesOnce = once(async () => {
     const settings = await getSloSettings(soClient);
@@ -28,6 +33,21 @@ export async function sloClientFactory({
   return {
     getSummaryIndices: async () => {
       return await getSummaryIndicesOnce();
+    },
+    getSlo: async (id: string, params: GetSLOParams) => {
+      const burnRatesClient = new DefaultBurnRatesClient(scopedClusterClient.asCurrentUser);
+      const summaryClient = new DefaultSummaryClient(
+        scopedClusterClient.asCurrentUser,
+        burnRatesClient
+      );
+      const definitionClient = new SloDefinitionClient(
+        repository,
+        scopedClusterClient.asCurrentUser,
+        logger
+      );
+      const getSLO = new GetSLO(definitionClient, summaryClient);
+
+      return getSLO.execute(id, spaceId, params);
     },
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/server/client/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/client/types.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import { GetSLOParams, GetSLOResponse } from '@kbn/slo-schema';
+
 export interface SLOClient {
   getSummaryIndices: () => Promise<string[]>;
+  getSlo: (id: string, params: GetSLOParams) => Promise<GetSLOResponse>;
 }

--- a/x-pack/solutions/observability/plugins/slo/server/client/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/client/types.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface SLOClient {
+  getSummaryIndices: () => Promise<string[]>;
+}

--- a/x-pack/solutions/observability/plugins/slo/server/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/index.ts
@@ -16,7 +16,7 @@ export async function plugin(ctx: PluginInitializerContext<SLOConfig>) {
   return new SLOPlugin(ctx);
 }
 
-export type { SloClient } from './client';
+export type { SloClient } from './client/slo_client';
 
 export type { SLOServerSetup, SLOServerStart } from './types';
 

--- a/x-pack/solutions/observability/plugins/slo/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/plugin.ts
@@ -231,6 +231,7 @@ export class SLOPlugin
         return sloClientFactory({
           request,
           getScopedClients,
+          logger: this.logger,
         });
       },
     };

--- a/x-pack/solutions/observability/plugins/slo/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/plugin.ts
@@ -23,7 +23,7 @@ import { AlertsLocatorDefinition, sloFeatureId } from '@kbn/observability-plugin
 import { DEPRECATED_ALERTING_CONSUMERS, SLO_BURN_RATE_RULE_TYPE_ID } from '@kbn/rule-data-utils';
 import { mapValues } from 'lodash';
 import { LOCK_ID_RESOURCE_INSTALLER } from '../common/constants';
-import { getSloClientWithRequest } from './client';
+import { sloClientFactory } from './client/slo_client';
 import { registerSloUsageCollector } from './lib/collectors/register';
 import { registerBurnRateRule } from './lib/rules/register_burn_rate_rule';
 import {
@@ -219,7 +219,7 @@ export class SLOPlugin
 
     this.tempSummaryCleanupTask?.start(plugins).catch(() => {});
 
-    const scopedClients = getScopedClientsStartFactory({
+    const getScopedClients = getScopedClientsStartFactory({
       coreStart: core,
       pluginsStart: plugins,
       logger: this.logger,
@@ -228,10 +228,9 @@ export class SLOPlugin
 
     return {
       getSloClientWithRequest: (request: KibanaRequest) => {
-        return getSloClientWithRequest({
+        return sloClientFactory({
           request,
-          soClient: core.savedObjects.getScopedClient(request),
-          esClient: internalEsClient,
+          getScopedClients,
         });
       },
     };

--- a/x-pack/solutions/observability/plugins/slo/server/routes/get_scoped_clients.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/get_scoped_clients.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CoreSetup, CoreStart, KibanaRequest, Logger, SavedObjectsClient } from '@kbn/core/server';
+import {
+  DefaultSummaryTransformManager,
+  DefaultTransformManager,
+  KibanaSavedObjectsSLORepository,
+} from '../services';
+import { DefaultSummaryTransformGenerator } from '../services/summary_transform_generator/summary_transform_generator';
+import { createTransformGenerators } from '../services/transform_generators';
+import { SLOPluginStartDependencies, SLOServerStart } from '../types';
+import { GetScopedClients } from './types';
+
+export function getScopedClientsSetupFactory({
+  core,
+  logger,
+  isServerless,
+}: {
+  core: CoreSetup<SLOPluginStartDependencies, SLOServerStart>;
+  logger: Logger;
+  isServerless: boolean;
+}): GetScopedClients {
+  return async (request) => {
+    const [coreStart, pluginsStart] = await core.getStartServices();
+    return getScopedClients({
+      request,
+      coreStart,
+      pluginsStart,
+      logger,
+      isServerless,
+    });
+  };
+}
+
+export function getScopedClientsStartFactory({
+  coreStart,
+  pluginsStart,
+  logger,
+  isServerless,
+}: {
+  coreStart: CoreStart;
+  pluginsStart: SLOPluginStartDependencies;
+  logger: Logger;
+  isServerless: boolean;
+}): GetScopedClients {
+  return async (request) =>
+    getScopedClients({
+      request,
+      coreStart,
+      pluginsStart,
+      logger,
+      isServerless,
+    });
+}
+
+export async function getScopedClients({
+  request,
+  coreStart,
+  pluginsStart,
+  logger,
+  isServerless,
+}: {
+  request: KibanaRequest;
+  coreStart: CoreStart;
+  pluginsStart: SLOPluginStartDependencies;
+  logger: Logger;
+  isServerless: boolean;
+}): ReturnType<GetScopedClients> {
+  const internalSoClient = new SavedObjectsClient(
+    coreStart.savedObjects.createInternalRepository()
+  );
+  const soClient = coreStart.savedObjects.getScopedClient(request);
+  const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
+
+  const [dataViewsService, rulesClient, { id: spaceId }, racClient] = await Promise.all([
+    pluginsStart.dataViews.dataViewsServiceFactory(soClient, scopedClusterClient.asCurrentUser),
+    pluginsStart.alerting.getRulesClientWithRequest(request),
+    pluginsStart.spaces?.spacesService.getActiveSpace(request) ?? { id: 'default' },
+    pluginsStart.ruleRegistry.getRacClientWithRequest(request),
+  ]);
+
+  const repository = new KibanaSavedObjectsSLORepository(soClient, logger);
+
+  const transformManager = new DefaultTransformManager(
+    createTransformGenerators(spaceId, dataViewsService, isServerless),
+    scopedClusterClient,
+    logger
+  );
+  const summaryTransformManager = new DefaultSummaryTransformManager(
+    new DefaultSummaryTransformGenerator(),
+    scopedClusterClient,
+    logger
+  );
+
+  return {
+    scopedClusterClient,
+    soClient,
+    internalSoClient,
+    dataViewsService,
+    rulesClient,
+    spaceId,
+    repository,
+    transformManager,
+    summaryTransformManager,
+    racClient,
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/server/routes/get_scoped_clients.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/get_scoped_clients.ts
@@ -58,7 +58,7 @@ export function getScopedClientsStartFactory({
     });
 }
 
-export async function getScopedClients({
+async function getScopedClients({
   request,
   coreStart,
   pluginsStart,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/create_slo.ts
@@ -29,7 +29,7 @@ export const createSLORoute = createSloServerRoute({
       repository,
       transformManager,
       summaryTransformManager,
-    } = await getScopedClients({ request, logger });
+    } = await getScopedClients(request);
 
     const core = await context.core;
     const userId = core.security.authc.getCurrentUser()?.username!;

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/delete_instances.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/delete_instances.ts
@@ -19,10 +19,10 @@ export const deleteSloInstancesRoute = createSloServerRoute({
     },
   },
   params: deleteSLOInstancesParamsSchema,
-  handler: async ({ request, logger, response, params, plugins, getScopedClients }) => {
+  handler: async ({ request, response, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
-    const { scopedClusterClient } = await getScopedClients({ request, logger });
+    const { scopedClusterClient } = await getScopedClients(request);
 
     const deleteSloInstances = new DeleteSLOInstances(scopedClusterClient.asCurrentUser);
     await deleteSloInstances.execute(params.body);

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/delete_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/delete_slo.ts
@@ -19,7 +19,7 @@ export const deleteSLORoute = createSloServerRoute({
     },
   },
   params: deleteSLOParamsSchema,
-  handler: async ({ response, params, logger, request, plugins, getScopedClients }) => {
+  handler: async ({ response, params, request, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
     const {
@@ -28,7 +28,7 @@ export const deleteSLORoute = createSloServerRoute({
       transformManager,
       summaryTransformManager,
       rulesClient,
-    } = await getScopedClients({ request, logger });
+    } = await getScopedClients(request);
 
     const deleteSLO = new DeleteSLO(
       repository,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/disable_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/disable_slo.ts
@@ -19,13 +19,12 @@ export const disableSLORoute = createSloServerRoute({
     },
   },
   params: manageSLOParamsSchema,
-  handler: async ({ context, response, request, params, logger, plugins, getScopedClients }) => {
+  handler: async ({ context, response, request, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
-    const { repository, transformManager, summaryTransformManager } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { repository, transformManager, summaryTransformManager } = await getScopedClients(
+      request
+    );
     const core = await context.core;
     const userId = core.security.authc.getCurrentUser()?.username!;
     const manageSLO = new ManageSLO(repository, transformManager, summaryTransformManager, userId);

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/enable_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/enable_slo.ts
@@ -19,13 +19,12 @@ export const enableSLORoute = createSloServerRoute({
     },
   },
   params: manageSLOParamsSchema,
-  handler: async ({ context, response, request, params, logger, plugins, getScopedClients }) => {
+  handler: async ({ context, response, request, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
-    const { repository, transformManager, summaryTransformManager } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { repository, transformManager, summaryTransformManager } = await getScopedClients(
+      request
+    );
 
     const core = await context.core;
     const userId = core.security.authc.getCurrentUser()?.username!;

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/fetch_health.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/fetch_health.ts
@@ -19,10 +19,10 @@ export const fetchSloHealthRoute = createSloServerRoute({
     },
   },
   params: fetchSLOHealthParamsSchema,
-  handler: async ({ request, logger, params, plugins, getScopedClients }) => {
+  handler: async ({ request, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
-    const { scopedClusterClient, repository } = await getScopedClients({ request, logger });
+    const { scopedClusterClient, repository } = await getScopedClients(request);
     const getSLOHealth = new GetSLOHealth(scopedClusterClient, repository);
 
     return await getSLOHealth.execute(params.body);

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/fetch_historical_summary.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/fetch_historical_summary.ts
@@ -19,9 +19,9 @@ export const fetchHistoricalSummary = createSloServerRoute({
     },
   },
   params: fetchHistoricalSummaryParamsSchema,
-  handler: async ({ request, logger, params, plugins, getScopedClients }) => {
+  handler: async ({ request, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient } = await getScopedClients({ request, logger });
+    const { scopedClusterClient } = await getScopedClients(request);
     const historicalSummaryClient = new HistoricalSummaryClient(scopedClusterClient.asCurrentUser);
 
     return await historicalSummaryClient.fetch(params.body);

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/find_definitions.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/find_definitions.ts
@@ -19,9 +19,9 @@ export const findSloDefinitionsRoute = createSloServerRoute({
     },
   },
   params: findSloDefinitionsParamsSchema,
-  handler: async ({ request, logger, params, plugins, getScopedClients }) => {
+  handler: async ({ request, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { repository } = await getScopedClients({ request, logger });
+    const { repository } = await getScopedClients(request);
     const findSloDefinitions = new FindSLODefinitions(repository);
 
     return await findSloDefinitions.execute(params?.query ?? {});

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/find_groups.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/find_groups.ts
@@ -21,7 +21,7 @@ export const findSLOGroupsRoute = createSloServerRoute({
   params: findSLOGroupsParamsSchema,
   handler: async ({ request, logger, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient, soClient, spaceId } = await getScopedClients({ request, logger });
+    const { scopedClusterClient, soClient, spaceId } = await getScopedClients(request);
 
     const findSLOGroups = new FindSLOGroups(scopedClusterClient, soClient, logger, spaceId);
     return await findSLOGroups.execute(params?.query ?? {});

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/find_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/find_slo.ts
@@ -22,10 +22,7 @@ export const findSLORoute = createSloServerRoute({
   params: findSLOParamsSchema,
   handler: async ({ request, logger, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient, repository, soClient, spaceId } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { scopedClusterClient, repository, soClient, spaceId } = await getScopedClients(request);
 
     const summarySearchClient = new DefaultSummarySearchClient(
       scopedClusterClient,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_diagnosis.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_diagnosis.ts
@@ -20,8 +20,8 @@ export const getDiagnosisRoute = createSloServerRoute({
     },
   },
   params: undefined,
-  handler: async ({ request, logger, plugins, getScopedClients }) => {
-    const { scopedClusterClient } = await getScopedClients({ request, logger });
+  handler: async ({ request, plugins, getScopedClients }) => {
+    const { scopedClusterClient } = await getScopedClients(request);
     const licensing = await plugins.licensing.start();
 
     try {

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_groupings.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_groupings.ts
@@ -23,10 +23,7 @@ export const getSLOGroupingsRoute = createSloServerRoute({
   params: getSLOGroupingsParamsSchema,
   handler: async ({ request, logger, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient, repository, soClient, spaceId } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { scopedClusterClient, repository, soClient, spaceId } = await getScopedClients(request);
 
     const settings = await getSloSettings(soClient);
 

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_preview_data.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_preview_data.ts
@@ -19,12 +19,9 @@ export const getPreviewData = createSloServerRoute({
     },
   },
   params: getPreviewDataParamsSchema,
-  handler: async ({ request, logger, params, plugins, getScopedClients }) => {
+  handler: async ({ request, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient, dataViewsService, spaceId } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { scopedClusterClient, dataViewsService, spaceId } = await getScopedClients(request);
 
     const service = new GetPreviewData(
       scopedClusterClient.asCurrentUser,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo.ts
@@ -22,10 +22,7 @@ export const getSLORoute = createSloServerRoute({
   params: getSLOParamsSchema,
   handler: async ({ request, logger, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient, spaceId, repository } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { scopedClusterClient, spaceId, repository } = await getScopedClients(request);
 
     const burnRatesClient = new DefaultBurnRatesClient(scopedClusterClient.asCurrentUser);
     const summaryClient = new DefaultSummaryClient(

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_burn_rates.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_burn_rates.ts
@@ -21,10 +21,7 @@ export const getSloBurnRates = createSloServerRoute({
   params: getSLOBurnRatesParamsSchema,
   handler: async ({ request, logger, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { scopedClusterClient, soClient, spaceId } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { scopedClusterClient, soClient, spaceId } = await getScopedClients(request);
 
     const { instanceId, windows, remoteName } = params.body;
 

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_settings.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_settings.ts
@@ -17,10 +17,9 @@ export const getSloSettingsRoute = createSloServerRoute({
       requiredPrivileges: ['slo_read'],
     },
   },
-  handler: async ({ context, plugins }) => {
+  handler: async ({ plugins, getScopedClients, request }) => {
     await assertPlatinumLicense(plugins);
-
-    const soClient = (await context.core).savedObjects.client;
+    const { soClient } = await getScopedClients(request);
 
     return await getSloSettings(soClient);
   },

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_stats_overview.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_stats_overview.ts
@@ -22,10 +22,7 @@ export const getSLOStatsOverview = createSloServerRoute({
   handler: async ({ request, logger, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
     const { scopedClusterClient, spaceId, soClient, rulesClient, racClient } =
-      await getScopedClients({
-        request,
-        logger,
-      });
+      await getScopedClients(request);
 
     const slosOverview = new GetSLOStatsOverview(
       soClient,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_suggestions.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_suggestions.ts
@@ -17,12 +17,9 @@ export const getSLOSuggestionsRoute = createSloServerRoute({
       requiredPrivileges: ['slo_read'],
     },
   },
-  handler: async ({ request, logger, plugins, getScopedClients }) => {
+  handler: async ({ request, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-    const { soClient } = await getScopedClients({
-      request,
-      logger,
-    });
+    const { soClient } = await getScopedClients(request);
 
     const getSLOSuggestions = new GetSLOSuggestions(soClient);
     return await getSLOSuggestions.execute();

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/inspect_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/inspect_slo.ts
@@ -29,7 +29,7 @@ export const inspectSLORoute = createSloServerRoute({
       repository,
       transformManager,
       summaryTransformManager,
-    } = await getScopedClients({ request, logger });
+    } = await getScopedClients(request);
 
     const core = await context.core;
     const basePath = corePlugins.http.basePath;

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/purge_rollup_data.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/purge_rollup_data.ts
@@ -18,10 +18,9 @@ export const bulkPurgeRollupRoute = createSloServerRoute({
     },
   },
   params: bulkPurgeRollupSchema,
-  handler: async ({ request, context, params, logger, plugins, getScopedClients }) => {
+  handler: async ({ request, params, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
-
-    const { repository, scopedClusterClient } = await getScopedClients({ request, logger });
+    const { repository, scopedClusterClient } = await getScopedClients(request);
     const purgeRollupData = new BulkPurgeRollupData(scopedClusterClient.asCurrentUser, repository);
 
     return purgeRollupData.execute(params.body);

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/put_slo_settings.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/put_slo_settings.ts
@@ -24,12 +24,9 @@ export const putSloSettings = (isServerless?: boolean) =>
       },
     },
     params: isServerless ? putSLOServerlessSettingsParamsSchema : putSLOSettingsParamsSchema,
-    handler: async ({ request, logger, params, plugins, getScopedClients }) => {
+    handler: async ({ request, params, plugins, getScopedClients }) => {
       await assertPlatinumLicense(plugins);
-      const { soClient } = await getScopedClients({
-        request,
-        logger,
-      });
+      const { soClient } = await getScopedClients(request);
 
       return await storeSloSettings(soClient, params.body as PutSLOSettingsParams);
     },

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/reset_slo.ts
@@ -23,7 +23,7 @@ export const resetSLORoute = createSloServerRoute({
     await assertPlatinumLicense(plugins);
 
     const { scopedClusterClient, spaceId, repository, transformManager, summaryTransformManager } =
-      await getScopedClients({ request, logger });
+      await getScopedClients(request);
 
     const basePath = corePlugins.http.basePath;
 

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/update_slo.ts
@@ -23,7 +23,7 @@ export const updateSLORoute = createSloServerRoute({
     await assertPlatinumLicense(plugins);
 
     const { scopedClusterClient, spaceId, repository, transformManager, summaryTransformManager } =
-      await getScopedClients({ request, logger });
+      await getScopedClients(request);
 
     const core = await context.core;
     const basePath = corePlugins.http.basePath;

--- a/x-pack/solutions/observability/plugins/slo/server/routes/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/types.ts
@@ -9,7 +9,6 @@ import {
   CoreSetup,
   IScopedClusterClient,
   KibanaRequest,
-  Logger,
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 import { DataViewsService } from '@kbn/data-views-plugin/common/data_views';
@@ -18,13 +17,7 @@ import type { DefaultRouteHandlerResources } from '@kbn/server-route-repository'
 import { SLORepository, TransformManager } from '../services';
 import { SLOPluginSetupDependencies, SLOPluginStartDependencies } from '../types';
 
-export type GetScopedClients = ({
-  request,
-  logger,
-}: {
-  request: KibanaRequest;
-  logger: Logger;
-}) => Promise<RouteHandlerScopedClients>;
+export type GetScopedClients = (request: KibanaRequest) => Promise<RouteHandlerScopedClients>;
 
 export interface RouteHandlerScopedClients {
   scopedClusterClient: IScopedClusterClient;

--- a/x-pack/solutions/observability/plugins/slo/server/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/types.ts
@@ -7,6 +7,7 @@
 
 import type { AlertingServerSetup, AlertingServerStart } from '@kbn/alerting-plugin/server';
 import { CloudSetup } from '@kbn/cloud-plugin/server';
+import type { KibanaRequest } from '@kbn/core/server';
 import { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { LicensingPluginSetup, LicensingPluginStart } from '@kbn/licensing-plugin/server';
@@ -14,6 +15,7 @@ import {
   RuleRegistryPluginSetupContract,
   RuleRegistryPluginStartContract,
 } from '@kbn/rule-registry-plugin/server';
+import { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { SharePluginSetup } from '@kbn/share-plugin/server';
 import { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import {
@@ -21,9 +23,7 @@ import {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
-import { SecurityPluginStart } from '@kbn/security-plugin/server';
-import type { KibanaRequest } from '@kbn/core/server';
-import type { SloClient } from './client';
+import type { SLOClient } from './client/types';
 
 export type { SLOConfig } from '../common/config';
 
@@ -31,7 +31,7 @@ export type { SLOConfig } from '../common/config';
 export interface SLOServerSetup {}
 
 export interface SLOServerStart {
-  getSloClientWithRequest: (request: KibanaRequest) => SloClient;
+  getSloClientWithRequest: (request: KibanaRequest) => Promise<SLOClient>;
 }
 
 export interface SLOPluginSetupDependencies {


### PR DESCRIPTION
### 🍒 Summary

> [!NOTE]
> Work in progress

This PR paves the way to a ubiquitous SLO client that will be used in the SLO route handlers and exposed from the SLO plugin to be consumed by other plugins.

### Short term

We will keep both the route handlers and the SLO client logic duplicated. The SLO client will contain only a subset of the services exposed by the routes, and maybe some extra services that the routes don't expose: like the suggest SLO service.

### Long term

We should replace the route handlers logic with the SLO client.
When Kibana starts, we provide a factory that creates a SLO Client scoped to a KibanaRequest. We will provide this factory to the route repository, and also expose it from the plugin for other plugin to use.

Route handlers becomes
```
const sloClient = getScopedSloClient(request);
sloClient.get(id);
```

> [!CAUTION]
> The plugin `slo` references `cases`, and if we were to import the SLO client from `cases`, we will have a circular dependency. 
> We might need to split the `slo` plugin into two plugins: `slo` and `slo_app`: the former would be mostly the server part of the actual `slo` with the exposed client, and `slo_app` would use `slo` and other plugins for the UI.




