### PR TITLE
[Index Management] Remove doc link from failure store configuration modal

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -309,7 +309,6 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       docsBase: `${ELASTIC_DOCS}solutions/search`,
       asyncSearch: `${ELASTIC_DOCS}solutions/search/async-search-api`,
       dataStreams: `${ELASTIC_DOCS}manage-data/data-store/data-streams`,
-      dataStreamsFailureStore: `${ELASTIC_DOCS}manage-data/data-store/data-streams/failure-store`,
       deprecationLogging: `${ELASTIC_DOCS}deploy-manage/monitor/logging-configuration/update-elasticsearch-logging-levels#deprecation-logging`,
       createEnrichPolicy: isServerless
         ? `${ELASTICSEARCH_SERVERLESS_APIS}operation/operation-enrich-put-policy`

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/configure_failure_store_modal/configure_failure_store_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/configure_failure_store_modal/configure_failure_store_modal.tsx
@@ -15,7 +15,6 @@ import {
   EuiButtonEmpty,
   EuiButton,
   EuiSpacer,
-  EuiLink,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -28,7 +27,6 @@ import {
   ToggleField,
 } from '../../../../../shared_imports';
 
-import { documentationService } from '../../../../services/documentation';
 import { DataStream } from '../../../../../../common';
 import { useAppContext } from '../../../../app_context';
 import { updateDSFailureStore } from '../../../../services/api';
@@ -125,22 +123,7 @@ export const ConfigureFailureStoreModal: React.FunctionComponent<Props> = ({
         <EuiModalBody>
           <FormattedMessage
             id="xpack.idxMgmt.dataStreams.configureFailureStoreModal.modalDescriptionText"
-            defaultMessage="A failure store is a secondary index within a data stream, used to store failed documents. {docLink}."
-            values={{
-              docLink: (
-                <EuiLink
-                  href={documentationService.getDataStreamsFailureStoreLink()}
-                  target="_blank"
-                  external
-                  data-test-subj="failureStoreDocLink"
-                >
-                  <FormattedMessage
-                    id="xpack.idxMgmt.dataStreams.configureFailureStoreModal.modalDescriptionLinkText"
-                    defaultMessage="Learn more"
-                  />
-                </EuiLink>
-              ),
-            }}
+            defaultMessage="A failure store is a secondary index within a data stream, used to store failed documents."
           />
           <EuiSpacer />
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/services/documentation.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/services/documentation.ts
@@ -16,7 +16,6 @@ class DocumentationService {
   private esDocsBase: string = '';
   private enrichPolicies: string = '';
   private createEnrichPolicies: string = '';
-  private dataStreamsFailureStore: string = '';
   private matchAllQuery: string = '';
   private indexManagement: string = '';
   private indexSettings: string = '';
@@ -79,7 +78,6 @@ class DocumentationService {
     this.esDocsBase = links.elasticsearch.docsBase;
     this.enrichPolicies = links.elasticsearch.enrichPolicies;
     this.createEnrichPolicies = links.elasticsearch.createEnrichPolicy;
-    this.dataStreamsFailureStore = links.elasticsearch.dataStreamsFailureStore;
     this.matchAllQuery = links.elasticsearch.matchAllQuery;
     this.indexManagement = links.management.indexManagement;
     this.indexSettings = links.elasticsearch.indexSettings;
@@ -203,10 +201,6 @@ class DocumentationService {
 
   public getCreateEnrichPolicyLink() {
     return this.createEnrichPolicies;
-  }
-
-  public getDataStreamsFailureStoreLink() {
-    return this.dataStreamsFailureStore;
   }
 
   public getMatchAllQueryLink() {


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/pull/223389

## Summary

Documentation for failure store configuration wont be ready on time https://github.com/elastic/docs-content/pull/1368/, so removing the link for now.