### PR TITLE
[ci] Silence SASS warnings

### DIFF
--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -224,6 +224,7 @@ export function getWebpackConfig(
                       includePaths: [Path.resolve(worker.repoRoot, 'node_modules')],
                       sourceMap: true,
                       quietDeps: true,
+                      silenceDeprecations: ['import', 'legacy-js-api'],
                     },
                   },
                 },


### PR DESCRIPTION
## Summary
Silences SASS module usage warnings around the deprecated `@import` statements.

While the sass/scss owner teams are migrating these usages, the dev server is clogged up with deprecation warnings. It's probably best to disable it, because it's annoying to everyone and not necessarily to the owners.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->