### PR TITLE
[7.17][build/docker] Upgrade Ubuntu to 24.04 (#222244)

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -38,7 +38,7 @@ export async function runDockerGenerator(
   }
 ) {
   let baseOSImage = '';
-  if (flags.ubuntu) baseOSImage = 'ubuntu:20.04';
+  if (flags.ubuntu) baseOSImage = 'ubuntu:24.04';
   if (flags.ubi) baseOSImage = 'redhat/ubi9-minimal:latest';
 
   let imageFlavor = '';

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -134,8 +134,10 @@ RUN chmod g+ws /usr/share/kibana && \
 # Remove the suid bit everywhere to mitigate "Stack Clash"
 RUN find / -xdev -perm -4000 -exec chmod u-s {} +
 
+{{! Ubuntu 24 containers include ubuntu:1000:1000 as part of a non-root standardization effort }}
+{{! Remove ubuntu to maintain the expected kibana user definition }}
 # Provide a non-root user to run the process.
-RUN groupadd --gid 1000 kibana && \
+RUN {{#ubuntu}}userdel -r ubuntu && {{/ubuntu}}groupadd --gid 1000 kibana && \
     useradd --uid 1000 --gid 1000 -G 0 \
       --home-dir /usr/share/kibana --no-create-home \
       kibana


### PR DESCRIPTION
Backports #222244 

20.04 is at end of standard support;
https://ubuntu.com/about/release-cycle