### PR TITLE
[8.19] Share modal re-architecture (#211665)

### DIFF
--- a/src/platform/packages/private/kbn-reporting/public/share/index.ts
+++ b/src/platform/packages/private/kbn-reporting/public/share/index.ts
@@ -7,8 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { reportingExportModalProvider } from './share_context_menu/register_pdf_png_modal_reporting';
-export { reportingCsvShareProvider as reportingCsvShareModalProvider } from './share_context_menu/register_csv_modal_reporting';
+export {
+  reportingPDFExportProvider,
+  reportingPNGExportProvider,
+} from './share_context_menu/register_pdf_png_modal_reporting';
+export { reportingCsvExportProvider } from './share_context_menu/register_csv_modal_reporting';
 export type { JobParamsProviderOptions, StartServices } from './share_context_menu';
 export { getSharedComponents } from './shared';
 export type { ReportingPublicComponents } from './shared';

--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
@@ -13,22 +13,37 @@ import React from 'react';
 import { firstValueFrom } from 'rxjs';
 import type { SerializedSearchSourceFields } from '@kbn/data-plugin/common';
 import { FormattedMessage, InjectedIntl } from '@kbn/i18n-react';
-import { ShareContext, ShareMenuItemV2 } from '@kbn/share-plugin/public';
+import { ShareContext, type ExportShare } from '@kbn/share-plugin/public';
 import { LocatorParams } from '@kbn/reporting-common/types';
 import { getSearchCsvJobParams, CsvSearchModeParams } from '../shared/get_search_csv_job_params';
 import type { ExportModalShareOpts } from '.';
 import { checkLicense } from '../..';
 
-export const reportingCsvShareProvider = ({
+export const reportingCsvExportProvider = ({
   apiClient,
   application,
   license,
   usesUiCapabilities,
   startServices$,
-}: ExportModalShareOpts) => {
-  const getShareMenuItems = ({ objectType, sharingData }: ShareContext) => {
-    if ('search' !== objectType) {
-      return [];
+}: ExportModalShareOpts): ExportShare => {
+  const getShareMenuItems = ({
+    objectType,
+    sharingData,
+  }: ShareContext): ReturnType<ExportShare['config']> => {
+    const licenseCheck = checkLicense(license.check('reporting', 'basic'));
+    const licenseToolTipContent = licenseCheck.message;
+    const licenseHasCsvReporting = licenseCheck.showLinks;
+    const licenseDisabled = !licenseCheck.enableLinks;
+
+    let capabilityHasCsvReporting = false;
+    if (usesUiCapabilities) {
+      capabilityHasCsvReporting = application.capabilities.discover?.generateCsv === true;
+    } else {
+      capabilityHasCsvReporting = true; // deprecated
+    }
+
+    if (!(licenseHasCsvReporting && capabilityHasCsvReporting)) {
+      return null;
     }
 
     const getSearchSource = sharingData.getSearchSource as ({
@@ -58,20 +73,6 @@ export const reportingCsvShareProvider = ({
         }),
       };
     };
-
-    const shareActions: ShareMenuItemV2[] = [];
-
-    const licenseCheck = checkLicense(license.check('reporting', 'basic'));
-    const licenseToolTipContent = licenseCheck.message;
-    const licenseHasCsvReporting = licenseCheck.showLinks;
-    const licenseDisabled = !licenseCheck.enableLinks;
-
-    let capabilityHasCsvReporting = false;
-    if (usesUiCapabilities) {
-      capabilityHasCsvReporting = application.capabilities.discover?.generateCsv === true;
-    } else {
-      capabilityHasCsvReporting = true; // deprecated
-    }
 
     const generateReportingJobCSV = ({ intl }: { intl: InjectedIntl }) => {
       const { reportType, decoratedJobParams } = getSearchCsvJobParams({
@@ -131,66 +132,50 @@ export const reportingCsvShareProvider = ({
       });
     };
 
-    if (licenseHasCsvReporting && capabilityHasCsvReporting) {
-      const panelTitle = i18n.translate(
-        'reporting.share.contextMenu.export.csvReportsButtonLabel',
-        {
-          defaultMessage: 'Export',
-        }
-      );
+    const panelTitle = i18n.translate('reporting.share.contextMenu.export.csvReportsButtonLabel', {
+      defaultMessage: 'Export',
+    });
 
-      const reportingUrl = new URL(window.location.origin);
+    const { reportType, decoratedJobParams } = getSearchCsvJobParams({
+      apiClient,
+      searchModeParams: getSearchModeParams(true),
+      title: sharingData.title as string,
+    });
 
-      const { reportType, decoratedJobParams } = getSearchCsvJobParams({
-        apiClient,
-        searchModeParams: getSearchModeParams(true),
-        title: sharingData.title as string,
-      });
+    const relativePath = apiClient.getReportingPublicJobPath(reportType, decoratedJobParams);
 
-      const relativePath = apiClient.getReportingPublicJobPath(reportType, decoratedJobParams);
+    const absoluteUrl = new URL(relativePath, window.location.href).toString();
 
-      const absoluteUrl = new URL(relativePath, window.location.href).toString();
-
-      shareActions.push({
-        shareMenuItem: {
-          name: panelTitle,
-          toolTipContent: licenseToolTipContent,
-          disabled: licenseDisabled,
-          ['data-test-subj']: 'Export',
-        },
-        helpText: (
-          <FormattedMessage
-            id="reporting.share.csv.reporting.helpTextCSV"
-            defaultMessage="Export a CSV of this {objectType}."
-            values={{ objectType }}
-          />
-        ),
-        reportType,
-        label: 'CSV',
-        copyURLButton: {
-          id: 'reporting.share.modalContent.csv.copyUrlButtonLabel',
-          dataTestSubj: 'shareReportingCopyURL',
-          label: 'Post URL',
-        },
-        generateExportButton: (
-          <FormattedMessage
-            id="reporting.share.generateButtonLabelCSV"
-            data-test-subj="generateReportButton"
-            defaultMessage="Generate CSV"
-          />
-        ),
-        generateExport: generateReportingJobCSV,
-        generateExportUrl: () => absoluteUrl,
-        generateCopyUrl: reportingUrl,
-        renderCopyURLButton: true,
-      });
-    }
-
-    return shareActions;
+    return {
+      name: panelTitle,
+      toolTipContent: licenseToolTipContent,
+      exportType: reportType,
+      label: 'CSV',
+      disabled: licenseDisabled,
+      generateAssetExport: generateReportingJobCSV,
+      generateAssetURIValue: () => absoluteUrl,
+      helpText: (
+        <FormattedMessage
+          id="reporting.share.csv.reporting.helpTextCSV"
+          defaultMessage="Export a CSV of this {objectType}."
+          values={{ objectType }}
+        />
+      ),
+      generateExportButton: (
+        <FormattedMessage
+          id="reporting.share.generateButtonLabelCSV"
+          data-test-subj="generateReportButton"
+          defaultMessage="Generate CSV"
+        />
+      ),
+      renderCopyURIButton: true,
+    };
   };
 
   return {
+    shareType: 'integration',
     id: 'csvReportsModal',
-    getShareMenuItems,
+    groupId: 'export',
+    config: getShareMenuItems,
   };
 };

--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_pdf_png_modal_reporting.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_pdf_png_modal_reporting.tsx
@@ -10,10 +10,10 @@
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
-import { ShareContext, ShareMenuItemV2, ShareMenuProvider } from '@kbn/share-plugin/public';
+import { ShareContext } from '@kbn/share-plugin/public';
 import React from 'react';
 import { firstValueFrom } from 'rxjs';
-import { ScreenshotExportOpts } from '@kbn/share-plugin/public/types';
+import { ExportGenerationOpts, ExportShare } from '@kbn/share-plugin/public/types';
 import { ExportModalShareOpts, JobParamsProviderOptions, ReportingSharingData } from '.';
 import { checkLicense } from '../../license_check';
 
@@ -39,16 +39,13 @@ const getJobParams = (opts: JobParamsProviderOptions, type: 'pngV2' | 'printable
   return { ...baseParams, locatorParams };
 };
 
-/**
- * This is used by Dashboard and Visualize apps (sharing modal)
- */
-export const reportingExportModalProvider = ({
+export const reportingPDFExportProvider = ({
   apiClient,
   license,
   application,
   usesUiCapabilities,
   startServices$,
-}: ExportModalShareOpts): ShareMenuProvider => {
+}: ExportModalShareOpts): ExportShare => {
   const getShareMenuItems = ({
     objectType,
     objectId,
@@ -57,7 +54,7 @@ export const reportingExportModalProvider = ({
     shareableUrl,
     shareableUrlForSavedObject,
     ...shareOpts
-  }: ShareContext) => {
+  }: ShareContext): ReturnType<ExportShare['config']> => {
     const { enableLinks, showLinks, message } = checkLicense(license.check('reporting', 'gold'));
     const licenseToolTipContent = message;
     const licenseHasScreenshotReporting = showLinks;
@@ -77,17 +74,18 @@ export const reportingExportModalProvider = ({
     }
 
     if (!licenseHasScreenshotReporting) {
-      return [];
+      return null;
     }
+
     // for lens png pdf and csv are combined into one modal
     const isSupportedType = ['dashboard', 'visualization', 'lens'].includes(objectType);
 
     if (!isSupportedType) {
-      return [];
+      return null;
     }
 
     if (objectType === 'dashboard' && !capabilityHasDashboardScreenshotReporting) {
-      return [];
+      return null;
     }
 
     if (
@@ -95,11 +93,10 @@ export const reportingExportModalProvider = ({
       !capabilityHasVisualizeScreenshotReporting &&
       !capabilityHasDashboardScreenshotReporting
     ) {
-      return [];
+      return null;
     }
 
     const { sharingData } = shareOpts as unknown as { sharingData: ReportingSharingData };
-    const shareActions: ShareMenuItemV2[] = [];
 
     const jobProviderOptions: JobParamsProviderOptions = {
       shareableUrl: isDirty ? shareableUrl : shareableUrlForSavedObject ?? shareableUrl,
@@ -109,7 +106,7 @@ export const reportingExportModalProvider = ({
 
     const requiresSavedState = sharingData.locatorParams === null;
 
-    const generateReportPDF = ({ intl, optimizedForPrinting = false }: ScreenshotExportOpts) => {
+    const generateReportPDF = ({ intl, optimizedForPrinting = false }: ExportGenerationOpts) => {
       const decoratedJobParams = apiClient.getDecoratedJobParams({
         ...getJobParams({ ...jobProviderOptions, optimizedForPrinting }, 'printablePdfV2')(),
       });
@@ -163,7 +160,7 @@ export const reportingExportModalProvider = ({
       });
     };
 
-    const generateExportUrlPDF = ({ optimizedForPrinting }: ScreenshotExportOpts) => {
+    const generateExportUrlPDF = ({ optimizedForPrinting }: ExportGenerationOpts) => {
       const jobParams = apiClient.getDecoratedJobParams(
         getJobParams({ ...jobProviderOptions, optimizedForPrinting }, 'printablePdfV2')()
       );
@@ -171,6 +168,96 @@ export const reportingExportModalProvider = ({
 
       return new URL(relativePathPDF, window.location.href).toString();
     };
+
+    return {
+      name: i18n.translate('reporting.shareContextMenu.ExportsButtonLabel', {
+        defaultMessage: 'PDF',
+      }),
+      toolTipContent: licenseToolTipContent,
+      disabled: licenseDisabled || sharingData.reportingDisabled,
+      label: 'PDF' as const,
+      generateAssetExport: generateReportPDF,
+      generateAssetURIValue: generateExportUrlPDF,
+      exportType: 'printablePdfV2',
+      requiresSavedState,
+      renderLayoutOptionSwitch: objectType === 'dashboard',
+      renderCopyURIButton: true,
+    };
+  };
+
+  return {
+    id: 'pdfReports',
+    shareType: 'integration',
+    groupId: 'export',
+    config: getShareMenuItems,
+  };
+};
+
+export const reportingPNGExportProvider = ({
+  apiClient,
+  license,
+  application,
+  usesUiCapabilities,
+  startServices$,
+}: ExportModalShareOpts): ExportShare => {
+  const getShareMenuItems = ({
+    objectType,
+    objectId,
+    isDirty,
+    onClose,
+    shareableUrl,
+    shareableUrlForSavedObject,
+    ...shareOpts
+  }: ShareContext): ReturnType<ExportShare['config']> | null => {
+    const { enableLinks, showLinks, message } = checkLicense(license.check('reporting', 'gold'));
+    const licenseToolTipContent = message;
+    const licenseHasScreenshotReporting = showLinks;
+    const licenseDisabled = !enableLinks;
+
+    let capabilityHasDashboardScreenshotReporting = false;
+    let capabilityHasVisualizeScreenshotReporting = false;
+    if (usesUiCapabilities) {
+      capabilityHasDashboardScreenshotReporting =
+        application.capabilities.dashboard?.generateScreenshot === true;
+      capabilityHasVisualizeScreenshotReporting =
+        application.capabilities.visualize?.generateScreenshot === true;
+    } else {
+      // deprecated
+      capabilityHasDashboardScreenshotReporting = true;
+      capabilityHasVisualizeScreenshotReporting = true;
+    }
+
+    if (!licenseHasScreenshotReporting) {
+      return null;
+    }
+    // for lens png pdf and csv are combined into one modal
+    const isSupportedType = ['dashboard', 'visualization', 'lens'].includes(objectType);
+
+    if (!isSupportedType) {
+      return null;
+    }
+
+    if (objectType === 'dashboard' && !capabilityHasDashboardScreenshotReporting) {
+      return null;
+    }
+
+    if (
+      isSupportedType &&
+      !capabilityHasVisualizeScreenshotReporting &&
+      !capabilityHasDashboardScreenshotReporting
+    ) {
+      return null;
+    }
+
+    const { sharingData } = shareOpts as unknown as { sharingData: ReportingSharingData };
+
+    const jobProviderOptions: JobParamsProviderOptions = {
+      shareableUrl: isDirty ? shareableUrl : shareableUrlForSavedObject ?? shareableUrl,
+      objectType,
+      sharingData,
+    };
+
+    const requiresSavedState = sharingData.locatorParams === null;
 
     const generateExportUrlPNG = () => {
       const jobParams = apiClient.getDecoratedJobParams(
@@ -181,7 +268,7 @@ export const reportingExportModalProvider = ({
       return new URL(relativePathPNG, window.location.href).toString();
     };
 
-    const generateReportPNG = ({ intl }: ScreenshotExportOpts) => {
+    const generateReportPNG = ({ intl }: ExportGenerationOpts) => {
       const decoratedJobParams = apiClient.getDecoratedJobParams({
         ...getJobParams(jobProviderOptions, 'pngV2')(),
       });
@@ -235,48 +322,25 @@ export const reportingExportModalProvider = ({
       });
     };
 
-    shareActions.push({
-      shareMenuItem: {
-        name: i18n.translate('reporting.shareContextMenu.ExportsButtonLabel', {
-          defaultMessage: 'PDF',
-        }),
-        toolTipContent: licenseToolTipContent,
-        disabled: licenseDisabled || sharingData.reportingDisabled,
-        ['data-test-subj']: 'imageExports',
-      },
-      label: 'PDF' as const,
-      generateExport: generateReportPDF,
-      generateExportUrl: generateExportUrlPDF,
-      reportType: 'printablePdfV2',
-      requiresSavedState,
-      layoutOption: objectType === 'dashboard' ? ('print' as const) : undefined,
-      renderLayoutOptionSwitch: objectType === 'dashboard',
-      renderCopyURLButton: true,
-    });
-
-    shareActions.push({
-      shareMenuItem: {
-        name: i18n.translate('reporting.shareContextMenu.ExportsButtonLabelPNG', {
-          defaultMessage: 'PNG export',
-        }),
-        toolTipContent: licenseToolTipContent,
-        disabled: licenseDisabled || sharingData.reportingDisabled,
-        ['data-test-subj']: 'imageExports',
-      },
+    return {
+      name: i18n.translate('reporting.shareContextMenu.ExportsButtonLabelPNG', {
+        defaultMessage: 'PNG export',
+      }),
+      toolTipContent: licenseToolTipContent,
+      disabled: licenseDisabled || sharingData.reportingDisabled,
       label: 'PNG' as const,
-      generateExport: generateReportPNG,
-      generateExportUrl: generateExportUrlPNG,
-      reportType: 'pngV2',
+      generateAssetExport: generateReportPNG,
+      generateAssetURIValue: generateExportUrlPNG,
+      exportType: 'pngV2',
       requiresSavedState,
-      layoutOption: objectType === 'dashboard' ? ('print' as const) : undefined,
-      renderCopyURLButton: true,
-    });
-
-    return shareActions;
+      renderCopyURIButton: true,
+    };
   };
 
   return {
-    id: 'modalImageReports',
-    getShareMenuItems,
+    shareType: 'integration',
+    groupId: 'export',
+    id: 'imageReports',
+    config: getShareMenuItems,
   };
 };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -150,7 +150,6 @@ export function ShowShareModal({
   shareService.toggleShareContextMenu({
     isDirty,
     anchorElement,
-    allowEmbed: true,
     allowShortUrl,
     shareableUrl,
     objectId: savedObjectId,
@@ -172,8 +171,10 @@ export function ShowShareModal({
                 />
               }
             >
-              {hasPanelChanges
-                ? shareModalStrings.getDraftSharePanelChangesWarning()
+              {Boolean(unsavedDashboardState?.panels)
+                ? allowShortUrl
+                  ? shareModalStrings.getDraftSharePanelChangesWarning()
+                  : shareModalStrings.getSnapshotShareWarning()
                 : shareModalStrings.getDraftShareWarning('link')}
             </EuiCallOut>
           ),
@@ -195,6 +196,12 @@ export function ShowShareModal({
                 : shareModalStrings.getDraftShareWarning('embed')}
             </EuiCallOut>
           ),
+          embedUrlParamExtensions: [
+            {
+              paramName: 'embed',
+              component: EmbedUrlParamExtension,
+            },
+          ],
           computeAnonymousCapabilities: showPublicUrlSwitch,
         },
       },
@@ -211,13 +218,6 @@ export function ShowShareModal({
         params: locatorParams,
       },
     },
-    embedUrlParamExtensions: [
-      {
-        paramName: 'embed',
-        component: EmbedUrlParamExtension,
-      },
-    ],
-    snapshotShareWarning: hasPanelChanges ? shareModalStrings.getSnapshotShareWarning() : undefined,
     shareableUrlLocatorParams: {
       locator: shareService.url.locators.get(
         DASHBOARD_APP_LOCATOR

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
@@ -100,7 +100,6 @@ export const getShareAppMenuItem = ({
 
         services.share.toggleShareContextMenu({
           anchorElement,
-          allowEmbed: false,
           allowShortUrl: !!services.capabilities.discover.createShortUrl,
           shareableUrl,
           shareableUrlForSavedObject,
@@ -111,6 +110,12 @@ export const getShareAppMenuItem = ({
             title: i18n.translate('discover.share.shareModal.title', {
               defaultMessage: 'Share this Discover session',
             }),
+            config: {
+              embed: {
+                disabled: true,
+                showPublicUrlSwitch,
+              },
+            },
           },
           sharingData: {
             isTextBased: isEsqlMode,
@@ -124,7 +129,6 @@ export const getShareAppMenuItem = ({
               }),
           },
           isDirty: !savedSearch.id || stateContainer.appState.hasChanged(),
-          showPublicUrlSwitch,
           onClose: () => {
             anchorElement?.focus();
           },

--- a/src/platform/plugins/shared/share/public/components/context/index.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.test.tsx
@@ -8,13 +8,21 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useShareTabsContext } from '.';
+import { useShareTabsContext, useShareContext } from '.';
 
 describe('share menu context', () => {
+  describe('useShareContext', () => {
+    it('throws an error if used outside of ShareMenuProvider tree', () => {
+      expect(() => renderHook(() => useShareContext())).toThrow(
+        /^Failed to call `useShareContext` because the context from ShareMenuProvider is missing./
+      );
+    });
+  });
+
   describe('useShareTabsContext', () => {
     it('throws an error if used outside of ShareMenuProvider tree', () => {
-      expect(() => renderHook(() => useShareTabsContext())).toThrow(
-        /^Failed to call `useShareTabsContext` because the context from ShareMenuProvider is missing./
+      expect(() => renderHook(() => useShareTabsContext('embed'))).toThrow(
+        /^Failed to call `useShareContext` because the context from ShareMenuProvider is missing./
       );
     });
   });

--- a/src/platform/plugins/shared/share/public/components/context/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.tsx
@@ -9,26 +9,11 @@
 
 import React, { type PropsWithChildren, createContext, useContext } from 'react';
 
-import { AnonymousAccessServiceContract } from '../../../common';
-import type {
-  ShareMenuItemV2,
-  UrlParamExtension,
-  BrowserUrlService,
-  ShareContext,
-} from '../../types';
+import type { ShareConfigs, ShareTypes, ShowShareMenuOptions } from '../../types';
 
-export type { ShareMenuItemV2, ShareContextObjectTypeConfig } from '../../types';
-
-export interface IShareContext extends ShareContext {
-  allowEmbed: boolean;
-  allowShortUrl: boolean;
-  shareMenuItems: ShareMenuItemV2[];
-  embedUrlParamExtensions?: UrlParamExtension[];
-  anonymousAccess?: AnonymousAccessServiceContract;
-  urlService: BrowserUrlService;
-  snapshotShareWarning?: string;
-  publicAPIEnabled?: boolean;
-  anchorElement?: HTMLElement;
+export interface IShareContext extends Omit<ShowShareMenuOptions, 'onClose'> {
+  onClose: () => void;
+  shareMenuItems: ShareConfigs[];
 }
 
 const ShareTabsContext = createContext<IShareContext | null>(null);
@@ -40,14 +25,42 @@ export const ShareMenuProvider = ({
   return <ShareTabsContext.Provider value={shareContext}>{children}</ShareTabsContext.Provider>;
 };
 
-export const useShareTabsContext = () => {
+export const useShareContext = () => {
   const context = useContext(ShareTabsContext);
 
   if (!context) {
     throw new Error(
-      'Failed to call `useShareTabsContext` because the context from ShareMenuProvider is missing. Ensure the component or React root is wrapped with ShareMenuProvider'
+      'Failed to call `useShareContext` because the context from ShareMenuProvider is missing. Ensure the component or React root is wrapped with ShareMenuProvider'
     );
   }
 
   return context;
+};
+
+export const useShareTabsContext = <
+  T extends Exclude<ShareTypes, 'legacy'>,
+  G extends T extends 'integration' ? string : never
+>(
+  shareType: T,
+  groupId?: G
+) => {
+  const context = useShareContext();
+
+  const { shareMenuItems, objectTypeMeta, ...rest } = context;
+
+  // the integration share type can have multiple implementations
+  const shareTypeImplementations: T extends 'integration'
+    ? Array<Extract<ShareConfigs, { shareType: T; groupId?: G }>>
+    : Extract<ShareConfigs, { shareType: T }> = (
+    shareType === 'integration' ? Array.prototype.filter : Array.prototype.find
+  ).call(shareMenuItems, (item) => item.shareType === shareType && item?.groupId === groupId);
+
+  return {
+    ...rest,
+    objectTypeMeta: {
+      ...objectTypeMeta,
+      config: objectTypeMeta.config[shareType],
+    },
+    shareMenuItems: shareTypeImplementations,
+  };
 };

--- a/src/platform/plugins/shared/share/public/components/share_tabs.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.test.tsx
@@ -47,12 +47,30 @@ const service = new UrlService<BrowserShortUrlClientFactoryCreateParams, Browser
 });
 
 const mockShareContext: IShareContext = {
-  shareMenuItems: [],
-  allowEmbed: true,
+  shareMenuItems: [
+    {
+      shareType: 'link',
+      config: {
+        shortUrlService: service.shortUrls.get(null),
+      },
+    },
+    {
+      shareType: 'embed',
+      config: {
+        shortUrlService: service.shortUrls.get(null),
+        anonymousAccess: { getCapabilities: jest.fn(), getState: jest.fn() },
+      },
+    },
+  ],
   allowShortUrl: true,
-  anonymousAccess: { getCapabilities: jest.fn(), getState: jest.fn() },
-  urlService: service,
-  objectTypeMeta: { title: 'title' },
+  objectTypeMeta: {
+    title: 'title',
+    config: {
+      embed: {
+        disabled: false,
+      },
+    },
+  },
   objectType: 'type',
   sharingData: { title: 'title', url: 'url' },
   isDirty: false,
@@ -66,9 +84,22 @@ const PNG = 'PNG' as const;
 
 describe('Share modal tabs', () => {
   describe('link tab', () => {
-    it('should not render the link tab when the disableShareUrl prop is true', async () => {
+    it('should not render the link tab when it is configured as disabled', async () => {
+      const disabledLinkShareContext = {
+        ...mockShareContext,
+        objectTypeMeta: {
+          ...mockShareContext.objectTypeMeta,
+          config: {
+            ...mockShareContext.objectTypeMeta.config,
+            link: {
+              disabled: true,
+            },
+          },
+        },
+      };
+
       const wrapper = mountWithIntl(
-        <ShareMenuProvider shareContext={{ ...mockShareContext, disabledShareUrl: true }}>
+        <ShareMenuProvider shareContext={{ ...disabledLinkShareContext }}>
           <ShareMenuTabs />
         </ShareMenuProvider>
       );
@@ -78,33 +109,55 @@ describe('Share modal tabs', () => {
 
   describe('export tab', () => {
     it('should render export tab when there are share menu items that are not disabled', async () => {
-      const testItem = [
-        {
-          shareMenuItem: { name: 'test', disabled: false },
-          label: CSV,
-          generateExport: mockGenerateExport,
-          generateExportUrl: mockGenerateExportUrl,
-        },
-      ];
+      const shareContextWithConfiguredExportItem: IShareContext = {
+        ...mockShareContext,
+        shareMenuItems: [
+          ...mockShareContext.shareMenuItems,
+          {
+            id: 'test-export',
+            shareType: 'integration',
+            groupId: 'export',
+            config: {
+              name: 'test',
+              disabled: false,
+              label: CSV,
+              generateExport: mockGenerateExport,
+              generateExportUrl: mockGenerateExportUrl,
+            },
+          },
+        ],
+      };
+
       const wrapper = mountWithIntl(
-        <ShareMenuProvider shareContext={{ ...mockShareContext, shareMenuItems: testItem }}>
+        <ShareMenuProvider shareContext={{ ...shareContextWithConfiguredExportItem }}>
           <ShareMenuTabs />
         </ShareMenuProvider>
       );
       expect(wrapper.find('[data-test-subj="export"]').exists()).toBeTruthy();
     });
-    it('should not render export tab when the license is disabled', async () => {
-      const testItems = [
-        {
-          shareMenuItem: { name: 'test', disabled: true },
-          label: CSV,
-          generateExport: mockGenerateExport,
-          generateExportUrl: mockGenerateExportUrl,
-        },
-      ];
+
+    it('should not render export tab when it has only one item configured as disabled', async () => {
+      const shareContextWithConfiguredExportItem: IShareContext = {
+        ...mockShareContext,
+        shareMenuItems: [
+          ...mockShareContext.shareMenuItems,
+          {
+            id: 'test-export',
+            shareType: 'integration',
+            groupId: 'export',
+            config: {
+              name: 'test',
+              disabled: true,
+              label: CSV,
+              generateExport: mockGenerateExport,
+              generateExportUrl: mockGenerateExportUrl,
+            },
+          },
+        ],
+      };
 
       const wrapper = mountWithIntl(
-        <ShareMenuProvider shareContext={{ ...mockShareContext, shareMenuItems: testItems }}>
+        <ShareMenuProvider shareContext={{ ...shareContextWithConfiguredExportItem }}>
           <ShareMenuTabs />
         </ShareMenuProvider>
       );
@@ -113,22 +166,39 @@ describe('Share modal tabs', () => {
     });
 
     it('would render the export tab when there is at least one export type which is not disabled', async () => {
-      const testItem = [
-        {
-          shareMenuItem: { name: 'test', disabled: false },
-          label: CSV,
-          generateExport: mockGenerateExport,
-          generateExportUrl: mockGenerateExportUrl,
-        },
-        {
-          shareMenuItem: { name: 'test', disabled: true },
-          label: PNG,
-          generateExport: mockGenerateExport,
-          generateExportUrl: mockGenerateExportUrl,
-        },
-      ];
+      const shareContextWithConfiguredExportItem: IShareContext = {
+        ...mockShareContext,
+        shareMenuItems: [
+          ...mockShareContext.shareMenuItems,
+          {
+            id: 'test-csv-export',
+            shareType: 'integration',
+            groupId: 'export',
+            config: {
+              name: 'test',
+              disabled: false,
+              label: CSV,
+              generateExport: mockGenerateExport,
+              generateExportUrl: mockGenerateExportUrl,
+            },
+          },
+          {
+            id: 'test-png-export',
+            shareType: 'integration',
+            groupId: 'export',
+            config: {
+              name: 'test',
+              disabled: true,
+              label: PNG,
+              generateExport: mockGenerateExport,
+              generateExportUrl: mockGenerateExportUrl,
+            },
+          },
+        ],
+      };
+
       const wrapper = mountWithIntl(
-        <ShareMenuProvider shareContext={{ ...mockShareContext, shareMenuItems: testItem }}>
+        <ShareMenuProvider shareContext={{ ...shareContextWithConfiguredExportItem }}>
           <ShareMenuTabs />
         </ShareMenuProvider>
       );

--- a/src/platform/plugins/shared/share/public/components/share_tabs.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.tsx
@@ -10,7 +10,7 @@
 import React, { type FC } from 'react';
 import { TabbedModal, type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
 
-import { ShareMenuProvider, useShareTabsContext, type IShareContext } from './context';
+import { ShareMenuProvider, useShareContext, type IShareContext } from './context';
 import { linkTab, embedTab, exportTab } from './tabs';
 
 export const ShareMenu: FC<{ shareContext: IShareContext }> = ({ shareContext }) => {
@@ -23,26 +23,34 @@ export const ShareMenu: FC<{ shareContext: IShareContext }> = ({ shareContext })
 
 // this file is intended to replace share_context_menu
 export const ShareMenuTabs = () => {
-  const shareContext = useShareTabsContext();
+  const shareContext = useShareContext();
 
-  const { allowEmbed, objectTypeMeta, onClose, shareMenuItems, anchorElement, disabledShareUrl } =
-    shareContext;
+  const { objectTypeMeta, onClose, shareMenuItems, anchorElement } = shareContext;
 
   const tabs: Array<IModalTabDeclaration<any>> = [];
 
-  // do not show the link tab if the share url is disabled
-  if (!disabledShareUrl) {
+  // Do not show the link tab if the share url is disabled
+  if (!objectTypeMeta?.config.link?.disabled) {
     tabs.push(linkTab);
   }
 
-  const enabledItems = shareMenuItems.filter(({ shareMenuItem }) => !shareMenuItem?.disabled);
-
-  // do not show the export tab if the license is disabled
-  if (enabledItems.length > 0) {
+  // Do not show the export tab if there's no export type enabled
+  if (
+    shareMenuItems.some(
+      (shareItem) =>
+        shareItem.shareType === 'integration' &&
+        shareItem.groupId === 'export' &&
+        !shareItem.config.disabled
+    )
+  ) {
     tabs.push(exportTab);
   }
 
-  if (allowEmbed) {
+  // Embed is disabled in the serverless offering, hence the need to check that we received it
+  if (
+    shareMenuItems.some(({ shareType }) => shareType === 'embed') &&
+    !objectTypeMeta?.config?.embed?.disabled
+  ) {
     tabs.push(embedTab);
   }
 

--- a/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.test.tsx
@@ -21,15 +21,23 @@ let urlService: BrowserUrlService;
 // eslint-disable-next-line prefer-const
 ({ service: urlService } = urlServiceTestSetup());
 
+const shortUrlService = urlService.shortUrls.get(null)!;
+
 const defaultProps: Pick<
   ComponentProps<typeof EmbedContent>,
-  'allowShortUrl' | 'isDirty' | 'shareableUrl' | 'urlService' | 'objectType'
+  | 'allowShortUrl'
+  | 'isDirty'
+  | 'shareableUrl'
+  | 'objectType'
+  | 'shortUrlService'
+  | 'anonymousAccess'
 > = {
   isDirty: false,
   objectType: 'dashboard',
   shareableUrl: '/home#/',
-  urlService,
+  shortUrlService,
   allowShortUrl: false,
+  anonymousAccess: { getState: jest.fn(), getCapabilities: jest.fn() },
 };
 
 const renderComponent = (props: ComponentProps<typeof EmbedContent>) => {

--- a/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/embed/embed_content.tsx
@@ -27,22 +27,21 @@ import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { format as formatUrl, parse as parseUrl } from 'url';
 import { AnonymousAccessState } from '../../../../common';
 
-import type { IShareContext, ShareContextObjectTypeConfig } from '../../context';
+import type { IShareContext } from '../../context';
+import type { EmbedShareConfig, EmbedShareUIConfig } from '../../../types';
 
 type EmbedProps = Pick<
   IShareContext,
   | 'shareableUrlLocatorParams'
   | 'shareableUrlForSavedObject'
   | 'shareableUrl'
-  | 'embedUrlParamExtensions'
   | 'objectType'
   | 'isDirty'
   | 'allowShortUrl'
-  | 'anonymousAccess'
-  | 'urlService'
-> & {
-  objectConfig?: ShareContextObjectTypeConfig;
-};
+> &
+  EmbedShareConfig['config'] & {
+    objectConfig?: EmbedShareUIConfig;
+  };
 
 interface UrlParams {
   [extensionName: string]: {
@@ -51,7 +50,6 @@ interface UrlParams {
 }
 
 export const EmbedContent = ({
-  embedUrlParamExtensions: urlParamExtensions,
   shareableUrlForSavedObject,
   shareableUrl,
   shareableUrlLocatorParams,
@@ -59,7 +57,7 @@ export const EmbedContent = ({
   objectConfig = {},
   isDirty,
   allowShortUrl,
-  urlService,
+  shortUrlService,
   anonymousAccess,
 }: EmbedProps) => {
   const urlParamsRef = useRef<UrlParams | undefined>(undefined);
@@ -73,7 +71,11 @@ export const EmbedContent = ({
   const [showPublicUrlSwitch, setShowPublicUrlSwitch] = useState(false);
   const copiedTextToolTipCleanupIdRef = useRef<ReturnType<typeof setTimeout>>();
 
-  const { draftModeCallOut: DraftModeCallout, computeAnonymousCapabilities } = objectConfig;
+  const {
+    draftModeCallOut: DraftModeCallout,
+    computeAnonymousCapabilities,
+    embedUrlParamExtensions: urlParamExtensions,
+  } = objectConfig;
 
   useEffect(() => {
     if (computeAnonymousCapabilities && anonymousAccess) {
@@ -172,15 +174,13 @@ export const EmbedContent = ({
   }, [shareableUrlForSavedObject, snapshotUrl, updateUrlParams]);
 
   const createShortUrl = useCallback(async () => {
-    const shortUrlService = urlService.shortUrls.get(null);
-
     if (shareableUrlLocatorParams) {
       const shortUrl = await shortUrlService.createWithLocator(shareableUrlLocatorParams);
       return shortUrl.locator.getUrl(shortUrl.params, { absolute: true });
     } else {
       return (await shortUrlService.createFromLongUrl(snapshotUrl)).url;
     }
-  }, [shareableUrlLocatorParams, snapshotUrl, urlService.shortUrls]);
+  }, [shareableUrlLocatorParams, snapshotUrl, shortUrlService]);
 
   const addUrlAnonymousAccessParameters = useCallback(
     (tempUrl: string): string => {

--- a/src/platform/plugins/shared/share/public/components/tabs/embed/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/embed/index.tsx
@@ -17,30 +17,27 @@ type IEmbedTab = IModalTabDeclaration<{ url: string; isNotSaved: boolean }>;
 
 const EmbedTabContent: NonNullable<IEmbedTab['content']> = ({ state, dispatch }) => {
   const {
-    embedUrlParamExtensions,
     shareableUrlForSavedObject,
     shareableUrl,
     objectType,
     objectTypeMeta,
     isDirty,
     allowShortUrl,
-    anonymousAccess,
-    urlService,
     shareableUrlLocatorParams,
-  } = useShareTabsContext()!;
+    shareMenuItems,
+  } = useShareTabsContext('embed');
 
   return (
     <EmbedContent
       {...{
-        embedUrlParamExtensions,
         shareableUrlForSavedObject,
         shareableUrl,
         objectType,
-        objectConfig: objectTypeMeta?.config?.embed,
+        objectConfig: objectTypeMeta?.config,
         isDirty,
-        anonymousAccess,
         allowShortUrl,
-        urlService,
+        anonymousAccess: shareMenuItems.config.anonymousAccess,
+        shortUrlService: shareMenuItems.config.shortUrlService,
         shareableUrlLocatorParams,
       }}
     />

--- a/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
@@ -26,19 +26,19 @@ import {
   EuiIconTip,
   type EuiRadioGroupOption,
 } from '@elastic/eui';
-import { SupportedExportTypes, ShareMenuItemV2 } from '../../../types';
 import { type IShareContext } from '../../context';
+import { ExportShareConfig } from '../../../types';
 
 type ExportProps = Pick<IShareContext, 'isDirty' | 'objectId' | 'objectType' | 'onClose'> & {
   layoutOption?: 'print';
-  aggregateReportTypes: ShareMenuItemV2[];
+  aggregateExportTypes: ExportShareConfig[];
   intl: InjectedIntl;
   publicAPIEnabled: boolean;
 };
 
 const ExportContentUi = ({
   isDirty,
-  aggregateReportTypes,
+  aggregateExportTypes,
   intl,
   onClose,
   publicAPIEnabled,
@@ -47,33 +47,32 @@ const ExportContentUi = ({
   const [usePrintLayout, setPrintLayout] = useState(false);
 
   const radioOptions = useMemo(() => {
-    return aggregateReportTypes.reduce<EuiRadioGroupOption[]>((acc, { reportType, label }) => {
-      if (reportType) {
-        acc.push({
-          id: reportType,
-          label,
-          'data-test-subj': `${reportType}-radioOption`,
-        });
-      }
+    return aggregateExportTypes.reduce<EuiRadioGroupOption[]>((acc, { id, config }) => {
+      acc.push({
+        id: config.exportType,
+        label: config.label,
+        'data-test-subj': `${config.exportType}-radioOption`,
+      });
+
       return acc;
     }, []);
-  }, [aggregateReportTypes]);
+  }, [aggregateExportTypes]);
 
-  const [selectedRadio, setSelectedRadio] = useState<SupportedExportTypes>(
-    radioOptions[0].id as SupportedExportTypes
-  );
+  const [selectedRadio, setSelectedRadio] = useState(radioOptions[0].id);
 
   const {
-    generateExportButton,
-    helpText,
-    warnings = [],
-    renderCopyURLButton,
-    generateExport,
-    generateExportUrl,
-    renderLayoutOptionSwitch,
+    config: {
+      generateExportButton,
+      helpText,
+      warnings = [],
+      renderCopyURIButton: renderCopyURLButton,
+      generateAssetExport: generateExport,
+      generateAssetURIValue: generateExportUrl,
+      renderLayoutOptionSwitch,
+    },
   } = useMemo(() => {
-    return aggregateReportTypes?.find(({ reportType }) => reportType === selectedRadio)!;
-  }, [selectedRadio, aggregateReportTypes]);
+    return aggregateExportTypes?.find(({ config }) => config.exportType === selectedRadio)!;
+  }, [selectedRadio, aggregateExportTypes]);
 
   const handlePrintLayoutChange = useCallback(
     (evt: EuiSwitchEvent) => {
@@ -196,7 +195,7 @@ const ExportContentUi = ({
           <EuiFlexGroup direction="row" justifyContent={'spaceBetween'}>
             <EuiRadioGroup
               options={radioOptions}
-              onChange={(id) => setSelectedRadio(id as SupportedExportTypes)}
+              onChange={(id) => setSelectedRadio(id)}
               name="image reporting radio group"
               idSelected={selectedRadio}
               legend={{

--- a/src/platform/plugins/shared/share/public/components/tabs/export/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/export/index.tsx
@@ -16,14 +16,17 @@ import { useShareTabsContext } from '../../context';
 type IExportTab = IModalTabDeclaration;
 
 const ExportTabContent = () => {
-  const { shareMenuItems, objectType, isDirty, onClose, publicAPIEnabled } = useShareTabsContext()!;
+  const { shareMenuItems, objectType, isDirty, onClose, publicAPIEnabled } = useShareTabsContext(
+    'integration',
+    'export'
+  );
 
   return (
     <ExportContent
       objectType={objectType}
       isDirty={isDirty}
       onClose={onClose}
-      aggregateReportTypes={shareMenuItems}
+      aggregateExportTypes={shareMenuItems}
       publicAPIEnabled={publicAPIEnabled ?? true}
     />
   );

--- a/src/platform/plugins/shared/share/public/components/tabs/link/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/index.tsx
@@ -55,11 +55,10 @@ const LinkTabContent: ILinkTab['content'] = ({ state, dispatch }) => {
     objectId,
     isDirty,
     shareableUrl,
-    urlService,
     shareableUrlLocatorParams,
     allowShortUrl,
-    delegatedShareUrlHandler,
-  } = useShareTabsContext()!;
+    shareMenuItems,
+  } = useShareTabsContext('link');
 
   const setDashboardLink = useCallback(
     (url: string) => {
@@ -87,11 +86,11 @@ const LinkTabContent: ILinkTab['content'] = ({ state, dispatch }) => {
     <LinkContent
       {...{
         objectType,
-        objectConfig: objectTypeMeta?.config?.link,
+        objectConfig: objectTypeMeta?.config,
         objectId,
         isDirty,
         shareableUrl,
-        urlService,
+        shortUrlService: shareMenuItems.config.shortUrlService,
         shareableUrlLocatorParams,
         dashboardLink: state?.dashboardUrl,
         setDashboardLink,
@@ -99,7 +98,6 @@ const LinkTabContent: ILinkTab['content'] = ({ state, dispatch }) => {
         setIsNotSaved,
         allowShortUrl,
         setIsClicked: state?.setIsClicked,
-        delegatedShareUrlHandler,
       }}
     />
   );

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
@@ -54,6 +54,8 @@ describe('LinkContent', () => {
       }),
   }));
 
+  const shortUrlService = urlService.shortUrls.get(null)!;
+
   beforeAll(() => {
     Object.defineProperty(document, 'execCommand', {
       value: jest.fn(() => true),
@@ -71,11 +73,13 @@ describe('LinkContent', () => {
     renderComponent({
       objectType,
       objectId,
+      objectConfig: {
+        delegatedShareUrlHandler,
+      },
       isDirty,
       shareableUrl,
-      urlService,
+      shortUrlService,
       allowShortUrl: true,
-      delegatedShareUrlHandler,
     });
 
     await user.click(screen.getByTestId('copyShareUrlButton'));
@@ -92,9 +96,10 @@ describe('LinkContent', () => {
     renderComponent({
       objectType,
       objectId,
+      objectConfig: {},
       isDirty,
       shareableUrl,
-      urlService,
+      shortUrlService,
       allowShortUrl: false,
     });
 
@@ -131,9 +136,10 @@ describe('LinkContent', () => {
     renderComponent({
       objectType,
       objectId,
+      objectConfig: {},
       isDirty,
       shareableUrl,
-      urlService,
+      shortUrlService,
       allowShortUrl: true,
       // @ts-ignore this locator is passed mainly to test the code path that invokes createWithLocator
       shareableUrlLocatorParams,
@@ -170,9 +176,10 @@ describe('LinkContent', () => {
     renderComponent({
       objectType,
       objectId,
+      objectConfig: {},
       isDirty,
       shareableUrl,
-      urlService,
+      shortUrlService,
       allowShortUrl: true,
     });
 

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -21,19 +21,21 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useState, useRef, useEffect } from 'react';
 import { TimeTypeSection } from './time_type_section';
-import type { IShareContext, ShareContextObjectTypeConfig } from '../../context';
+import type { IShareContext } from '../../context';
+import type { LinkShareConfig, LinkShareUIConfig } from '../../../types';
 
 type LinkProps = Pick<
   IShareContext,
   | 'objectType'
   | 'objectId'
   | 'isDirty'
-  | 'urlService'
   | 'shareableUrl'
-  | 'delegatedShareUrlHandler'
   | 'shareableUrlLocatorParams'
   | 'allowShortUrl'
-> & { objectConfig?: ShareContextObjectTypeConfig };
+> &
+  LinkShareConfig['config'] & {
+    objectConfig?: LinkShareUIConfig;
+  };
 
 interface UrlParams {
   [extensionName: string]: {
@@ -46,10 +48,9 @@ export const LinkContent = ({
   objectType,
   objectConfig = {},
   shareableUrl,
-  urlService,
+  shortUrlService,
   shareableUrlLocatorParams,
   allowShortUrl,
-  delegatedShareUrlHandler,
 }: LinkProps) => {
   const [snapshotUrl, setSnapshotUrl] = useState<string>('');
   const [isTextCopied, setTextCopied] = useState(false);
@@ -59,6 +60,8 @@ export const LinkContent = ({
   const urlToCopy = useRef<string | undefined>(undefined);
   const copiedTextToolTipCleanupIdRef = useRef<ReturnType<typeof setTimeout>>();
   const timeRange = shareableUrlLocatorParams?.params?.timeRange;
+
+  const { delegatedShareUrlHandler, draftModeCallOut: DraftModeCallout } = objectConfig;
 
   const getUrlWithUpdatedParams = useCallback((tempUrl: string): string => {
     const urlWithUpdatedParams = urlParamsRef.current
@@ -83,8 +86,6 @@ export const LinkContent = ({
   }, [getUrlWithUpdatedParams, shareableUrl]);
 
   const createShortUrl = useCallback(async () => {
-    const shortUrlService = urlService.shortUrls.get(null);
-
     if (shareableUrlLocatorParams) {
       const shortUrl = await shortUrlService.createWithLocator(
         shareableUrlLocatorParams,
@@ -94,14 +95,14 @@ export const LinkContent = ({
     } else {
       return (await shortUrlService.createFromLongUrl(snapshotUrl, isAbsoluteTime)).url;
     }
-  }, [shareableUrlLocatorParams, urlService, snapshotUrl, isAbsoluteTime]);
+  }, [shareableUrlLocatorParams, shortUrlService, snapshotUrl, isAbsoluteTime]);
 
   const copyUrlHelper = useCallback(async () => {
     setIsLoading(true);
 
     if (!urlToCopy.current) {
       urlToCopy.current = delegatedShareUrlHandler
-        ? delegatedShareUrlHandler()
+        ? await delegatedShareUrlHandler()
         : allowShortUrl
         ? await createShortUrl()
         : snapshotUrl;
@@ -122,7 +123,6 @@ export const LinkContent = ({
     setIsLoading(false);
   }, [snapshotUrl, delegatedShareUrlHandler, allowShortUrl, createShortUrl]);
 
-  const { draftModeCallOut: DraftModeCallout } = objectConfig;
   const changeTimeType = (e: EuiSwitchEvent) => {
     setIsAbsoluteTime(e.target.checked);
     if (urlToCopy?.current && e.target.checked !== isAbsoluteTime) {

--- a/src/platform/plugins/shared/share/public/index.ts
+++ b/src/platform/plugins/shared/share/public/index.ts
@@ -22,12 +22,11 @@ export type {
 
 export type {
   ShareContext,
-  ShareMenuProvider,
   ShareMenuItemLegacy,
-  ShareMenuItemV2,
   ShowShareMenuOptions,
   ShareContextMenuPanelItem,
   BrowserUrlService,
+  ExportShare,
 } from './types';
 
 export type { RedirectOptions } from '../common/url_service';

--- a/src/platform/plugins/shared/share/public/mocks.ts
+++ b/src/platform/plugins/shared/share/public/mocks.ts
@@ -16,7 +16,7 @@ import type { BrowserShortUrlClientFactoryCreateParams } from './url_service/sho
 export type Setup = jest.Mocked<SharePublicSetup>;
 export type Start = jest.Mocked<SharePublicStart>;
 
-const url = new UrlService<BrowserShortUrlClientFactoryCreateParams, BrowserShortUrlClient>({
+export const url = new UrlService<BrowserShortUrlClientFactoryCreateParams, BrowserShortUrlClient>({
   navigate: async () => {},
   getUrl: async ({ app, path }, { absolute }) => {
     return `${absolute ? 'http://localhost:8888' : ''}/app/${app}${path}`;
@@ -40,6 +40,7 @@ const url = new UrlService<BrowserShortUrlClientFactoryCreateParams, BrowserShor
 const createSetupContract = (): Setup => {
   const setupContract: Setup = {
     register: jest.fn(),
+    registerShareIntegration: jest.fn(),
     url,
     navigate: jest.fn(),
     setAnonymousAccessServiceProvider: jest.fn(),

--- a/src/platform/plugins/shared/share/public/plugin.test.mocks.ts
+++ b/src/platform/plugins/shared/share/public/plugin.test.mocks.ts
@@ -13,6 +13,6 @@ import { shareMenuManagerMock } from './services/share_menu_manager.mock';
 export const registryMock = shareMenuRegistryMock.create();
 export const managerMock = shareMenuManagerMock.create();
 jest.doMock('./services', () => ({
-  ShareMenuRegistry: jest.fn(() => registryMock),
+  ShareRegistry: jest.fn(() => registryMock),
   ShareMenuManager: jest.fn(() => managerMock),
 }));

--- a/src/platform/plugins/shared/share/public/plugin.test.ts
+++ b/src/platform/plugins/shared/share/public/plugin.test.ts
@@ -65,15 +65,11 @@ describe('SharePlugin', () => {
         await service.setup(coreSetup);
         const start = await service.start({} as CoreStart);
         expect(registryMock.start).toHaveBeenCalled();
-        expect(managerMock.start).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.anything(),
-          expect.objectContaining({
-            getShareMenuItems: expect.any(Function),
-          }),
-          true, // disableEmbed - true because buildFlavor === 'serverless'
-          undefined
-        );
+        expect(managerMock.start).toHaveBeenCalledWith({
+          resolveShareItemsForShareContext: expect.any(Function),
+          core: expect.objectContaining({}),
+          isServerless: expect.any(Boolean),
+        });
         expect(start.toggleShareContextMenu).toBeDefined();
       });
 
@@ -91,15 +87,11 @@ describe('SharePlugin', () => {
         setup.setAnonymousAccessServiceProvider(anonymousAccessServiceProvider);
         const start = await service.start({} as CoreStart);
         expect(registryMock.start).toHaveBeenCalled();
-        expect(managerMock.start).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.anything(),
-          expect.objectContaining({
-            getShareMenuItems: expect.any(Function),
-          }),
-          true, // disableEmbed - true because buildFlavor === 'serverless'
-          anonymousAccessServiceProvider
-        );
+        expect(managerMock.start).toHaveBeenCalledWith({
+          resolveShareItemsForShareContext: expect.any(Function),
+          core: expect.objectContaining({}),
+          isServerless: expect.any(Boolean),
+        });
         expect(start.toggleShareContextMenu).toBeDefined();
       });
     });

--- a/src/platform/plugins/shared/share/public/plugin.ts
+++ b/src/platform/plugins/shared/share/public/plugin.ts
@@ -11,7 +11,7 @@ import './index.scss';
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import { ShareMenuManager, ShareMenuManagerStart } from './services';
-import { ShareMenuRegistry, ShareMenuRegistrySetup } from './services';
+import { ShareRegistry, ShareMenuRegistrySetup } from './services';
 import { UrlService } from '../common/url_service';
 import { RedirectManager } from './url_service';
 import type { RedirectOptions } from '../common/url_service/locators/redirect';
@@ -27,7 +27,7 @@ import { registrations } from './lib/registrations';
 import type { BrowserUrlService } from './types';
 
 /** @public */
-export type SharePublicSetup = ShareMenuRegistrySetup & {
+export interface SharePublicSetup extends ShareMenuRegistrySetup {
   /**
    * Utilities to work with URL locators and short URLs.
    */
@@ -43,7 +43,7 @@ export type SharePublicSetup = ShareMenuRegistrySetup & {
    * Sets the provider for the anonymous access service; this is consumed by the Security plugin to avoid a circular dependency.
    */
   setAnonymousAccessServiceProvider: (provider: () => AnonymousAccessServiceContract) => void;
-};
+}
 
 /** @public */
 export type SharePublicStart = ShareMenuManagerStart & {
@@ -74,7 +74,7 @@ export class SharePlugin
       SharePublicStartDependencies
     >
 {
-  private readonly shareMenuRegistry?: ShareMenuRegistry = new ShareMenuRegistry();
+  private readonly shareRegistry = new ShareRegistry();
   private readonly shareContextMenu = new ShareMenuManager();
   private redirectManager?: RedirectManager;
   private url?: BrowserUrlService;
@@ -124,7 +124,7 @@ export class SharePlugin
     registrations.setup({ analytics });
 
     return {
-      ...this.shareMenuRegistry!.setup(),
+      ...this.shareRegistry.setup(),
       url: this.url,
       navigate: (options: RedirectOptions) => this.redirectManager!.navigate(options),
       setAnonymousAccessServiceProvider: (provider: () => AnonymousAccessServiceContract) => {
@@ -137,14 +137,18 @@ export class SharePlugin
   }
 
   public start(core: CoreStart): SharePublicStart {
-    const disableEmbed = this.initializerContext.env.packageInfo.buildFlavor === 'serverless';
-    const sharingContextMenuStart = this.shareContextMenu.start(
+    const isServerless = this.initializerContext.env.packageInfo.buildFlavor === 'serverless';
+
+    const { resolveShareItemsForShareContext } = this.shareRegistry.start({
+      urlService: this.url!,
+      anonymousAccessServiceProvider: () => this.anonymousAccessServiceProvider!(),
+    });
+
+    const sharingContextMenuStart = this.shareContextMenu.start({
       core,
-      this.url!,
-      this.shareMenuRegistry!.start(),
-      disableEmbed,
-      this.anonymousAccessServiceProvider
-    );
+      isServerless,
+      resolveShareItemsForShareContext,
+    });
 
     return {
       ...sharingContextMenuStart,

--- a/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
+++ b/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
@@ -10,26 +10,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { toMountPoint } from '@kbn/react-kibana-mount';
-import type { CoreStart } from '@kbn/core/public';
+import { CoreStart } from '@kbn/core/public';
 import type { RenderingService } from '@kbn/core-rendering-browser';
-import type { ShowShareMenuOptions } from '../types';
-import type { ShareMenuRegistryStart } from './share_menu_registry';
-import type { AnonymousAccessServiceContract } from '../../common/anonymous_access';
-import type { BrowserUrlService, ShareMenuItemV2 } from '../types';
+import { ShowShareMenuOptions } from '../types';
+import { ShareRegistry } from './share_menu_registry';
+import type { ShareConfigs } from '../types';
 import { ShareMenu } from '../components/share_tabs';
+
+interface ShareMenuManagerStartDeps {
+  core: CoreStart;
+  isServerless: boolean;
+  resolveShareItemsForShareContext: ShareRegistry['resolveShareItemsForShareContext'];
+}
 
 export class ShareMenuManager {
   private isOpen = false;
-
   private container = document.createElement('div');
 
-  start(
-    core: CoreStart,
-    urlService: BrowserUrlService,
-    shareRegistry: ShareMenuRegistryStart,
-    disableEmbed: boolean,
-    anonymousAccessServiceProvider?: () => AnonymousAccessServiceContract
-  ) {
+  start({ core, resolveShareItemsForShareContext, isServerless }: ShareMenuManagerStartDeps) {
     return {
       /**
        * Collects share menu items from registered providers and mounts the share context menu under
@@ -41,17 +39,20 @@ export class ShareMenuManager {
           this.onClose();
           options.onClose?.();
         };
-        const menuItems = shareRegistry.getShareMenuItems({ ...options, onClose });
-        const anonymousAccess = anonymousAccessServiceProvider?.();
+
+        const menuItems = resolveShareItemsForShareContext({
+          ...options,
+          isServerless,
+          onClose,
+        });
+
         this.toggleShareContextMenu(
           {
             ...options,
-            allowEmbed: disableEmbed ? false : options.allowEmbed,
             onClose,
             menuItems,
-            urlService,
-            anonymousAccess,
-            publicAPIEnabled: !disableEmbed,
+            publicAPIEnabled: !isServerless,
+            ...core,
           },
           core.rendering
         );
@@ -67,7 +68,6 @@ export class ShareMenuManager {
   private toggleShareContextMenu(
     {
       anchorElement,
-      allowEmbed,
       allowShortUrl,
       objectId,
       objectType,
@@ -76,23 +76,13 @@ export class ShareMenuManager {
       menuItems,
       shareableUrl,
       shareableUrlLocatorParams,
-      embedUrlParamExtensions,
-      showPublicUrlSwitch,
-      urlService,
-      anonymousAccess,
-      snapshotShareWarning,
       onClose,
-      disabledShareUrl,
       isDirty,
-      delegatedShareUrlHandler,
       publicAPIEnabled,
     }: ShowShareMenuOptions & {
-      anchorElement: HTMLElement;
-      menuItems: ShareMenuItemV2[];
-      urlService: BrowserUrlService;
-      anonymousAccess: AnonymousAccessServiceContract | undefined;
+      menuItems: ShareConfigs[];
       onClose: () => void;
-      isDirty: boolean;
+      i18n: CoreStart['i18n'];
     },
     rendering: RenderingService
   ) {
@@ -109,23 +99,15 @@ export class ShareMenuManager {
     const mount = toMountPoint(
       <ShareMenu
         shareContext={{
-          publicAPIEnabled,
-          anchorElement,
-          allowEmbed,
-          allowShortUrl,
           objectId,
           objectType,
           objectTypeMeta,
+          anchorElement,
+          publicAPIEnabled,
+          allowShortUrl,
           sharingData,
           shareableUrl,
           shareableUrlLocatorParams,
-          delegatedShareUrlHandler,
-          embedUrlParamExtensions,
-          anonymousAccess,
-          showPublicUrlSwitch,
-          urlService,
-          snapshotShareWarning,
-          disabledShareUrl,
           isDirty,
           shareMenuItems: menuItems,
           onClose: () => {

--- a/src/platform/plugins/shared/share/public/services/share_menu_registry.mock.ts
+++ b/src/platform/plugins/shared/share/public/services/share_menu_registry.mock.ts
@@ -9,27 +9,30 @@
 
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import {
-  ShareMenuRegistry,
+  ShareRegistry,
   ShareMenuRegistrySetup,
   ShareMenuRegistryStart,
 } from './share_menu_registry';
-import { ShareMenuItemV2, ShareContext } from '../types';
+import { ShareContext, ShareConfigs } from '../types';
 
 const createSetupMock = (): jest.Mocked<ShareMenuRegistrySetup> => {
   const setup = {
     register: jest.fn(),
+    registerShareIntegration: jest.fn(),
   };
   return setup;
 };
 
 const createStartMock = (): jest.Mocked<ShareMenuRegistryStart> => {
   const start = {
-    getShareMenuItems: jest.fn((_props: ShareContext) => [] as ShareMenuItemV2[]),
+    resolveShareItemsForShareContext: jest.fn(
+      (_props: ShareContext & { isServerless: boolean }) => [] as ShareConfigs[]
+    ),
   };
   return start;
 };
 
-const createMock = (): jest.Mocked<PublicMethodsOf<ShareMenuRegistry>> => {
+const createMock = (): jest.Mocked<PublicMethodsOf<ShareRegistry>> => {
   const service = {
     setup: jest.fn(),
     start: jest.fn(),

--- a/src/platform/plugins/shared/share/public/services/share_menu_registry.test.ts
+++ b/src/platform/plugins/shared/share/public/services/share_menu_registry.test.ts
@@ -7,54 +7,202 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ShareMenuRegistry } from './share_menu_registry';
-import { ShareMenuItemV2, ShareContext } from '../types';
+import { ShareRegistry } from './share_menu_registry';
+import { ShareContext, ShareIntegration, ShareRegistryApiStart } from '../types';
+import { url } from '../mocks';
 
 describe('ShareActionsRegistry', () => {
-  describe('setup', () => {
+  const startDeps: ShareRegistryApiStart = {
+    urlService: url,
+    anonymousAccessServiceProvider: () => ({
+      getCapabilities: jest.fn(),
+      getState: jest.fn(),
+    }),
+  };
+
+  describe('registerShareIntegration', () => {
     test('throws when registering duplicate id', () => {
-      const setup = new ShareMenuRegistry().setup();
-      setup.register({
+      const shareRegistrySetup = new ShareRegistry().setup();
+
+      shareRegistrySetup.registerShareIntegration({
         id: 'csvReports',
-        getShareMenuItems: () => [],
+        config: () => ({}),
       });
+
       expect(() =>
-        setup.register({
+        shareRegistrySetup.registerShareIntegration({
           id: 'csvReports',
-          getShareMenuItems: () => [],
+          config: () => ({}),
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Share menu provider with id [csvReports] has already been registered. Use a unique id."`
+        `"Share action with type [integration] for app [*] has already been registered."`
       );
     });
   });
 
   describe('start', () => {
-    describe('getActions', () => {
-      test('returns a flat list of actions returned by all providers', () => {
-        const service = new ShareMenuRegistry();
-        const registerFunction = service.setup().register;
-        const shareAction1 = {} as ShareMenuItemV2;
-        const shareAction2 = {} as ShareMenuItemV2;
-        const shareAction3 = {} as ShareMenuItemV2;
-        const provider1Callback = jest.fn(() => [shareAction1]);
-        const provider2Callback = jest.fn(() => [shareAction2, shareAction3]);
-        registerFunction({
-          id: 'csvReports',
-          getShareMenuItems: provider1Callback,
-        });
-        registerFunction({
-          id: 'screenCaptureReports',
-          getShareMenuItems: provider2Callback,
-        });
-        const context = {} as ShareContext;
-        expect(service.start().getShareMenuItems(context)).toEqual([
-          shareAction1,
-          shareAction2,
-          shareAction3,
+    describe('resolveShareItemsForShareContext', () => {
+      test('it returns the default share actions for any requested app scope without performing any prior registrations', () => {
+        const { resolveShareItemsForShareContext } = new ShareRegistry().start(startDeps);
+
+        const context = {
+          objectType: 'someRandomObjectType',
+        } as ShareContext;
+
+        expect(resolveShareItemsForShareContext({ ...context, isServerless: false })).toEqual([
+          expect.objectContaining({
+            shareType: 'link',
+          }),
+          expect.objectContaining({
+            shareType: 'embed',
+          }),
         ]);
-        expect(provider1Callback).toHaveBeenCalledWith(context);
-        expect(provider2Callback).toHaveBeenCalledWith(context);
+      });
+
+      test('it excludes the default embed share actions for any requested app scope in serverless', () => {
+        const { resolveShareItemsForShareContext } = new ShareRegistry().start(startDeps);
+
+        const context = {
+          objectType: 'someRandomObjectType',
+        } as ShareContext;
+
+        expect(resolveShareItemsForShareContext({ ...context, isServerless: true })).toEqual(
+          expect.not.arrayContaining([
+            expect.objectContaining({
+              shareType: 'embed',
+            }),
+          ])
+        );
+      });
+
+      test('returns a flat list of actions returned by all providers', () => {
+        const service = new ShareRegistry();
+        const { registerShareIntegration: registerFunction } = service.setup();
+
+        const shareAction1ConfigFactory = jest.fn(() => ({}));
+        const shareAction1: ShareIntegration = {
+          id: 'shareAction1',
+          shareType: 'integration',
+          config: shareAction1ConfigFactory,
+        };
+
+        const shareAction2ConfigFactory = jest.fn(() => ({}));
+        const shareAction2: ShareIntegration = {
+          id: 'shareAction2',
+          shareType: 'integration',
+          config: shareAction2ConfigFactory,
+        };
+
+        const shareAction3ConfigFactory = jest.fn(() => ({}));
+        const shareAction3: ShareIntegration = {
+          id: 'shareAction3',
+          shareType: 'integration',
+          config: shareAction3ConfigFactory,
+        };
+
+        registerFunction(shareAction1);
+        registerFunction(shareAction2);
+        registerFunction(shareAction3);
+
+        const context = { objectType: 'anotherRandomShareObjectType' } as ShareContext;
+        const isServerless = false;
+
+        const { resolveShareItemsForShareContext } = service.start(startDeps);
+
+        expect(resolveShareItemsForShareContext({ ...context, isServerless })).toEqual([
+          expect.objectContaining({
+            shareType: 'link',
+            config: expect.any(Object),
+          }),
+          expect.objectContaining({
+            shareType: 'embed',
+            config: expect.any(Object),
+          }),
+          expect.objectContaining({
+            shareType: 'integration',
+            id: 'shareAction1',
+            config: expect.any(Object),
+          }),
+          expect.objectContaining({
+            shareType: 'integration',
+            id: 'shareAction2',
+            config: expect.any(Object),
+          }),
+          expect.objectContaining({
+            shareType: 'integration',
+            id: 'shareAction3',
+            config: expect.any(Object),
+          }),
+        ]);
+
+        [shareAction1ConfigFactory, shareAction2ConfigFactory, shareAction3ConfigFactory].forEach(
+          (factory) => {
+            expect(factory).toHaveBeenCalledTimes(1);
+            expect(shareAction1ConfigFactory).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ...context,
+                urlService: expect.any(Object),
+                anonymousAccessServiceProvider: expect.any(Function),
+              })
+            );
+          }
+        );
+      });
+
+      test('it returns a flat list of actions registered to the requested scope', () => {
+        const service = new ShareRegistry();
+        const { registerShareIntegration: registerFunction } = service.setup();
+        const context = { objectType: 'randomObjectType' } as ShareContext;
+
+        const isServerless = false;
+
+        const shareAction1ConfigFactory = jest.fn(() => ({}));
+        const shareAction1: ShareIntegration = {
+          id: 'shareAction1',
+          shareType: 'integration',
+          config: shareAction1ConfigFactory,
+        };
+
+        const shareAction2ConfigFactory = jest.fn(() => ({}));
+        const shareAction2: ShareIntegration = {
+          id: 'shareAction2',
+          shareType: 'integration',
+          config: shareAction2ConfigFactory,
+        };
+
+        const shareAction3ConfigFactory = jest.fn(() => ({}));
+        const shareAction3: ShareIntegration = {
+          id: 'shareAction3',
+          shareType: 'integration',
+          config: shareAction3ConfigFactory,
+        };
+
+        registerFunction(context.objectType, shareAction1);
+        registerFunction('someOtherRandomObjectType', shareAction2);
+        registerFunction(context.objectType, shareAction3);
+
+        const { resolveShareItemsForShareContext } = service.start(startDeps);
+
+        expect(resolveShareItemsForShareContext({ ...context, isServerless })).toEqual([
+          expect.objectContaining({
+            shareType: 'link',
+            config: expect.any(Object),
+          }),
+          expect.objectContaining({
+            shareType: 'embed',
+            config: expect.any(Object),
+          }),
+          expect.objectContaining({
+            shareType: 'integration',
+            id: 'shareAction1',
+            config: expect.any(Object),
+          }),
+          expect.objectContaining({
+            shareType: 'integration',
+            id: 'shareAction3',
+            config: expect.any(Object),
+          }),
+        ]);
       });
     });
   });

--- a/src/platform/plugins/shared/share/public/services/share_menu_registry.ts
+++ b/src/platform/plugins/shared/share/public/services/share_menu_registry.ts
@@ -7,48 +7,175 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import {
+import type {
+  BrowserUrlService,
   ShareContext,
-  ShareMenuProvider,
-  ShareMenuProviderV2,
+  ShareConfigs,
+  ShareRegistryPublicApi,
+  ShareActionIntents,
+  InternalShareActionIntent,
+  ShareIntegration,
+  ShareRegistryApiStart,
   ShareMenuProviderLegacy,
 } from '../types';
+import type { AnonymousAccessServiceContract } from '../../common/anonymous_access';
 
-export class ShareMenuRegistry {
-  private readonly shareMenuProviders = new Map<string, ShareMenuProvider>();
+export class ShareRegistry implements ShareRegistryPublicApi {
+  private urlService?: BrowserUrlService;
+  private anonymousAccessServiceProvider?: () => AnonymousAccessServiceContract;
 
-  public setup() {
+  private readonly globalMarker: string = '*';
+
+  constructor() {
+    // register default share actions
+    this.registerLinkShareAction();
+    this.registerEmbedShareAction();
+  }
+
+  private readonly shareOptionsStore: Record<
+    string,
+    Map<InternalShareActionIntent | `integration-${string}` | 'legacy', ShareActionIntents>
+  > = {
+    [this.globalMarker]: new Map(),
+  };
+
+  setup() {
     return {
       /**
-       * Register an additional source of items for share context menu items. All registered providers
-       * will be called if a consumer displays the context menu. Returned `ShareMenuItem`s will be shown
-       * in the context menu together with the default built-in share options.
-       * Each share provider needs a globally unique id.
-       * @param shareMenuProvider
+       * @deprecated Use {@link registerShareIntegration} instead.
        */
-      register: (shareMenuProvider: ShareMenuProvider) => {
-        if (this.shareMenuProviders.has(shareMenuProvider.id)) {
-          throw new Error(
-            `Share menu provider with id [${shareMenuProvider.id}] has already been registered. Use a unique id.`
-          );
-        }
-        this.shareMenuProviders.set(shareMenuProvider.id, shareMenuProvider);
-      },
+      register: this.register.bind(this),
+      registerShareIntegration: this.registerShareIntegration.bind(this),
     };
   }
 
-  public start() {
+  start({ urlService, anonymousAccessServiceProvider }: ShareRegistryApiStart) {
+    this.urlService = urlService;
+    this.anonymousAccessServiceProvider = anonymousAccessServiceProvider;
+
     return {
-      getShareMenuItems: (context: ShareContext) =>
-        Array.from(this.shareMenuProviders.values()).flatMap((shareActionProvider) =>
-          (
-            (shareActionProvider as ShareMenuProviderV2).getShareMenuItems ??
-            (shareActionProvider as ShareMenuProviderLegacy).getShareMenuItemsLegacy
-          ).call(shareActionProvider, context)
-        ),
+      resolveShareItemsForShareContext: this.resolveShareItemsForShareContext.bind(this),
     };
+  }
+
+  private registerShareIntentAction(
+    shareObject: string,
+    shareActionIntent: ShareActionIntents
+  ): void {
+    if (!this.shareOptionsStore[shareObject]) {
+      this.shareOptionsStore[shareObject] = new Map();
+    }
+
+    const shareContextMap = this.shareOptionsStore[shareObject];
+
+    const recordKey =
+      shareActionIntent.shareType === 'integration'
+        ? (`integration-${shareActionIntent.groupId || 'unknown'}-${shareActionIntent.id}` as const)
+        : shareActionIntent.shareType;
+
+    if (shareContextMap.has(recordKey)) {
+      throw new Error(
+        `Share action with type [${shareActionIntent.shareType}] for app [${shareObject}] has already been registered.`
+      );
+    }
+
+    shareContextMap.set(recordKey, shareActionIntent);
+  }
+
+  private registerLinkShareAction(): void {
+    this.registerShareIntentAction(this.globalMarker, {
+      shareType: 'link',
+      config: ({ urlService }) => ({
+        shortUrlService: urlService?.shortUrls.get(null)!,
+      }),
+    });
+  }
+
+  private registerEmbedShareAction(): void {
+    this.registerShareIntentAction(this.globalMarker, {
+      shareType: 'embed',
+      config: ({ urlService, anonymousAccessServiceProvider }) => ({
+        anonymousAccess: anonymousAccessServiceProvider!(),
+        shortUrlService: urlService.shortUrls.get(null),
+      }),
+    });
+  }
+
+  /**
+   * @description provides an escape hatch to support allowing legacy share menu items to be registered
+   */
+  private register(value: ShareMenuProviderLegacy) {
+    // implement backwards compatibility for the share plugin
+    this.registerShareIntentAction(this.globalMarker, {
+      shareType: 'legacy',
+      id: value.id,
+      config: value.getShareMenuItemsLegacy,
+    });
+  }
+
+  private registerShareIntegration<I extends ShareIntegration>(
+    ...args: [string, Omit<I, 'shareType'>] | [Omit<I, 'shareType'>]
+  ): void {
+    const [shareObject, shareActionIntent] =
+      args.length === 1 ? [this.globalMarker, args[0]] : args;
+    this.registerShareIntentAction(shareObject, {
+      shareType: 'integration',
+      ...shareActionIntent,
+    });
+  }
+
+  private getShareConfigOptionsForObject(
+    objectType: ShareContext['objectType']
+  ): ShareActionIntents[] {
+    const shareContextMap = this.shareOptionsStore[objectType];
+    const globalOptions = Array.from(this.shareOptionsStore[this.globalMarker].values());
+
+    if (!shareContextMap) {
+      return globalOptions;
+    }
+
+    return globalOptions.concat(Array.from(shareContextMap.values()));
+  }
+
+  private resolveShareItemsForShareContext({
+    objectType,
+    isServerless,
+    ...shareContext
+  }: ShareContext & { isServerless: boolean }): ShareConfigs[] {
+    if (!this.urlService || !this.anonymousAccessServiceProvider) {
+      throw new Error('ShareOptionsManager#start was not invoked');
+    }
+
+    return this.getShareConfigOptionsForObject(objectType)
+      .map((shareAction) => {
+        let config: ShareConfigs['config'] | null;
+
+        if (shareAction.shareType === 'legacy') {
+          config = shareAction.config.call(null, {
+            objectType,
+            ...shareContext,
+          });
+        } else {
+          config = shareAction.config.call(null, {
+            urlService: this.urlService!,
+            anonymousAccessServiceProvider: this.anonymousAccessServiceProvider,
+            objectType,
+            ...shareContext,
+          });
+        }
+
+        return {
+          ...shareAction,
+          config,
+        } as ShareConfigs;
+      })
+      .filter((shareAction) => {
+        return isServerless
+          ? shareAction.shareType !== 'embed' && shareAction.config
+          : shareAction.config;
+      });
   }
 }
 
-export type ShareMenuRegistrySetup = ReturnType<ShareMenuRegistry['setup']>;
-export type ShareMenuRegistryStart = ReturnType<ShareMenuRegistry['start']>;
+export type ShareMenuRegistryStart = ReturnType<ShareRegistry['start']>;
+export type ShareMenuRegistrySetup = ReturnType<ShareRegistry['setup']>;

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -7,24 +7,221 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ComponentType, ReactElement, ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import type { InjectedIntl } from '@kbn/i18n-react';
 import { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
-import type { Capabilities, ThemeServiceSetup } from '@kbn/core/public';
+import type { Capabilities } from '@kbn/core/public';
+import type { EuiIconProps } from '@elastic/eui';
 import type { UrlService, LocatorPublic } from '../common/url_service';
 import type { BrowserShortUrlClientFactoryCreateParams } from './url_service/short_urls/short_url_client_factory';
 import type { BrowserShortUrlClient } from './url_service/short_urls/short_url_client';
+import { AnonymousAccessServiceContract } from '../common/anonymous_access';
+
+export interface ShareRegistryApiStart {
+  urlService: BrowserUrlService;
+  anonymousAccessServiceProvider?: () => AnonymousAccessServiceContract;
+}
+
+export type ShareTypes = 'link' | 'embed' | 'legacy' | 'integration';
+
+export type InternalShareActionIntent = Exclude<ShareTypes, 'integration' | 'legacy'>;
+
+type ShareActionUserInputBase<E extends Record<string, unknown> = Record<string, unknown>> = {
+  /**
+   * The title of the share action
+   */
+  draftModeCallOut?: ReactNode;
+  helpText?: ReactNode;
+  CTAButtonConfig?: {
+    id: string;
+    dataTestSubj: string;
+    label: string;
+  };
+  disabled?: boolean;
+} & E;
+
+export interface ShareMenuProviderLegacy {
+  readonly id: string;
+  getShareMenuItemsLegacy: (context: ShareContext) => ShareMenuItemLegacy[];
+}
+
+type ShareImplementationFactory<
+  T extends Omit<ShareTypes, 'legacy'>,
+  C extends Record<string, unknown> = Record<string, unknown>
+> = T extends 'integration'
+  ? {
+      id: string;
+      groupId?: string;
+      shareType: T;
+      config: (ctx: ShareContext & ShareRegistryApiStart) => C | null;
+    }
+  : {
+      shareType: T;
+      config: (ctx: ShareContext & ShareRegistryApiStart) => C | null;
+    };
+
+// New type definition to extract the config return type
+type ShareImplementation<T> = Omit<T, 'config'> & {
+  config: T extends ShareImplementationFactory<any, infer R> ? R : never;
+};
+
+/**
+ * @description implementation definition for creating a share action for sharing object links
+ */
+export type LinkShare = ShareImplementationFactory<
+  'link',
+  {
+    shortUrlService: ReturnType<BrowserUrlService['shortUrls']['get']>;
+  }
+>;
+
+/**
+ * @description implementation definition for creating a share action for sharing embed links
+ */
+export type EmbedShare = ShareImplementationFactory<
+  'embed',
+  {
+    anonymousAccess: AnonymousAccessServiceContract;
+    shortUrlService: ReturnType<BrowserUrlService['shortUrls']['get']>;
+  }
+>;
+
+/**
+ * @description skeleton definition for implementing a share action integration
+ */
+export type ShareIntegration<
+  IntegrationParameters extends Record<string, unknown> = Record<string, unknown>
+> = ShareImplementationFactory<'integration', IntegrationParameters>;
+
+/**
+ * @description implementation definition to support legacy share implementation
+ */
+export interface ShareLegacy {
+  shareType: 'legacy';
+  id: ShareMenuProviderLegacy['id'];
+  config: ShareMenuProviderLegacy['getShareMenuItemsLegacy'];
+}
+
+/**
+ * @description Share integration implementation definition for performing exports within kibana
+ */
+export interface ExportShare
+  extends ShareIntegration<{
+    /**
+     * @deprecated only kept around for legacy reasons
+     */
+    name?: string;
+    /**
+     * @deprecated only kept around for legacy reasons
+     */
+    icon?: EuiIconProps['type'];
+    /**
+     * @deprecated only kept around for legacy reasons
+     */
+    sortOrder?: number;
+    /**
+     * @deprecated only kept around for legacy reasons
+     */
+    toolTipContent?: string;
+    label: string;
+    exportType: string;
+    /**
+     * allows disabling the export action based on there factors, for instance licensing
+     */
+    disabled?: boolean;
+    helpText?: ReactNode;
+    generateExportButton?: ReactNode;
+    generateAssetExport: (args: ExportGenerationOpts) => Promise<unknown>;
+    generateAssetURIValue: (args: ExportGenerationOpts) => string | undefined;
+    renderCopyURIButton?: boolean;
+    warnings?: Array<{ title: string; message: string }>;
+    requiresSavedState?: boolean;
+    supportedLayoutOptions?: Array<'print'>;
+    renderLayoutOptionSwitch?: boolean;
+  }> {
+  groupId: 'export';
+}
+
+export type ShareActionIntents = LinkShare | EmbedShare | ShareLegacy | ShareIntegration;
+
+export type LinkShareConfig = ShareImplementation<LinkShare>;
+export type EmbedShareConfig = ShareImplementation<EmbedShare>;
+export type ExportShareConfig = ShareImplementation<ExportShare>;
+export type ShareIntegrationConfig = ShareImplementation<ShareIntegration>;
+
+export type LegacyIntegrationConfig = Omit<ShareLegacy, 'config'> & {
+  config: ReturnType<ShareLegacy['config']>;
+};
+
+export type ShareConfigs =
+  | LinkShareConfig
+  | EmbedShareConfig
+  | ExportShareConfig
+  | LegacyIntegrationConfig
+  | ShareIntegrationConfig;
+
+export type LinkShareUIConfig = ShareActionUserInputBase<{
+  /**
+   *
+   * @description allows a consumer to provide a custom method which when invoked
+   * handles providing a share url in the context of said consumer
+   */
+  delegatedShareUrlHandler?: () => Promise<string>;
+}>;
+
+export type EmbedShareUIConfig = ShareActionUserInputBase<{
+  embedUrlParamExtensions?: UrlParamExtension[];
+  computeAnonymousCapabilities?: (anonymousUserCapabilities: Capabilities) => boolean;
+  /**
+   * @deprecated use computeAnonymousCapabilities defined on objectTypeMeta config
+   */
+  showPublicUrlSwitch?: (anonymousUserCapabilities: Capabilities) => boolean;
+}>;
+
+type ExportShareUIConfig = ShareActionUserInputBase<{}>;
+
+export interface ShareUIConfig {
+  link: LinkShareUIConfig;
+  embed: EmbedShareUIConfig;
+  integration: {
+    [key: string]: ShareActionUserInputBase;
+    export: ExportShareUIConfig;
+  };
+}
+
+export interface SharingData {
+  title: string;
+  locatorParams: {
+    id: string;
+    params: Record<string, unknown>;
+  };
+}
+
+interface ShareRegistryInternalApi {
+  registerShareIntegration<I extends ShareIntegration>(shareObject: string, arg: I): void;
+  registerShareIntegration<I extends ShareIntegration>(arg: I): void;
+
+  resolveShareItemsForShareContext(args: ShareContext): ShareConfigs[];
+}
+
+export abstract class ShareRegistryPublicApi {
+  abstract setup(): {
+    /**
+     * @description registers a share menu provider for a specific object type
+     */
+    registerShareIntegration: ShareRegistryInternalApi['registerShareIntegration'];
+  };
+
+  abstract start(args: ShareRegistryApiStart): {
+    resolveShareItemsForShareContext: ShareRegistryInternalApi['resolveShareItemsForShareContext'];
+  };
+}
 
 export type BrowserUrlService = UrlService<
   BrowserShortUrlClientFactoryCreateParams,
   BrowserShortUrlClient
 >;
-
-export interface ShareContextObjectTypeConfig {
-  draftModeCallOut?: ReactNode;
-  computeAnonymousCapabilities?: (anonymousUserCapabilities: Capabilities) => boolean;
-}
 
 /**
  * @public
@@ -36,14 +233,22 @@ export interface ShareContextObjectTypeConfig {
  * to render the menu as a popover.
  * */
 export interface ShareContext {
+  /**
+   * The type of the object to share. for example lens, dashboard, etc.
+   */
   objectType: string;
   /**
    * Allows for passing contextual information that each consumer can provide to customize the share menu
    */
   objectTypeMeta: {
     title: string;
-    config?: Partial<Record<'link' | 'export' | 'embed', ShareContextObjectTypeConfig>>;
+    config: Partial<{
+      [T in Exclude<ShareTypes, 'legacy'>]: ShareUIConfig[T];
+    }>;
   };
+  /**
+   * Id of the object that's been attempted to be shared
+   */
   objectId?: string;
   /**
    * Current url for sharing. This can be set in cases where `window.location.href`
@@ -63,20 +268,9 @@ export interface ShareContext {
     locator: LocatorPublic<any>;
     params: any;
   };
-  /**
-   *
-   * @description allows a consumer to provide a custom method which when invoked
-   * handles providing a share url in the context of said consumer
-   */
-  delegatedShareUrlHandler?: () => string;
   sharingData: { [key: string]: unknown };
   isDirty: boolean;
   onClose: () => void;
-  /**
-   * @deprecated use computeAnonymousCapabilities defined on objectTypeMeta config
-   */
-  showPublicUrlSwitch?: (anonymousUserCapabilities: Capabilities) => boolean;
-  disabledShareUrl?: boolean;
 }
 
 /**
@@ -90,13 +284,6 @@ export interface ShareContextMenuPanelItem
   name: string; // EUI will accept a `ReactNode` for the `name` prop, but `ShareContentMenu` assumes a `string`.
   sortOrder?: number;
 }
-
-export type SupportedExportTypes =
-  | 'pngV2'
-  | 'printablePdfV2'
-  | 'csv_v2'
-  | 'csv_searchsource'
-  | 'lens_csv';
 
 /**
  * @public
@@ -113,53 +300,10 @@ export interface ShareMenuItemLegacy extends ShareMenuItemBase {
   panel?: EuiContextMenuPanelDescriptor;
 }
 
-export interface ScreenshotExportOpts {
+export interface ExportGenerationOpts {
   optimizedForPrinting?: boolean;
   intl: InjectedIntl;
 }
-
-export interface ShareMenuItemV2 extends ShareMenuItemBase {
-  // extended props to support share modal
-  label: 'PDF' | 'CSV' | 'PNG';
-  reportType?: SupportedExportTypes;
-  requiresSavedState?: boolean;
-  helpText?: ReactElement;
-  copyURLButton?: { id: string; dataTestSubj: string; label: string };
-  generateExportButton?: ReactElement;
-  /**
-   * Function to trigger an export
-   */
-  generateExport: (args: ScreenshotExportOpts) => Promise<unknown>;
-  /**
-   * Function to generate a URL to be used for automating export
-   * Not applicable for exports that do not call a remote API (i.e Lens CSV export)
-   */
-  generateExportUrl?: (args: ScreenshotExportOpts) => string | undefined;
-  theme?: ThemeServiceSetup;
-  renderLayoutOptionSwitch?: boolean;
-  layoutOption?: 'print';
-  generateCopyUrl?: URL;
-  renderCopyURLButton?: boolean;
-  warnings?: Array<{ title: string; message: string }>;
-}
-
-export interface ShareMenuProviderV2 {
-  readonly id: string;
-  getShareMenuItems: (context: ShareContext) => ShareMenuItemV2[];
-}
-export interface ShareMenuProviderLegacy {
-  readonly id: string;
-  getShareMenuItemsLegacy: (context: ShareContext) => ShareMenuItemLegacy[];
-}
-
-/**
- * @public
- * A source for additional menu items shown in the share context menu. Any provider
- * registered via `share.register()` will be called if a consumer displays the context
- * menu. Returned `ShareMenuItem`s will be shown in the context menu together with the
- * default built-in share options. Each share provider needs a globally unique id.
- * */
-export type ShareMenuProvider = ShareMenuProviderV2 | ShareMenuProviderLegacy;
 
 interface UrlParamExtensionProps {
   setParamValue: (values: {}) => void;
@@ -172,11 +316,8 @@ export interface UrlParamExtension {
 
 /** @public */
 export interface ShowShareMenuOptions extends Omit<ShareContext, 'onClose'> {
-  anchorElement: HTMLElement;
-  allowEmbed: boolean;
+  anchorElement?: HTMLElement;
   allowShortUrl: boolean;
-  embedUrlParamExtensions?: UrlParamExtension[];
-  snapshotShareWarning?: string;
   onClose?: () => void;
   publicAPIEnabled?: boolean;
 }

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
@@ -402,7 +402,6 @@ export const getTopNavConfig = (
           // TODO: support sharing in by-value mode
           share.toggleShareContextMenu({
             anchorElement,
-            allowEmbed: true,
             allowShortUrl: Boolean(visualizeCapabilities.createShortUrl),
             shareableUrl: unhashUrl(window.location.href),
             objectId: savedVis?.id,

--- a/x-pack/platform/plugins/private/reporting/public/plugin.ts
+++ b/x-pack/platform/plugins/private/reporting/public/plugin.ts
@@ -15,7 +15,7 @@ import { i18n } from '@kbn/i18n';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
 import type { ScreenshotModePluginSetup } from '@kbn/screenshot-mode-plugin/public';
-import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
+import type { SharePluginSetup, SharePluginStart, ExportShare } from '@kbn/share-plugin/public';
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
 
 import { durationToNumber } from '@kbn/reporting-common';
@@ -24,8 +24,9 @@ import { ReportingAPIClient } from '@kbn/reporting-public';
 
 import {
   getSharedComponents,
-  reportingCsvShareModalProvider,
-  reportingExportModalProvider,
+  reportingCsvExportProvider,
+  reportingPDFExportProvider,
+  reportingPNGExportProvider,
 } from '@kbn/reporting-public/share';
 import { ReportingCsvPanelAction } from '@kbn/reporting-csv-share-panel';
 import { InjectedIntl } from '@kbn/i18n-react';
@@ -211,8 +212,10 @@ export class ReportingPublicPlugin
 
     startServices$.subscribe(([{ application }, { licensing }]) => {
       licensing.license$.subscribe((license) => {
-        shareSetup.register(
-          reportingCsvShareModalProvider({
+        shareSetup.registerShareIntegration<ExportShare>(
+          'search',
+          // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
+          reportingCsvExportProvider({
             apiClient,
             license,
             application,
@@ -222,8 +225,20 @@ export class ReportingPublicPlugin
         );
 
         if (this.config.export_types.pdf.enabled || this.config.export_types.png.enabled) {
-          shareSetup.register(
-            reportingExportModalProvider({
+          shareSetup.registerShareIntegration<ExportShare>(
+            // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
+            reportingPDFExportProvider({
+              apiClient,
+              license,
+              application,
+              startServices$,
+              usesUiCapabilities,
+            })
+          );
+
+          shareSetup.registerShareIntegration<ExportShare>(
+            // TODO: export the reporting pdf export provider for registration in the actual plugins that depend on it
+            reportingPNGExportProvider({
               apiClient,
               license,
               application,

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/csv_download_provider/csv_download_provider.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/csv_download_provider/csv_download_provider.tsx
@@ -13,7 +13,7 @@ import { exporters } from '@kbn/data-plugin/public';
 import { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { Datatable } from '@kbn/expressions-plugin/common';
-import { ShareMenuItemV2, ShareMenuProviderV2 } from '@kbn/share-plugin/public/types';
+import { ExportShare } from '@kbn/share-plugin/public/types';
 import { FormatFactory } from '../../../common/types';
 
 export interface CSVSharingData {
@@ -105,48 +105,44 @@ interface DownloadPanelShareOpts {
   atLeastGold: () => boolean;
 }
 
-export const downloadCsvShareProvider = ({
+export const downloadCsvLensShareProvider = ({
   uiSettings,
   formatFactoryFn,
   atLeastGold,
-}: DownloadPanelShareOpts): ShareMenuProviderV2 => {
-  const getShareMenuItems: ShareMenuProviderV2['getShareMenuItems'] = ({
-    objectType,
-    sharingData,
-  }) => {
-    if ('lens' !== objectType) {
-      return [];
-    }
+}: DownloadPanelShareOpts): ExportShare => {
+  return {
+    shareType: 'integration',
+    id: 'csvDownloadLens',
+    groupId: 'export',
+    config({ sharingData }) {
+      // TODO fix sharingData types
+      const { title, datatables, csvEnabled } = sharingData as unknown as CSVSharingData;
 
-    // TODO fix sharingData types
-    const { title, datatables, csvEnabled } = sharingData as unknown as CSVSharingData;
+      const panelTitle = i18n.translate(
+        'xpack.lens.reporting.shareContextMenu.csvReportsButtonLabel',
+        {
+          defaultMessage: 'CSV Download',
+        }
+      );
 
-    const panelTitle = i18n.translate(
-      'xpack.lens.reporting.shareContextMenu.csvReportsButtonLabel',
-      {
-        defaultMessage: 'CSV Download',
-      }
-    );
+      const downloadCSVHandler = () =>
+        downloadCSVs({
+          title,
+          formatFactory: formatFactoryFn(),
+          datatables,
+          uiSettings,
+        });
 
-    const downloadCSVHandler = () =>
-      downloadCSVs({
-        title,
-        formatFactory: formatFactoryFn(),
-        datatables,
-        uiSettings,
-      });
-
-    return [
-      {
-        shareMenuItem: {
-          name: panelTitle,
-          icon: 'document',
-          disabled: !csvEnabled,
-          sortOrder: 1,
-        },
-        label: 'CSV' as const,
-        reportType: 'lens_csv' as const,
-        generateExport: downloadCSVHandler,
+      return {
+        name: panelTitle,
+        icon: 'document',
+        sortOrder: 1,
+        label: 'CSV',
+        exportType: 'lens_csv',
+        supportedLayoutOptions: ['print'],
+        requiresSavedState: false,
+        generateAssetExport: downloadCSVHandler,
+        generateAssetURIValue: () => '',
         warnings: getWarnings(datatables),
         ...(atLeastGold()
           ? {
@@ -165,12 +161,7 @@ export const downloadCsvShareProvider = ({
                 <FormattedMessage id="xpack.lens.share.csvButton" defaultMessage="Download CSV" />
               ),
             }),
-      } satisfies ShareMenuItemV2,
-    ];
-  };
-
-  return {
-    id: 'csvDownloadLens',
-    getShareMenuItems,
+      };
+    },
   };
 };

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
@@ -40,7 +40,12 @@ import {
 } from '../utils';
 import { combineQueryAndFilters, getLayerMetaInfo } from './show_underlying_data';
 import { changeIndexPattern } from '../state_management/lens_slice';
-import { DEFAULT_LENS_LAYOUT_DIMENSIONS, getShareURL } from './share_action';
+import {
+  DEFAULT_LENS_LAYOUT_DIMENSIONS,
+  ShareableConfiguration,
+  getLocatorParams,
+  getShareURL,
+} from './share_action';
 import { getDatasourceLayers } from '../state_management/utils';
 
 function getSaveButtonMeta({
@@ -593,27 +598,20 @@ export const LensTopNavMenu = ({
 
             const activeVisualization = visualizationMap[visualization.activeId];
 
-            const {
-              shareableUrl,
-              savedObjectURL,
-              reportingLocatorParams: locatorParams,
-            } = await getShareURL(
-              shortUrlService,
-              { application, data },
-              {
-                filters,
-                query,
-                activeDatasourceId,
-                datasourceStates,
-                datasourceMap,
-                visualizationMap,
-                visualization,
-                currentDoc,
-                adHocDataViews: adHocDataViews.map((dataView) => dataView.toSpec()),
-              },
-              shareUrlEnabled,
-              isCurrentStateDirty
-            );
+            const configuration: ShareableConfiguration = {
+              filters,
+              query,
+              activeDatasourceId,
+              datasourceStates,
+              datasourceMap,
+              visualizationMap,
+              visualization,
+              currentDoc,
+              adHocDataViews: adHocDataViews.map((dataView) => dataView.toSpec()),
+            };
+
+            const { shareURL: shareLocatorParams, reporting: reportingLocatorParams } =
+              getLocatorParams(data, configuration, isCurrentStateDirty);
 
             const datasourceLayers = getDatasourceLayers(
               datasourceStates,
@@ -636,7 +634,7 @@ export const LensTopNavMenu = ({
               title: title || defaultLensTitle,
               locatorParams: {
                 id: LENS_APP_LOCATOR,
-                params: locatorParams,
+                params: reportingLocatorParams,
               },
               layout: {
                 dimensions:
@@ -647,13 +645,7 @@ export const LensTopNavMenu = ({
 
             share.toggleShareContextMenu({
               anchorElement,
-              allowEmbed: false,
               allowShortUrl: false,
-              delegatedShareUrlHandler: () => {
-                return isCurrentStateDirty || !currentDoc?.savedObjectId
-                  ? shareableUrl!
-                  : savedObjectURL.href;
-              },
               objectId: currentDoc?.savedObjectId,
               objectType: 'lens',
               objectTypeMeta: {
@@ -678,16 +670,33 @@ export const LensTopNavMenu = ({
                         />
                       </EuiCallOut>
                     ),
+                    delegatedShareUrlHandler: async () => {
+                      const { shareableUrl, savedObjectURL } = getShareURL(
+                        shortUrlService,
+                        shareLocatorParams,
+                        { application, data },
+                        configuration,
+                        shareUrlEnabled,
+                        isCurrentStateDirty
+                      );
+
+                      return !currentDoc?.savedObjectId
+                        ? (await shareableUrl)!
+                        : savedObjectURL.href;
+                    },
+                    // disable the menu if both shortURL permission and the visualization has not been saved
+                    // TODO: improve here the disabling state with more specific checks
+                    disabled: Boolean(!shareUrlEnabled && !currentDoc?.savedObjectId),
+                  },
+                  embed: {
+                    disabled: true,
+                    showPublicUrlSwitch: () => false,
                   },
                 },
               },
               sharingData,
               // only want to know about changes when savedObjectURL.href
               isDirty: isCurrentStateDirty || !currentDoc?.savedObjectId,
-              // disable the menu if both shortURL permission and the visualization has not been saved
-              // TODO: improve here the disabling state with more specific checks
-              disabledShareUrl: Boolean(!shareUrlEnabled && !currentDoc?.savedObjectId),
-              showPublicUrlSwitch: () => false,
               onClose: () => {
                 anchorElement?.focus();
               },

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/share_action.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/share_action.ts
@@ -16,7 +16,7 @@ import type { DatasourceMap, VisualizationMap } from '../types';
 import { extractReferencesFromState, getResolvedDateRange } from '../utils';
 import { getEditPath } from '../../common/constants';
 
-interface ShareableConfiguration
+export interface ShareableConfiguration
   extends Pick<
     LensAppState,
     'activeDatasourceId' | 'datasourceStates' | 'visualization' | 'filters' | 'query'
@@ -117,21 +117,16 @@ export function getLocatorParams(
   };
 }
 
-export async function getShareURL(
+export function getShareURL(
   shortUrlService: (params: LensAppLocatorParams) => Promise<string>,
+  shareLocatorParams: LensAppLocatorParams,
   services: Pick<LensAppServices, 'application' | 'data'>,
   configuration: ShareableConfiguration,
   shareUrlEnabled: boolean,
   isDirty: boolean
 ) {
-  const { shareURL: locatorParams, reporting: reportingLocatorParams } = getLocatorParams(
-    services.data,
-    configuration,
-    isDirty
-  );
   return {
-    shareableUrl: await (shareUrlEnabled ? shortUrlService(locatorParams) : undefined),
+    shareableUrl: shareUrlEnabled ? shortUrlService(shareLocatorParams) : undefined,
     savedObjectURL: getShareURLForSavedObject(services, configuration.currentDoc),
-    reportingLocatorParams,
   };
 }

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -59,7 +59,7 @@ import { createStartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { AdvancedUiActionsSetup } from '@kbn/ui-actions-enhanced-plugin/public';
 import type { DocLinksStart } from '@kbn/core-doc-links-browser';
-import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
+import type { SharePluginSetup, SharePluginStart, ExportShare } from '@kbn/share-plugin/public';
 import {
   ContentManagementPublicSetup,
   ContentManagementPublicStart,
@@ -139,7 +139,7 @@ import { setupExpressions } from './expressions';
 import { OpenInDiscoverDrilldown } from './trigger_actions/open_in_discover_drilldown';
 import { ChartInfoApi } from './chart_info_api';
 import { type LensAppLocator, LensAppLocatorDefinition } from '../common/locator/locator';
-import { downloadCsvShareProvider } from './app_plugin/csv_download_provider/csv_download_provider';
+import { downloadCsvLensShareProvider } from './app_plugin/csv_download_provider/csv_download_provider';
 import { LensDocument } from './persistence/saved_object_store';
 import {
   CONTENT_ID,
@@ -424,8 +424,9 @@ export class LensPlugin {
     if (share) {
       this.locator = share.url.locators.create(new LensAppLocatorDefinition());
 
-      share.register(
-        downloadCsvShareProvider({
+      share.registerShareIntegration<ExportShare>(
+        'lens',
+        downloadCsvLensShareProvider({
           uiSettings: core.uiSettings,
           formatFactoryFn: () => startServices().plugins.fieldFormats.deserialize,
           atLeastGold: () => {

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -1975,6 +1975,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     async openCSVDownloadShare() {
       await this.ensureShareMenuIsOpen('export');
       await testSubjects.click('export');
+      await testSubjects.click('lens_csv-radioOption');
     },
 
     async setCSVDownloadDebugFlag(value: boolean = true) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Share modal re-architecture (#211665)](https://github.com/elastic/kibana/pull/211665)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-23T11:34:18Z","message":"Share modal re-architecture (#211665)\n\n## Summary\n\nThis PR attempts to rework the internals for how the share plugin works,\nand brings with it a slight modification to how configs are registered\nto the share plugin, with this PR the share plugin now defines the\nfollowing share types i.e. `links`, `embeds` and `integrations`. As such\nnative implementations (i.e. copy link and embed) provided by sharedUX\nremain internal to the share plugin.\n\nOne might then ask what happens to the existing export functionality\nprovided by the reporting plugin, in this PR the export functionality is\nnow modelled as an integration that's simply grouped as an export, see\nthe type definition for the Export type. Accompanying this change, a new\nmethod has been introduced `registerShareIntegration` that's similar to\nthe previous method `register`, with a slight difference, in that now\nregistered integrations can be scoped to a specific object type like so.\n\n```ts\nshare.registerShareIntegration('lens', {\n\t...\n\tconfig: () => ({\n\t\tsomeValue: 'This integration value can only be retrieved within the lens objectType scope'\n\t})\n})\n```\n\nThe expected return type for config is defined by the user, as such the\nexport integration type defines it's own expected type that suits the\ncurrent implementation of the share modal.\n\n\n\nFurthermore there's been a clean up with the config options that\ntypically would be passed to the `toggleShareMenu` method, properties\nthat are specific to a specific share type are now expected to be\nprovided within the config property for that specific share type.\n\n## How to test\n\n- This change is transparent to the user with all share functionality\nworking as should, regardless respective teams should verify that all\nshare behaviour work as expected.\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"37afbb56d807a75d148fc509be82c140be8cb0c8","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:SharedUX","v9.1.0"],"title":"Share modal re-architecture","number":211665,"url":"https://github.com/elastic/kibana/pull/211665","mergeCommit":{"message":"Share modal re-architecture (#211665)\n\n## Summary\n\nThis PR attempts to rework the internals for how the share plugin works,\nand brings with it a slight modification to how configs are registered\nto the share plugin, with this PR the share plugin now defines the\nfollowing share types i.e. `links`, `embeds` and `integrations`. As such\nnative implementations (i.e. copy link and embed) provided by sharedUX\nremain internal to the share plugin.\n\nOne might then ask what happens to the existing export functionality\nprovided by the reporting plugin, in this PR the export functionality is\nnow modelled as an integration that's simply grouped as an export, see\nthe type definition for the Export type. Accompanying this change, a new\nmethod has been introduced `registerShareIntegration` that's similar to\nthe previous method `register`, with a slight difference, in that now\nregistered integrations can be scoped to a specific object type like so.\n\n```ts\nshare.registerShareIntegration('lens', {\n\t...\n\tconfig: () => ({\n\t\tsomeValue: 'This integration value can only be retrieved within the lens objectType scope'\n\t})\n})\n```\n\nThe expected return type for config is defined by the user, as such the\nexport integration type defines it's own expected type that suits the\ncurrent implementation of the share modal.\n\n\n\nFurthermore there's been a clean up with the config options that\ntypically would be passed to the `toggleShareMenu` method, properties\nthat are specific to a specific share type are now expected to be\nprovided within the config property for that specific share type.\n\n## How to test\n\n- This change is transparent to the user with all share functionality\nworking as should, regardless respective teams should verify that all\nshare behaviour work as expected.\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"37afbb56d807a75d148fc509be82c140be8cb0c8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211665","number":211665,"mergeCommit":{"message":"Share modal re-architecture (#211665)\n\n## Summary\n\nThis PR attempts to rework the internals for how the share plugin works,\nand brings with it a slight modification to how configs are registered\nto the share plugin, with this PR the share plugin now defines the\nfollowing share types i.e. `links`, `embeds` and `integrations`. As such\nnative implementations (i.e. copy link and embed) provided by sharedUX\nremain internal to the share plugin.\n\nOne might then ask what happens to the existing export functionality\nprovided by the reporting plugin, in this PR the export functionality is\nnow modelled as an integration that's simply grouped as an export, see\nthe type definition for the Export type. Accompanying this change, a new\nmethod has been introduced `registerShareIntegration` that's similar to\nthe previous method `register`, with a slight difference, in that now\nregistered integrations can be scoped to a specific object type like so.\n\n```ts\nshare.registerShareIntegration('lens', {\n\t...\n\tconfig: () => ({\n\t\tsomeValue: 'This integration value can only be retrieved within the lens objectType scope'\n\t})\n})\n```\n\nThe expected return type for config is defined by the user, as such the\nexport integration type defines it's own expected type that suits the\ncurrent implementation of the share modal.\n\n\n\nFurthermore there's been a clean up with the config options that\ntypically would be passed to the `toggleShareMenu` method, properties\nthat are specific to a specific share type are now expected to be\nprovided within the config property for that specific share type.\n\n## How to test\n\n- This change is transparent to the user with all share functionality\nworking as should, regardless respective teams should verify that all\nshare behaviour work as expected.\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"37afbb56d807a75d148fc509be82c140be8cb0c8"}}]}] BACKPORT-->