### PR TITLE
[Embeddable Rebuild] Fix panel title sync with saved object when using defaultTitle

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.test.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.test.tsx
@@ -89,6 +89,17 @@ describe('customize panel editor', () => {
       expect(titleInput).toHaveValue('Default title');
     });
 
+    // Even if the input value matches defaultTitle on apply, we expect setTitle(undefined) to be called,  meaning the title is treated as "not customized".
+    it('should not set panel custom title if it matches default title on apply', async () => {
+      api.defaultTitle$ = new BehaviorSubject<string | undefined>('Default title');
+      renderPanelEditor();
+      const titleInput = screen.getByTestId('customEmbeddablePanelTitleInput');
+      expect(titleInput).toHaveValue('Default title');
+      await userEvent.click(screen.getByTestId('saveCustomizePanelButton'));
+      expect(setTitle).toHaveBeenCalledWith(undefined);
+      expect(api.title$?.getValue()).toBeUndefined();
+    });
+
     it('should use title even when empty string', () => {
       api.defaultTitle$ = new BehaviorSubject<string | undefined>('Default title');
       setTitle('');

--- a/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.tsx
@@ -99,7 +99,13 @@ export const CustomizePanelEditor = ({
   const dateFormat = useMemo(() => core.uiSettings.get<string>(UI_SETTINGS.DATE_FORMAT), []);
 
   const save = () => {
-    if (panelTitle !== api.title$?.value) api.setTitle?.(panelTitle);
+    // If the panel title matches the default title, we set api.title to undefined to indicate there's no custom title.
+    // This ensures the panel stays in sync with the centrally saved object's title and reflects any updates to its title.
+    if (panelTitle === api?.defaultTitle$?.value) {
+      api.setTitle?.(undefined);
+    } else if (panelTitle !== api.title$?.value) {
+      api.setTitle?.(panelTitle);
+    }
     if (hideTitle !== api.hideTitle$?.value) api.setHideTitle?.(hideTitle);
     if (panelDescription !== api.description$?.value) api.setDescription?.(panelDescription);
 


### PR DESCRIPTION
## Summary

Bug description (also the bug video below):
The bug occurred in the Customize Panel Editor, where the PanelTitle—even when matching the defaultTitle from the central Saved Object—was not always properly synchronized with that object. This led to situations where the default panel title was incorrectly stored as a custom override, breaking the link to the saved object. There were two specific cases where this happened:

### 🧪 Add a panel from the library, then click apply button without making changes

1. Add a panel from the library to the Dashboard
2. Open the Customize Panel editor using the settings icon
3. Without changing the title, click Apply button to exit the editor

🔥 This writes the defaultTitle into the API title field unnecessarily, making it look like a custom title. This breaks future title synchronization with the saved object.

### 🧪 Change the panel title, then reset to default

1. Add a panel from the library to the Dashboard
2. Open the Customize Panel editor and update the title to a custom one
3. Click Apply
4. Reopen the Customize Panel editor
5. Click Reset to default to restore the original title

🔥 Although the UI shows the correct library title again, it's written into the API title field. Since it's now stored as a custom value, future updates to the library title won’t be reflected—breaking synchronization.

Fix:
The logic was updated to correctly detect when the panel title matches the defaultTitle. In such cases, it clears the title field in the API (by setting it to `undefined`) to indicate that the panel should inherit the title from the saved object. This ensures proper synchronization: any future updates to the saved object's title will be reflected automatically in the panel.


Closes #188858

Below the bug video:

https://github.com/user-attachments/assets/f784679c-8eaa-47b4-942d-e3802faee076







<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->