### PR TITLE
[Security Solution][Endpoint] Fix create of endpoint artifacts to ensure global items require the global artifact management privilege

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
@@ -242,6 +242,7 @@ export class BlocklistValidator extends BaseValidator {
     await this.validateBlocklistData(item);
     await this.validateCanCreateByPolicyArtifacts(item);
     await this.validateByPolicyItem(item);
+    await this.validateCanCreateGlobalArtifacts(item);
     await this.validateCreateOwnerSpaceIds(item);
 
     return item;

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/endpoint_exceptions_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/endpoint_exceptions_validator.ts
@@ -43,6 +43,7 @@ export class EndpointExceptionsValidator extends BaseValidator {
 
   async validatePreCreateItem(item: CreateExceptionListItemOptions) {
     await this.validateHasWritePrivilege();
+    await this.validateCanCreateGlobalArtifacts(item);
     await this.validateCreateOwnerSpaceIds(item);
 
     return item;
@@ -54,6 +55,7 @@ export class EndpointExceptionsValidator extends BaseValidator {
   ) {
     await this.validateHasWritePrivilege();
     await this.validateUpdateOwnerSpaceIds(item, currentItem);
+    await this.validateCanUpdateItemInActiveSpace(item, currentItem);
 
     return item;
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
@@ -60,6 +60,7 @@ export class EventFilterValidator extends BaseValidator {
     }
 
     await this.validateCreateOwnerSpaceIds(item);
+    await this.validateCanCreateGlobalArtifacts(item);
 
     return item;
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/host_isolation_exceptions_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/host_isolation_exceptions_validator.ts
@@ -79,6 +79,7 @@ export class HostIsolationExceptionsValidator extends BaseValidator {
     await this.validateHasWritePrivilege();
     await this.validateHostIsolationData(item);
     await this.validateByPolicyItem(item);
+    await this.validateCanCreateGlobalArtifacts(item);
     await this.validateCreateOwnerSpaceIds(item);
 
     return item;

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_app_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_app_validator.ts
@@ -227,8 +227,8 @@ export class TrustedAppValidator extends BaseValidator {
     await this.validateTrustedAppData(item);
     await this.validateCanCreateByPolicyArtifacts(item);
     await this.validateByPolicyItem(item);
-    await this.validateCreateOwnerSpaceIds(item);
     await this.validateCanCreateGlobalArtifacts(item);
+    await this.validateCreateOwnerSpaceIds(item);
 
     return item;
   }


### PR DESCRIPTION
## Summary

- Fix the create of Event Filters, Blocklists, Endpoint Exceptions and Host Isolation Exceptions so that an error is returned when space awareness feature is enabled and the user does not have the Global Artifact Management privilege.

> [!NOTE]
> Trusted Applications were already correctly validating this during create of an artifact

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




