### PR TITLE
[Discover][ES|QL] Update query for recommended database queries to use db.system.name

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions/set_esql_recommended_queries.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions/set_esql_recommended_queries.ts
@@ -29,7 +29,7 @@ const TRACES_ESQL_RECOMMENDED_QUERIES = [
     name: i18n.translate('xpack.observability.recommendedQueries.slowDatabaseQueries.name', {
       defaultMessage: 'Database queries',
     }),
-    query: `FROM ${TRACES_INDEX_PATTERN} | WHERE QSTR("span.type:db OR db.system:*")`,
+    query: `FROM ${TRACES_INDEX_PATTERN} | WHERE QSTR("span.type:db OR db.system.name:*")`,
     description: i18n.translate(
       'xpack.observability.recommendedQueries.slowDatabaseQueries.description',
       {


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/222908.

While working on the recommended queries, I completely missed that `db.system` has been replaced by `db.system.name` in the [semconv](https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/#database-client-span-attributes). 

The OTel demo is still using `db.system` for now, and since I was using it to test, I didn't catch the change.





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->