### PR TITLE
[Automatic Migrations] Add integration test for update endpoint.

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/index.ts
@@ -10,6 +10,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('@ess @serverless SecuritySolution SIEM Migrations', () => {
     loadTestFile(require.resolve('./create'));
     loadTestFile(require.resolve('./get'));
+    loadTestFile(require.resolve('./update'));
     loadTestFile(require.resolve('./delete'));
     loadTestFile(require.resolve('./rules/create'));
     loadTestFile(require.resolve('./rules/get'));

--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/update.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/update.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+import { deleteAllRuleMigrations, ruleMigrationRouteHelpersFactory } from '../../utils';
+
+export default ({ getService }: FtrProviderContext) => {
+  const es = getService('es');
+  const supertest = getService('supertest');
+  const ruleMigrationRoutes = ruleMigrationRouteHelpersFactory(supertest);
+  describe('@ess @serverless @serverlessQA Update API', () => {
+    let migrationId: string;
+    beforeEach(async () => {
+      await deleteAllRuleMigrations(es);
+      const name = 'First Migration';
+      const creationResponse = await ruleMigrationRoutes.create({ body: { name } });
+      migrationId = creationResponse.body.migration_id;
+    });
+
+    it('should update migration name without any issues', async () => {
+      const updatedName = 'Updated Migration Name';
+      await ruleMigrationRoutes.update({
+        migrationId,
+        body: { name: updatedName },
+      });
+
+      const { body } = await ruleMigrationRoutes.get({
+        migrationId,
+      });
+
+      expect(body.id).toBe(migrationId);
+      expect(body.name).toBe(updatedName);
+    });
+
+    describe('Error handling', () => {
+      it('should return 404 if migration ID does not exist', async () => {
+        const { body } = await ruleMigrationRoutes.update({
+          migrationId: 'non-existing-migration-id',
+          body: { name: 'New Name' },
+          expectStatusCode: 404,
+        });
+
+        expect(body).toMatchObject({
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'No Migration found with id: non-existing-migration-id',
+        });
+      });
+    });
+  });
+};

--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/utils/rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/utils/rules.ts
@@ -40,6 +40,7 @@ import {
   StartRuleMigrationRequestBody,
   StartRuleMigrationResponse,
   StopRuleMigrationResponse,
+  UpdateRuleMigrationRequestBody,
   UpdateRuleMigrationRulesResponse,
 } from '@kbn/security-solution-plugin/common/siem_migrations/model/api/rules/rule_migration.gen';
 import { API_VERSIONS } from '@kbn/security-solution-plugin/common/constants';
@@ -56,12 +57,17 @@ export interface RequestParams {
   expectStatusCode?: number;
 }
 
-export interface CreateMigrationRequestParams extends RequestParams {
+export interface CreateRuleMigrationRequestParams extends RequestParams {
   body?: CreateRuleMigrationRequestBody;
 }
+
 export interface MigrationRequestParams extends RequestParams {
   /** `id` of the migration to get rules documents for */
   migrationId: string;
+}
+
+export interface UpdateRuleMigrationRequestParams extends MigrationRequestParams {
+  body: UpdateRuleMigrationRequestBody;
 }
 
 export interface GetRuleMigrationRulesParams extends MigrationRequestParams {
@@ -96,7 +102,7 @@ export const ruleMigrationRouteHelpersFactory = (supertest: SuperTest.Agent) => 
     create: async ({
       body = { name: 'test migration' },
       expectStatusCode = 200,
-    }: CreateMigrationRequestParams): Promise<{
+    }: CreateRuleMigrationRequestParams): Promise<{
       body: CreateRuleMigrationResponse;
     }> => {
       const response = await supertest
@@ -108,6 +114,22 @@ export const ruleMigrationRouteHelpersFactory = (supertest: SuperTest.Agent) => 
 
       assertStatusCode(expectStatusCode, response);
 
+      return response;
+    },
+
+    update: async ({
+      migrationId,
+      body,
+      expectStatusCode = 200,
+    }: UpdateRuleMigrationRequestParams): Promise<{ body: undefined }> => {
+      const response = await supertest
+        .patch(replaceParams(SIEM_RULE_MIGRATION_PATH, { migration_id: migrationId }))
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .send(body);
+
+      assertStatusCode(expectStatusCode, response);
       return response;
     },
 


### PR DESCRIPTION
## Summary

This small PR simply adds an integration test for `/update` endpoint for rule migration.






<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->