### PR TITLE
[8.19] Rule gaps callout (#224268)

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -494,6 +494,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       detectionsReq: `${SECURITY_SOLUTION_DOCS}detections-permissions-section.html`,
       networkMap: `${SECURITY_SOLUTION_DOCS}conf-map-ui.html`,
       troubleshootGaps: `${SECURITY_SOLUTION_DOCS}alerts-ui-monitor.html#troubleshoot-gaps`,
+      gapsTable: `${SECURITY_SOLUTION_DOCS}/alerts-ui-monitor.html#gaps-table`,
       ruleApiOverview: isServerless
         ? `${KIBANA_SERVERLESS_APIS}group/endpoint-security-detections-api`
         : `${KIBANA_APIS}group/endpoint-security-detections-api`,

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -494,7 +494,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       detectionsReq: `${SECURITY_SOLUTION_DOCS}detections-permissions-section.html`,
       networkMap: `${SECURITY_SOLUTION_DOCS}conf-map-ui.html`,
       troubleshootGaps: `${SECURITY_SOLUTION_DOCS}alerts-ui-monitor.html#troubleshoot-gaps`,
-      gapsTable: `${SECURITY_SOLUTION_DOCS}/alerts-ui-monitor.html#gaps-table`,
+      gapsTable: `${SECURITY_SOLUTION_DOCS}alerts-ui-monitor.html#gaps-table`,
       ruleApiOverview: isServerless
         ? `${KIBANA_SERVERLESS_APIS}group/endpoint-security-detections-api`
         : `${KIBANA_APIS}group/endpoint-security-detections-api`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -345,6 +345,7 @@ export interface DocLinks {
     readonly detectionsReq: string;
     readonly networkMap: string;
     readonly troubleshootGaps: string;
+    readonly gapsTable: string;
     readonly ruleApiOverview: string;
     readonly configureAlertSuppression: string;
   };

--- a/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/get_rules_with_gaps/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/gaps/apis/get_rules_with_gaps/schemas/v1.ts
@@ -11,6 +11,9 @@ export const getRuleIdsWithGapBodySchema = schema.object(
     end: schema.string(),
     start: schema.string(),
     statuses: schema.maybe(schema.arrayOf(schema.string())),
+    has_unfilled_intervals: schema.maybe(schema.boolean()),
+    has_in_progress_intervals: schema.maybe(schema.boolean()),
+    has_filled_intervals: schema.maybe(schema.boolean()),
   },
   {
     validate({ start, end }) {
@@ -34,4 +37,5 @@ export const getRuleIdsWithGapBodySchema = schema.object(
 export const getRuleIdsWithGapResponseSchema = schema.object({
   total: schema.number(),
   rule_ids: schema.arrayOf(schema.string()),
+  latest_gap_timestamp: schema.maybe(schema.number()),
 });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_rule_ids_with_gaps/get_rule_ids_with_gaps.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_rule_ids_with_gaps/get_rule_ids_with_gaps.test.ts
@@ -150,6 +150,9 @@ describe('getRuleIdsWithGaps', () => {
         unique_rule_ids: {
           buckets: [{ key: 'rule-1' }, { key: 'rule-2' }],
         },
+        latest_gap_timestamp: {
+          value: 1704067200000,
+        },
       };
 
       eventLogClient.aggregateEventsWithAuthFilter.mockResolvedValue({
@@ -163,13 +166,17 @@ describe('getRuleIdsWithGaps', () => {
         filter,
         expect.objectContaining({
           filter: `event.action: gap AND event.provider: alerting AND kibana.alert.rule.gap.range <= "2024-01-02T00:00:00.000Z" AND kibana.alert.rule.gap.range >= "2024-01-01T00:00:00.000Z" AND (kibana.alert.rule.gap.status : unfilled OR kibana.alert.rule.gap.status : partially_filled)`,
-          aggs: { unique_rule_ids: { terms: { field: 'rule.id', size: 10000 } } },
+          aggs: {
+            latest_gap_timestamp: { max: { field: '@timestamp' } },
+            unique_rule_ids: { terms: { field: 'rule.id', size: 10000 } },
+          },
         })
       );
 
       expect(result).toEqual({
         total: 2,
         ruleIds: ['rule-1', 'rule-2'],
+        latestGapTimestamp: 1704067200000,
       });
     });
 
@@ -178,6 +185,9 @@ describe('getRuleIdsWithGaps', () => {
         aggregations: {
           unique_rule_ids: {
             buckets: [],
+          },
+          latest_gap_timestamp: {
+            value: null,
           },
         },
       });
@@ -189,13 +199,17 @@ describe('getRuleIdsWithGaps', () => {
         filter,
         expect.objectContaining({
           filter: expect.stringContaining('event.action: gap AND event.provider: alerting'),
-          aggs: { unique_rule_ids: { terms: { field: 'rule.id', size: 10000 } } },
+          aggs: {
+            latest_gap_timestamp: { max: { field: '@timestamp' } },
+            unique_rule_ids: { terms: { field: 'rule.id', size: 10000 } },
+          },
         })
       );
 
       expect(result).toEqual({
         total: 0,
         ruleIds: [],
+        latestGapTimestamp: null,
       });
     });
 
@@ -212,7 +226,10 @@ describe('getRuleIdsWithGaps', () => {
         filter,
         expect.objectContaining({
           filter: `event.action: gap AND event.provider: alerting AND kibana.alert.rule.gap.range <= "2024-01-02T00:00:00.000Z" AND kibana.alert.rule.gap.range >= "2024-01-01T00:00:00.000Z"`,
-          aggs: { unique_rule_ids: { terms: { field: 'rule.id', size: 10000 } } },
+          aggs: {
+            latest_gap_timestamp: { max: { field: '@timestamp' } },
+            unique_rule_ids: { terms: { field: 'rule.id', size: 10000 } },
+          },
         })
       );
     });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_rule_ids_with_gaps/schemas/get_rules_with_gaps.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/get_rule_ids_with_gaps/schemas/get_rules_with_gaps.ts
@@ -11,9 +11,13 @@ export const getRuleIdsWithGapsParamsSchema = schema.object({
   start: schema.string(),
   end: schema.string(),
   statuses: schema.maybe(schema.arrayOf(schema.string())),
+  hasUnfilledIntervals: schema.maybe(schema.boolean()),
+  hasInProgressIntervals: schema.maybe(schema.boolean()),
+  hasFilledIntervals: schema.maybe(schema.boolean()),
 });
 
 export const getRuleIdsWithGapsResponseSchema = schema.object({
   total: schema.number(),
   ruleIds: schema.arrayOf(schema.string()),
+  latestGapTimestamp: schema.maybe(schema.number()),
 });

--- a/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/build_gaps_filter.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/build_gaps_filter.test.ts
@@ -53,4 +53,94 @@ describe('buildGapsFilter', () => {
         '(kibana.alert.rule.gap.status : unfilled OR kibana.alert.rule.gap.status : partially_filled)'
     );
   });
+
+  describe('interval filters', () => {
+    it('should build filter with hasUnfilledIntervals = true', () => {
+      expect(buildGapsFilter({ hasUnfilledIntervals: true })).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'kibana.alert.rule.gap.unfilled_intervals: *'
+      );
+    });
+
+    it('should build filter with hasUnfilledIntervals = false', () => {
+      expect(buildGapsFilter({ hasUnfilledIntervals: false })).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'NOT kibana.alert.rule.gap.unfilled_intervals: *'
+      );
+    });
+
+    it('should build filter with hasInProgressIntervals = true', () => {
+      expect(buildGapsFilter({ hasInProgressIntervals: true })).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'kibana.alert.rule.gap.in_progress_intervals: *'
+      );
+    });
+
+    it('should build filter with hasInProgressIntervals = false', () => {
+      expect(buildGapsFilter({ hasInProgressIntervals: false })).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'NOT kibana.alert.rule.gap.in_progress_intervals: *'
+      );
+    });
+
+    it('should build filter with hasFilledIntervals = true', () => {
+      expect(buildGapsFilter({ hasFilledIntervals: true })).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'kibana.alert.rule.gap.filled_intervals: *'
+      );
+    });
+
+    it('should build filter with hasFilledIntervals = false', () => {
+      expect(buildGapsFilter({ hasFilledIntervals: false })).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'NOT kibana.alert.rule.gap.filled_intervals: *'
+      );
+    });
+
+    it('should build filter with multiple interval filters', () => {
+      expect(
+        buildGapsFilter({
+          hasUnfilledIntervals: true,
+          hasInProgressIntervals: false,
+          hasFilledIntervals: true,
+        })
+      ).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'kibana.alert.rule.gap.unfilled_intervals: * AND ' +
+          'NOT kibana.alert.rule.gap.in_progress_intervals: * AND ' +
+          'kibana.alert.rule.gap.filled_intervals: *'
+      );
+    });
+
+    it('should ignore interval filters when set to undefined', () => {
+      expect(
+        buildGapsFilter({
+          hasUnfilledIntervals: undefined,
+          hasInProgressIntervals: undefined,
+          hasFilledIntervals: undefined,
+        })
+      ).toBe('event.action: gap AND event.provider: alerting');
+    });
+
+    it('should build complex filter with all parameters', () => {
+      expect(
+        buildGapsFilter({
+          start: '2024-01-01',
+          end: '2024-01-02',
+          statuses: [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
+          hasUnfilledIntervals: true,
+          hasInProgressIntervals: false,
+          hasFilledIntervals: true,
+        })
+      ).toBe(
+        'event.action: gap AND event.provider: alerting AND ' +
+          'kibana.alert.rule.gap.range <= "2024-01-02" AND ' +
+          'kibana.alert.rule.gap.range >= "2024-01-01" AND ' +
+          '(kibana.alert.rule.gap.status : unfilled OR kibana.alert.rule.gap.status : partially_filled) AND ' +
+          'kibana.alert.rule.gap.unfilled_intervals: * AND ' +
+          'NOT kibana.alert.rule.gap.in_progress_intervals: * AND ' +
+          'kibana.alert.rule.gap.filled_intervals: *'
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/build_gaps_filter.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/build_gaps_filter.ts
@@ -5,14 +5,28 @@
  * 2.0.
  */
 
+const getFilterForInterval = (hasInterval: boolean | undefined, field: string) => {
+  if (hasInterval === undefined) {
+    return null;
+  }
+  const fieldFilter = `kibana.alert.rule.gap.${field}: *`;
+  return hasInterval ? fieldFilter : `NOT ${fieldFilter}`;
+};
+
 export const buildGapsFilter = ({
   start,
   end,
   statuses,
+  hasUnfilledIntervals,
+  hasInProgressIntervals,
+  hasFilledIntervals,
 }: {
   start?: string;
   end?: string;
   statuses?: string[];
+  hasUnfilledIntervals?: boolean;
+  hasInProgressIntervals?: boolean;
+  hasFilledIntervals?: boolean;
 }) => {
   const baseFilter = 'event.action: gap AND event.provider: alerting';
 
@@ -23,5 +37,25 @@ export const buildGapsFilter = ({
     ? `(${statuses.map((status) => `kibana.alert.rule.gap.status : ${status}`).join(' OR ')})`
     : null;
 
-  return [baseFilter, endFilter, startFilter, statusesFilter].filter(Boolean).join(' AND ');
+  const hasUnfilledIntervalsFilter = getFilterForInterval(
+    hasUnfilledIntervals,
+    'unfilled_intervals'
+  );
+  const hasInProgressIntervalsFilter = getFilterForInterval(
+    hasInProgressIntervals,
+    'in_progress_intervals'
+  );
+  const hasFilledIntervalsFilter = getFilterForInterval(hasFilledIntervals, 'filled_intervals');
+
+  return [
+    baseFilter,
+    endFilter,
+    startFilter,
+    statusesFilter,
+    hasUnfilledIntervalsFilter,
+    hasInProgressIntervalsFilter,
+    hasFilledIntervalsFilter,
+  ]
+    .filter(Boolean)
+    .join(' AND ');
 };

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/get_rule_ids_with_gaps_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/get_rule_ids_with_gaps_route.test.ts
@@ -64,7 +64,7 @@ describe('getRuleIdsWithGapsRoute', () => {
 
     rulesClient.getRuleIdsWithGaps.mockResolvedValueOnce(mockResult);
     const [, handler] = router.post.mock.calls[0];
-    const [context, req, res] = mockHandlerArguments({ rulesClient }, { query: mockBody });
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { body: mockBody });
     await handler(context, req, res);
     expect(verifyApiAccess).toHaveBeenCalledWith(licenseState);
   });
@@ -79,7 +79,7 @@ describe('getRuleIdsWithGapsRoute', () => {
       throw new Error('Failure');
     });
     const [, handler] = router.post.mock.calls[0];
-    const [context, req, res] = mockHandlerArguments({ rulesClient }, { query: mockBody });
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { body: mockBody });
     await expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/get_rule_ids_with_gaps_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/get_rule_ids_with_gaps_route.ts
@@ -14,7 +14,7 @@ import type { ILicenseState } from '../../../../lib';
 import { verifyAccessAndContext } from '../../../lib';
 import type { AlertingRequestHandlerContext } from '../../../../types';
 import { INTERNAL_ALERTING_GAPS_GET_RULES_API_PATH } from '../../../../types';
-import { transformResponseV1 } from './transforms';
+import { transformRequestV1, transformResponseV1 } from './transforms';
 
 export const getRuleIdsWithGapsRoute = (
   router: IRouter<AlertingRequestHandlerContext>,
@@ -41,7 +41,7 @@ export const getRuleIdsWithGapsRoute = (
         const alertingContext = await context.alerting;
         const rulesClient = await alertingContext.getRulesClient();
         const body: GetRuleIdsWithGapBodyV1 = req.body;
-        const result = await rulesClient.getRuleIdsWithGaps(body);
+        const result = await rulesClient.getRuleIdsWithGaps(transformRequestV1(body));
         const response: GetRuleIdsWithGapResponseV1 = {
           body: transformResponseV1(result),
         };

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/transforms/transform_request/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/transforms/transform_request/latest.ts
@@ -5,7 +5,4 @@
  * 2.0.
  */
 
-export { transformResponse } from './transform_response/latest';
-
-export { transformResponse as transformResponseV1 } from './transform_response/v1';
-export { transformRequest as transformRequestV1 } from './transform_request/v1';
+export * from './v1';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/transforms/transform_request/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/transforms/transform_request/v1.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GetRuleIdsWithGapBodyV1 } from '../../../../../../../common/routes/gaps/apis/get_rules_with_gaps';
+import type { GetRuleIdsWithGapsParams } from '../../../../../../application/rule/methods/get_rule_ids_with_gaps/types';
+
+export const transformRequest = (request: GetRuleIdsWithGapBodyV1): GetRuleIdsWithGapsParams => ({
+  start: request.start,
+  end: request.end,
+  statuses: request.statuses,
+  hasUnfilledIntervals: request.has_unfilled_intervals,
+  hasInProgressIntervals: request.has_in_progress_intervals,
+  hasFilledIntervals: request.has_filled_intervals,
+});

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/transforms/transform_response/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_rule_ids_with_gaps/transforms/transform_response/v1.ts
@@ -13,4 +13,5 @@ export const transformResponse = (
 ): GetRuleIdsWithGapResponseBodyV1 => ({
   total: response.total,
   rule_ids: response.ruleIds,
+  latest_gap_timestamp: response.latestGapTimestamp,
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/api.ts
@@ -119,10 +119,16 @@ export const getRuleIdsWithGaps = async ({
   start,
   end,
   statuses = [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
+  hasUnfilledIntervals,
+  hasInProgressIntervals,
+  hasFilledIntervals,
 }: {
   start: string;
   end: string;
   statuses: string[];
+  hasUnfilledIntervals?: boolean;
+  hasInProgressIntervals?: boolean;
+  hasFilledIntervals?: boolean;
   signal?: AbortSignal;
 }): Promise<GetRuleIdsWithGapResponseBody> =>
   KibanaServices.get().http.fetch<GetRuleIdsWithGapResponseBody>(
@@ -133,6 +139,15 @@ export const getRuleIdsWithGaps = async ({
         start,
         end,
         statuses,
+        ...(hasUnfilledIntervals !== undefined && {
+          has_unfilled_intervals: hasUnfilledIntervals,
+        }),
+        ...(hasInProgressIntervals !== undefined && {
+          has_in_progress_intervals: hasInProgressIntervals,
+        }),
+        ...(hasFilledIntervals !== undefined && {
+          has_filled_intervals: hasFilledIntervals,
+        }),
       }),
       signal,
     }

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/hooks/use_fill_gap.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/hooks/use_fill_gap.tsx
@@ -9,6 +9,7 @@ import { useMutation } from '@tanstack/react-query';
 import type { IHttpFetchError } from '@kbn/core/public';
 import { useInvalidateFindGapsQuery } from './use_find_gaps_for_rule';
 import { useInvalidateFindBackfillQuery } from './use_find_backfills_for_rules';
+import { useInvalidateGetRuleIdsWithGapsQuery } from './use_get_rule_ids_with_gaps';
 import { fillGapByIdForRule } from '../api';
 
 export const FILL_GAP_BY_ID_MUTATION_KEY = ['POST', 'FILL_GAP_BY_ID_MUTATION_KEY'];
@@ -22,11 +23,13 @@ export const useFillGapMutation = (
 ) => {
   const invalidateFindGapsQuery = useInvalidateFindGapsQuery();
   const invalidateFindBackfillsQuery = useInvalidateFindBackfillQuery();
+  const invalidateGetRuleIdsWithGapsQuery = useInvalidateGetRuleIdsWithGapsQuery();
   return useMutation((fillGapsOptions: FillGapQuery) => fillGapByIdForRule(fillGapsOptions), {
     ...options,
     onSettled: (...args) => {
       invalidateFindGapsQuery();
       invalidateFindBackfillsQuery();
+      invalidateGetRuleIdsWithGapsQuery();
       if (options?.onSettled) {
         options.onSettled(...args);
       }

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/hooks/use_get_rule_ids_with_gaps.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/hooks/use_get_rule_ids_with_gaps.tsx
@@ -4,30 +4,62 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { useCallback } from 'react';
 import type { GetRuleIdsWithGapResponseBody } from '@kbn/alerting-plugin/common/routes/gaps/apis/get_rules_with_gaps';
 import type { UseQueryOptions } from '@tanstack/react-query';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRuleIdsWithGaps } from '../api';
 import type { GapRangeValue } from '../../constants';
 import { getGapRange } from './utils';
 
 const GET_RULE_IDS_WITH_GAPS = ['GET_RULE_IDS_WITH_GAPS'];
 
+export const useInvalidateGetRuleIdsWithGapsQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useCallback(() => {
+    queryClient.invalidateQueries([GET_RULE_IDS_WITH_GAPS], {
+      refetchType: 'active',
+    });
+  }, [queryClient]);
+};
+
 export const useGetRuleIdsWithGaps = (
   {
     gapRange,
     statuses,
+    hasUnfilledIntervals,
+    hasInProgressIntervals,
+    hasFilledIntervals,
   }: {
     gapRange: GapRangeValue;
     statuses: string[];
+    hasUnfilledIntervals?: boolean;
+    hasInProgressIntervals?: boolean;
+    hasFilledIntervals?: boolean;
   },
   options?: UseQueryOptions<GetRuleIdsWithGapResponseBody>
 ) => {
   return useQuery<GetRuleIdsWithGapResponseBody>(
-    [GET_RULE_IDS_WITH_GAPS, gapRange, ...statuses],
+    [
+      GET_RULE_IDS_WITH_GAPS,
+      gapRange,
+      ...statuses,
+      hasUnfilledIntervals,
+      hasInProgressIntervals,
+      hasFilledIntervals,
+    ],
     async ({ signal }) => {
       const { start, end } = getGapRange(gapRange);
-      const response = await getRuleIdsWithGaps({ signal, start, end, statuses });
+      const response = await getRuleIdsWithGaps({
+        signal,
+        start,
+        end,
+        statuses,
+        hasUnfilledIntervals,
+        hasInProgressIntervals,
+        hasFilledIntervals,
+      });
 
       return response;
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/hooks/use_schedule_rule_run_mutation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/api/hooks/use_schedule_rule_run_mutation.ts
@@ -11,6 +11,7 @@ import type { ScheduleBackfillProps } from '../../types';
 import { scheduleRuleRun } from '../api';
 import { useInvalidateFindBackfillQuery } from './use_find_backfills_for_rules';
 import { useInvalidateFindGapsQuery } from './use_find_gaps_for_rule';
+import { useInvalidateGetRuleIdsWithGapsQuery } from './use_get_rule_ids_with_gaps';
 
 export const SCHEDULE_RULE_RUN_MUTATION_KEY = [
   'POST',
@@ -22,11 +23,13 @@ export const useScheduleRuleRunMutation = (
 ) => {
   const invalidateBackfillQuery = useInvalidateFindBackfillQuery();
   const invalidateFindGapsQuery = useInvalidateFindGapsQuery();
+  const invalidateGetRuleIdsWithGapsQuery = useInvalidateGetRuleIdsWithGapsQuery();
   return useMutation((scheduleOptions: ScheduleBackfillProps) => scheduleRuleRun(scheduleOptions), {
     ...options,
     onSettled: (...args) => {
       invalidateBackfillQuery();
       invalidateFindGapsQuery();
+      invalidateGetRuleIdsWithGapsQuery();
       if (options?.onSettled) {
         options.onSettled(...args);
       }

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rule_gaps_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rule_gaps_callout/index.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiCallOut,
+  EuiSpacer,
+  EuiButton,
+  EuiFlexGroup,
+  EuiButtonEmpty,
+  EuiLink,
+} from '@elastic/eui';
+import { gapStatus } from '@kbn/alerting-plugin/common';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import moment from 'moment';
+import { useGetRuleIdsWithGaps } from '../../api/hooks/use_get_rule_ids_with_gaps';
+import { GapRangeValue } from '../../constants';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useKibana } from '../../../../common/lib/kibana';
+import { SecurityPageName } from '../../../../../common/constants';
+import { useGetSecuritySolutionUrl } from '../../../../common/components/link_to';
+import { AllRulesTabs } from '../../../rule_management_ui/components/rules_table/rules_table_toolbar';
+import {
+  RULE_GAPS_CALLOUT_DASHBOARD,
+  RULE_GAPS_CALLOUT_MONITORING_TAB,
+  RULE_GAPS_CALLOUT_TITLE,
+} from './translations';
+
+const DISMISSAL_STORAGE_KEY = 'rule-gaps-callout-dismissed';
+
+export const RuleGapsCallout = () => {
+  const { docLinks, spaces } = useKibana().services;
+  const getSecuritySolutionUrl = useGetSecuritySolutionUrl();
+
+  const [spaceId, setSpaceId] = useState('');
+  useEffect(() => {
+    if (spaces) {
+      spaces.getActiveSpace().then((space) => setSpaceId(space.id));
+    }
+  }, [spaces]);
+  const storeGapsInEventLogEnabled = useIsExperimentalFeatureEnabled('storeGapsInEventLogEnabled');
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  const { data } = useGetRuleIdsWithGaps({
+    gapRange: GapRangeValue.LAST_24_H,
+    statuses: [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
+    hasUnfilledIntervals: true,
+  });
+
+  useEffect(() => {
+    const checkDismissalStatus = () => {
+      const dismissalData = localStorage.getItem(DISMISSAL_STORAGE_KEY);
+      if (!dismissalData || !data?.latest_gap_timestamp) return;
+
+      const { timestamp, latestGapTimestamp } = JSON.parse(dismissalData);
+      const dismissalTime = moment(timestamp);
+      const now = moment();
+
+      // Show callout again if 24 hours passed or there's a newer gap
+      const hasNewerGap =
+        latestGapTimestamp && moment(data.latest_gap_timestamp).isAfter(moment(latestGapTimestamp));
+      const isExpired = now.diff(dismissalTime, 'hours') >= 24;
+
+      if (hasNewerGap || isExpired) {
+        setIsDismissed(false);
+        localStorage.removeItem(DISMISSAL_STORAGE_KEY);
+      } else {
+        setIsDismissed(true);
+      }
+    };
+
+    checkDismissalStatus();
+  }, [data?.latest_gap_timestamp]);
+
+  const handleDismiss = useCallback(() => {
+    const dismissalData = {
+      timestamp: moment().toISOString(),
+      latestGapTimestamp: data?.latest_gap_timestamp,
+    };
+    localStorage.setItem(DISMISSAL_STORAGE_KEY, JSON.stringify(dismissalData));
+    setIsDismissed(true);
+  }, [data?.latest_gap_timestamp]);
+
+  if (!data || data?.total === 0 || !storeGapsInEventLogEnabled || isDismissed) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiCallOut
+        color="warning"
+        title={RULE_GAPS_CALLOUT_TITLE}
+        iconType="warning"
+        onDismiss={handleDismiss}
+      >
+        <>
+          <p>
+            <FormattedMessage
+              id="xpack.securitySolution.ruleGaps.callout.message"
+              defaultMessage="Gaps in rule executions might lead to missing alerts. Go to the Rule Monitoring tab to find affected rules and begin remediating gaps. {link}"
+              values={{
+                link: (
+                  <EuiLink
+                    href={docLinks.links.siem.gapsTable}
+                    data-test-subj="monitoringLogsLink"
+                    target="_blank"
+                  >
+                    {i18n.translate('xpack.securitySolution.ruleGaps.callout.messageLink', {
+                      defaultMessage: 'Learn more',
+                    })}
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+          <EuiFlexGroup>
+            {spaceId && (
+              <EuiButton
+                href={getSecuritySolutionUrl({
+                  deepLinkId: SecurityPageName.rules,
+                  path: AllRulesTabs.monitoring,
+                })}
+                fill
+                color="warning"
+                size="s"
+              >
+                {RULE_GAPS_CALLOUT_MONITORING_TAB}
+              </EuiButton>
+            )}
+            <EuiButtonEmpty
+              href={getSecuritySolutionUrl({
+                deepLinkId: SecurityPageName.dashboards,
+                path: `security-detection-rule-monitoring-${spaceId}`,
+              })}
+              color="warning"
+              size="s"
+            >
+              {RULE_GAPS_CALLOUT_DASHBOARD}
+            </EuiButtonEmpty>
+          </EuiFlexGroup>
+        </>
+      </EuiCallOut>
+      <EuiSpacer size="s" />
+    </>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rule_gaps_callout/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rule_gaps_callout/translations.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const RULE_GAPS_CALLOUT_TITLE = i18n.translate(
+  'xpack.securitySolution.ruleGaps.callout.title',
+  {
+    defaultMessage: 'Rule execution gaps detected in the past 24 hours',
+  }
+);
+
+export const RULE_GAPS_CALLOUT_DASHBOARD = i18n.translate(
+  'xpack.securitySolution.ruleGaps.callout.dashboard',
+  {
+    defaultMessage: 'View dashboard',
+  }
+);
+
+export const RULE_GAPS_CALLOUT_MONITORING_TAB = i18n.translate(
+  'xpack.securitySolution.ruleGaps.callout.monitoringTab',
+  {
+    defaultMessage: 'Monitoring tab',
+  }
+);
+
+export const RULES_MONITORING = i18n.translate(
+  'xpack.securitySolution.ruleGaps.callout.rulesMonitoring',
+  {
+    defaultMessage: 'Rules Monitoring',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/index.tsx
@@ -18,6 +18,7 @@ import {
   EuiBadge,
   EuiFilterButton,
   EuiFilterGroup,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { gapStatus } from '@kbn/alerting-plugin/common';
@@ -33,9 +34,14 @@ export const RulesWithGapsOverviewPanel = () => {
     },
     actions: { setFilterOptions },
   } = useRulesTableContext();
-  const { data } = useGetRuleIdsWithGaps({
+  const { data: totalRulesWithGaps } = useGetRuleIdsWithGaps({
     gapRange: gapSearchRange ?? defaultRangeValue,
     statuses: [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
+  });
+  const { data: inProgressRulesWithGaps } = useGetRuleIdsWithGaps({
+    gapRange: gapSearchRange ?? defaultRangeValue,
+    statuses: [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
+    hasInProgressIntervals: true,
   });
   const [isPopoverOpen, setPopover] = useState(false);
 
@@ -113,7 +119,13 @@ export const RulesWithGapsOverviewPanel = () => {
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiBadge color={data?.total === 0 ? 'success' : 'warning'}>{data?.total}</EuiBadge>
+              {inProgressRulesWithGaps && totalRulesWithGaps && (
+                <EuiToolTip position="bottom" content={i18n.RULE_GAPS_OVERVIEW_PANEL_TOOLTIP_TEXT}>
+                  <EuiBadge color={totalRulesWithGaps?.total === 0 ? 'success' : 'warning'}>
+                    {totalRulesWithGaps?.total} {'/'} {inProgressRulesWithGaps?.total}
+                  </EuiBadge>
+                </EuiToolTip>
+              )}
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/translations.tsx
@@ -16,7 +16,7 @@ export const RULE_GAPS_OVERVIEW_PANEL_LABEL = i18n.translate(
 export const RULE_GAPS_OVERVIEW_PANEL_SHOW_RULES_WITH_GAPS_LABEL = i18n.translate(
   'xpack.securitySolution.ruleGapsOverviewPanel.showRulesWithGapsLabel',
   {
-    defaultMessage: 'Only rules with gaps',
+    defaultMessage: 'Only rules with unfilled gaps',
   }
 );
 
@@ -38,5 +38,12 @@ export const RULE_GAPS_OVERVIEW_PANEL_LAST_7_DAYS_LABEL = i18n.translate(
   'xpack.securitySolution.ruleGapsOverviewPanel.last7DaysLabel',
   {
     defaultMessage: 'Last 7 days',
+  }
+);
+
+export const RULE_GAPS_OVERVIEW_PANEL_TOOLTIP_TEXT = i18n.translate(
+  'xpack.securitySolution.ruleGapsOverviewPanel.tooltipText',
+  {
+    defaultMessage: 'Rules with unfilled gaps / Rules with gaps being filled now',
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/index.tsx
@@ -14,6 +14,7 @@ import { RulesTables } from './rules_tables';
 import { AllRulesTabs, RulesTableToolbar } from './rules_table_toolbar';
 import { UpgradePrebuiltRulesTable } from './upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table';
 import { UpgradePrebuiltRulesTableContextProvider } from './upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context';
+import { RuleGapsCallout } from '../../../rule_gaps/components/rule_gaps_callout';
 
 /**
  * Table Component for displaying all Rules for a given cluster. Provides the ability to filter
@@ -31,6 +32,7 @@ export const AllRules = React.memo(() => {
     return (
       <>
         <RulesManagementTour />
+        {tabName !== AllRulesTabs.monitoring && <RuleGapsCallout />}
         <RulesTableToolbar />
         <EuiSpacer />
         <RulesTables selectedTab={tabName as AllRulesTabs} />

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/fetch_rules_by_query_or_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/fetch_rules_by_query_or_ids.ts
@@ -72,6 +72,7 @@ export const fetchRulesByQueryOrIds = async ({
       start: gapRange.start,
       end: gapRange.end,
       statuses: [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
+      hasUnfilledIntervals: true,
     });
     ruleIdsWithGaps = ruleIdsWithGapsResponse.ruleIds;
     if (ruleIdsWithGaps.length === 0) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/find_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/find_rules/route.ts
@@ -59,6 +59,7 @@ export const findRulesRoute = (router: SecuritySolutionPluginRouter, logger: Log
               start: query.gaps_range_start,
               end: query.gaps_range_end,
               statuses: [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
+              hasUnfilledIntervals: true,
             });
             ruleIds = ruleIdsWithGaps.ruleIds;
             if (ruleIds.length === 0) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Rule gaps callout (#224268)](https://github.com/elastic/kibana/pull/224268)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Khristinin Nikita","email":"nikita.khristinin@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T16:02:44Z","message":"Rule gaps callout (#224268)\n\n##  Rule gaps callout\n\n### Summary\nThis PR introduces a new callout on the **Rules** page and improves the\n**Gaps** panel with clearer metrics and filtering logic to enhance the\nuser experience when managing gap filling.\n\n---\n\n### Key Changes\n\n1. **Rules Page – Callout for Recent Gaps**\n- A dismissible callout is displayed if there are any unfilled gaps in\nthe **last 24 hours**.\n   - The callout includes:\n     - A link to the Gaps dashboard.\n     - A link to relevant documentation.\n- Once dismissed, the callout won’t reappear for 24 hours **unless** new\ngaps are detected during that time.\n\n2. **Gaps Panel – Rule Count Display**\n   - Displays two separate counts:\n     - The **number of rules with unfilled gaps**.\n- The **number of rules currently in progress** (gaps are being filled).\n   - Provides users with a quick overview of the current gap state.\n\n3. **Filtering Logic**\n- The filter now only shows **rules with unfilled gaps that can still be\nfilled**.\n- Example: If 5 rules had unfilled gaps and filling started for 3, the\nfiltered list will only show the remaining 2.\n\n\n**Note**: we don't immediately update number for rules with gap\n\"in-progress\", because gap update async and can happen after bulk\nrequest if finished.\n\n\nhttps://github.com/user-attachments/assets/3c913129-16c3-449a-9847-a01e2657e9aa\n\n\n\n### How to test\n\nEnable FF `storeGapsInEventLogEnabled`.\n\n[Use this tool to create a lot of rules with/without\ngaps](https://github.com/elastic/security-documents-generator)\n\n```\n//  will create 100 without gaps, and 5 minute interval\nyarn start rules --rules 100 -g 0 -c -i \"5m\" -f 1\n```\n\nAlternatively you can create a rule with small interval (1m) and\nlookback time(1s). Enable rule, wait for completion and then disable it.\nWait 5m (> 4x interval). Then enable it and rule should fail and\ngenerate gap.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"40feb02ab4a8eadb01685385c8880b0ed3b520fe","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0"],"title":"Rule gaps callout","number":224268,"url":"https://github.com/elastic/kibana/pull/224268","mergeCommit":{"message":"Rule gaps callout (#224268)\n\n##  Rule gaps callout\n\n### Summary\nThis PR introduces a new callout on the **Rules** page and improves the\n**Gaps** panel with clearer metrics and filtering logic to enhance the\nuser experience when managing gap filling.\n\n---\n\n### Key Changes\n\n1. **Rules Page – Callout for Recent Gaps**\n- A dismissible callout is displayed if there are any unfilled gaps in\nthe **last 24 hours**.\n   - The callout includes:\n     - A link to the Gaps dashboard.\n     - A link to relevant documentation.\n- Once dismissed, the callout won’t reappear for 24 hours **unless** new\ngaps are detected during that time.\n\n2. **Gaps Panel – Rule Count Display**\n   - Displays two separate counts:\n     - The **number of rules with unfilled gaps**.\n- The **number of rules currently in progress** (gaps are being filled).\n   - Provides users with a quick overview of the current gap state.\n\n3. **Filtering Logic**\n- The filter now only shows **rules with unfilled gaps that can still be\nfilled**.\n- Example: If 5 rules had unfilled gaps and filling started for 3, the\nfiltered list will only show the remaining 2.\n\n\n**Note**: we don't immediately update number for rules with gap\n\"in-progress\", because gap update async and can happen after bulk\nrequest if finished.\n\n\nhttps://github.com/user-attachments/assets/3c913129-16c3-449a-9847-a01e2657e9aa\n\n\n\n### How to test\n\nEnable FF `storeGapsInEventLogEnabled`.\n\n[Use this tool to create a lot of rules with/without\ngaps](https://github.com/elastic/security-documents-generator)\n\n```\n//  will create 100 without gaps, and 5 minute interval\nyarn start rules --rules 100 -g 0 -c -i \"5m\" -f 1\n```\n\nAlternatively you can create a rule with small interval (1m) and\nlookback time(1s). Enable rule, wait for completion and then disable it.\nWait 5m (> 4x interval). Then enable it and rule should fail and\ngenerate gap.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"40feb02ab4a8eadb01685385c8880b0ed3b520fe"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224268","number":224268,"mergeCommit":{"message":"Rule gaps callout (#224268)\n\n##  Rule gaps callout\n\n### Summary\nThis PR introduces a new callout on the **Rules** page and improves the\n**Gaps** panel with clearer metrics and filtering logic to enhance the\nuser experience when managing gap filling.\n\n---\n\n### Key Changes\n\n1. **Rules Page – Callout for Recent Gaps**\n- A dismissible callout is displayed if there are any unfilled gaps in\nthe **last 24 hours**.\n   - The callout includes:\n     - A link to the Gaps dashboard.\n     - A link to relevant documentation.\n- Once dismissed, the callout won’t reappear for 24 hours **unless** new\ngaps are detected during that time.\n\n2. **Gaps Panel – Rule Count Display**\n   - Displays two separate counts:\n     - The **number of rules with unfilled gaps**.\n- The **number of rules currently in progress** (gaps are being filled).\n   - Provides users with a quick overview of the current gap state.\n\n3. **Filtering Logic**\n- The filter now only shows **rules with unfilled gaps that can still be\nfilled**.\n- Example: If 5 rules had unfilled gaps and filling started for 3, the\nfiltered list will only show the remaining 2.\n\n\n**Note**: we don't immediately update number for rules with gap\n\"in-progress\", because gap update async and can happen after bulk\nrequest if finished.\n\n\nhttps://github.com/user-attachments/assets/3c913129-16c3-449a-9847-a01e2657e9aa\n\n\n\n### How to test\n\nEnable FF `storeGapsInEventLogEnabled`.\n\n[Use this tool to create a lot of rules with/without\ngaps](https://github.com/elastic/security-documents-generator)\n\n```\n//  will create 100 without gaps, and 5 minute interval\nyarn start rules --rules 100 -g 0 -c -i \"5m\" -f 1\n```\n\nAlternatively you can create a rule with small interval (1m) and\nlookback time(1s). Enable rule, wait for completion and then disable it.\nWait 5m (> 4x interval). Then enable it and rule should fail and\ngenerate gap.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"40feb02ab4a8eadb01685385c8880b0ed3b520fe"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->