### PR TITLE
[ResponseOps] Updated activity index

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
@@ -16,8 +16,41 @@ export const CAI_ACTIVITY_INDEX_ALIAS = '.cases-activity';
 export const CAI_ACTIVITY_INDEX_VERSION = 1;
 
 export const CAI_ACTIVITY_SOURCE_QUERY: QueryDslQueryContainer = {
-  term: {
-    type: 'cases-user-actions',
+  bool: {
+    must: [
+      {
+        term: {
+          type: 'cases-user-actions',
+        },
+      },
+      {
+        bool: {
+          should: [
+            {
+              term: {
+                'cases-user-actions.type': 'severity',
+              },
+            },
+            {
+              term: {
+                'cases-user-actions.type': 'category',
+              },
+            },
+            {
+              term: {
+                'cases-user-actions.type': 'status',
+              },
+            },
+            {
+              term: {
+                'cases-user-actions.type': 'tags',
+              },
+            },
+          ],
+          minimum_should_match: 1,
+        },
+      },
+    ],
   },
 };
 
@@ -42,6 +75,33 @@ export const getActivitySynchronizationSourceQuery = (
           'cases-user-actions.created_at': {
             gte: lastSyncAt.toISOString(),
           },
+        },
+      },
+      {
+        bool: {
+          should: [
+            {
+              term: {
+                'cases-user-actions.type': 'severity',
+              },
+            },
+            {
+              term: {
+                'cases-user-actions.type': 'category',
+              },
+            },
+            {
+              term: {
+                'cases-user-actions.type': 'status',
+              },
+            },
+            {
+              term: {
+                'cases-user-actions.type': 'tags',
+              },
+            },
+          ],
+          minimum_should_match: 1,
         },
       },
     ],

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/activity_index/constants.ts
@@ -33,6 +33,11 @@ export const CAI_ACTIVITY_SOURCE_QUERY: QueryDslQueryContainer = {
             },
             {
               term: {
+                'cases-user-actions.type': 'delete_case',
+              },
+            },
+            {
+              term: {
                 'cases-user-actions.type': 'category',
               },
             },
@@ -83,6 +88,11 @@ export const getActivitySynchronizationSourceQuery = (
             {
               term: {
                 'cases-user-actions.type': 'severity',
+              },
+            },
+            {
+              term: {
+                'cases-user-actions.type': 'delete_case',
               },
             },
             {


### PR DESCRIPTION
## Summary

The cases activity analytics index will only have user actions of type:
- tags
- status
- severity
- category

