### PR TITLE
Allowing dtstart for Task Manager rrule

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.test.ts
@@ -105,6 +105,55 @@ describe('getFirstRunAt', () => {
     expect(firstRunAtDate).toEqual(new Date('2025-04-16T12:15:00Z'));
   });
 
+  test('should return the calculated runAt from fixed dtstart when an rrule with fixed time and dtstart is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          dtstart: '2025-06-15T13:01:02Z',
+          freq: 3,
+          interval: 1,
+          tzid: 'UTC',
+          byhour: [12],
+          byminute: [15],
+        },
+      },
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next day from 2025-06-15 is 2025-06-16
+    // The time is set to 12:15
+    expect(firstRunAtDate).toEqual(new Date('2025-06-16T12:15:00.000Z'));
+  });
+
+  test('should return the calculated runAt from now if using fixed dtstart calculates runAt in the past', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          dtstart: '2025-03-10T13:01:02Z',
+          freq: 3,
+          interval: 1,
+          tzid: 'UTC',
+          byhour: [12],
+          byminute: [15],
+        },
+      },
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next day from 2025-03-10 is 2025-03-11 which is in the past so the first runAt is set
+    // based on now which is fixed to '2025-04-15T13:01:02Z'
+    // The time is set to 12:15
+    expect(firstRunAtDate).toEqual(new Date('2025-04-16T12:15:00Z'));
+  });
+
   test('should return the calculated runAt when an rrule with only byhour is provided', () => {
     const taskInstance = {
       id: 'id',

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.ts
@@ -24,10 +24,13 @@ export function getFirstRunAt({
 
   if (taskInstance.schedule?.rrule && rruleHasFixedTime(taskInstance.schedule.rrule)) {
     try {
+      const dtstart = taskInstance.schedule.rrule.dtstart
+        ? new Date(taskInstance.schedule.rrule.dtstart)
+        : now;
       const rrule = new RRule({
         ...taskInstance.schedule.rrule,
         bysecond: [0],
-        dtstart: now,
+        dtstart,
       });
       return rrule.after(now)?.toISOString() || nowString;
     } catch (e) {

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
@@ -11,8 +11,7 @@ import { getNextRunAt } from './get_next_run_at';
 import { loggerMock } from '@kbn/logging-mocks';
 const mockLogger = loggerMock.create();
 
-// Failing: See https://github.com/elastic/kibana/issues/220501
-describe.skip('getNextRunAt', () => {
+describe('getNextRunAt', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -103,6 +102,37 @@ describe.skip('getNextRunAt', () => {
     expect(nextRunAt.getUTCMinutes()).toBe(15);
     expect(nextRunAt.getUTCSeconds()).toBe(currentSecond);
     expect(nextRunAt.getUTCMilliseconds()).toBe(currentMilliseconds);
+  });
+
+  test('should use now even if dtstart defined in rrule with a fixed time when it is given to calculate the next runAt', () => {
+    jest.useFakeTimers();
+    const now = new Date('2025-04-30T10:00:00.000Z');
+    jest.setSystemTime(now);
+    const testStart = new Date(now.getTime() - 500);
+    const testRunAt = new Date(now.getTime() - 1000);
+    const nextRunAt = getNextRunAt(
+      taskManagerMock.createTask({
+        schedule: {
+          rrule: {
+            dtstart: '2025-01-15T13:01:02Z',
+            freq: 3, // Daily
+            interval: 1,
+            tzid: 'UTC',
+            byhour: [12],
+            byminute: [15],
+          },
+        },
+        runAt: testRunAt,
+        startedAt: testStart,
+      }),
+      0,
+      mockLogger
+    );
+
+    const expectedNextRunAt = new Date('2025-04-30T12:15:59.500Z');
+    expect(nextRunAt).toEqual(expectedNextRunAt);
+
+    jest.clearAllTimers();
   });
 
   test('should use the rrule with a basic interval time when it is given to calculate the next runAt', () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_model_versions.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_model_versions.ts
@@ -12,6 +12,7 @@ import {
   taskSchemaV3,
   taskSchemaV4,
   taskSchemaV5,
+  taskSchemaV6,
 } from '../schemas/task';
 
 // IMPORTANT!!!
@@ -82,6 +83,13 @@ export const taskModelVersions: SavedObjectsModelVersionMap = {
     schemas: {
       forwardCompatibility: taskSchemaV5.extends({}, { unknowns: 'ignore' }),
       create: taskSchemaV5,
+    },
+  },
+  '6': {
+    changes: [],
+    schemas: {
+      forwardCompatibility: taskSchemaV6.extends({}, { unknowns: 'ignore' }),
+      create: taskSchemaV6,
     },
   },
 };

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  rruleSchedule as rruleScheduleV1,
+  scheduleRruleSchema as scheduleRruleSchemaV1,
+} from './v1';
+export {
+  rruleSchedule as rruleScheduleV2,
+  scheduleRruleSchema as scheduleRruleSchemaV2,
+} from './v2';

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v1.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v1.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 import { Frequency } from '@kbn/rrule';
 import moment from 'moment-timezone';
 
-function validateTimezone(timezone: string) {
+export function validateTimezone(timezone: string) {
   if (moment.tz.zone(timezone) != null) {
     return;
   }
@@ -36,7 +36,7 @@ const validateRecurrenceByWeekday = (array: string[]) => {
   }
 };
 
-const rruleCommon = schema.object({
+export const rruleCommon = schema.object({
   freq: schema.oneOf([
     schema.literal(0),
     schema.literal(1),
@@ -57,15 +57,21 @@ const rruleCommon = schema.object({
   tzid: schema.string({ validate: validateTimezone, defaultValue: 'UTC' }),
 });
 
-const byminute = schema.maybe(schema.arrayOf(schema.number({ min: 0, max: 59 }), { minSize: 1 }));
-const byhour = schema.maybe(schema.arrayOf(schema.number({ min: 0, max: 23 }), { minSize: 1 }));
-const byweekday = schema.maybe(
+export const byminute = schema.maybe(
+  schema.arrayOf(schema.number({ min: 0, max: 59 }), { minSize: 1 })
+);
+export const byhour = schema.maybe(
+  schema.arrayOf(schema.number({ min: 0, max: 23 }), { minSize: 1 })
+);
+export const byweekday = schema.maybe(
   schema.arrayOf(schema.string(), {
     minSize: 1,
     validate: validateRecurrenceByWeekday,
   })
 );
-const bymonthday = schema.maybe(schema.arrayOf(schema.number({ min: 1, max: 31 }), { minSize: 1 }));
+export const bymonthday = schema.maybe(
+  schema.arrayOf(schema.number({ min: 1, max: 31 }), { minSize: 1 })
+);
 
 const rruleMonthly = rruleCommon.extends({
   freq: schema.literal(Frequency.MONTHLY),
@@ -92,3 +98,6 @@ const rruleDaily = rruleCommon.extends({
 });
 
 export const rruleSchedule = schema.oneOf([rruleMonthly, rruleWeekly, rruleDaily]);
+export const scheduleRruleSchema = schema.object({
+  rrule: rruleSchedule,
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v2.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v2.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { Frequency } from '@kbn/rrule';
+import { byhour, byminute, byweekday, bymonthday, rruleCommon as rruleCommonV1 } from './v1';
+
+const rruleCommon = rruleCommonV1.extends({
+  dtstart: schema.maybe(schema.string()),
+});
+
+const rruleMonthly = rruleCommon.extends({
+  freq: schema.literal(Frequency.MONTHLY),
+  byhour,
+  byminute,
+  byweekday,
+  bymonthday,
+});
+
+const rruleWeekly = rruleCommon.extends({
+  freq: schema.literal(Frequency.WEEKLY),
+  byhour,
+  byminute,
+  byweekday,
+  bymonthday: schema.never(),
+});
+
+const rruleDaily = rruleCommon.extends({
+  freq: schema.literal(Frequency.DAILY),
+  byhour,
+  byminute,
+  byweekday,
+  bymonthday: schema.never(),
+});
+
+export const rruleSchedule = schema.oneOf([rruleMonthly, rruleWeekly, rruleDaily]);
+export const scheduleRruleSchema = schema.object({
+  rrule: rruleSchedule,
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { isInterval } from '../../lib/intervals';
-import { rruleSchedule } from './rrule';
+import { scheduleRruleSchemaV1, scheduleRruleSchemaV2 } from './rrule';
 
 export function validateDuration(duration: string) {
   if (!isInterval(duration)) {
@@ -59,10 +59,6 @@ export const scheduleIntervalSchema = schema.object({
   interval: schema.string({ validate: validateDuration }),
 });
 
-export const scheduleRruleSchema = schema.object({
-  rrule: rruleSchedule,
-});
-
 export const taskSchemaV4 = taskSchemaV3.extends({
   apiKey: schema.maybe(schema.string()),
   userScope: schema.maybe(
@@ -75,5 +71,9 @@ export const taskSchemaV4 = taskSchemaV3.extends({
 });
 
 export const taskSchemaV5 = taskSchemaV4.extends({
-  schedule: schema.maybe(schema.oneOf([scheduleIntervalSchema, scheduleRruleSchema])),
+  schedule: schema.maybe(schema.oneOf([scheduleIntervalSchema, scheduleRruleSchemaV1])),
+});
+
+export const taskSchemaV6 = taskSchemaV5.extends({
+  schedule: schema.maybe(schema.oneOf([scheduleIntervalSchema, scheduleRruleSchemaV2])),
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -266,6 +266,7 @@ export interface RruleSchedule {
 }
 
 interface RruleCommon {
+  dtstart?: string;
   freq: Frequency;
   interval: number;
   tzid: string;


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



