### PR TITLE
[Observability/Logs] Fix PDF/PNG reporting timeout for stream embeddable

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/log_stream/log_stream_react_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/log_stream/log_stream_react_embeddable.tsx
@@ -87,7 +87,7 @@ export function getLogStreamEmbeddableFactory(services: Services) {
               theme$={services.coreStart.theme.theme$}
             >
               <EuiThemeProvider darkMode={darkMode}>
-                <div style={{ width: '100%', position: 'relative' }}>
+                <div data-shared-item="" style={{ width: '100%', position: 'relative' }}>
                   <LogStream
                     logView={{ type: 'log-view-reference', logViewId: 'default' }}
                     startTimestamp={startTimestamp}


### PR DESCRIPTION
## Summary

Closes #161316 

 PDF/PNG Reporting waits for each dashboard panel to flip data-render-complete="true" on a DOM element that also carries data-shared-item.
The deprecated Log Stream embeddable never exposed such an element, so Reporting timed-out after 60 s and completed “with warnings”.

With the empty attribute present, Reporting detects render completion and finishes without warnings.




## How to test 🧪 :

- Make sure you have trial license locally
- In Stack `Management > Saved objects` import stream embeddable object ( see below)
- Add some logs data using synthrace 
- Go to `Dashboards` and Share the dashboard in PDF
- Go to `Stack Management > Reporting`
- PDF should be done in few seconds

### Create stream embeddable object:

- `{"attributes":{"controlGroupInput":{"chainingSystem":"HIERARCHICAL","controlStyle":"oneLine","ignoreParentSettingsJSON":"{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}","panelsJSON":"{}","showApplySelections":false},"description":"Dashboard to test Old Logs Stream Component","kibanaSavedObjectMeta":{"searchSourceJSON":"{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"},"optionsJSON":"{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}","panelsJSON":"[{\"type\":\"LOG_STREAM_EMBEDDABLE\",\"title\":\"Log stream\",\"embeddableConfig\":{\"timeRange\":{\"from\":\"now-1d\",\"to\":\"now\"},\"enhancements\":{}},\"panelIndex\":\"007ae236-4c6a-4509-b3e6-0ea82a70a070\",\"gridData\":{\"i\":\"007ae236-4c6a-4509-b3e6-0ea82a70a070\",\"y\":0,\"x\":0,\"w\":29,\"h\":27}}]","timeRestore":false,"title":"PDF Report test","version":3},"coreMigrationVersion":"8.8.0","created_at":"2025-06-16T11:03:19.212Z","created_by":"u_aL2aSMHLXN4K3J3Rnm1qbDWzXwMxid2fsn7Icg_S9eU_0","id":"c3448139-0e6a-4650-926c-7977a752930e","managed":false,"references":[],"type":"dashboard","typeMigrationVersion":"10.2.0","updated_at":"2025-06-16T14:23:15.285Z","updated_by":"u_aL2aSMHLXN4K3J3Rnm1qbDWzXwMxid2fsn7Icg_S9eU_0","version":"WzMxNzI5NywyM10="}
{"excludedObjects":[],"excludedObjectsCount":0,"exportedCount":1,"missingRefCount":0,"missingReferences":[]}`

- Copy that and save the file as .ndjson
