### PR TITLE
[Dataset Quality] Skip tests which require `read_failure_store` on ES 9.0

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_streams_failure_store.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_streams_failure_store.ts
@@ -27,7 +27,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       .query({ start, end });
   }
 
-  describe('Failure-store flag on data-streams', function() {
+  describe('Failure-store flag on data-streams', function () {
     // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
     // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
     // and running these tests will result in an "unknown index privilege [read_failure_store]" error.

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_streams_failure_store.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/data_streams_failure_store.ts
@@ -27,7 +27,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       .query({ start, end });
   }
 
-  describe('Failure-store flag on data-streams', () => {
+  describe('Failure-store flag on data-streams', function() {
+    // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
+    // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
+    // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
+    this.onlyEsVersion('8.19 || >=9.1');
+
     let client: LogsSynthtraceEsClient;
     let supertestAdmin: any;
 


### PR DESCRIPTION
Fixes #225201 

## Summary

The PR skips the Dataset Quality API integration test suite which depends on reading Failure Store index privileges. Because when this test suite runs in Kibana 8.19 against ES 9.0 in a forward compatibility test runs, it raises the error:

```bash
[00:04:43]           â”‚ proc [kibana] [2025-06-25T05:40:33.223+00:00][WARN ][http.server.kbn-internal-api-restricted] Access to uri [/internal/dataset_quality/data_streams/logs-synth.fs-default/details] with method [get] is deprecated {"service":{"node":{"roles":["background_tasks","ui"]}}}
[00:04:43]           â”‚ proc [kibana] [2025-06-25T05:40:33.252+00:00][ERROR][plugins.datasetQuality] illegal_argument_exception
[00:04:43]           â”‚ proc [kibana] 	Root causes:
[00:04:43]           â”‚ proc [kibana] 		illegal_argument_exception: unknown index privilege [read_failure_store]. a privilege must be either one of the predefined fixed indices privileges [all,auto_configure,create,create_doc,create_index,cross_cluster_replication,cross_cluster_replication_internal,delete,delete_index,index,maintenance,manage,manage_data_stream_lifecycle,manage_follow_index,manage_ilm,manage_leader_index,monitor,none,read,read_cross_cluster,view_index_metadata,write] or a pattern over one of the available index actions {"service":{"node":{"roles":["background_tasks","ui"]}}}
[00:04:43]           â”‚ proc [kibana] [2025-06-25T05:40:33.291+00:00][WARN ][http.server.kbn-internal-api-restricted] Access to uri [/internal/dataset_quality/data_streams/logs-synth.no-default/details] with method [get] is deprecated {"service":{"node":{"roles":["background_tasks","ui"]}}}
[00:04:43]           â”‚ proc [kibana] [2025-06-25T05:40:33.305+00:00][ERROR][plugins.datasetQuality] illegal_argument_exception
```

This happens because the test accesses endpoint `data_stream/{index}/details` which inquire user's index privileges including `read_failure_store`, which is not available in **ES 9.0** as `ES 9.0` does not support Failure Store.

<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->