### PR TITLE
[8.19] unify csv icon across app in export menu (#224752)

### DIFF
--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/register_csv_modal_reporting.tsx
@@ -132,7 +132,7 @@ export const reportingCsvExportProvider = ({
       name: panelTitle,
       exportType: reportType,
       label: 'CSV',
-      icon: 'documents',
+      icon: 'tableDensityNormal',
       generateAssetExport: generateReportingJobCSV,
       helpText: (
         <FormattedMessage

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/csv_download_provider/csv_download_provider.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/csv_download_provider/csv_download_provider.tsx
@@ -136,7 +136,7 @@ export const downloadCsvLensShareProvider = ({
       return {
         id: 'csvDownloadLens',
         name: panelTitle,
-        icon: 'document',
+        icon: 'tableDensityNormal',
         sortOrder: 1,
         label: 'CSV',
         exportType: 'lens_csv',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [unify csv icon across app in export menu (#224752)](https://github.com/elastic/kibana/pull/224752)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-23T08:19:18Z","message":"unify csv icon across app in export menu (#224752)\n\n## Summary\n\nThis PR unifies the icon displayed for CSV exports across kibana\n\n<img width=\"285\" alt=\"Screenshot 2025-06-20 at 20 37 47\"\nsrc=\"https://github.com/user-attachments/assets/7510332b-d9d0-458e-a73d-950fc84fdb48\"\n/>\n\n\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2435f29f323e4d696f31dc1fb14736b40a5b447f","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:SharedUX","v9.1.0"],"title":"unify csv icon across app in export menu","number":224752,"url":"https://github.com/elastic/kibana/pull/224752","mergeCommit":{"message":"unify csv icon across app in export menu (#224752)\n\n## Summary\n\nThis PR unifies the icon displayed for CSV exports across kibana\n\n<img width=\"285\" alt=\"Screenshot 2025-06-20 at 20 37 47\"\nsrc=\"https://github.com/user-attachments/assets/7510332b-d9d0-458e-a73d-950fc84fdb48\"\n/>\n\n\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2435f29f323e4d696f31dc1fb14736b40a5b447f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224752","number":224752,"mergeCommit":{"message":"unify csv icon across app in export menu (#224752)\n\n## Summary\n\nThis PR unifies the icon displayed for CSV exports across kibana\n\n<img width=\"285\" alt=\"Screenshot 2025-06-20 at 20 37 47\"\nsrc=\"https://github.com/user-attachments/assets/7510332b-d9d0-458e-a73d-950fc84fdb48\"\n/>\n\n\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2435f29f323e4d696f31dc1fb14736b40a5b447f"}}]}] BACKPORT-->