### PR TITLE
Adds missing model Claude 3.7 to accepted models

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/common/models.ts
+++ b/x-pack/solutions/search/plugins/search_playground/common/models.ts
@@ -39,6 +39,12 @@ export const MODELS: ModelProvider[] = [
     provider: LLMs.bedrock,
   },
   {
+    name: 'Anthropic Claude 3.7 Sonnet',
+    model: 'anthropic.claude-3-7-sonnet-20250219-v1:0',
+    promptTokenLimit: 200000,
+    provider: LLMs.bedrock,
+  },
+  {
     name: 'Google Gemini 1.5 Pro',
     model: 'gemini-1.5-pro-002',
     promptTokenLimit: 2097152,

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.test.tsx
@@ -142,6 +142,18 @@ describe('useLLMsModels Query Hook', () => {
           promptTokenLimit: 200000,
         },
         {
+          connectorId: 'connectorId2',
+          connectorName: 'Bedrock Connector',
+          connectorType: LLMs.bedrock,
+          disabled: false,
+          icon: expect.any(String),
+          id: 'connectorId2Anthropic Claude 3.7 Sonnet',
+          name: 'Anthropic Claude 3.7 Sonnet',
+          showConnectorName: false,
+          value: 'anthropic.claude-3-7-sonnet-20250219-v1:0',
+          promptTokenLimit: 200000,
+        },
+        {
           connectorId: 'connectorId3',
           connectorName: 'OpenAI OSS Model Connector',
           connectorType: LLMs.openai_other,


### PR DESCRIPTION
## Summary

With the new Claude 3.7 Elastic Managed LLM we're seeing an unhandled error in Kibana playground. We can reproduce it by:

1. Indexing few but very large documents in Elasticsearch (10 docs, each 7mb)
2. Setting the docs to send setting as 10
3. Setting context to always query the index (I think there is some function calling, not sure what happens under the hood but this worked as I wanted to consistently).

![image](https://github.com/user-attachments/assets/5e926f0a-f8bd-4685-bbaa-4187700e01b2)

Thread: https://elastic.slack.com/archives/C08DT72KR6J/p1750686748616369?thread_ts=1750685837.561949&cid=C08DT72KR6J

We're not 100% sure this fixes the issue but we do know the model should be added.

### Checklist

Check the PR satisfies following conditions. 

- [ ] Cannot reproduce the issue after the model entry is used on QA environment

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

No known risks




<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->