### PR TITLE
Skip failing synthetics multispace monitor test suite for MKI

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/legacy_and_multispace_monitor_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/legacy_and_multispace_monitor_api.ts
@@ -18,6 +18,9 @@ import { getFixtureJson } from './helpers/get_fixture_json';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('LegacyAndMultiSpaceMonitorAPI', function () {
+    // Fails on MKI, see https://github.com/elastic/kibana/issues/225431
+    this.tags(['failsOnMKI']);
+
     const supertest = getService('supertestWithoutAuth');
     const kibanaServer = getService('kibanaServer');
     const samlAuth = getService('samlAuth');


### PR DESCRIPTION
## Summary

This PR skips the failing synthetics multispace monitors API test suite for MKI runs.

For failure details see #225431

