### PR TITLE
[8.17] [Docs] Adds security advisory message to 8.18.3 and 8.17.8 (#225016)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -100,6 +100,8 @@ include::upgrade-notes.asciidoc[]
 
 The 8.17.8 release includes the following fixes.
 
+IMPORTANT: The 8.17.8 release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory for more details].
+
 [float]
 [[fixes-v8.17.8]]
 === Fixes


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.17`:
 - [[Docs] Adds security advisory message to 8.18.3 and 8.17.8 (#225016)](https://github.com/elastic/kibana/pull/225016)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2025-06-24T10:18:31Z","message":"[Docs] Adds security advisory message to 8.18.3 and 8.17.8 (#225016)\n\nThis PR adds a security advisory message and link to 8.18.3 and 8.17.8\nas requested by @ismisepaul\n\nThe change looks like this (changing the release version based on where\nthe message is added):\n<img width=\"862\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f12b8851-e24a-4f66-8a64-b5f30204df85\"\n/>","sha":"6c68f8a7eba9240f3e476dc73abf578ff174eb34","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:version","v8.19.0","v8.18.3","v8.17.8"],"title":"[Docs] Adds security advisory message to 8.18.3 and 8.17.8","number":225016,"url":"https://github.com/elastic/kibana/pull/225016","mergeCommit":{"message":"[Docs] Adds security advisory message to 8.18.3 and 8.17.8 (#225016)\n\nThis PR adds a security advisory message and link to 8.18.3 and 8.17.8\nas requested by @ismisepaul\n\nThe change looks like this (changing the release version based on where\nthe message is added):\n<img width=\"862\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f12b8851-e24a-4f66-8a64-b5f30204df85\"\n/>","sha":"6c68f8a7eba9240f3e476dc73abf578ff174eb34"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225016","number":225016,"mergeCommit":{"message":"[Docs] Adds security advisory message to 8.18.3 and 8.17.8 (#225016)\n\nThis PR adds a security advisory message and link to 8.18.3 and 8.17.8\nas requested by @ismisepaul\n\nThe change looks like this (changing the release version based on where\nthe message is added):\n<img width=\"862\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f12b8851-e24a-4f66-8a64-b5f30204df85\"\n/>","sha":"6c68f8a7eba9240f3e476dc73abf578ff174eb34"}},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->