### PR TITLE
[OneDiscover][Tabs] Show the correct query in the unvisited tab preview

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_preview_data.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_preview_data.ts
@@ -16,24 +16,32 @@ import { TabStatus } from '@kbn/unified-tabs';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { isEqual } from 'lodash';
-import type { RuntimeStateManager } from '../../state_management/redux';
-import { selectTabRuntimeState, useInternalStateSelector } from '../../state_management/redux';
+import type { RuntimeStateManager, TabState } from '../../state_management/redux';
+import {
+  selectTabRuntimeState,
+  useInternalStateSelector,
+  selectAllTabs,
+} from '../../state_management/redux';
 import { FetchStatus } from '../../../types';
 
 export const usePreviewData = (runtimeStateManager: RuntimeStateManager) => {
-  const allTabIds = useInternalStateSelector((state) => state.tabs.allIds);
+  const allTabs = useInternalStateSelector(selectAllTabs);
+
   const previewDataMap$ = useMemo(
     () =>
       combineLatest(
-        allTabIds.reduce<Record<string, Observable<TabPreviewData>>>(
-          (acc, tabId) => ({
+        allTabs.reduce<Record<string, Observable<TabPreviewData>>>((acc, tabState) => {
+          return {
             ...acc,
-            [tabId]: getPreviewDataObservable(runtimeStateManager, tabId),
-          }),
-          {}
-        )
+            [tabState.id]: getPreviewDataObservable(
+              runtimeStateManager,
+              tabState.id,
+              tabState.initialAppState
+            ),
+          };
+        }, {})
       ),
-    [allTabIds, runtimeStateManager]
+    [allTabs, runtimeStateManager]
   );
   const previewDataMap = useObservable(previewDataMap$);
   const getPreviewData = useCallback(
@@ -83,12 +91,20 @@ const getPreviewQuery = (query: TabPreviewData['query'] | undefined): TabPreview
   };
 };
 
-const getPreviewDataObservable = (runtimeStateManager: RuntimeStateManager, tabId: string) =>
+const getPreviewDataObservable = (
+  runtimeStateManager: RuntimeStateManager,
+  tabId: string,
+  initialAppState: TabState['initialAppState'] | undefined
+) =>
   selectTabRuntimeState(runtimeStateManager, tabId).stateContainer$.pipe(
     switchMap((tabStateContainer) => {
       if (!tabStateContainer) {
-        // TODO: show the real query for tabs which are not yet initialized
-        return of({ status: TabStatus.DEFAULT, query: DEFAULT_PREVIEW_QUERY });
+        return of({
+          status: TabStatus.DEFAULT,
+          query: initialAppState?.query
+            ? getPreviewQuery(initialAppState.query)
+            : DEFAULT_PREVIEW_QUERY,
+        });
       }
 
       const { appState } = tabStateContainer;

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_preview_data.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_preview_data.ts
@@ -31,13 +31,10 @@ export const usePreviewData = (runtimeStateManager: RuntimeStateManager) => {
     () =>
       combineLatest(
         allTabs.reduce<Record<string, Observable<TabPreviewData>>>((acc, tabState) => {
+          const tabId = tabState.id;
           return {
             ...acc,
-            [tabState.id]: getPreviewDataObservable(
-              runtimeStateManager,
-              tabState.id,
-              tabState.initialAppState
-            ),
+            [tabId]: getPreviewDataObservable(runtimeStateManager, tabId, tabState.initialAppState),
           };
         }, {})
       ),


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/221507

## Summary

This PR fixes the query which is shown in the tab preview popover.
Before it was working correctly only for already visited tab.
Now it should work for all tabs (once they are restored from local storage after a page refresh).

![Jun-24-2025 13-49-30](https://github.com/user-attachments/assets/e7150aee-a7ad-47ec-941a-587a05ed7989)




