### PR TITLE
[Fleet] disable Save button if target versions not changed

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/manage_auto_upgrade_agents_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/manage_auto_upgrade_agents_modal/index.tsx
@@ -4,8 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import React, { useCallback, useState } from 'react';
+import { isEqual } from 'lodash';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -51,6 +51,10 @@ export const ManageAutoUpgradeAgentsModal: React.FunctionComponent<
   });
   const latestVersion = agentsAvailableVersions?.items[0];
   const [errors, setErrors] = useState<string[]>([]);
+
+  const targetVersionsChanged = useMemo(() => {
+    return isEqual(targetVersions, agentPolicy.required_versions || []) === false;
+  }, [targetVersions, agentPolicy.required_versions]);
 
   const submitUpdateAgentPolicy = async () => {
     setIsLoading(true);
@@ -103,7 +107,7 @@ export const ManageAutoUpgradeAgentsModal: React.FunctionComponent<
       }
       onCancel={() => onClose(false)}
       onConfirm={onSubmit}
-      confirmButtonDisabled={isLoading || errors.length > 0}
+      confirmButtonDisabled={isLoading || errors.length > 0 || !targetVersionsChanged}
       cancelButtonText={
         <FormattedMessage
           id="xpack.fleet.manageAutoUpgradeAgents.cancelButtonLabel"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/225037

Make Save button disabled if target versions haven't changed in Manage auto-upgrade agents modal

https://github.com/user-attachments/assets/260dd0ab-bd0a-4977-bfb5-575071bb5a37



