### PR TITLE
[Console] Fix test for opening docs with shortcut

### DIFF
--- a/src/platform/test/functional/apps/console/_misc_console_behavior.ts
+++ b/src/platform/test/functional/apps/console/_misc_console_behavior.ts
@@ -113,8 +113,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await PageObjects.console.getCurrentLineNumber()).to.be(4);
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/218255
-      describe.skip('open documentation', () => {
+      describe('open documentation', () => {
         const requests = ['GET _search', 'GET test_index/_search', 'GET /_search'];
         requests.forEach((request) => {
           it('should open documentation when Ctrl+/ is pressed', async () => {
@@ -131,7 +130,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               const url = await browser.getCurrentUrl();
               // The url that is open is https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
               // but it redirects to https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search
-              expect(url).to.contain('operation-search');
+              expect(url).to.contain('www.elastic.co/docs');
             });
           });
         });


### PR DESCRIPTION
Fixes #218255 and #213784

## Summary

This PR fixes flaky test in Console responsible for opening documentation with keyboard shortcut by checking if the opened tab contains `www.elastic.co/docs`. Also discussed here: https://github.com/elastic/kibana/issues/218255#issuecomment-2916785827

### Why is it happening?
The most recent failure was to the URL being https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-render-search-template-3 instead of https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search.

![Screenshot 2025-06-25 at 14 44 51](https://github.com/user-attachments/assets/348a8cad-8ff8-4ba8-a0d4-0903c0962b74)

It looks like when documentation page is opened and it's scrolled even a little bit up the URL changes to the previous section which causes flakiness.

https://github.com/user-attachments/assets/270ca2df-4ef2-447a-a858-e9f5889edd95

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->