### PR TITLE
[Telemetry] Dev-only endpoint to force-send telemetry

### DIFF
--- a/src/platform/plugins/shared/telemetry/server/routes/index.ts
+++ b/src/platform/plugins/shared/telemetry/server/routes/index.ts
@@ -10,6 +10,7 @@
 import type { Observable } from 'rxjs';
 import type { IRouter, Logger, SavedObjectsClient } from '@kbn/core/server';
 import type { TelemetryCollectionManagerPluginSetup } from '@kbn/telemetry-collection-manager-plugin/server';
+import { registerTelemetryForceSend } from './telemetry_force_send';
 import type { TelemetryConfigType } from '../config';
 import { registerTelemetryConfigRoutes } from './telemetry_config';
 import { registerTelemetryOptInRoutes } from './telemetry_opt_in';
@@ -38,4 +39,7 @@ export function registerRoutes(options: RegisterRoutesParams) {
   registerTelemetryOptInStatsRoutes(router, telemetryCollectionManager);
   registerTelemetryUserHasSeenNotice(router, options.currentKibanaVersion);
   registerTelemetryLastReported(router, savedObjectsInternalClient$);
+  if (isDev) {
+    registerTelemetryForceSend(options);
+  }
 }

--- a/src/platform/plugins/shared/telemetry/server/routes/telemetry_force_send.ts
+++ b/src/platform/plugins/shared/telemetry/server/routes/telemetry_force_send.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { IRouter } from '@kbn/core/server';
+import type { TelemetryCollectionManagerPluginSetup } from '@kbn/telemetry-collection-manager-plugin/server';
+import { firstValueFrom, type Observable } from 'rxjs';
+import { schema } from '@kbn/config-schema';
+import fetch from 'node-fetch';
+import { PAYLOAD_CONTENT_ENCODING } from '../../common/constants';
+import type { TelemetryConfigType } from '../config';
+import { getTelemetryChannelEndpoint } from '../../common/telemetry_config';
+
+export interface RegisterTelemetryForceSendParams {
+  logger: Logger;
+  config$: Observable<TelemetryConfigType>;
+  currentKibanaVersion: string;
+  router: IRouter;
+  telemetryCollectionManager: TelemetryCollectionManagerPluginSetup;
+}
+
+export function registerTelemetryForceSend({
+  config$,
+  currentKibanaVersion,
+  router,
+  telemetryCollectionManager,
+}: RegisterTelemetryForceSendParams) {
+  router.versioned
+    .post({
+      access: 'internal',
+      path: '/internal/telemetry/force_send',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'Only registered in dev mode: this is a helper for developers to force send telemetry',
+        },
+      },
+      enableQueryVersion: true, // Allow specifying the version through querystring so that we can use it in Dev Console
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: schema.object({
+              // If provided, the telemetry will be sent to this local index instead of the default one
+              localIndex: schema.maybe(schema.string()),
+            }),
+          },
+        },
+      },
+      async (context, req, res) => {
+        // If a local index is provided, we will use it to write the telemetry data to that index
+        const localIndex = req.body?.localIndex;
+        if (localIndex) {
+          const esClient = (await context.core).elasticsearch.client.asCurrentUser;
+
+          // if it doesn't exist, create the index with very basic mappings
+          if (!(await esClient.indices.exists({ index: localIndex }))) {
+            await esClient.indices.create({
+              index: localIndex,
+              mappings: {
+                dynamic: false, // Disable dynamic mapping
+                properties: {
+                  timestamp: { type: 'date' },
+                  'cluster-uuid': { type: 'keyword' },
+                },
+              },
+            });
+          }
+
+          const clusters = await telemetryCollectionManager.getStats({
+            unencrypted: true,
+            refreshCache: true,
+          });
+          await esClient.bulk({
+            index: localIndex,
+            operations: clusters.flatMap(({ clusterUuid, stats }) => [
+              { create: {} },
+              {
+                timestamp: new Date().toISOString(),
+                'cluster-uuid': clusterUuid,
+                'original-body': stats,
+              },
+            ]),
+          });
+          return res.ok({
+            body: `Telemetry documents indexed in the local index ${localIndex}. GET /${localIndex}/_search to see your documents.`,
+          });
+        } else {
+          // TODO: Selective copy-paste from the fetcher.ts file. We should refactor this and use the common EBT Shipper to maintain only one client.
+          const payload = await telemetryCollectionManager.getStats({
+            unencrypted: false,
+            refreshCache: true,
+          });
+          const config = await firstValueFrom(config$);
+          const telemetryUrl = getTelemetryChannelEndpoint({
+            appendServerlessChannelsSuffix: config.appendServerlessChannelsSuffix,
+            channelName: 'snapshot',
+            env: config.sendUsageTo,
+          });
+          await Promise.all(
+            payload.map(async ({ clusterUuid, stats }) => {
+              await fetch(telemetryUrl, {
+                method: 'post',
+                body: stats,
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-Elastic-Stack-Version': currentKibanaVersion,
+                  'X-Elastic-Cluster-ID': clusterUuid,
+                  'X-Elastic-Content-Encoding': PAYLOAD_CONTENT_ENCODING,
+                },
+              });
+            })
+          );
+          return res.ok({
+            body: `Telemetry shipped to ${telemetryUrl}. Check the results in the receiving system.`,
+          });
+        }
+      }
+    );
+}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/140881

When running Kibana in dev mode, a new endpoint is registered to force-send the Snapshot Telemetry payload.

There are 2 ways of using it:

1. Force generate a new Snapshot telemetry payload and send it to the remote Telemetry Web API
```
POST kbn:/internal/telemetry/force_send?apiVersion=1&elasticInternalOrigin=true
{}
```
2. Force generate a new Snapshot telemetry document and index it in the provided index
```
POST kbn:/internal/telemetry/force_send?apiVersion=1&elasticInternalOrigin=true
{ "localIndex": "my-telemetry-test" }
```

NOTE: To avoid the [max field limit](https://www.elastic.co/docs/reference/elasticsearch/index-settings/mapping-limit) error, if the index does not exist, it will add `dynamic: false` to the mappings. If you want to query the data, make sure to add any mappings that you need to the index.



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->