### PR TITLE
[Connector][XSOAR] Enable XSOAR connector in the UI

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xsoar/xsoar.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xsoar/xsoar.tsx
@@ -19,7 +19,6 @@ interface ValidationErrors {
 export function getConnectorType(): XSOARConnector {
   return {
     id: XSOAR_CONNECTOR_ID,
-    hideInUi: true,
     iconClass: lazy(() => import('./logo')),
     selectMessage: i18n.SELECT_MESSAGE,
     actionTypeTitle: XSOAR_TITLE,


### PR DESCRIPTION
## Summary

This PR removes the `hideInUI` flag for XSOAR connector.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)






<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->