### PR TITLE
[8.19] Add export derivative integration type  (#223994)

### DIFF
--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
@@ -132,6 +132,7 @@ export const reportingCsvExportProvider = ({
       name: panelTitle,
       exportType: reportType,
       label: 'CSV',
+      icon: 'documents',
       generateAssetExport: generateReportingJobCSV,
       helpText: (
         <FormattedMessage

--- a/src/platform/plugins/shared/share/public/components/context/index.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useShareTabsContext, useShareContext } from '.';
+import { useShareTypeContext, useShareContext } from '.';
 
 describe('share menu context', () => {
   describe('useShareContext', () => {
@@ -21,7 +21,7 @@ describe('share menu context', () => {
 
   describe('useShareTabsContext', () => {
     it('throws an error if used outside of ShareMenuProvider tree', () => {
-      expect(() => renderHook(() => useShareTabsContext('embed'))).toThrow(
+      expect(() => renderHook(() => useShareTypeContext('embed'))).toThrow(
         /^Failed to call `useShareContext` because the context from ShareMenuProvider is missing./
       );
     });

--- a/src/platform/plugins/shared/share/public/components/context/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.tsx
@@ -16,17 +16,17 @@ export interface IShareContext extends Omit<ShowShareMenuOptions, 'onClose'> {
   shareMenuItems: ShareConfigs[];
 }
 
-const ShareTabsContext = createContext<IShareContext | null>(null);
+const ShareContext = createContext<IShareContext | null>(null);
 
-export const ShareMenuProvider = ({
+export const ShareProvider = ({
   shareContext,
   children,
 }: PropsWithChildren<{ shareContext: IShareContext }>) => {
-  return <ShareTabsContext.Provider value={shareContext}>{children}</ShareTabsContext.Provider>;
+  return <ShareContext.Provider value={shareContext}>{children}</ShareContext.Provider>;
 };
 
 export const useShareContext = () => {
-  const context = useContext(ShareTabsContext);
+  const context = useContext(ShareContext);
 
   if (!context) {
     throw new Error(
@@ -37,7 +37,7 @@ export const useShareContext = () => {
   return context;
 };
 
-export const useShareTabsContext = <
+export const useShareTypeContext = <
   T extends Exclude<ShareTypes, 'legacy'>,
   G extends T extends 'integration' ? string : never
 >(
@@ -53,7 +53,10 @@ export const useShareTabsContext = <
     ? Array<Extract<ShareConfigs, { shareType: T; groupId?: G }>>
     : Extract<ShareConfigs, { shareType: T }> = (
     shareType === 'integration' ? Array.prototype.filter : Array.prototype.find
-  ).call(shareMenuItems, (item) => item.shareType === shareType && item?.groupId === groupId);
+  ).call(
+    shareMenuItems,
+    (item) => item.shareType === shareType && item?.groupId === (groupId ?? item?.groupId)
+  );
 
   type ObjectTypeMetaConfig = IShareContext['objectTypeMeta']['config'];
 

--- a/src/platform/plugins/shared/share/public/components/share_tabs.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { ShareMenuTabs } from './share_tabs';
-import { ShareMenuProvider, type IShareContext } from './context';
+import { ShareProvider, type IShareContext } from './context';
 import { screen, render } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { KibanaLocation, LocatorGetUrlParams, UrlService } from '../../common/url_service';
@@ -91,9 +91,9 @@ describe('Share modal tabs', () => {
   it('does not render an export tab', () => {
     render(
       <IntlProvider locale="en">
-        <ShareMenuProvider shareContext={{ ...mockShareContext }}>
+        <ShareProvider shareContext={{ ...mockShareContext }}>
           <ShareMenuTabs />
-        </ShareMenuProvider>
+        </ShareProvider>
       </IntlProvider>
     );
     expect(screen.queryByTestId('export')).not.toBeInTheDocument();
@@ -116,9 +116,9 @@ describe('Share modal tabs', () => {
 
       render(
         <IntlProvider locale="en">
-          <ShareMenuProvider shareContext={{ ...disabledLinkShareContext }}>
+          <ShareProvider shareContext={{ ...disabledLinkShareContext }}>
             <ShareMenuTabs />
-          </ShareMenuProvider>
+          </ShareProvider>
         </IntlProvider>
       );
       expect(screen.queryByTestId('link')).not.toBeInTheDocument();

--- a/src/platform/plugins/shared/share/public/components/share_tabs.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.tsx
@@ -10,14 +10,14 @@
 import React, { type FC } from 'react';
 import { TabbedModal, type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
 
-import { ShareMenuProvider, useShareContext, type IShareContext } from './context';
+import { ShareProvider, useShareContext, type IShareContext } from './context';
 import { linkTab, embedTab } from './tabs';
 
 export const ShareMenu: FC<{ shareContext: IShareContext }> = ({ shareContext }) => {
   return (
-    <ShareMenuProvider {...{ shareContext }}>
+    <ShareProvider {...{ shareContext }}>
       <ShareMenuTabs />
-    </ShareMenuProvider>
+    </ShareProvider>
   );
 };
 

--- a/src/platform/plugins/shared/share/public/components/tabs/embed/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/embed/index.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
 import { EmbedContent } from './embed_content';
-import { useShareTabsContext } from '../../context';
+import { useShareTypeContext } from '../../context';
 
 type IEmbedTab = IModalTabDeclaration<{ url: string; isNotSaved: boolean }>;
 
@@ -25,7 +25,7 @@ const EmbedTabContent: NonNullable<IEmbedTab['content']> = ({ state, dispatch })
     allowShortUrl,
     shareableUrlLocatorParams,
     shareMenuItems,
-  } = useShareTabsContext('embed');
+  } = useShareTypeContext('embed');
 
   return (
     <EmbedContent

--- a/src/platform/plugins/shared/share/public/components/tabs/link/index.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/index.tsx
@@ -10,7 +10,7 @@
 import React, { useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { type IModalTabDeclaration } from '@kbn/shared-ux-tabbed-modal';
-import { useShareTabsContext } from '../../context';
+import { useShareTypeContext } from '../../context';
 import { LinkContent } from './link_content';
 
 type ILinkTab = IModalTabDeclaration<{
@@ -58,7 +58,7 @@ const LinkTabContent: ILinkTab['content'] = ({ state, dispatch }) => {
     shareableUrlLocatorParams,
     allowShortUrl,
     shareMenuItems,
-  } = useShareTabsContext('link');
+  } = useShareTypeContext('link');
 
   const setDashboardLink = useCallback(
     (url: string) => {

--- a/src/platform/plugins/shared/share/public/index.ts
+++ b/src/platform/plugins/shared/share/public/index.ts
@@ -27,6 +27,7 @@ export type {
   ShareContextMenuPanelItem,
   BrowserUrlService,
   ExportShare,
+  ExportShareDerivatives,
 } from './types';
 
 export type { RedirectOptions } from '../common/url_service';

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -9,7 +9,12 @@
 
 import type { ComponentType, ReactNode } from 'react';
 import type { InjectedIntl } from '@kbn/i18n-react';
-import { EuiContextMenuPanelDescriptor, type EuiCodeProps, type EuiIconProps } from '@elastic/eui';
+import {
+  EuiContextMenuPanelDescriptor,
+  type EuiCodeProps,
+  type EuiIconProps,
+  type EuiFlyoutProps,
+} from '@elastic/eui';
 import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
 import type { ILicense } from '@kbn/licensing-plugin/public';
 import type { Capabilities } from '@kbn/core/public';
@@ -167,11 +172,29 @@ export interface ExportShare
   groupId: 'export';
 }
 
+/**
+ * @description Share integration implementation definition that build off exports within kibana,
+ * reach out to the shared ux team before settling on using this interface
+ */
+export interface ExportShareDerivatives
+  extends ShareIntegration<{
+    label: React.FC<{ openFlyout: () => void }>;
+    toolTipContent?: ReactNode;
+    flyoutContent: React.FC<{
+      closeFlyout: () => void;
+      flyoutRef: React.RefObject<HTMLDivElement>;
+    }>;
+    flyoutSizing?: Pick<EuiFlyoutProps, 'size' | 'maxWidth'>;
+  }> {
+  groupId: 'exportDerivatives';
+}
+
 export type ShareActionIntents = LinkShare | EmbedShare | ShareLegacy | ShareIntegration;
 
 export type LinkShareConfig = ShareImplementation<LinkShare>;
 export type EmbedShareConfig = ShareImplementation<EmbedShare>;
 export type ExportShareConfig = ShareImplementation<ExportShare>;
+export type ExportShareDerivativesConfig = ShareImplementation<ExportShareDerivatives>;
 export type ShareIntegrationConfig = ShareImplementation<ShareIntegration>;
 
 export type LegacyIntegrationConfig = Omit<ShareLegacy, 'config'> & {
@@ -181,9 +204,10 @@ export type LegacyIntegrationConfig = Omit<ShareLegacy, 'config'> & {
 export type ShareConfigs =
   | LinkShareConfig
   | EmbedShareConfig
+  | ShareIntegrationConfig
   | ExportShareConfig
-  | LegacyIntegrationConfig
-  | ShareIntegrationConfig;
+  | ExportShareDerivativesConfig
+  | LegacyIntegrationConfig;
 
 export type LinkShareUIConfig = ShareActionUserInputBase<{
   /**

--- a/src/platform/test/functional/page_objects/export_page.ts
+++ b/src/platform/test/functional/page_objects/export_page.ts
@@ -35,14 +35,20 @@ export class ExportPageObject extends FtrService {
     return isEnabled;
   }
 
-  async clickPopoverItem(label: string) {
+  async clickPopoverItem(
+    label: string,
+    exportPopoverOpener: () => Promise<void> = this.clickExportTopNavButton.bind(this)
+  ) {
     this.log.debug(`clickPopoverItem label: ${label}`);
 
     await this.retry.waitFor('ascertain that export popover is open', async () => {
-      const isExportPopoverOpen = await this.isExportPopoverOpen();
+      let isExportPopoverOpen = await this.isExportPopoverOpen();
+
       if (!isExportPopoverOpen) {
-        await this.clickExportTopNavButton();
+        await exportPopoverOpener();
+        isExportPopoverOpen = await this.isExportPopoverOpen();
       }
+
       return isExportPopoverOpen;
     });
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -2007,7 +2007,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
 
     async openCSVDownloadExport() {
       await this.clickExportButton();
-      await exports.clickPopoverItem('CSV');
+      await exports.clickPopoverItem('CSV', this.clickExportButton);
     },
 
     async setCSVDownloadDebugFlag(value: boolean = true) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add export derivative integration type  (#223994)](https://github.com/elastic/kibana/pull/223994)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-17T10:12:11Z","message":"Add export derivative integration type  (#223994)\n\nThis PR adds a new share integration type (i.e. the `exportDerivative`).\nThis integration is a special one that is only to be used in a scenario\nwhere a team would like to offer some extra functionality that depends\non the availability of some `export` integration. Specifically because\nof the way this has been coupled to be presented to the user the\n`exportDerivative` type integration would only be displayed to the user\nwhen at least one export integration exists.\n\nThis particular integration is also much more flexible, in that it only\naccepts a label to denote what should be rendered to the user, and a\nfreeform component that will be rendered into the flyout that will in\nturn open when the provided label is clicked.\n\nOne might configure an integration for this like so;\n\n```ts\n      share.registerShareIntegration<ExportShareDerivatives>({\n        id: 'scheduledReporting',\n        groupId: 'exportDerivatives',\n        config: () => ({\n          label: ({ openFlyout }) =>\n            React.createElement(\n              EuiButton,\n              { iconType: 'calendar', onClick: openFlyout },\n              'schedule report'\n            ),\n          flyoutContent: ({ closeFlyout , flyoutRef }) => {\n            return React.createElement(\n              EuiButton,\n              {\n                iconType: 'calendar',\n              },\n              'Click me'\n            );\n          },\n        }),\n      });\n```\n \n The following config would produce the following experience;\n \n \n![ScreenRecording2025-06-14at15 04 54-ezgif\ncom-optimize](https://github.com/user-attachments/assets/52a232b3-7ce9-491b-8913-a8e3cd91e207)\n\n\n","sha":"b275c9e9dc1ac74294a52d31b6037c3cf0d8d18c","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:SharedUX","v9.1.0"],"title":"Add export derivative integration type ","number":223994,"url":"https://github.com/elastic/kibana/pull/223994","mergeCommit":{"message":"Add export derivative integration type  (#223994)\n\nThis PR adds a new share integration type (i.e. the `exportDerivative`).\nThis integration is a special one that is only to be used in a scenario\nwhere a team would like to offer some extra functionality that depends\non the availability of some `export` integration. Specifically because\nof the way this has been coupled to be presented to the user the\n`exportDerivative` type integration would only be displayed to the user\nwhen at least one export integration exists.\n\nThis particular integration is also much more flexible, in that it only\naccepts a label to denote what should be rendered to the user, and a\nfreeform component that will be rendered into the flyout that will in\nturn open when the provided label is clicked.\n\nOne might configure an integration for this like so;\n\n```ts\n      share.registerShareIntegration<ExportShareDerivatives>({\n        id: 'scheduledReporting',\n        groupId: 'exportDerivatives',\n        config: () => ({\n          label: ({ openFlyout }) =>\n            React.createElement(\n              EuiButton,\n              { iconType: 'calendar', onClick: openFlyout },\n              'schedule report'\n            ),\n          flyoutContent: ({ closeFlyout , flyoutRef }) => {\n            return React.createElement(\n              EuiButton,\n              {\n                iconType: 'calendar',\n              },\n              'Click me'\n            );\n          },\n        }),\n      });\n```\n \n The following config would produce the following experience;\n \n \n![ScreenRecording2025-06-14at15 04 54-ezgif\ncom-optimize](https://github.com/user-attachments/assets/52a232b3-7ce9-491b-8913-a8e3cd91e207)\n\n\n","sha":"b275c9e9dc1ac74294a52d31b6037c3cf0d8d18c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223994","number":223994,"mergeCommit":{"message":"Add export derivative integration type  (#223994)\n\nThis PR adds a new share integration type (i.e. the `exportDerivative`).\nThis integration is a special one that is only to be used in a scenario\nwhere a team would like to offer some extra functionality that depends\non the availability of some `export` integration. Specifically because\nof the way this has been coupled to be presented to the user the\n`exportDerivative` type integration would only be displayed to the user\nwhen at least one export integration exists.\n\nThis particular integration is also much more flexible, in that it only\naccepts a label to denote what should be rendered to the user, and a\nfreeform component that will be rendered into the flyout that will in\nturn open when the provided label is clicked.\n\nOne might configure an integration for this like so;\n\n```ts\n      share.registerShareIntegration<ExportShareDerivatives>({\n        id: 'scheduledReporting',\n        groupId: 'exportDerivatives',\n        config: () => ({\n          label: ({ openFlyout }) =>\n            React.createElement(\n              EuiButton,\n              { iconType: 'calendar', onClick: openFlyout },\n              'schedule report'\n            ),\n          flyoutContent: ({ closeFlyout , flyoutRef }) => {\n            return React.createElement(\n              EuiButton,\n              {\n                iconType: 'calendar',\n              },\n              'Click me'\n            );\n          },\n        }),\n      });\n```\n \n The following config would produce the following experience;\n \n \n![ScreenRecording2025-06-14at15 04 54-ezgif\ncom-optimize](https://github.com/user-attachments/assets/52a232b3-7ce9-491b-8913-a8e3cd91e207)\n\n\n","sha":"b275c9e9dc1ac74294a52d31b6037c3cf0d8d18c"}}]}] BACKPORT-->