### PR TITLE
[Fleet] Add tooltip to Last activity column in Agent list UI

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
@@ -271,14 +271,22 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
         lastCheckin ? (
           <EuiToolTip
             content={
-              <FormattedDate
-                value={lastCheckin}
-                year="numeric"
-                month="short"
-                day="2-digit"
-                timeZoneName="short"
-                hour="numeric"
-                minute="numeric"
+              <FormattedMessage
+                id="xpack.fleet.agentList.lastActivityTooltip"
+                defaultMessage="Last checked in at {lastCheckin}"
+                values={{
+                  lastCheckin: (
+                    <FormattedDate
+                      value={lastCheckin}
+                      year="numeric"
+                      month="short"
+                      day="2-digit"
+                      timeZoneName="short"
+                      hour="numeric"
+                      minute="numeric"
+                    />
+                  ),
+                }}
               />
             }
           >

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
@@ -17,7 +17,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
+import { FormattedDate, FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
 import { css } from '@emotion/css';
 
 import type { Agent, AgentPolicy } from '../../../../types';
@@ -268,7 +268,23 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
       }),
       width: '100px',
       render: (lastCheckin: string) =>
-        lastCheckin ? <FormattedRelative value={lastCheckin} /> : undefined,
+        lastCheckin ? (
+          <EuiToolTip
+            content={
+              <FormattedDate
+                value={lastCheckin}
+                year="numeric"
+                month="short"
+                day="2-digit"
+                timeZoneName="short"
+                hour="numeric"
+                minute="numeric"
+              />
+            }
+          >
+            <FormattedRelative value={lastCheckin} />
+          </EuiToolTip>
+        ) : undefined,
     },
     {
       field: AGENTS_TABLE_FIELDS.VERSION,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/221172

Add tooltip to Last activity column in Agent list UI to make it easier to check the exact date. The relative date displayed in the column is rounded and sometimes misleading.

<img width="1654" alt="image" src="https://github.com/user-attachments/assets/73bfcf9e-2064-48e4-9a71-c0912613aa6d" />



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->