### PR TITLE
[8.19] [ES|QL] Prioritize recommended fields in the editor (#224359)

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -524,11 +524,12 @@ export const ESQLEditor = memo(function ESQLEditor({
             (await kibana.services?.esql?.getEditorExtensionsAutocomplete(
               queryString,
               activeSolutionId
-            )) ?? { recommendedQueries: [] }
+            )) ?? { recommendedQueries: [], recommendedFields: [] }
           );
         }
         return {
           recommendedQueries: [],
+          recommendedFields: [],
         };
       },
       getInferenceEndpoints: kibana.services?.esql?.getInferenceEndpointsAutocomplete,

--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -22,6 +22,7 @@ import type {
   ESQLControlVariable,
   IndicesAutocompleteResult,
   RecommendedQuery,
+  RecommendedField,
 } from '@kbn/esql-types';
 import { InferenceEndpointsAutocompleteResult } from '@kbn/esql-types';
 
@@ -115,7 +116,7 @@ export interface EsqlPluginStartBase {
   getEditorExtensionsAutocomplete: (
     queryString: string,
     activeSolutionId: string
-  ) => Promise<{ recommendedQueries: RecommendedQuery[] }>;
+  ) => Promise<{ recommendedQueries: RecommendedQuery[]; recommendedFields: RecommendedField[] }>;
   variablesService: ESQLVariableService;
   getLicense: () => Promise<ILicense | undefined>;
   getInferenceEndpointsAutocomplete: () => Promise<InferenceEndpointsAutocompleteResult>;

--- a/src/platform/packages/shared/kbn-esql-types/index.ts
+++ b/src/platform/packages/shared/kbn-esql-types/index.ts
@@ -27,6 +27,7 @@ export {
 
 export {
   type RecommendedQuery,
+  type RecommendedField,
   type ResolveIndexResponse,
 } from './src/extensions_autocomplete_types';
 

--- a/src/platform/packages/shared/kbn-esql-types/src/extensions_autocomplete_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/extensions_autocomplete_types.ts
@@ -16,6 +16,13 @@ export interface RecommendedQuery {
   description?: string;
 }
 
+export interface RecommendedField {
+  // The name of the recommended field, will be used to prioritize the field in the autocomplete suggestions
+  name: string;
+  // The associated index pattern for the field, used to match the field with the current query's index pattern
+  pattern: string;
+}
+
 interface ResolveIndexResponseItem {
   name: string;
 }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
@@ -105,6 +105,20 @@ export const editorExtensions = {
       query: 'from logs* | STATS count(*) by host',
     },
   ],
+  recommendedFields: [
+    {
+      name: 'host.name',
+      pattern: 'logs*',
+    },
+    {
+      name: 'user.name',
+      pattern: 'logs*',
+    },
+    {
+      name: 'kubernetes.something.something',
+      pattern: 'logs*',
+    },
+  ],
 };
 
 export const inferenceEndpoints: InferenceEndpointAutocompleteItem[] = [
@@ -150,9 +164,10 @@ export function getCallbackMocks(): ESQLCallbacks {
       if (queryString.includes('logs*')) {
         return {
           recommendedQueries: editorExtensions.recommendedQueries,
+          recommendedFields: editorExtensions.recommendedFields,
         };
       }
-      return { recommendedQueries: [] };
+      return { recommendedQueries: [], recommendedFields: [] };
     }),
     getInferenceEndpoints: jest.fn(async (taskType: InferenceTaskType) => ({ inferenceEndpoints })),
   };

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.keep.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.keep.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { attachTriggerCommand, setup } from './helpers';
+
+describe('autocomplete.suggest', () => {
+  describe('KEEP', () => {
+    it('suggests available fields after KEEP', async () => {
+      const { assertSuggestions } = await setup();
+
+      assertSuggestions('FROM a | KEEP /', [
+        '`any#Char$Field`',
+        'booleanField',
+        'cartesianPointField',
+        'cartesianShapeField',
+        'counterDoubleField',
+        'counterIntegerField',
+        'counterLongField',
+        'dateField',
+        'dateNanosField',
+        'doubleField',
+        'functionNamedParametersField',
+        'geoPointField',
+        'geoShapeField',
+        'integerField',
+        'ipField',
+        'keywordField',
+        'kubernetes.something.something',
+        'longField',
+        'textField',
+        'unsignedLongField',
+        'versionField',
+      ]);
+    });
+
+    it('prioritizes the extensions registry suggestions', async () => {
+      const { assertSuggestionsOrder } = await setup();
+
+      assertSuggestionsOrder('FROM logs* | KEEP /', 'kubernetes.something.something', '1C');
+    });
+
+    it('suggests command and pipe after a field has been used in KEEP', async () => {
+      const { assertSuggestions } = await setup();
+
+      assertSuggestions('FROM logs* | KEEP doubleField /', [attachTriggerCommand('| '), ',']);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -284,8 +284,18 @@ export function getFieldsByTypeRetriever(
         ...options,
         supportsControls: canSuggestVariables && !lastCharIsQuestionMark,
       };
+      const editorExtensions = (await resourceRetriever?.getEditorExtensions?.(queryForFields)) ?? {
+        recommendedQueries: [],
+        recommendedFields: [],
+      };
+      const recommendedFieldsFromExtensions = editorExtensions.recommendedFields;
       const fields = await helpers.getFieldsByType(expectedType, ignored);
-      return buildFieldsDefinitionsWithMetadata(fields, updatedOptions, getVariables);
+      return buildFieldsDefinitionsWithMetadata(
+        fields,
+        recommendedFieldsFromExtensions,
+        updatedOptions,
+        getVariables
+      );
     },
     getFieldsMap: helpers.getFieldsMap,
   };

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
@@ -94,6 +94,7 @@ const getFieldSuggestions = async (
   const getVariables = callbacks?.getVariables;
   const joinFields = buildFieldsDefinitionsWithMetadata(
     lookupIndexFields.filter((f) => !ignoredFields.includes(f.name)),
+    [],
     { supportsControls },
     getVariables
   );

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -9,7 +9,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { memoize } from 'lodash';
-import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
+import { ESQLVariableType, type ESQLControlVariable, type RecommendedField } from '@kbn/esql-types';
 import { SuggestionRawDefinition } from './types';
 import { groupingFunctionDefinitions } from '../definitions/generated/grouping_functions';
 import { aggFunctionDefinitions } from '../definitions/generated/aggregation_functions';
@@ -198,8 +198,27 @@ export const getSuggestionsAfterNot = (): SuggestionRawDefinition[] => {
     .map(getOperatorSuggestion);
 };
 
+/**
+ * Generates a sort key for field suggestions based on their categorization.
+ * Recommended fields are prioritized, followed by ECS fields.
+ *
+ * @param isEcs - True if the field is an Elastic Common Schema (ECS) field.
+ * @param isRecommended - True if the field is a recommended field from the registry.
+ * @returns A string representing the sort key ('1C' for recommended, '1D' for ECS, 'D' for others).
+ */
+const getFieldsSortText = (isEcs: boolean, isRecommended: boolean) => {
+  if (isRecommended) {
+    return '1C';
+  }
+  if (isEcs) {
+    return '1D';
+  }
+  return 'D';
+};
+
 export const buildFieldsDefinitionsWithMetadata = (
   fields: ESQLFieldWithMetadata[],
+  recommendedFieldsFromExtensions: RecommendedField[] = [],
   options?: {
     advanceCursor?: boolean;
     openSuggestions?: boolean;
@@ -212,6 +231,13 @@ export const buildFieldsDefinitionsWithMetadata = (
   const fieldsSuggestions = fields.map((field) => {
     const fieldType = field.type.charAt(0).toUpperCase() + field.type.slice(1);
     const titleCaseType = `${field.name} (${fieldType})`;
+    // Check if the field is in the recommended fields from extensions list
+    // and if so, mark it as recommended. This also ensures that recommended fields
+    // that are registered wrongly, won't be shown as suggestions.
+    const fieldIsRecommended = recommendedFieldsFromExtensions.some(
+      (recommendedField) => recommendedField.name === field.name
+    );
+    const sortText = getFieldsSortText(Boolean(field.isEcs), Boolean(fieldIsRecommended));
     return {
       label: field.name,
       text:
@@ -220,8 +246,7 @@ export const buildFieldsDefinitionsWithMetadata = (
         (options?.advanceCursor ? ' ' : ''),
       kind: 'Variable',
       detail: titleCaseType,
-      // If detected to be an ECS field, push it up to the top of the list
-      sortText: field.isEcs ? '1D' : 'D',
+      sortText,
       command: options?.openSuggestions ? TRIGGER_SUGGESTION_COMMAND : undefined,
     };
   }) as SuggestionRawDefinition[];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
@@ -6,7 +6,12 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import type { ESQLControlVariable, IndexAutocompleteItem, RecommendedQuery } from '@kbn/esql-types';
+import type {
+  ESQLControlVariable,
+  IndexAutocompleteItem,
+  RecommendedQuery,
+  RecommendedField,
+} from '@kbn/esql-types';
 import { InferenceEndpointsAutocompleteResult } from '@kbn/esql-types/src/inference_endpoint_autocomplete_types';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { ESQLFieldWithMetadata } from '../validation/types';
@@ -51,9 +56,10 @@ export interface ESQLCallbacks {
   canSuggestVariables?: () => boolean;
   getJoinIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
   getTimeseriesIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
-  getEditorExtensions?: (
-    queryString: string
-  ) => Promise<{ recommendedQueries: RecommendedQuery[] }>;
+  getEditorExtensions?: (queryString: string) => Promise<{
+    recommendedQueries: RecommendedQuery[];
+    recommendedFields: RecommendedField[];
+  }>;
   getInferenceEndpoints?: (
     taskType: InferenceTaskType
   ) => Promise<InferenceEndpointsAutocompleteResult>;

--- a/src/platform/plugins/shared/esql/server/README.md
+++ b/src/platform/plugins/shared/esql/server/README.md
@@ -23,6 +23,8 @@ Currently, we support the following type of extension:
 
 * **Recommended Queries**: These queries are suggested to users in the ES|QL editor, particularly after the **`FROM <index_pattern>`** command. They guide users by offering relevant starting points or common analytical patterns for their selected data source.
 
+* **Recommended Fields**: These are field suggestions presented to users based on the active index pattern in their ES|QL query. They help users discover relevant fields for their current data context, making it easier to build queries without prior knowledge of the dataset's schema.
+
 The registry intelligently handles both exact index pattern matches (e.g., "logs-2023-10-01") and wildcard patterns (e.g., "logs*"). This ensures users receive comprehensive and contextually appropriate suggestions, whether they specify a precise index or a broad pattern. For instance, a recommended query registered for logs* will be suggested if the user's query uses FROM logs-2024-01-15.
 
 **Note**: The registry will only return indices (remote or local) that exist in the instance.
@@ -49,10 +51,11 @@ Here's an example of how to register `recommendedQueries`:
       esql: ESQLSetup;
       // ... other dependencies
     }
+    const solutionId: SolutionId = 'oblt'; // Or 'security', 'es', 'chat', etc.
 
     // Inside your plugin's `Plugin` class
     public setup(core: CoreSetup, { esql }: SetupDeps) {
-        // Register your array of recommended queries
+        // --- Registering Recommended Queries ---
         const esqlExtensionsRegistry = esql.getExtensionsRegistry();
         esqlExtensionsRegistry.setRecommendedQueries(
           [
@@ -69,7 +72,26 @@ Here's an example of how to register `recommendedQueries`:
               query: 'from movies | STATS count(*)',
             },
           ],
-            'oblt'
+           solutionId
+        );
+
+        // --- Registering Recommended Fields ---
+        esqlExtensionsRegistry.setRecommendedFields(
+          [
+            {
+              name: 'log_level',
+              pattern: 'logs*', // This field is relevant for any index starting with 'logs...'
+            },
+            {
+              name: 'host.ip',
+              pattern: 'logs-apache_error', // This field is specific to 'logs-apache_error'
+            },
+            {
+              name: 'http.request.method',
+              pattern: 'logs*',
+            },
+          ],
+            solutionId
         );
         return {};
     }

--- a/src/platform/plugins/shared/esql/server/extensions_registry/index.test.ts
+++ b/src/platform/plugins/shared/esql/server/extensions_registry/index.test.ts
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import type { RecommendedQuery, ResolveIndexResponse } from '@kbn/esql-types';
+import type { RecommendedQuery, RecommendedField, ResolveIndexResponse } from '@kbn/esql-types';
 import { ESQLExtensionsRegistry } from '.';
 
 describe('ESQLExtensionsRegistry', () => {
@@ -223,6 +223,213 @@ describe('ESQLExtensionsRegistry', () => {
       );
 
       expect(result).toEqual([]);
+    });
+  });
+
+  // --- setRecommendedFields tests ---
+  describe('setRecommendedFields', () => {
+    beforeEach(() => {
+      availableDatasources = {
+        indices: [
+          { name: 'logs-web' },
+          { name: 'metrics-cpu' },
+          { name: 'user-activity' },
+          { name: 'app-events' },
+        ],
+        data_streams: [],
+        aliases: [],
+      };
+    });
+
+    it('should add recommended fields to the registry', () => {
+      const solutionId = 'security';
+      const fields: RecommendedField[] = [
+        { name: 'user.id', pattern: 'logs-web' },
+        { name: 'http.request.method', pattern: 'logs-web' },
+        { name: 'cpu.usage', pattern: 'metrics-cpu' },
+      ];
+
+      registry.setRecommendedFields(fields, solutionId);
+
+      const retrievedFieldsForLogs = registry.getRecommendedFields(
+        'FROM logs-web',
+        availableDatasources,
+        solutionId
+      );
+      expect(retrievedFieldsForLogs).toEqual([fields[0], fields[1]]);
+
+      const retrievedFieldsForMetrics = registry.getRecommendedFields(
+        'FROM metrics-cpu',
+        availableDatasources,
+        solutionId
+      );
+      expect(retrievedFieldsForMetrics).toEqual([fields[2]]);
+    });
+
+    it('should skip malformed recommended fields (missing name or pattern)', () => {
+      const solutionId = 'security';
+      const fields: RecommendedField[] = [
+        { name: 'valid_field', pattern: 'user-activity' },
+        { name: 'Missing Pattern' } as RecommendedField, // Malformed (missing pattern)
+        { pattern: 'app-events' } as RecommendedField, // Malformed (missing name)
+      ];
+
+      registry.setRecommendedFields(fields, solutionId);
+
+      const retrievedFields = registry.getRecommendedFields(
+        'FROM user-activity',
+        availableDatasources,
+        solutionId
+      );
+      expect(retrievedFields).toEqual([{ name: 'valid_field', pattern: 'user-activity' }]);
+    });
+
+    it('should not add duplicate recommended fields for the same registryId and field name', () => {
+      const solutionId = 'security';
+      const fieldA: RecommendedField = { name: 'event.duration', pattern: 'app-events' };
+      const fields: RecommendedField[] = [fieldA, { ...fieldA }]; // Duplicate entry
+
+      registry.setRecommendedFields(fields, solutionId);
+      const retrievedFields = registry.getRecommendedFields(
+        'FROM app-events',
+        availableDatasources,
+        solutionId
+      );
+      expect(retrievedFields).toEqual([fieldA]);
+    });
+
+    it('should handle different solution IDs correctly for fields', () => {
+      const field1: RecommendedField = { name: 'error.message', pattern: 'logs-web' };
+      const field2: RecommendedField = { name: 'user.agent', pattern: 'logs-web' }; // Same pattern, different solution
+
+      registry.setRecommendedFields([field1], 'oblt');
+      registry.setRecommendedFields([field2], 'security');
+
+      // Retrieve for oblst
+      const fieldsOblt = registry.getRecommendedFields(
+        'FROM logs-web',
+        availableDatasources,
+        'oblt'
+      );
+      expect(fieldsOblt).toEqual([field1]);
+
+      // Retrieve for security
+      const fieldsSecurity = registry.getRecommendedFields(
+        'FROM logs-web',
+        availableDatasources,
+        'security'
+      );
+      expect(fieldsSecurity).toEqual([field2]);
+    });
+  });
+
+  // --- getRecommendedFields tests ---
+  describe('getRecommendedFields', () => {
+    beforeEach(() => {
+      availableDatasources = {
+        indices: [
+          { name: 'app-logs-2023' },
+          { name: 'app-logs-2024' },
+          { name: 'metrics-http' },
+          { name: 'server-logs' },
+          { name: 'user-events' },
+        ],
+        data_streams: [],
+        aliases: [],
+      };
+
+      // Setup some initial fields in the registry
+      const registeredFields: RecommendedField[] = [
+        { name: 'log.level', pattern: 'app-logs-2023' },
+        { name: 'http.response.status_code', pattern: 'metrics-http' },
+        { name: 'app.name', pattern: 'app-logs-*' },
+        { name: 'server.name', pattern: 'server-logs' },
+      ];
+
+      registry.setRecommendedFields(
+        [registeredFields[0], registeredFields[1], registeredFields[2]],
+        'security'
+      );
+      // Register a field for a different solution to test filtering
+      registry.setRecommendedFields([registeredFields[3]], 'oblt');
+    });
+
+    it('should return an empty array if checkSourceExistence returns false for fields', () => {
+      const result = registry.getRecommendedFields(
+        'FROM non_existent_data_stream',
+        availableDatasources,
+        'security'
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should return fields matching the exact index pattern from the query string', () => {
+      const result = registry.getRecommendedFields(
+        'FROM app-logs-2023',
+        availableDatasources,
+        'security'
+      );
+      expect(result).toEqual([
+        { name: 'log.level', pattern: 'app-logs-2023' },
+        { name: 'app.name', pattern: 'app-logs-*' },
+      ]);
+    });
+
+    it('should return fields matching a wildcard pattern from the query string', () => {
+      const result = registry.getRecommendedFields(
+        'FROM app-logs-*',
+        availableDatasources,
+        'security'
+      );
+      expect(result).toEqual([
+        { name: 'log.level', pattern: 'app-logs-2023' },
+        { name: 'app.name', pattern: 'app-logs-*' },
+      ]);
+    });
+
+    it('should return fields where the registered pattern covers the concrete index in the query string', () => {
+      const result = registry.getRecommendedFields(
+        'FROM app-logs-2024',
+        availableDatasources,
+        'security'
+      );
+      expect(result).toEqual([{ name: 'app.name', pattern: 'app-logs-*' }]);
+    });
+
+    it('should filter fields by activeSolutionId', () => {
+      const result = registry.getRecommendedFields(
+        'FROM server-logs',
+        availableDatasources,
+        'security'
+      );
+      expect(result).toEqual([]); // Should be empty because it's set for 'oblt', not 'security'
+    });
+
+    it('should return an empty array if no matching indices are found by findMatchingIndicesFromPattern for fields', () => {
+      const result = registry.getRecommendedFields(
+        'FROM no_matching_field_index',
+        {
+          indices: [{ name: 'no_matching_field_index' }],
+          data_streams: [],
+          aliases: [],
+        },
+        'security'
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should return unique fields when multiple registry entries yield the same field name', () => {
+      const commonField: RecommendedField = { name: 'user.ip', pattern: 'user-events' };
+      // Register the same field under different solution/index pattern combinations
+      registry.setRecommendedFields([{ ...commonField }], 'security');
+      registry.setRecommendedFields([{ ...commonField }], 'oblt');
+
+      const result = registry.getRecommendedFields(
+        'FROM user-events',
+        availableDatasources,
+        'security'
+      );
+      expect(result).toEqual([commonField]); // Should only return one instance of the field
     });
   });
 });

--- a/src/platform/plugins/shared/esql/server/extensions_registry/index.ts
+++ b/src/platform/plugins/shared/esql/server/extensions_registry/index.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { uniqBy } from 'lodash';
-import type { RecommendedQuery, ResolveIndexResponse } from '@kbn/esql-types';
+import type { RecommendedQuery, RecommendedField, ResolveIndexResponse } from '@kbn/esql-types';
 import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
 import { checkSourceExistence, findMatchingIndicesFromPattern } from './utils';
 
@@ -16,8 +16,8 @@ type SolutionId = 'es' | 'oblt' | 'security';
 /**
  * `ESQLExtensionsRegistry` serves as a central hub for managing and retrieving extrensions of the ES|QL editor.
  *
- * It allows for the registration of queries, associating them with specific index patterns and solutions.
- * This registry is designed to intelligently provide relevant recommended queries
+ * It allows for the registration of queries and fields associating them with specific index patterns and solutions.
+ * This registry is designed to intelligently provide relevant recommended queries and fields
  * based on the index patterns present in an active ES|QL query or available data sources.
  *
  * The class handles both exact index pattern matches (e.g., "logs-2023-10-01")
@@ -27,21 +27,28 @@ type SolutionId = 'es' | 'oblt' | 'security';
 
 export class ESQLExtensionsRegistry {
   private recommendedQueries: Map<string, RecommendedQuery[]> = new Map();
+  private recommendedFields: Map<string, RecommendedField[]> = new Map();
 
-  setRecommendedQueries(
-    recommendedQueries: RecommendedQuery[],
-    activeSolutionId: SolutionId
+  private setRecommendedItems<T extends { name: string }>(
+    map: Map<string, T[]>,
+    items: T[],
+    activeSolutionId: SolutionId,
+    getIndexPattern: (item: T) => string | undefined,
+    isDuplicate: (existingItems: T[], newItem: T) => boolean,
+    itemTypeName: string // e.g., 'query' or 'field' for error messages
   ): void {
-    if (!Array.isArray(recommendedQueries)) {
-      throw new Error('Recommended queries must be an array');
+    if (!Array.isArray(items)) {
+      throw new Error(`Recommended ${itemTypeName}s must be an array`);
     }
-    for (const recommendedQuery of recommendedQueries) {
-      if (typeof recommendedQuery.name !== 'string' || typeof recommendedQuery.query !== 'string') {
-        continue; // Skip if the recommended query is malformed
+
+    for (const item of items) {
+      if (typeof item.name !== 'string') {
+        continue; // Skip if the recommended item is malformed (missing name)
       }
-      const indexPattern = getIndexPatternFromESQLQuery(recommendedQuery.query);
+
+      const indexPattern = getIndexPattern(item);
       if (!indexPattern) {
-        // No index pattern found for query, possibly malformed or not ES|QL
+        // No index pattern found, possibly malformed or not valid for registration
         continue;
       }
 
@@ -49,27 +56,28 @@ export class ESQLExtensionsRegistry {
       // The > is not a valid character in index names, so it won't conflict with actual index names
       const registryId = `${activeSolutionId}>${indexPattern}`;
 
-      if (this.recommendedQueries.has(registryId)) {
-        const existingQueries = this.recommendedQueries.get(registryId);
-        // check if the recommended query already exists
-        if (existingQueries && existingQueries.some((q) => q.query === recommendedQuery.query)) {
-          // If the query already exists, skip adding it again
+      if (map.has(registryId)) {
+        const existingItems = map.get(registryId)!;
+        if (isDuplicate(existingItems, item)) {
+          // If the item already exists, skip adding it again
           continue;
         }
-        // If the index pattern already exists, push the new recommended query
-        this.recommendedQueries.get(registryId)!.push(recommendedQuery);
+        // If the index pattern already exists, push the new recommended item
+        existingItems.push(item);
       } else {
         // If the index pattern doesn't exist, create a new array
-        this.recommendedQueries.set(registryId, [recommendedQuery]);
+        map.set(registryId, [item]);
       }
     }
   }
 
-  getRecommendedQueries(
+  private getRecommendedItems<T>(
+    map: Map<string, T[]>,
     queryString: string,
     availableDatasources: ResolveIndexResponse,
-    activeSolutionId: SolutionId
-  ): RecommendedQuery[] {
+    activeSolutionId: SolutionId,
+    uniqByProperty: keyof T // Property name for lodash's uniqBy
+  ): T[] {
     // Validates that the index pattern extracted from the ES|QL `FROM` command
     // exists within the available `sources` (indices, aliases, or data streams).
     // If the specified source isn't found, no recommended queries will be returned.
@@ -78,24 +86,88 @@ export class ESQLExtensionsRegistry {
       return [];
     }
 
-    const recommendedQueries: RecommendedQuery[] = [];
-
+    const recommendedItems: T[] = [];
     // Determines relevant recommended queries based on the ESQL `FROM` command's index pattern.
     // This includes:
     // 1. **Direct matches**: If the command uses a specific index (e.g., `logs-2023`), it retrieves queries registered for that exact index.
     // 2. **Pattern coverage**: If the command uses a wildcard pattern (e.g., `logs-*`), it returns queries registered for concrete indices that match this pattern (e.g., a recommended query for `logs-2023`).
     // 3. **Reverse coverage**: If the command specifies a concrete index, it also includes queries whose *registered pattern* covers that specific index (e.g., a recommended query for `logs*` would be returned for `logs-2023`).
-    const matchingIndices = findMatchingIndicesFromPattern(this.recommendedQueries, indexPattern);
+    const matchingIndices = findMatchingIndicesFromPattern(map, indexPattern);
     if (matchingIndices.length > 0) {
-      recommendedQueries.push(
+      recommendedItems.push(
         ...matchingIndices
           .map((index) => {
             const registryId = `${activeSolutionId}>${index}`;
-            return this.recommendedQueries.get(registryId) || [];
+            return map.get(registryId) || [];
           })
           .flat()
       );
     }
-    return uniqBy(recommendedQueries, 'query');
+    return uniqBy(recommendedItems, uniqByProperty);
+  }
+
+  setRecommendedQueries(
+    recommendedQueries: RecommendedQuery[],
+    activeSolutionId: SolutionId
+  ): void {
+    this.setRecommendedItems(
+      this.recommendedQueries,
+      recommendedQueries,
+      activeSolutionId,
+      (recommendedQuery) => {
+        // Ensure it has a 'query' property
+        if (typeof recommendedQuery.query !== 'string') {
+          return undefined;
+        }
+        return getIndexPatternFromESQLQuery(recommendedQuery.query);
+      },
+      (existingQueries, newQuery) => existingQueries.some((q) => q.query === newQuery.query),
+      'query'
+    );
+  }
+
+  getRecommendedQueries(
+    queryString: string,
+    availableDatasources: ResolveIndexResponse,
+    activeSolutionId: SolutionId
+  ): RecommendedQuery[] {
+    return this.getRecommendedItems(
+      this.recommendedQueries,
+      queryString,
+      availableDatasources,
+      activeSolutionId,
+      'query'
+    );
+  }
+
+  setRecommendedFields(recommendedFields: RecommendedField[], activeSolutionId: SolutionId): void {
+    this.setRecommendedItems(
+      this.recommendedFields,
+      recommendedFields,
+      activeSolutionId,
+      (field) => {
+        // Ensure it has a 'pattern' property
+        if (typeof field.pattern !== 'string') {
+          return undefined;
+        }
+        return field.pattern;
+      },
+      (existingFields, newField) => existingFields.some((f) => f.name === newField.name),
+      'field'
+    );
+  }
+
+  getRecommendedFields(
+    queryString: string,
+    availableDatasources: ResolveIndexResponse,
+    activeSolutionId: SolutionId
+  ): RecommendedField[] {
+    return this.getRecommendedItems(
+      this.recommendedFields,
+      queryString,
+      availableDatasources,
+      activeSolutionId,
+      'name'
+    );
   }
 }

--- a/src/platform/plugins/shared/esql/server/extensions_registry/utils.ts
+++ b/src/platform/plugins/shared/esql/server/extensions_registry/utils.ts
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import type { RecommendedQuery, ResolveIndexResponse } from '@kbn/esql-types';
+import type { ResolveIndexResponse } from '@kbn/esql-types';
 
 /**
  * Returns a boolean if the pattern exists in the sources.
@@ -98,8 +98,8 @@ function createPatternRegex(pattern: string): RegExp {
  * @param pattern The pattern string (e.g., "logs*", "my_index", "logs-02122024").
  * @returns An array of matching index names.
  */
-export function findMatchingIndicesFromPattern(
-  registry: Map<string, RecommendedQuery[]>,
+export function findMatchingIndicesFromPattern<T>(
+  registry: Map<string, T[]>,
   indexPattern: string
 ): string[] {
   const matchingIndices: string[] = [];

--- a/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_esql_extensions_route.ts
@@ -84,14 +84,23 @@ export const registerESQLExtensionsRoute = (
 
         // Validate solutionId
         const validSolutionId = isSolutionId(solutionId) ? solutionId : 'oblt'; // No solutionId provided, or invalid
+
         const recommendedQueries = extensionsRegistry.getRecommendedQueries(
           query,
           sources,
           validSolutionId
         );
+
+        const recommendedFields = extensionsRegistry.getRecommendedFields(
+          query,
+          sources,
+          validSolutionId
+        );
+
         return response.ok({
           body: {
             recommendedQueries,
+            recommendedFields,
           },
         });
       } catch (error) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES|QL] Prioritize recommended fields in the editor (#224359)](https://github.com/elastic/kibana/pull/224359)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T08:59:08Z","message":"[ES|QL] Prioritize recommended fields in the editor (#224359)\n\n## Summary\n\nAdds the ability to register recommended fields per datasource. It\nfollows the logic [of the recommended queries]\n(https://github.com/elastic/kibana/pull/221474). \n\nThese fields will get prioritized in the editor. So the fields\nprioritization goes like:\n\n- recommended fields from the registry first\n- ecs schema second\n- everything else\n\n### How to register them\n\n- Use the esql server side registry as described in the aforementioned\nPR\n- Register the fields like that\n\n```\n    this.extensionsRegistry.setRecommendedFields(\n      [\n        {\n          name: 'log_level',\n          pattern: 'logs*', // This field is relevant for any index starting with 'logs...'\n        },\n        {\n          name: 'host.ip.keyword',\n          pattern: 'logs-apache_error', // This field is specific to 'logs-apache_error'\n        },\n        {\n          name: 'http.request.method',\n          pattern: 'logs*',\n        },\n      ],\n      'oblt'\n    );\n```\n\nYou will see that the fields are getting prioritized in the editor\n\n<img width=\"730\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c4941579-c04f-4c5f-875d-369355420a3d\"\n/>\n\n\nAs a bonus: The good thing with the recommended fields is that we are\nprioritizing fields that exist in the datasource. So this means that a\nsolution team can register fields per datasource and not afraid if these\nfields do not exist at the instance\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"642edd2f435d12a2f8ca7f337d8691645763e441","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[ES|QL] Prioritize recommended fields in the editor","number":224359,"url":"https://github.com/elastic/kibana/pull/224359","mergeCommit":{"message":"[ES|QL] Prioritize recommended fields in the editor (#224359)\n\n## Summary\n\nAdds the ability to register recommended fields per datasource. It\nfollows the logic [of the recommended queries]\n(https://github.com/elastic/kibana/pull/221474). \n\nThese fields will get prioritized in the editor. So the fields\nprioritization goes like:\n\n- recommended fields from the registry first\n- ecs schema second\n- everything else\n\n### How to register them\n\n- Use the esql server side registry as described in the aforementioned\nPR\n- Register the fields like that\n\n```\n    this.extensionsRegistry.setRecommendedFields(\n      [\n        {\n          name: 'log_level',\n          pattern: 'logs*', // This field is relevant for any index starting with 'logs...'\n        },\n        {\n          name: 'host.ip.keyword',\n          pattern: 'logs-apache_error', // This field is specific to 'logs-apache_error'\n        },\n        {\n          name: 'http.request.method',\n          pattern: 'logs*',\n        },\n      ],\n      'oblt'\n    );\n```\n\nYou will see that the fields are getting prioritized in the editor\n\n<img width=\"730\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c4941579-c04f-4c5f-875d-369355420a3d\"\n/>\n\n\nAs a bonus: The good thing with the recommended fields is that we are\nprioritizing fields that exist in the datasource. So this means that a\nsolution team can register fields per datasource and not afraid if these\nfields do not exist at the instance\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"642edd2f435d12a2f8ca7f337d8691645763e441"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224359","number":224359,"mergeCommit":{"message":"[ES|QL] Prioritize recommended fields in the editor (#224359)\n\n## Summary\n\nAdds the ability to register recommended fields per datasource. It\nfollows the logic [of the recommended queries]\n(https://github.com/elastic/kibana/pull/221474). \n\nThese fields will get prioritized in the editor. So the fields\nprioritization goes like:\n\n- recommended fields from the registry first\n- ecs schema second\n- everything else\n\n### How to register them\n\n- Use the esql server side registry as described in the aforementioned\nPR\n- Register the fields like that\n\n```\n    this.extensionsRegistry.setRecommendedFields(\n      [\n        {\n          name: 'log_level',\n          pattern: 'logs*', // This field is relevant for any index starting with 'logs...'\n        },\n        {\n          name: 'host.ip.keyword',\n          pattern: 'logs-apache_error', // This field is specific to 'logs-apache_error'\n        },\n        {\n          name: 'http.request.method',\n          pattern: 'logs*',\n        },\n      ],\n      'oblt'\n    );\n```\n\nYou will see that the fields are getting prioritized in the editor\n\n<img width=\"730\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c4941579-c04f-4c5f-875d-369355420a3d\"\n/>\n\n\nAs a bonus: The good thing with the recommended fields is that we are\nprioritizing fields that exist in the datasource. So this means that a\nsolution team can register fields per datasource and not afraid if these\nfields do not exist at the instance\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"642edd2f435d12a2f8ca7f337d8691645763e441"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->