### PR TITLE
Using migrated roles on Fleet server side

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/index.ts
@@ -62,6 +62,7 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
 
     loadTestFile(require.resolve('./space_awareness'));
     loadTestFile(require.resolve('./artifacts'));
+    loadTestFile(require.resolve('./role_backwards_compatibility'));
     loadTestFile(require.resolve('./response_actions'));
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/role_backwards_compatibility.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/role_backwards_compatibility.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import TestAgent from 'supertest/lib/agent';
+import { ENDPOINT_ARTIFACT_LIST_IDS, ENDPOINT_LIST_ID } from '@kbn/securitysolution-list-constants';
+import { ExceptionsListItemGenerator } from '@kbn/security-solution-plugin/common/endpoint/data_generators/exceptions_list_item_generator';
+import { Role } from '@kbn/security-plugin-types-common';
+import { GLOBAL_ARTIFACT_TAG } from '@kbn/security-solution-plugin/common/endpoint/service/artifacts';
+import { SECURITY_FEATURE_ID } from '@kbn/security-solution-plugin/common/constants';
+import { ArtifactTestData } from '../../../../../security_solution_endpoint/services/endpoint_artifacts';
+import { FtrProviderContext } from '../../../../ftr_provider_context_edr_workflows';
+
+export const SIEM_VERSIONS = ['siem', 'siemV2', 'siemV3'] as const;
+
+export default function ({ getService }: FtrProviderContext) {
+  const exceptionsGenerator = new ExceptionsListItemGenerator();
+
+  const utils = getService('securitySolutionUtils');
+  const rolesUsersProvider = getService('rolesUsersProvider');
+  const endpointArtifactTestResources = getService('endpointArtifactTestResources');
+  const log = getService('log');
+  const supertest = getService('supertest');
+
+  describe('@ess @skipInServerless, @skipInServerlessMKI Endpoint Artifacts space awareness user role backwards compatibility until siemV3', function () {
+    const afterEachDataCleanup: Array<Pick<ArtifactTestData, 'cleanup'>> = [];
+
+    let globalArtifactManagerRole: Role;
+    let supertestGlobalArtifactManager: TestAgent;
+
+    // testing with all SIEM versions for backward compatibility
+    for (const siemVersion of SIEM_VERSIONS) {
+      describe(`with ${siemVersion} feature version`, () => {
+        before(async () => {
+          globalArtifactManagerRole = Object.assign(
+            rolesUsersProvider.loader.getPreDefinedRole('t1_analyst'),
+            { name: 'globalArtifactManager' }
+          );
+
+          delete globalArtifactManagerRole.kibana[0].feature[SECURITY_FEATURE_ID];
+
+          globalArtifactManagerRole.kibana[0].feature[siemVersion] = [
+            'all', // for Endpoint Exceptions
+            'trusted_applications_all',
+            'event_filters_all',
+            'blocklist_all',
+            'host_isolation_exceptions_all',
+
+            // adding global access to current version, old version should receive it during rule migration
+            ...(siemVersion === SECURITY_FEATURE_ID ? ['global_artifact_management_all'] : []),
+          ];
+
+          rolesUsersProvider.loader.create(globalArtifactManagerRole);
+
+          const globalArtifactManagerUser = await rolesUsersProvider.loader.create(
+            globalArtifactManagerRole
+          );
+
+          supertestGlobalArtifactManager = await utils.createSuperTest(
+            globalArtifactManagerUser.username,
+            globalArtifactManagerUser.password
+          );
+        });
+
+        after(async () => {
+          if (globalArtifactManagerRole) {
+            await rolesUsersProvider.loader.delete(globalArtifactManagerRole.name);
+            // @ts-expect-error
+            globalArtifactManagerRole = undefined;
+          }
+        });
+
+        afterEach(async () => {
+          await Promise.allSettled(afterEachDataCleanup.splice(0).map((data) => data.cleanup()));
+        });
+
+        const artifactListIds = [...ENDPOINT_ARTIFACT_LIST_IDS, ENDPOINT_LIST_ID] as const;
+
+        for (const artifactListId of artifactListIds) {
+          it(`should allow creating a global artifact on ${artifactListId} list`, async () => {
+            const createdArtifact = await endpointArtifactTestResources.createArtifact(
+              artifactListId,
+              { tags: [GLOBAL_ARTIFACT_TAG] },
+              { supertest: supertestGlobalArtifactManager }
+            );
+
+            afterEachDataCleanup.push(createdArtifact);
+          });
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

So far this is only an acceptance test which should fail until the underlying issue is not fixed.

With the given scenario a suspected underlying bug can be brought forward:
- `endpointManagementSpaceAwarenessEnabled` feature flag is enabled: this requires users to have `global_artifact_management_all` privilege for modifying global artifacts
- a user role uses a deprecated `siem` or `siemV2` feature

The role migration introduced in #219566 makes sure that these users have the new `global_artifact_management_all` privilege, and this works in most cases, but seemingly, on server side when validating an API call, it does not applied.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



