### PR TITLE
[Oblt Onboarding] Adjust E2E tests for serverless

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/playwright.config.ts
@@ -54,19 +54,19 @@ export default defineConfig({
   },
 
   projects: [
-    {
-      name: 'auth',
-      testMatch: '*stateful/auth.ts',
-      use: {
-        viewport: { width: 1920, height: 1080 },
-        launchOptions: {
-          logger: {
-            isEnabled: () => true,
-            log: (name, severity, message) => log.info(`[${severity}] ${name} ${message}`),
-          },
-        },
-      },
-    },
+    // {
+    //   name: 'auth',
+    //   testMatch: '*stateful/auth.ts',
+    //   use: {
+    //     viewport: { width: 1920, height: 1080 },
+    //     launchOptions: {
+    //       logger: {
+    //         isEnabled: () => true,
+    //         log: (name, severity, message) => log.info(`[${severity}] ${name} ${message}`),
+    //       },
+    //     },
+    //   },
+    // },
     {
       name: 'stateful',
       testMatch: '*stateful/*.spec.ts',
@@ -74,22 +74,6 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         viewport: { width: 1920, height: 1200 },
         storageState: STORAGE_STATE,
-        launchOptions: {
-          logger: {
-            isEnabled: () => true,
-            log: (name, severity, message) => log.info(`[${severity}] ${name} ${message}`),
-          },
-        },
-      },
-      dependencies: ['auth'],
-    },
-    {
-      name: 'teardown',
-      testMatch: 'teardown.setup.ts',
-      use: {
-        viewport: { width: 1920, height: 1080 },
-        storageState: STORAGE_STATE,
-        testIdAttribute: 'data-test-subj',
         launchOptions: {
           logger: {
             isEnabled: () => true,

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/auth_serverless.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/auth_serverless.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect, type Page } from '@playwright/test';
+import { STORAGE_STATE } from '../playwright.config';
+import { waitForOneOf } from '../lib/helpers';
+import { log } from '../lib/logger';
+import { assertEnv } from '../lib/assert_env';
+
+const isLocalCluster = process.env.CLUSTER_ENVIRONMENT === 'local';
+
+export async function serverlessAuth(page: Page) {
+  assertEnv(process.env.KIBANA_BASE_URL, 'KIBANA_BASE_URL is not defined.');
+  assertEnv(process.env.KIBANA_USERNAME, 'KIBANA_USERNAME is not defined.');
+  assertEnv(process.env.KIBANA_PASSWORD, 'KIBANA_PASSWORD is not defined.');
+
+  const loginURL = isLocalCluster
+    ? `${process.env.KIBANA_BASE_URL}/login`
+    : process.env.KIBANA_BASE_URL;
+
+  await page.goto(loginURL);
+  log.info(`...waiting for login page elements to appear.`);
+
+  if (isLocalCluster) {
+    await page.getByLabel('Username').fill(process.env.KIBANA_USERNAME);
+  } else {
+    await page.getByLabel('Email').fill(process.env.KIBANA_USERNAME);
+  }
+  await page.getByLabel('Password', { exact: true }).click();
+  await page.getByLabel('Password', { exact: true }).fill(process.env.KIBANA_PASSWORD);
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  const [index] = await waitForOneOf([
+    page.getByTestId('helpMenuButton'),
+    page.getByText('Select your space'),
+    page.getByTestId('loginErrorMessage'),
+  ]);
+
+  const spaceSelector = index === 1;
+  const isAuthenticated = index === 0;
+
+  if (isAuthenticated) {
+    await page.context().storageState({ path: STORAGE_STATE });
+  } else if (spaceSelector) {
+    await page.getByRole('link', { name: 'Default' }).click();
+    await expect(page.getByTestId('helpMenuButton')).toBeVisible();
+    await page.context().storageState({ path: STORAGE_STATE });
+  } else {
+    log.error('Username or password is incorrect.');
+    throw new Error('Authentication is failed.');
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/auto_detect.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/auto_detect.spec.ts
@@ -10,6 +10,19 @@ import path from 'node:path';
 import { test } from './fixtures/base_page';
 import { HostDetailsPage } from './pom/pages/host_details.page';
 import { assertEnv } from '../lib/assert_env';
+import { serverlessAuth } from './auth_serverless';
+
+test.use({
+  ignoreHTTPSErrors: true,
+});
+
+test.beforeAll(async ({ browser }) => {
+  await serverlessAuth(
+    await browser.newPage({
+      storageState: undefined,
+    })
+  );
+});
 
 test.beforeEach(async ({ page }) => {
   await page.goto(`${process.env.KIBANA_BASE_URL}/app/observabilityOnboarding`);


### PR DESCRIPTION
This change adjusts the Playwright onboarding tests to work on serverless clusters.