### PR TITLE
[9.0] [Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224786)

### DIFF
--- a/x-pack/test/dataset_quality_api_integration/tests/data_streams/data_stream_details.spec.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/data_streams/data_stream_details.spec.ts
@@ -38,7 +38,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   }
 
   registry.when('DataStream Details', { config: 'basic' }, () => {
-    describe('gets the data stream details', () => {
+    describe('gets the data stream details', function () {
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       before(async () => {
         await synthtrace.index([
           timerange(start, end)

--- a/x-pack/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
@@ -58,7 +58,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   }
 
   registry.when('Api Key privileges check', { config: 'basic' }, () => {
-    describe('index privileges', () => {
+    describe('index privileges', function () {
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('returns user authorization as false for noAccessUser', async () => {
         const resp = await callApiAs('noAccessUser');
 
@@ -122,7 +127,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
     });
 
-    describe('when required privileges are set', () => {
+    describe('when required privileges are set', function () {
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       describe('and categorized datastreams', () => {
         const integration = 'my-custom-integration';
 

--- a/x-pack/test/dataset_quality_api_integration/tests/data_streams/total_docs.spec.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/data_streams/total_docs.spec.ts
@@ -31,7 +31,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   }
 
   registry.when('Total docs', { config: 'basic' }, () => {
-    describe('authorization', () => {
+    describe('authorization', function () {
+      // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
+      // These versions are not expected to work together.
+      // The tests raise "unknown index privilege [read_failure_store]" error in ES 9.0.
+      this.onlyEsVersion('8.19 || >=9.1');
+
       it('should return a 403 when the user does not have sufficient privileges', async () => {
         const err = await expectToReject<DatasetQualityApiError>(() => callApiAs('noAccessUser'));
         expect(err.res.status).to.be(403);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224786)](https://github.com/elastic/kibana/pull/224786)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2025-06-24T08:39:44Z","message":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224786)\n\nThe PR skips test suites for ES 9.0.* which were failing when these\ntests ran in Kibana 8.19 branch against ES 9.0.* in forward\ncompatibility runs.","sha":"5a6f844c0154ac15fd68b1fe5237b8d778c0f033","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:obs-ux-logs","backport:version","v9.1.0","v8.19.0","v9.0.3"],"title":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0","number":224786,"url":"https://github.com/elastic/kibana/pull/224786","mergeCommit":{"message":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224786)\n\nThe PR skips test suites for ES 9.0.* which were failing when these\ntests ran in Kibana 8.19 branch against ES 9.0.* in forward\ncompatibility runs.","sha":"5a6f844c0154ac15fd68b1fe5237b8d778c0f033"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224786","number":224786,"mergeCommit":{"message":"[Dataset Quality] Fix ES Promotion forward compatibility test failures for ES 9.0 (#224786)\n\nThe PR skips test suites for ES 9.0.* which were failing when these\ntests ran in Kibana 8.19 branch against ES 9.0.* in forward\ncompatibility runs.","sha":"5a6f844c0154ac15fd68b1fe5237b8d778c0f033"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225017","number":225017,"state":"OPEN"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->