### PR TITLE
[8.19] [Synthetics] Replace `EuiErrorBoundary` with `KibanaErrorBoundary` (#224317)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/error_callout.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/error_callout.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '../../../utils/testing/rtl_helpers';
+import { ErrorCallout } from './error_callout';
+import { IHttpSerializedFetchError } from '../../../state';
+
+describe('ErrorCallout', () => {
+  it('renders error info', () => {
+    const error: IHttpSerializedFetchError = {
+      name: 'Test Error',
+      body: {
+        error: 'Test Error',
+        message: 'Test Message',
+        statusCode: 500,
+      },
+      requestUrl: 'http://localhost:5601',
+    };
+
+    const { getByText } = render(<ErrorCallout {...error} />);
+
+    expect(getByText('Status:'));
+    expect(getByText('500'));
+    expect(getByText('Error fetching monitor details'));
+    expect(getByText('Unable to fetch monitor details'));
+    expect(getByText('Message:'));
+    expect(getByText('Test Message'));
+    expect(getByText('Error:'));
+    expect(getByText('Test Error'));
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/error_callout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/error_callout.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCallOut, EuiDescriptionList } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { IHttpSerializedFetchError } from '../../../state';
+
+/**
+ * Use this component when displaying fetch-related errors.
+ */
+export function ErrorCallout(error: IHttpSerializedFetchError<unknown>) {
+  const listItems = [];
+  if (error.body?.statusCode) {
+    listItems.push({
+      title: i18n.translate('xpack.synthetics.monitorDetailFlyout.fetchError.statusCode', {
+        defaultMessage: 'Status:',
+      }),
+      description: error.body.statusCode,
+    });
+  }
+  if (error.body?.error) {
+    listItems.push({
+      title: i18n.translate('xpack.synthetics.monitorDetailFlyout.fetchError.error', {
+        defaultMessage: 'Error:',
+      }),
+      description: error.body.error,
+    });
+  }
+  if (error.body?.message) {
+    listItems.push({
+      title: i18n.translate('xpack.synthetics.monitorDetailFlyout.fetchError.messageTitle', {
+        defaultMessage: 'Message:',
+      }),
+      description: error.body.message,
+    });
+  }
+  return (
+    <EuiCallOut
+      color="danger"
+      title={i18n.translate('xpack.synthetics.monitorDetail.errorTitle', {
+        defaultMessage: 'Error fetching monitor details',
+      })}
+      iconType="alert"
+    >
+      <p>
+        {i18n.translate('xpack.synthetics.monitorDetailFlyout.fetchError.description', {
+          defaultMessage: 'Unable to fetch monitor details',
+        })}
+      </p>
+
+      {listItems.length > 0 && (
+        <EuiDescriptionList compressed type="responsiveColumn" listItems={listItems} />
+      )}
+    </EuiCallOut>
+  );
+}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
@@ -108,7 +108,7 @@ describe('Monitor Detail Flyout', () => {
         },
       }
     );
-    getByText(testErrorText);
+    getByText(testErrorText, { exact: false });
   });
 
   it('renders loading state while fetching', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -11,7 +11,6 @@ import {
   EuiDescriptionList,
   EuiDescriptionListDescription,
   EuiDescriptionListTitle,
-  EuiErrorBoundary,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -32,11 +31,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from '@kbn/observability-shared-plugin/public';
 import { FlyoutParamProps } from './types';
 import { useKibanaSpace } from '../../../../../../hooks/use_kibana_space';
-import { useOverviewStatus } from '../../hooks/use_overview_status';
 import { MonitorDetailsPanel } from '../../../common/components/monitor_details_panel';
 import { ClientPluginsStart } from '../../../../../../plugin';
 import { LocationsStatus, useStatusByLocation } from '../../../../hooks/use_status_by_location';
-import { MonitorEnabled } from '../../management/monitor_list_table/monitor_enabled';
 import { ActionsPopover } from './actions_popover';
 import {
   getMonitorAction,
@@ -48,10 +45,13 @@ import {
   selectSyntheticsMonitorLoading,
   setFlyoutConfig,
 } from '../../../../state';
+import { ErrorCallout } from '../../../common/components/error_callout';
+import { MonitorStatus } from '../../../common/components/monitor_status';
 import { useMonitorDetail } from '../../../../hooks/use_monitor_detail';
+import { useOverviewStatus } from '../../hooks/use_overview_status';
+import { MonitorEnabled } from '../../management/monitor_list_table/monitor_enabled';
 import { ConfigKey, EncryptedSyntheticsMonitor, OverviewStatusMetaData } from '../types';
 import { useMonitorDetailLocator } from '../../../../hooks/use_monitor_detail_locator';
-import { MonitorStatus } from '../../../common/components/monitor_status';
 import { MonitorLocationSelect } from '../../../common/components/monitor_location_select';
 import { quietFetchOverviewStatusAction } from '../../../../state/overview_status';
 
@@ -287,7 +287,7 @@ export function MonitorDetailFlyout(props: Props) {
       onClose={props.onClose}
       paddingSize="none"
     >
-      {error && !isLoading && <EuiErrorBoundary>{error?.body?.message}</EuiErrorBoundary>}
+      {error && !isLoading && <ErrorCallout {...error} />}
       {isLoading && <LoadingState />}
       {monitorObject && (
         <>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout.tsx
@@ -10,7 +10,6 @@ import { i18n } from '@kbn/i18n';
 import {
   EuiButtonEmpty,
   EuiCallOut,
-  EuiErrorBoundary,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -18,6 +17,7 @@ import {
   EuiLoadingSpinner,
   EuiTitle,
 } from '@elastic/eui';
+import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
 
 import { LoadingState } from '../monitors_page/overview/overview/monitor_detail_flyout';
 import { ServiceLocationErrors, SyntheticsMonitor } from '../../../../../common/runtime_types';
@@ -65,7 +65,7 @@ export function TestNowModeFlyout({
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiErrorBoundary>
+        <KibanaSectionErrorBoundary sectionName="xpack.synthetics.monitorManagement.testNowFlyout.body">
           {isPushing && (
             <EuiCallOut color="primary">
               {PushingLabel} <EuiLoadingSpinner />
@@ -82,7 +82,7 @@ export function TestNowModeFlyout({
           ) : (
             !isPushing && <LoadingState />
           )}
-        </EuiErrorBoundary>
+        </KibanaSectionErrorBoundary>
       </EuiFlyoutBody>
       <EuiFlyoutFooter>
         <EuiButtonEmpty
@@ -97,7 +97,7 @@ export function TestNowModeFlyout({
     </EuiFlyout>
   );
 
-  return <>{(testRun || inProgress) && <EuiErrorBoundary>{flyout}</EuiErrorBoundary>}</>;
+  return testRun || inProgress ? flyout : null;
 }
 
 const TEST_RESULT = i18n.translate('xpack.synthetics.monitorManagement.testResult', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/synthetics_app.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/synthetics_app.tsx
@@ -11,6 +11,7 @@ import { APP_WRAPPER_CLASS } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { InspectorContextProvider } from '@kbn/observability-shared-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { KibanaErrorBoundaryProvider } from '@kbn/shared-ux-error-boundary';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { Router } from '@kbn/shared-ux-router';
 
@@ -59,21 +60,23 @@ const Application = (props: SyntheticsAppProps) => {
           },
         }}
       >
-        <SyntheticsSharedContext {...props}>
-          <Router history={appMountParameters.history}>
-            <SyntheticsSettingsContextProvider {...props}>
-              <PerformanceContextProvider>
-                <div className={APP_WRAPPER_CLASS} data-test-subj="syntheticsApp">
-                  <InspectorContextProvider>
-                    <PageRouter />
-                    <ActionMenu appMountParameters={appMountParameters} />
-                    <TestNowModeFlyoutContainer />
-                  </InspectorContextProvider>
-                </div>
-              </PerformanceContextProvider>
-            </SyntheticsSettingsContextProvider>
-          </Router>
-        </SyntheticsSharedContext>
+        <KibanaErrorBoundaryProvider analytics={coreStart.analytics}>
+          <SyntheticsSharedContext {...props}>
+            <Router history={appMountParameters.history}>
+              <SyntheticsSettingsContextProvider {...props}>
+                <PerformanceContextProvider>
+                  <div className={APP_WRAPPER_CLASS} data-test-subj="syntheticsApp">
+                    <InspectorContextProvider>
+                      <PageRouter />
+                      <ActionMenu appMountParameters={appMountParameters} />
+                      <TestNowModeFlyoutContainer />
+                    </InspectorContextProvider>
+                  </div>
+                </PerformanceContextProvider>
+              </SyntheticsSettingsContextProvider>
+            </Router>
+          </SyntheticsSharedContext>
+        </KibanaErrorBoundaryProvider>
       </KibanaThemeProvider>
     </KibanaRenderContextProvider>
   );

--- a/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
@@ -115,7 +115,8 @@
     "@kbn/fields-metadata-plugin",
     "@kbn/alerts-ui-shared",
     "@kbn/core-lifecycle-server",
-    "@kbn/charts-plugin"
+    "@kbn/charts-plugin",
+    "@kbn/shared-ux-error-boundary"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Replace `EuiErrorBoundary` with `KibanaErrorBoundary` (#224317)](https://github.com/elastic/kibana/pull/224317)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Justin Kambic","email":"jk@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T19:13:58Z","message":"[Synthetics] Replace `EuiErrorBoundary` with `KibanaErrorBoundary` (#224317)\n\n## Summary 🌷 \n\nResolves https://github.com/elastic/observability-dev/issues/4568\n\n### Test Now flyout\n\nChecked this by throwing an error within the flyout:\n\n<img width=\"1584\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d8cfe96e-8b1b-4c28-819e-82411b5f20af\"\n/>\n\n### Monitor detail flyout\n\nIn the case of this flyout, IMO, we should not use an error boundary. We\nare receiving an error that has been caught and placed into the plugin's\nRedux store, and then selecting that as part of the render procedure of\nthis component. Thus, we should display it using `EuiCallout`, which is\nthe recommended course per [the\ndocs](https://eui.elastic.co/docs/patterns/error-messages/error-banners/).\n\nExample implementation below:\n\n_note:_ all the copy here is placeholder and we should run it by our\ntech writers.\n\n<img width=\"607\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ef60258e-e50e-4fa7-adc5-b77469ddc0fb\"\n/>\n\nWe should not use an error boundary, as they are there specifically to\nhandle unforeseen errors that we can't account for at development time.\nIn this case, we have already caught the error and persisted it in app\nstate, so I don't think it's appropriate to display it in an error\nboundary as the runtime is still progressing and is not broken.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"78b2013468a49381eeadecf0bc15eaf1bb8db7aa","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management"],"title":"[Synthetics] Replace `EuiErrorBoundary` with `KibanaErrorBoundary`","number":224317,"url":"https://github.com/elastic/kibana/pull/224317","mergeCommit":{"message":"[Synthetics] Replace `EuiErrorBoundary` with `KibanaErrorBoundary` (#224317)\n\n## Summary 🌷 \n\nResolves https://github.com/elastic/observability-dev/issues/4568\n\n### Test Now flyout\n\nChecked this by throwing an error within the flyout:\n\n<img width=\"1584\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d8cfe96e-8b1b-4c28-819e-82411b5f20af\"\n/>\n\n### Monitor detail flyout\n\nIn the case of this flyout, IMO, we should not use an error boundary. We\nare receiving an error that has been caught and placed into the plugin's\nRedux store, and then selecting that as part of the render procedure of\nthis component. Thus, we should display it using `EuiCallout`, which is\nthe recommended course per [the\ndocs](https://eui.elastic.co/docs/patterns/error-messages/error-banners/).\n\nExample implementation below:\n\n_note:_ all the copy here is placeholder and we should run it by our\ntech writers.\n\n<img width=\"607\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ef60258e-e50e-4fa7-adc5-b77469ddc0fb\"\n/>\n\nWe should not use an error boundary, as they are there specifically to\nhandle unforeseen errors that we can't account for at development time.\nIn this case, we have already caught the error and persisted it in app\nstate, so I don't think it's appropriate to display it in an error\nboundary as the runtime is still progressing and is not broken.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"78b2013468a49381eeadecf0bc15eaf1bb8db7aa"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224317","number":224317,"mergeCommit":{"message":"[Synthetics] Replace `EuiErrorBoundary` with `KibanaErrorBoundary` (#224317)\n\n## Summary 🌷 \n\nResolves https://github.com/elastic/observability-dev/issues/4568\n\n### Test Now flyout\n\nChecked this by throwing an error within the flyout:\n\n<img width=\"1584\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d8cfe96e-8b1b-4c28-819e-82411b5f20af\"\n/>\n\n### Monitor detail flyout\n\nIn the case of this flyout, IMO, we should not use an error boundary. We\nare receiving an error that has been caught and placed into the plugin's\nRedux store, and then selecting that as part of the render procedure of\nthis component. Thus, we should display it using `EuiCallout`, which is\nthe recommended course per [the\ndocs](https://eui.elastic.co/docs/patterns/error-messages/error-banners/).\n\nExample implementation below:\n\n_note:_ all the copy here is placeholder and we should run it by our\ntech writers.\n\n<img width=\"607\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ef60258e-e50e-4fa7-adc5-b77469ddc0fb\"\n/>\n\nWe should not use an error boundary, as they are there specifically to\nhandle unforeseen errors that we can't account for at development time.\nIn this case, we have already caught the error and persisted it in app\nstate, so I don't think it's appropriate to display it in an error\nboundary as the runtime is still progressing and is not broken.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"78b2013468a49381eeadecf0bc15eaf1bb8db7aa"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->