### PR TITLE
[One Discover][Security Solution] Replace the use of Ecsflat with fieldsMetadata

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/src/field_constants.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/field_constants.ts
@@ -16,6 +16,7 @@ export const ERROR_MESSAGE_FIELD = 'error.message';
 export const EVENT_ORIGINAL_FIELD = 'event.original';
 export const EVENT_OUTCOME_FIELD = 'event.outcome';
 export const INDEX_FIELD = '_index';
+export const EVENT_CATEGORY_FIELD = 'event.category';
 
 // Trace fields
 export const TRACE_ID_FIELD = 'trace.id';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
@@ -9,7 +9,7 @@
 
 import React, { useMemo, useState } from 'react';
 import type { FC, PropsWithChildren } from 'react';
-import { getFieldValue } from '@kbn/discover-utils';
+import { fieldConstants, getFieldValue } from '@kbn/discover-utils';
 import type { DocViewerComponent } from '@kbn/unified-doc-viewer/src/services/types';
 import {
   EuiTitle,
@@ -19,6 +19,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
+  EuiSkeletonText,
 } from '@elastic/eui';
 import * as i18n from '../translations';
 import { getSecurityTimelineRedirectUrl } from '../utils';
@@ -62,10 +63,16 @@ export const ExpandableSection: FC<PropsWithChildren<{ title: string }>> = ({
 export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
   const {
     application: { getUrlForApp },
+    fieldsMetadata,
   } = useDiscoverServices();
 
   const timelinesURL = getUrlForApp('securitySolutionUI', {
     path: 'alerts',
+  });
+
+  const result = fieldsMetadata?.useFieldsMetadata({
+    attributes: ['allowed_values', 'name', 'flat_name'],
+    fieldNames: [fieldConstants.EVENT_CATEGORY_FIELD],
   });
 
   const reason = useMemo(() => getFieldValue(hit, 'kibana.alert.reason') as string, [hit]);
@@ -100,9 +107,18 @@ export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
     >
       <EuiFlexItem>
         <ExpandableSection title={i18n.aboutSectionTitle}>
-          <EuiText size="s" data-test-subj="about">
-            {getEcsAllowedValueDescription(eventCategory)}
-          </EuiText>
+          {result?.loading ? (
+            <EuiSkeletonText
+              lines={2}
+              size={'s'}
+              isLoading={result?.loading}
+              contentAriaLabel="Demo skeleton text"
+            />
+          ) : (
+            <EuiText size="s" data-test-subj="about">
+              {getEcsAllowedValueDescription(result?.fieldsMetadata, eventCategory)}
+            </EuiText>
+          )}
         </ExpandableSection>
       </EuiFlexItem>
       {description ? (

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
@@ -112,7 +112,7 @@ export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
               lines={2}
               size={'s'}
               isLoading={result?.loading}
-              contentAriaLabel="Demo skeleton text"
+              contentAriaLabel={i18n.ecsDescriptionLoadingAriaLable}
             />
           ) : (
             <EuiText size="s" data-test-subj="about">

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/translations.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/translations.ts
@@ -54,3 +54,10 @@ export const reasonSectionTitle = i18n.translate(
     defaultMessage: 'Reason',
   }
 );
+
+export const ecsDescriptionLoadingAriaLable = i18n.translate(
+  'discover.profile.security.flyout.ecsDescriptionLoadingAriaLabel',
+  {
+    defaultMessage: 'Loading ECS description',
+  }
+);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/ecs_description.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/ecs_description.ts
@@ -7,9 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EcsFlat } from '@elastic/ecs';
+import type { UseFieldsMetadataHook } from '@kbn/fields-metadata-plugin/public/hooks/use_fields_metadata';
 import * as i18n from '../translations';
-export type EcsAllowedValue = (typeof EcsFlat)['event.category']['allowed_values'][0];
 
 /**
  * Helper function to return the description of an allowed value of the specified field
@@ -17,8 +16,11 @@ export type EcsAllowedValue = (typeof EcsFlat)['event.category']['allowed_values
  * @param value
  * @returns ecs description of the value
  */
-export const getEcsAllowedValueDescription = (value: string): string => {
-  const allowedValues: EcsAllowedValue[] = EcsFlat['event.category']?.allowed_values ?? [];
+export const getEcsAllowedValueDescription = (
+  fieldsMetadata: ReturnType<UseFieldsMetadataHook>['fieldsMetadata'] = {},
+  value: string
+): string => {
+  const allowedValues = fieldsMetadata['event.category']?.allowed_values ?? [];
   const result =
     allowedValues?.find((item) => item.name === value)?.description ?? i18n.noEcsDescriptionReason;
   return result;


### PR DESCRIPTION
## Summary

As per [comments](https://github.com/elastic/kibana/pull/204756#discussion_r2162038673) by @davismcphee , this PR removes  the usage of `EcsFlat` and replaces it with `fieldsMetadata`.


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->