### PR TITLE
[8.19] [Data Discovery] Remove SO client usages (#224495)

### DIFF
--- a/examples/discover_customization_examples/kibana.jsonc
+++ b/examples/discover_customization_examples/kibana.jsonc
@@ -12,7 +12,8 @@
       "discover",
       "embeddable",
       "kibanaUtils",
-      "data"
+      "data",
+      "savedSearch"
     ]
   }
 }

--- a/examples/discover_customization_examples/tsconfig.json
+++ b/examples/discover_customization_examples/tsconfig.json
@@ -13,6 +13,8 @@
     "@kbn/i18n-react",
     "@kbn/react-kibana-context-theme",
     "@kbn/data-plugin",
+    "@kbn/saved-search-plugin",
+    "@kbn/content-management-utils",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.test.ts
@@ -398,32 +398,6 @@ describe('Test discover state actions', () => {
     discoverServiceMock.data.search.searchSource.create = jest
       .fn()
       .mockReturnValue(savedSearchMock.searchSource);
-    discoverServiceMock.core.savedObjects.client.resolve = jest.fn().mockReturnValue({
-      saved_object: {
-        attributes: {
-          kibanaSavedObjectMeta: {
-            searchSourceJSON:
-              '{"query":{"query":"","language":"kuery"},"filter":[],"indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index"}',
-          },
-          title: 'The saved search that will save the world',
-          sort: [],
-          columns: ['test123'],
-          description: 'description',
-          hideChart: false,
-        },
-        id: 'the-saved-search-id',
-        type: 'search',
-        references: [
-          {
-            name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-            id: 'the-data-view-id',
-            type: 'index-pattern',
-          },
-        ],
-        namespaces: ['default'],
-      },
-      outcome: 'exactMatch',
-    });
   });
 
   afterEach(() => {

--- a/src/platform/plugins/shared/saved_search/public/services/saved_searches/types.ts
+++ b/src/platform/plugins/shared/saved_search/public/services/saved_searches/types.ts
@@ -8,15 +8,15 @@
  */
 
 import type { Reference } from '@kbn/content-management-utils';
-import type { ResolvedSimpleSavedObject } from '@kbn/core/public';
+import type { SavedObjectsResolveResponse } from '@kbn/core-saved-objects-api-server';
 import type { SavedSearch as SavedSearchCommon, SavedSearchAttributes } from '../../../common';
 
 /** @public **/
 export interface SavedSearch extends SavedSearchCommon {
   sharingSavedObjectProps?: {
-    outcome?: ResolvedSimpleSavedObject['outcome'];
-    aliasTargetId?: ResolvedSimpleSavedObject['alias_target_id'];
-    aliasPurpose?: ResolvedSimpleSavedObject['alias_purpose'];
+    outcome?: SavedObjectsResolveResponse['outcome'];
+    aliasTargetId?: SavedObjectsResolveResponse['alias_target_id'];
+    aliasPurpose?: SavedObjectsResolveResponse['alias_purpose'];
     errorJSON?: string;
   };
 }

--- a/src/platform/plugins/shared/saved_search/tsconfig.json
+++ b/src/platform/plugins/shared/saved_search/tsconfig.json
@@ -28,6 +28,7 @@
     "@kbn/utility-types",
     "@kbn/search-types",
     "@kbn/unified-data-table",
+    "@kbn/core-saved-objects-api-server",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Data Discovery] Remove SO client usages (#224495)](https://github.com/elastic/kibana/pull/224495)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T22:51:27Z","message":"[Data Discovery] Remove SO client usages (#224495)\n\n## Summary\n\nWhile checking out our remaining browser SO client usages, I realized it\nwould be _really_ easy to get rid of them. This PR does that.\n\nResolves #224357.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"21a288a097ea0b5329ea6786295d49e5100bfa89","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.1.0","v8.19.0"],"title":"[Data Discovery] Remove SO client usages","number":224495,"url":"https://github.com/elastic/kibana/pull/224495","mergeCommit":{"message":"[Data Discovery] Remove SO client usages (#224495)\n\n## Summary\n\nWhile checking out our remaining browser SO client usages, I realized it\nwould be _really_ easy to get rid of them. This PR does that.\n\nResolves #224357.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"21a288a097ea0b5329ea6786295d49e5100bfa89"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224495","number":224495,"mergeCommit":{"message":"[Data Discovery] Remove SO client usages (#224495)\n\n## Summary\n\nWhile checking out our remaining browser SO client usages, I realized it\nwould be _really_ easy to get rid of them. This PR does that.\n\nResolves #224357.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"21a288a097ea0b5329ea6786295d49e5100bfa89"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->