### PR TITLE
[EBT] Add `Meta` description for EBT metrics on management pages

### DIFF
--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
@@ -10,7 +10,16 @@
 type ApmPageId = 'services' | 'traces' | 'dependencies';
 type InfraPageId = 'hosts';
 type OnboardingPageId = 'onboarding';
+type AlertingPageId = 'alerts';
+type SloPageId = 'slos';
+type SyntheticsPageId = 'synthetics';
 
-export type Key = `${ApmPageId}` | `${InfraPageId}` | `${OnboardingPageId}`;
+export type Key =
+  | `${ApmPageId}`
+  | `${InfraPageId}`
+  | `${OnboardingPageId}`
+  | `${AlertingPageId}`
+  | `${SloPageId}`
+  | `${SyntheticsPageId}`;
 
 export type DescriptionWithPrefix = `[ttfmp_${Key}] ${string}`;

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
@@ -11,6 +11,7 @@ type ApmPageId = 'services' | 'traces' | 'dependencies';
 type InfraPageId = 'hosts';
 type OnboardingPageId = 'onboarding';
 type AlertingPageId = 'alerts';
+type AlertDetailsPageId = 'alert_details';
 type SloPageId = 'slos';
 type SyntheticsPageId = 'synthetics';
 
@@ -19,6 +20,7 @@ export type Key =
   | `${InfraPageId}`
   | `${OnboardingPageId}`
   | `${AlertingPageId}`
+  | `${AlertDetailsPageId}`
   | `${SloPageId}`
   | `${SyntheticsPageId}`;
 

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/index.tsx
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/index.tsx
@@ -24,4 +24,5 @@ function dynamic<TElement extends React.ComponentType<any>, TRef = {}>(loader: L
 export { usePerformanceContext } from './context/use_performance_context';
 export { perfomanceMarkers } from './performance_markers';
 export { usePageReady } from './context/use_page_ready';
+export { type Meta } from './context/performance_context';
 export const PerformanceContextProvider = dynamic(() => import('./context/performance_context'));

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -197,7 +197,7 @@ export function AlertDetails() {
     isReady: !isLoading && !!alertDetail && activeTabId === 'overview',
     meta: {
       description:
-        '[ttfmp_alerts] The Observability Alert Details overview page has loaded successfully',
+        '[ttfmp_alert_details] The Observability Alert Details overview page has loaded successfully',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -195,6 +195,10 @@ export function AlertDetails() {
   usePageReady({
     isRefreshing: isLoading,
     isReady: !isLoading && !!alertDetail && activeTabId === 'overview',
+    meta: {
+      description:
+        '[ttfmp_services] The Observability Alert Details overview page has loaded successfully',
+    },
   });
 
   if (isLoading) {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -197,7 +197,7 @@ export function AlertDetails() {
     isReady: !isLoading && !!alertDetail && activeTabId === 'overview',
     meta: {
       description:
-        '[ttfmp_services] The Observability Alert Details overview page has loaded successfully',
+        '[ttfmp_alerts] The Observability Alert Details overview page has loaded successfully',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -197,7 +197,7 @@ export function AlertDetails() {
     isReady: !isLoading && !!alertDetail && activeTabId === 'overview',
     meta: {
       description:
-        '[ttfmp_alert_details] The Observability Alert Details overview page has loaded successfully',
+        '[ttfmp_alert_details] The Observability Alert Details overview page has loaded successfully.',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
@@ -136,7 +136,7 @@ function InternalAlertsPage() {
     meta: {
       rangeFrom: alertSearchBarStateProps.rangeFrom,
       rangeTo: alertSearchBarStateProps.rangeTo,
-      description: '[ttfmp_services] The Observability Alerts page has loaded a table of alerts.',
+      description: '[ttfmp_alerts] The Observability Alerts page has loaded a table of alerts.',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
@@ -136,6 +136,7 @@ function InternalAlertsPage() {
     meta: {
       rangeFrom: alertSearchBarStateProps.rangeFrom,
       rangeTo: alertSearchBarStateProps.rangeTo,
+      description: '[ttfmp_services] The Observability Alerts page has loaded a table of alerts.',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/slo_details.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/slo_details.tsx
@@ -109,7 +109,7 @@ export function SloDetailsPage() {
     isReady: !isLoading && slo !== undefined,
     isRefreshing: isRefetching,
     meta: {
-      description: '[ttfmp_services] The SLO details page has loaded and SLO data is present',
+      description: '[ttfmp_slos] The SLO details page has loaded and SLO data is present',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/slo_details.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/slo_details.tsx
@@ -109,7 +109,7 @@ export function SloDetailsPage() {
     isReady: !isLoading && slo !== undefined,
     isRefreshing: isRefetching,
     meta: {
-      description: '[ttfmp_slos] The SLO details page has loaded and SLO data is present',
+      description: '[ttfmp_slos] The SLO details page has loaded and SLO data is present.',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/slo_details.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/slo_details.tsx
@@ -108,6 +108,9 @@ export function SloDetailsPage() {
   usePageReady({
     isReady: !isLoading && slo !== undefined,
     isRefreshing: isRefetching,
+    meta: {
+      description: '[ttfmp_services] The SLO details page has loaded and SLO data is present',
+    },
   });
 
   useBreadcrumbs(getBreadcrumbs(basePath, slo), { serverless });

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
@@ -82,6 +82,9 @@ export function SloList() {
   usePageReady({
     isReady: !isLoading && sloList !== undefined,
     isRefreshing: isLoading,
+    meta: {
+      description: '[ttfmp_services] The SLOs list has loaded and SLO data is present',
+    },
   });
 
   return (

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
@@ -83,7 +83,7 @@ export function SloList() {
     isReady: !isLoading && sloList !== undefined,
     isRefreshing: isLoading,
     meta: {
-      description: '[ttfmp_services] The SLOs list has loaded and SLO data is present',
+      description: '[ttfmp_slos] The SLOs list has loaded and SLO data is present',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
@@ -82,8 +82,12 @@ export function SloList() {
   usePageReady({
     isReady: !isLoading && sloList !== undefined,
     isRefreshing: isLoading,
+    customMetrics: {
+      key1: 'slo_list_count',
+      value1: sloList?.total ?? 0,
+    },
     meta: {
-      description: '[ttfmp_slos] The SLOs list has loaded and SLO data is present',
+      description: '[ttfmp_slos] The SLOs list has finished loading.',
     },
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
@@ -40,7 +40,7 @@ export const MonitorListContainer = ({
   const { status: overviewStatus } = useSelector(selectOverviewStatus);
 
   useSyntheticsPageReady({
-    meta: { description: '[ttfmp_services] Synthetics monitor list has loaded' },
+    meta: { description: '[ttfmp_synthetics] Synthetics monitor list has loaded' },
   });
 
   // TODO: Display inline errors in the management table

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
@@ -39,7 +39,9 @@ export const MonitorListContainer = ({
 
   const { status: overviewStatus } = useSelector(selectOverviewStatus);
 
-  useSyntheticsPageReady();
+  useSyntheticsPageReady({
+    meta: { description: '[ttfmp_services] Synthetics monitor list has loaded' },
+  });
 
   // TODO: Display inline errors in the management table
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
@@ -40,7 +40,7 @@ export const MonitorListContainer = ({
   const { status: overviewStatus } = useSelector(selectOverviewStatus);
 
   useSyntheticsPageReady({
-    meta: { description: '[ttfmp_synthetics] Synthetics monitor list has loaded' },
+    meta: { description: '[ttfmp_synthetics] Synthetics monitor list has loaded.' },
   });
 
   // TODO: Display inline errors in the management table

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -43,7 +43,7 @@ export const OverviewPage: React.FC = () => {
   const { loading: locationsLoading, locationsLoaded } = useSelector(selectServiceLocationsState);
 
   useSyntheticsPageReady({
-    meta: { description: '[ttfmp_synthetics] Synthetics overview page has loaded monitor data' },
+    meta: { description: '[ttfmp_synthetics] Synthetics overview page has loaded monitor data.' },
   });
 
   useEffect(() => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -43,7 +43,7 @@ export const OverviewPage: React.FC = () => {
   const { loading: locationsLoading, locationsLoaded } = useSelector(selectServiceLocationsState);
 
   useSyntheticsPageReady({
-    meta: { description: '[ttfmp_services] Synthetics overview page has loaded monitor data' },
+    meta: { description: '[ttfmp_synthetics] Synthetics overview page has loaded monitor data' },
   });
 
   useEffect(() => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -42,7 +42,9 @@ export const OverviewPage: React.FC = () => {
 
   const { loading: locationsLoading, locationsLoaded } = useSelector(selectServiceLocationsState);
 
-  useSyntheticsPageReady();
+  useSyntheticsPageReady({
+    meta: { description: '[ttfmp_services] Synthetics overview page has loaded monitor data' },
+  });
 
   useEffect(() => {
     if (!locationsLoading && !locationsLoaded) {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_page_ready.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_page_ready.ts
@@ -6,10 +6,10 @@
  */
 
 import { useDispatch, useSelector } from 'react-redux';
-import { usePageReady } from '@kbn/ebt-tools';
+import { usePageReady, type Meta } from '@kbn/ebt-tools';
 import { initialLoadReported, selectOverviewStatus } from '../state/overview_status';
 
-export const useSyntheticsPageReady = () => {
+export const useSyntheticsPageReady = (props?: { meta?: Meta }) => {
   const {
     loaded,
     isInitialLoad,
@@ -29,5 +29,6 @@ export const useSyntheticsPageReady = () => {
     // This will collect the metric even when we are periodically refreshing the data in the background
     // and not only when the user decides to refresh the data, the action is the same
     isRefreshing: loaded && isLoadingOverviewStatus,
+    meta: props?.meta,
   });
 };


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/observability-dev/issues/4556.

This PR will amend the existing EBT `onPageReady` tracking for TTFCP with some descriptions to help consumers of the telemetry data understand the context around what we are tracking for this timing data.

Also exports the `Meta` type for re-use in a Synthetics-specific implementation that needs to accept this parameter.