### PR TITLE
[9.0] [Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224920)

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -100,7 +100,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       await synthtrace.clean();
     });
 
-    describe('navigate to dataset details', () => {
+    describe('navigate to dataset details', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should navigate to right dataset', async () => {
         await PageObjects.datasetQuality.navigateToDetails({ dataStream: regularDataStreamName });
 
@@ -164,7 +169,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
     });
 
-    describe('overview summary panel', () => {
+    describe('overview summary panel', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should show summary KPIs', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: apacheAccessDataStreamName,
@@ -180,7 +190,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
     });
 
-    describe('overview integrations', () => {
+    describe('overview integrations', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should hide the integration section for non integrations', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: regularDataStreamName,
@@ -352,7 +367,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
     });
 
-    describe('degraded fields table', () => {
+    describe('degraded fields table', function () {
+      // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+      // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+      // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it(' should show empty degraded fields table when no degraded fields are present', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: regularDataStreamName,

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_privileges.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_privileges.ts
@@ -132,7 +132,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
         });
       });
 
-      describe('User can monitor some data streams', () => {
+      describe('User can monitor some data streams', function () {
+        // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+        // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+        // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+        this.onlyEsVersion('8.19 || >=9.1');
+
         before(async () => {
           // Index logs for synth-* and apache.access datasets
           await synthtrace.index(getInitialTestLogs({ to, count: 4 }));

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
@@ -33,7 +33,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
     version: '1.14.0',
   };
 
-  describe('Dataset quality table', () => {
+  describe('Dataset quality table', function () {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     before(async () => {
       // Install Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(pkg);

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
@@ -28,7 +28,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   };
   const allDatasetNames = [apacheAccessDatasetHumanName, ...datasetNames];
 
-  describe('Dataset quality table filters', () => {
+  describe('Dataset quality table filters', function () {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     before(async () => {
       // Install Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(pkg);

--- a/x-pack/test/functional/apps/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/test/functional/apps/dataset_quality/degraded_field_flyout.ts
@@ -53,7 +53,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   const apmAppDatasetName = 'apm.app.tug';
   const apmAppDataStreamName = `${type}-${apmAppDatasetName}-${defaultNamespace}`;
 
-  describe('Degraded fields flyout', () => {
+  describe('Degraded fields flyout', function () {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     describe('degraded field flyout open-close', () => {
       before(async () => {
         await synthtrace.index([


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224920)](https://github.com/elastic/kibana/pull/224920)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2025-06-24T11:23:34Z","message":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224920)\n\nUpdates the Dataset Quality functional test suite to skip tests\nwhen running in Kibana 8.19 against Elasticsearch 9.0 in a forward\ncompatibility test run. , where the `read_failure_store` index privilege\nis not available. The privilege checks for `read_failure_store` fail as\nthey are incompatible with ES 9.0, since ES 9.0 does not support Failure\nStore.\n\n#### Context\n\nWhile investigating e2e test failures related to the missing\n`read_failure_store` privilege in ES 9.0, it was found that almost all\nDataset Quality test suites fail. The failures occur because the\nfollowing endpoints which most of the e2e tests depend on, check for\nthis privilege and error out:\n\n- `/settings`\n- `/details`\n- `/total_docs`\n- `/stats`\n\n#### Error thrown by endpoints:\n```yaml\nerror: \"Internal Server Error\"\nmessage: \"illegal_argument_exception\\n\\tRoot causes:\\n\\t\\tillegal_argument_exception: unknown index privilege [read_failure_store]. a privilege must be either one of the predefined fixed indices privileges [all,auto_configure,create,create_doc,create_index,cross_cluster_replication,cross_cluster_replication_internal,delete,delete_index,index,maintenance,manage,manage_data_stream_lifecycle,manage_follow_index,manage_ilm,manage_leader_index,monitor,none,read,read_cross_cluster,view_index_metadata,write] or a pattern over one of the available index actions\"\nstatusCode: 500\n```\n#### Screenshots\n<table>\n<tr><th>Main Page</th><th>Details Page</th></tr>\n<tr>\n<td>\n\n\n![image](https://github.com/user-attachments/assets/7bd56da7-e4ca-44c2-91d1-4d6adea7af96)\n\n\n</td>\n<td>\n\n\n![image](https://github.com/user-attachments/assets/ca392166-36dc-4a2a-8dc4-5d5c0d72ed59)\n\n\n</td>\n</tr>\n</table>","sha":"17cd533792204e3593d7ddf5b7bad70f98693e7e","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:obs-ux-logs","backport:version","v9.1.0","v8.19.0","v9.0.3"],"title":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0","number":224920,"url":"https://github.com/elastic/kibana/pull/224920","mergeCommit":{"message":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224920)\n\nUpdates the Dataset Quality functional test suite to skip tests\nwhen running in Kibana 8.19 against Elasticsearch 9.0 in a forward\ncompatibility test run. , where the `read_failure_store` index privilege\nis not available. The privilege checks for `read_failure_store` fail as\nthey are incompatible with ES 9.0, since ES 9.0 does not support Failure\nStore.\n\n#### Context\n\nWhile investigating e2e test failures related to the missing\n`read_failure_store` privilege in ES 9.0, it was found that almost all\nDataset Quality test suites fail. The failures occur because the\nfollowing endpoints which most of the e2e tests depend on, check for\nthis privilege and error out:\n\n- `/settings`\n- `/details`\n- `/total_docs`\n- `/stats`\n\n#### Error thrown by endpoints:\n```yaml\nerror: \"Internal Server Error\"\nmessage: \"illegal_argument_exception\\n\\tRoot causes:\\n\\t\\tillegal_argument_exception: unknown index privilege [read_failure_store]. a privilege must be either one of the predefined fixed indices privileges [all,auto_configure,create,create_doc,create_index,cross_cluster_replication,cross_cluster_replication_internal,delete,delete_index,index,maintenance,manage,manage_data_stream_lifecycle,manage_follow_index,manage_ilm,manage_leader_index,monitor,none,read,read_cross_cluster,view_index_metadata,write] or a pattern over one of the available index actions\"\nstatusCode: 500\n```\n#### Screenshots\n<table>\n<tr><th>Main Page</th><th>Details Page</th></tr>\n<tr>\n<td>\n\n\n![image](https://github.com/user-attachments/assets/7bd56da7-e4ca-44c2-91d1-4d6adea7af96)\n\n\n</td>\n<td>\n\n\n![image](https://github.com/user-attachments/assets/ca392166-36dc-4a2a-8dc4-5d5c0d72ed59)\n\n\n</td>\n</tr>\n</table>","sha":"17cd533792204e3593d7ddf5b7bad70f98693e7e"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224920","number":224920,"mergeCommit":{"message":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224920)\n\nUpdates the Dataset Quality functional test suite to skip tests\nwhen running in Kibana 8.19 against Elasticsearch 9.0 in a forward\ncompatibility test run. , where the `read_failure_store` index privilege\nis not available. The privilege checks for `read_failure_store` fail as\nthey are incompatible with ES 9.0, since ES 9.0 does not support Failure\nStore.\n\n#### Context\n\nWhile investigating e2e test failures related to the missing\n`read_failure_store` privilege in ES 9.0, it was found that almost all\nDataset Quality test suites fail. The failures occur because the\nfollowing endpoints which most of the e2e tests depend on, check for\nthis privilege and error out:\n\n- `/settings`\n- `/details`\n- `/total_docs`\n- `/stats`\n\n#### Error thrown by endpoints:\n```yaml\nerror: \"Internal Server Error\"\nmessage: \"illegal_argument_exception\\n\\tRoot causes:\\n\\t\\tillegal_argument_exception: unknown index privilege [read_failure_store]. a privilege must be either one of the predefined fixed indices privileges [all,auto_configure,create,create_doc,create_index,cross_cluster_replication,cross_cluster_replication_internal,delete,delete_index,index,maintenance,manage,manage_data_stream_lifecycle,manage_follow_index,manage_ilm,manage_leader_index,monitor,none,read,read_cross_cluster,view_index_metadata,write] or a pattern over one of the available index actions\"\nstatusCode: 500\n```\n#### Screenshots\n<table>\n<tr><th>Main Page</th><th>Details Page</th></tr>\n<tr>\n<td>\n\n\n![image](https://github.com/user-attachments/assets/7bd56da7-e4ca-44c2-91d1-4d6adea7af96)\n\n\n</td>\n<td>\n\n\n![image](https://github.com/user-attachments/assets/ca392166-36dc-4a2a-8dc4-5d5c0d72ed59)\n\n\n</td>\n</tr>\n</table>","sha":"17cd533792204e3593d7ddf5b7bad70f98693e7e"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225059","number":225059,"state":"MERGED","mergeCommit":{"sha":"ec89ec63f4aa38b6f8e8bf808aaddfbe3dabf3ca","message":"[8.19] [Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224920) (#225059)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Dataset Quality] Fix ES Promotion forward compatibility test\nfailures for ES 9.0\n(#224920)](https://github.com/elastic/kibana/pull/224920)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Abdul Wahab Zahid <awahab07@yahoo.com>"}},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->