### PR TITLE
[Fleet] Fix export CSV in Agent list

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/export_csv.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/export_csv.tsx
@@ -70,7 +70,6 @@ export function useExportCSV() {
     const sort = getSortConfig(sortField, sortOrder) as EsQuerySortValue[];
 
     const searchSource: SearchSourceFields = {
-      type: 'search',
       query: {
         query: '',
         language: 'kuery',


### PR DESCRIPTION
## Summary

Export CSV currently failing with the error `Unknown key for a VALUE_STRING in [type]`

<img width="1163" alt="image" src="https://github.com/user-attachments/assets/3935247e-adf3-49d2-aa9f-2ac561a7956e" />

To verify, try exporting in Agent list, and check that the CSV contains the expected rows.

<img width="1166" alt="image" src="https://github.com/user-attachments/assets/184976b7-2af5-4929-83e8-9b0cba9f6ae6" />
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/711737c8-d054-4fa3-93c5-8c9749b805fb" />






<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->