### PR TITLE
[9.0][Security Assistant] Add space id provider

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
@@ -21,6 +21,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Mock the necessary hooks and components
 jest.mock('@kbn/elastic-assistant', () => ({
+  AssistantSpaceIdProvider: jest.fn(({children}) => <div data-test-subj="AssistantSpaceProvider" >{children}</div>),
   useAssistantContext: jest.fn(),
   useFetchCurrentUserConversations: jest.fn(),
   mergeBaseWithPersistedConversations: jest.fn(),
@@ -34,6 +35,9 @@ jest.mock('@kbn/elastic-assistant/impl/assistant/use_conversation', () => ({
 }));
 jest.mock('../../common/lib/kibana', () => ({
   useKibana: jest.fn(),
+}));
+jest.mock('../../common/hooks/use_space_id', () => ({
+  useSpaceId: jest.fn().mockReturnValue('default'),
 }));
 
 const useAssistantContextMock = useAssistantContext as jest.Mock;

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
@@ -131,7 +131,7 @@ describe('ManagementSettings', () => {
     expect(navigateToApp).toHaveBeenCalledWith('home');
   });
 
-  it('renders AssistantSettingsManagement when conversations are available and securityAIAssistant is enabled', () => {
+  it('renders AssistantSettingsManagement when spaceId, conversations are available and securityAIAssistant is enabled', () => {
     renderComponent({
       conversations: mockConversations,
       spaceId: 'default',

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
@@ -21,7 +21,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Mock the necessary hooks and components
 jest.mock('@kbn/elastic-assistant', () => ({
-  AssistantSpaceIdProvider: jest.fn(({children}) => <div data-test-subj="AssistantSpaceProvider" >{children}</div>),
+  AssistantSpaceIdProvider: jest.fn(({ children }) => (
+    <div data-test-subj="AssistantSpaceProvider">{children}</div>
+  )),
   useAssistantContext: jest.fn(),
   useFetchCurrentUserConversations: jest.fn(),
   mergeBaseWithPersistedConversations: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
@@ -131,7 +131,7 @@ describe('ManagementSettings', () => {
     expect(navigateToApp).toHaveBeenCalledWith('home');
   });
 
-  it.only('renders AssistantSettingsManagement when conversations are available and securityAIAssistant is enabled', () => {
+  it('renders AssistantSettingsManagement when conversations are available and securityAIAssistant is enabled', () => {
     renderComponent({
       conversations: mockConversations,
       spaceId: 'default',

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.test.tsx
@@ -18,12 +18,10 @@ import {
 import { useKibana } from '../../common/lib/kibana';
 import { useConversation } from '@kbn/elastic-assistant/impl/assistant/use_conversation';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSpaceId } from '../../common/hooks/use_space_id';
 
 // Mock the necessary hooks and components
 jest.mock('@kbn/elastic-assistant', () => ({
-  AssistantSpaceIdProvider: jest.fn(({ children }) => (
-    <div data-test-subj="AssistantSpaceProvider">{children}</div>
-  )),
   useAssistantContext: jest.fn(),
   useFetchCurrentUserConversations: jest.fn(),
   mergeBaseWithPersistedConversations: jest.fn(),
@@ -39,13 +37,14 @@ jest.mock('../../common/lib/kibana', () => ({
   useKibana: jest.fn(),
 }));
 jest.mock('../../common/hooks/use_space_id', () => ({
-  useSpaceId: jest.fn().mockReturnValue('default'),
+  useSpaceId: jest.fn(),
 }));
 
 const useAssistantContextMock = useAssistantContext as jest.Mock;
 const useFetchCurrentUserConversationsMock = useFetchCurrentUserConversations as jest.Mock;
 const useKibanaMock = useKibana as jest.Mock;
 const useConversationMock = useConversation as jest.Mock;
+const useSpaceIdMock = useSpaceId as jest.Mock;
 
 describe('ManagementSettings', () => {
   const queryClient = new QueryClient();
@@ -61,9 +60,11 @@ describe('ManagementSettings', () => {
   const renderComponent = ({
     isAssistantEnabled = true,
     conversations,
+    spaceId,
   }: {
     isAssistantEnabled?: boolean;
     conversations: Record<string, Conversation>;
+    spaceId?: string;
   }) => {
     useAssistantContextMock.mockReturnValue({
       baseConversations,
@@ -107,6 +108,8 @@ describe('ManagementSettings', () => {
       getDefaultConversation,
     });
 
+    useSpaceIdMock.mockReturnValue(spaceId);
+
     return render(
       <MemoryRouter>
         <QueryClientProvider client={queryClient}>
@@ -123,14 +126,23 @@ describe('ManagementSettings', () => {
   it('navigates to home if securityAIAssistant is disabled', () => {
     renderComponent({
       conversations: mockConversations,
+      spaceId: 'default',
     });
     expect(navigateToApp).toHaveBeenCalledWith('home');
   });
 
-  it('renders AssistantSettingsManagement when conversations are available and securityAIAssistant is enabled', () => {
+  it.only('renders AssistantSettingsManagement when conversations are available and securityAIAssistant is enabled', () => {
+    renderComponent({
+      conversations: mockConversations,
+      spaceId: 'default',
+    });
+    expect(screen.getByTestId('AssistantSettingsManagement')).toBeInTheDocument();
+  });
+
+  it('does not render AssistantSettingsManagement when spaceId is not available', () => {
     renderComponent({
       conversations: mockConversations,
     });
-    expect(screen.getByTestId('AssistantSettingsManagement')).toBeInTheDocument();
+    expect(screen.queryByTestId('AssistantSettingsManagement')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
@@ -132,8 +132,8 @@ export const ManagementSettings = React.memo(() => {
     navigateToApp('home');
   }
 
-  if (conversations) {
-    return spaceId ? (
+  if (conversations && spaceId) {
+    return (
       <AssistantSpaceIdProvider spaceId={spaceId}>
         <AssistantSettingsManagement
           selectedConversation={currentConversation}
@@ -142,7 +142,7 @@ export const ManagementSettings = React.memo(() => {
           currentTab={currentTab}
         />
       </AssistantSpaceIdProvider>
-    ) : null;
+    );
   }
 
   return <></>;

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
@@ -132,8 +132,8 @@ export const ManagementSettings = React.memo(() => {
     navigateToApp('home');
   }
 
-  if (conversations && spaceId) {
-    return (
+  if (conversations) {
+    return spaceId ? (
       <AssistantSpaceIdProvider spaceId={spaceId}>
         <AssistantSettingsManagement
           selectedConversation={currentConversation}
@@ -142,7 +142,7 @@ export const ManagementSettings = React.memo(() => {
           currentTab={currentTab}
         />
       </AssistantSpaceIdProvider>
-    );
+    ) : null;
   }
 
   return <></>;

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
@@ -11,6 +11,7 @@ import type { Conversation } from '@kbn/elastic-assistant';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { i18n } from '@kbn/i18n';
 import {
+  AssistantSpaceIdProvider,
   mergeBaseWithPersistedConversations,
   useAssistantContext,
   useFetchCurrentUserConversations,
@@ -23,6 +24,7 @@ import { CONVERSATIONS_TAB } from '@kbn/elastic-assistant/impl/assistant/setting
 import type { SettingsTabs } from '@kbn/elastic-assistant/impl/assistant/settings/types';
 
 import { useKibana } from '../../common/lib/kibana';
+import { useSpaceId } from '../../common/hooks/use_space_id';
 
 const defaultSelectedConversationId = WELCOME_CONVERSATION_TITLE;
 
@@ -32,7 +34,7 @@ export const ManagementSettings = React.memo(() => {
     http,
     assistantAvailability: { isAssistantEnabled },
   } = useAssistantContext();
-
+  const spaceId = useSpaceId();
   const {
     application: {
       navigateToApp,
@@ -131,14 +133,16 @@ export const ManagementSettings = React.memo(() => {
   }
 
   if (conversations) {
-    return (
-      <AssistantSettingsManagement
-        selectedConversation={currentConversation}
-        dataViews={dataViews}
-        onTabChange={handleTabChange}
-        currentTab={currentTab}
-      />
-    );
+    return spaceId ? (
+      <AssistantSpaceIdProvider spaceId={spaceId}>
+        <AssistantSettingsManagement
+          selectedConversation={currentConversation}
+          dataViews={dataViews}
+          onTabChange={handleTabChange}
+          currentTab={currentTab}
+        />
+      </AssistantSpaceIdProvider>
+    ) : null;
   }
 
   return <></>;

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/stack_management/management_settings.tsx
@@ -11,12 +11,12 @@ import type { Conversation } from '@kbn/elastic-assistant';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { i18n } from '@kbn/i18n';
 import {
-  AssistantSpaceIdProvider,
   mergeBaseWithPersistedConversations,
   useAssistantContext,
   useFetchCurrentUserConversations,
   WELCOME_CONVERSATION_TITLE,
 } from '@kbn/elastic-assistant';
+import { AssistantSpaceIdProvider } from '@kbn/elastic-assistant/impl/assistant/use_space_aware_context';
 import { useConversation } from '@kbn/elastic-assistant/impl/assistant/use_conversation';
 import type { FetchConversationsResponse } from '@kbn/elastic-assistant/impl/assistant/api';
 import { SECURITY_AI_SETTINGS } from '@kbn/elastic-assistant/impl/assistant/settings/translations';


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/224127
Steps to reproduce: ([env](https://p.elstc.co/paste/dCC00dnn#LuamGjJXtPsgm8c0vixEsUsEifVy6RT21CsTv17YpNh))
1. Visit app/management/kibana/securityAiAssistantManagement?tab=knowledge_base
2. Observe that the knowledge base is not showed due to a client side error:

<img width="2557" alt="Screenshot 2025-06-24 at 09 56 13" src="https://github.com/user-attachments/assets/e69673cb-5f5b-4a8a-a729-05c82d48f9e1" />

Expected: https://www.elastic.co/docs/solutions/security/ai/ai-assistant-knowledge-base#_option_2_enable_knowledge_base_from_the_security_ai_settings

<img width="2558" alt="Screenshot 2025-06-24 at 11 15 23" src="https://github.com/user-attachments/assets/2b6e2614-038d-43b3-b18a-4554cba4ccce" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

