### PR TITLE
Potential fix for code scanning alert no. 590: Double escaping or unescaping

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.ts
@@ -72,5 +72,5 @@ export const checkForTripleQuotesAndQueries = (
  * This function unescapes chars that are invalid in a Console string.
  */
 export const unescapeInvalidChars = (str: string): string => {
-  return str.replace(/\\\\/g, '\\').replace(/\\"/g, '"');
+  return str.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
 };


### PR DESCRIPTION
Potential fix for [https://github.com/elastic/kibana/security/code-scanning/590](https://github.com/elastic/kibana/security/code-scanning/590)

To fix the issue, we need to ensure that the unescaping process is performed in the correct order to avoid double unescaping. Specifically:
1. The replacement for `\\"` should be performed before the replacement for `\\\\`. This ensures that sequences like `\\\\\\"` are correctly unescaped to `\\"` and then to `"`, without any unintended double unescaping.
2. The order of the `.replace()` calls in the `unescapeInvalidChars` function should be swapped.

This change will ensure that the function behaves as intended and avoids the double unescaping issue.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
