### PR TITLE
[SIEM Migrations] Update siem migrations permissions to check v3 instead of v2

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/capabilities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/service/capabilities.ts
@@ -7,7 +7,7 @@
 
 import type { Capabilities } from '@kbn/core/public';
 import {
-  SECURITY_FEATURE_ID_V2,
+  SECURITY_FEATURE_ID_V3,
   SIEM_MIGRATIONS_FEATURE_ID,
 } from '@kbn/security-solution-features/constants';
 import { i18n } from '@kbn/i18n';
@@ -20,7 +20,7 @@ export interface MissingCapability {
 
 const minimumCapabilities: MissingCapability[] = [
   {
-    capability: `${SECURITY_FEATURE_ID_V2}.show`,
+    capability: `${SECURITY_FEATURE_ID_V3}.show`,
     description: i18n.translate(
       'xpack.securitySolution.siemMigrations.service.capabilities.securityAll',
       { defaultMessage: 'Security > Security: Read' }
@@ -37,7 +37,7 @@ const minimumCapabilities: MissingCapability[] = [
 
 const allCapabilities: MissingCapability[] = [
   {
-    capability: `${SECURITY_FEATURE_ID_V2}.crud`,
+    capability: `${SECURITY_FEATURE_ID_V3}.crud`,
     description: i18n.translate(
       'xpack.securitySolution.siemMigrations.service.capabilities.securityAll',
       { defaultMessage: 'Security > Security: All' }


### PR DESCRIPTION
## Summary

Security Solution was recently updated with a new set of v3 permissions, the SIEM migrations code was still looking at v2, which no longer exist at run time, and so the cards were showing a permissions error. PR updates these card configs to use v3.

Before:
![image](https://github.com/user-attachments/assets/4e37e30a-0639-4dbe-acc6-b6bffbf5b043)
Updated:
![image](https://github.com/user-attachments/assets/5210f7c1-8d38-4eed-b995-ed0507bada33)






