### PR TITLE
[Lens] fix by value lens drilldowns saved with injected references

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_integrations.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_integrations.ts
@@ -73,7 +73,13 @@ export function initializeIntegrations(
             references: [...cleanedState.references, ...(dynamicActionsReferences ?? [])],
           };
         }
-        return cleanedState;
+        return {
+          rawState: {
+            ...cleanedState.rawState,
+            ...dynamicActionsState,
+          },
+          references: [...cleanedState.references, ...(dynamicActionsReferences ?? [])],
+        };
       },
       // TODO: workout why we have this duplicated
       getFullAttributes: () => getLatestState().attributes,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/225344

https://github.com/elastic/kibana/pull/223149 moved dynamic action injection/extraction from dashboard to embeddables.  https://github.com/elastic/kibana/pull/223149 muffed the implementation for the lens embeddable and failed to spread dynamicActionsState and dynamicActionsReferences into serialized state for by-value panels.

This PR resolve the issue by spreading dynamicActionsState and dynamicActionsReferences with lens state for by-value panels.

After applying fix, dashboard saved object should contain drilldown reference and enhancements state should no longer contain hard coded `dashboardId`.
```
{
  "attributes": {
    "panelsJSON": "[{\"type\":\"lens\",\"embeddableConfig\":{\"enhancements\":{\"dynamicActions\":{\"events\":[{\"eventId\":\"63700c7c-13e2-4aa2-8a58-7d2c19c42b34\",\"triggers\":[\"FILTER_TRIGGER\"],\"action\":{\"factoryId\":\"DASHBOARD_TO_DASHBOARD_DRILLDOWN\",\"name\":\"Go to Dashboard\",\"config\":{\"openInNewTab\":false,\"useCurrentDateRange\":true,\"useCurrentFilters\":true}}}]}},\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"filters\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"attributes\":{\"title\":\"\",\"visualizationType\":\"lnsXY\",\"type\":\"lens\",\"references\":[{\"type\":\"index-pattern\",\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"indexpattern-datasource-layer-5374d213-dba0-47d7-b4f2-9226d08a35cc\"}],\"state\":{\"visualization\":{\"legend\":{\"isVisible\":true,\"position\":\"right\"},\"valueLabels\":\"hide\",\"fittingFunction\":\"Linear\",\"axisTitlesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"tickLabelsVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"labelsOrientation\":{\"x\":0,\"yLeft\":0,\"yRight\":0},\"gridlinesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"preferredSeriesType\":\"bar_stacked\",\"layers\":[{\"layerId\":\"5374d213-dba0-47d7-b4f2-9226d08a35cc\",\"accessors\":[\"d1180bfd-63e2-437e-a027-faa0face26ff\"],\"position\":\"top\",\"seriesType\":\"bar_stacked\",\"showGridlines\":false,\"layerType\":\"data\",\"colorMapping\":{\"assignments\":[],\"specialAssignments\":[{\"rules\":[{\"type\":\"other\"}],\"color\":{\"type\":\"loop\"},\"touched\":false}],\"paletteId\":\"default\",\"colorMode\":{\"type\":\"categorical\"}},\"xAccessor\":\"dc975f9c-772f-4fc1-bc1e-70339f2c5906\"}]},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"datasourceStates\":{\"formBased\":{\"layers\":{\"5374d213-dba0-47d7-b4f2-9226d08a35cc\":{\"columns\":{\"dc975f9c-772f-4fc1-bc1e-70339f2c5906\":{\"label\":\"Top 5 values of machine.os.keyword\",\"dataType\":\"string\",\"operationType\":\"terms\",\"scale\":\"ordinal\",\"sourceField\":\"machine.os.keyword\",\"isBucketed\":true,\"params\":{\"size\":5,\"orderBy\":{\"type\":\"column\",\"columnId\":\"d1180bfd-63e2-437e-a027-faa0face26ff\"},\"orderDirection\":\"desc\",\"otherBucket\":true,\"missingBucket\":false,\"parentFormat\":{\"id\":\"terms\"},\"include\":[],\"exclude\":[],\"includeIsRegex\":false,\"excludeIsRegex\":false}},\"d1180bfd-63e2-437e-a027-faa0face26ff\":{\"label\":\"Count of records\",\"dataType\":\"number\",\"operationType\":\"count\",\"isBucketed\":false,\"scale\":\"ratio\",\"sourceField\":\"___records___\",\"params\":{\"emptyAsNull\":true}}},\"columnOrder\":[\"dc975f9c-772f-4fc1-bc1e-70339f2c5906\",\"d1180bfd-63e2-437e-a027-faa0face26ff\"],\"incompleteColumns\":{},\"sampling\":1}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"internalReferences\":[],\"adHocDataViews\":{}}}},\"panelIndex\":\"74c07c77-979f-4fd9-8b07-889f4a93f9e0\",\"gridData\":{\"x\":0,\"y\":0,\"w\":24,\"h\":15,\"i\":\"74c07c77-979f-4fd9-8b07-889f4a93f9e0\"}}]",
  },
  "references": [
    {
      "type": "index-pattern",
      "id": "90943e30-9a47-11e8-b64d-95841ca0b247",
      "name": "74c07c77-979f-4fd9-8b07-889f4a93f9e0:indexpattern-datasource-layer-5374d213-dba0-47d7-b4f2-9226d08a35cc"
    },
    {
      "name": "74c07c77-979f-4fd9-8b07-889f4a93f9e0:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:63700c7c-13e2-4aa2-8a58-7d2c19c42b34:dashboardId",
      "type": "dashboard",
      "id": "edf84fe0-e1a0-11e7-b6d5-4dc382ef7f5b"
    }
  ],
}
```

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->