### PR TITLE
[8.19] [Response Ops][Actions] Using fake request to create scoped client for `ConnectorTokenClient` unsecured actions usage. (#223447)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.ts
@@ -672,9 +672,13 @@ export class ActionsPlugin
     });
   };
 
-  private instantiateAuthorization = (request: KibanaRequest) => {
+  private instantiateAuthorization = (
+    request: KibanaRequest,
+    authorizationMode?: AuthorizationMode
+  ) => {
     return new ActionsAuthorization({
       request,
+      authorizationMode,
       authorization: this.security?.authz,
     });
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Actions] Using fake request to create scoped client for `ConnectorTokenClient` unsecured actions usage. (#223447)](https://github.com/elastic/kibana/pull/223447)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T17:31:34Z","message":"[Response Ops][Actions] Using fake request to create scoped client for `ConnectorTokenClient` unsecured actions usage. (#223447)\n\n## Summary\n\nAddresses a bug with the `ConnectorTokenClient` when using the\n`UnsecuredActionClient` to execute actions directly (vs enqueuing a task\nfor execution). We previous pass in an internal saved objects repository\n(that doesn't require a user request) to the `ConnectorTokenClient` when\nusing the `UnsecuredActionsClient` but this does not create the\n`connector_token` saved object correctly so the next time it's read, we\nget a `Failed to decrypt attribute` error.\n\nThis only occurs when using the `sendAttachmentEmail` with the MS\nExchange connector function added in this PR:\nhttps://github.com/elastic/kibana/pull/219164. It does not affect the\nother email service methods.\n\n## To Verify\n\n1. Ask me for MS Exchange credentials\n2. Add this to your Kibana config:\n\n```\nxpack.actions.preconfigured:\n  test-exchange-email:\n    name: preconfigured-exchange-email\n    actionTypeId: .email\n    config:\n      service: exchange_server\n      clientId: <clientId>\n      tenantId: <tenantId>\n      from: <from>\n    secrets:\n      clientSecret: <secret>\nnotifications.connectors.default.email: test-exchange-email\n```\n3. Make this change to the code so Kibana sends 2 emails when it starts\nup:\n\n```\n--- a/x-pack/platform/plugins/shared/notifications/server/plugin.ts\n+++ b/x-pack/platform/plugins/shared/notifications/server/plugin.ts\n@@ -40,6 +40,27 @@ export class NotificationsPlugin\n   public start(_core: CoreStart, plugins: NotificationsServerStartDependencies) {\n     const emailStartContract = this.emailServiceProvider.start(plugins);\n\n+    const emailService = emailStartContract.getEmailService();\n+    emailService\n+      .sendAttachmentEmail({\n+        to: ['<email>'],\n+        subject: 'yo',\n+        message: 'i am here',\n+        attachments: [],\n+        spaceId: 'default',\n+      })\n+      .then(() => {\n+        new Promise((resolve) => setTimeout(resolve, 5000)).then(() => {\n+          emailService.sendAttachmentEmail({\n+            to: ['<email>'],\n+            subject: 'yo',\n+            message: 'i am here again',\n+            attachments: [],\n+            spaceId: 'default',\n+          });\n+        });\n+      });\n+\n     return {\n```\n\n4. Verify there are no decryption errors for the `connector_token` SO\nlogged and that the emails are sent successfully.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3af496d11a55365097cdc00cbf551c407a66ff55","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Feature:Actions","Team:ResponseOps","backport:version","v9.1.0","v8.19.0"],"title":"[Response Ops][Actions] Using fake request to create scoped client for `ConnectorTokenClient` unsecured actions usage.","number":223447,"url":"https://github.com/elastic/kibana/pull/223447","mergeCommit":{"message":"[Response Ops][Actions] Using fake request to create scoped client for `ConnectorTokenClient` unsecured actions usage. (#223447)\n\n## Summary\n\nAddresses a bug with the `ConnectorTokenClient` when using the\n`UnsecuredActionClient` to execute actions directly (vs enqueuing a task\nfor execution). We previous pass in an internal saved objects repository\n(that doesn't require a user request) to the `ConnectorTokenClient` when\nusing the `UnsecuredActionsClient` but this does not create the\n`connector_token` saved object correctly so the next time it's read, we\nget a `Failed to decrypt attribute` error.\n\nThis only occurs when using the `sendAttachmentEmail` with the MS\nExchange connector function added in this PR:\nhttps://github.com/elastic/kibana/pull/219164. It does not affect the\nother email service methods.\n\n## To Verify\n\n1. Ask me for MS Exchange credentials\n2. Add this to your Kibana config:\n\n```\nxpack.actions.preconfigured:\n  test-exchange-email:\n    name: preconfigured-exchange-email\n    actionTypeId: .email\n    config:\n      service: exchange_server\n      clientId: <clientId>\n      tenantId: <tenantId>\n      from: <from>\n    secrets:\n      clientSecret: <secret>\nnotifications.connectors.default.email: test-exchange-email\n```\n3. Make this change to the code so Kibana sends 2 emails when it starts\nup:\n\n```\n--- a/x-pack/platform/plugins/shared/notifications/server/plugin.ts\n+++ b/x-pack/platform/plugins/shared/notifications/server/plugin.ts\n@@ -40,6 +40,27 @@ export class NotificationsPlugin\n   public start(_core: CoreStart, plugins: NotificationsServerStartDependencies) {\n     const emailStartContract = this.emailServiceProvider.start(plugins);\n\n+    const emailService = emailStartContract.getEmailService();\n+    emailService\n+      .sendAttachmentEmail({\n+        to: ['<email>'],\n+        subject: 'yo',\n+        message: 'i am here',\n+        attachments: [],\n+        spaceId: 'default',\n+      })\n+      .then(() => {\n+        new Promise((resolve) => setTimeout(resolve, 5000)).then(() => {\n+          emailService.sendAttachmentEmail({\n+            to: ['<email>'],\n+            subject: 'yo',\n+            message: 'i am here again',\n+            attachments: [],\n+            spaceId: 'default',\n+          });\n+        });\n+      });\n+\n     return {\n```\n\n4. Verify there are no decryption errors for the `connector_token` SO\nlogged and that the emails are sent successfully.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3af496d11a55365097cdc00cbf551c407a66ff55"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223447","number":223447,"mergeCommit":{"message":"[Response Ops][Actions] Using fake request to create scoped client for `ConnectorTokenClient` unsecured actions usage. (#223447)\n\n## Summary\n\nAddresses a bug with the `ConnectorTokenClient` when using the\n`UnsecuredActionClient` to execute actions directly (vs enqueuing a task\nfor execution). We previous pass in an internal saved objects repository\n(that doesn't require a user request) to the `ConnectorTokenClient` when\nusing the `UnsecuredActionsClient` but this does not create the\n`connector_token` saved object correctly so the next time it's read, we\nget a `Failed to decrypt attribute` error.\n\nThis only occurs when using the `sendAttachmentEmail` with the MS\nExchange connector function added in this PR:\nhttps://github.com/elastic/kibana/pull/219164. It does not affect the\nother email service methods.\n\n## To Verify\n\n1. Ask me for MS Exchange credentials\n2. Add this to your Kibana config:\n\n```\nxpack.actions.preconfigured:\n  test-exchange-email:\n    name: preconfigured-exchange-email\n    actionTypeId: .email\n    config:\n      service: exchange_server\n      clientId: <clientId>\n      tenantId: <tenantId>\n      from: <from>\n    secrets:\n      clientSecret: <secret>\nnotifications.connectors.default.email: test-exchange-email\n```\n3. Make this change to the code so Kibana sends 2 emails when it starts\nup:\n\n```\n--- a/x-pack/platform/plugins/shared/notifications/server/plugin.ts\n+++ b/x-pack/platform/plugins/shared/notifications/server/plugin.ts\n@@ -40,6 +40,27 @@ export class NotificationsPlugin\n   public start(_core: CoreStart, plugins: NotificationsServerStartDependencies) {\n     const emailStartContract = this.emailServiceProvider.start(plugins);\n\n+    const emailService = emailStartContract.getEmailService();\n+    emailService\n+      .sendAttachmentEmail({\n+        to: ['<email>'],\n+        subject: 'yo',\n+        message: 'i am here',\n+        attachments: [],\n+        spaceId: 'default',\n+      })\n+      .then(() => {\n+        new Promise((resolve) => setTimeout(resolve, 5000)).then(() => {\n+          emailService.sendAttachmentEmail({\n+            to: ['<email>'],\n+            subject: 'yo',\n+            message: 'i am here again',\n+            attachments: [],\n+            spaceId: 'default',\n+          });\n+        });\n+      });\n+\n     return {\n```\n\n4. Verify there are no decryption errors for the `connector_token` SO\nlogged and that the emails are sent successfully.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3af496d11a55365097cdc00cbf551c407a66ff55"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->