### PR TITLE
[useUnsavedChangesPrompt] Don't prompt when history is replaced given its option.

### DIFF
--- a/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.test.tsx
+++ b/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.test.tsx
@@ -61,6 +61,25 @@ describe('useUnsavedChangesPrompt', () => {
     expect(addSpy).not.toBeCalledWith('beforeunload', expect.anything());
   });
 
+  it('should not block if only replaced', () => {
+    renderHook(() =>
+      useUnsavedChangesPrompt({
+        hasUnsavedChanges: false,
+        http: coreStart.http,
+        openConfirm: coreStart.overlays.openConfirm,
+        history,
+        navigateToUrl,
+      })
+    );
+
+    act(() => history.replace('/test'));
+
+    expect(history.location.pathname).toBe('/test');
+    expect(history.location.search).toBe('');
+    expect(coreStart.overlays.openConfirm).not.toBeCalled();
+    expect(addSpy).not.toBeCalledWith('beforeunload', expect.anything());
+  });
+
   it('should block if edited', async () => {
     coreStart.overlays.openConfirm.mockResolvedValue(true);
 

--- a/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.test.tsx
+++ b/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.test.tsx
@@ -61,25 +61,6 @@ describe('useUnsavedChangesPrompt', () => {
     expect(addSpy).not.toBeCalledWith('beforeunload', expect.anything());
   });
 
-  it('should not block if only replaced', () => {
-    renderHook(() =>
-      useUnsavedChangesPrompt({
-        hasUnsavedChanges: false,
-        http: coreStart.http,
-        openConfirm: coreStart.overlays.openConfirm,
-        history,
-        navigateToUrl,
-      })
-    );
-
-    act(() => history.replace('/test'));
-
-    expect(history.location.pathname).toBe('/test');
-    expect(history.location.search).toBe('');
-    expect(coreStart.overlays.openConfirm).not.toBeCalled();
-    expect(addSpy).not.toBeCalledWith('beforeunload', expect.anything());
-  });
-
   it('should block if edited', async () => {
     coreStart.overlays.openConfirm.mockResolvedValue(true);
 
@@ -137,5 +118,25 @@ describe('useUnsavedChangesPrompt', () => {
     expect(history.location.pathname).toBe('/test');
 
     expect(blockSpy).not.toBeCalled();
+  });
+
+  it('should not block if replaced when shouldPromptOnReplace is false', () => {
+    renderHook(() =>
+      useUnsavedChangesPrompt({
+        hasUnsavedChanges: false,
+        http: coreStart.http,
+        openConfirm: coreStart.overlays.openConfirm,
+        history,
+        navigateToUrl,
+        shouldPromptOnReplace: false,
+      })
+    );
+
+    act(() => history.replace('/test'));
+
+    expect(history.location.pathname).toBe('/test');
+    expect(history.location.search).toBe('');
+    expect(coreStart.overlays.openConfirm).not.toBeCalled();
+    expect(addSpy).not.toBeCalledWith('beforeunload', expect.anything());
   });
 });

--- a/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.tsx
+++ b/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.tsx
@@ -87,7 +87,11 @@ export const useUnsavedChangesPrompt = (props: Props) => {
       cancelButtonText = DEFAULT_CANCEL_BUTTON,
     } = props;
 
-    const unblock = history.block((state) => {
+    const unblock = history.block((state, action) => {
+      if (action === 'REPLACE') {
+        return;
+      }
+
       async function confirmAsync() {
         const confirmResponse = await openConfirm(messageText, {
           title: titleText,

--- a/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.tsx
+++ b/src/platform/packages/shared/kbn-unsaved-changes-prompt/src/unsaved_changes_prompt/unsaved_changes_prompt.tsx
@@ -42,10 +42,12 @@ interface SpaBlockingProps extends BaseProps {
   cancelButtonText?: string;
   confirmButtonText?: string;
   blockSpaNavigation?: true;
+  shouldPromptOnReplace?: boolean;
 }
 
 interface BrowserBlockingProps extends BaseProps {
   blockSpaNavigation: false;
+  shouldPromptOnReplace?: boolean;
 }
 
 type Props = SpaBlockingProps | BrowserBlockingProps;
@@ -54,7 +56,7 @@ const isSpaBlocking = (props: Props): props is SpaBlockingProps =>
   props.blockSpaNavigation !== false;
 
 export const useUnsavedChangesPrompt = (props: Props) => {
-  const { hasUnsavedChanges, blockSpaNavigation = true } = props;
+  const { hasUnsavedChanges, blockSpaNavigation = true, shouldPromptOnReplace = true } = props;
 
   useEffect(() => {
     if (hasUnsavedChanges) {
@@ -88,7 +90,7 @@ export const useUnsavedChangesPrompt = (props: Props) => {
     } = props;
 
     const unblock = history.block((state, action) => {
-      if (action === 'REPLACE') {
+      if (!shouldPromptOnReplace && action === 'REPLACE') {
         return;
       }
 
@@ -117,5 +119,5 @@ export const useUnsavedChangesPrompt = (props: Props) => {
     });
 
     return unblock;
-  }, [hasUnsavedChanges, blockSpaNavigation, props]);
+  }, [hasUnsavedChanges, blockSpaNavigation, shouldPromptOnReplace, props]);
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/page_content.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/page_content.tsx
@@ -89,6 +89,7 @@ export function StreamDetailEnrichmentContentImpl() {
     http: core.http,
     navigateToUrl: core.application.navigateToUrl,
     openConfirm: core.overlays.openConfirm,
+    shouldPromptOnReplace: false,
   });
 
   if (!isReady) {


### PR DESCRIPTION
## 📓 Summary

Fixes an issue with prompting the user about leaving the page when the URL changes due to data source changes.


https://github.com/user-attachments/assets/88e36769-96a4-4499-87f0-1e6db4502725



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->