### PR TITLE
[8.18] [Security Solution] Enforce sending the request to API even if offline, for air-gapped environment. (#220510)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_context/query_client.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_context/query_client.ts
@@ -7,4 +7,13 @@
 
 import { QueryClient } from '@tanstack/react-query';
 
-export const casesQueryClient = new QueryClient();
+export const casesQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      networkMode: 'always',
+    },
+    mutations: {
+      networkMode: 'always',
+    },
+  },
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/app.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/app.tsx
@@ -65,7 +65,16 @@ import { ErrorLayout, PermissionsError } from './layouts';
 
 const FEEDBACK_URL = 'https://ela.st/fleet-feedback';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      networkMode: 'always',
+    },
+    mutations: {
+      networkMode: 'always',
+    },
+  },
+});
 
 export const WithPermissionsAndSetup = memo<{ children?: React.ReactNode }>(({ children }) => {
   useBreadcrumbs('base');

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/app.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/app.tsx
@@ -43,7 +43,16 @@ import { IntegrationsHeader } from './components/header';
 import { AgentEnrollmentFlyout } from './components';
 import { ReadOnlyContextProvider } from './hooks/use_read_only_context';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      networkMode: 'always',
+    },
+    mutations: {
+      networkMode: 'always',
+    },
+  },
+});
 
 const EmptyContext = () => <></>;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/query_client/query_client_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/query_client/query_client_provider.tsx
@@ -25,7 +25,11 @@ export class SecuritySolutionQueryClient extends QueryClient {
           refetchOnWindowFocus: false,
           refetchOnMount: true,
           keepPreviousData: true,
-          ...(options?.defaultOptions?.queries ?? {}),
+          ...(options?.defaultOptions?.queries ?? { networkMode: 'always' }),
+        },
+        mutations: {
+          networkMode: 'always',
+          ...(options?.defaultOptions?.mutations ?? { networkMode: 'always' }),
         },
       },
     };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Solution] Enforce sending the request to API even if offline, for air-gapped environment. (#220510)](https://github.com/elastic/kibana/pull/220510)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jacek Kolezynski","email":"jacek.kolezynski@elastic.co"},"sourceCommit":{"committedDate":"2025-06-10T10:14:45Z","message":"[Security Solution] Enforce sending the request to API even if offline, for air-gapped environment. (#220510)\n\n**Resolves: #181808**\n\n## Summary\n\nI am fixing the issue of the Rules and Alerts tabs in Security, as well\nas the Fleet tab in Management, that gets stalled in air-gapped\nenvironment. I am doing so by enforcing the request to be sent to the\nAPI even when offline.\n\n### Historical context:\nDuring investigation of the original issue #181808 I proved that Kibana\ndoesn't try to reach to EPR in the air-gapped environment (that is, with\nthe `xpack.fleet.isAirGapped: true` flag, and WIFI being turned ON). I\ncommented this\n[here](https://github.com/elastic/kibana/issues/181808#issuecomment-2829911511)\nand we closed the issue. However, @111andre111 reached out to us saying\nthat this wasn't enough, as the real issue remains, that is, Kibana\ndoesn't behave properly when:\n- `xpack.fleet.isAirGapped` flag is set to `true`\n- there is no Internet connection (WIFI off or cable physically\ndisconnected)\n\nThat's why we reopened the ticket and I restarted the investigation. \nMy first observation was that when I turn off the WIFI, I cannot see\nrequests to the API being sent in the Network tab in Dev Tools, most\nimportantly to the `_bootstrap` endpoint at the first entrance to the\nSolution app, and other endpoints later. I searched that the browser\ndiscovers being offline and suppresses such calls. When WIFI is back ON,\nthen the browser sends these requests. That was exactly what I saw in\nthe Network tab.\nI searched and found an option to force browser to always send the\nrequest, regardless of what it thinks about connectivity. Such option,\n`networkMode: 'always'`, can be added to TanStackQuery client.\n\nI started working on adding this option to occurences of `useQuery` and\n`useMutation`, and immediately sounded success, as the behavior was\ncorrect. However, @xcrzx rigthfully pointed out, that it would be much\nbetter to only add it to one place, that is the configuration of the\nQueryClient. I did it, and to my surprise, the problem returned.\nI noticed that adding this option to the QueryClient in Fleet solved the\nproblem in the Fleet tab immediately, but adding this option to the\n`SecuritySolutionQueryClient` does nothing, like it was completely\nignored.\nI searched different options and spent two more days debugging the\nproblem, but then, when paired up again with Dmitrii, he found that the\n`SecuritySolutionQueryClient` is overshadowed by some other QueryClient\npresent in the stack of components much below, the `CasesContext`. That\ndiscovery enabled me to add this new setting to the other QueryClient,\nand this fixes the issue. However, we think that it will be worth\ninvestigating why we need this second context, as the situation when one\nQueryClient overshadows another one, smells badly and may be a source of\nother issues as well (I will reach out to the team responsible for the\nCasesContext and ask if we can unify this somehow).\n\n## BEFORE\n\n\nhttps://github.com/user-attachments/assets/662dab73-b1bd-4d6b-9d15-c35efab679c6\n\n## AFTER\n\n\nhttps://github.com/user-attachments/assets/b905bde0-150d-478d-9734-9003fb5bcf66\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ad35a4a33c3bd4d4f4e33acff20f4ebaa3242ce","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Fleet","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","ci:build-all-platforms","ci:build-os-packages","Feature:Prebuilt Detection Rules","ci:build-cloud-image","backport:version","v9.1.0","v8.19.0","v9.0.3"],"title":"[Security Solution] Enforce sending the request to API even if offline, for air-gapped environment.","number":220510,"url":"https://github.com/elastic/kibana/pull/220510","mergeCommit":{"message":"[Security Solution] Enforce sending the request to API even if offline, for air-gapped environment. (#220510)\n\n**Resolves: #181808**\n\n## Summary\n\nI am fixing the issue of the Rules and Alerts tabs in Security, as well\nas the Fleet tab in Management, that gets stalled in air-gapped\nenvironment. I am doing so by enforcing the request to be sent to the\nAPI even when offline.\n\n### Historical context:\nDuring investigation of the original issue #181808 I proved that Kibana\ndoesn't try to reach to EPR in the air-gapped environment (that is, with\nthe `xpack.fleet.isAirGapped: true` flag, and WIFI being turned ON). I\ncommented this\n[here](https://github.com/elastic/kibana/issues/181808#issuecomment-2829911511)\nand we closed the issue. However, @111andre111 reached out to us saying\nthat this wasn't enough, as the real issue remains, that is, Kibana\ndoesn't behave properly when:\n- `xpack.fleet.isAirGapped` flag is set to `true`\n- there is no Internet connection (WIFI off or cable physically\ndisconnected)\n\nThat's why we reopened the ticket and I restarted the investigation. \nMy first observation was that when I turn off the WIFI, I cannot see\nrequests to the API being sent in the Network tab in Dev Tools, most\nimportantly to the `_bootstrap` endpoint at the first entrance to the\nSolution app, and other endpoints later. I searched that the browser\ndiscovers being offline and suppresses such calls. When WIFI is back ON,\nthen the browser sends these requests. That was exactly what I saw in\nthe Network tab.\nI searched and found an option to force browser to always send the\nrequest, regardless of what it thinks about connectivity. Such option,\n`networkMode: 'always'`, can be added to TanStackQuery client.\n\nI started working on adding this option to occurences of `useQuery` and\n`useMutation`, and immediately sounded success, as the behavior was\ncorrect. However, @xcrzx rigthfully pointed out, that it would be much\nbetter to only add it to one place, that is the configuration of the\nQueryClient. I did it, and to my surprise, the problem returned.\nI noticed that adding this option to the QueryClient in Fleet solved the\nproblem in the Fleet tab immediately, but adding this option to the\n`SecuritySolutionQueryClient` does nothing, like it was completely\nignored.\nI searched different options and spent two more days debugging the\nproblem, but then, when paired up again with Dmitrii, he found that the\n`SecuritySolutionQueryClient` is overshadowed by some other QueryClient\npresent in the stack of components much below, the `CasesContext`. That\ndiscovery enabled me to add this new setting to the other QueryClient,\nand this fixes the issue. However, we think that it will be worth\ninvestigating why we need this second context, as the situation when one\nQueryClient overshadows another one, smells badly and may be a source of\nother issues as well (I will reach out to the team responsible for the\nCasesContext and ask if we can unify this somehow).\n\n## BEFORE\n\n\nhttps://github.com/user-attachments/assets/662dab73-b1bd-4d6b-9d15-c35efab679c6\n\n## AFTER\n\n\nhttps://github.com/user-attachments/assets/b905bde0-150d-478d-9734-9003fb5bcf66\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ad35a4a33c3bd4d4f4e33acff20f4ebaa3242ce"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220510","number":220510,"mergeCommit":{"message":"[Security Solution] Enforce sending the request to API even if offline, for air-gapped environment. (#220510)\n\n**Resolves: #181808**\n\n## Summary\n\nI am fixing the issue of the Rules and Alerts tabs in Security, as well\nas the Fleet tab in Management, that gets stalled in air-gapped\nenvironment. I am doing so by enforcing the request to be sent to the\nAPI even when offline.\n\n### Historical context:\nDuring investigation of the original issue #181808 I proved that Kibana\ndoesn't try to reach to EPR in the air-gapped environment (that is, with\nthe `xpack.fleet.isAirGapped: true` flag, and WIFI being turned ON). I\ncommented this\n[here](https://github.com/elastic/kibana/issues/181808#issuecomment-2829911511)\nand we closed the issue. However, @111andre111 reached out to us saying\nthat this wasn't enough, as the real issue remains, that is, Kibana\ndoesn't behave properly when:\n- `xpack.fleet.isAirGapped` flag is set to `true`\n- there is no Internet connection (WIFI off or cable physically\ndisconnected)\n\nThat's why we reopened the ticket and I restarted the investigation. \nMy first observation was that when I turn off the WIFI, I cannot see\nrequests to the API being sent in the Network tab in Dev Tools, most\nimportantly to the `_bootstrap` endpoint at the first entrance to the\nSolution app, and other endpoints later. I searched that the browser\ndiscovers being offline and suppresses such calls. When WIFI is back ON,\nthen the browser sends these requests. That was exactly what I saw in\nthe Network tab.\nI searched and found an option to force browser to always send the\nrequest, regardless of what it thinks about connectivity. Such option,\n`networkMode: 'always'`, can be added to TanStackQuery client.\n\nI started working on adding this option to occurences of `useQuery` and\n`useMutation`, and immediately sounded success, as the behavior was\ncorrect. However, @xcrzx rigthfully pointed out, that it would be much\nbetter to only add it to one place, that is the configuration of the\nQueryClient. I did it, and to my surprise, the problem returned.\nI noticed that adding this option to the QueryClient in Fleet solved the\nproblem in the Fleet tab immediately, but adding this option to the\n`SecuritySolutionQueryClient` does nothing, like it was completely\nignored.\nI searched different options and spent two more days debugging the\nproblem, but then, when paired up again with Dmitrii, he found that the\n`SecuritySolutionQueryClient` is overshadowed by some other QueryClient\npresent in the stack of components much below, the `CasesContext`. That\ndiscovery enabled me to add this new setting to the other QueryClient,\nand this fixes the issue. However, we think that it will be worth\ninvestigating why we need this second context, as the situation when one\nQueryClient overshadows another one, smells badly and may be a source of\nother issues as well (I will reach out to the team responsible for the\nCasesContext and ask if we can unify this somehow).\n\n## BEFORE\n\n\nhttps://github.com/user-attachments/assets/662dab73-b1bd-4d6b-9d15-c35efab679c6\n\n## AFTER\n\n\nhttps://github.com/user-attachments/assets/b905bde0-150d-478d-9734-9003fb5bcf66\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ad35a4a33c3bd4d4f4e33acff20f4ebaa3242ce"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/223204","number":223204,"state":"MERGED","mergeCommit":{"sha":"dfad25f66d859c35095d09d5ab832746d1c9fba2","message":"[8.19] [Security Solution] Enforce sending the request to API even if offline, for air-gapped environment. (#220510) (#223204)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Enforce sending the request to API even if\noffline, for air-gapped environment.\n(#220510)](https://github.com/elastic/kibana/pull/220510)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jacek Kolezynski <jacek.kolezynski@elastic.co>"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/223205","number":223205,"state":"MERGED","mergeCommit":{"sha":"0af79efd1ddde344765e2c403e104517d31fe067","message":"[9.0] [Security Solution] Enforce sending the request to API even if offline, for air-gapped environment. (#220510) (#223205)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution] Enforce sending the request to API even if\noffline, for air-gapped environment.\n(#220510)](https://github.com/elastic/kibana/pull/220510)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jacek Kolezynski <jacek.kolezynski@elastic.co>"}}]}] BACKPORT-->