### PR TITLE
[8.19] [ObsUX][Infra][APM] Hide Settings from serverless navigation (#225436)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -83,10 +83,6 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
               defaultMessage: 'AI Assistant',
             }),
           },
-          {
-            link: 'inventory',
-            spaceBefore: 'm',
-          },
           ...(streamsAvailable
             ? [
                 {
@@ -104,6 +100,7 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
             : []),
           {
             id: 'apm',
+            link: 'apm:services',
             title: i18n.translate('xpack.observability.obltNav.applications', {
               defaultMessage: 'Applications',
             }),
@@ -165,6 +162,7 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
           },
           {
             id: 'metrics',
+            link: 'metrics:inventory',
             title: i18n.translate('xpack.observability.obltNav.infrastructure', {
               defaultMessage: 'Infrastructure',
             }),

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -80,7 +80,6 @@ export const createNavigationTree = ({
               defaultMessage: 'AI Assistant',
             }),
           },
-          { link: 'inventory', spaceBefore: 'm' },
           ...(streamsAvailable
             ? [
                 {
@@ -101,6 +100,7 @@ export const createNavigationTree = ({
             : []),
           {
             id: 'apm',
+            link: 'apm:services',
             title: i18n.translate('xpack.serverlessObservability.nav.applications', {
               defaultMessage: 'Applications',
             }),
@@ -116,7 +116,7 @@ export const createNavigationTree = ({
                   },
                   { link: 'apm:traces' },
                   { link: 'apm:dependencies' },
-                  { link: 'apm:settings' },
+                  { link: 'apm:settings', sideNavStatus: 'hidden' },
                   {
                     id: 'synthetics',
                     title: i18n.translate('xpack.serverlessObservability.nav.synthetics', {
@@ -153,6 +153,7 @@ export const createNavigationTree = ({
           },
           {
             id: 'metrics',
+            link: 'metrics:inventory',
             title: i18n.translate('xpack.serverlessObservability.nav.infrastructure', {
               defaultMessage: 'Infrastructure',
             }),
@@ -170,7 +171,7 @@ export const createNavigationTree = ({
                     ),
                   },
                   { link: 'metrics:hosts' },
-                  { link: 'metrics:settings' },
+                  { link: 'metrics:settings', sideNavStatus: 'hidden' },
                 ],
               },
             ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ObsUX][Infra][APM] Hide Settings from serverless navigation (#225436)](https://github.com/elastic/kibana/pull/225436)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-06-26T13:40:05Z","message":"[ObsUX][Infra][APM] Hide Settings from serverless navigation (#225436)\n\n## Summary\n\nCloses [#222240](https://github.com/elastic/kibana/issues/222240)\n\nThis PR adds the prop `sideNavStatus: 'hidden'` to the settings links to\nprevent them from appearing in the nav bar, but keeping them in the\nbreadcrumbs.\nIt also fixes the `Application` breadcrumb not being clickable.\n\n## Screenshots\n\n| Description | Before | After |\n|--------|--------|--------|\n| Classic Infra |\n![image](https://github.com/user-attachments/assets/3b179b0b-cdca-4bc1-a4be-beffe689dbd1)\n|\n![image](https://github.com/user-attachments/assets/79a3cf5d-e7af-42eb-aa22-361f6f3f7527)\n|\n| Classic APM |\n![image](https://github.com/user-attachments/assets/4944000a-e583-47c9-8647-7152b9eab60d)\n|![image](https://github.com/user-attachments/assets/ab88c54c-8d5c-47fc-b46f-efc197da6673)\n|\n| Serverless Infra |\n![image](https://github.com/user-attachments/assets/eece25d8-be06-457a-a4c8-940ce5f02790)\n|\n![image](https://github.com/user-attachments/assets/ca2b0d57-f0b3-4517-807e-a91e42e507bb)\n|\n| Serverless APM |\n![image](https://github.com/user-attachments/assets/228bedba-7687-42cd-b47a-557bfbfda210)\n|\n![image](https://github.com/user-attachments/assets/7c7f551f-3d6a-4dcf-8ac3-167f0db0d05e)\n|","sha":"76642fbf16ef8ea9af5096103c45cc94265ec6fd","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","ci:project-deploy-observability","Team:obs-ux-infra_services","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[ObsUX][Infra][APM] Hide Settings from serverless navigation","number":225436,"url":"https://github.com/elastic/kibana/pull/225436","mergeCommit":{"message":"[ObsUX][Infra][APM] Hide Settings from serverless navigation (#225436)\n\n## Summary\n\nCloses [#222240](https://github.com/elastic/kibana/issues/222240)\n\nThis PR adds the prop `sideNavStatus: 'hidden'` to the settings links to\nprevent them from appearing in the nav bar, but keeping them in the\nbreadcrumbs.\nIt also fixes the `Application` breadcrumb not being clickable.\n\n## Screenshots\n\n| Description | Before | After |\n|--------|--------|--------|\n| Classic Infra |\n![image](https://github.com/user-attachments/assets/3b179b0b-cdca-4bc1-a4be-beffe689dbd1)\n|\n![image](https://github.com/user-attachments/assets/79a3cf5d-e7af-42eb-aa22-361f6f3f7527)\n|\n| Classic APM |\n![image](https://github.com/user-attachments/assets/4944000a-e583-47c9-8647-7152b9eab60d)\n|![image](https://github.com/user-attachments/assets/ab88c54c-8d5c-47fc-b46f-efc197da6673)\n|\n| Serverless Infra |\n![image](https://github.com/user-attachments/assets/eece25d8-be06-457a-a4c8-940ce5f02790)\n|\n![image](https://github.com/user-attachments/assets/ca2b0d57-f0b3-4517-807e-a91e42e507bb)\n|\n| Serverless APM |\n![image](https://github.com/user-attachments/assets/228bedba-7687-42cd-b47a-557bfbfda210)\n|\n![image](https://github.com/user-attachments/assets/7c7f551f-3d6a-4dcf-8ac3-167f0db0d05e)\n|","sha":"76642fbf16ef8ea9af5096103c45cc94265ec6fd"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225436","number":225436,"mergeCommit":{"message":"[ObsUX][Infra][APM] Hide Settings from serverless navigation (#225436)\n\n## Summary\n\nCloses [#222240](https://github.com/elastic/kibana/issues/222240)\n\nThis PR adds the prop `sideNavStatus: 'hidden'` to the settings links to\nprevent them from appearing in the nav bar, but keeping them in the\nbreadcrumbs.\nIt also fixes the `Application` breadcrumb not being clickable.\n\n## Screenshots\n\n| Description | Before | After |\n|--------|--------|--------|\n| Classic Infra |\n![image](https://github.com/user-attachments/assets/3b179b0b-cdca-4bc1-a4be-beffe689dbd1)\n|\n![image](https://github.com/user-attachments/assets/79a3cf5d-e7af-42eb-aa22-361f6f3f7527)\n|\n| Classic APM |\n![image](https://github.com/user-attachments/assets/4944000a-e583-47c9-8647-7152b9eab60d)\n|![image](https://github.com/user-attachments/assets/ab88c54c-8d5c-47fc-b46f-efc197da6673)\n|\n| Serverless Infra |\n![image](https://github.com/user-attachments/assets/eece25d8-be06-457a-a4c8-940ce5f02790)\n|\n![image](https://github.com/user-attachments/assets/ca2b0d57-f0b3-4517-807e-a91e42e507bb)\n|\n| Serverless APM |\n![image](https://github.com/user-attachments/assets/228bedba-7687-42cd-b47a-557bfbfda210)\n|\n![image](https://github.com/user-attachments/assets/7c7f551f-3d6a-4dcf-8ac3-167f0db0d05e)\n|","sha":"76642fbf16ef8ea9af5096103c45cc94265ec6fd"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->