### PR TITLE
[Security Solution][Sourcerer] Fix cell actions for DV manager

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
@@ -9,6 +9,7 @@ import type { TimelineNonEcsData } from '@kbn/timelines-plugin/common';
 import { useCallback, useMemo } from 'react';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { RenderContext } from '@kbn/response-ops-alerts-table/types';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import type { UseDataGridColumnsSecurityCellActionsProps } from '../../../common/components/cell_actions';
 import { useDataGridColumnsSecurityCellActions } from '../../../common/components/cell_actions';
 import { SecurityCellActionsTrigger, SecurityCellActionType } from '../../../app/actions/constants';
@@ -19,6 +20,7 @@ import type {
   SecurityAlertsTableContext,
   GetSecurityAlertsTableProp,
 } from '../../components/alerts_table/types';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 
 export const useCellActionsOptions = (
   tableId: TableId,
@@ -27,6 +29,9 @@ export const useCellActionsOptions = (
     'columns' | 'oldAlertsData' | 'pageIndex' | 'pageSize' | 'dataGridRef'
   >
 ) => {
+  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+  const dataView = useDataView(SourcererScopeName.detections);
+
   const {
     columns = [],
     oldAlertsData: data = [],
@@ -35,7 +40,9 @@ export const useCellActionsOptions = (
     dataGridRef,
   } = context ?? {};
   const getFieldSpec = useGetFieldSpec(SourcererScopeName.detections);
-  const dataViewId = useDataViewId(SourcererScopeName.detections);
+  const oldDataViewId = useDataViewId(SourcererScopeName.detections);
+  const dataViewId = newDataViewPickerEnabled ? dataView?.dataView?.id : oldDataViewId;
+
   const cellActionsMetadata = useMemo(
     () => ({ scopeId: tableId, dataViewId }),
     [dataViewId, tableId]
@@ -44,14 +51,16 @@ export const useCellActionsOptions = (
     () =>
       columns.map(
         (column) =>
-          getFieldSpec(column.id) ?? {
+          (newDataViewPickerEnabled
+            ? dataView.dataView?.fields?.getByName(column.id)?.toSpec()
+            : getFieldSpec(column.id)) ?? {
             name: '',
             type: '', // When type is an empty string all cell actions are incompatible
             aggregatable: false,
             searchable: false,
           }
       ),
-    [columns, getFieldSpec]
+    [columns, dataView.dataView?.fields, getFieldSpec, newDataViewPickerEnabled]
   );
 
   /**


### PR DESCRIPTION
## Summary

Prior to this change, with data view manager feature flag enabled, we would only see the "expand" cell action in the alerts. Now,
all the actions should be visible. This was because cell actions rendering was unintentinally omitted in the initial batch of changes that added data view sourcing from the new store / hooks.

fixes https://github.com/elastic/security-team/issues/12853

### Testing

```
xpack.securitySolution.enableExperimental: ['newDataViewPickerEnabled']
```

then navigate to alerts page, hovering on timeline cell for example should render full set of hover actions.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->