### PR TITLE
[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0

### DIFF
--- a/x-pack/test/dataset_quality_api_integration/tests/data_streams/data_stream_details.spec.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/data_streams/data_stream_details.spec.ts
@@ -39,9 +39,11 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when('DataStream Details', { config: 'basic' }, () => {
     describe('gets the data stream details', function () {
-      // this mutes the forward-compatibility test with Elasticsearch, 8.19 kibana and 9.0 ES.
-      // There are not expected to work together.
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
       this.onlyEsVersion('8.19 || >=9.1');
+
       before(async () => {
         await synthtrace.index([
           timerange(start, end)

--- a/x-pack/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
@@ -60,7 +60,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   }
 
   registry.when('Api Key privileges check', { config: 'basic' }, () => {
-    describe('index privileges', () => {
+    describe('index privileges', function () {
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('returns user authorization as false for noAccessUser', async () => {
         const resp = await callApiAs('noAccessUser');
 
@@ -125,7 +130,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
     });
 
-    describe('when required privileges are set', () => {
+    describe('when required privileges are set', function () {
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       describe('and categorized datastreams', () => {
         const integration = 'my-custom-integration';
 

--- a/x-pack/test/dataset_quality_api_integration/tests/data_streams/total_docs.spec.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/data_streams/total_docs.spec.ts
@@ -31,7 +31,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   }
 
   registry.when('Total docs', { config: 'basic' }, () => {
-    describe('authorization', () => {
+    describe('authorization', function () {
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should return a 403 when the user does not have sufficient privileges', async () => {
         const err = await expectToReject<DatasetQualityApiError>(() => callApiAs('noAccessUser'));
         expect(err.res.status).to.be(403);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/222501

## Summary

The PR skips test suites for ES 9.0.* which were failing when these tests ran in Kibana 8.19 branch against ES 9.0.* in forward compatibility runs.

<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->