### PR TITLE
[Fleet] Update query in delete unenrolled agents task

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/delete_unenrolled_agents_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/delete_unenrolled_agents_task.ts
@@ -116,7 +116,6 @@ export class DeleteUnenrolledAgentsTask {
                   active: false,
                 },
               },
-              { exists: { field: 'unenrolled_at' } },
             ],
           },
         },


### PR DESCRIPTION
## Summary

Issue reported by users that some unenrolled agents on the UI are not being deleted by the background task.
The cause turned out to be a discrepancy in how unenrolled agents are determined on the UI versus the background task.

The UI shows agents as unenrolled if `active:false` field matches (logic [here](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/server/services/agents/build_status_runtime_field.ts#L115-L119))

The delete unenrolled agents task also queried on the existence of `unenrolled_at` field.
It seems some agents don't have this field set, those should be deleted too.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->