### PR TITLE
[SecuritySolution] Fix the error where the fork branch was inserted at the end of the query

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helpers.ts
@@ -87,10 +87,10 @@ function moveForkBranchToToplevel(
   forkCommand: ESQLCommand<'fork'>,
   validBranch: ESQLAstQueryExpression
 ) {
-  mutate.generic.commands.remove(root, forkCommand);
-
   // Find where the fork index is to insert the valid branch
   const forkIndex = root.commands.findIndex((cmd) => cmd.name === 'fork');
+  mutate.generic.commands.remove(root, forkCommand);
+
   validBranch.commands.reverse().forEach((command) => {
     mutate.generic.commands.insert(root, command, forkIndex);
   });


### PR DESCRIPTION
## Summary

Fix the FORK removal logic to insert the branch in the correct position when only one FORK branch is valid.

### How to reproduce it
* Start empty kibana
* Generate data with resolve_generator `node x-pack/solutions/security/plugins/security_solution/scripts/endpoint/resolver_generator.js`
* Go to "Privileged user monitoring" page and add some privileged users
* On the Dashboard page, scroll down to "Privileged user activity" and click the "Authentications" tab
* It should display "No results found" instead of an error

### Before fix
![Screenshot 2025-06-25 at 09 16 51](https://github.com/user-attachments/assets/3fe0e9c2-7ab9-4d31-8380-10ce09683d1c)


### After fix
![Screenshot 2025-06-25 at 10 25 15](https://github.com/user-attachments/assets/cc220d66-1f53-4ac4-9615-278784db36ef)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
