### PR TITLE
[ObsUX][Infra][APM] Hide Settings from serverless navigation

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -69,10 +69,6 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
               defaultMessage: 'AI Assistant',
             }),
           },
-          {
-            link: 'inventory',
-            spaceBefore: 'm',
-          },
           ...(streamsAvailable
             ? [
                 {
@@ -90,6 +86,7 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
             : []),
           {
             id: 'apm',
+            link: 'apm:services',
             title: i18n.translate('xpack.observability.obltNav.applications', {
               defaultMessage: 'Applications',
             }),
@@ -151,6 +148,7 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
           },
           {
             id: 'metrics',
+            link: 'metrics:inventory',
             title: i18n.translate('xpack.observability.obltNav.infrastructure', {
               defaultMessage: 'Infrastructure',
             }),

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -78,7 +78,6 @@ export const createNavigationTree = ({
               defaultMessage: 'AI Assistant',
             }),
           },
-          { link: 'inventory', spaceBefore: 'm' },
           ...(streamsAvailable
             ? [
                 {
@@ -99,6 +98,7 @@ export const createNavigationTree = ({
             : []),
           {
             id: 'apm',
+            link: 'apm:services',
             title: i18n.translate('xpack.serverlessObservability.nav.applications', {
               defaultMessage: 'Applications',
             }),
@@ -114,7 +114,7 @@ export const createNavigationTree = ({
                   },
                   { link: 'apm:traces' },
                   { link: 'apm:dependencies' },
-                  { link: 'apm:settings' },
+                  { link: 'apm:settings', sideNavStatus: 'hidden' },
                 ],
               },
               {
@@ -151,6 +151,7 @@ export const createNavigationTree = ({
           },
           {
             id: 'metrics',
+            link: 'metrics:inventory',
             title: i18n.translate('xpack.serverlessObservability.nav.infrastructure', {
               defaultMessage: 'Infrastructure',
             }),
@@ -168,7 +169,7 @@ export const createNavigationTree = ({
                     ),
                   },
                   { link: 'metrics:hosts' },
-                  { link: 'metrics:settings' },
+                  { link: 'metrics:settings', sideNavStatus: 'hidden' },
                 ],
               },
             ],


### PR DESCRIPTION
## Summary

Closes [#222240](https://github.com/elastic/kibana/issues/222240)

This PR adds the prop `sideNavStatus: 'hidden'` to the settings links to prevent them from appearing in the nav bar, but keeping them in the breadcrumbs. 
It also fixes the `Application` breadcrumb not being clickable.

## Screenshots

| Description | Before | After |
|--------|--------|--------|
| Classic Infra | ![image](https://github.com/user-attachments/assets/3b179b0b-cdca-4bc1-a4be-beffe689dbd1) | ![image](https://github.com/user-attachments/assets/79a3cf5d-e7af-42eb-aa22-361f6f3f7527) |
| Classic APM | ![image](https://github.com/user-attachments/assets/4944000a-e583-47c9-8647-7152b9eab60d) |![image](https://github.com/user-attachments/assets/ab88c54c-8d5c-47fc-b46f-efc197da6673) |
| Serverless Infra | ![image](https://github.com/user-attachments/assets/eece25d8-be06-457a-a4c8-940ce5f02790) | ![image](https://github.com/user-attachments/assets/ca2b0d57-f0b3-4517-807e-a91e42e507bb) |
| Serverless APM | ![image](https://github.com/user-attachments/assets/228bedba-7687-42cd-b47a-557bfbfda210) | ![image](https://github.com/user-attachments/assets/7c7f551f-3d6a-4dcf-8ac3-167f0db0d05e) | 



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->