### PR TITLE
[Security Solution][Sourcerer] Cache spec to base calls

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/kuery/index.ts
@@ -12,7 +12,7 @@ import {
   FilterStateStore,
   buildEsQuery,
 } from '@kbn/es-query';
-import { get, isEmpty, memoize } from 'lodash/fp';
+import { get, isEmpty } from 'lodash/fp';
 import memoizeOne from 'memoize-one';
 import type { DataViewSpec } from '@kbn/data-plugin/common';
 import { prepareKQLParam } from '../../../../common/utils/kql';


### PR DESCRIPTION
## Summary

This PR adds an in-memory cache to spec-to-base calls, local tests show:

- Total time across all measures: 5.40ms without the cache for all the invocations, 
- Total time across all measures: **0.40ms with the cache enabled**

mind that this is for test data only with limited number of fields per data view
