### PR TITLE
[8.17] [Docs] Adds 8.17.8 release notes (#224490)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@
 
 Review important information about the {kib} 8.x releases.
 
+* <<release-notes-8.17.8>>
 * <<release-notes-8.17.7>>
 * <<release-notes-8.17.6>>
 * <<release-notes-8.17.5>>
@@ -93,6 +94,40 @@ Review important information about the {kib} 8.x releases.
 
 
 include::upgrade-notes.asciidoc[]
+
+[[release-notes-8.17.8]]
+== {kib} 8.17.8
+
+The 8.17.8 release includes the following fixes.
+
+[float]
+[[fixes-v8.17.8]]
+=== Fixes
+Alerting::
+* Fixes an issue causing the interface to freeze when an error occurred after deleting a connector ({kibana-pull}221958[#221958]).
+Dashboards and Visualizations::
+* Fixes an issue that prevented navigating through pages when inspecting a chart's data ({kibana-pull}223537[#223537]).
+* Fixes an issue preventing **Canvas** embeddables from correctly refreshing ({kibana-pull}221326[#221326]).
+* Correctly applies default timezone in **TSVB** when the timezone parameter is set to default in Advanced Settings ({kibana-pull}220658[#220658]).
+Data ingestion and Fleet::
+* Fixes the `UnenrollInactiveAgentsTask` query to un-enroll only those agents that are inactive for longer than what is defined in the `unenroll_timeout` setting ({kibana-pull}222592[#222592]).
+* Fixes an issue preventing some integrations from correctly showing as installed ({kibana-pull}221624[#221624]).
+Elastic Observability solution::
+* Fixes network error handling on the **Error details** page in Synthetics ({kibana-pull}224296[#224296]).
+* Fixes an issue causing the screenshot of the first step to appear for each step of the last successful test run in Synthetics ({kibana-pull}224220[#224220]).
+* Fixes an accessibility issue in Synthetics settings, causing the focus to move out of the page when using `cc` and `bcc` elements in the email connector form ({kibana-pull}223828[#223828]).
+* Prevents loss of unsaved changes after manually running a Synthetics test ({kibana-pull}222503[#222503]).
+* Fixes an issue preventing metrics graphs from appearing on the Services **Inventory** page ({kibana-pull}222439[#222439]).
+* Fixes a navigation issue where clicking the error count on an APM waterfall item triggers a full page reload ({kibana-pull}221664[#221664]).
+* Fixes pagination not working on the Services **Inventory** page when progressive loading is enabled ({kibana-pull}220514[#220514]).
+* Fixes an issue with Uptime rules appearing in the **Create rule** modal even when the `observability:enableLegacyUptimeApp` setting is disabled ({kibana-pull}220005[#220005]).
+Elastic Security solution::
+For the Elastic Security 8.17.8 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+Machine Learning::
+* Fixes an issue with **Anomaly Explorer** where the selected overall swimlane bucket is not respected for `viewBy jobId` ({kibana-pull}222845[#222845]).
+* Fixes the inference endpoint assignment to the trained model object ({kibana-pull}222076[#222076]).
+Installation and upgrade::
+* Fixes an issue where `/etc/default/kibana` on Debian packages and `/etc/sysconfig/kibana` on RPM packages would be overwritten during upgrade ({kibana-pull}221276[#221276]).
 
 [[release-notes-8.17.7]]
 == {kib} 8.17.7
@@ -538,7 +573,6 @@ Dashboards & Visualizations::
 Data ingestion and Fleet::
 * Allows to create integration policy with no agent policies ({kibana-pull}201051[#201051]).
 Discover::
-* Addresses chart performance issues for non-transformational and non-time-based ES|QL queries ({kibana-pull}200583[#200583]).
 ES|QL::
 * Fixes an issue causing the the ES|QL editor to incorrectly use the light theme in some cases ({kibana-pull}200233[#200233]).
 Elastic Observability solution::


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.17`:
 - [[Docs] Adds 8.17.8 release notes (#224490)](https://github.com/elastic/kibana/pull/224490)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"wajihaparvez","email":"wajiha.parvez@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T17:02:44Z","message":"[Docs] Adds 8.17.8 release notes (#224490)\n\n## Summary\n\nThis PR adds the 8.17.8 release notes for Kibana.\nPreview\n[here](https://kibana_bk_224490.docs-preview.app.elstc.co/guide/en/kibana/8.x/release-notes-8.17.8.html).\n\nCloses: https://github.com/elastic/docs-content/issues/1748\n\n---------\n\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"ffdb7d78782e07a0ab572a703ad922ff6b1930be","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:version","v8.17.0","v8.18.0"],"title":"[Docs] Adds 8.17.8 release notes","number":224490,"url":"https://github.com/elastic/kibana/pull/224490","mergeCommit":{"message":"[Docs] Adds 8.17.8 release notes (#224490)\n\n## Summary\n\nThis PR adds the 8.17.8 release notes for Kibana.\nPreview\n[here](https://kibana_bk_224490.docs-preview.app.elstc.co/guide/en/kibana/8.x/release-notes-8.17.8.html).\n\nCloses: https://github.com/elastic/docs-content/issues/1748\n\n---------\n\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"ffdb7d78782e07a0ab572a703ad922ff6b1930be"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.17","8.18"],"targetPullRequestStates":[{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->