### PR TITLE
[Discover][APM] Enable Traces in Discover by default

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.ts
@@ -23,7 +23,6 @@ export const createTracesDataSourceProfileProvider = ({
   tracesContextService,
 }: ProfileProviderServices): DataSourceProfileProvider => ({
   profileId: OBSERVABILITY_TRACES_DATA_SOURCE_PROFILE_ID,
-  isExperimental: true,
   restrictedToProductFeature: TRACES_PRODUCT_FEATURE_ID,
   profile: {
     getDefaultAppState: (prev) => (params) => ({

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/profile.ts
@@ -27,7 +27,6 @@ export const createObservabilityTracesSpanDocumentProfileProvider = ({
   apmErrorsContextService,
   logsContextService,
 }: ProfileProviderServices): DocumentProfileProvider => ({
-  isExperimental: true,
   profileId: OBSERVABILITY_TRACES_SPAN_DOCUMENT_PROFILE_ID,
   restrictedToProductFeature: TRACES_PRODUCT_FEATURE_ID,
   profile: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/profile.ts
@@ -23,7 +23,6 @@ export const createObservabilityTracesTransactionDocumentProfileProvider = ({
   apmErrorsContextService,
   logsContextService,
 }: ProfileProviderServices): DocumentProfileProvider => ({
-  isExperimental: true,
   profileId: OBSERVABILITY_TRACES_TRANSACTION_DOCUMENT_PROFILE_ID,
   restrictedToProductFeature: TRACES_PRODUCT_FEATURE_ID,
   profile: {


### PR DESCRIPTION
Closes #224081

This PR enables Traces in Discover by default. There's no longer a need to enable trace related profiles in the yml configuration, it will work out of the box.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->