### PR TITLE
[7.17][Lens] Error on`Records` aggregation field when switching `i18n.locale`

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/document_field.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/document_field.ts
@@ -16,9 +16,7 @@ export const documentField: IndexPatternField = {
   displayName: i18n.translate('xpack.lens.indexPattern.records', {
     defaultMessage: 'Records',
   }),
-  name: i18n.translate('xpack.lens.indexPattern.records', {
-    defaultMessage: 'Records',
-  }),
+  name: 'Records',
   type: 'document',
   aggregatable: true,
   searchable: true,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/document_field.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/document_field.ts
@@ -16,7 +16,9 @@ export const documentField: IndexPatternField = {
   displayName: i18n.translate('xpack.lens.indexPattern.records', {
     defaultMessage: 'Records',
   }),
-  name: 'Records',
+  name: i18n.translate('xpack.lens.indexPattern.records', {
+    defaultMessage: 'Records',
+  }),
   type: 'document',
   aggregatable: true,
   searchable: true,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/helpers.tsx
@@ -13,6 +13,7 @@ import {
   ReferenceBasedIndexPatternColumn,
 } from './column_types';
 import { IndexPattern } from '../../types';
+import { documentField } from '../../document_field';
 
 export function getInvalidFieldMessage(
   column: FieldBasedIndexPatternColumn,
@@ -22,7 +23,13 @@ export function getInvalidFieldMessage(
     return;
   }
   const { sourceField, operationType } = column;
-  const field = sourceField ? indexPattern.getFieldByName(sourceField) : undefined;
+  let field = sourceField ? indexPattern.getFieldByName(sourceField) : undefined;
+
+  if (!field && operationType === 'count') {
+    // This is a hotfix for https://github.com/elastic/kibana/issues/224593
+    field = documentField;
+  }
+
   const operationDefinition = operationType && operationDefinitionMap[operationType];
 
   const isInvalid = Boolean(


### PR DESCRIPTION
## Summary

This PR fixes an issue where switching to any `locale` other than `'en'` would cause the error `未找到字段 Records` or `Field Records not found`.

This was first fix in #123894 or `v8.1.0` but never backported to `7.x`.

> Note: This would only occur if someone saved a dashboard/vis in a different `locale` then they are currently using or for hardcoded sample data dashboards.

Fixes #224593

## The solution

The fix applied in #123894 is very invasive and corrects all usages of the translated `name` across the source code and saved objects.

I would rather avoid that in `7.17` with a simpler hot fix. Mostly because the full fix will already be applied in the migrations when upgrading to `8.1.0`.

This fix for `7.17` just provides the `documentField` when the `field` lookup fails and the `column.operationType` is `'count'`.

## The issue

The main issue is call to `indexPattern.getFieldByName(sourceField)` below...

https://github.com/elastic/kibana/blob/e670d16d1e3c728ec9e2c21a9363d477ae663e2a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/helpers.tsx#L25

All fields of an index pattern are sourced from the mapping of the elasticsearch index, with the exception of the `Records` field, which is injected into the field list dynamically. But the definition of this `documentField` below also translates the `name` property. Thus the `sourceField` lookup value is sometimes `'Records'` and sometimes `'记录'` (i.e. `'Records'` in Chinese).

https://github.com/elastic/kibana/blob/e670d16d1e3c728ec9e2c21a9363d477ae663e2a/x-pack/plugins/lens/public/indexpattern_datasource/document_field.ts#L16-L21

This translation should only apply to the `displayName` property of the `documentField`, originally there was only a `name` property.

The issue now comes from the saved object of the sample data dashboard where `sourceField` remains as `'Records'`, causing the field not found error.

In current `main` we treat this document name as a constant `__records__`, since https://github.com/elastic/kibana/pull/123894.

https://github.com/elastic/kibana/blob/f0b862f1136c31a0761b6f19ba06411fb52b4959/x-pack/platform/plugins/shared/lens/public/datasources/form_based/document_field.ts#L12-L27

## Release Notes

Fixes a field lookup issue for count aggregations in Lens when using a locale other than 'en'.