### PR TITLE
[Security Assistant] `PROMPT_CONTEXTS` to `promptContexts`

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/provider.tsx
@@ -87,7 +87,7 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
     notifications,
   ]);
 
-  const PROMPT_CONTEXTS = useFindPromptContexts({
+  const promptContexts = useFindPromptContexts({
     context: {
       isAssistantEnabled:
         hasEnterpriseLicence &&
@@ -107,9 +107,9 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
   );
   useEffect(() => {
     if (isEmpty(promptContext)) {
-      elasticAssistantSharedState.promptContexts.setPromptContext(PROMPT_CONTEXTS);
+      elasticAssistantSharedState.promptContexts.setPromptContext(promptContexts);
     }
-  }, [elasticAssistantSharedState.promptContexts, promptContext, PROMPT_CONTEXTS]);
+  }, [elasticAssistantSharedState.promptContexts, promptContext, promptContexts]);
 
   if (!assistantContextValue) {
     return null;


### PR DESCRIPTION
## Summary

Fixes capitalization of a const that is no longer static. Wanted to do this yesterday, but didn't want to interrupt the builds for feature freeze.


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->