### PR TITLE
[ES Service] Create clients more lazily

### DIFF
--- a/src/core/packages/elasticsearch/client-server-internal/src/scoped_cluster_client.test.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/scoped_cluster_client.test.ts
@@ -19,7 +19,7 @@ describe('ScopedClusterClient', () => {
     const secondaryAuthClient = createEsClient();
 
     const scopedClusterClient = new ScopedClusterClient({
-      asInternalUser: internalClient,
+      asInternalUserFactory: () => internalClient,
       asCurrentUserFactory: () => scopedClient,
       asSecondaryAuthUserFactory: () => secondaryAuthClient,
     });
@@ -33,7 +33,7 @@ describe('ScopedClusterClient', () => {
     const secondaryAuthClient = createEsClient();
 
     const scopedClusterClient = new ScopedClusterClient({
-      asInternalUser: internalClient,
+      asInternalUserFactory: () => internalClient,
       asCurrentUserFactory: () => scopedClient,
       asSecondaryAuthUserFactory: () => secondaryAuthClient,
     });
@@ -47,7 +47,7 @@ describe('ScopedClusterClient', () => {
     const secondaryAuthClient = createEsClient();
 
     const scopedClusterClient = new ScopedClusterClient({
-      asInternalUser: internalClient,
+      asInternalUserFactory: () => internalClient,
       asCurrentUserFactory: () => scopedClient,
       asSecondaryAuthUserFactory: () => secondaryAuthClient,
     });
@@ -61,7 +61,7 @@ describe('ScopedClusterClient', () => {
     const secondaryAuthClient = createEsClient();
 
     const scopedClusterClient = new ScopedClusterClient({
-      asInternalUser: internalClient,
+      asInternalUserFactory: () => internalClient,
       asCurrentUserFactory: () => scopedClient,
       asSecondaryAuthUserFactory: () => secondaryAuthClient,
     });
@@ -78,7 +78,7 @@ describe('ScopedClusterClient', () => {
     const secondaryAuthClient = createEsClient();
 
     const scopedClusterClient = new ScopedClusterClient({
-      asInternalUser: internalClient,
+      asInternalUserFactory: () => internalClient,
       asCurrentUserFactory: () => scopedClient,
       asSecondaryAuthUserFactory: () => secondaryAuthClient,
     });

--- a/src/core/packages/elasticsearch/client-server-internal/src/scoped_cluster_client.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/scoped_cluster_client.ts
@@ -11,26 +11,33 @@ import type { ElasticsearchClient, IScopedClusterClient } from '@kbn/core-elasti
 
 /** @internal **/
 export class ScopedClusterClient implements IScopedClusterClient {
-  public readonly asInternalUser;
-
+  readonly #asInternalUserFactory: () => ElasticsearchClient;
   readonly #asCurrentUserFactory: () => ElasticsearchClient;
   readonly #asSecondaryAuthUserFactory: () => ElasticsearchClient;
 
+  #asInternalUserClient?: ElasticsearchClient;
   #asCurrentUserClient?: ElasticsearchClient;
   #asSecondaryAuthUserClient?: ElasticsearchClient;
 
   constructor({
-    asInternalUser,
+    asInternalUserFactory,
     asCurrentUserFactory,
     asSecondaryAuthUserFactory,
   }: {
-    asInternalUser: ElasticsearchClient;
+    asInternalUserFactory: () => ElasticsearchClient;
     asCurrentUserFactory: () => ElasticsearchClient;
     asSecondaryAuthUserFactory: () => ElasticsearchClient;
   }) {
-    this.asInternalUser = asInternalUser;
+    this.#asInternalUserFactory = asInternalUserFactory;
     this.#asCurrentUserFactory = asCurrentUserFactory;
     this.#asSecondaryAuthUserFactory = asSecondaryAuthUserFactory;
+  }
+
+  public get asInternalUser() {
+    if (this.#asInternalUserClient === undefined) {
+      this.#asInternalUserClient = this.#asInternalUserFactory();
+    }
+    return this.#asInternalUserClient;
   }
 
   public get asCurrentUser() {


### PR DESCRIPTION
## Summary

Exploring if postponing the creation of the ES clients improves performance in any way.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



