### PR TITLE
[8.19] [ResponseOps][Cases] Populate total alerts and comments in the cases saved objects (#223992)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_get.test.ts
@@ -21,7 +21,9 @@ describe('bulkGet', () => {
       unauthorized: [],
     });
 
-    clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+    clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+      new Map()
+    );
 
     beforeEach(() => {
       jest.clearAllMocks();

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_get.ts
@@ -49,7 +49,7 @@ export const bulkGet = async (
         operation: Operations.bulkGetCases,
       });
 
-    const commentTotals = await attachmentService.getter.getCaseCommentStats({
+    const commentTotals = await attachmentService.getter.getCaseAttatchmentStats({
       caseIds: authorizedCases.map((theCase) => theCase.id),
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.test.ts
@@ -53,7 +53,9 @@ describe('update', () => {
         saved_objects: [{ ...mockCases[0], attributes: { assignees: cases.cases[0].assignees } }],
       });
 
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
     });
 
     it('notifies an assignee', async () => {
@@ -437,7 +439,9 @@ describe('update', () => {
         per_page: 10,
         page: 1,
       });
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
     });
 
     it(`does not throw error when category is non empty string less than ${MAX_CATEGORY_LENGTH} characters`, async () => {
@@ -571,7 +575,9 @@ describe('update', () => {
         per_page: 10,
         page: 1,
       });
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
     });
 
     it(`does not throw error when title is non empty string less than ${MAX_TITLE_LENGTH} characters`, async () => {
@@ -706,7 +712,9 @@ describe('update', () => {
         per_page: 10,
         page: 1,
       });
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
     });
 
     it(`does not throw error when description is non empty string less than ${MAX_DESCRIPTION_LENGTH} characters`, async () => {
@@ -848,7 +856,7 @@ describe('update', () => {
       const caseCommentsStats = new Map();
       caseCommentsStats.set(mockCases[0].id, { userComments: 1, alerts: 2 });
       caseCommentsStats.set(mockCases[1].id, { userComments: 3, alerts: 4 });
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
         caseCommentsStats
       );
     });
@@ -972,7 +980,9 @@ describe('update', () => {
         ]
       `);
 
-      expect(clientArgs.services.attachmentService.getter.getCaseCommentStats).toHaveBeenCalledWith(
+      expect(
+        clientArgs.services.attachmentService.getter.getCaseAttatchmentStats
+      ).toHaveBeenCalledWith(
         expect.objectContaining({
           caseIds: [mockCases[0].id, mockCases[1].id],
         })
@@ -992,7 +1002,9 @@ describe('update', () => {
         per_page: 10,
         page: 1,
       });
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
     });
 
     it('does not throw error when tags array is empty', async () => {
@@ -1197,7 +1209,9 @@ describe('update', () => {
           customFields: defaultCustomFieldsConfiguration,
         },
       ]);
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
     });
 
     it('can update customFields', async () => {
@@ -1587,7 +1601,7 @@ describe('update', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      clientArgsMock.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(
+      clientArgsMock.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
         new Map()
       );
     });
@@ -1807,7 +1821,7 @@ describe('update', () => {
           per_page: 10,
           page: 1,
         });
-        clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(
+        clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
           new Map()
         );
       });
@@ -1915,7 +1929,9 @@ describe('update', () => {
         saved_objects: mockCases,
       });
 
-      clientArgs.services.attachmentService.getter.getCaseCommentStats.mockResolvedValue(new Map());
+      clientArgs.services.attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+        new Map()
+      );
     });
 
     it('calculates metrics correctly', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
@@ -516,7 +516,7 @@ export const bulkUpdate = async (
       alertsService,
     });
 
-    const commentsMap = await attachmentService.getter.getCaseCommentStats({
+    const commentsMap = await attachmentService.getter.getCaseAttatchmentStats({
       caseIds,
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/get.ts
@@ -103,7 +103,7 @@ export const getCasesByAlertID = async (
       return [];
     }
 
-    const commentStats = await attachmentService.getter.getCaseCommentStats({
+    const commentStats = await attachmentService.getter.getCaseAttatchmentStats({
       caseIds,
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/common/types/case.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/types/case.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { omit } from 'lodash';
+import { number } from 'io-ts';
 import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common';
 import {
   CaseTransformedAttributesRt,
@@ -52,8 +53,9 @@ describe('case types', () => {
       assignees: [],
       observables: [],
     };
+
     const caseTransformedAttributesProps = CaseTransformedAttributesRt.types.reduce(
-      (acc, type) => ({ ...acc, ...type.type.props }),
+      (acc, type) => ({ ...acc, ...type.type.props, total_comments: number, total_alerts: number }),
       {}
     );
 
@@ -77,6 +79,18 @@ describe('case types', () => {
       expect(decodedRes._tag).toEqual('Right');
       // @ts-expect-error: the check above ensures that right exists
       expect(decodedRes.right).toEqual({ description: 'test' });
+    });
+
+    it('does not remove the attachment stats', () => {
+      const decodedRes = type.decode({
+        description: 'test',
+        total_alerts: 0,
+        total_comments: 0,
+      });
+
+      expect(decodedRes._tag).toEqual('Right');
+      // @ts-expect-error: the check above ensures that right exists
+      expect(decodedRes.right).toEqual({ description: 'test', total_alerts: 0, total_comments: 0 });
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
@@ -7,7 +7,7 @@
 
 import type { SavedObject } from '@kbn/core-saved-objects-server';
 import type { Type } from 'io-ts';
-import { exact, partial, strict, string } from 'io-ts';
+import { exact, partial, strict, string, number } from 'io-ts';
 import type { CaseAttributes, Observable } from '../../../common/types/domain';
 import { CaseAttributesRt } from '../../../common/types/domain';
 import type { ConnectorPersisted } from './connectors';
@@ -64,16 +64,28 @@ type CasePersistedCustomFields = Array<{
 }>;
 
 export type CaseTransformedAttributes = CaseAttributes;
+export type CaseTransformedAttributesWithAttachmentStats = CaseAttributes & {
+  total_comments: number;
+  total_alerts: number;
+};
 
 export const CaseTransformedAttributesRt = CaseAttributesRt;
 
-export const getPartialCaseTransformedAttributesRt = (): Type<Partial<CaseAttributes>> => {
+export const getPartialCaseTransformedAttributesRt = (): Type<
+  Partial<CaseTransformedAttributesWithAttachmentStats>
+> => {
   const caseTransformedAttributesProps = CaseAttributesRt.types.reduce(
     (acc, type) => Object.assign(acc, type.type.props),
     {}
   );
 
-  return exact(partial({ ...caseTransformedAttributesProps }));
+  return exact(
+    /**
+     * We add the `total_comments` and `total_alerts` properties to allow the
+     * attachments stats to be updated.
+     */
+    partial({ ...caseTransformedAttributesProps, total_comments: number, total_alerts: number })
+  );
 };
 
 export type CaseSavedObject = SavedObject<CasePersistedAttributes>;

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -249,7 +249,7 @@ export class AttachmentGetter {
     }
   }
 
-  public async getCaseCommentStats({
+  public async getCaseAttatchmentStats({
     caseIds,
   }: {
     caseIds: string[];

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
@@ -287,12 +287,16 @@ describe('CasesService', () => {
 
         await service.patchCase({
           caseId: '1',
-          updatedAttributes: createCasePostParams({
-            connector: createJiraConnector(),
-            externalService: createExternalService(),
-            severity: CaseSeverity.CRITICAL,
-            status: CaseStatuses['in-progress'],
-          }),
+          updatedAttributes: {
+            ...createCasePostParams({
+              connector: createJiraConnector(),
+              externalService: createExternalService(),
+              severity: CaseSeverity.CRITICAL,
+              status: CaseStatuses['in-progress'],
+            }),
+            total_alerts: 10,
+            total_comments: 5,
+          },
           originalCase: {} as CaseSavedObjectTransformed,
         });
 
@@ -327,6 +331,8 @@ describe('CasesService', () => {
               "defacement",
             ],
             "title": "Super Bad Security Issue",
+            "total_alerts": 10,
+            "total_comments": 5,
             "updated_at": "2019-11-25T21:54:48.952Z",
             "updated_by": Object {
               "email": "testemail@elastic.co",
@@ -661,6 +667,33 @@ describe('CasesService', () => {
           expect(patchAttributes.status).toEqual(expectedStatus);
         }
       );
+
+      it('updates the total attachment stats', async () => {
+        unsecuredSavedObjectsClient.update.mockResolvedValue(
+          {} as SavedObjectsUpdateResponse<CasePersistedAttributes>
+        );
+
+        await service.patchCase({
+          caseId: '1',
+          updatedAttributes: {
+            ...createCasePostParams({
+              connector: createJiraConnector(),
+              externalService: createExternalService(),
+              severity: CaseSeverity.CRITICAL,
+              status: CaseStatuses['in-progress'],
+            }),
+            total_alerts: 10,
+            total_comments: 5,
+          },
+          originalCase: {} as CaseSavedObjectTransformed,
+        });
+
+        const patchAttributes = unsecuredSavedObjectsClient.update.mock
+          .calls[0][2] as CasePersistedAttributes;
+
+        expect(patchAttributes.total_alerts).toEqual(10);
+        expect(patchAttributes.total_comments).toEqual(5);
+      });
     });
 
     describe('bulkPatch', () => {
@@ -765,6 +798,39 @@ describe('CasesService', () => {
         expect(patchResults[1].attributes.status).toEqual(CasePersistedStatus.IN_PROGRESS);
         expect(patchResults[2].attributes.status).toEqual(CasePersistedStatus.CLOSED);
       });
+
+      it('updates the total attachment stats', async () => {
+        unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+          saved_objects: [
+            createCaseSavedObjectResponse({ caseId: '1' }),
+            createCaseSavedObjectResponse({ caseId: '2' }),
+            createCaseSavedObjectResponse({ caseId: '3' }),
+          ],
+        });
+
+        await service.patchCases({
+          cases: [
+            {
+              caseId: '1',
+              updatedAttributes: {
+                ...createCasePostParams({
+                  connector: getNoneCaseConnector(),
+                  status: CaseStatuses.open,
+                }),
+                total_alerts: 10,
+                total_comments: 5,
+              },
+              originalCase: {} as CaseSavedObjectTransformed,
+            },
+          ],
+        });
+
+        const patchResults = unsecuredSavedObjectsClient.bulkUpdate.mock
+          .calls[0][0] as unknown as Array<SavedObject<CasePersistedAttributes>>;
+
+        expect(patchResults[0].attributes.total_alerts).toEqual(10);
+        expect(patchResults[0].attributes.total_comments).toEqual(5);
+      });
     });
 
     describe('createCase', () => {
@@ -852,8 +918,8 @@ describe('CasesService', () => {
               "defacement",
             ],
             "title": "Super Bad Security Issue",
-            "total_alerts": -1,
-            "total_comments": -1,
+            "total_alerts": 0,
+            "total_comments": 0,
             "updated_at": "2019-11-25T21:54:48.952Z",
             "updated_by": Object {
               "email": "testemail@elastic.co",
@@ -895,8 +961,8 @@ describe('CasesService', () => {
         const postAttributes = unsecuredSavedObjectsClient.create.mock
           .calls[0][1] as CasePersistedAttributes;
 
-        expect(postAttributes.total_alerts).toEqual(-1);
-        expect(postAttributes.total_comments).toEqual(-1);
+        expect(postAttributes.total_alerts).toEqual(0);
+        expect(postAttributes.total_comments).toEqual(0);
       });
 
       it('moves the connector.id and connector_id to the references', async () => {
@@ -1073,8 +1139,8 @@ describe('CasesService', () => {
                     "defacement",
                   ],
                   "title": "Super Bad Security Issue",
-                  "total_alerts": -1,
-                  "total_comments": -1,
+                  "total_alerts": 0,
+                  "total_comments": 0,
                   "updated_at": "2019-11-25T21:54:48.952Z",
                   "updated_by": Object {
                     "email": "testemail@elastic.co",
@@ -1112,8 +1178,8 @@ describe('CasesService', () => {
       const postAttributes = unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0][0]
         .attributes as CasePersistedAttributes;
 
-      expect(postAttributes.total_alerts).toEqual(-1);
-      expect(postAttributes.total_comments).toEqual(-1);
+      expect(postAttributes.total_alerts).toEqual(0);
+      expect(postAttributes.total_comments).toEqual(0);
     });
   });
 
@@ -2200,7 +2266,10 @@ describe('CasesService', () => {
      * - external_service
      * - category
      *
-     * Decode is not expected to throw an error as they are defined.
+     * The following fields can be undefined:
+     * - total_alerts
+     * - total_comments
+     * - incremental_id
      */
     const attributesToValidateIfMissing = omit(
       caseTransformedAttributesProps,
@@ -2212,6 +2281,8 @@ describe('CasesService', () => {
       'customFields',
       'observables',
       'incremental_id',
+      'total_alerts',
+      'total_comments',
       'in_progress_at',
       'time_to_acknowledge',
       'time_to_resolve',

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
@@ -181,7 +181,7 @@ export class CasesService {
       return accMap;
     }, new Map<string, SavedObjectsFindResult<CaseTransformedAttributes>>());
 
-    const commentTotals = await this.attachmentService.getter.getCaseCommentStats({
+    const commentTotals = await this.attachmentService.getter.getCaseAttatchmentStats({
       caseIds: Array.from(casesMap.keys()),
     });
 
@@ -594,8 +594,8 @@ export class CasesService {
       const decodedAttributes = decodeOrThrow(CaseTransformedAttributesRt)(attributes);
       const transformedAttributes = transformAttributesToESModel(decodedAttributes);
 
-      transformedAttributes.attributes.total_alerts = -1;
-      transformedAttributes.attributes.total_comments = -1;
+      transformedAttributes.attributes.total_alerts = 0;
+      transformedAttributes.attributes.total_comments = 0;
 
       const createdCase = await this.unsecuredSavedObjectsClient.create<CasePersistedAttributes>(
         CASE_SAVED_OBJECT,
@@ -626,8 +626,8 @@ export class CasesService {
         const { attributes: transformedAttributes, referenceHandler } =
           transformAttributesToESModel(decodedAttributes);
 
-        transformedAttributes.total_alerts = -1;
-        transformedAttributes.total_comments = -1;
+        transformedAttributes.total_alerts = 0;
+        transformedAttributes.total_comments = 0;
 
         return {
           type: CASE_SAVED_OBJECT,

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/transform.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/transform.test.ts
@@ -243,6 +243,28 @@ describe('case transforms', () => {
         expect(transformedAttributes.attributes.status).toBe(expectedStatusValue);
       }
     );
+
+    it('does not return the total alerts', () => {
+      expect(
+        transformUpdateResponseToExternalModel({
+          type: 'a',
+          id: '1',
+          attributes: { total_alerts: 2 },
+          references: undefined,
+        }).attributes
+      ).not.toHaveProperty('total_alerts');
+    });
+
+    it('does not return the total comments', () => {
+      expect(
+        transformUpdateResponseToExternalModel({
+          type: 'a',
+          id: '1',
+          attributes: { total_comments: 2 },
+          references: undefined,
+        }).attributes
+      ).not.toHaveProperty('total_comments');
+    });
   });
 
   describe('transformAttributesToESModel', () => {
@@ -437,6 +459,22 @@ describe('case transforms', () => {
       expect(transformAttributesToESModel({ incremental_id: 100 }).attributes).not.toHaveProperty(
         'incremental_id'
       );
+    });
+
+    it('does not remove the total alerts', () => {
+      expect(transformAttributesToESModel({ total_alerts: 10 }).attributes).toMatchInlineSnapshot(`
+        Object {
+          "total_alerts": 10,
+        }
+      `);
+    });
+
+    it('does not remove the total comments', () => {
+      expect(transformAttributesToESModel({ total_comments: 5 }).attributes).toMatchInlineSnapshot(`
+        Object {
+          "total_comments": 5,
+        }
+      `);
     });
   });
 
@@ -654,6 +692,32 @@ describe('case transforms', () => {
 
       expect(
         transformSavedObjectToExternalModel(CaseSOResponseWithObservables).attributes.incremental_id
+      ).not.toBeDefined();
+    });
+
+    it('does not return the total comments', () => {
+      const resWithTotalComments = createCaseSavedObjectResponse({
+        overrides: {
+          total_comments: 3,
+        },
+      });
+
+      expect(
+        // @ts-expect-error: total_comments is not defined in the attributes
+        transformSavedObjectToExternalModel(resWithTotalComments).attributes.total_comments
+      ).not.toBeDefined();
+    });
+
+    it('does not return the total alerts', () => {
+      const resWithTotalAlerts = createCaseSavedObjectResponse({
+        overrides: {
+          total_alerts: 2,
+        },
+      });
+
+      expect(
+        // @ts-expect-error: total_alerts is not defined in the attributes
+        transformSavedObjectToExternalModel(resWithTotalAlerts).attributes.total_alerts
       ).not.toBeDefined();
     });
   });

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/transform.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/transform.ts
@@ -32,7 +32,11 @@ import {
   transformESConnectorToExternalModel,
 } from '../transform';
 import { ConnectorReferenceHandler } from '../connector_reference_handler';
-import type { CasePersistedAttributes, CaseTransformedAttributes } from '../../common/types/case';
+import type {
+  CasePersistedAttributes,
+  CaseTransformedAttributes,
+  CaseTransformedAttributesWithAttachmentStats,
+} from '../../common/types/case';
 import type { ExternalServicePersisted } from '../../common/types/external_service';
 
 export function transformUpdateResponseToExternalModel(
@@ -89,10 +93,14 @@ export function transformAttributesToESModel(caseAttributes: CaseTransformedAttr
   attributes: CasePersistedAttributes;
   referenceHandler: ConnectorReferenceHandler;
 };
-export function transformAttributesToESModel(caseAttributes: Partial<CaseTransformedAttributes>): {
+
+export function transformAttributesToESModel(
+  caseAttributes: Partial<CaseTransformedAttributesWithAttachmentStats>
+): {
   attributes: Partial<CasePersistedAttributes>;
   referenceHandler: ConnectorReferenceHandler;
 };
+
 export function transformAttributesToESModel(caseAttributes: Partial<CaseTransformedAttributes>): {
   attributes: Partial<CasePersistedAttributes>;
   referenceHandler: ConnectorReferenceHandler;

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/types.ts
@@ -26,6 +26,11 @@ export interface PushedArgs {
   pushed_by: User;
 }
 
+export interface AttachmentStatsAttributes {
+  total_comments: number;
+  total_alerts: number;
+}
+
 export interface GetCaseArgs {
   id: string;
 }
@@ -57,7 +62,7 @@ export interface BulkCreateCasesArgs extends IndexRefresh {
 
 export interface PatchCase extends IndexRefresh {
   caseId: string;
-  updatedAttributes: Partial<CaseTransformedAttributes & PushedArgs>;
+  updatedAttributes: Partial<CaseTransformedAttributes & PushedArgs & AttachmentStatsAttributes>;
   originalCase: CaseSavedObjectTransformed;
   version?: string;
 }

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -158,7 +158,7 @@ const createAttachmentGetterServiceMock = (): AttachmentGetterServiceMock => {
     get: jest.fn(),
     bulkGet: jest.fn(),
     getAllAlertsAttachToCase: jest.fn(),
-    getCaseCommentStats: jest.fn(),
+    getCaseAttatchmentStats: jest.fn(),
     getAttachmentIdsForCases: jest.fn(),
     getFileAttachments: jest.fn(),
     getAllAlertIds: jest.fn(),

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/bulk_create_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/bulk_create_cases.ts
@@ -18,6 +18,7 @@ import {
   getSpaceUrlPrefix,
   removeServerGeneratedPropertiesFromCase,
   removeServerGeneratedPropertiesFromUserAction,
+  getCaseSavedObjectsFromES,
 } from '../../../../common/lib/api';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
@@ -231,6 +232,28 @@ export default ({ getService }: FtrProviderContext): void => {
           category: null,
           customFields: [],
         },
+      });
+    });
+
+    describe('attachment stats', () => {
+      it('should set the attachment stats to zero', async () => {
+        await bulkCreateCases({
+          data: {
+            cases: [getPostCaseRequest(), getPostCaseRequest({ severity: CaseSeverity.MEDIUM })],
+          },
+        });
+
+        const res = await getCaseSavedObjectsFromES({ es });
+
+        expect(res.body.hits.hits.length).to.eql(2);
+
+        const firstCase = res.body.hits.hits[0]._source?.cases!;
+        const secondCase = res.body.hits.hits[1]._source?.cases!;
+
+        expect(firstCase.total_alerts).to.eql(0);
+        expect(firstCase.total_comments).to.eql(0);
+        expect(secondCase.total_alerts).to.eql(0);
+        expect(secondCase.total_comments).to.eql(0);
       });
     });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -24,6 +24,7 @@ import {
   removeServerGeneratedPropertiesFromUserAction,
   createConfiguration,
   getConfigurationRequest,
+  getCaseSavedObjectsFromES,
 } from '../../../../common/lib/api';
 import {
   secOnly,
@@ -719,6 +720,21 @@ export default ({ getService }: FtrProviderContext): void => {
             400
           );
         });
+      });
+    });
+
+    describe('attachment stats', () => {
+      it('should set the attachment stats to zero', async () => {
+        await createCase(supertest, getPostCaseRequest());
+
+        const res = await getCaseSavedObjectsFromES({ es });
+
+        expect(res.body.hits.hits.length).to.eql(1);
+
+        const theCase = res.body.hits.hits[0]._source?.cases!;
+
+        expect(theCase.total_alerts).to.eql(0);
+        expect(theCase.total_comments).to.eql(0);
       });
     });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
@@ -37,7 +37,6 @@ import {
   superUserSpace1Auth,
   getCaseSavedObjectsFromES,
   bulkCreateAttachments,
-  resolveCase,
   getCase,
 } from '../../../../common/lib/api';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
@@ -38,6 +38,7 @@ import {
   getCaseSavedObjectsFromES,
   bulkCreateAttachments,
   resolveCase,
+  getCase,
 } from '../../../../common/lib/api';
 import {
   globalRead,
@@ -297,12 +298,13 @@ export default ({ getService }: FtrProviderContext): void => {
           expectedHttpCode: 200,
         });
 
-        const resolvedCase = await resolveCase({
+        const resolvedCase = await getCase({
           supertest,
           caseId: postedCase.id,
+          includeComments: true,
         });
 
-        const caseComments = resolvedCase.case.comments!;
+        const caseComments = resolvedCase.comments!;
 
         const userComment = caseComments?.find((comment) => comment.type === 'user');
         const alertComment = caseComments?.find((comment) => comment.type === 'alert');

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_create_attachments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_create_attachments.ts
@@ -26,6 +26,7 @@ import {
   postExternalReferenceSOReq,
   fileMetadata,
   postCommentAlertMultipleIdsReq,
+  postCommentActionsReq,
 } from '../../../../common/lib/mock';
 import {
   deleteAllCaseItems,
@@ -41,6 +42,7 @@ import {
   deleteAllFiles,
   getAllComments,
   createComment,
+  getCaseSavedObjectsFromES,
 } from '../../../../common/lib/api';
 import {
   createAlertsIndex,
@@ -1537,6 +1539,32 @@ export default ({ getService }: FtrProviderContext): void => {
           params: [postCommentUserReq],
           expectedHttpCode: 200,
         });
+      });
+
+      it('should set the attachment stats correctly', async () => {
+        const postedCase = await createCase(supertest, postCaseReq);
+
+        await bulkCreateAttachments({
+          supertest,
+          caseId: postedCase.id,
+          params: [
+            postCommentUserReq,
+            postCommentUserReq,
+            postCommentAlertReq,
+            // an attachment that is not a comment or an alert should not affect the stats
+            postCommentActionsReq,
+          ],
+          expectedHttpCode: 200,
+        });
+
+        const res = await getCaseSavedObjectsFromES({ es });
+
+        expect(res.body.hits.hits.length).to.eql(1);
+
+        const theCase = res.body.hits.hits[0]._source?.cases!;
+
+        expect(theCase.total_alerts).to.eql(1);
+        expect(theCase.total_comments).to.eql(2);
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Cases] Populate total alerts and comments in the cases saved objects (#223992)](https://github.com/elastic/kibana/pull/223992)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T16:56:01Z","message":"[ResponseOps][Cases] Populate total alerts and comments in the cases saved objects (#223992)\n\n## Summary\n\nThis is a farewell PR to Cases. Probably my last PR to the cases\ncodebase. It was quite a journey, and I learned a lot. I hope the best\nfor the feature of Cases.\n\n## Decisions\n\nJust before Cases was forbidden to do migrations, we did a last\nmigration to all cases to persist `total_alerts: -1` and\n`total_comments: -1`. We did that so that in the future, when we would\nwant to populate the fields, we would know which cases have their fields\npopulated and which do not. In this PR, due to time constraints and\ncriticality of the feature, I took the following decisions:\n\n- Cases return from their APIs the total comments and alerts of each\ncase. They do that by doing an aggregation, getting the counts, and\nmerging them with the response. I did not change that behavior. In\nfollowing PRs, it can be optimized and fetch the stats only for cases\nthat do not yet have their stats populated (cases with -1 in the counts)\n- When a case is created, the counts are zero.\n- When a comment or alert is added, I do an aggregation to get the stats\n(total alerts and comments) of the current case, and then update the\ncounters with the number of the newly created attachments. The case is\nupdated without version checks. In race conditions, where an attachment\nis being added before updating the case, the numbers could be off. This\nis a deliberate choice. It can be fixed later with retries and version\nconcurrency control.\n- The case service will continue to not return the `total_alerts` and\n`total_comments`.\n- The case service will accept the `total_alerts` and `total_comments`\nattributes to be able to set them.\n\nFixes: https://github.com/elastic/kibana/issues/217636\n\ncc @michaelolo24 \n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"f30335ac3d74bd3310167a27d035544c72068111","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Cases","backport:version","v9.1.0","v8.19.0"],"title":"[ResponseOps][Cases] Populate total alerts and comments in the cases saved objects","number":223992,"url":"https://github.com/elastic/kibana/pull/223992","mergeCommit":{"message":"[ResponseOps][Cases] Populate total alerts and comments in the cases saved objects (#223992)\n\n## Summary\n\nThis is a farewell PR to Cases. Probably my last PR to the cases\ncodebase. It was quite a journey, and I learned a lot. I hope the best\nfor the feature of Cases.\n\n## Decisions\n\nJust before Cases was forbidden to do migrations, we did a last\nmigration to all cases to persist `total_alerts: -1` and\n`total_comments: -1`. We did that so that in the future, when we would\nwant to populate the fields, we would know which cases have their fields\npopulated and which do not. In this PR, due to time constraints and\ncriticality of the feature, I took the following decisions:\n\n- Cases return from their APIs the total comments and alerts of each\ncase. They do that by doing an aggregation, getting the counts, and\nmerging them with the response. I did not change that behavior. In\nfollowing PRs, it can be optimized and fetch the stats only for cases\nthat do not yet have their stats populated (cases with -1 in the counts)\n- When a case is created, the counts are zero.\n- When a comment or alert is added, I do an aggregation to get the stats\n(total alerts and comments) of the current case, and then update the\ncounters with the number of the newly created attachments. The case is\nupdated without version checks. In race conditions, where an attachment\nis being added before updating the case, the numbers could be off. This\nis a deliberate choice. It can be fixed later with retries and version\nconcurrency control.\n- The case service will continue to not return the `total_alerts` and\n`total_comments`.\n- The case service will accept the `total_alerts` and `total_comments`\nattributes to be able to set them.\n\nFixes: https://github.com/elastic/kibana/issues/217636\n\ncc @michaelolo24 \n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"f30335ac3d74bd3310167a27d035544c72068111"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223992","number":223992,"mergeCommit":{"message":"[ResponseOps][Cases] Populate total alerts and comments in the cases saved objects (#223992)\n\n## Summary\n\nThis is a farewell PR to Cases. Probably my last PR to the cases\ncodebase. It was quite a journey, and I learned a lot. I hope the best\nfor the feature of Cases.\n\n## Decisions\n\nJust before Cases was forbidden to do migrations, we did a last\nmigration to all cases to persist `total_alerts: -1` and\n`total_comments: -1`. We did that so that in the future, when we would\nwant to populate the fields, we would know which cases have their fields\npopulated and which do not. In this PR, due to time constraints and\ncriticality of the feature, I took the following decisions:\n\n- Cases return from their APIs the total comments and alerts of each\ncase. They do that by doing an aggregation, getting the counts, and\nmerging them with the response. I did not change that behavior. In\nfollowing PRs, it can be optimized and fetch the stats only for cases\nthat do not yet have their stats populated (cases with -1 in the counts)\n- When a case is created, the counts are zero.\n- When a comment or alert is added, I do an aggregation to get the stats\n(total alerts and comments) of the current case, and then update the\ncounters with the number of the newly created attachments. The case is\nupdated without version checks. In race conditions, where an attachment\nis being added before updating the case, the numbers could be off. This\nis a deliberate choice. It can be fixed later with retries and version\nconcurrency control.\n- The case service will continue to not return the `total_alerts` and\n`total_comments`.\n- The case service will accept the `total_alerts` and `total_comments`\nattributes to be able to set them.\n\nFixes: https://github.com/elastic/kibana/issues/217636\n\ncc @michaelolo24 \n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"f30335ac3d74bd3310167a27d035544c72068111"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->