### PR TITLE
[Security Solution][EA][PrivMon]Add comprehensive unit tests for key_insights_panel tiles

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/account_switches_tile/account_switches_tile.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/account_switches_tile/account_switches_tile.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestProviders } from '../../../../../../common/mock';
+import { AccountSwitchesTile } from './account_switches_tile';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the KeyInsightsTile component
+jest.mock('../common/key_insights_tile', () => ({
+  KeyInsightsTile: jest.fn(({ title, label, getEsqlQuery, id, spaceId, inspectTitle }) => (
+    <div data-test-subj="key-insights-tile">
+      <div data-test-subj="tile-title" data-props={JSON.stringify(title.props)}>
+        {title}
+      </div>
+      <div data-test-subj="tile-label" data-props={JSON.stringify(label.props)}>
+        {label}
+      </div>
+      <div data-test-subj="tile-id">{id}</div>
+      <div data-test-subj="tile-space-id">{spaceId}</div>
+      <div data-test-subj="inspect-title" data-props={JSON.stringify(inspectTitle.props)}>
+        {inspectTitle}
+      </div>
+      <div data-test-subj="esql-query">{getEsqlQuery('test-namespace')}</div>
+    </div>
+  )),
+}));
+
+// Mock the ESQL query function
+jest.mock('./esql_query', () => ({
+  getAccountSwitchesEsqlCount: jest.fn(() => 'mocked esql query for account switches'),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {},
+  timeFieldName: '@timestamp',
+};
+
+describe('AccountSwitchesTile', () => {
+  const defaultProps = {
+    spaceId: 'test-space',
+    sourcerDataView: mockDataView,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the tile with correct props', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('key-insights-tile')).toBeInTheDocument();
+  });
+
+  it('passes correct title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const titleElement = getByTestId('tile-title');
+    expect(titleElement).toBeInTheDocument();
+    // Parse the props from the data attribute
+    const titleProps = JSON.parse(titleElement.getAttribute('data-props') || '{}');
+    expect(titleProps.id).toBe('xpack.securitySolution.privmon.accountSwitches.title');
+    expect(titleProps.defaultMessage).toBe('Account Switches');
+  });
+
+  it('passes correct label to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const labelElement = getByTestId('tile-label');
+    expect(labelElement).toBeInTheDocument();
+    const labelProps = JSON.parse(labelElement.getAttribute('data-props') || '{}');
+    expect(labelProps.id).toBe('xpack.securitySolution.privmon.accountSwitches.label');
+    expect(labelProps.defaultMessage).toBe('Account Switches');
+  });
+
+  it('passes correct inspect title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const inspectTitleElement = getByTestId('inspect-title');
+    expect(inspectTitleElement).toBeInTheDocument();
+    const inspectTitleProps = JSON.parse(inspectTitleElement.getAttribute('data-props') || '{}');
+    expect(inspectTitleProps.id).toBe(
+      'xpack.securitySolution.privmon.accountSwitches.inspectTitle'
+    );
+    expect(inspectTitleProps.defaultMessage).toBe('Account switches');
+  });
+
+  it('passes correct id to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const idElement = getByTestId('tile-id');
+    expect(idElement).toBeInTheDocument();
+    expect(idElement.textContent).toBe('privileged-user-monitoring-account-switches');
+  });
+
+  it('passes spaceId to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement).toBeInTheDocument();
+    expect(spaceIdElement.textContent).toBe('test-space');
+  });
+
+  it('calls getEsqlQuery function with namespace', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const esqlQueryElement = getByTestId('esql-query');
+    expect(esqlQueryElement).toBeInTheDocument();
+    expect(esqlQueryElement.textContent).toBe('mocked esql query for account switches');
+  });
+
+  it('renders with different spaceId', () => {
+    const propsWithDifferentSpaceId = {
+      ...defaultProps,
+      spaceId: 'different-space',
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <AccountSwitchesTile {...propsWithDifferentSpaceId} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement.textContent).toBe('different-space');
+  });
+
+  it('renders with different sourcerDataView', () => {
+    const differentDataView: DataViewSpec = {
+      ...mockDataView,
+      id: 'different-dataview',
+      title: 'different-*',
+    };
+
+    const propsWithDifferentDataView = {
+      ...defaultProps,
+      sourcerDataView: differentDataView,
+    };
+
+    render(
+      <TestProviders>
+        <AccountSwitchesTile {...propsWithDifferentDataView} />
+      </TestProviders>
+    );
+
+    // The component should render without errors
+    expect(document.querySelector('[data-test-subj="key-insights-tile"]')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/account_switches_tile/esql_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/account_switches_tile/esql_query.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copy// Mock the helper functions  
+jest.mock('../../../queries/account_switches_esql_query', () => ({
+  getAccountSwitchesEsqlSource: jest.fn((namespace: string, indexPattern: string, fields: Record<string, unknown>) => 
+    `FROM ${indexPattern} | WHERE some_field = "${namespace}"`
+  ),
+}));lasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAccountSwitchesEsqlCount } from './esql_query';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the helper functions
+jest.mock('../../../queries/account_switches_esql_query', () => ({
+  getAccountSwitchesEsqlSource: jest.fn(
+    (namespace: string, indexPattern: string, fields: Record<string, { type: string }>) =>
+      `FROM ${indexPattern} | WHERE some_field = "${namespace}"`
+  ),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {
+    'user.name': { type: 'string' },
+    '@timestamp': { type: 'date' },
+  },
+  timeFieldName: '@timestamp',
+};
+
+describe('getAccountSwitchesEsqlCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a valid ESQL query with COUNT(*)', () => {
+    const namespace = 'test-namespace';
+    const result = getAccountSwitchesEsqlCount(namespace, mockDataView);
+
+    expect(result).toContain('FROM test-*');
+    expect(result).toContain('WHERE some_field = "test-namespace"');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should use the index pattern from the data view', () => {
+    const namespace = 'test-namespace';
+    const customDataView = {
+      ...mockDataView,
+      title: 'custom-index-*',
+    };
+
+    const result = getAccountSwitchesEsqlCount(namespace, customDataView);
+
+    expect(result).toContain('FROM custom-index-*');
+  });
+
+  it('should handle empty data view title', () => {
+    const namespace = 'test-namespace';
+    const emptyDataView = {
+      ...mockDataView,
+      title: '',
+    };
+
+    const result = getAccountSwitchesEsqlCount(namespace, emptyDataView);
+
+    expect(result).toContain('FROM ');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should handle undefined data view title', () => {
+    const namespace = 'test-namespace';
+    const undefinedDataView = {
+      ...mockDataView,
+      title: undefined,
+    } as DataViewSpec;
+
+    const result = getAccountSwitchesEsqlCount(namespace, undefinedDataView);
+
+    expect(result).toContain('FROM ');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should handle undefined data view fields', () => {
+    const namespace = 'test-namespace';
+    const undefinedFieldsDataView = {
+      ...mockDataView,
+      fields: undefined,
+    } as DataViewSpec;
+
+    const result = getAccountSwitchesEsqlCount(namespace, undefinedFieldsDataView);
+
+    expect(result).toContain('FROM test-*');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should pass correct parameters to the source query function', () => {
+    const namespace = 'test-namespace';
+    const getAccountSwitchesEsqlSource = jest.requireMock(
+      '../../../queries/account_switches_esql_query'
+    ).getAccountSwitchesEsqlSource;
+
+    getAccountSwitchesEsqlCount(namespace, mockDataView);
+
+    expect(getAccountSwitchesEsqlSource).toHaveBeenCalledWith(
+      namespace,
+      'test-*',
+      mockDataView.fields
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/active_privileged_users_tile/active_privileged_users_tile.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/active_privileged_users_tile/active_privileged_users_tile.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestProviders } from '../../../../../../common/mock';
+import { ActivePrivilegedUsersTile } from './active_privileged_users_tile';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the KeyInsightsTile component
+jest.mock('../common/key_insights_tile', () => ({
+  KeyInsightsTile: jest.fn(({ title, label, getEsqlQuery, id, spaceId, inspectTitle }) => (
+    <div data-test-subj="key-insights-tile">
+      <div data-test-subj="tile-title" data-props={JSON.stringify(title.props)}>
+        {title}
+      </div>
+      <div data-test-subj="tile-label" data-props={JSON.stringify(label.props)}>
+        {label}
+      </div>
+      <div data-test-subj="tile-id">{id}</div>
+      <div data-test-subj="tile-space-id">{spaceId}</div>
+      <div data-test-subj="inspect-title" data-props={JSON.stringify(inspectTitle.props)}>
+        {inspectTitle}
+      </div>
+      <div data-test-subj="esql-query">{getEsqlQuery('test-namespace')}</div>
+    </div>
+  )),
+}));
+
+// Mock the ESQL query function
+jest.mock('./esql_query', () => ({
+  getActivePrivilegedUsersEsqlCount: jest.fn(() => 'mocked esql query for active privileged users'),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {},
+  timeFieldName: '@timestamp',
+};
+
+describe('ActivePrivilegedUsersTile', () => {
+  const defaultProps = {
+    spaceId: 'test-space',
+    sourcerDataView: mockDataView,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the tile with correct props', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('key-insights-tile')).toBeInTheDocument();
+  });
+
+  it('passes correct title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const titleElement = getByTestId('tile-title');
+    expect(titleElement).toBeInTheDocument();
+    const titleProps = JSON.parse(titleElement.getAttribute('data-props') || '{}');
+    expect(titleProps.id).toBe('xpack.securitySolution.privmon.activePrivilegedUsers.title');
+    expect(titleProps.defaultMessage).toBe('Active Privileged Users');
+  });
+
+  it('passes correct label to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const labelElement = getByTestId('tile-label');
+    expect(labelElement).toBeInTheDocument();
+    const labelProps = JSON.parse(labelElement.getAttribute('data-props') || '{}');
+    expect(labelProps.id).toBe('xpack.securitySolution.privmon.activePrivilegedUsers.label');
+    expect(labelProps.defaultMessage).toBe('Active Privileged Users');
+  });
+
+  it('passes correct inspect title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const inspectTitleElement = getByTestId('inspect-title');
+    expect(inspectTitleElement).toBeInTheDocument();
+    const inspectTitleProps = JSON.parse(inspectTitleElement.getAttribute('data-props') || '{}');
+    expect(inspectTitleProps.id).toBe(
+      'xpack.securitySolution.privmon.activePrivilegedUsers.inspectTitle'
+    );
+    expect(inspectTitleProps.defaultMessage).toBe('Active privileged users');
+  });
+
+  it('passes correct id to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const idElement = getByTestId('tile-id');
+    expect(idElement).toBeInTheDocument();
+    expect(idElement.textContent).toBe('privileged-user-monitoring-active-users');
+  });
+
+  it('passes spaceId to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement).toBeInTheDocument();
+    expect(spaceIdElement.textContent).toBe('test-space');
+  });
+
+  it('calls getEsqlQuery function with namespace', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const esqlQueryElement = getByTestId('esql-query');
+    expect(esqlQueryElement).toBeInTheDocument();
+    expect(esqlQueryElement.textContent).toBe('mocked esql query for active privileged users');
+  });
+
+  it('renders with different spaceId', () => {
+    const propsWithDifferentSpaceId = {
+      ...defaultProps,
+      spaceId: 'different-space',
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...propsWithDifferentSpaceId} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement.textContent).toBe('different-space');
+  });
+
+  it('renders with different sourcerDataView', () => {
+    const differentDataView: DataViewSpec = {
+      ...mockDataView,
+      id: 'different-dataview',
+      title: 'different-*',
+    };
+
+    const propsWithDifferentDataView = {
+      ...defaultProps,
+      sourcerDataView: differentDataView,
+    };
+
+    render(
+      <TestProviders>
+        <ActivePrivilegedUsersTile {...propsWithDifferentDataView} />
+      </TestProviders>
+    );
+
+    expect(document.querySelector('[data-test-subj="key-insights-tile"]')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/active_privileged_users_tile/esql_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/active_privileged_users_tile/esql_query.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getActivePrivilegedUsersEsqlCount } from './esql_query';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the helper functions
+jest.mock('../../../queries/helpers', () => ({
+  getPrivilegedMonitorUsersJoin: jest.fn(
+    (namespace: string) => `| JOIN privileged_users_${namespace} ON user.name`
+  ),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {
+    'user.name': { type: 'string' },
+    '@timestamp': { type: 'date' },
+  },
+  timeFieldName: '@timestamp',
+};
+
+describe('getActivePrivilegedUsersEsqlCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a valid ESQL query with COUNT_DISTINCT', () => {
+    const namespace = 'test-namespace';
+    const result = getActivePrivilegedUsersEsqlCount(namespace, mockDataView);
+
+    expect(result).toContain('FROM test-* METADATA _id, _index');
+    expect(result).toContain('| JOIN privileged_users_test-namespace ON user.name');
+    expect(result).toContain('| STATS `COUNT(*)` = COUNT_DISTINCT(user.name)');
+  });
+
+  it('should use the index pattern from the data view', () => {
+    const namespace = 'test-namespace';
+    const customDataView = {
+      ...mockDataView,
+      title: 'custom-index-*',
+    };
+
+    const result = getActivePrivilegedUsersEsqlCount(namespace, customDataView);
+
+    expect(result).toContain('FROM custom-index-* METADATA _id, _index');
+  });
+
+  it('should handle empty data view title', () => {
+    const namespace = 'test-namespace';
+    const emptyDataView = {
+      ...mockDataView,
+      title: '',
+    };
+
+    const result = getActivePrivilegedUsersEsqlCount(namespace, emptyDataView);
+
+    expect(result).toContain('FROM  METADATA _id, _index');
+    expect(result).toContain('| STATS `COUNT(*)` = COUNT_DISTINCT(user.name)');
+  });
+
+  it('should handle undefined data view title', () => {
+    const namespace = 'test-namespace';
+    const undefinedDataView = {
+      ...mockDataView,
+      title: undefined,
+    } as DataViewSpec;
+
+    const result = getActivePrivilegedUsersEsqlCount(namespace, undefinedDataView);
+
+    expect(result).toContain('FROM  METADATA _id, _index');
+    expect(result).toContain('| STATS `COUNT(*)` = COUNT_DISTINCT(user.name)');
+  });
+
+  it('should pass correct namespace to helper function', () => {
+    const namespace = 'test-namespace';
+    const getPrivilegedMonitorUsersJoin = jest.requireMock(
+      '../../../queries/helpers'
+    ).getPrivilegedMonitorUsersJoin;
+
+    getActivePrivilegedUsersEsqlCount(namespace, mockDataView);
+
+    expect(getPrivilegedMonitorUsersJoin).toHaveBeenCalledWith(namespace);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/alerts_triggered_tile/alerts_triggered_tile.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/alerts_triggered_tile/alerts_triggered_tile.test.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestProviders } from '../../../../../../common/mock';
+import { AlertsTriggeredTile } from './alerts_triggered_tile';
+
+// Mock the KeyInsightsTile component
+jest.mock('../common/key_insights_tile', () => ({
+  KeyInsightsTile: jest.fn(({ title, label, getEsqlQuery, id, spaceId, inspectTitle }) => (
+    <div data-test-subj="key-insights-tile">
+      <div data-test-subj="tile-title" data-props={JSON.stringify(title.props)}>
+        {title}
+      </div>
+      <div data-test-subj="tile-label" data-props={JSON.stringify(label.props)}>
+        {label}
+      </div>
+      <div data-test-subj="tile-id">{id}</div>
+      <div data-test-subj="tile-space-id">{spaceId}</div>
+      <div data-test-subj="inspect-title" data-props={JSON.stringify(inspectTitle.props)}>
+        {inspectTitle}
+      </div>
+      <div data-test-subj="esql-query">{getEsqlQuery('test-namespace')}</div>
+    </div>
+  )),
+}));
+
+// Mock the ESQL query function
+jest.mock('./esql_query', () => ({
+  getAlertsTriggeredEsqlCount: jest.fn(() => 'mocked esql query for alerts triggered'),
+}));
+
+// Mock the useSignalIndex hook
+jest.mock(
+  '../../../../../../detections/containers/detection_engine/alerts/use_signal_index',
+  () => ({
+    useSignalIndex: jest.fn(() => ({
+      signalIndexName: 'test-alerts-index',
+    })),
+  })
+);
+
+describe('AlertsTriggeredTile', () => {
+  const defaultProps = {
+    spaceId: 'test-space',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the tile with correct props', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('key-insights-tile')).toBeInTheDocument();
+  });
+
+  it('passes correct title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const titleElement = getByTestId('tile-title');
+    expect(titleElement).toBeInTheDocument();
+    const titleProps = JSON.parse(titleElement.getAttribute('data-props') || '{}');
+    expect(titleProps.id).toBe('xpack.securitySolution.privmon.alertsTriggered.title');
+    expect(titleProps.defaultMessage).toBe('Alerts Triggered');
+  });
+
+  it('passes correct label to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const labelElement = getByTestId('tile-label');
+    expect(labelElement).toBeInTheDocument();
+    const labelProps = JSON.parse(labelElement.getAttribute('data-props') || '{}');
+    expect(labelProps.id).toBe('xpack.securitySolution.privmon.alertsTriggered.label');
+    expect(labelProps.defaultMessage).toBe('Alerts Triggered');
+  });
+
+  it('passes correct inspect title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const inspectTitleElement = getByTestId('inspect-title');
+    expect(inspectTitleElement).toBeInTheDocument();
+    const inspectTitleProps = JSON.parse(inspectTitleElement.getAttribute('data-props') || '{}');
+    expect(inspectTitleProps.id).toBe(
+      'xpack.securitySolution.privmon.alertsTriggered.inspectTitle'
+    );
+    expect(inspectTitleProps.defaultMessage).toBe('Alerts Triggered');
+  });
+
+  it('passes correct id to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const idElement = getByTestId('tile-id');
+    expect(idElement).toBeInTheDocument();
+    expect(idElement.textContent).toBe('privileged-user-monitoring-alerts-triggered');
+  });
+
+  it('passes spaceId to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement).toBeInTheDocument();
+    expect(spaceIdElement.textContent).toBe('test-space');
+  });
+
+  it('calls getEsqlQuery function with namespace and uses signalIndexName', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const esqlQueryElement = getByTestId('esql-query');
+    expect(esqlQueryElement).toBeInTheDocument();
+    expect(esqlQueryElement.textContent).toBe('mocked esql query for alerts triggered');
+  });
+
+  it('renders with different spaceId', () => {
+    const propsWithDifferentSpaceId = {
+      spaceId: 'different-space',
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsTriggeredTile {...propsWithDifferentSpaceId} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement.textContent).toBe('different-space');
+  });
+
+  it('handles different signal index names from useSignalIndex hook', () => {
+    const mockUseSignalIndex = jest.requireMock(
+      '../../../../../../detections/containers/detection_engine/alerts/use_signal_index'
+    ).useSignalIndex;
+    mockUseSignalIndex.mockReturnValue({
+      signalIndexName: 'custom-alerts-index',
+    });
+
+    render(
+      <TestProviders>
+        <AlertsTriggeredTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(mockUseSignalIndex).toHaveBeenCalled();
+    expect(document.querySelector('[data-test-subj="key-insights-tile"]')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/alerts_triggered_tile/esql_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/alerts_triggered_tile/esql_query.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAlertsTriggeredEsqlCount } from './esql_query';
+
+// Mock the helper functions
+jest.mock('../../../queries/helpers', () => ({
+  getPrivilegedMonitorUsersJoin: jest.fn(
+    (namespace: string) => `| JOIN privileged_users_${namespace} ON user.name`
+  ),
+}));
+
+describe('getAlertsTriggeredEsqlCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a valid ESQL query with alerts index', () => {
+    const namespace = 'test-namespace';
+    const alertsIndexName = '.alerts-security.alerts-test';
+
+    const result = getAlertsTriggeredEsqlCount(namespace, alertsIndexName);
+
+    expect(result).toContain('FROM .alerts-security.alerts-test METADATA _id, _index');
+    expect(result).toContain('| JOIN privileged_users_test-namespace ON user.name');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should return empty string when alertsIndexName is null', () => {
+    const namespace = 'test-namespace';
+    const alertsIndexName = null;
+
+    const result = getAlertsTriggeredEsqlCount(namespace, alertsIndexName);
+
+    expect(result).toBe('');
+  });
+
+  it('should return empty string when alertsIndexName is undefined', () => {
+    const namespace = 'test-namespace';
+    const alertsIndexName = null;
+
+    const result = getAlertsTriggeredEsqlCount(namespace, alertsIndexName);
+
+    expect(result).toBe('');
+  });
+
+  it('should return empty string when alertsIndexName is empty string', () => {
+    const namespace = 'test-namespace';
+    const alertsIndexName = '';
+
+    const result = getAlertsTriggeredEsqlCount(namespace, alertsIndexName);
+
+    expect(result).toBe('');
+  });
+
+  it('should pass correct namespace to helper function', () => {
+    const namespace = 'test-namespace';
+    const alertsIndexName = '.alerts-security.alerts-test';
+    const getPrivilegedMonitorUsersJoin = jest.requireMock(
+      '../../../queries/helpers'
+    ).getPrivilegedMonitorUsersJoin;
+
+    getAlertsTriggeredEsqlCount(namespace, alertsIndexName);
+
+    expect(getPrivilegedMonitorUsersJoin).toHaveBeenCalledWith(namespace);
+  });
+
+  it('should handle different alert index names', () => {
+    const namespace = 'test-namespace';
+    const alertsIndexName = '.alerts-security.alerts-custom';
+
+    const result = getAlertsTriggeredEsqlCount(namespace, alertsIndexName);
+
+    expect(result).toContain('FROM .alerts-security.alerts-custom METADATA _id, _index');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/anomalies_detected_tile/anomalies_detected_tile.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/anomalies_detected_tile/anomalies_detected_tile.test.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestProviders } from '../../../../../../common/mock';
+import { AnomaliesDetectedTile } from './anomalies_detected_tile';
+
+// Mock the KeyInsightsTile component
+jest.mock('../common/key_insights_tile', () => ({
+  KeyInsightsTile: jest.fn(({ title, label, getEsqlQuery, id, spaceId, inspectTitle }) => (
+    <div data-test-subj="key-insights-tile">
+      <div data-test-subj="tile-title" data-props={JSON.stringify(title.props)}>
+        {title}
+      </div>
+      <div data-test-subj="tile-label" data-props={JSON.stringify(label.props)}>
+        {label}
+      </div>
+      <div data-test-subj="tile-id">{id}</div>
+      <div data-test-subj="tile-space-id">{spaceId}</div>
+      <div data-test-subj="inspect-title" data-props={JSON.stringify(inspectTitle.props)}>
+        {inspectTitle}
+      </div>
+      <div data-test-subj="esql-query">{getEsqlQuery('test-namespace')}</div>
+    </div>
+  )),
+}));
+
+// Mock the ESQL query function
+jest.mock('./esql_query', () => ({
+  getAnomaliesDetectedEsqlQuery: jest.fn(() => 'mocked esql query for anomalies detected'),
+}));
+
+describe('AnomaliesDetectedTile', () => {
+  const defaultProps = {
+    spaceId: 'test-space',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the tile with correct props', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('key-insights-tile')).toBeInTheDocument();
+  });
+
+  it('passes correct title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const titleElement = getByTestId('tile-title');
+    expect(titleElement).toBeInTheDocument();
+    const titleProps = JSON.parse(titleElement.getAttribute('data-props') || '{}');
+    expect(titleProps.id).toBe('xpack.securitySolution.privmon.anomaliesDetected.title');
+    expect(titleProps.defaultMessage).toBe('Anomalies Detected');
+  });
+
+  it('passes correct label to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const labelElement = getByTestId('tile-label');
+    expect(labelElement).toBeInTheDocument();
+    const labelProps = JSON.parse(labelElement.getAttribute('data-props') || '{}');
+    expect(labelProps.id).toBe('xpack.securitySolution.privmon.anomaliesDetected.label');
+    expect(labelProps.defaultMessage).toBe('Anomalies Detected');
+  });
+
+  it('passes correct inspect title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const inspectTitleElement = getByTestId('inspect-title');
+    expect(inspectTitleElement).toBeInTheDocument();
+    const inspectTitleProps = JSON.parse(inspectTitleElement.getAttribute('data-props') || '{}');
+    expect(inspectTitleProps.id).toBe(
+      'xpack.securitySolution.privmon.anomaliesDetected.inspectTitle'
+    );
+    expect(inspectTitleProps.defaultMessage).toBe('Anomalies detected');
+  });
+
+  it('passes correct id to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const idElement = getByTestId('tile-id');
+    expect(idElement).toBeInTheDocument();
+    expect(idElement.textContent).toBe('privileged-user-monitoring-anomalies-detected');
+  });
+
+  it('passes spaceId to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement).toBeInTheDocument();
+    expect(spaceIdElement.textContent).toBe('test-space');
+  });
+
+  it('calls getEsqlQuery function with namespace', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const esqlQueryElement = getByTestId('esql-query');
+    expect(esqlQueryElement).toBeInTheDocument();
+    expect(esqlQueryElement.textContent).toBe('mocked esql query for anomalies detected');
+  });
+
+  it('renders with different spaceId', () => {
+    const propsWithDifferentSpaceId = {
+      spaceId: 'different-space',
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <AnomaliesDetectedTile {...propsWithDifferentSpaceId} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement.textContent).toBe('different-space');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/anomalies_detected_tile/esql_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/anomalies_detected_tile/esql_query.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAnomaliesDetectedEsqlQuery } from './esql_query';
+
+// Mock the helper functions
+jest.mock('../../../queries/helpers', () => ({
+  getPrivilegedMonitorUsersJoin: jest.fn(
+    (namespace: string) => `| JOIN privileged_users_${namespace} ON user.name`
+  ),
+}));
+
+describe('getAnomaliesDetectedEsqlQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a valid ESQL query for anomalies', () => {
+    const namespace = 'test-namespace';
+
+    const result = getAnomaliesDetectedEsqlQuery(namespace);
+
+    expect(result).toContain('FROM .ml-anomalies-shared');
+    expect(result).toContain('| WHERE record_score IS NOT NULL AND record_score > 0');
+    expect(result).toContain('| WHERE user.name IS NOT NULL');
+    expect(result).toContain('| JOIN privileged_users_test-namespace ON user.name');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should pass correct namespace to helper function', () => {
+    const namespace = 'test-namespace';
+    const getPrivilegedMonitorUsersJoin = jest.requireMock(
+      '../../../queries/helpers'
+    ).getPrivilegedMonitorUsersJoin;
+
+    getAnomaliesDetectedEsqlQuery(namespace);
+
+    expect(getPrivilegedMonitorUsersJoin).toHaveBeenCalledWith(namespace);
+  });
+
+  it('should handle different namespaces', () => {
+    const namespace = 'custom-namespace';
+
+    const result = getAnomaliesDetectedEsqlQuery(namespace);
+
+    expect(result).toContain('| JOIN privileged_users_custom-namespace ON user.name');
+  });
+
+  it('should always use the ml-anomalies-shared index', () => {
+    const namespace = 'test-namespace';
+
+    const result = getAnomaliesDetectedEsqlQuery(namespace);
+
+    expect(result).toContain('FROM .ml-anomalies-shared');
+  });
+
+  it('should include all required WHERE clauses', () => {
+    const namespace = 'test-namespace';
+
+    const result = getAnomaliesDetectedEsqlQuery(namespace);
+
+    // Check that the query includes the record_score filter
+    expect(result).toContain('WHERE record_score IS NOT NULL AND record_score > 0');
+    // Check that the query includes the user.name filter
+    expect(result).toContain('WHERE user.name IS NOT NULL');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/authentications_tile/authentications_tile.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/authentications_tile/authentications_tile.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestProviders } from '../../../../../../common/mock';
+import { AuthenticationsTile } from './authentications_tile';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the KeyInsightsTile component
+jest.mock('../common/key_insights_tile', () => ({
+  KeyInsightsTile: jest.fn(({ title, label, getEsqlQuery, id, spaceId, inspectTitle }) => (
+    <div data-test-subj="key-insights-tile">
+      <div data-test-subj="tile-title" data-props={JSON.stringify(title.props)}>
+        {title}
+      </div>
+      <div data-test-subj="tile-label" data-props={JSON.stringify(label.props)}>
+        {label}
+      </div>
+      <div data-test-subj="tile-id">{id}</div>
+      <div data-test-subj="tile-space-id">{spaceId}</div>
+      <div data-test-subj="inspect-title" data-props={JSON.stringify(inspectTitle.props)}>
+        {inspectTitle}
+      </div>
+      <div data-test-subj="esql-query">{getEsqlQuery('test-namespace')}</div>
+    </div>
+  )),
+}));
+
+// Mock the ESQL query function
+jest.mock('./esql_query', () => ({
+  getAuthenticationsEsqlCount: jest.fn(() => 'mocked esql query for authentications'),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {},
+  timeFieldName: '@timestamp',
+};
+
+describe('AuthenticationsTile', () => {
+  const defaultProps = {
+    spaceId: 'test-space',
+    sourcerDataView: mockDataView,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the tile with correct props', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('key-insights-tile')).toBeInTheDocument();
+  });
+
+  it('passes correct title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const titleElement = getByTestId('tile-title');
+    expect(titleElement).toBeInTheDocument();
+    const titleProps = JSON.parse(titleElement.getAttribute('data-props') || '{}');
+    expect(titleProps.id).toBe('xpack.securitySolution.privmon.authentications.title');
+    expect(titleProps.defaultMessage).toBe('Authentications');
+  });
+
+  it('passes correct label to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const labelElement = getByTestId('tile-label');
+    expect(labelElement).toBeInTheDocument();
+    const labelProps = JSON.parse(labelElement.getAttribute('data-props') || '{}');
+    expect(labelProps.id).toBe('xpack.securitySolution.privmon.authentications.label');
+    expect(labelProps.defaultMessage).toBe('Authentications');
+  });
+
+  it('passes correct inspect title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const inspectTitleElement = getByTestId('inspect-title');
+    expect(inspectTitleElement).toBeInTheDocument();
+    const inspectTitleProps = JSON.parse(inspectTitleElement.getAttribute('data-props') || '{}');
+    expect(inspectTitleProps.id).toBe(
+      'xpack.securitySolution.privmon.authentications.inspectTitle'
+    );
+    expect(inspectTitleProps.defaultMessage).toBe('Authentications');
+  });
+
+  it('passes correct id to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const idElement = getByTestId('tile-id');
+    expect(idElement).toBeInTheDocument();
+    expect(idElement.textContent).toBe('privileged-user-monitoring-authentications');
+  });
+
+  it('passes spaceId to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement).toBeInTheDocument();
+    expect(spaceIdElement.textContent).toBe('test-space');
+  });
+
+  it('calls getEsqlQuery function with namespace', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const esqlQueryElement = getByTestId('esql-query');
+    expect(esqlQueryElement).toBeInTheDocument();
+    expect(esqlQueryElement.textContent).toBe('mocked esql query for authentications');
+  });
+
+  it('renders with different spaceId', () => {
+    const propsWithDifferentSpaceId = {
+      ...defaultProps,
+      spaceId: 'different-space',
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <AuthenticationsTile {...propsWithDifferentSpaceId} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement.textContent).toBe('different-space');
+  });
+
+  it('renders with different sourcerDataView', () => {
+    const differentDataView: DataViewSpec = {
+      ...mockDataView,
+      id: 'different-dataview',
+      title: 'different-*',
+    };
+
+    const propsWithDifferentDataView = {
+      ...defaultProps,
+      sourcerDataView: differentDataView,
+    };
+
+    render(
+      <TestProviders>
+        <AuthenticationsTile {...propsWithDifferentDataView} />
+      </TestProviders>
+    );
+
+    expect(document.querySelector('[data-test-subj="key-insights-tile"]')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/authentications_tile/esql_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/authentications_tile/esql_query.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAuthenticationsEsqlCount } from './esql_query';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the helper functions
+jest.mock('../../../queries/authentications_esql_query', () => ({
+  getAuthenticationsEsqlSource: jest.fn(
+    (namespace: string, indexPattern: string, fields: Record<string, { type: string }>) =>
+      `FROM ${indexPattern} | WHERE authentication_field = "${namespace}"`
+  ),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {
+    'user.name': { type: 'string' },
+    '@timestamp': { type: 'date' },
+  },
+  timeFieldName: '@timestamp',
+};
+
+describe('getAuthenticationsEsqlCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a valid ESQL query with COUNT(*)', () => {
+    const namespace = 'test-namespace';
+    const result = getAuthenticationsEsqlCount(namespace, mockDataView);
+
+    expect(result).toContain('FROM test-*');
+    expect(result).toContain('WHERE authentication_field = "test-namespace"');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should use the index pattern from the data view', () => {
+    const namespace = 'test-namespace';
+    const customDataView = {
+      ...mockDataView,
+      title: 'custom-index-*',
+    };
+
+    const result = getAuthenticationsEsqlCount(namespace, customDataView);
+
+    expect(result).toContain('FROM custom-index-*');
+  });
+
+  it('should handle empty data view title', () => {
+    const namespace = 'test-namespace';
+    const emptyDataView = {
+      ...mockDataView,
+      title: '',
+    };
+
+    const result = getAuthenticationsEsqlCount(namespace, emptyDataView);
+
+    expect(result).toContain('FROM ');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should handle undefined data view title', () => {
+    const namespace = 'test-namespace';
+    const undefinedDataView = {
+      ...mockDataView,
+      title: undefined,
+    } as DataViewSpec;
+
+    const result = getAuthenticationsEsqlCount(namespace, undefinedDataView);
+
+    expect(result).toContain('FROM ');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should handle undefined data view fields', () => {
+    const namespace = 'test-namespace';
+    const undefinedFieldsDataView = {
+      ...mockDataView,
+      fields: undefined,
+    } as DataViewSpec;
+
+    const result = getAuthenticationsEsqlCount(namespace, undefinedFieldsDataView);
+
+    expect(result).toContain('FROM test-*');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should pass correct parameters to the source query function', () => {
+    const namespace = 'test-namespace';
+    const getAuthenticationsEsqlSource = jest.requireMock(
+      '../../../queries/authentications_esql_query'
+    ).getAuthenticationsEsqlSource;
+
+    getAuthenticationsEsqlCount(namespace, mockDataView);
+
+    expect(getAuthenticationsEsqlSource).toHaveBeenCalledWith(
+      namespace,
+      'test-*',
+      mockDataView.fields
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/granted_rights_tile/esql_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/granted_rights_tile/esql_query.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getGrantedRightsEsqlCount } from './esql_query';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the helper functions
+jest.mock('../../../queries/granted_rights_esql_query', () => ({
+  getGrantedRightsEsqlSource: jest.fn(
+    (namespace: string, indexPattern: string, fields: Record<string, { type: string }>) =>
+      `FROM ${indexPattern} | WHERE granted_rights_field = "${namespace}"`
+  ),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {
+    'user.name': { type: 'string' },
+    '@timestamp': { type: 'date' },
+  },
+  timeFieldName: '@timestamp',
+};
+
+describe('getGrantedRightsEsqlCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a valid ESQL query with COUNT(*)', () => {
+    const namespace = 'test-namespace';
+    const result = getGrantedRightsEsqlCount(namespace, mockDataView);
+
+    expect(result).toContain('FROM test-*');
+    expect(result).toContain('WHERE granted_rights_field = "test-namespace"');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should use the index pattern from the data view', () => {
+    const namespace = 'test-namespace';
+    const customDataView = {
+      ...mockDataView,
+      title: 'custom-index-*',
+    };
+
+    const result = getGrantedRightsEsqlCount(namespace, customDataView);
+
+    expect(result).toContain('FROM custom-index-*');
+  });
+
+  it('should handle empty data view title', () => {
+    const namespace = 'test-namespace';
+    const emptyDataView = {
+      ...mockDataView,
+      title: '',
+    };
+
+    const result = getGrantedRightsEsqlCount(namespace, emptyDataView);
+
+    expect(result).toContain('FROM ');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should handle undefined data view title', () => {
+    const namespace = 'test-namespace';
+    const undefinedDataView = {
+      ...mockDataView,
+      title: undefined,
+    } as DataViewSpec;
+
+    const result = getGrantedRightsEsqlCount(namespace, undefinedDataView);
+
+    expect(result).toContain('FROM ');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should handle undefined data view fields', () => {
+    const namespace = 'test-namespace';
+    const undefinedFieldsDataView = {
+      ...mockDataView,
+      fields: undefined,
+    } as DataViewSpec;
+
+    const result = getGrantedRightsEsqlCount(namespace, undefinedFieldsDataView);
+
+    expect(result).toContain('FROM test-*');
+    expect(result).toContain('| STATS COUNT(*)');
+  });
+
+  it('should pass correct parameters to the source query function', () => {
+    const namespace = 'test-namespace';
+    const getGrantedRightsEsqlSource = jest.requireMock(
+      '../../../queries/granted_rights_esql_query'
+    ).getGrantedRightsEsqlSource;
+
+    getGrantedRightsEsqlCount(namespace, mockDataView);
+
+    expect(getGrantedRightsEsqlSource).toHaveBeenCalledWith(
+      namespace,
+      'test-*',
+      mockDataView.fields
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/granted_rights_tile/granted_rights_tile.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/granted_rights_tile/granted_rights_tile.test.tsx
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestProviders } from '../../../../../../common/mock';
+import { GrantedRightsTile } from './granted_rights_tile';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock the KeyInsightsTile component
+jest.mock('../common/key_insights_tile', () => ({
+  KeyInsightsTile: jest.fn(({ title, label, getEsqlQuery, id, spaceId, inspectTitle }) => (
+    <div data-test-subj="key-insights-tile">
+      <div data-test-subj="tile-title" data-props={JSON.stringify(title.props)}>
+        {title}
+      </div>
+      <div data-test-subj="tile-label" data-props={JSON.stringify(label.props)}>
+        {label}
+      </div>
+      <div data-test-subj="tile-id">{id}</div>
+      <div data-test-subj="tile-space-id">{spaceId}</div>
+      <div data-test-subj="inspect-title" data-props={JSON.stringify(inspectTitle.props)}>
+        {inspectTitle}
+      </div>
+      <div data-test-subj="esql-query">{getEsqlQuery('test-namespace')}</div>
+    </div>
+  )),
+}));
+
+// Mock the ESQL query function
+jest.mock('./esql_query', () => ({
+  getGrantedRightsEsqlCount: jest.fn(() => 'mocked esql query for granted rights'),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {},
+  timeFieldName: '@timestamp',
+};
+
+describe('GrantedRightsTile', () => {
+  const defaultProps = {
+    spaceId: 'test-space',
+    sourcerDataView: mockDataView,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the tile with correct props', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('key-insights-tile')).toBeInTheDocument();
+  });
+
+  it('passes correct title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const titleElement = getByTestId('tile-title');
+    expect(titleElement).toBeInTheDocument();
+    const titleProps = JSON.parse(titleElement.getAttribute('data-props') || '{}');
+    expect(titleProps.id).toBe('xpack.securitySolution.privmon.grantedRights.title');
+    expect(titleProps.defaultMessage).toBe('Granted Rights');
+  });
+
+  it('passes correct label to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const labelElement = getByTestId('tile-label');
+    expect(labelElement).toBeInTheDocument();
+    const labelProps = JSON.parse(labelElement.getAttribute('data-props') || '{}');
+    expect(labelProps.id).toBe('xpack.securitySolution.privmon.grantedRights.label');
+    expect(labelProps.defaultMessage).toBe('Granted Rights');
+  });
+
+  it('passes correct inspect title to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const inspectTitleElement = getByTestId('inspect-title');
+    expect(inspectTitleElement).toBeInTheDocument();
+    const inspectTitleProps = JSON.parse(inspectTitleElement.getAttribute('data-props') || '{}');
+    expect(inspectTitleProps.id).toBe('xpack.securitySolution.privmon.grantedRights.inspectTitle');
+    expect(inspectTitleProps.defaultMessage).toBe('Granted rights');
+  });
+
+  it('passes correct id to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const idElement = getByTestId('tile-id');
+    expect(idElement).toBeInTheDocument();
+    expect(idElement.textContent).toBe('privileged-user-monitoring-granted-rights');
+  });
+
+  it('passes spaceId to KeyInsightsTile', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement).toBeInTheDocument();
+    expect(spaceIdElement.textContent).toBe('test-space');
+  });
+
+  it('calls getEsqlQuery function with namespace', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...defaultProps} />
+      </TestProviders>
+    );
+
+    const esqlQueryElement = getByTestId('esql-query');
+    expect(esqlQueryElement).toBeInTheDocument();
+    expect(esqlQueryElement.textContent).toBe('mocked esql query for granted rights');
+  });
+
+  it('renders with different spaceId', () => {
+    const propsWithDifferentSpaceId = {
+      ...defaultProps,
+      spaceId: 'different-space',
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <GrantedRightsTile {...propsWithDifferentSpaceId} />
+      </TestProviders>
+    );
+
+    const spaceIdElement = getByTestId('tile-space-id');
+    expect(spaceIdElement.textContent).toBe('different-space');
+  });
+
+  it('renders with different sourcerDataView', () => {
+    const differentDataView: DataViewSpec = {
+      ...mockDataView,
+      id: 'different-dataview',
+      title: 'different-*',
+    };
+
+    const propsWithDifferentDataView = {
+      ...defaultProps,
+      sourcerDataView: differentDataView,
+    };
+
+    render(
+      <TestProviders>
+        <GrantedRightsTile {...propsWithDifferentDataView} />
+      </TestProviders>
+    );
+
+    expect(document.querySelector('[data-test-subj="key-insights-tile"]')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/index.test.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestProviders } from '../../../../../common/mock';
+import { KeyInsightsPanel } from '.';
+import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+
+// Mock all tile components
+jest.mock('./active_privileged_users_tile', () => ({
+  ActivePrivilegedUsersTile: jest.fn(({ spaceId, sourcerDataView }) => (
+    <div data-test-subj="active-privileged-users-tile">
+      <div data-test-subj="space-id">{spaceId}</div>
+      <div data-test-subj="dataview-id">{sourcerDataView.id}</div>
+    </div>
+  )),
+}));
+
+jest.mock('./alerts_triggered_tile', () => ({
+  AlertsTriggeredTile: jest.fn(({ spaceId }) => (
+    <div data-test-subj="alerts-triggered-tile">
+      <div data-test-subj="space-id">{spaceId}</div>
+    </div>
+  )),
+}));
+
+jest.mock('./anomalies_detected_tile', () => ({
+  AnomaliesDetectedTile: jest.fn(({ spaceId }) => (
+    <div data-test-subj="anomalies-detected-tile">
+      <div data-test-subj="space-id">{spaceId}</div>
+    </div>
+  )),
+}));
+
+jest.mock('./granted_rights_tile', () => ({
+  GrantedRightsTile: jest.fn(({ spaceId, sourcerDataView }) => (
+    <div data-test-subj="granted-rights-tile">
+      <div data-test-subj="space-id">{spaceId}</div>
+      <div data-test-subj="dataview-id">{sourcerDataView.id}</div>
+    </div>
+  )),
+}));
+
+jest.mock('./account_switches_tile', () => ({
+  AccountSwitchesTile: jest.fn(({ spaceId, sourcerDataView }) => (
+    <div data-test-subj="account-switches-tile">
+      <div data-test-subj="space-id">{spaceId}</div>
+      <div data-test-subj="dataview-id">{sourcerDataView.id}</div>
+    </div>
+  )),
+}));
+
+jest.mock('./authentications_tile', () => ({
+  AuthenticationsTile: jest.fn(({ spaceId, sourcerDataView }) => (
+    <div data-test-subj="authentications-tile">
+      <div data-test-subj="space-id">{spaceId}</div>
+      <div data-test-subj="dataview-id">{sourcerDataView.id}</div>
+    </div>
+  )),
+}));
+
+const mockDataView: DataViewSpec = {
+  id: 'test-dataview',
+  title: 'test-*',
+  fields: {},
+  timeFieldName: '@timestamp',
+};
+
+describe('KeyInsightsPanel', () => {
+  const defaultProps = {
+    spaceId: 'test-space',
+    sourcerDataView: mockDataView,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all tiles', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <KeyInsightsPanel {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('active-privileged-users-tile')).toBeInTheDocument();
+    expect(getByTestId('alerts-triggered-tile')).toBeInTheDocument();
+    expect(getByTestId('anomalies-detected-tile')).toBeInTheDocument();
+    expect(getByTestId('granted-rights-tile')).toBeInTheDocument();
+    expect(getByTestId('account-switches-tile')).toBeInTheDocument();
+    expect(getByTestId('authentications-tile')).toBeInTheDocument();
+  });
+
+  it('passes spaceId to all tiles', () => {
+    const { getAllByTestId } = render(
+      <TestProviders>
+        <KeyInsightsPanel {...defaultProps} />
+      </TestProviders>
+    );
+
+    const spaceIdElements = getAllByTestId('space-id');
+    expect(spaceIdElements).toHaveLength(6);
+    spaceIdElements.forEach((element) => {
+      expect(element.textContent).toBe('test-space');
+    });
+  });
+
+  it('passes sourcerDataView to tiles that need it', () => {
+    const { getAllByTestId } = render(
+      <TestProviders>
+        <KeyInsightsPanel {...defaultProps} />
+      </TestProviders>
+    );
+
+    const dataviewIdElements = getAllByTestId('dataview-id');
+    // Only 4 tiles use sourcerDataView: ActivePrivilegedUsers, GrantedRights, AccountSwitches, Authentications
+    expect(dataviewIdElements).toHaveLength(4);
+    dataviewIdElements.forEach((element) => {
+      expect(element.textContent).toBe('test-dataview');
+    });
+  });
+
+  it('renders with different spaceId', () => {
+    const propsWithDifferentSpaceId = {
+      ...defaultProps,
+      spaceId: 'different-space',
+    };
+
+    const { getAllByTestId } = render(
+      <TestProviders>
+        <KeyInsightsPanel {...propsWithDifferentSpaceId} />
+      </TestProviders>
+    );
+
+    const spaceIdElements = getAllByTestId('space-id');
+    spaceIdElements.forEach((element) => {
+      expect(element.textContent).toBe('different-space');
+    });
+  });
+
+  it('renders with different sourcerDataView', () => {
+    const differentDataView: DataViewSpec = {
+      ...mockDataView,
+      id: 'different-dataview',
+      title: 'different-*',
+    };
+
+    const propsWithDifferentDataView = {
+      ...defaultProps,
+      sourcerDataView: differentDataView,
+    };
+
+    const { getAllByTestId } = render(
+      <TestProviders>
+        <KeyInsightsPanel {...propsWithDifferentDataView} />
+      </TestProviders>
+    );
+
+    const dataviewIdElements = getAllByTestId('dataview-id');
+    dataviewIdElements.forEach((element) => {
+      expect(element.textContent).toBe('different-dataview');
+    });
+  });
+
+  it('renders with proper CSS styling', () => {
+    const { container } = render(
+      <TestProviders>
+        <KeyInsightsPanel {...defaultProps} />
+      </TestProviders>
+    );
+
+    // Check that the main EuiFlexGroup is rendered
+    const flexGroup = container.querySelector('.euiFlexGroup');
+    expect(flexGroup).toBeInTheDocument();
+
+    // Check that all tiles are wrapped in styled divs
+    const tileWrappers = container.querySelectorAll('.euiFlexItem > div');
+    expect(tileWrappers).toHaveLength(6);
+  });
+
+  it('calls tile components with correct props', () => {
+    const ActivePrivilegedUsersTile = jest.requireMock(
+      './active_privileged_users_tile'
+    ).ActivePrivilegedUsersTile;
+    const AlertsTriggeredTile = jest.requireMock('./alerts_triggered_tile').AlertsTriggeredTile;
+    const AnomaliesDetectedTile = jest.requireMock(
+      './anomalies_detected_tile'
+    ).AnomaliesDetectedTile;
+    const GrantedRightsTile = jest.requireMock('./granted_rights_tile').GrantedRightsTile;
+    const AccountSwitchesTile = jest.requireMock('./account_switches_tile').AccountSwitchesTile;
+    const AuthenticationsTile = jest.requireMock('./authentications_tile').AuthenticationsTile;
+
+    render(
+      <TestProviders>
+        <KeyInsightsPanel {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(ActivePrivilegedUsersTile).toHaveBeenCalledWith(
+      {
+        spaceId: 'test-space',
+        sourcerDataView: mockDataView,
+      },
+      {}
+    );
+
+    expect(AlertsTriggeredTile).toHaveBeenCalledWith(
+      {
+        spaceId: 'test-space',
+      },
+      {}
+    );
+
+    expect(AnomaliesDetectedTile).toHaveBeenCalledWith(
+      {
+        spaceId: 'test-space',
+      },
+      {}
+    );
+
+    expect(GrantedRightsTile).toHaveBeenCalledWith(
+      {
+        spaceId: 'test-space',
+        sourcerDataView: mockDataView,
+      },
+      {}
+    );
+
+    expect(AccountSwitchesTile).toHaveBeenCalledWith(
+      {
+        spaceId: 'test-space',
+        sourcerDataView: mockDataView,
+      },
+      {}
+    );
+
+    expect(AuthenticationsTile).toHaveBeenCalledWith(
+      {
+        spaceId: 'test-space',
+        sourcerDataView: mockDataView,
+      },
+      {}
+    );
+  });
+});


### PR DESCRIPTION

## Summary

- Added unit tests for all 6 tile components (AccountSwitches, ActivePrivilegedUsers, AlertsTriggered, AnomaliesDetected, Authentications, GrantedRights)
- Added unit tests for all ESQL query functions with edge case coverage
- Added integration tests for KeyInsightsPanel component
- Added comprehensive test coverage for KeyInsightsTile component including 'N/A' state handling
- Fixed all TypeScript and ESLint errors (replaced 'any' types with proper types, converted require statements to jest.requireMock)
- All tests pass (13 test suites, 94 tests)
- Ensures proper mocking of FormattedMessage props and external dependencies
- Tests cover error handling, data validation, and integration scenarios

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




