### PR TITLE
[ES|QL] Adds inline docs for the SAMPLE command

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
@@ -575,6 +575,56 @@ FROM employees
       ),
     },
     {
+      label: i18n.translate('languageDocumentation.documentationESQL.sample', {
+        defaultMessage: 'SAMPLE',
+      }),
+      preview: true,
+      description: (
+        <Markdown
+          openLinksInNewTab={true}
+          markdownContent={i18n.translate(
+            'languageDocumentation.documentationESQL.sample.markdown',
+            {
+              defaultMessage: `### SAMPLE
+The \`SAMPLE\` command samples a fraction of the table rows. 
+
+**Syntax**
+
+\`\`\` esql
+SAMPLE probability
+\`\`\` 
+
+**Parameters**
+
+* \`probability\`: The probability that a row is included in the sample. The value must be between 0 and 1, exclusive.
+
+**Example**
+
+The following example shows the detection of a step change:
+
+\`\`\` esql
+FROM employees
+| KEEP emp_no
+| SAMPLE 0.05
+\`\`\` 
+
+| emp_no:integer |
+|----------------|
+| 10018          |
+| 10024          |
+| 10062          |
+| 10081          |
+
+`,
+              ignoreTag: true,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
       label: i18n.translate('languageDocumentation.documentationESQL.sort', {
         defaultMessage: 'SORT',
       }),

--- a/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
@@ -575,7 +575,7 @@ FROM employees
       ),
     },
     {
-      label: i18n.translate('languageDocumentation.documentationESQL.sample', {
+      label: i18n.translate('languageDocumentation.documentationESQL.sampleCommand', {
         defaultMessage: 'SAMPLE',
       }),
       preview: true,
@@ -583,7 +583,7 @@ FROM employees
         <Markdown
           openLinksInNewTab={true}
           markdownContent={i18n.translate(
-            'languageDocumentation.documentationESQL.sample.markdown',
+            'languageDocumentation.documentationESQL.sampleCommand.markdown',
             {
               defaultMessage: `### SAMPLE
 The \`SAMPLE\` command samples a fraction of the table rows. 


### PR DESCRIPTION
This PR adds inline docs for the CHANGE POINT command. It mimics the content currently at https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-sample

<img width="526" alt="image" src="https://github.com/user-attachments/assets/2eb9e99c-d768-4149-98b1-ec90717dc51b" />

Closes: https://github.com/elastic/docs-content/issues/1825

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->