### PR TITLE
[ES|QL] Enable `COMPLETION` in tech preview

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.fork.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.fork.test.ts
@@ -59,6 +59,7 @@ describe('autocomplete.suggest', () => {
           'EVAL ',
           'GROK ',
           'CHANGE_POINT ',
+          'COMPLETION ',
           'MV_EXPAND ',
           'DROP ',
           'KEEP ',

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -712,7 +712,7 @@ export const commandDefinitions: Array<CommandDefinition<any>> = [
     fieldsSuggestionsAfter: fieldsSuggestionsAfterFork,
   },
   {
-    hidden: true,
+    hidden: false,
     name: 'completion',
     preview: true,
     description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.completionDoc', {


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/218052

Enables `COMPLETION` command in tech preview.

<img width="765" alt="image" src="https://github.com/user-attachments/assets/bae432c9-8d0e-44a8-befa-734d23628870" />





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->