### PR TITLE
[Security Solution][Sourcerer] Fix timeline filters for DV manager

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
@@ -14,11 +14,11 @@ import deepEqual from 'fast-deep-equal';
 import type { Filter } from '@kbn/es-query';
 
 import type { FilterManager } from '@kbn/data-plugin/public';
-import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import type { DataView } from '@kbn/data-views-plugin/common';
 import { FilterItems } from '@kbn/unified-search-plugin/public';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { useEnableExperimental } from '../../../../common/hooks/use_experimental_features';
-import { useDataViewSpec } from '../../../../data_view_manager/hooks/use_data_view_spec';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -75,17 +75,10 @@ const StatefulSearchOrFilterComponent = React.memo<Props>(
       services: { data },
     } = useKibana();
 
-    const { sourcererDataView: oldSourcererDataViewSpec } = useSourcererDataView(
-      SourcererScopeName.timeline
-    );
+    const { sourcererDataView: dataViewSpec } = useSourcererDataView(SourcererScopeName.timeline);
 
-    const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(SourcererScopeName.timeline);
-    const { newDataViewPickerEnabled } = useEnableExperimental();
-
-    const dataViewSpec: DataViewSpec = useMemo(
-      () => (newDataViewPickerEnabled ? experimentalDataViewSpec : oldSourcererDataViewSpec),
-      [experimentalDataViewSpec, newDataViewPickerEnabled, oldSourcererDataViewSpec]
-    );
+    const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+    const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
     const getIsDataProviderVisible = useMemo(
       () => timelineSelectors.dataProviderVisibilitySelector(),
@@ -121,7 +114,14 @@ const StatefulSearchOrFilterComponent = React.memo<Props>(
       };
     }, [data.dataViews, filterQuery, addError, dataViewSpec, newDataViewPickerEnabled]);
 
-    const arrDataView = useMemo(() => (dataView != null ? [dataView] : []), [dataView]);
+    // NOTE: re-using data view that is already created and available through data view manager
+    const arrDataView = useMemo(() => {
+      if (newDataViewPickerEnabled) {
+        return experimentalDataView ? [experimentalDataView] : [];
+      }
+
+      return dataView != null ? [dataView] : [];
+    }, [dataView, experimentalDataView, newDataViewPickerEnabled]);
 
     // Keep filter manager in sync with redux filters
     useEffect(() => {


### PR DESCRIPTION
## Summary

Filters we applied but no listed in the timeline, again - some mismatch in how the data view object was passed around.

## Testing

Set the feature flag:

```
xpack.securitySolution.enableExperimental: ['newDataViewPickerEnabled']
```
Then, adding a filter via cell action should render the correct pill in the top level filters pane.


### Checklist

Check the PR satisfies following conditions. 
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->