### PR TITLE
[8.19] Share experience Improvements (#222242)

### DIFF
--- a/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.test.tsx
+++ b/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.test.tsx
@@ -42,6 +42,7 @@ describe('TabbedModal', () => {
 
         return (
           <EuiFieldText
+            data-test-subj="log-user-input-field"
             placeholder="Placeholder text"
             value={state.inputText}
             onChange={onChange}
@@ -57,10 +58,28 @@ describe('TabbedModal', () => {
       },
     };
 
-    it('renders the modal component', async () => {
+    it("when a single tab definition is passed it simply renders it's content into the modal component without tabs", async () => {
       render(
         <TabbedModal
           tabs={[tabDefinition]}
+          defaultSelectedTabId="logUserInput"
+          onClose={modalOnCloseHandler}
+        />
+      );
+
+      expect(screen.queryByText(tabDefinition.name)).not.toBeInTheDocument();
+
+      expect(screen.getByTestId('log-user-input-field')).toBeInTheDocument();
+
+      await userEvent.click(await screen.findByTestId(tabDefinition.modalActionBtn!.dataTestSubj));
+
+      expect(mockedHandlerFn).toHaveBeenCalled();
+    });
+
+    it('renders the tabbed modal with tabs for tab definition with length greater than 1', async () => {
+      render(
+        <TabbedModal
+          tabs={[tabDefinition, { ...tabDefinition, id: 'anotherTab', name: 'another tab' }]}
           defaultSelectedTabId="logUserInput"
           onClose={modalOnCloseHandler}
         />

--- a/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.tsx
+++ b/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.tsx
@@ -127,21 +127,29 @@ const TabbedModalInner: FC<ITabbedModalInner> = ({
   );
 
   const renderTabs = useCallback(() => {
-    return tabs.map((tab, index) => {
-      return (
-        <EuiTab
-          key={index}
-          onClick={() => onSelectedTabChanged(tab.id)}
-          isSelected={tab.id === selectedTabId}
-          disabled={tab.disabled}
-          prepend={tab.prepend}
-          append={tab.append}
-          data-test-subj={tab.id}
-        >
-          {tab.name}
-        </EuiTab>
-      );
-    });
+    if (tabs.length === 1) {
+      return null;
+    }
+
+    return (
+      <EuiTabs>
+        {tabs.map((tab, index) => {
+          return (
+            <EuiTab
+              key={index}
+              onClick={() => onSelectedTabChanged(tab.id)}
+              isSelected={tab.id === selectedTabId}
+              disabled={tab.disabled}
+              prepend={tab.prepend}
+              append={tab.append}
+              data-test-subj={tab.id}
+            >
+              {tab.name}
+            </EuiTab>
+          );
+        })}
+      </EuiTabs>
+    );
   }, [onSelectedTabChanged, selectedTabId, tabs]);
 
   const modalPositionOverrideStyles: React.CSSProperties = {
@@ -170,17 +178,22 @@ const TabbedModalInner: FC<ITabbedModalInner> = ({
       </EuiModalHeader>
       <EuiModalBody>
         <Fragment>
-          <EuiTabs>{renderTabs()}</EuiTabs>
+          <Fragment>{renderTabs()}</Fragment>
           <EuiSpacer size="m" />
           {React.createElement(function RenderSelectedTabContent() {
             useLayoutEffect(onTabContentRender, []);
             return (
-              <SelectedTabContent
-                {...{
-                  state: selectedTabState,
-                  dispatch,
-                }}
-              />
+              <div
+                css={{ display: 'contents' }}
+                data-test-subj={`tabbedModal-${selectedTabId}-content`}
+              >
+                <SelectedTabContent
+                  {...{
+                    state: selectedTabState,
+                    dispatch,
+                  }}
+                />
+              </div>
             );
           })}
         </Fragment>

--- a/src/platform/plugins/shared/share/public/components/export_integrations/index.ts
+++ b/src/platform/plugins/shared/share/public/components/export_integrations/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { ExportMenu } from './export_popover';
+export { ExportMenu } from './export_integrations';

--- a/src/platform/plugins/shared/share/public/components/share_tabs.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_tabs.tsx
@@ -34,7 +34,7 @@ export const ShareMenuTabs = () => {
     tabs.push(linkTab);
   }
 
-  // Embed is disabled in the serverless offering, hence the need to check that we received it
+  // Embed is disabled in the serverless offering, hence the need to check if the embed tab should be shown
   if (
     shareMenuItems.some(({ shareType }) => shareType === 'embed') &&
     !objectTypeMeta?.config?.embed?.disabled

--- a/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
+++ b/src/platform/plugins/shared/share/public/services/share_menu_manager.tsx
@@ -16,7 +16,7 @@ import { ShowShareMenuOptions } from '../types';
 import { ShareRegistry } from './share_menu_registry';
 import type { ShareConfigs } from '../types';
 import { ShareMenu } from '../components/share_tabs';
-import { ExportMenu } from '../components/export_popover';
+import { ExportMenu } from '../components/export_integrations';
 
 interface ShareMenuManagerStartDeps {
   core: CoreStart;

--- a/src/platform/plugins/shared/share/tsconfig.json
+++ b/src/platform/plugins/shared/share/tsconfig.json
@@ -31,7 +31,8 @@
     "@kbn/core-rendering-browser",
     "@kbn/std",
     "@kbn/core-logging-server-mocks",
-    "@kbn/core-http-router-server-mocks"
+    "@kbn/core-http-router-server-mocks",
+    "@kbn/licensing-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/share/tsconfig.json
+++ b/src/platform/plugins/shared/share/tsconfig.json
@@ -31,8 +31,7 @@
     "@kbn/core-rendering-browser",
     "@kbn/std",
     "@kbn/core-logging-server-mocks",
-    "@kbn/core-http-router-server-mocks",
-    "@kbn/licensing-plugin"
+    "@kbn/core-http-router-server-mocks"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/test/functional/page_objects/export_page.ts
+++ b/src/platform/test/functional/page_objects/export_page.ts
@@ -24,7 +24,7 @@ export class ExportPageObject extends FtrService {
   }
 
   async isExportPopoverOpen() {
-    return await this.testSubjects.exists('exportPopover');
+    return await this.testSubjects.exists('exportPopoverPanel');
   }
 
   async isPopoverItemEnabled(label: string) {

--- a/x-pack/test/functional/apps/lens/group1/ad_hoc_data_view.ts
+++ b/x-pack/test/functional/apps/lens/group1/ad_hoc_data_view.ts
@@ -190,7 +190,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should be possible to download a visualization with adhoc dataViews', async () => {
       await lens.setCSVDownloadDebugFlag(true);
-      await lens.openCSVDownloadExport();
+      await lens.triggerCSVDownloadExport();
 
       const csv = await lens.getCSVContent();
       expect(csv).to.be.ok();

--- a/x-pack/test/functional/apps/lens/group4/share.ts
+++ b/x-pack/test/functional/apps/lens/group4/share.ts
@@ -56,9 +56,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should enable both download and URL sharing for valid configuration', async () => {
-      await lens.clickShareModal();
-
       expect(await lens.isExportActionEnabled()).to.eql(true);
+
+      await lens.clickShareButton();
       expect(await lens.isShareActionEnabled('link'));
     });
 
@@ -84,7 +84,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should be able to download CSV data of the current visualization', async () => {
       await lens.setCSVDownloadDebugFlag(true);
-      await lens.openCSVDownloadExport();
+      await lens.triggerCSVDownloadExport();
 
       const csv = await lens.getCSVContent();
       expect(csv).to.be.ok();
@@ -106,7 +106,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         field: 'bytes',
       });
 
-      await lens.openCSVDownloadExport();
+      await lens.triggerCSVDownloadExport();
 
       const csv = await lens.getCSVContent();
       expect(csv).to.be.ok();

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -1922,7 +1922,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       );
     },
 
-    async clickShareModal() {
+    async clickShareButton() {
       return await testSubjects.click('lnsApp_shareButton');
     },
 
@@ -1941,19 +1941,17 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     async isShareActionEnabled(action: 'link') {
       switch (action) {
         case 'link':
-          return await testSubjects.isEnabled('link');
+          return await testSubjects.isEnabled('tabbedModal-link-content');
         default:
-          return await testSubjects.isEnabled(action);
+          return await testSubjects.isEnabled(`tabbedModal-${action}-content`);
       }
     },
 
     async ensureShareMenuIsOpen(action: 'link') {
-      await this.clickShareModal();
-
-      if (!(await testSubjects.exists('shareContextModal'))) {
-        await this.clickShareModal();
-      }
-      if (!(await this.isShareActionEnabled(action))) {
+      if (
+        (await testSubjects.exists('shareContextModal')) &&
+        !(await this.isShareActionEnabled(action))
+      ) {
         throw Error(`${action} sharing feature is disabled`);
       }
       return await testSubjects.click(action);
@@ -1993,7 +1991,9 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     async getUrl() {
-      await this.ensureShareMenuIsOpen('link');
+      await this.clickShareButton();
+
+      await this.isShareActionEnabled('link');
       const url = await share.getSharedUrl();
 
       if (!url) {
@@ -2005,8 +2005,9 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       return url;
     },
 
-    async openCSVDownloadExport() {
+    async triggerCSVDownloadExport() {
       await this.clickExportButton();
+      // simply clicking the export button is enough, to trigger the CSV download in lens
       await exports.clickPopoverItem('CSV', this.clickExportButton);
     },
 
@@ -2022,7 +2023,6 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     async getCSVContent() {
-      await testSubjects.click('generateReportButton');
       return await browser.execute<
         [void],
         Record<string, { content: string; type: string }> | undefined


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Share experience Improvements (#222242)](https://github.com/elastic/kibana/pull/222242)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-23T09:37:41Z","message":"Share experience Improvements (#222242)\n\n## Summary\n\nCloses #222093 \n\nChanges\n\n- restrict copy link height\n~- copy link to clipboard for lens without opening flyout, when lens is\nalready saved~\n- display share modal without tab indicator when there's only one share\noption available\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4bedf051b449f0f72fe3c379c7fcb1c876e641b7","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:SharedUX","v9.1.0"],"title":"Share experience Improvements","number":222242,"url":"https://github.com/elastic/kibana/pull/222242","mergeCommit":{"message":"Share experience Improvements (#222242)\n\n## Summary\n\nCloses #222093 \n\nChanges\n\n- restrict copy link height\n~- copy link to clipboard for lens without opening flyout, when lens is\nalready saved~\n- display share modal without tab indicator when there's only one share\noption available\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4bedf051b449f0f72fe3c379c7fcb1c876e641b7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/222242","number":222242,"mergeCommit":{"message":"Share experience Improvements (#222242)\n\n## Summary\n\nCloses #222093 \n\nChanges\n\n- restrict copy link height\n~- copy link to clipboard for lens without opening flyout, when lens is\nalready saved~\n- display share modal without tab indicator when there's only one share\noption available\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4bedf051b449f0f72fe3c379c7fcb1c876e641b7"}}]}] BACKPORT-->