### PR TITLE
[8.17][Fleet] Remove extra quotations around api key in agent yml file

### DIFF
--- a/x-pack/plugins/fleet/common/services/full_agent_policy_to_yaml.ts
+++ b/x-pack/plugins/fleet/common/services/full_agent_policy_to_yaml.ts
@@ -74,6 +74,6 @@ function _formatSecrets(
 }
 
 function replaceApiKey(ymlText: string, apiKey: string) {
-  const regex = new RegExp(/\$\{API_KEY}/, 'g');
+  const regex = new RegExp(/\'\$\{API_KEY}\'/, 'g');
   return ymlText.replace(regex, `'${apiKey}'`);
 }


### PR DESCRIPTION
## Summary

Closes #212720 

- Fixed regex pattern to remove the extra set of quotations around the api_key. Note, this fix is only valid for 8.17, as on newer versions, the quotations are already removed by the `js-yaml `dependency. See [this comment](https://github.com/elastic/kibana/issues/212720#issuecomment-3005317486) for more info


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

N/A

