### PR TITLE
[8.19] Render accordion in integration readme (#223916)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1300,6 +1300,8 @@
     "redux-thunk": "^2.4.2",
     "redux-thunks": "^1.0.0",
     "reflect-metadata": "^0.2.1",
+    "rehype-raw": "5.1.0",
+    "rehype-sanitize": "4.0.0",
     "remark-gfm": "1.0.0",
     "remark-parse-no-trim": "^8.0.4",
     "remark-stringify": "^8.0.3",

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/overview/markdown_renderers.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/overview/markdown_renderers.tsx
@@ -13,6 +13,8 @@ import {
   EuiTable,
   EuiTableRow,
   EuiTableRowCell,
+  EuiAccordion,
+  EuiSpacer,
 } from '@elastic/eui';
 import React from 'react';
 import type { MutableRefObject } from 'react';
@@ -113,6 +115,39 @@ export const markdownRenderers = (
       props: React.ClassAttributes<HTMLImageElement> & React.ImgHTMLAttributes<HTMLImageElement>
     ) => {
       return <img style={{ maxWidth: '100%' }} {...props} alt={props.alt} />;
+    },
+    details: ({ children, node }) => {
+      const [summaryNode, ...bodyNodes] = React.Children.toArray(children).reduce<
+        [React.ReactElement | null, React.ReactNode[]]
+      >(
+        ([summary, body], child) => {
+          if (summary === null && React.isValidElement(child) && child.type === 'summary') {
+            return [child, body];
+          }
+          return [summary, [...body, child]];
+        },
+        [null, []]
+      );
+
+      const summaryText = summaryNode
+        ? React.Children.toArray(summaryNode.props.children).join('')
+        : '';
+
+      const id = getAnchorId(children[0]?.toString(), node.position?.start.line);
+
+      return (
+        <>
+          <EuiAccordion
+            id={id}
+            buttonContent={summaryText}
+            initialIsOpen={false}
+            data-test-subj="integrationsDocs.accordion"
+          >
+            {bodyNodes}
+          </EuiAccordion>
+          <EuiSpacer size="m" />
+        </>
+      );
     },
   };
 };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.test.tsx
@@ -10,9 +10,10 @@ import React from 'react';
 import { createIntegrationsTestRendererMock } from '../../../../../../../mock';
 
 import { Readme } from './readme';
+import { waitFor } from '@testing-library/dom';
 
 describe('Readme', () => {
-  function render() {
+  function render(markdown: string | undefined) {
     const refs = {
       current: {
         set: jest.fn(),
@@ -21,20 +22,111 @@ describe('Readme', () => {
     } as any;
     const testRenderer = createIntegrationsTestRendererMock();
     return testRenderer.render(
-      <Readme
-        packageName="test"
-        version="1.0.0"
-        markdown="# Test ![Image](../img/image.png)>"
-        refs={refs}
-      />
+      <Readme packageName="test" version="1.0.0" markdown={markdown} refs={refs} />
     );
   }
-  it('should render img tag with max width', () => {
-    const result = render();
 
-    const img = result.getByAltText('Image');
+  it('should render img tag with max width', async () => {
+    const result = render('# Test ![Image](../img/image.png)>');
 
-    expect(img).toHaveStyle('max-width: 100%');
-    expect(img).toHaveAttribute('src', '/mock/api/fleet/epm/packages/test/1.0.0/img/image.png');
+    await waitFor(() => {
+      const img = result.getByAltText('Image');
+
+      expect(img).toHaveStyle('max-width: 100%');
+      expect(img).toHaveAttribute('src', '/mock/api/fleet/epm/packages/test/1.0.0/img/image.png');
+    });
+  });
+
+  it('should render exported fields as accordions', async () => {
+    const result = render(`
+# Test Integration
+
+This is a test integration.
+
+## Data streams
+
+### Logs
+
+This integration collects logs.
+
+#### Requirements and setup
+
+Some requirements and setup instructions.
+
+**Exported fields**
+
+| Field | Description | Type |
+|---|---|---|
+| @timestamp | Event timestamp. | date |
+| integration.category | The log category name. | keyword |
+
+### Metrics
+
+Some metrics information.
+
+**Exported fields**
+
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| integration.id | Some id | keyword |  |  |
+`);
+
+    await waitFor(() => {
+      const accordionSummaries = result.getAllByTestId('integrationsDocs.accordion');
+      expect(accordionSummaries.length).toBe(2);
+
+      const tables = result.container.querySelectorAll('table');
+      expect(tables.length).toBe(2);
+    });
+  });
+
+  it('should render empty markdown', async () => {
+    const result = render('');
+    await waitFor(() => {
+      expect(result.container).not.toBeEmptyDOMElement();
+    });
+  });
+
+  it('should render even if markdown undefined', async () => {
+    const result = render(undefined);
+    await waitFor(() => {
+      const skeletonWrappers = result.getAllByTestId('euiSkeletonLoadingAriaWrapper');
+      expect(skeletonWrappers.length).toBeGreaterThan(0);
+
+      expect(result.container).not.toBeEmptyDOMElement();
+    });
+  });
+
+  it('should render correct if no exported fields found', async () => {
+    const result = render(`
+# Test Integration
+
+This is a test integration.
+
+## Data streams
+
+### Logs
+
+This integration collects logs.
+
+#### Requirements and setup
+
+Some requirements and setup instructions.
+`);
+
+    await waitFor(() => {
+      expect(result.container).not.toBeEmptyDOMElement();
+
+      const accordion = result.queryByTestId('integrationsDocs.accordion');
+      expect(accordion).not.toBeInTheDocument();
+    });
+  });
+
+  it('should remove script tags', async () => {
+    const result = render('<script>alert("This should not run")</script>');
+    await waitFor(() => {
+      expect(result.queryByText('This should not run')).not.toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.tsx
@@ -6,14 +6,17 @@
  */
 
 import { EuiText, EuiSkeletonText, EuiSpacer } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { MutableRefObject } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import rehypeRaw from 'rehype-raw';
 
 import { useLinks } from '../../../../../hooks';
 
 import { markdownRenderers } from './markdown_renderers';
+import MarkdownIt from 'markdown-it';
 
 export function Readme({
   packageName,
@@ -38,21 +41,77 @@ export function Readme({
     [toRelativeImage, packageName, version]
   );
 
+  const wrapAllExportedFieldsTables = (content: string | undefined): string | undefined => {
+    if (!content) return content;
+
+    const md = new MarkdownIt();
+    const tokens = md.parse(content, {});
+    const lines = content.split('\n');
+
+    const exportedFieldsLines: number[] = lines
+      .map((line, index) => (line.trim() === '**Exported fields**' ? index : -1))
+      .filter((index) => index !== -1);
+
+    if (exportedFieldsLines.length === 0) return content;
+
+    const tableRanges: Array<[number, number]> = tokens
+      .filter((token) => token.type === 'table_open' && token.map)
+      .map((token) => token.map as [number, number]);
+
+    const usedTables = new Set<number>();
+    const insertions: Array<{ summaryLine: number; start: number; end: number }> = [];
+
+    for (const summaryLine of exportedFieldsLines) {
+      // Find the first table that starts after the summary line and hasn't been used yet
+      const table = tableRanges.find(([start], idx) => start > summaryLine && !usedTables.has(idx));
+      if (table) {
+        const [start, end] = table;
+        usedTables.add(tableRanges.indexOf(table));
+        insertions.push({ summaryLine, start, end });
+      }
+    }
+
+    const newLines: string[] = [];
+    let currentLine = 0;
+
+    for (const { summaryLine, start, end } of insertions) {
+      newLines.push(...lines.slice(currentLine, summaryLine));
+      currentLine = summaryLine + 1;
+
+      newLines.push(...lines.slice(currentLine, start));
+      currentLine = start;
+
+      newLines.push('<details><summary>Exported fields</summary>', '');
+      newLines.push(...lines.slice(start, end));
+      newLines.push('', '</details>');
+
+      currentLine = end;
+    }
+
+    newLines.push(...lines.slice(currentLine));
+
+    return newLines.join('\n');
+  };
+
+  const markdownWithCollapsable = useMemo(() => wrapAllExportedFieldsTables(markdown), [markdown]);
+
   return (
     <>
-      {markdown !== undefined ? (
+      {markdownWithCollapsable !== undefined ? (
         <EuiText grow={true}>
           <ReactMarkdown
             transformImageUri={handleImageUri}
             components={markdownRenderers(refs)}
+            rehypePlugins={[rehypeRaw, [rehypeSanitize]]}
             remarkPlugins={[remarkGfm]}
           >
-            {markdown}
+            {markdownWithCollapsable}
           </ReactMarkdown>
         </EuiText>
       ) : (
         <EuiText>
           {/* simulates a long page of text loading */}
+
           <EuiSkeletonText lines={5} />
           <EuiSpacer size="m" />
           <EuiSkeletonText lines={6} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -19958,6 +19958,13 @@ hast-util-raw@^6.1.0:
     xtend "^4.0.0"
     zwitch "^1.0.0"
 
+hast-util-sanitize@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-3.0.2.tgz#b0b783220af528ba8fe6999f092d138908678520"
+  integrity sha512-+2I0x2ZCAyiZOO/sb4yNLFmdwPBnyJ4PBkVTUMKMqBwYNA+lXSgOmoRXlJFazoyid9QPogRRKgKhVEodv181sA==
+  dependencies:
+    xtend "^4.0.0"
+
 hast-util-to-html@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-7.1.1.tgz#39818b8bbfcb8eaa87846a120b3875487b27d094"
@@ -27399,7 +27406,7 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
-rehype-raw@^5.1.0:
+rehype-raw@5.1.0, rehype-raw@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-5.1.0.tgz#66d5e8d7188ada2d31bc137bc19a1000cf2c6b7e"
   integrity sha512-MDvHAb/5mUnif2R+0IPCYJU8WjHa9UzGtM/F4AVy5GixPlDZ1z3HacYy4xojDU+uBa+0X/3PIfyQI26/2ljJNA==
@@ -27413,6 +27420,13 @@ rehype-react@^6.2.1:
   dependencies:
     "@mapbox/hast-util-table-cell-style" "^0.2.0"
     hast-to-hyperscript "^9.0.0"
+
+rehype-sanitize@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-sanitize/-/rehype-sanitize-4.0.0.tgz#b5241cf66bcedc49cd4e924a5f7a252f00a151ad"
+  integrity sha512-ZCr/iQRr4JeqPjun5i9CHHILVY7i45VnLu1CkkibDrSyFQ7dTLSvw8OIQpHhS4RSh9h/9GidxFw1bRb0LOxIag==
+  dependencies:
+    hast-util-sanitize "^3.0.0"
 
 rehype-stringify@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Render accordion in integration readme (#223916)](https://github.com/elastic/kibana/pull/223916)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hanna Tamoudi","email":"hanna.tamoudi@elastic.co"},"sourceCommit":{"committedDate":"2025-06-24T11:22:55Z","message":"Render accordion in integration readme (#223916)\n\n## Summary\n\n[Support collapsible section in Integration\nREADME](https://github.com/elastic/integration-experience/issues/82)\nThe public Integrations docs page recently added support for collapsible\nsections (e.g., for field tables and sample events). This PR brings the\nsame functionality to Kibana to reduce scrolling and help users focus on\nthe most relevant information.\n\nTo display an accordion, the README should include the following markup:\n```\n<details>\n  <summary>Click to expand</summary>\n  This content is hidden by default.\n</details>\n```\nHowever, we do not want to modify the integration READMEs directly.\nDoing so would cause these tags to appear as raw HTML in older versions\nof Kibana\nBumping the minimum supported Kibana version for each integration is\nalso not a solution, as it would complicate backports and maintenance.\n\n#### Proposed solution\nDetect in Kibana parts that should be collapsible, like `exported\nfields` and update the markdown with the necessary markups. Similar to\nwhat the `integration-docs` does in\nhttps://github.com/elastic/integration-docs/issues/342\n\n\n#### Dependencies added:\n- `rehype-raw`: Parse and render HTML inside Markdown.\n- `rehype-sanitize`: Sanitize potentially unsafe HTML.\n\n#### Version pinning for compatibility\n- `rehype-sanitize@4.0.0`: Uses hast-util-sanitize@3+, which provides a\nbuilt-in default schema and is compatible with CommonJS environments.\n- `rehype-raw@5.1.0`: The latest version that supports CommonJS. Later\nversions are ESM-only.\n\n\n\nhttps://github.com/user-attachments/assets/15f0822b-9b36-45e6-a47e-c8fa0dedd4c3\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"869e162812a449742aad9ddd99f1acf838c278f1","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","enhancement","backport missing","Team:Fleet","Team:Security-Scalability","backport:version","v9.1.0","v8.19.0"],"title":"Render accordion in integration readme","number":223916,"url":"https://github.com/elastic/kibana/pull/223916","mergeCommit":{"message":"Render accordion in integration readme (#223916)\n\n## Summary\n\n[Support collapsible section in Integration\nREADME](https://github.com/elastic/integration-experience/issues/82)\nThe public Integrations docs page recently added support for collapsible\nsections (e.g., for field tables and sample events). This PR brings the\nsame functionality to Kibana to reduce scrolling and help users focus on\nthe most relevant information.\n\nTo display an accordion, the README should include the following markup:\n```\n<details>\n  <summary>Click to expand</summary>\n  This content is hidden by default.\n</details>\n```\nHowever, we do not want to modify the integration READMEs directly.\nDoing so would cause these tags to appear as raw HTML in older versions\nof Kibana\nBumping the minimum supported Kibana version for each integration is\nalso not a solution, as it would complicate backports and maintenance.\n\n#### Proposed solution\nDetect in Kibana parts that should be collapsible, like `exported\nfields` and update the markdown with the necessary markups. Similar to\nwhat the `integration-docs` does in\nhttps://github.com/elastic/integration-docs/issues/342\n\n\n#### Dependencies added:\n- `rehype-raw`: Parse and render HTML inside Markdown.\n- `rehype-sanitize`: Sanitize potentially unsafe HTML.\n\n#### Version pinning for compatibility\n- `rehype-sanitize@4.0.0`: Uses hast-util-sanitize@3+, which provides a\nbuilt-in default schema and is compatible with CommonJS environments.\n- `rehype-raw@5.1.0`: The latest version that supports CommonJS. Later\nversions are ESM-only.\n\n\n\nhttps://github.com/user-attachments/assets/15f0822b-9b36-45e6-a47e-c8fa0dedd4c3\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"869e162812a449742aad9ddd99f1acf838c278f1"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223916","number":223916,"mergeCommit":{"message":"Render accordion in integration readme (#223916)\n\n## Summary\n\n[Support collapsible section in Integration\nREADME](https://github.com/elastic/integration-experience/issues/82)\nThe public Integrations docs page recently added support for collapsible\nsections (e.g., for field tables and sample events). This PR brings the\nsame functionality to Kibana to reduce scrolling and help users focus on\nthe most relevant information.\n\nTo display an accordion, the README should include the following markup:\n```\n<details>\n  <summary>Click to expand</summary>\n  This content is hidden by default.\n</details>\n```\nHowever, we do not want to modify the integration READMEs directly.\nDoing so would cause these tags to appear as raw HTML in older versions\nof Kibana\nBumping the minimum supported Kibana version for each integration is\nalso not a solution, as it would complicate backports and maintenance.\n\n#### Proposed solution\nDetect in Kibana parts that should be collapsible, like `exported\nfields` and update the markdown with the necessary markups. Similar to\nwhat the `integration-docs` does in\nhttps://github.com/elastic/integration-docs/issues/342\n\n\n#### Dependencies added:\n- `rehype-raw`: Parse and render HTML inside Markdown.\n- `rehype-sanitize`: Sanitize potentially unsafe HTML.\n\n#### Version pinning for compatibility\n- `rehype-sanitize@4.0.0`: Uses hast-util-sanitize@3+, which provides a\nbuilt-in default schema and is compatible with CommonJS environments.\n- `rehype-raw@5.1.0`: The latest version that supports CommonJS. Later\nversions are ESM-only.\n\n\n\nhttps://github.com/user-attachments/assets/15f0822b-9b36-45e6-a47e-c8fa0dedd4c3\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"869e162812a449742aad9ddd99f1acf838c278f1"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->