### PR TITLE
[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -129,7 +129,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       await synthtrace.deleteCustomPipeline('synth.2@pipeline');
     });
 
-    describe('navigate to dataset details', () => {
+    describe('navigate to dataset details', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should navigate to right dataset', async () => {
         await PageObjects.datasetQuality.navigateToDetails({ dataStream: regularDataStreamName });
 
@@ -193,7 +198,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
     });
 
-    describe('overview summary panel', () => {
+    describe('overview summary panel', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should show summary KPIs', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: apacheAccessDataStreamName,
@@ -209,7 +219,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
     });
 
-    describe('failed docs', () => {
+    describe('failed docs', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should show it in summary KPIs', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: failedDataStreamName,
@@ -275,7 +290,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
     });
 
-    describe('overview integrations', () => {
+    describe('overview integrations', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should hide the integration section for non integrations', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: regularDataStreamName,
@@ -448,7 +468,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
     });
 
-    describe('degraded fields table', () => {
+    describe('degraded fields table', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it(' should show empty degraded fields table when no degraded fields are present', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: regularDataStreamName,

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_privileges.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_privileges.ts
@@ -132,7 +132,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
         });
       });
 
-      describe('User can monitor some data streams', () => {
+      describe('User can monitor some data streams', function () {
+        // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+        // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+        // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+        this.onlyEsVersion('8.19 || >=9.1');
+
         before(async () => {
           // Index logs for synth-* and apache.access datasets
           await synthtrace.index(getInitialTestLogs({ to, count: 4 }));

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
@@ -39,7 +39,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
   const failedDatasetName = datasetNames[1];
 
-  describe('Dataset quality table', () => {
+  describe('Dataset quality table', function () {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     before(async () => {
       // Install Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(pkg);

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
@@ -28,7 +28,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   };
   const allDatasetNames = [apacheAccessDatasetHumanName, ...datasetNames];
 
-  describe('Dataset quality table filters', () => {
+  describe('Dataset quality table filters', function () {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     before(async () => {
       // Install Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(pkg);

--- a/x-pack/test/functional/apps/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/test/functional/apps/dataset_quality/degraded_field_flyout.ts
@@ -53,7 +53,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   const apmAppDatasetName = 'apm.app.tug';
   const apmAppDataStreamName = `${type}-${apmAppDatasetName}-${defaultNamespace}`;
 
-  describe('Degraded fields flyout', () => {
+  describe('Degraded fields flyout', function () {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     describe('degraded field flyout open-close', () => {
       before(async () => {
         await synthtrace.index([

--- a/x-pack/test/functional/apps/dataset_quality/failed_docs_flyout.ts
+++ b/x-pack/test/functional/apps/dataset_quality/failed_docs_flyout.ts
@@ -29,7 +29,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   const failedDatasetName = datasetNames[1];
   const failedDataStreamName = `${type}-${failedDatasetName}-${defaultNamespace}`;
 
-  describe('Failed docs flyout', () => {
+  describe('Failed docs flyout', function () {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     describe('failed docs flyout open-close', () => {
       before(async () => {
         await synthtrace.createCustomPipeline(processors, 'synth.2@pipeline');


### PR DESCRIPTION
Fixes #222500 

## Summary

This PR updates the Dataset Quality functional test suite to skip tests when running in Kibana 8.19 against Elasticsearch 9.0 in a forward compatibility test run. , where the `read_failure_store` index privilege is not available. The privilege checks for `read_failure_store` fail as they are incompatible with ES 9.0, since ES 9.0 does not support Failure Store.

#### Context

While investigating e2e test failures related to the missing `read_failure_store` privilege in ES 9.0, it was found that almost all Dataset Quality test suites fail. The failures occur because the following endpoints which most of the e2e tests depend on, check for this privilege and error out:

- `/settings`
- `/details`
- `/total_docs`
- `/stats`

#### Error thrown by endpoints:
```yaml
error: "Internal Server Error"
message: "illegal_argument_exception\n\tRoot causes:\n\t\tillegal_argument_exception: unknown index privilege [read_failure_store]. a privilege must be either one of the predefined fixed indices privileges [all,auto_configure,create,create_doc,create_index,cross_cluster_replication,cross_cluster_replication_internal,delete,delete_index,index,maintenance,manage,manage_data_stream_lifecycle,manage_follow_index,manage_ilm,manage_leader_index,monitor,none,read,read_cross_cluster,view_index_metadata,write] or a pattern over one of the available index actions"
statusCode: 500
```
#### Screenshots
<table>
<tr><th>Main Page</th><th>Details Page</th></tr>
<tr>
<td>

![image](https://github.com/user-attachments/assets/7bd56da7-e4ca-44c2-91d1-4d6adea7af96)


</td>
<td>

![image](https://github.com/user-attachments/assets/ca392166-36dc-4a2a-8dc4-5d5c0d72ed59)


</td>
</tr>
</table>


<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->