### PR TITLE
Hide agentless option in add integration flyout

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -177,6 +177,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     packageInfo &&
     packageHasAtLeastOneSecret({ packageInfo });
 
+  const hideAgentlessSelector = !!addIntegrationFlyoutProps;
   // Save package policy
   const {
     onSubmit,
@@ -209,7 +210,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     hasFleetAddAgentsPrivileges,
     setNewAgentPolicy,
     setSelectedPolicyTab,
-    hideAgentlessSelector: !!addIntegrationFlyoutProps,
+    hideAgentlessSelector,
   });
 
   if (addIntegrationFlyoutProps?.agentPolicy) {
@@ -456,7 +457,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
           />
 
           {/* TODO move SetupTechnologySelector out of extensionView */}
-          {!extensionView && isAgentlessIntegration(packageInfo) && (
+          {!extensionView && !hideAgentlessSelector && isAgentlessIntegration(packageInfo) && (
             <SetupTechnologySelector
               disabled={false}
               allowedSetupTechnologies={allowedSetupTechnologies}
@@ -515,6 +516,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       handleExtensionViewOnChange,
       handleSetupTechnologyChange,
       allowedSetupTechnologies,
+      hideAgentlessSelector,
     ]
   );
 


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/kibana/issues/225028
Builds off of: https://github.com/elastic/kibana/pull/223221

Similar issue to 223221, but handles adding integrations like Okta to an existing policy that have an agentless option.

To test:
* Go to an existing agent policy
* Click Add Integration
* Select Okta
* You should not see the option to deploy as agentless

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



