### PR TITLE
[Security] Fix `siemV3` migration for Endpoint Exceptions on Serverless

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/product_features/security_product_features_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/product_features/security_product_features_config.ts
@@ -93,6 +93,10 @@ const securityProductFeaturesConfig: Record<
                         // Users who have been able to write ANY Artifact before are now granted with this privilege to keep existing behavior.
                         // This migration is for Endpoint Exceptions artifact in Serverless offering, as it included in Security:ALL privilege.
                         'global_artifact_management_all',
+
+                        // As we are switching from `all` to `minimal_all`, Endpoint Exceptions is needed to be added, as it was included in `all`,
+                        // but not in `minimal_all`.
+                        'endpoint_exceptions_all',
                       ],
                     };
                   }

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/role_migrations/trial_license_complete_tier/siem_v3_global_artifact_management.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/role_migrations/trial_license_complete_tier/siem_v3_global_artifact_management.ts
@@ -133,14 +133,27 @@ export default function ({ getService }: FtrProviderContext) {
 
         describe(`${deprecatedSiem}:ALL`, () => {
           // siem:ALL includes Endpoint Exceptions both on ESS and Serverless
-          it('should add global_artifact_management:ALL', async () => {
+          it('@skipInServerless should add global_artifact_management:ALL on ESS', async () => {
             await putDeprecatedSiemPrivilegesInRole(['all']);
 
             expect(await getMigratedSiemFeaturesFromRole()).to.eql([
               // sub-features toggle enabled to show Global Artifact Management
               'minimal_all',
-              // Endpoint exceptions are tied to siem:ALL, hence the global_artifact_management_all
+              // Endpoint exceptions are tied to siem:ALL, hence the global_artifact_management_all to keep behaviour
               'global_artifact_management_all',
+            ]);
+          });
+
+          it('@skipInEss should add global_artifact_management:ALL and endpoint_exceptions:ALL on serverless', async () => {
+            await putDeprecatedSiemPrivilegesInRole(['all']);
+
+            expect(await getMigratedSiemFeaturesFromRole()).to.eql([
+              // sub-features toggle enabled to show Global Artifact Management
+              'minimal_all',
+              // Endpoint exceptions are tied to siem:ALL, hence the global_artifact_management_all to keep behaviour
+              'global_artifact_management_all',
+              // Enpdoint Exceptions were included in siem:ALL, so we need to include them in siem:MINIMAL_ALL
+              'endpoint_exceptions_all',
             ]);
           });
         });

--- a/x-pack/test_serverless/api_integration/test_suites/security/platform_security/authorization.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/platform_security/authorization.ts
@@ -1085,6 +1085,8 @@ export default function ({ getService }: FtrProviderContext) {
                 "ui:siemV3/investigation-guide-interactions",
                 "ui:siemV3/threat-intelligence",
                 "ui:siemV3/writeGlobalArtifacts",
+                "ui:siemV3/showEndpointExceptions",
+                "ui:siemV3/crudEndpointExceptions",
               ],
               "blocklist_all": Array [
                 "login:",
@@ -3737,6 +3739,8 @@ export default function ({ getService }: FtrProviderContext) {
                 "ui:siemV3/investigation-guide-interactions",
                 "ui:siemV3/threat-intelligence",
                 "ui:siemV3/writeGlobalArtifacts",
+                "ui:siemV3/showEndpointExceptions",
+                "ui:siemV3/crudEndpointExceptions",
               ],
               "blocklist_all": Array [
                 "login:",


### PR DESCRIPTION
## Summary

Endpoint Exception ALL privilege got lost, because the original migration (PR: https://github.com/elastic/kibana/pull/219566) did this:
- for `siem:ALL` or `siemV2:ALL`:
  - it adds the new `global_artifact_management_all`, because `siemVX` all meant that user can write Endpoint Exceptions
  - and: it changed `siemVX:ALL` to `siemVX:MINIMAL_ALL`, in order to enabled the sub-features toggle, so it is visible to the user that they are granted a new sub-privilege

and the issue: Endpoint Exceptions are not included in `siemVX:MINIMAL_ALL`, and thanks to this the user lost their access to Endpoint Exceptions.

this PR solves this issue.

### visualization

with this change, the `siem/siemV2:ALL` -> `siemV3` migration graph now looks like this:

```mermaid
flowchart LR
    classDef serverless stroke:blue,stroke-dasharray: 5 5

    subgraph siemV2[siem/siemV2]
        all1[all]
    end

    subgraph siemV3
        subgraph minall2[minimal_all]
            g1[global_artifact_management_all]

            eea["`endpoint_exceptions_all
                (only serverless)`"]:::serverless
        end
    end

    all1 -->|keep access to the included Endpoint Exceptions ALL| g1
    all1 -->|enable sub-feature toggle| minall2

    all1 -->|keep access to EE ALL, as it WAS included in ALL. only serverless| eea
    linkStyle 2 stroke:#00f,color:blue
```

see the previous ones here: https://github.com/elastic/kibana/pull/219566

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


