### PR TITLE
Update copy for bulk fill gaps UI

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
@@ -394,7 +394,7 @@ export const BULK_FILL_RULE_GAPS_CONFIRMATION_CONFIRM = i18n.translate(
 export const BULK_MANUAL_RULE_RUN_LIMIT_ERROR_TITLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkManualRuleRunLimitErrorMessage',
   {
-    defaultMessage: 'This action can only be applied',
+    defaultMessage: 'Cannot execute the bulk action',
   }
 );
 
@@ -410,6 +410,30 @@ export const BULK_MANUAL_RULE_RUN_LIMIT_ERROR_MESSAGE = (rulesCount: number) =>
 
 export const BULK_MANUAL_RULE_RUN_LIMIT_ERROR_CLOSE_BUTTON = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkManualRuleRunLimitErrorCloseButton',
+  {
+    defaultMessage: 'Close',
+  }
+);
+
+export const BULK_FILL_RULE_GAPS_LIMIT_ERROR_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkFillRuleGapsRuleLimitErrorMessage',
+  {
+    defaultMessage: 'Cannot execute the bulk action',
+  }
+);
+
+export const BULK_FILL_RULE_GAPS_LIMIT_ERROR_MESSAGE = (rulesCount: number) =>
+  i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkFillRuleGapsRuleLimitErrorTitle',
+    {
+      values: { rulesCount },
+      defaultMessage:
+        'Cannot schedule gap fills for more than {rulesCount, plural, =1 {# rule} other {# rules}}.',
+    }
+  );
+
+export const BULK_FILL_RULE_GAPS_LIMIT_ERROR_CLOSE_BUTTON = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkFillRuleGapsRuleLimitErrorCloseButton',
   {
     defaultMessage: 'Close',
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/bulk_fill_rule_gaps/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/bulk_fill_rule_gaps/index.tsx
@@ -42,7 +42,7 @@ const BulkFillRuleGapsModalComponent = ({
       <EuiCallOut
         size="s"
         iconType="warning"
-        title={i18n.BULK_FILL_RULE_GAPS_NOTIFIACTIONS_LIMITATIONS}
+        title={i18n.BULK_FILL_RULE_GAPS_NOTIFICATIONS_LIMITATIONS}
       />,
     ];
     if (rulesCount > 1) {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/bulk_fill_rule_gaps/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/bulk_fill_rule_gaps/translations.ts
@@ -37,7 +37,7 @@ export const BULK_FILL_RULE_GAPS_END_AT_TITLE = i18n.translate(
 export const BULK_FILL_RULE_GAPS_CONFIRM_BUTTON = i18n.translate(
   'xpack.securitySolution.bulkFillRuleGapsModal.confirmButton',
   {
-    defaultMessage: 'Run',
+    defaultMessage: 'Schedule gap fills',
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/bulk_fill_rule_gaps/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/bulk_fill_rule_gaps/translations.ts
@@ -69,7 +69,7 @@ export const BULK_FILL_RULE_GAPS_START_DATE_OUT_OF_RANGE_ERROR = (maxDaysLookbac
       'Rule gap fills cannot be scheduled earlier than {maxDaysLookback, plural, =1 {# day} other {# days}} ago',
   });
 
-export const BULK_FILL_RULE_GAPS_NOTIFIACTIONS_LIMITATIONS = i18n.translate(
+export const BULK_FILL_RULE_GAPS_NOTIFICATIONS_LIMITATIONS = i18n.translate(
   'xpack.securitySolution.bulkFillRuleGapsModal.notificationsLimitations',
   {
     defaultMessage:

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_limit_error_modal.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+} from '@elastic/eui';
+
+interface BulkManualRuleRunRulesLimitErrorModalProps {
+  onClose: () => void;
+  text: {
+    title: string,
+    message: string
+    closeButton: string
+  }
+}
+
+const BulkActionRuleLimitErrorModalComponent = ({
+  onClose,
+  text,
+}: BulkManualRuleRunRulesLimitErrorModalProps) => {
+  return (
+    <EuiModal onClose={onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>{text.title}</EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        {text.message}
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton onClick={onClose} fill>
+          {text.closeButton}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};
+
+export const BulkActionRuleLimitErrorModal = React.memo(
+  BulkActionRuleLimitErrorModalComponent
+);
+
+BulkActionRuleLimitErrorModal.displayName = 'BulkActionRuleLimitErrorModal';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_limit_error_modal.tsx
@@ -18,10 +18,10 @@ import {
 interface BulkManualRuleRunRulesLimitErrorModalProps {
   onClose: () => void;
   text: {
-    title: string,
-    message: string
-    closeButton: string
-  }
+    title: string;
+    message: string;
+    closeButton: string;
+  };
 }
 
 const BulkActionRuleLimitErrorModalComponent = ({
@@ -33,9 +33,7 @@ const BulkActionRuleLimitErrorModalComponent = ({
       <EuiModalHeader>
         <EuiModalHeaderTitle>{text.title}</EuiModalHeaderTitle>
       </EuiModalHeader>
-      <EuiModalBody>
-        {text.message}
-      </EuiModalBody>
+      <EuiModalBody>{text.message}</EuiModalBody>
       <EuiModalFooter>
         <EuiButton onClick={onClose} fill>
           {text.closeButton}
@@ -45,8 +43,6 @@ const BulkActionRuleLimitErrorModalComponent = ({
   );
 };
 
-export const BulkActionRuleLimitErrorModal = React.memo(
-  BulkActionRuleLimitErrorModalComponent
-);
+export const BulkActionRuleLimitErrorModal = React.memo(BulkActionRuleLimitErrorModalComponent);
 
 BulkActionRuleLimitErrorModal.displayName = 'BulkActionRuleLimitErrorModal';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_manual_rule_run_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_manual_rule_run_limit_error_modal.tsx
@@ -18,14 +18,12 @@ const text = {
   title: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_TITLE,
   message: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_MESSAGE(MAX_MANUAL_RULE_RUN_BULK_SIZE),
   closeButton: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_CLOSE_BUTTON,
-}
+};
 
 const BulkManualRuleRunLimitErrorModalComponent = ({
   onClose,
 }: BulkManualRuleRunRulesLimitErrorModalProps) => {
-  return (
-    <BulkActionRuleLimitErrorModal onClose={onClose} text={text} />
-  )
+  return <BulkActionRuleLimitErrorModal onClose={onClose} text={text} />;
 };
 
 export const BulkManualRuleRunLimitErrorModal = React.memo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_schedule_gap_fills_rule_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_schedule_gap_fills_rule_limit_error_modal.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { MAX_MANUAL_RULE_RUN_BULK_SIZE } from '../../../../../../common/constants';
+import { MAX_BULK_FILL_RULE_GAPS_BULK_SIZE } from '../../../../../../common/constants';
 import * as i18n from '../../../../common/translations';
 import { BulkActionRuleLimitErrorModal } from './bulk_action_rule_limit_error_modal';
 
@@ -15,12 +15,12 @@ interface BulkManualRuleRunRulesLimitErrorModalProps {
 }
 
 const text = {
-  title: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_TITLE,
-  message: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_MESSAGE(MAX_MANUAL_RULE_RUN_BULK_SIZE),
-  closeButton: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_CLOSE_BUTTON,
+  title: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_TITLE,
+  message: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_MESSAGE(MAX_BULK_FILL_RULE_GAPS_BULK_SIZE),
+  closeButton: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_CLOSE_BUTTON,
 }
 
-const BulkManualRuleRunLimitErrorModalComponent = ({
+const BulkFillRuleGapsRuleLimitErrorModalComponent = ({
   onClose,
 }: BulkManualRuleRunRulesLimitErrorModalProps) => {
   return (
@@ -28,8 +28,8 @@ const BulkManualRuleRunLimitErrorModalComponent = ({
   )
 };
 
-export const BulkManualRuleRunLimitErrorModal = React.memo(
-  BulkManualRuleRunLimitErrorModalComponent
+export const BulkFillRuleGapsRuleLimitErrorModal = React.memo(
+  BulkFillRuleGapsRuleLimitErrorModalComponent
 );
 
-BulkManualRuleRunLimitErrorModal.displayName = 'BulkManualRuleRunLimitErrorModal';
+BulkFillRuleGapsRuleLimitErrorModal.displayName = 'BulkFillRuleGapsRuleLimitErrorModal';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_schedule_gap_fills_rule_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_schedule_gap_fills_rule_limit_error_modal.tsx
@@ -18,14 +18,12 @@ const text = {
   title: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_TITLE,
   message: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_MESSAGE(MAX_BULK_FILL_RULE_GAPS_BULK_SIZE),
   closeButton: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_CLOSE_BUTTON,
-}
+};
 
 const BulkFillRuleGapsRuleLimitErrorModalComponent = ({
   onClose,
 }: BulkManualRuleRunRulesLimitErrorModalProps) => {
-  return (
-    <BulkActionRuleLimitErrorModal onClose={onClose} text={text} />
-  )
+  return <BulkActionRuleLimitErrorModal onClose={onClose} text={text} />;
 };
 
 export const BulkFillRuleGapsRuleLimitErrorModal = React.memo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
@@ -778,6 +778,7 @@ export const useBulkActions = ({
       showBulkDuplicateConfirmation,
       showManualRuleRunConfirmation,
       showManualRuleRunLimitError,
+      showBulkFillRuleGapsRuleLimitError,
       clearRulesSelection,
       confirmDeletion,
       bulkExport,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
@@ -13,7 +13,7 @@ import { toMountPoint } from '@kbn/react-kibana-mount';
 import React, { useCallback, useMemo } from 'react';
 import { BulkFillRuleGapsEventTypes } from '../../../../../common/lib/telemetry/events/bulk_fill_rule_gaps/types';
 import { ML_RULES_UNAVAILABLE } from './translations';
-import { MAX_MANUAL_RULE_RUN_BULK_SIZE } from '../../../../../../common/constants';
+import { MAX_BULK_FILL_RULE_GAPS_BULK_SIZE, MAX_MANUAL_RULE_RUN_BULK_SIZE } from '../../../../../../common/constants';
 import type { TimeRange } from '../../../../rule_gaps/types';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
@@ -65,6 +65,7 @@ interface UseBulkActionsArgs {
   showManualRuleRunConfirmation: () => Promise<TimeRange | null>;
   showBulkFillRuleGapsConfirmation: () => Promise<TimeRange | null>;
   showManualRuleRunLimitError: () => void;
+  showBulkFillRuleGapsRuleLimitError: () => void;
   completeBulkEditForm: (
     bulkActionEditType: BulkActionEditType
   ) => Promise<BulkActionEditPayload | null>;
@@ -79,6 +80,7 @@ export const useBulkActions = ({
   showManualRuleRunConfirmation,
   showBulkFillRuleGapsConfirmation,
   showManualRuleRunLimitError,
+  showBulkFillRuleGapsRuleLimitError,
   completeBulkEditForm,
   executeBulkActionsDryRun,
 }: UseBulkActionsArgs) => {
@@ -313,8 +315,8 @@ export const useBulkActions = ({
 
         setIsPreflightInProgress(false);
 
-        if ((dryRunResult?.succeededRulesCount ?? 0) > MAX_MANUAL_RULE_RUN_BULK_SIZE) {
-          showManualRuleRunLimitError();
+        if ((dryRunResult?.succeededRulesCount ?? 0) > MAX_BULK_FILL_RULE_GAPS_BULK_SIZE) {
+          showBulkFillRuleGapsRuleLimitError();
           return;
         }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
@@ -13,7 +13,10 @@ import { toMountPoint } from '@kbn/react-kibana-mount';
 import React, { useCallback, useMemo } from 'react';
 import { BulkFillRuleGapsEventTypes } from '../../../../../common/lib/telemetry/events/bulk_fill_rule_gaps/types';
 import { ML_RULES_UNAVAILABLE } from './translations';
-import { MAX_BULK_FILL_RULE_GAPS_BULK_SIZE, MAX_MANUAL_RULE_RUN_BULK_SIZE } from '../../../../../../common/constants';
+import {
+  MAX_BULK_FILL_RULE_GAPS_BULK_SIZE,
+  MAX_MANUAL_RULE_RUN_BULK_SIZE,
+} from '../../../../../../common/constants';
 import type { TimeRange } from '../../../../rule_gaps/types';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_tables.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_tables.tsx
@@ -50,6 +50,7 @@ import { BulkEditDeleteAlertSuppressionConfirmation } from './bulk_actions/bulk_
 import { BulkActionEditTypeEnum } from '../../../../../common/api/detection_engine/rule_management';
 import { BulkFillRuleGapsModal } from '../../../rule_gaps/components/bulk_fill_rule_gaps';
 import { useBulkFillRuleGapsConfirmation } from '../../../rule_gaps/components/bulk_fill_rule_gaps/use_bulk_fill_rule_gaps_confirmation';
+import { BulkFillRuleGapsRuleLimitErrorModal } from './bulk_actions/bulk_schedule_gap_fills_rule_limit_error_modal';
 
 const INITIAL_SORT_FIELD = 'enabled';
 
@@ -143,6 +144,12 @@ export const RulesTables = React.memo<RulesTableProps>(({ selectedTab }) => {
     hideManualRuleRunLimitError,
   ] = useBoolState();
 
+  const [
+    isBulkFillRuleGapsRuleLimitErrorVisible,
+    showBulkFillRuleGapsRuleLimitError,
+    hideBulkFillRuleGapsRuleLimitError,
+  ] = useBoolState();
+
   const {
     bulkEditActionType,
     isBulkEditFlyoutVisible,
@@ -161,6 +168,7 @@ export const RulesTables = React.memo<RulesTableProps>(({ selectedTab }) => {
     showManualRuleRunConfirmation,
     showBulkFillRuleGapsConfirmation,
     showManualRuleRunLimitError,
+    showBulkFillRuleGapsRuleLimitError,
     completeBulkEditForm,
     executeBulkActionsDryRun,
   });
@@ -316,6 +324,9 @@ export const RulesTables = React.memo<RulesTableProps>(({ selectedTab }) => {
       )}
       {isManualRuleRunLimitErrorVisible && (
         <BulkManualRuleRunLimitErrorModal onClose={hideManualRuleRunLimitError} />
+      )}
+      {isBulkFillRuleGapsRuleLimitErrorVisible && (
+        <BulkFillRuleGapsRuleLimitErrorModal onClose={hideBulkFillRuleGapsRuleLimitError} />
       )}
       {isBulkActionConfirmationVisible && bulkAction && (
         <BulkActionDryRunConfirmation


### PR DESCRIPTION
## Summary

These are small copy changes in two modals for the bulk schedule gap fills feature.

## Rule limitation modal
Before
![image](https://github.com/user-attachments/assets/32bbf714-fab9-408b-8f84-f7dd9999f866)

After
![image](https://github.com/user-attachments/assets/978740f3-5a33-492b-ba2c-3eb357b92384)

## Time range selection modal
Before
![image](https://github.com/user-attachments/assets/18d61683-a109-421d-9010-53fe0db50c29)

After
![image](https://github.com/user-attachments/assets/c3a79266-959c-4473-ab3f-d574211c3b3e)

Additionally I have also made a small change to the rule limitation modal for manual runs
Before
![image](https://github.com/user-attachments/assets/6d7fc487-016e-4331-9d53-89a4da5e6cd6)

After
![image](https://github.com/user-attachments/assets/226b6c7f-ee8c-46eb-8ad5-21272e25c9b0)

## How to test?
Generate 101 rules using [this tool](https://github.com/elastic/security-documents-generator).
`yarn start rules --rules 100 -c -i"5m"`

### Rules limitation modal
1. Go to the rules page
2. Trigger the rules limitation modal by clicking on "Select all 101 rules"
3. Then click on Bulk actions > Manual run and Bulk actions > fill gaps respectively.

### Time range selection modal for bulk gap fills
1. Go to the rules page
2. Select a couple of rules
3. Then click on Bulk actions > fill gaps

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->