### PR TITLE
[Docs] Adds security advisory message to 8.18.3 and 8.17.8

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -104,6 +104,8 @@ include::upgrade-notes.asciidoc[]
 
 The 8.18.3 release includes the following fixes.
 
+IMPORTANT: The 8.18.3 release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory for more details].
+
 [float]
 [[known-issues-8.18.3]]
 === Known issues

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -622,6 +622,8 @@ Machine Learning::
 
 The 8.17.8 release includes the following fixes.
 
+IMPORTANT: The 8.17.8 release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory for more details].
+
 [float]
 [[fixes-v8.17.8]]
 === Fixes


### PR DESCRIPTION
This PR adds a security advisory message and link to 8.18.3 and 8.17.8 as requested by @ismisepaul 

The change looks like this (changing the release version based on where the message is added):
<img width="862" alt="image" src="https://github.com/user-attachments/assets/f12b8851-e24a-4f66-8a64-b5f30204df85" />
