### PR TITLE
add label to SLO settings switch

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_settings/settings_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_settings/settings_form.tsx
@@ -61,6 +61,12 @@ export function SettingsForm() {
     });
   };
 
+  const remoteClustersSwitchLabel = i18n.translate(
+    'xpack.slo.settingsForm.euiFormRow.useAllRemoteClustersLabel',
+    {
+      defaultMessage: 'Use all remote clusters',
+    }
+  );
   return (
     <EuiForm component="form">
       <EuiDescribedFormGroup
@@ -79,13 +85,9 @@ export function SettingsForm() {
           </p>
         }
       >
-        <EuiFormRow
-          label={i18n.translate('xpack.slo.settingsForm.euiFormRow.useAllRemoteClustersLabel', {
-            defaultMessage: 'Use all remote clusters',
-          })}
-        >
+        <EuiFormRow label={remoteClustersSwitchLabel}>
           <EuiSwitch
-            label=""
+            label={remoteClustersSwitchLabel}
             checked={useAllRemoteClusters}
             onChange={(evt) => setUseAllRemoteClusters(evt.target.checked)}
           />

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_settings/settings_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_settings/settings_form.tsx
@@ -88,7 +88,6 @@ export function SettingsForm() {
         <EuiFormRow label={remoteClustersSwitchLabel}>
           <EuiSwitch
             label={remoteClustersSwitchLabel}
-            ariaLabel={remoteClustersSwitchLabel}
             checked={useAllRemoteClusters}
             onChange={(evt) => setUseAllRemoteClusters(evt.target.checked)}
           />

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_settings/settings_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_settings/settings_form.tsx
@@ -88,6 +88,7 @@ export function SettingsForm() {
         <EuiFormRow label={remoteClustersSwitchLabel}>
           <EuiSwitch
             label={remoteClustersSwitchLabel}
+            ariaLabel={remoteClustersSwitchLabel}
             checked={useAllRemoteClusters}
             onChange={(evt) => setUseAllRemoteClusters(evt.target.checked)}
           />


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/222561

The label for the switch on the SLO settings page was missing. I added `label` and `ariaLabel` and here's the result:

<img width="500" alt="Screenshot 2025-06-23 at 13 45 44" src="https://github.com/user-attachments/assets/ce1978cb-e063-4013-9a5d-741cdabb365a" />

## How to test
In order to test open Voice Over (Cmd + F5) and then use `Tab` button to move to the `Use all remote clusters` switch.



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->