### PR TITLE
[Logs Essentials] Disable AIOPS features and capabilities

### DIFF
--- a/config/serverless.oblt.logs_essentials.yml
+++ b/config/serverless.oblt.logs_essentials.yml
@@ -4,3 +4,4 @@
 xpack.infra.enabled: false
 xpack.slo.enabled: false
 xpack.observabilityAIAssistant.enabled: false
+xpack.aiops.ui.enabled: false


### PR DESCRIPTION
## 📓 Summary

Given the setting introduced in [#221286 [ML] AIOps: Adds ability to disable AIOps features in Kibana](https://github.com/elastic/kibana/pull/221286), this adds the expected configuration value to disable all the AIOPS features for `logs_essentials` projects.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->