### PR TITLE
[8.19] [Obs AI Assistant] Add custom plugin for highlighting user and assistant responses when they have redacted entities (#224605)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_timeline.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_timeline.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { highlightContent } from './chat_timeline';
+
+describe('highlightContent', () => {
+  const entity = 'John Doe';
+
+  it('highlights anonymized entities', () => {
+    const content = `Hi, my name is ${entity}.`;
+    const startPos = content.indexOf(entity);
+    const endPos = startPos + entity.length;
+
+    const result = highlightContent(content, [
+      { start_pos: startPos, end_pos: endPos, entity, class_name: 'PER' },
+    ]);
+
+    expect(result).toBe(`Hi, my name is !{anonymized{"entityClass":"PER","content":"${entity}"}}.`);
+  });
+
+  it('does not highlight entities that are inside inlined code', () => {
+    const content = `Here is my full name, inlined in code \`${entity}\`.`;
+    const startPos = content.indexOf(entity);
+    const endPos = startPos + entity.length;
+
+    const result = highlightContent(content, [
+      { start_pos: startPos, end_pos: endPos, entity, class_name: 'PER' },
+    ]);
+
+    // The content should remain unchanged because the entity is inside inline code.
+    expect(result).toBe(content);
+  });
+
+  it('does not highlight entities that are inside fenced code blocks', () => {
+    const content = `Here is code block:
+        \`\`\`
+        ${entity}
+        \`\`\`
+        End.`;
+    const startPos = content.indexOf(entity);
+    const endPos = startPos + entity.length;
+
+    const result = highlightContent(content, [
+      { start_pos: startPos, end_pos: endPos, entity, class_name: 'PER' },
+    ]);
+
+    // The content should remain unchanged because the entity is inside a fenced code block.
+    expect(result).toBe(content);
+  });
+});

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/anonymized_highlight.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/anonymized_highlight.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { Plugin } from 'unified';
+import type { RemarkTokenizer } from '@elastic/eui';
+
+/**
+ * Markdown parser for anonymized inline syntax.
+ * Matches `!{anonymized{...}}` and passes the JSON configuration on the node.
+ */
+export const anonymizedHighlightPlugin: Plugin = function () {
+  const Parser = this.Parser;
+  const tokenizers = Parser.prototype.inlineTokenizers;
+  const methods = Parser.prototype.inlineMethods;
+  const TOKEN = '!{anonymized';
+  const TOKEN_LEN = TOKEN.length;
+
+  const tokenizeAnonymized: RemarkTokenizer = function (eat, value, silent) {
+    if (!value.startsWith(TOKEN)) return false;
+
+    const nextChar = value.charAt(TOKEN_LEN);
+    if (nextChar !== '{' && nextChar !== '}') return false;
+
+    if (silent) return true;
+
+    // Checking for the JSON configuration block
+    const hasConfig = nextChar === '{';
+
+    let match = TOKEN;
+    let configuration = {} as Record<string, unknown>;
+
+    if (hasConfig) {
+      let configStr = '';
+      let open = 0;
+      // Start reading after the keyword
+      const startIdx = TOKEN_LEN;
+      for (let i = startIdx; i < value.length; i++) {
+        const ch = value[i];
+        if (ch === '{') {
+          open++;
+          configStr += ch;
+        } else if (ch === '}') {
+          open--;
+          if (open === -1) {
+            break; // reached the final closing bracket of the whole syntax
+          }
+          configStr += ch;
+        } else {
+          configStr += ch;
+        }
+      }
+
+      match += configStr;
+
+      try {
+        configuration = JSON.parse(configStr);
+      } catch (e) {
+        const now = eat.now();
+        this.file.fail(`Unable to parse anonymized JSON configuration: ${e}`, {
+          line: now.line,
+          column: now.column + TOKEN_LEN,
+        });
+      }
+    }
+
+    match += '}';
+
+    return eat(match)({
+      type: 'anonymized',
+      ...configuration,
+    });
+  };
+
+  tokenizeAnonymized.locator = (value: any, fromIndex: number) => value.indexOf(TOKEN, fromIndex);
+
+  tokenizers.anonymized = tokenizeAnonymized;
+  methods.splice(methods.indexOf('text'), 0, 'anonymized');
+};

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/message_text.test.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/message_text.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MessageText } from './message_text';
+
+const renderComponent = (content: string, props: Partial<Parameters<typeof MessageText>[0]> = {}) =>
+  render(<MessageText loading={false} content={content} onActionClick={jest.fn()} {...props} />);
+
+describe('MessageText', () => {
+  describe('anonymizedHighlightPlugin', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('renders anonymized highlighted content with dedicated parser', () => {
+      const entity = 'John Doe';
+      const message = `Hi, my name is !{anonymized{"entityClass":"PER", "content": "${entity}"}}.`;
+
+      renderComponent(message);
+
+      const anonymizedNode = screen.getByTestId('anonymizedContent');
+
+      // Ensure the highlighted anonymized elements are rendered
+      expect(anonymizedNode).toBeInTheDocument();
+      expect(anonymizedNode).toHaveTextContent(entity);
+
+      // Ensure original markup is not present in the DOM
+      expect(screen.queryByText(message)).not.toBeInTheDocument();
+    });
+
+    it('renders multiple anonymized entities correctly', () => {
+      const firstEntity = '{Alice}';
+      const secondEntity = '((Bob()))))';
+
+      const message = `Names: !{anonymized{"entityClass":"PER", "content": "${firstEntity}"}} and !{anonymized{"entityClass":"PER", "content": "${secondEntity}"}}.`;
+
+      renderComponent(message);
+
+      const anonymizedNodes = screen.getAllByTestId('anonymizedContent');
+      expect(anonymizedNodes.length).toBe(2);
+      expect(anonymizedNodes[0]).toHaveTextContent(firstEntity);
+      expect(anonymizedNodes[1]).toHaveTextContent(secondEntity);
+
+      // Ensure original markup is not present in the DOM
+      expect(screen.queryByText('anonymized')).not.toBeInTheDocument();
+    });
+
+    it('leaves plain text unchanged when no anonymized entities are present', () => {
+      const message = 'No anonymized entities here.';
+      renderComponent(message);
+
+      expect(screen.getByText(message)).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/message_text.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/message_text.tsx
@@ -14,6 +14,7 @@ import {
   EuiText,
   getDefaultEuiMarkdownParsingPlugins,
   getDefaultEuiMarkdownProcessingPlugins,
+  EuiCode,
 } from '@elastic/eui';
 import { css } from '@emotion/css';
 import classNames from 'classnames';
@@ -22,7 +23,7 @@ import React, { useMemo } from 'react';
 import type { Node } from 'unist';
 import { ChatActionClickHandler } from '../chat/types';
 import { CodeBlock, EsqlCodeBlock } from './esql_code_block';
-
+import { anonymizedHighlightPlugin } from './anonymized_highlight';
 interface Props {
   content: string;
   loading: boolean;
@@ -135,6 +136,7 @@ export function MessageText({
 
     processingPlugins[1][1].components = {
       ...components,
+      anonymized: (props) => <EuiCode data-test-subj="anonymizedContent">{props.content}</EuiCode>,
       cursor: Cursor,
       codeBlock: (props) => {
         return (
@@ -186,22 +188,25 @@ export function MessageText({
     };
 
     return {
-      parsingPluginList: [loadingCursorPlugin, esqlLanguagePlugin, ...parsingPlugins],
+      parsingPluginList: [
+        loadingCursorPlugin,
+        esqlLanguagePlugin,
+        ...parsingPlugins,
+        anonymizedHighlightPlugin,
+      ],
       processingPluginList: processingPlugins,
     };
   }, [loading, onActionClick]);
 
   return (
     <EuiText size="s" className={containerClassName}>
-      {anonymizedHighlightedContent || (
-        <EuiMarkdownFormat
-          textSize="s"
-          parsingPluginList={parsingPluginList}
-          processingPluginList={processingPluginList}
-        >
-          {`${content}${loading ? CURSOR : ''}`}
-        </EuiMarkdownFormat>
-      )}
+      <EuiMarkdownFormat
+        textSize="s"
+        parsingPluginList={parsingPluginList}
+        processingPluginList={processingPluginList}
+      >
+        {`${anonymizedHighlightedContent || content}${loading ? CURSOR : ''}`}
+      </EuiMarkdownFormat>
     </EuiText>
   );
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs AI Assistant] Add custom plugin for highlighting user and assistant responses when they have redacted entities (#224605)](https://github.com/elastic/kibana/pull/224605)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Srdjan Lulic","email":"srdjan.lulic@elastic.co"},"sourceCommit":{"committedDate":"2025-06-25T13:41:19Z","message":"[Obs AI Assistant] Add custom plugin for highlighting user and assistant responses when they have redacted entities (#224605)\n\nCloses: https://github.com/elastic/obs-ai-assistant-team/issues/264\n\n## Summary\n\nAdd custom plugin for highlighting user and assistant responses when\nthey have redacted entities:\n\n- Custom plugin for `EuiMarkdownFormat` that highlights all content\nwrapped inside anonymized node. The parsing plugin follows the approach\nfrom [EUI\ndocs](https://eui.elastic.co/docs/components/editors-and-syntax/markdown/plugins/#putting-it-all-together-a-simple-chart-plugin)\nand is used as follows:\n   ```\n!{anonymized{\"entityClass\":\"<entity class>\", \"content\": \"<content\"}}\n    ```  \n- Highlighted content is currently rendered as `EuiCode`, but it can be\nmore sophisticated (i.e highlight differently depending on the entity\nclass).\n- Allows using the same highlighting logic for messages from both `user`\nand `assistant` roles.\n- Currently **skipping highlighting inside the code blocks** - may\nrequire customising the default plugins further.\n\nManually tested: \n- Function calling seems to work as expected.\n- Search results with PII are highlighted in the table.\n- Custom regex matches are highlighted correctly.\n\n### Testing instructions:\n1. Used setup from https://github.com/elastic/kibana/pull/216352 to set\nup NER model locally.\n2. Added to `kibana.dev.yml`:\n```\nuiSettings:\n  overrides:\n    'observability:aiAssistantAnonymizationRules': |\n      [\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[A-Za-z]{2,}\",\n          \"enabled\": true,\n          \"entityClass\": \"EMAIL\"\n        },\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"https?://[^\\\\s]+\",\n          \"enabled\": true,\n          \"entityClass\": \"URL\"\n        },\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"\\\\b(?:\\\\d{1,3}\\\\.){3}\\\\d{1,3}\\\\b\",\n          \"enabled\": true,\n          \"entityClass\": \"IP\"\n        },\n        {\n          \"type\": \"ner\",\n          \"enabled\": true\n        }\n      ]\n```\n3. Used the assistant (see screenshots below)\n\n### Screenshots\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d1f9bd57-7e76-43dc-88a6-d0be5fb15092\"\n/>\n\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed63626b-b32d-45f8-9cf4-c575320d0dfc\"\n/>\n\n\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0b591158-9186-406a-aab3-e3be538216dc\"\n/>\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"05b4fdd854e62b761b480a2d64b76ba4cd13511e","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0"],"title":"[Obs AI Assistant] Add custom plugin for highlighting user and assistant responses when they have redacted entities","number":224605,"url":"https://github.com/elastic/kibana/pull/224605","mergeCommit":{"message":"[Obs AI Assistant] Add custom plugin for highlighting user and assistant responses when they have redacted entities (#224605)\n\nCloses: https://github.com/elastic/obs-ai-assistant-team/issues/264\n\n## Summary\n\nAdd custom plugin for highlighting user and assistant responses when\nthey have redacted entities:\n\n- Custom plugin for `EuiMarkdownFormat` that highlights all content\nwrapped inside anonymized node. The parsing plugin follows the approach\nfrom [EUI\ndocs](https://eui.elastic.co/docs/components/editors-and-syntax/markdown/plugins/#putting-it-all-together-a-simple-chart-plugin)\nand is used as follows:\n   ```\n!{anonymized{\"entityClass\":\"<entity class>\", \"content\": \"<content\"}}\n    ```  \n- Highlighted content is currently rendered as `EuiCode`, but it can be\nmore sophisticated (i.e highlight differently depending on the entity\nclass).\n- Allows using the same highlighting logic for messages from both `user`\nand `assistant` roles.\n- Currently **skipping highlighting inside the code blocks** - may\nrequire customising the default plugins further.\n\nManually tested: \n- Function calling seems to work as expected.\n- Search results with PII are highlighted in the table.\n- Custom regex matches are highlighted correctly.\n\n### Testing instructions:\n1. Used setup from https://github.com/elastic/kibana/pull/216352 to set\nup NER model locally.\n2. Added to `kibana.dev.yml`:\n```\nuiSettings:\n  overrides:\n    'observability:aiAssistantAnonymizationRules': |\n      [\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[A-Za-z]{2,}\",\n          \"enabled\": true,\n          \"entityClass\": \"EMAIL\"\n        },\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"https?://[^\\\\s]+\",\n          \"enabled\": true,\n          \"entityClass\": \"URL\"\n        },\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"\\\\b(?:\\\\d{1,3}\\\\.){3}\\\\d{1,3}\\\\b\",\n          \"enabled\": true,\n          \"entityClass\": \"IP\"\n        },\n        {\n          \"type\": \"ner\",\n          \"enabled\": true\n        }\n      ]\n```\n3. Used the assistant (see screenshots below)\n\n### Screenshots\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d1f9bd57-7e76-43dc-88a6-d0be5fb15092\"\n/>\n\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed63626b-b32d-45f8-9cf4-c575320d0dfc\"\n/>\n\n\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0b591158-9186-406a-aab3-e3be538216dc\"\n/>\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"05b4fdd854e62b761b480a2d64b76ba4cd13511e"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224605","number":224605,"mergeCommit":{"message":"[Obs AI Assistant] Add custom plugin for highlighting user and assistant responses when they have redacted entities (#224605)\n\nCloses: https://github.com/elastic/obs-ai-assistant-team/issues/264\n\n## Summary\n\nAdd custom plugin for highlighting user and assistant responses when\nthey have redacted entities:\n\n- Custom plugin for `EuiMarkdownFormat` that highlights all content\nwrapped inside anonymized node. The parsing plugin follows the approach\nfrom [EUI\ndocs](https://eui.elastic.co/docs/components/editors-and-syntax/markdown/plugins/#putting-it-all-together-a-simple-chart-plugin)\nand is used as follows:\n   ```\n!{anonymized{\"entityClass\":\"<entity class>\", \"content\": \"<content\"}}\n    ```  \n- Highlighted content is currently rendered as `EuiCode`, but it can be\nmore sophisticated (i.e highlight differently depending on the entity\nclass).\n- Allows using the same highlighting logic for messages from both `user`\nand `assistant` roles.\n- Currently **skipping highlighting inside the code blocks** - may\nrequire customising the default plugins further.\n\nManually tested: \n- Function calling seems to work as expected.\n- Search results with PII are highlighted in the table.\n- Custom regex matches are highlighted correctly.\n\n### Testing instructions:\n1. Used setup from https://github.com/elastic/kibana/pull/216352 to set\nup NER model locally.\n2. Added to `kibana.dev.yml`:\n```\nuiSettings:\n  overrides:\n    'observability:aiAssistantAnonymizationRules': |\n      [\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[A-Za-z]{2,}\",\n          \"enabled\": true,\n          \"entityClass\": \"EMAIL\"\n        },\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"https?://[^\\\\s]+\",\n          \"enabled\": true,\n          \"entityClass\": \"URL\"\n        },\n        {\n          \"type\": \"regex\",\n          \"pattern\": \"\\\\b(?:\\\\d{1,3}\\\\.){3}\\\\d{1,3}\\\\b\",\n          \"enabled\": true,\n          \"entityClass\": \"IP\"\n        },\n        {\n          \"type\": \"ner\",\n          \"enabled\": true\n        }\n      ]\n```\n3. Used the assistant (see screenshots below)\n\n### Screenshots\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d1f9bd57-7e76-43dc-88a6-d0be5fb15092\"\n/>\n\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed63626b-b32d-45f8-9cf4-c575320d0dfc\"\n/>\n\n\n<img width=\"689\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0b591158-9186-406a-aab3-e3be538216dc\"\n/>\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"05b4fdd854e62b761b480a2d64b76ba4cd13511e"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->