### PR TITLE
Add namespace to default grouping csp fields

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -182,6 +182,7 @@ export const FINDINGS_GROUPING_OPTIONS = {
   CLOUD_ACCOUNT_ID: 'cloud.account.id',
   ORCHESTRATOR_CLUSTER_NAME: 'orchestrator.cluster.name',
   ORCHESTRATOR_CLUSTER_ID: 'orchestrator.cluster.id',
+  NAMESPACE: 'data_stream.namespace',
 };
 
 export const VULNERABILITY_FIELDS = {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
@@ -100,6 +100,12 @@ export const defaultGroupingOptions: GroupOption[] = [
     }),
     key: FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID,
   },
+  {
+    label: i18n.translate('xpack.csp.findings.latestFindings.groupNamespace', {
+      defaultMessage: 'Namespace',
+    }),
+    key: FINDINGS_GROUPING_OPTIONS.NAMESPACE,
+  },
 ];
 
 export const groupingTitle = i18n.translate('xpack.csp.findings.latestFindings.groupBy', {


### PR DESCRIPTION
## Summary
Cloud Security supports namespaces from the upcoming release.
This PR adds namespace as default grouping field in the Findings page.
<img width="1722" alt="image" src="https://github.com/user-attachments/assets/55973acf-c9e3-48c6-99f5-324aba0c8e7d" />


<img width="1721" alt="image" src="https://github.com/user-attachments/assets/fdbbc621-3d44-402d-8a3a-e5c781b86431" />
