### PR TITLE
[8.19] [Docs] Replace `@private` with `@internal` (#224835)

### DIFF
--- a/src/core/packages/analytics/browser-internal/src/analytics_service.ts
+++ b/src/core/packages/analytics/browser-internal/src/analytics_service.ts
@@ -89,7 +89,7 @@ export class AnalyticsService {
 
   /**
    * Enriches the events with a session_id, so we can correlate them and understand funnels.
-   * @private
+   * @internal
    */
   private registerSessionIdContext() {
     this.analyticsClient.registerContextProvider({
@@ -107,7 +107,7 @@ export class AnalyticsService {
   /**
    * Enriches the event with the build information.
    * @param core The core context.
-   * @private
+   * @internal
    */
   private registerBuildInfoAnalyticsContext(core: CoreContext) {
     this.analyticsClient.registerContextProvider({
@@ -142,7 +142,7 @@ export class AnalyticsService {
 
   /**
    * Enriches events with the current Browser's information
-   * @private
+   * @internal
    */
   private registerBrowserInfoAnalyticsContext() {
     this.analyticsClient.registerContextProvider({
@@ -175,7 +175,7 @@ export class AnalyticsService {
   /**
    * Enriches the events with the Elasticsearch info (cluster name, uuid and version).
    * @param injectedMetadata The injected metadata service.
-   * @private
+   * @internal
    */
   private registerElasticsearchInfoContext(injectedMetadata: InternalInjectedMetadataSetup) {
     this.analyticsClient.registerContextProvider({

--- a/src/core/packages/analytics/server-internal/src/analytics_service.ts
+++ b/src/core/packages/analytics/server-internal/src/analytics_service.ts
@@ -74,7 +74,7 @@ export class AnalyticsService {
   /**
    * Enriches the event with the build information.
    * @param core The core context.
-   * @private
+   * @internal
    */
   private registerBuildInfoAnalyticsContext(core: CoreContext) {
     this.analyticsClient.registerContextProvider({

--- a/src/core/packages/apps/server-internal/src/core_app.ts
+++ b/src/core/packages/apps/server-internal/src/core_app.ts
@@ -296,7 +296,7 @@ export class CoreAppsService {
    * Registers the HTTP API that allows updating in-memory the settings that opted-in to be dynamically updatable.
    * @param router {@link IRouter}
    * @param savedObjectClient$ An observable of a {@link SavedObjectsClientContract | savedObjects client} that will be used to update the document
-   * @private
+   * @internal
    */
   private registerInternalCoreSettingsRoute(
     router: IRouter,

--- a/src/core/packages/chrome/browser-internal/src/register_analytics_context_provider.ts
+++ b/src/core/packages/chrome/browser-internal/src/register_analytics_context_provider.ts
@@ -14,7 +14,7 @@ import type { AnalyticsServiceSetup } from '@kbn/core-analytics-browser';
  * Registers the Analytics context provider to enrich events with the page title.
  * @param analytics Analytics service.
  * @param pageTitle$ Observable emitting the page title.
- * @private
+ * @internal
  */
 export function registerAnalyticsContextProvider(
   analytics: AnalyticsServiceSetup,

--- a/src/core/packages/config/server-internal/src/ensure_valid_configuration.ts
+++ b/src/core/packages/config/server-internal/src/ensure_valid_configuration.ts
@@ -18,7 +18,7 @@ const legacyInvalidConfigExitCode = 64;
 /**
  * Parameters for the helper {@link ensureValidConfiguration}
  *
- * @private
+ * @internal
  */
 export interface EnsureValidConfigurationParameters extends ConfigValidateParameters {
   /**
@@ -32,7 +32,7 @@ export interface EnsureValidConfigurationParameters extends ConfigValidateParame
  * @param configService The {@link IConfigService} instance that has the raw configuration preloaded.
  * @param params {@link EnsureValidConfigurationParameters | Options} to enable/disable extra edge-cases.
  *
- * @private
+ * @internal
  */
 export async function ensureValidConfiguration(
   configService: IConfigService,

--- a/src/core/packages/elasticsearch/server-internal/src/get_cluster_info.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/get_cluster_info.ts
@@ -11,7 +11,7 @@ import type { Observable } from 'rxjs';
 import { defer, map, retry, shareReplay } from 'rxjs';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 
-/** @private */
+/** @internal */
 export interface ClusterInfo {
   cluster_name: string;
   cluster_uuid: string;
@@ -22,7 +22,7 @@ export interface ClusterInfo {
 /**
  * Returns the cluster info from the Elasticsearch cluster.
  * @param internalClient Elasticsearch client
- * @private
+ * @internal
  */
 export function getClusterInfo$(internalClient: ElasticsearchClient): Observable<ClusterInfo> {
   return defer(() => internalClient.info()).pipe(

--- a/src/core/packages/elasticsearch/server-internal/src/register_analytics_context_provider.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/register_analytics_context_provider.ts
@@ -15,7 +15,7 @@ import type { ClusterInfo } from './get_cluster_info';
  * Registers the Analytics context provider to enrich events with the cluster info.
  * @param analytics Analytics service.
  * @param context$ Observable emitting the cluster info.
- * @private
+ * @internal
  */
 export function registerAnalyticsContextProvider(
   analytics: AnalyticsServiceSetup,

--- a/src/core/packages/execution-context/browser-internal/src/execution_context_service.ts
+++ b/src/core/packages/execution-context/browser-internal/src/execution_context_service.ts
@@ -116,7 +116,7 @@ export class ExecutionContextService
   /**
    * Sets the analytics context provider based on the execution context details.
    * @param analytics The analytics service
-   * @private
+   * @internal
    */
   private enrichAnalyticsContext(analytics: AnalyticsServiceSetup) {
     analytics.registerContextProvider({

--- a/src/core/packages/pricing/common/src/pricing_tiers_client.ts
+++ b/src/core/packages/pricing/common/src/pricing_tiers_client.ts
@@ -37,7 +37,7 @@ export class PricingTiersClient implements IPricingTiersClient {
    *
    * @param product - The product to check
    * @returns True if the product is active, false otherwise
-   * @private
+   * @internal
    */
   private isActiveProduct = (product: PricingProduct) => {
     return Boolean(this.tiers.products?.some((currentProduct) => isEqual(currentProduct, product)));
@@ -47,7 +47,7 @@ export class PricingTiersClient implements IPricingTiersClient {
    * Checks if pricing tiers are enabled in the current configuration.
    *
    * @returns True if pricing tiers are enabled, false otherwise
-   * @private
+   * @internal
    */
   private isEnabled = () => {
     return this.tiers.enabled;

--- a/src/core/packages/pricing/common/src/product_features_registry.ts
+++ b/src/core/packages/pricing/common/src/product_features_registry.ts
@@ -18,7 +18,7 @@ import { PricingProductFeature } from './types';
 export class ProductFeaturesRegistry {
   /**
    * Internal storage for registered product features.
-   * @private
+   * @internal
    */
   private readonly productFeatures: Map<string, PricingProductFeature>;
 

--- a/src/platform/packages/private/kbn-repo-packages/modern/package.js
+++ b/src/platform/packages/private/kbn-repo-packages/modern/package.js
@@ -48,7 +48,7 @@ class Package {
   }
 
   /**
-   * @private
+   * @internal
    */
   constructor(
     /**

--- a/src/platform/packages/private/kbn-tinymath/src/functions/lib/transpose.js
+++ b/src/platform/packages/private/kbn-tinymath/src/functions/lib/transpose.js
@@ -9,7 +9,7 @@
 
 /**
  * Transposes a 2D array, i.e. turns the rows into columns and vice versa. Scalar values are also included in the transpose.
- * @private
+ * @internal
  * @param {any[][]} args an array or an array that contains arrays
  * @param {number} index index of the first array element in args
  * @return {any[][]} transpose of args

--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/coloring/color_ranges/utils/color_ranges_crud.ts
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/coloring/color_ranges/utils/color_ranges_crud.ts
@@ -12,7 +12,7 @@ import type { ColorRange, ColorRangeAccessor } from '../types';
 
 /**
  * Allows to update a ColorRange
- * @private
+ * @internal
  */
 const updateColorRangeItem = (
   colorRanges: ColorRange[],

--- a/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/app_menu_registry.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/app_menu_registry.ts
@@ -28,7 +28,7 @@ export class AppMenuRegistry {
   /**
    * As custom actions can be registered under a submenu from both root and data source profiles, we need to keep track of them separately.
    * Otherwise, it would be less predictable. For example, we would override/reset the actions from the data source profile with the ones from the root profile.
-   * @private
+   * @internal
    */
   private customSubmenuItemsBySubmenuId: Map<
     string,

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metric_events/helpers.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metric_events/helpers.ts
@@ -15,7 +15,7 @@ const PERFORMANCE_METRIC_EVENT_TYPE = 'performance_metric';
 /**
  * Register the `performance_metric` event type
  * @param analytics The {@link AnalyticsClient} during the setup phase (it has the method `registerEventType`)
- * @private To be called only by core's Analytics Service
+ * @internal To be called only by core's Analytics Service
  */
 export function registerPerformanceMetricEventType(
   analytics: Pick<AnalyticsClient, 'registerEventType'>

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -105,7 +105,7 @@ export async function validateQuery(
 }
 
 /**
- * @private
+ * @internal
  */
 export const ignoreErrorsMap: Record<keyof ESQLCallbacks, ErrorTypes[]> = {
   getColumnsFor: ['unknownColumn', 'wrongArgumentType', 'unsupportedFieldType'],

--- a/src/platform/packages/shared/kbn-field-types/src/kbn_field_types.ts
+++ b/src/platform/packages/shared/kbn-field-types/src/kbn_field_types.ts
@@ -11,7 +11,7 @@ import { createKbnFieldTypes, kbnFieldTypeUnknown } from './kbn_field_types_fact
 import { KbnFieldType } from './kbn_field_type';
 import { ES_FIELD_TYPES, KBN_FIELD_TYPES } from './types';
 
-/** @private */
+/** @internal */
 const registeredKbnTypes = createKbnFieldTypes();
 
 /**

--- a/src/platform/packages/shared/kbn-safer-lodash-set/lodash/_baseSet.js
+++ b/src/platform/packages/shared/kbn-safer-lodash-set/lodash/_baseSet.js
@@ -17,7 +17,7 @@ var assignValue = require('lodash/_assignValue'),
 /**
  * The base implementation of `_.set`.
  *
- * @private
+ * @internal
  * @param {Object} object The object to modify.
  * @param {Array|string} path The path of the property to set.
  * @param {*} value The value to set.

--- a/src/platform/packages/shared/kbn-spaces-utils/src/common/spaces_url_parser.ts
+++ b/src/platform/packages/shared/kbn-spaces-utils/src/common/spaces_url_parser.ts
@@ -18,7 +18,7 @@ const spaceContextRegex = /^\/s\/([a-z0-9_\-]+)/;
  * @param serverBasePath The server's base path.
  * @returns the space id.
  *
- * @private
+ * @internal
  */
 export function getSpaceIdFromPath(
   requestBasePath?: string | null,

--- a/src/platform/plugins/private/vis_types/timeseries/common/check_ui_restrictions.ts
+++ b/src/platform/plugins/private/vis_types/timeseries/common/check_ui_restrictions.ts
@@ -17,7 +17,7 @@ import {
 
 /**
  * Generic method for checking all types of the UI Restrictions
- * @private
+ * @internal
  */
 const checkUIRestrictions = (
   key: string,

--- a/src/platform/plugins/private/vis_types/timeseries/server/lib/vis_data/helpers/get_timerange_mode.ts
+++ b/src/platform/plugins/private/vis_types/timeseries/server/lib/vis_data/helpers/get_timerange_mode.ts
@@ -14,20 +14,20 @@ const OVERRIDE_INDEX_PATTERN_KEY = 'override_index_pattern';
 
 /**
  * Check if passed 'series' has overridden index pattern or not.
- * @private
+ * @internal
  */
 const hasOverriddenIndexPattern = (series?: Series) =>
   Boolean(series?.[OVERRIDE_INDEX_PATTERN_KEY]);
 
 /**
  * Get value of Time Range Mode for panel
- * @private
+ * @internal
  */
 const getPanelTimeRangeMode = (panel: Panel) => panel[TIME_RANGE_MODE_KEY];
 
 /**
  * Get value of Time Range Mode for series
- * @private
+ * @internal
  */
 const getSeriesTimeRangeMode = (series: Series) => series[TIME_RANGE_MODE_KEY];
 

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/time_cache.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/time_cache.ts
@@ -83,7 +83,7 @@ export class TimeCache {
   /**
    * Get parsed min/max values
    * @returns {{min: number, max: number}}
-   * @private
+   * @internal
    */
   _getBounds(): CacheBounds {
     const bounds = this._timefilter.calculateBounds(this._timeRange!);

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/vega_parser.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/vega_parser.ts
@@ -320,7 +320,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
 
   /**
    * Calculate container-direction CSS property for binding placement
-   * @private
+   * @internal
    */
   _parseControlPlacement() {
     this.containerDir = this._config?.controlsLocation
@@ -357,7 +357,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
   /**
    * Parse {config: kibana: {...}} portion of the Vega spec (or root-level _hostConfig for backward compat)
    * @returns {object} kibana config
-   * @private
+   * @internal
    */
   _parseConfig(): KibanaConfig | {} {
     let result: KibanaConfig | null = null;
@@ -467,7 +467,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
   /**
    * Parse map-specific configuration
    * @returns {{mapStyle: *|string, delayRepaint: boolean, latitude: number, longitude: number, zoom, minZoom, maxZoom, zoomControl: *|boolean, maxBounds: *}}
-   * @private
+   * @internal
    */
   _parseMapConfig() {
     const res: VegaConfig = {
@@ -552,7 +552,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
   /**
    * Parse Vega schema element
    * @returns {object} isVegaLite, libVersion
-   * @private
+   * @internal
    */
   private parseSchema(spec: VegaSpec) {
     try {
@@ -593,7 +593,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
   /**
    * Replace all instances of ES requests with raw values.
    * Also handle any other type of url: {type: xxx, ...}
-   * @private
+   * @internal
    */
   async _resolveDataUrls() {
     if (!this._urlParsers) {
@@ -652,7 +652,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
    * @param {*} obj current location in the object tree
    * @param {function({object})} onFind Call this function for all url objects
    * @param {string} [key] field name of the current object
-   * @private
+   * @internal
    */
 
   _findObjectDataUrls(obj: VegaSpec | Data, onFind: (data: Data) => void, key?: unknown) {
@@ -695,7 +695,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
 
   /**
    * Inject default colors into the spec.config
-   * @private
+   * @internal
    */
   _setDefaultColors() {
     // Add the default palette
@@ -749,7 +749,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
    * Given an object, and an array of fields, ensure that obj.fld1.fld2. ... .fldN is set to value if it doesn't exist.
    * @param {*} value
    * @param {string} fields
-   * @private
+   * @internal
    */
   _setDefaultValue(value: unknown, ...fields: string[]) {
     let o = this.spec;
@@ -771,7 +771,7 @@ The URL is an identifier only. Kibana and your browser will never access this UR
 
   /**
    * Add a warning to the warnings array
-   * @private
+   * @internal
    */
   _onWarning(...args: any[]) {
     if (!this.hideWarnings) {

--- a/src/platform/plugins/private/vis_types/vega/public/vega_view/vega_base_view.js
+++ b/src/platform/plugins/private/vis_types/vega/public/vega_view/vega_base_view.js
@@ -438,7 +438,7 @@ export class VegaBaseView {
 
   /**
    * Parse start and end values, determining the mode, and if order should be reversed
-   * @private
+   * @internal
    */
   static _parseTimeRange(start, end) {
     const absStart = moment(start);

--- a/src/platform/plugins/private/vis_types/vislib/public/vislib/lib/handler.js
+++ b/src/platform/plugins/private/vis_types/vislib/public/vislib/lib/handler.js
@@ -129,7 +129,7 @@ export class Handler {
    * used to render the Vis. Throws a no results error if data is not
    * present.
    *
-   * @private
+   * @internal
    */
   _validateData() {
     const dataType = this.data.type;

--- a/src/platform/plugins/shared/console/public/lib/autocomplete_entities/mapping.ts
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete_entities/mapping.ts
@@ -123,7 +123,7 @@ export class Mapping implements BaseMapping {
 
   /**
    * Map of the currently loading mappings for index patterns specified by a user.
-   * @private
+   * @internal
    */
   private loadingState: Record<string, boolean> = {};
 

--- a/src/platform/plugins/shared/data/common/search/aggs/agg_type.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/agg_type.ts
@@ -253,7 +253,7 @@ export class AggType<
    * Used to create the values exposed by the agg_types module.
    *
    * @class AggType
-   * @private
+   * @internal
    * @param {object} config - used to set the properties of the AggType
    */
   constructor(config: AggTypeConfig<TAggConfig>) {

--- a/src/platform/plugins/shared/data/common/search/aggs/utils/date_interval_utils/least_common_multiple.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/utils/date_interval_utils/least_common_multiple.ts
@@ -15,7 +15,7 @@
  * pass in fractional numbers there usually will be an output, but that's not necessarily
  * the greatest common divisor of those two numbers.
  *
- * @private
+ * @internal
  */
 function greatestCommonDivisor(a: number, b: number): number {
   return a === 0 ? Math.abs(b) : greatestCommonDivisor(b % a, a);

--- a/src/platform/plugins/shared/data/common/search/search_source/search_source.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/search_source.ts
@@ -223,7 +223,7 @@ export class SearchSource {
   /**
    * Internal, do not use. Overrides all search source fields with the new field array.
    *
-   * @private
+   * @internal
    * @param newFields New field array.
    */
   private setFields(newFields: SearchSourceFields) {

--- a/src/platform/plugins/shared/data/public/search/session/search_session_state.ts
+++ b/src/platform/plugins/shared/data/public/search/session/search_session_state.ts
@@ -77,7 +77,7 @@ export interface TrackedSearch<SearchDescriptor = unknown, SearchMeta extends {}
  * Internal state of SessionService
  * {@link SearchSessionState} is inferred from this state
  *
- * @private
+ * @internal
  */
 export interface SessionStateInternal<SearchDescriptor = unknown, SearchMeta extends {} = {}> {
   /**

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -198,7 +198,7 @@ export class SessionService {
   /**
    * Holds snapshot of last cleared session so that it can be continued
    * Can be used to re-use a session between apps
-   * @private
+   * @internal
    */
   private lastSessionSnapshot?: SessionSnapshot;
 

--- a/src/platform/plugins/shared/data/server/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/server/search/session/session_service.ts
@@ -266,7 +266,7 @@ export class SearchSessionService implements ISearchSessionService {
   /**
    * Used to batch requests that add searches into the session saved object
    * Requests are grouped and executed per sessionId
-   * @private
+   * @internal
    */
   private readonly trackIdBatchQueueMap = new Map<
     string /* sessionId */,

--- a/src/platform/plugins/shared/expressions/common/execution/execution.ts
+++ b/src/platform/plugins/shared/expressions/common/execution/execution.ts
@@ -240,7 +240,7 @@ export class Execution<
   /**
    * Keeping track of any child executions
    * Needed to cancel child executions in case parent execution is canceled
-   * @private
+   * @internal
    */
   private readonly childExecutions: Execution[] = [];
   private cacheTimeout: number = 30000;

--- a/src/platform/plugins/shared/field_formats/common/field_format.ts
+++ b/src/platform/plugins/shared/field_formats/common/field_format.ts
@@ -53,13 +53,13 @@ export abstract class FieldFormat {
 
   /**
    * @property {string} - Field Format Type
-   * @private
+   * @internal
    */
   static fieldType: string | string[];
 
   /**
    * @property {FieldFormatConvert}
-   * @private
+   * @internal
    * have to remove the private because of
    * https://github.com/Microsoft/TypeScript/issues/17293
    */
@@ -83,7 +83,7 @@ export abstract class FieldFormat {
 
   /**
    * @property {Function} - ref to child class
-   * @private
+   * @internal
    */
   public type = this.constructor as typeof FieldFormat;
   public allowsNumericalAggregations?: boolean;

--- a/src/platform/plugins/shared/field_formats/common/field_formats_registry.ts
+++ b/src/platform/plugins/shared/field_formats/common/field_formats_registry.ts
@@ -291,7 +291,7 @@ export class FieldFormatsRegistry {
   /**
    * FieldFormat decorator - provide a one way to add meta-params for all field formatters
    *
-   * @private
+   * @internal
    * @param  {FieldFormatInstanceType} fieldFormat - field format type
    * @return {FieldFormatInstanceType | undefined}
    */

--- a/src/platform/plugins/shared/telemetry/public/plugin.ts
+++ b/src/platform/plugins/shared/telemetry/public/plugin.ts
@@ -308,7 +308,7 @@ export class TelemetryPlugin
    * Kibana should skip telemetry collection if reporting is taking a screenshot
    * or Synthetics monitoring is navigating Kibana.
    * @param screenshotMode {@link ScreenshotModePluginSetup}
-   * @private
+   * @internal
    */
   private shouldSkipTelemetry(screenshotMode: ScreenshotModePluginSetup): boolean {
     return screenshotMode.isScreenshotMode() || isSyntheticsMonitor();
@@ -329,7 +329,7 @@ export class TelemetryPlugin
   /**
    * Retrieve the up-to-date configuration
    * @param http HTTP helper to make requests to the server
-   * @private
+   * @internal
    */
   private async refreshConfig(http: HttpStart | HttpSetup): Promise<TelemetryPluginConfig> {
     const updatedConfig = await this.fetchUpdatedConfig(http);
@@ -347,7 +347,7 @@ export class TelemetryPlugin
    * This is a security feature, not included in the OSS build, so we need to fallback to `true`
    * in case it is `undefined`.
    * @param application CoreStart.application
-   * @private
+   * @internal
    */
   private getCanUserChangeSettings(application: ApplicationStart): boolean {
     return (application.capabilities?.savedObjectsManagement?.edit as boolean | undefined) ?? true;
@@ -379,7 +379,7 @@ export class TelemetryPlugin
   /**
    * Fetch configuration from the server and merge it with the one the browser already knows
    * @param http The HTTP helper to make the requests
-   * @private
+   * @internal
    */
   private async fetchUpdatedConfig(http: HttpStart | HttpSetup): Promise<TelemetryPluginConfig> {
     const {

--- a/src/platform/plugins/shared/telemetry/server/plugin.ts
+++ b/src/platform/plugins/shared/telemetry/server/plugin.ts
@@ -121,12 +121,12 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
   private readonly fetcherTask: FetcherTask;
   private readonly shouldStartSnapshotTelemetryFetcher: boolean;
   /**
-   * @private Used to mark the completion of the old UI Settings migration
+   * @internal Used to mark the completion of the old UI Settings migration
    */
   private savedObjectsInternalRepository?: ISavedObjectsRepository;
 
   /**
-   * @private
+   * @internal
    * Used to interact with the Telemetry Saved Object.
    * Some users may not have access to the document but some queries
    * are still relevant to them like fetching when was the last time it was reported.

--- a/src/platform/plugins/shared/telemetry_collection_manager/server/plugin.ts
+++ b/src/platform/plugins/shared/telemetry_collection_manager/server/plugin.ts
@@ -99,7 +99,7 @@ export class TelemetryCollectionManagerPlugin
    * Checks if Kibana is in a healthy state to attempt the Telemetry report generation:
    * - Elasticsearch is active.
    * - SavedObjects client is active.
-   * @private
+   * @internal
    */
   private async shouldGetTelemetry() {
     const { elasticsearch, savedObjects } = await firstValueFrom(this.coreStatus$);
@@ -142,7 +142,7 @@ export class TelemetryCollectionManagerPlugin
    * It may return undefined if the ES and SO clients are not initialised yet.
    * @param config {@link StatsGetterConfig}
    * @param usageCollection {@link UsageCollectionSetup}
-   * @private
+   * @internal
    */
   private getStatsCollectionConfig(
     config: StatsGetterConfig,
@@ -163,7 +163,7 @@ export class TelemetryCollectionManagerPlugin
    * depending on whether the request is encrypted or not:
    * If the request is unencrypted, we intentionally scope the results to "what the user can see".
    * @param config {@link StatsGetterConfig}
-   * @private
+   * @internal
    */
   private getElasticsearchClient(config: StatsGetterConfig): ElasticsearchClient | undefined {
     return this.elasticsearchClient?.asInternalUser;
@@ -174,7 +174,7 @@ export class TelemetryCollectionManagerPlugin
    * depending on whether the request is encrypted or not:
    * If the request is unencrypted, we intentionally scope the results to "what the user can see"
    * @param config {@link StatsGetterConfig}
-   * @private
+   * @internal
    */
   private getSavedObjectsClient(config: StatsGetterConfig): SavedObjectsClientContract | undefined {
     if (this.savedObjectsService) {

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/filter_editor.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/filter_editor.tsx
@@ -197,7 +197,7 @@ class FilterEditorComponent extends Component<FilterEditorProps, State> {
    * Than the currently selected data view need to load the data view from the id to display the filter
    * correctly
    * @param dataViewId
-   * @private
+   * @internal
    */
   private async loadDataView(dataViewId: string, dataViews: DataViewsContract) {
     try {

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
@@ -214,7 +214,7 @@ export class QueryStringInput extends PureComponent<QueryStringInputProps, State
 
   /**
    * If any element within the container is currently focused
-   * @private
+   * @internal
    */
   private isFocusWithin = false;
 
@@ -910,7 +910,7 @@ export class QueryStringInput extends PureComponent<QueryStringInputProps, State
    * check first if value has changed because of {@link formatTextAreaValue},
    * if this is just a formatting change, then skip this update by re-using current textarea value.
    * This is needed to avoid re-rendering to preserve focus and selection
-   * @private
+   * @internal
    */
   private forwardNewValueIfNeeded(newQueryString: string) {
     const oldQueryString = this.inputRef?.value ?? '';

--- a/src/platform/plugins/shared/usage_collection/server/collector/collector.ts
+++ b/src/platform/plugins/shared/usage_collection/server/collector/collector.ts
@@ -17,7 +17,7 @@ export class Collector<TFetchReturn, ExtraOptions extends object = {}>
   public readonly fetch: CollectorFetchMethod<TFetchReturn, ExtraOptions>;
   public readonly isReady: CollectorOptions<TFetchReturn>['isReady'];
   /**
-   * @private Constructor of a Collector. It should be called via the CollectorSet factory methods: `makeStatsCollector` and `makeUsageCollector`
+   * @internal Constructor of a Collector. It should be called via the CollectorSet factory methods: `makeStatsCollector` and `makeUsageCollector`
    * @param log {@link Logger}
    * @param collectorDefinition {@link CollectorOptions}
    */

--- a/src/platform/plugins/shared/usage_collection/server/collector/usage_collector.ts
+++ b/src/platform/plugins/shared/usage_collection/server/collector/usage_collector.ts
@@ -21,7 +21,7 @@ export type UsageCollectorOptions<
   Required<Pick<CollectorOptions<TFetchReturn>, 'schema'>>;
 
 /**
- * @private Only used in fixtures as a type
+ * @internal Only used in fixtures as a type
  */
 export class UsageCollector<TFetchReturn, ExtraOptions extends object = {}> extends Collector<
   TFetchReturn,

--- a/src/platform/plugins/shared/visualizations/public/vis_types/schemas.ts
+++ b/src/platform/plugins/shared/visualizations/public/vis_types/schemas.ts
@@ -11,7 +11,7 @@ import _, { defaults } from 'lodash';
 import { AggGroupNames, AggParam } from '@kbn/data-plugin/public';
 import type { ISchemas, Schema } from './types';
 
-/** @private **/
+/** @internal **/
 export class Schemas implements ISchemas {
   all: Schema[] = [];
   [AggGroupNames.Buckets]: Schema[] = [];

--- a/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/common/metadata_service/initialize_metadata.ts
+++ b/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/common/metadata_service/initialize_metadata.ts
@@ -16,7 +16,7 @@ import type { Logger } from '@kbn/logging';
 import type { MetadataService } from './metadata_service';
 
 /**
- * @private
+ * @internal
  */
 export function initializeMetadata({
   metadataService,

--- a/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.ts
+++ b/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.ts
@@ -181,7 +181,7 @@ export class MetadataService {
    * Schedules a timer that calls `fn` to update the {@link FlatMetadata} until `untilFn` returns true.
    * @param fn Method to calculate the dynamic metadata.
    * @param untilFn Method that returns true when the scheduler should stop calling fn (potentially because the dynamic value is not expected to change anymore).
-   * @private
+   * @internal
    */
   private scheduleUntil(
     fn: () => Partial<FlatMetadata> | Promise<Partial<FlatMetadata>>,

--- a/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/public/plugin.ts
+++ b/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/public/plugin.ts
@@ -100,7 +100,7 @@ export class CloudExperimentsPlugin
 
   /**
    * Sets up the OpenFeature LaunchDarkly provider
-   * @private
+   * @internal
    */
   private createOpenFeatureProvider(initialFeatureFlags: Record<string, unknown>) {
     const { launch_darkly: ldConfig } = this.initializerContext.config.get<{

--- a/x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/public/plugin.ts
+++ b/x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/public/plugin.ts
@@ -64,7 +64,7 @@ export class CloudFullStoryPlugin implements Plugin {
    * If the right config is provided, register the FullStory shipper to the analytics client.
    * @param analytics Core's Analytics service's setup contract.
    * @param staticAssets Core's http.staticAssets helper.
-   * @private
+   * @internal
    */
   private async setupFullStory({ analytics, staticAssets }: SetupFullStoryDeps) {
     const { org_id: fullStoryOrgId, eventTypesAllowlist, pageVarsDebounceTime } = this.config;

--- a/x-pack/platform/plugins/private/monitoring/server/kibana_monitoring/bulk_uploader.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/kibana_monitoring/bulk_uploader.ts
@@ -139,7 +139,7 @@ export class BulkUploader implements IBulkUploader {
 
   /**
    * Retrieves the OpsMetrics in the same format as the `kibana_stats` collector
-   * @private
+   * @internal
    */
   private async getOpsMetrics() {
     const {

--- a/x-pack/platform/plugins/shared/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
+++ b/x-pack/platform/plugins/shared/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
@@ -231,7 +231,7 @@ export class EncryptedSavedObjectsService {
    * Takes saved object attributes for the specified type and, depending on the type definition,
    * either strips encrypted attributes, replaces with original decrypted value if available, or
    * prepares them for decryption.
-   * @private
+   * @internal
    */
   private prepareAttributesForStripOrDecrypt<T extends Record<string, unknown>>(
     descriptor: SavedObjectDescriptor,

--- a/x-pack/platform/plugins/shared/features/common/kibana_feature.ts
+++ b/x-pack/platform/plugins/shared/features/common/kibana_feature.ts
@@ -148,7 +148,7 @@ export interface KibanaFeatureConfig {
   privilegesTooltip?: string;
 
   /**
-   * @private
+   * @internal
    */
   reserved?: {
     description: string;

--- a/x-pack/platform/plugins/shared/fleet/server/services/artifacts/client.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/artifacts/client.ts
@@ -54,7 +54,7 @@ export class FleetArtifactsClient implements ArtifactsClientInterface {
   /**
    * Creates a `kuery` string using the provided value on input that is bound to the integration package
    * @param kuery
-   * @private
+   * @internal
    */
   private buildFilter(kuery: string): string {
     return `(package_name: "${this.packageName}")${kuery ? ` AND ${kuery}` : ''}`;

--- a/x-pack/platform/plugins/shared/fleet/server/services/files/types.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/files/types.ts
@@ -113,7 +113,7 @@ export interface HostUploadedFileMetadata {
 
 /**
  * The File metadata that is stored along with files uploaded to kibana (via the Files plugin)
- * @private
+ * @internal
  */
 export interface FileCustomMeta {
   target_agents: string[];

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/types.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/types.ts
@@ -23,7 +23,7 @@ import { ProcessorsDispatch, State as ProcessorsReducerState } from './processor
  */
 export type ProcessorSelector = string[];
 
-/** @private */
+/** @internal */
 export interface ProcessorInternal<CustomProcessorOptions = {}> {
   id: string;
   type: string;

--- a/x-pack/platform/plugins/shared/ml/public/application/capabilities/check_capabilities.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/capabilities/check_capabilities.ts
@@ -39,7 +39,7 @@ export class MlCapabilitiesService {
 
   /**
    * Updates on manual request, e.g. in the route resolver.
-   * @private
+   * @internal
    */
   private _updateRequested$ = new BehaviorSubject<number>(Date.now());
 

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/alerts/anomaly_detection_alerts_state_service.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/alerts/anomaly_detection_alerts_state_service.ts
@@ -54,7 +54,7 @@ export type AlertsQuery = Exclude<RuleRegistrySearchRequest['query'], undefined>
 export class AnomalyDetectionAlertsStateService extends StateService {
   /**
    * Subject that holds the anomaly detection alerts from the alert-as-data index.
-   * @private
+   * @internal
    */
   private readonly _aadAlerts$ = new BehaviorSubject<AnomalyDetectionAlert[]>([]);
 

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline_state_service.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline_state_service.ts
@@ -138,7 +138,7 @@ export class AnomalyTimelineStateService extends StateService {
 
   /**
    * Initializes required subscriptions for fetching swim lanes data.
-   * @private
+   * @internal
    */
   protected _initSubscriptions(): Subscription {
     const subscription = new Subscription();
@@ -476,7 +476,7 @@ export class AnomalyTimelineStateService extends StateService {
 
   /**
    * Obtain the list of 'View by' fields per job and viewBySwimlaneFieldName
-   * @private
+   * @internal
    *
    * TODO check for possible enhancements/refactoring. Has been moved from explorer_utils as-is.
    */

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/jobs_list_view/jobs_list_view.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/jobs_list_view/jobs_list_view.js
@@ -78,7 +78,7 @@ export class JobsListViewUI extends Component {
     /**
      * Indicates if the filters has been initialized by {@link JobFilterBar} component
      * @type {boolean}
-     * @private
+     * @internal
      */
     this._isFiltersSet = false;
   }

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
@@ -483,7 +483,7 @@ export class JobCreator {
 
   /**
    * Extends assigned calendars with created job id.
-   * @private
+   * @internal
    */
   private async _updateCalendars() {
     if (this._calendars.length === 0) {

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/deployment_params_mapper.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/deployment_params_mapper.ts
@@ -75,7 +75,7 @@ export class DeploymentParamsMapper {
    * Gets the min allowed number of allocations.
    * - 0 for serverless and ESS with enabled autoscaling.
    * - 1 otherwise
-   * @private
+   * @internal
    */
   private get minAllowedNumberOfAllocation(): number {
     return !this.showNodeInfo || this.cloudInfo.isMlAutoscalingEnabled ? 0 : 1;
@@ -133,7 +133,7 @@ export class DeploymentParamsMapper {
   /**
    * Returns allocation values accounting for the number of threads per allocation.
    * @param params
-   * @private
+   * @internal
    */
   private getAllocationsParams(
     params: DeploymentParamsUI

--- a/x-pack/platform/plugins/shared/ml/server/models/notifications_service/notifications_service_provider.ts
+++ b/x-pack/platform/plugins/shared/ml/server/models/notifications_service/notifications_service_provider.ts
@@ -45,7 +45,7 @@ export class NotificationsService {
 
   /**
    * Provides entity IDs per type for the current space.
-   * @private
+   * @internal
    */
   private async _getEntityIdsPerType() {
     const [adJobIds, dfaJobIds, modelIds] = await Promise.all([

--- a/x-pack/platform/plugins/shared/security/public/analytics/register_user_context.ts
+++ b/x-pack/platform/plugins/shared/security/public/analytics/register_user_context.ts
@@ -21,7 +21,7 @@ interface UserIdContext {
  * @param analytics Core's Analytics service. The Setup contract.
  * @param authc {@link AuthenticationServiceSetup} used to get the current user's information
  * @param cloudId The Cloud Org ID.
- * @private
+ * @internal
  */
 export function registerUserContext(
   analytics: AnalyticsServiceSetup,

--- a/x-pack/platform/plugins/shared/spaces/common/types/space/v1.ts
+++ b/x-pack/platform/plugins/shared/spaces/common/types/space/v1.ts
@@ -61,7 +61,7 @@ export interface Space {
   /**
    * Indicates that this space is reserved (system controlled).
    * Reserved spaces cannot be created or deleted by end-users.
-   * @private
+   * @internal
    */
   _reserved?: boolean;
 

--- a/x-pack/platform/plugins/shared/spaces/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/plugin.ts
@@ -63,17 +63,17 @@ export interface SpacesPluginSetup {
 
   /**
    * Registries exposed for the security plugin to transparently provide authorization and audit logging.
-   * @private
+   * @internal
    */
   spacesClient: {
     /**
      * Sets the client repository factory.
-     * @private
+     * @internal
      */
     setClientRepositoryFactory: (factory: SpacesClientRepositoryFactory) => void;
     /**
      * Registers a client wrapper.
-     * @private
+     * @internal
      */
     registerClientWrapper: (wrapper: SpacesClientWrapper) => void;
   };

--- a/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client_service.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client_service.ts
@@ -22,7 +22,7 @@ import type { ConfigType } from '../config';
 
 /**
  * For consumption by the security plugin only.
- * @private
+ * @internal
  */
 export type SpacesClientWrapper = (
   request: KibanaRequest,
@@ -31,7 +31,7 @@ export type SpacesClientWrapper = (
 
 /**
  * For consumption by the security plugin only.
- * @private
+ * @internal
  */
 export type SpacesClientRepositoryFactory = (
   request: KibanaRequest,

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/response_actions/is_response_action_supported.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/response_actions/is_response_action_supported.ts
@@ -16,7 +16,7 @@ type SupportMap = Record<
   Record<ResponseActionType, Record<ResponseActionAgentType, boolean>>
 >;
 
-/** @private */
+/** @internal */
 const RESPONSE_ACTIONS_SUPPORT_MAP: SupportMap = {
   isolate: {
     automated: {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.ts
@@ -127,7 +127,7 @@ type ResponderDataForEndpointHost = Omit<ResponderActionData, 'handleResponseAct
  * @param endpointAgentId
  * @param enabled
  *
- * @private
+ * @internal
  */
 const useResponderDataForEndpointHost = (
   endpointAgentId: string,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/endpoint/endpoint_alert_data_mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/endpoint/endpoint_alert_data_mock.ts
@@ -70,7 +70,7 @@ const setAlertDetailsItemDataOverrides = (
   return data;
 };
 
-/** @private */
+/** @internal */
 const generateEndpointAlertDetailsItemDataMock = (
   overrides: AlertDetailsItemDataOverrides = {}
 ): TimelineEventsDetailsItem[] => {
@@ -145,7 +145,7 @@ const generateEndpointAlertDetailsItemDataMock = (
   return data;
 };
 
-/** @private */
+/** @internal */
 const generateSentinelOneAlertDetailsItemDataMock = (
   overrides: AlertDetailsItemDataOverrides = {}
 ): TimelineEventsDetailsItem[] => {
@@ -217,7 +217,7 @@ const generateMicrosoftDefenderEndpointAlertDetailsItemDataMock = (
   return data;
 };
 
-/** @private */
+/** @internal */
 const generateCrowdStrikeAlertDetailsItemDataMock = (
   overrides: AlertDetailsItemDataOverrides = {}
 ): TimelineEventsDetailsItem[] => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/types.ts
@@ -314,7 +314,7 @@ export interface ConsoleProps extends CommonProps {
   /**
    * For internal use only!
    * Provided by the ConsoleManager to indicate that the console is being managed by it
-   * @private
+   * @internal
    */
   managedKey?: symbol;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -581,7 +581,7 @@ export const getEndpointConsoleCommands = ({
   }
 };
 
-/** @private */
+/** @internal */
 const disableCommand = (command: CommandDefinition, agentType: ResponseActionAgentType) => {
   command.helpDisabled = true;
   command.helpHidden = true;
@@ -589,7 +589,7 @@ const disableCommand = (command: CommandDefinition, agentType: ResponseActionAge
     UPGRADE_AGENT_FOR_RESPONDER(agentType, command.name as ConsoleResponseActionCommands);
 };
 
-/** @private */
+/** @internal */
 const adjustCommandsForSentinelOne = ({
   commandList,
   platform,
@@ -659,7 +659,7 @@ const adjustCommandsForSentinelOne = ({
   });
 };
 
-/** @private */
+/** @internal */
 const adjustCommandsForCrowdstrike = ({
   commandList,
   crowdstrikeRunScriptEnabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/running_processes_action_results/running_processes_action_results.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/running_processes_action_results/running_processes_action_results.tsx
@@ -89,7 +89,7 @@ interface EndpointRunningProcessesResultsProps {
   'data-test-subj'?: string;
 }
 
-/** @private */
+/** @internal */
 const EndpointRunningProcessesResults = memo<EndpointRunningProcessesResultsProps>(
   ({ action, agentId, 'data-test-subj': dataTestSubj }) => {
     const testId = useTestIdGenerator(dataTestSubj);
@@ -191,7 +191,7 @@ interface SentinelOneRunningProcessesResultsProps {
   'data-test-subj'?: string;
 }
 
-/** @private */
+/** @internal */
 const SentinelOneRunningProcessesResults = memo<SentinelOneRunningProcessesResultsProps>(
   ({ action, agentId, 'data-test-subj': dataTestSubj }) => {
     const testId = useTestIdGenerator(dataTestSubj);

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/screens/stack_management/role_page.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/screens/stack_management/role_page.ts
@@ -136,7 +136,7 @@ export const ENDPOINT_SUB_FEATURE_PRIVILEGE_IDS = Object.freeze([
 
 type EndpointSubFeaturePrivilegeId = (typeof ENDPOINT_SUB_FEATURE_PRIVILEGE_IDS)[number];
 
-/* @private */
+/* @internal */
 const privilegeMapToTitle = Object.freeze({
   all: 'All',
   read: 'Read',

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/login.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/login.ts
@@ -108,7 +108,7 @@ login.withCustomRole = (role: Role): ReturnType<typeof sendApiLoginRequest> => {
  * @param username
  * @param password
  *
- * @private
+ * @internal
  */
 const sendApiLoginRequest = (
   username: string,

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
@@ -37,7 +37,7 @@ interface AgentDownloadStorageSettings {
 
 /**
  * Class for managing Agent Downloads on the local disk
- * @private
+ * @internal
  */
 class AgentDownloadStorage extends SettingsStorage<AgentDownloadStorageSettings> {
   private downloadsFolderExists = false;

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/endpoint_artifact_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/endpoint_artifact_services.ts
@@ -86,7 +86,7 @@ const ensureArtifactListExists = memoize(
  * Creates an exception list item.
  * NOTE: this method does NOT create the list itself.
  *
- * @private
+ * @internal
  *
  * @param kbnClient
  * @param data

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/crowdstrike/crowdstrike_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/crowdstrike/crowdstrike_actions_client.ts
@@ -96,7 +96,7 @@ export class CrowdstrikeActionsClient extends ResponseActionsClientImpl {
 
   /**
    * Sends actions to Crowdstrike directly (via Connector)
-   * @private
+   * @internal
    */
   private async sendAction(
     actionType: SUB_ACTION,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/microsoft/defender/endpoint/ms_defender_endpoint_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/microsoft/defender/endpoint/ms_defender_endpoint_actions_client.ts
@@ -126,7 +126,7 @@ export class MicrosoftDefenderEndpointActionsClient extends ResponseActionsClien
 
   /**
    * Sends actions to Ms Defender for Endpoint directly (via Connector)
-   * @private
+   * @internal
    */
   private async sendAction<
     TResponse = unknown,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
@@ -205,7 +205,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
 
   /**
    * Sends actions to SentinelOne directly (via Connector)
-   * @private
+   * @internal
    */
   private async sendAction<
     TResponse = unknown,
@@ -978,7 +978,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
    * retrieve script info. for scripts that are used to handle Elastic response actions
    * @param scriptType
    * @param osType
-   * @private
+   * @internal
    */
   private async fetchScriptInfo<
     TScriptOptions extends SentinelOneScriptArgs = SentinelOneScriptArgs
@@ -1105,7 +1105,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
    * document for them and returns it. (NOTE: the response is NOT written to ES - only returned)
    * @param actionRequests
    * @param command
-   * @private
+   * @internal
    */
   private async checkPendingIsolateOrReleaseActions(
     actionRequests: Array<
@@ -1592,7 +1592,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
    * Calculates the state of a SentinelOne Task using the response from their task status API. It
    * returns a normalized object with basic info derived from the task status value
    * @param taskStatusRecord
-   * @private
+   * @internal
    */
   private calculateTaskState(taskStatusRecord: SentinelOneRemoteScriptExecutionStatus): {
     isPending: boolean;

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_requests.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_requests.ts
@@ -147,7 +147,7 @@ export const fetchActionRequests = async ({
   };
 };
 
-/** @private */
+/** @internal */
 const getActionTypeFilter = (actionType: string): QueryDslBoolQuery => {
   return actionType === 'manual'
     ? {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_responses.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_responses.ts
@@ -17,7 +17,7 @@ import { ACTIONS_SEARCH_PAGE_SIZE } from '../constants';
 import { catchAndWrapError } from '../../../utils';
 import { ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN } from '../../../../../common/endpoint/constants';
 
-/** @private */
+/** @internal */
 const buildSearchQuery = (
   actionIds: string[] = [],
   agentIds: string[] = []

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
@@ -176,7 +176,7 @@ export class EndpointMetadataService {
    * @param _fleetAgent
    * @param _fleetAgentPolicy
    * @param _endpointPackagePolicy
-   * @private
+   * @internal
    */
   // eslint-disable-next-line complexity
   private async enrichHostMetadata(

--- a/x-pack/test/security_solution_ftr/services/detections/index.ts
+++ b/x-pack/test/security_solution_ftr/services/detections/index.ts
@@ -34,7 +34,7 @@ export class DetectionsTestService extends FtrService {
    * when things fail.
    *
    * @param ignoredStatusCodes
-   * @private
+   * @internal
    *
    * @example
    *

--- a/x-pack/test/security_solution_ftr/services/timeline/index.ts
+++ b/x-pack/test/security_solution_ftr/services/timeline/index.ts
@@ -27,7 +27,7 @@ export class TimelineTestService extends FtrService {
    * when things fail.
    *
    * @param ignoredStatusCodes
-   * @private
+   * @internal
    *
    * @example
    *


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Docs] Replace `@private` with `@internal` (#224835)](https://github.com/elastic/kibana/pull/224835)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alejandro Fernández Haro","email":"alejandro.haro@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T17:59:17Z","message":"[Docs] Replace `@private` with `@internal` (#224835)","sha":"474f8480b7c91573afd6772c94dc9d63c122f069","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","Team:Operations","Team:Security","Team:Monitoring",":ml","Team:Presentation","Feature:ExpressionLanguage","Team:Visualizations","Team:Kibana Management","release_note:skip","Team:Fleet","Team: SecuritySolution","Team:Defend Workflows","Team:DataDiscovery","Team:ML","Team:SharedUX","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[Docs] Replace `@private` with `@internal`","number":224835,"url":"https://github.com/elastic/kibana/pull/224835","mergeCommit":{"message":"[Docs] Replace `@private` with `@internal` (#224835)","sha":"474f8480b7c91573afd6772c94dc9d63c122f069"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224835","number":224835,"mergeCommit":{"message":"[Docs] Replace `@private` with `@internal` (#224835)","sha":"474f8480b7c91573afd6772c94dc9d63c122f069"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->