### PR TITLE
[Security Solution][Sourcerer] Dont dispatch with empty params

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.test.ts
@@ -21,6 +21,8 @@ jest.mock('react-redux', () => {
 });
 
 describe('useSelectDataView', () => {
+  beforeEach(jest.clearAllMocks);
+
   it('should render and dispatch data view selection actions', () => {
     const { result } = renderHook(
       () => {
@@ -34,6 +36,28 @@ describe('useSelectDataView', () => {
     expect(useDispatch()).toHaveBeenCalledWith({
       payload: { id: 'test', scope: 'default' },
       type: 'x-pack/security_solution/dataViewManager/selectDataView',
+    });
+  });
+
+  describe('when trying to call the hook with empty params', () => {
+    it('should render but not dispatch data view selection', () => {
+      const { result } = renderHook(
+        () => {
+          return useSelectDataView();
+        },
+        { wrapper: TestProviders }
+      );
+
+      result.current({
+        id: undefined,
+        fallbackPatterns: [],
+        scope: DataViewManagerScopeName.default,
+      });
+
+      expect(useDispatch()).not.toHaveBeenCalledWith({
+        payload: { id: 'test', scope: 'default' },
+        type: 'x-pack/security_solution/dataViewManager/selectDataView',
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
@@ -21,6 +21,9 @@ export const useSelectDataView = () => {
 
   return useCallback(
     (params: {
+      /**
+       * Data view id, if empty - you have to specify fallbackPatterns instead
+       */
       id?: string | null;
       /**
        * List of patterns that will be used to construct the adhoc data view when

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
@@ -14,6 +14,7 @@ import { selectDataViewAsync } from '../redux/actions';
  * This hook wraps the dispatch call that updates the redux store with new data view selection.
  * It is the recommended entry point for altering the data view selection.
  * Manual action dispatches are not required and should be avoided outside of the data view manager scope.
+ * Note: it will not select anything if neither params.id or params.fallbackPatterns are set.
  */
 export const useSelectDataView = () => {
   const dispatch = useDispatch();

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
@@ -10,6 +10,22 @@ import { useCallback } from 'react';
 import type { DataViewManagerScopeName } from '../constants';
 import { selectDataViewAsync } from '../redux/actions';
 
+interface UseSelectDataViewParams {
+  /**
+   * Data view id, if empty - you have to specify fallbackPatterns instead
+   */
+  id?: string | null;
+  /**
+   * List of patterns that will be used to construct the adhoc data view when
+   * .id param is not provided or the data view does not exist
+   */
+  fallbackPatterns?: string[];
+  /**
+   * Data view selection will be applied to the scopes listed here
+   */
+  scope: DataViewManagerScopeName;
+}
+
 /**
  * This hook wraps the dispatch call that updates the redux store with new data view selection.
  * It is the recommended entry point for altering the data view selection.
@@ -20,21 +36,7 @@ export const useSelectDataView = () => {
   const dispatch = useDispatch();
 
   return useCallback(
-    (params: {
-      /**
-       * Data view id, if empty - you have to specify fallbackPatterns instead
-       */
-      id?: string | null;
-      /**
-       * List of patterns that will be used to construct the adhoc data view when
-       * .id param is not provided or the data view does not exist
-       */
-      fallbackPatterns?: string[];
-      /**
-       * Data view selection will be applied to the scopes listed here
-       */
-      scope: DataViewManagerScopeName;
-    }) => {
+    (params: UseSelectDataViewParams) => {
       if (!(params.id || params.fallbackPatterns?.length)) {
         return;
       }

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
@@ -31,6 +31,10 @@ export const useSelectDataView = () => {
        */
       scope: DataViewManagerScopeName;
     }) => {
+      if (!(params.id || params.fallbackPatterns?.length)) {
+        return;
+      }
+
       dispatch(selectDataViewAsync(params));
     },
     [dispatch]


### PR DESCRIPTION
## Summary

Added a check that will prevent dispatches when either id or fallbacks patterns are not provided.
The only thing I am not sure about is some kind of warning, we need to log it somehow probably.

Closes https://github.com/elastic/kibana/issues/223156

## Testing

Flip the flag: `xpack.securitySolution.enableExperimental: ['newDataViewPickerEnabled']`
then try to investigate alert in timeline.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->