### PR TITLE
[Observability:OtherTools:LogsAnomalies] Add keyboard accessibility to scrollable Swimlane container

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/swimlane_container.tsx
@@ -451,6 +451,11 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
               overflowX: 'hidden',
             }}
             grow={false}
+            tabIndex={0}
+            role="region"
+            aria-label={i18n.translate('xpack.ml.explorer.swimlane.scrollableRegion.ariaLabel', {
+              defaultMessage: 'Scrollable anomaly swimlane chart',
+            })}
           >
             <>
               <div>


### PR DESCRIPTION

closes : #223307 

## Summary

Fixes accessibility violation where scrollable ML anomaly swimlane containers were not keyboard accessible.
## Problem

- **Issue:** axe-core detected "Scrollable region must have keyboard access" violation
- **Location:** Observability → Other tools → Logs anomalies page
- **Impact:** Users relying on keyboard navigation couldn't access scrollable swimlane content

## Solution

Enhanced the [SwimlaneContainer](cci:1://file:///Users/robertstelmach/Documents/Elastic/kibana/x-pack/platform/plugins/shared/ml/public/application/explorer/swimlane_container.tsx:164:0-603:2) component with proper accessibility attributes:

- `tabIndex={0}` - Makes scrollable region focusable via Tab key
- `role="region"` - Identifies as navigational landmark for screen readers
- `aria-label` - Provides descriptive text 

## How to test

- Navigate observability->Other tools -> Logs categories
- Make sure its populated with some data
- Run axe-core
- Expand a row in logs categories table by clicking on the expansion at the end of the table
- The error should be gone
 