### PR TITLE
[8.19] [Observability Alerting] Refetch alert detail rule data on edit flyout submit (#222118)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -127,6 +127,10 @@ export function AlertDetails() {
     await Promise.all([refetchRelatedDashboards(), refetch()]);
   }, [refetch, refetchRelatedDashboards]);
 
+  // used to trigger refetch when rule edit flyout closes
+  const onUpdate = useCallback(() => {
+    refetch();
+  }, [refetch]);
   const [alertStatus, setAlertStatus] = useState<AlertStatus>();
   const { euiTheme } = useEuiTheme();
   const [sources, setSources] = useState<AlertDetailsSource[]>();
@@ -408,6 +412,7 @@ export function AlertDetails() {
               alertIndex={alertDetail?.raw._index}
               alertStatus={alertStatus}
               onUntrackAlert={onUntrackAlert}
+              onUpdate={onUpdate}
             />
           </CasesContext>,
         ],

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/header_actions.tsx
@@ -39,6 +39,7 @@ export interface HeaderActionsProps {
   alertIndex?: string;
   alertStatus?: AlertStatus;
   onUntrackAlert: () => void;
+  onUpdate?: () => void;
 }
 
 export function HeaderActions({
@@ -46,6 +47,7 @@ export function HeaderActions({
   alertIndex,
   alertStatus,
   onUntrackAlert,
+  onUpdate,
 }: HeaderActionsProps) {
   const { services } = useKibana();
   const {
@@ -233,6 +235,7 @@ export function HeaderActions({
           }}
           onSubmit={() => {
             setRuleConditionsFlyoutOpen(false);
+            onUpdate?.();
             refetch();
           }}
         />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Observability Alerting] Refetch alert detail rule data on edit flyout submit (#222118)](https://github.com/elastic/kibana/pull/222118)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Justin Kambic","email":"jk@elastic.co"},"sourceCommit":{"committedDate":"2025-06-13T19:58:44Z","message":"[Observability Alerting] Refetch alert detail rule data on edit flyout submit (#222118)\n\n## Summary\n\nResolves #221428.\n\nWe noticed recently when we added the Investigation Guide that, if the\nuser edits the values in the guide using the edit flyout, the data on\nthe main page will not refresh when they submit.\n\nThis patch would add an `onUpdate` handler prop to the Header Actions\ncomponent that would enable it to trigger the refresh on the parent\ncomponent when the user submits the form in the edit flyout.\n\nExample:\n\n\n![20250530164523](https://github.com/user-attachments/assets/bd796824-e0d6-464d-b10e-89537d9b590e)","sha":"188669773e9cc1981b5e89f24afcfdc379ad3058","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport missing","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management"],"title":"[Observability Alerting] Refetch alert detail rule data on edit flyout submit","number":222118,"url":"https://github.com/elastic/kibana/pull/222118","mergeCommit":{"message":"[Observability Alerting] Refetch alert detail rule data on edit flyout submit (#222118)\n\n## Summary\n\nResolves #221428.\n\nWe noticed recently when we added the Investigation Guide that, if the\nuser edits the values in the guide using the edit flyout, the data on\nthe main page will not refresh when they submit.\n\nThis patch would add an `onUpdate` handler prop to the Header Actions\ncomponent that would enable it to trigger the refresh on the parent\ncomponent when the user submits the form in the edit flyout.\n\nExample:\n\n\n![20250530164523](https://github.com/user-attachments/assets/bd796824-e0d6-464d-b10e-89537d9b590e)","sha":"188669773e9cc1981b5e89f24afcfdc379ad3058"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222118","number":222118,"mergeCommit":{"message":"[Observability Alerting] Refetch alert detail rule data on edit flyout submit (#222118)\n\n## Summary\n\nResolves #221428.\n\nWe noticed recently when we added the Investigation Guide that, if the\nuser edits the values in the guide using the edit flyout, the data on\nthe main page will not refresh when they submit.\n\nThis patch would add an `onUpdate` handler prop to the Header Actions\ncomponent that would enable it to trigger the refresh on the parent\ncomponent when the user submits the form in the edit flyout.\n\nExample:\n\n\n![20250530164523](https://github.com/user-attachments/assets/bd796824-e0d6-464d-b10e-89537d9b590e)","sha":"188669773e9cc1981b5e89f24afcfdc379ad3058"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->