### PR TITLE
[Fleet] fix UI error when no tags filter is selected

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -40,7 +40,7 @@ interface Props {
   allTags: string[];
   selectedTags: string[];
   button: HTMLElement;
-  onTagsUpdated: () => void;
+  onTagsUpdated: (tagsToAdd: string[]) => void;
   onClosePopover: () => void;
 }
 
@@ -93,7 +93,7 @@ export const TagsAddRemove: React.FC<Props> = ({
     isRenameOrDelete = false
   ) => {
     if (hasCompleted) {
-      return onTagsUpdated();
+      return onTagsUpdated(tagsToAdd);
     }
     const selected = labels.filter((tag) => tag.checked === 'on').map((tag) => tag.label);
     const newSelectedTags = difference(selected, tagsToRemove).concat(tagsToAdd);
@@ -115,7 +115,7 @@ export const TagsAddRemove: React.FC<Props> = ({
       updateTagsHook.updateTags(
         agentId,
         newSelectedTags,
-        () => onTagsUpdated(),
+        () => onTagsUpdated(tagsToAdd),
         successMessage,
         errorMessage
       );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -412,8 +412,15 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           allTags={allTags ?? []}
           selectedTags={agentToAddRemoveTags?.tags ?? []}
           button={tagsPopoverButton!}
-          onTagsUpdated={() => {
-            refreshAgents();
+          onTagsUpdated={(tagsToAdd: string[]) => {
+            refreshAgents({ refreshTags: true });
+            // close popover if agent is going to disappear from view to prevent UI error
+            if (
+              tagsToAdd.length > 0 &&
+              (selectedTags[0] === 'No Tags' || kuery.includes('not tags:*'))
+            ) {
+              setShowTagsAddRemove(false);
+            }
           }}
           onClosePopover={() => {
             setShowTagsAddRemove(false);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/224055

To verify:
- filter on `No Tags` or `not tags:*` in Agent list
- add tag to an agent
- expect that the agent disappears from view and there is no UI error


https://github.com/user-attachments/assets/77982bc9-13a8-4141-b0a0-e9198706691f




<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->