### PR TITLE
[ES|QL] Enables enrich suggestion in fork

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/index.ts
@@ -52,6 +52,7 @@ export { Builder, type AstNodeParserFields, type AstNodeTemplate } from './src/b
 export {
   createParser,
   parse,
+  Parser,
   parseErrors,
   type ParseOptions,
   type ParseResult,

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/index.ts
@@ -7,6 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { createParser, parse, parseErrors, type ParseOptions, type ParseResult } from './parser';
+export {
+  createParser,
+  parse,
+  parseErrors,
+  Parser,
+  type ParseOptions,
+  type ParseResult,
+} from './parser';
 
 export { ESQLErrorListener } from './esql_error_listener';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.fork.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.fork.test.ts
@@ -23,6 +23,7 @@ import {
   getFunctionSignaturesByReturnType,
   setup,
   lookupIndexFields,
+  policies,
 } from './helpers';
 
 describe('autocomplete.suggest', () => {
@@ -61,6 +62,7 @@ describe('autocomplete.suggest', () => {
           'CHANGE_POINT ',
           'MV_EXPAND ',
           'DROP ',
+          'ENRICH ',
           'KEEP ',
           'RENAME ',
           'SAMPLE ',
@@ -184,6 +186,18 @@ describe('autocomplete.suggest', () => {
             expected.sort();
 
             expect(labels).toEqual(expected);
+          });
+
+          test('enrich', async () => {
+            const expectedPolicyNameSuggestions = policies
+              .map(({ name, suggestedAs }) => suggestedAs || name)
+              .map((name) => `${name} `);
+
+            await assertSuggestions(`FROM a | FORK (ENRICH /)`, expectedPolicyNameSuggestions);
+            await assertSuggestions(
+              `FROM a | FORK (ENRICH policy ON /)`,
+              getFieldNamesByType('any').map((v) => `${v} `)
+            );
           });
 
           describe('stats', () => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/suggest.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/suggest.ts
@@ -36,7 +36,7 @@ const FORK_AVAILABLE_COMMANDS = [
   'rename',
   'sample',
   'join',
-  // 'enrich', // not suggesting enrich for now, there are client side validation issues
+  'enrich',
 ];
 
 export async function suggest(

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.test.ts
@@ -7,28 +7,28 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { Parser } from '@kbn/esql-ast';
-import { hasEnrichCommand } from './helpers';
+import { getEnrichCommands } from './helpers';
 
-describe('hasEnrichCommand', () => {
-  test('should return true in case of an enrich command', async () => {
+describe('getEnrichCommands', () => {
+  test('should return the command in case of an enrich command', async () => {
     const { root } = Parser.parse('FROM index | ENRICH policy ON field');
-    expect(hasEnrichCommand(root.commands)).toBe(true);
+    expect(getEnrichCommands(root.commands).length).toBe(1);
   });
 
-  test('should return false if enrich is not present', async () => {
+  test('should return empty array if enrich is not present', async () => {
     const { root } = Parser.parse('FROM index | STATS COUNT() BY field');
-    expect(hasEnrichCommand(root.commands)).toBe(false);
+    expect(getEnrichCommands(root.commands)).toStrictEqual([]);
   });
 
-  test('should return true in case of an enrich command inside a fork branch', async () => {
+  test('should return the command in case of an enrich command inside a fork branch', async () => {
     const { root } = Parser.parse(
       'FROM index | FORK (ENRICH policy ON @timestamp WITH col0 = bikes_count) (DROP @timestamp) '
     );
-    expect(hasEnrichCommand(root.commands)).toBe(true);
+    expect(getEnrichCommands(root.commands).length).toBe(1);
   });
 
-  test('should return false in case of forck branches without enrich', async () => {
+  test('should return empty array in case of forck branches without enrich', async () => {
     const { root } = Parser.parse('FROM index | FORK (STATS COUNT()) (DROP @timestamp) ');
-    expect(hasEnrichCommand(root.commands)).toBe(false);
+    expect(getEnrichCommands(root.commands)).toStrictEqual([]);
   });
 });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { Parser } from '@kbn/esql-ast';
+import { hasEnrichCommand } from './helpers';
+
+describe('hasEnrichCommand', () => {
+  test('should return true in case of an enrich command', async () => {
+    const { root } = Parser.parse('FROM index | ENRICH policy ON field');
+    expect(hasEnrichCommand(root.commands)).toBe(true);
+  });
+
+  test('should return false if enrich is not present', async () => {
+    const { root } = Parser.parse('FROM index | STATS COUNT() BY field');
+    expect(hasEnrichCommand(root.commands)).toBe(false);
+  });
+
+  test('should return true in case of an enrich command inside a fork branch', async () => {
+    const { root } = Parser.parse(
+      'FROM index | FORK (ENRICH policy ON @timestamp WITH col0 = bikes_count) (DROP @timestamp) '
+    );
+    expect(hasEnrichCommand(root.commands)).toBe(true);
+  });
+
+  test('should return false in case of forck branches without enrich', async () => {
+    const { root } = Parser.parse('FROM index | FORK (STATS COUNT()) (DROP @timestamp) ');
+    expect(hasEnrichCommand(root.commands)).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
@@ -149,5 +149,5 @@ export function collapseWrongArgumentTypeMessages(
  * This function traverses the provided ESQL commands and collects all commands with the name 'enrich'.
  * @returns {ESQLCommand[]} - An array of ESQLCommand objects that represent the 'enrich' commands found in the input.
  */
-export const getEnrichCommands = (commands: ESQLCommand[]) =>
-  Walker.matchAll(commands, {type: 'command', name: 'enrich'});
+export const getEnrichCommands = (commands: ESQLCommand[]): ESQLCommand[] =>
+  Walker.matchAll(commands, { type: 'command', name: 'enrich' }) as ESQLCommand[];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
@@ -144,44 +144,6 @@ export function collapseWrongArgumentTypeMessages(
 }
 
 /**
- * Checks if the provided object or any of its nested objects contains an 'enrich' command.
- *
- * @param obj - The object or array of objects to check.
- * @returns {boolean} - Returns true if an 'enrich' command is found, otherwise false.
- */
-export function hasEnrichCommand(obj: ESQLCommand | ESQLCommand[]): boolean {
-  if (typeof obj !== 'object' || obj === null) {
-    return false;
-  }
-
-  if (Array.isArray(obj)) {
-    for (const item of obj) {
-      if (hasEnrichCommand(item)) {
-        return true;
-      }
-    }
-  } else {
-    // Check if the current object has a 'name' property and it's 'enrich'
-    if ('name' in obj && obj.name === 'enrich') {
-      return true;
-    }
-
-    // Recursively check all properties of the current object
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        const value = (obj as unknown as Record<string, unknown>)[key];
-        if (typeof value === 'object' && value !== null) {
-          if (hasEnrichCommand(value as ESQLCommand | ESQLCommand[])) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-  return false;
-}
-
-/**
  * Collects all 'enrich' commands from a list of ESQL commands.
  * @param commands - The list of ESQL commands to search through.
  * This function traverses the provided ESQL commands and collects all commands with the name 'enrich'.

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
@@ -7,16 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  ESQLAst,
-  ESQLAstItem,
-  ESQLAstTimeseriesCommand,
-  ESQLAstQueryExpression,
-  ESQLColumn,
-  ESQLMessage,
-  ESQLSingleAstItem,
-  ESQLSource,
-  ESQLCommand,
+import {
+  type ESQLAst,
+  type ESQLAstItem,
+  type ESQLAstTimeseriesCommand,
+  type ESQLAstQueryExpression,
+  type ESQLColumn,
+  type ESQLMessage,
+  type ESQLSingleAstItem,
+  type ESQLSource,
+  type ESQLCommand,
+  Walker,
 } from '@kbn/esql-ast';
 import { mutate, synth } from '@kbn/esql-ast';
 import { FunctionDefinition } from '../definitions/types';
@@ -178,4 +179,22 @@ export function hasEnrichCommand(obj: ESQLCommand | ESQLCommand[]): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Collects all 'enrich' commands from a list of ESQL commands.
+ * @param commands - The list of ESQL commands to search through.
+ * This function traverses the provided ESQL commands and collects all commands with the name 'enrich'.
+ * @returns {ESQLCommand[]} - An array of ESQLCommand objects that represent the 'enrich' commands found in the input.
+ */
+export function getEnrichCommands(commands: ESQLCommand[]): ESQLCommand[] {
+  const enrichCommands: ESQLCommand[] = [];
+  Walker.walk(commands, {
+    visitCommand: (node) => {
+      if (node.name === 'enrich') {
+        enrichCommands.push(node);
+      }
+    },
+  });
+  return enrichCommands;
 }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/helpers.ts
@@ -149,14 +149,5 @@ export function collapseWrongArgumentTypeMessages(
  * This function traverses the provided ESQL commands and collects all commands with the name 'enrich'.
  * @returns {ESQLCommand[]} - An array of ESQLCommand objects that represent the 'enrich' commands found in the input.
  */
-export function getEnrichCommands(commands: ESQLCommand[]): ESQLCommand[] {
-  const enrichCommands: ESQLCommand[] = [];
-  Walker.walk(commands, {
-    visitCommand: (node) => {
-      if (node.name === 'enrich') {
-        enrichCommands.push(node);
-      }
-    },
-  });
-  return enrichCommands;
-}
+export const getEnrichCommands = (commands: ESQLCommand[]) =>
+  Walker.matchAll(commands, {type: 'command', name: 'enrich'});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
@@ -19,7 +19,6 @@ import {
   buildQueryForFieldsForStringSources,
   buildQueryForFieldsFromSource,
   buildQueryForFieldsInPolicies,
-  hasEnrichCommand,
   getEnrichCommands,
 } from './helpers';
 import type { ESQLFieldWithMetadata, ESQLPolicy } from './types';
@@ -54,7 +53,8 @@ export async function retrievePolicies(
   commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
 ): Promise<Map<string, ESQLPolicy>> {
-  if (!callbacks || !hasEnrichCommand(commands)) {
+  const enrichCommands = getEnrichCommands(commands);
+  if (!callbacks || !enrichCommands.length) {
     return new Map();
   }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
@@ -19,6 +19,7 @@ import {
   buildQueryForFieldsForStringSources,
   buildQueryForFieldsFromSource,
   buildQueryForFieldsInPolicies,
+  hasEnrichCommand,
 } from './helpers';
 import type { ESQLFieldWithMetadata, ESQLPolicy } from './types';
 
@@ -52,7 +53,7 @@ export async function retrievePolicies(
   commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
 ): Promise<Map<string, ESQLPolicy>> {
-  if (!callbacks || commands.every(({ name }) => name !== 'enrich')) {
+  if (!callbacks || !hasEnrichCommand(commands)) {
     return new Map();
   }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
@@ -20,6 +20,7 @@ import {
   buildQueryForFieldsFromSource,
   buildQueryForFieldsInPolicies,
   hasEnrichCommand,
+  getEnrichCommands,
 } from './helpers';
 import type { ESQLFieldWithMetadata, ESQLPolicy } from './types';
 
@@ -83,7 +84,7 @@ export async function retrievePoliciesFields(
   if (!callbacks) {
     return new Map();
   }
-  const enrichCommands = commands.filter(({ name }) => name === 'enrich');
+  const enrichCommands = getEnrichCommands(commands);
   if (!enrichCommands.length) {
     return new Map();
   }


### PR DESCRIPTION
## Summary

Fixing this https://github.com/elastic/kibana/issues/192255#issuecomment-2991343277

I hadn't enabled the enrich suggestion as it has some client side validation issues. This PR is fixing them and enables the enrich suggestions in FORK

<img width="796" alt="image" src="https://github.com/user-attachments/assets/0b599e36-18d3-4504-b572-50575bb9e159" />



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->