### PR TITLE
Fix flaky dashboard view count test

### DIFF
--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_listing.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_listing.ts
@@ -269,8 +269,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           return Number(viewsStr);
         }
 
-        const views1 = await getViewsCount();
-        expect(views1).to.be(1);
+        // it might take a bit for the view to be counted
+        await retry.try(async () => {
+          const views1 = await getViewsCount();
+          expect(views1).to.be(1);
+        });
 
         await listingTable.clickItemLink('dashboard', DASHBOARD_NAME);
         await dashboard.waitForRenderComplete();


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/223562




<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->