### PR TITLE
[8.19] [Security Solution] [AI assistant ] Fix error where llm.bindTools is not a function. (#225268)

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
@@ -173,7 +173,7 @@ export const postDefendInsightsRoute = (router: IRouter<ElasticAssistantRequestH
             promptGroupId,
             savedObjectsClient,
           });
-          const toolInstance = assistantTool.getTool({ ...assistantToolParams, description });
+          const toolInstance = await assistantTool.getTool({ ...assistantToolParams, description });
 
           const { currentInsight, defendInsightId } = await createDefendInsight(
             endpointIds,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
@@ -240,7 +240,7 @@ export interface AssistantTool {
   description: string;
   sourceRegister: string;
   isSupported: (params: AssistantToolParams) => boolean;
-  getTool: (params: AssistantToolParams) => StructuredToolInterface | null;
+  getTool: (params: AssistantToolParams) => Promise<StructuredToolInterface | null>;
 }
 
 export type AssistantToolLlm =
@@ -279,3 +279,14 @@ export interface AssistantToolParams {
     | ActionsClientChatVertexAI
     | ActionsClientChatOpenAI;
 }
+
+/**
+ * Helper type for working with AssistantToolParams when some properties are required.
+ *
+ *
+ * ```ts
+ * export type MyNewTypeWithAssistantContext = Require<AssistantToolParams, 'assistantContext'>
+ * ```
+ */
+
+export type Require<T extends object, P extends keyof T> = Omit<T, P> & Required<Pick<T, P>>;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.test.ts
@@ -86,13 +86,13 @@ describe('AlertCountsTool', () => {
 
   describe('getTool', () => {
     it('returns a `DynamicTool` with a `func` that calls `esClient.search()` with the expected query', async () => {
-      const tool: DynamicTool = ALERT_COUNTS_TOOL.getTool({
+      const tool: DynamicTool = (await ALERT_COUNTS_TOOL.getTool({
         alertsIndexPattern,
         esClient,
         replacements,
         request,
         ...rest,
-      }) as DynamicTool;
+      })) as DynamicTool;
 
       await tool.func('');
 
@@ -163,13 +163,13 @@ describe('AlertCountsTool', () => {
     });
 
     it('includes citations', async () => {
-      const tool: DynamicTool = ALERT_COUNTS_TOOL.getTool({
+      const tool: DynamicTool = (await ALERT_COUNTS_TOOL.getTool({
         alertsIndexPattern,
         esClient,
         replacements,
         request,
         ...rest,
-      }) as DynamicTool;
+      })) as DynamicTool;
 
       (contentReferencesStore.add as jest.Mock).mockImplementation(
         (creator: Parameters<ContentReferencesStore['add']>[0]) => {
@@ -184,8 +184,8 @@ describe('AlertCountsTool', () => {
       expect(result).toContain('Citation: {reference(exampleContentReferenceId)}');
     });
 
-    it('returns null when the alertsIndexPattern is undefined', () => {
-      const tool = ALERT_COUNTS_TOOL.getTool({
+    it('returns null when the alertsIndexPattern is undefined', async () => {
+      const tool = await ALERT_COUNTS_TOOL.getTool({
         // alertsIndexPattern is undefined
         esClient,
         replacements,
@@ -197,15 +197,15 @@ describe('AlertCountsTool', () => {
       expect(tool).toBeNull();
     });
 
-    it('returns a tool instance with the expected tags', () => {
-      const tool = ALERT_COUNTS_TOOL.getTool({
+    it('returns a tool instance with the expected tags', async () => {
+      const tool = (await ALERT_COUNTS_TOOL.getTool({
         alertsIndexPattern,
         esClient,
         replacements,
         request,
 
         ...rest,
-      }) as DynamicTool;
+      })) as DynamicTool;
 
       expect(tool.tags).toEqual(['alerts', 'alerts-count']);
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.ts
@@ -10,12 +10,12 @@ import { tool } from '@langchain/core/tools';
 import { requestHasRequiredAnonymizationParams } from '@kbn/elastic-assistant-plugin/server/lib/langchain/helpers';
 import type { AssistantTool, AssistantToolParams } from '@kbn/elastic-assistant-plugin/server';
 import { contentReferenceString, securityAlertsPageReference } from '@kbn/elastic-assistant-common';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { getAlertsCountQuery } from './get_alert_counts_query';
 import { APP_UI_ID } from '../../../../common';
 
-export interface AlertCountsToolParams extends AssistantToolParams {
-  alertsIndexPattern: string;
-}
+export type AlertCountsToolParams = Require<AssistantToolParams, 'alertsIndexPattern'>;
+
 export const ALERT_COUNTS_TOOL_DESCRIPTION =
   'Call this for the counts of last 24 hours of open and acknowledged alerts in the environment, grouped by their severity and workflow status. The response will be JSON and from it you can summarize the information to answer the question.';
 
@@ -31,7 +31,7 @@ export const ALERT_COUNTS_TOOL: AssistantTool = {
     const { request, alertsIndexPattern } = params;
     return requestHasRequiredAnonymizationParams(request) && alertsIndexPattern != null;
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
     const { alertsIndexPattern, esClient, contentReferencesStore } =
       params as AlertCountsToolParams;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.test.ts
@@ -47,22 +47,22 @@ describe('DEFEND_INSIGHTS_TOOL', () => {
     expect(DEFEND_INSIGHTS_TOOL.sourceRegister).toBe(APP_UI_ID);
   });
 
-  it('should return tool if supported', () => {
+  it('should return tool if supported', async () => {
     (requestHasRequiredAnonymizationParams as jest.Mock).mockReturnValue(true);
-    const tool = DEFEND_INSIGHTS_TOOL.getTool(mockParams);
+    const tool = await DEFEND_INSIGHTS_TOOL.getTool(mockParams);
     expect(tool).toBeInstanceOf(DynamicTool);
   });
 
-  it('should return null if not request missing anonymization params', () => {
+  it('should return null if not request missing anonymization params', async () => {
     (requestHasRequiredAnonymizationParams as jest.Mock).mockReturnValue(false);
-    const tool = DEFEND_INSIGHTS_TOOL.getTool(mockParams);
+    const tool = await DEFEND_INSIGHTS_TOOL.getTool(mockParams);
     expect(tool).toBeNull();
   });
 
-  it('should return null if LLM is not provided', () => {
+  it('should return null if LLM is not provided', async () => {
     (requestHasRequiredAnonymizationParams as jest.Mock).mockReturnValue(true);
     const paramsWithoutLLM = { ...mockParams, llm: undefined };
-    const tool = DEFEND_INSIGHTS_TOOL.getTool(paramsWithoutLLM) as DynamicTool;
+    const tool = await DEFEND_INSIGHTS_TOOL.getTool(paramsWithoutLLM) as DynamicTool;
 
     expect(tool).toBeNull();
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.test.ts
@@ -62,7 +62,7 @@ describe('DEFEND_INSIGHTS_TOOL', () => {
   it('should return null if LLM is not provided', async () => {
     (requestHasRequiredAnonymizationParams as jest.Mock).mockReturnValue(true);
     const paramsWithoutLLM = { ...mockParams, llm: undefined };
-    const tool = await DEFEND_INSIGHTS_TOOL.getTool(paramsWithoutLLM) as DynamicTool;
+    const tool = (await DEFEND_INSIGHTS_TOOL.getTool(paramsWithoutLLM)) as DynamicTool;
 
     expect(tool).toBeNull();
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.ts
@@ -47,7 +47,6 @@ export const DEFEND_INSIGHTS_TOOL: AssistantTool = Object.freeze({
   description: DEFEND_INSIGHTS_TOOL_DESCRIPTION,
   sourceRegister: APP_UI_ID,
 
-
   isSupported: (params: AssistantToolParams): boolean => {
     const { llm, request } = params;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights/index.ts
@@ -47,13 +47,14 @@ export const DEFEND_INSIGHTS_TOOL: AssistantTool = Object.freeze({
   description: DEFEND_INSIGHTS_TOOL_DESCRIPTION,
   sourceRegister: APP_UI_ID,
 
+
   isSupported: (params: AssistantToolParams): boolean => {
     const { llm, request } = params;
 
     return requestHasRequiredAnonymizationParams(request) && llm != null;
   },
 
-  getTool(params: AssistantToolParams): DynamicTool | null {
+  async getTool(params: AssistantToolParams): Promise<DynamicTool | null> {
     if (!this.isSupported(params)) return null;
 
     const {

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/ask_about_esql_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/ask_about_esql_tool.ts
@@ -10,13 +10,11 @@ import type { AssistantTool, AssistantToolParams } from '@kbn/elastic-assistant-
 import { z } from '@kbn/zod';
 import { lastValueFrom } from 'rxjs';
 import { naturalLanguageToEsql } from '@kbn/inference-plugin/server';
-import type { ElasticAssistantApiRequestHandlerContext } from '@kbn/elastic-assistant-plugin/server/types';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { APP_UI_ID } from '../../../../common';
 import { getPromptSuffixForOssModel } from './utils/common';
 
-export type ESQLToolParams = AssistantToolParams & {
-  assistantContext: ElasticAssistantApiRequestHandlerContext;
-};
+export type ESQLToolParams = Require<AssistantToolParams, 'assistantContext'>;
 
 const TOOL_NAME = 'AskAboutEsqlTool';
 
@@ -49,7 +47,7 @@ export const ASK_ABOUT_ESQL_TOOL: AssistantTool = {
       assistantContext.getRegisteredFeatures('securitySolutionUI').advancedEsqlGeneration
     );
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
 
     const { connectorId, inference, logger, request, isOssModel } = params as ESQLToolParams;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/analyse_index_pattern/nodes/analyze_compressed_index_mapping_agent/analyze_compressed_index_mapping_agent.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/analyse_index_pattern/nodes/analyze_compressed_index_mapping_agent/analyze_compressed_index_mapping_agent.ts
@@ -19,7 +19,7 @@ const structuredOutput = z.object({
     .describe('Whether the index pattern contains the required fields for the query'),
 });
 
-export const getAnalyzeCompressedIndexMappingAgent = ({
+export const getAnalyzeCompressedIndexMappingAgent = async ({
   createLlmInstance,
 }: {
   createLlmInstance: CreateLlmInstance;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/analyse_index_pattern/nodes/explore_partial_index_mapping_agent/explore_partial_index_mapping_agent.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/analyse_index_pattern/nodes/explore_partial_index_mapping_agent/explore_partial_index_mapping_agent.ts
@@ -12,7 +12,7 @@ import type { CreateLlmInstance } from '../../../../utils/common';
 import type { AnalyzeIndexPatternAnnotation } from '../../state';
 import { getInspectIndexMappingTool } from '../../../../tools/inspect_index_mapping_tool/inspect_index_mapping_tool';
 
-export const getExplorePartialIndexMappingAgent = ({
+export const getExplorePartialIndexMappingAgent = async ({
   createLlmInstance,
   esClient,
 }: {
@@ -24,6 +24,7 @@ export const getExplorePartialIndexMappingAgent = ({
     esClient,
     indexPattern: 'placeholder',
   });
+
   const llmWithTools = llm.bindTools([tool]);
 
   return async (state: typeof AnalyzeIndexPatternAnnotation.State) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/analyse_index_pattern/nodes/explore_partial_index_mapping_responder/explore_partial_index_mapping_responder.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/analyse_index_pattern/nodes/explore_partial_index_mapping_responder/explore_partial_index_mapping_responder.ts
@@ -18,7 +18,7 @@ const structuredOutput = z.object({
     .describe('Whether the index pattern contains the required fields for the query'),
 });
 
-export const getExplorePartialIndexMappingResponder = ({
+export const getExplorePartialIndexMappingResponder = async ({
   createLlmInstance,
 }: {
   createLlmInstance: CreateLlmInstance;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/generate_esql/generate_esql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/generate_esql/generate_esql.ts
@@ -8,11 +8,6 @@
 import type { ElasticsearchClient, KibanaRequest, Logger } from '@kbn/core/server';
 import { END, START, StateGraph } from '@langchain/langgraph';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
-import type {
-  ActionsClientChatBedrockConverse,
-  ActionsClientChatVertexAI,
-  ActionsClientChatOpenAI,
-} from '@kbn/langchain/server';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { GenerateEsqlAnnotation } from './state';
 
@@ -41,8 +36,9 @@ import { getBuildUnvalidatedReportFromLastMessageNode } from './nodes/build_unva
 
 import { getSelectIndexPattern } from './nodes/select_index_pattern/select_index_pattern';
 import { getSelectIndexPatternGraph } from '../select_index_pattern/select_index_pattern';
+import type { CreateLlmInstance } from '../../utils/common';
 
-export const getGenerateEsqlGraph = ({
+export const getGenerateEsqlGraph = async ({
   esClient,
   connectorId,
   inference,
@@ -55,10 +51,7 @@ export const getGenerateEsqlGraph = ({
   inference: InferenceServerStart;
   logger: Logger;
   request: KibanaRequest;
-  createLlmInstance: () =>
-    | ActionsClientChatBedrockConverse
-    | ActionsClientChatVertexAI
-    | ActionsClientChatOpenAI;
+  createLlmInstance: CreateLlmInstance;
 }) => {
   const nlToEsqlAgentNode = getNlToEsqlAgent({
     connectorId,
@@ -90,7 +83,7 @@ export const getGenerateEsqlGraph = ({
 
   const buildUnvalidatedReportFromLastMessageNode = getBuildUnvalidatedReportFromLastMessageNode();
 
-  const identifyIndexGraph = getSelectIndexPatternGraph({
+  const identifyIndexGraph = await getSelectIndexPatternGraph({
     esClient,
     createLlmInstance,
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/generate_esql/nodes/select_index_pattern/select_index_pattern.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/generate_esql/nodes/select_index_pattern/select_index_pattern.ts
@@ -14,7 +14,7 @@ import { NL_TO_ESQL_AGENT_WITHOUT_VALIDATION_NODE } from '../../constants';
 export const getSelectIndexPattern = ({
   identifyIndexGraph,
 }: {
-  identifyIndexGraph: ReturnType<typeof getSelectIndexPatternGraph>;
+  identifyIndexGraph: Awaited<ReturnType<typeof getSelectIndexPatternGraph>>;
 }) => {
   return async (state: typeof GenerateEsqlAnnotation.State) => {
     const childGraphOutput = await identifyIndexGraph.invoke({

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/select_index_pattern/nodes/analyse_index_pattern/analyse_index_pattern.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/select_index_pattern/nodes/analyse_index_pattern/analyse_index_pattern.ts
@@ -11,7 +11,7 @@ import type { getAnalyzeIndexPatternGraph } from '../../../analyse_index_pattern
 export const getAnalyzeIndexPattern = ({
   analyzeIndexPatternGraph,
 }: {
-  analyzeIndexPatternGraph: ReturnType<typeof getAnalyzeIndexPatternGraph>;
+  analyzeIndexPatternGraph: Awaited<ReturnType<typeof getAnalyzeIndexPatternGraph>>;
 }) => {
   return async ({
     input,

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/select_index_pattern/nodes/select_index/select_index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/select_index_pattern/nodes/select_index/select_index.ts
@@ -5,23 +5,11 @@
  * 2.0.
  */
 
-import type {
-  ActionsClientChatBedrockConverse,
-  ActionsClientChatVertexAI,
-  ActionsClientChatOpenAI,
-} from '@kbn/langchain/server';
 import { Command } from '@langchain/langgraph';
 
 import type { SelectIndexPatternAnnotation } from '../../state';
 
-export const getSelectIndexPattern = ({
-  createLlmInstance,
-}: {
-  createLlmInstance: () =>
-    | ActionsClientChatBedrockConverse
-    | ActionsClientChatVertexAI
-    | ActionsClientChatOpenAI;
-}) => {
+export const getSelectIndexPattern = () => {
   return async (state: typeof SelectIndexPatternAnnotation.State) => {
     const indexPatternAnalysis = Object.values(state.indexPatternAnalysis);
     const candidateIndexPatterns = indexPatternAnalysis.filter(

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/select_index_pattern/nodes/shortlist_index_patterns/shortlist_index_patterns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/graphs/select_index_pattern/nodes/shortlist_index_patterns/shortlist_index_patterns.ts
@@ -5,15 +5,11 @@
  * 2.0.
  */
 
-import type {
-  ActionsClientChatBedrockConverse,
-  ActionsClientChatVertexAI,
-  ActionsClientChatOpenAI,
-} from '@kbn/langchain/server';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { Command } from '@langchain/langgraph';
 import { z } from '@kbn/zod';
 import type { SelectIndexPatternAnnotation } from '../../state';
+import type { CreateLlmInstance } from '../../../../utils/common';
 
 const ShortlistedIndexPatterns = z
   .object({
@@ -23,13 +19,10 @@ const ShortlistedIndexPatterns = z
     'Object containing array of shortlisted index patterns that might be used to generate the query'
   );
 
-export const getShortlistIndexPatterns = ({
+export const getShortlistIndexPatterns = async ({
   createLlmInstance,
 }: {
-  createLlmInstance: () =>
-    | ActionsClientChatBedrockConverse
-    | ActionsClientChatVertexAI
-    | ActionsClientChatOpenAI;
+  createLlmInstance: CreateLlmInstance;
 }) => {
   const llm = createLlmInstance();
 

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/nl_to_esql_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/nl_to_esql_tool.ts
@@ -10,14 +10,13 @@ import type { AssistantTool, AssistantToolParams } from '@kbn/elastic-assistant-
 import { lastValueFrom } from 'rxjs';
 import { naturalLanguageToEsql } from '@kbn/inference-plugin/server';
 import { z } from '@kbn/zod';
-import type { ElasticAssistantApiRequestHandlerContext } from '@kbn/elastic-assistant-plugin/server/types';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { APP_UI_ID } from '../../../../common';
 import { getPromptSuffixForOssModel } from './utils/common';
 
 // select only some properties of AssistantToolParams
-export type ESQLToolParams = AssistantToolParams & {
-  assistantContext: ElasticAssistantApiRequestHandlerContext;
-};
+
+export type ESQLToolParams = Require<AssistantToolParams, 'assistantContext'>;
 
 const TOOL_NAME = 'NaturalLanguageESQLTool';
 
@@ -47,7 +46,7 @@ export const NL_TO_ESQL_TOOL: AssistantTool = {
       !assistantContext.getRegisteredFeatures('securitySolutionUI').advancedEsqlGeneration
     );
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
 
     const { connectorId, inference, logger, request, isOssModel } = params as ESQLToolParams;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/types.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AssistantToolParams } from '@kbn/elastic-assistant-plugin/server';
+
+export type CreateLlmInstance = Exclude<AssistantToolParams['createLlmInstance'], undefined>;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/utils/common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/esql/utils/common.ts
@@ -5,14 +5,10 @@
  * 2.0.
  */
 
-import type {
-  ActionsClientChatBedrockConverse,
-  ActionsClientChatVertexAI,
-  ActionsClientChatOpenAI,
-} from '@kbn/langchain/server';
 import type { BaseMessage } from '@langchain/core/messages';
 import { AIMessage } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/dist/messages/tool';
+import type { AssistantToolParams } from '@kbn/elastic-assistant-plugin/server';
 import { toolDetails } from '../tools/inspect_index_mapping_tool/inspect_index_mapping_tool';
 
 export const getPromptSuffixForOssModel = (toolName: string) => `
@@ -30,10 +26,7 @@ export const messageContainsToolCalls = (message: BaseMessage): message is AIMes
   );
 };
 
-export type CreateLlmInstance = () =>
-  | ActionsClientChatBedrockConverse
-  | ActionsClientChatVertexAI
-  | ActionsClientChatOpenAI;
+export type CreateLlmInstance = Exclude<AssistantToolParams['createLlmInstance'], undefined>;
 
 export const requireFirstInspectIndexMappingCallWithEmptyKey = (
   newMessage: AIMessage,

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.test.ts
@@ -34,7 +34,9 @@ describe('KnowledgeBaseRetievalTool', () => {
 
   describe('DynamicStructuredTool', () => {
     it('includes citations', async () => {
-      const tool = KNOWLEDGE_BASE_RETRIEVAL_TOOL.getTool(defaultArgs) as DynamicStructuredTool;
+      const tool = (await KNOWLEDGE_BASE_RETRIEVAL_TOOL.getTool(
+        defaultArgs
+      )) as DynamicStructuredTool;
 
       getKnowledgeBaseDocumentEntries.mockResolvedValue([
         new Document({

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.ts
@@ -8,15 +8,13 @@
 import { tool } from '@langchain/core/tools';
 import { z } from '@kbn/zod';
 import type { AssistantTool, AssistantToolParams } from '@kbn/elastic-assistant-plugin/server';
-import type { AIAssistantKnowledgeBaseDataClient } from '@kbn/elastic-assistant-plugin/server/ai_assistant_data_clients/knowledge_base';
 import { Document } from 'langchain/document';
 import type { ContentReferencesStore } from '@kbn/elastic-assistant-common';
 import { knowledgeBaseReference, contentReferenceBlock } from '@kbn/elastic-assistant-common';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { APP_UI_ID } from '../../../../common';
 
-export interface KnowledgeBaseRetrievalToolParams extends AssistantToolParams {
-  kbDataClient: AIAssistantKnowledgeBaseDataClient;
-}
+export type KnowledgeBaseRetrievalToolParams = Require<AssistantToolParams, 'kbDataClient'>;
 
 const toolDetails = {
   // note: this description is overwritten when `getTool` is called
@@ -34,7 +32,7 @@ export const KNOWLEDGE_BASE_RETRIEVAL_TOOL: AssistantTool = {
     const { kbDataClient, isEnabledKnowledgeBase } = params;
     return isEnabledKnowledgeBase && kbDataClient != null;
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
 
     const { kbDataClient, logger, contentReferencesStore } =

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_write_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_write_tool.ts
@@ -8,16 +8,15 @@
 import { tool } from '@langchain/core/tools';
 import { z } from '@kbn/zod';
 import type { AssistantTool, AssistantToolParams } from '@kbn/elastic-assistant-plugin/server';
-import type { AIAssistantKnowledgeBaseDataClient } from '@kbn/elastic-assistant-plugin/server/ai_assistant_data_clients/knowledge_base';
 import { DocumentEntryType } from '@kbn/elastic-assistant-common';
 import type { KnowledgeBaseEntryCreateProps } from '@kbn/elastic-assistant-common';
-import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { APP_UI_ID } from '../../../../common';
 
-export interface KnowledgeBaseWriteToolParams extends AssistantToolParams {
-  kbDataClient: AIAssistantKnowledgeBaseDataClient;
-  telemetry: AnalyticsServiceSetup;
-}
+export type KnowledgeBaseWriteToolParams = Require<
+  AssistantToolParams,
+  'kbDataClient' | 'telemetry'
+>;
 
 const toolDetails = {
   // note: this description is overwritten when `getTool` is called
@@ -35,7 +34,7 @@ export const KNOWLEDGE_BASE_WRITE_TOOL: AssistantTool = {
     const { isEnabledKnowledgeBase, kbDataClient } = params;
     return isEnabledKnowledgeBase && kbDataClient != null;
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
 
     const { telemetry, kbDataClient, logger } = params as KnowledgeBaseWriteToolParams;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.test.ts
@@ -137,7 +137,7 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
   });
   describe('getTool', () => {
     it('returns a `DynamicTool` with a `func` that calls `esClient.search()` with the expected query', async () => {
-      const tool: DynamicTool = OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
+      const tool: DynamicTool = (await OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
         alertsIndexPattern,
         anonymizationFields,
         onNewReplacements: jest.fn(),
@@ -145,7 +145,7 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
         request,
         size: request.body.size,
         ...rest,
-      }) as DynamicTool;
+      })) as DynamicTool;
 
       await tool.func('');
 
@@ -235,7 +235,7 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
     });
 
     it('includes citations', async () => {
-      const tool: DynamicTool = OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
+      const tool: DynamicTool = (await OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
         alertsIndexPattern,
         anonymizationFields,
         onNewReplacements: jest.fn(),
@@ -243,7 +243,7 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
         request,
         size: request.body.size,
         ...rest,
-      }) as DynamicTool;
+      })) as DynamicTool;
 
       (esClient.search as jest.Mock).mockResolvedValue({
         hits: {
@@ -265,8 +265,8 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
       expect(result).toContain('Citation,{reference(exampleContentReferenceId)}');
     });
 
-    it('returns null when alertsIndexPattern is undefined', () => {
-      const tool = OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
+    it('returns null when alertsIndexPattern is undefined', async () => {
+      const tool = await OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
         // alertsIndexPattern is undefined
         anonymizationFields,
         onNewReplacements: jest.fn(),
@@ -279,8 +279,8 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
       expect(tool).toBeNull();
     });
 
-    it('returns null when size is undefined', () => {
-      const tool = OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
+    it('returns null when size is undefined', async () => {
+      const tool = await OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
         alertsIndexPattern,
         anonymizationFields,
         onNewReplacements: jest.fn(),
@@ -293,8 +293,8 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
       expect(tool).toBeNull();
     });
 
-    it('returns null when size out of range', () => {
-      const tool = OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
+    it('returns null when size out of range', async () => {
+      const tool = await OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
         alertsIndexPattern,
         anonymizationFields,
         onNewReplacements: jest.fn(),
@@ -307,8 +307,8 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
       expect(tool).toBeNull();
     });
 
-    it('returns a tool instance with the expected tags', () => {
-      const tool = OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
+    it('returns a tool instance with the expected tags', async () => {
+      const tool = (await OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL.getTool({
         alertsIndexPattern,
         anonymizationFields,
         onNewReplacements: jest.fn(),
@@ -316,7 +316,7 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
         request,
         size: request.body.size,
         ...rest,
-      }) as DynamicTool;
+      })) as DynamicTool;
 
       expect(tool.tags).toEqual(['alerts', 'open-and-acknowledged-alerts']);
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.ts
@@ -19,12 +19,13 @@ import {
 import { tool } from '@langchain/core/tools';
 import { requestHasRequiredAnonymizationParams } from '@kbn/elastic-assistant-plugin/server/lib/langchain/helpers';
 import type { AssistantTool, AssistantToolParams } from '@kbn/elastic-assistant-plugin/server';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { APP_UI_ID } from '../../../../common';
 
-export interface OpenAndAcknowledgedAlertsToolParams extends AssistantToolParams {
-  alertsIndexPattern: string;
-  size: number;
-}
+export type OpenAndAcknowledgedAlertsToolParams = Require<
+  AssistantToolParams,
+  'alertsIndexPattern' | 'size'
+>;
 
 export const OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL_DESCRIPTION =
   'Call this for knowledge about the latest n open and acknowledged alerts (sorted by `kibana.alert.risk_score`) in the environment, or when answering questions about open alerts. Do not call this tool for alert count or quantity. The output is an array of the latest n open and acknowledged alerts.';
@@ -50,7 +51,7 @@ export const OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL: AssistantTool = {
       !sizeIsOutOfRange(size)
     );
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
 
     const {

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.test.ts
@@ -57,14 +57,14 @@ describe('ProductDocumentationTool', () => {
   });
 
   describe('getTool', () => {
-    it('should return a tool as expected when all required values are present', () => {
-      const tool = PRODUCT_DOCUMENTATION_TOOL.getTool(defaultArgs) as DynamicTool;
+    it('should return a tool as expected when all required values are present', async () => {
+      const tool = (await PRODUCT_DOCUMENTATION_TOOL.getTool(defaultArgs)) as DynamicTool;
       expect(tool.name).toEqual('ProductDocumentationTool');
       expect(tool.tags).toEqual(['product-documentation']);
     });
 
-    it('returns null if llmTasks plugin is not provided', () => {
-      const tool = PRODUCT_DOCUMENTATION_TOOL.getTool({
+    it('returns null if llmTasks plugin is not provided', async () => {
+      const tool = await PRODUCT_DOCUMENTATION_TOOL.getTool({
         ...defaultArgs,
         llmTasks: undefined,
       });
@@ -72,8 +72,8 @@ describe('ProductDocumentationTool', () => {
       expect(tool).toBeNull();
     });
 
-    it('returns null if connectorId is not provided', () => {
-      const tool = PRODUCT_DOCUMENTATION_TOOL.getTool({
+    it('returns null if connectorId is not provided', async () => {
+      const tool = await PRODUCT_DOCUMENTATION_TOOL.getTool({
         ...defaultArgs,
         connectorId: undefined,
       });
@@ -86,7 +86,7 @@ describe('ProductDocumentationTool', () => {
       retrieveDocumentation.mockResolvedValue({ documents: [] });
     });
     it('the tool invokes retrieveDocumentation', async () => {
-      const tool = PRODUCT_DOCUMENTATION_TOOL.getTool(defaultArgs) as DynamicStructuredTool;
+      const tool = (await PRODUCT_DOCUMENTATION_TOOL.getTool(defaultArgs)) as DynamicStructuredTool;
 
       await tool.func({ query: 'What is Kibana Security?', product: 'kibana' });
 
@@ -101,7 +101,7 @@ describe('ProductDocumentationTool', () => {
     });
 
     it('includes citations', async () => {
-      const tool = PRODUCT_DOCUMENTATION_TOOL.getTool(defaultArgs) as DynamicStructuredTool;
+      const tool = (await PRODUCT_DOCUMENTATION_TOOL.getTool(defaultArgs)) as DynamicStructuredTool;
 
       (retrieveDocumentation as jest.Mock).mockResolvedValue({
         documents: [

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.ts
@@ -15,7 +15,13 @@ import {
 } from '@kbn/elastic-assistant-common';
 import type { ContentReferencesStore } from '@kbn/elastic-assistant-common';
 import type { RetrieveDocumentationResultDoc } from '@kbn/llm-tasks-plugin/server';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { APP_UI_ID } from '../../../../common';
+
+export type ProductDocumentationToolParams = Require<
+  AssistantToolParams,
+  'llmTasks' | 'connectorId'
+>;
 
 const toolDetails = {
   // note: this description is overwritten when `getTool` is called
@@ -29,17 +35,14 @@ const toolDetails = {
 export const PRODUCT_DOCUMENTATION_TOOL: AssistantTool = {
   ...toolDetails,
   sourceRegister: APP_UI_ID,
-  isSupported: (params: AssistantToolParams): params is AssistantToolParams => {
+  isSupported: (params: AssistantToolParams): params is ProductDocumentationToolParams => {
     return params.llmTasks != null && params.connectorId != null;
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
 
     const { connectorId, llmTasks, request, contentReferencesStore } =
-      params as AssistantToolParams;
-
-    // This check is here in order to satisfy TypeScript
-    if (llmTasks == null || connectorId == null) return null;
+      params as ProductDocumentationToolParams;
 
     return tool(
       async ({ query, product }) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.test.ts
@@ -53,7 +53,9 @@ In previous publications,`,
         }),
       ]);
 
-      const tool = SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(defaultArgs) as DynamicStructuredTool;
+      const tool = (await SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(
+        defaultArgs
+      )) as DynamicStructuredTool;
 
       (contentReferencesStore.add as jest.Mock).mockImplementation(
         (creator: Parameters<ContentReferencesStore['add']>[0]) => {
@@ -81,7 +83,9 @@ In previous publications,`,
           pageContent: `hello world`,
         }),
       ]);
-      const tool = SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(defaultArgs) as DynamicStructuredTool;
+      const tool = (await SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(
+        defaultArgs
+      )) as DynamicStructuredTool;
 
       (contentReferencesStore.add as jest.Mock).mockImplementation(
         (creator: Parameters<ContentReferencesStore['add']>[0]) => {
@@ -104,7 +108,9 @@ In previous publications,`,
     it('Responds with The "AI Assistant knowledge base" needs to be installed... when no docs and no kb install', async () => {
       getKnowledgeBaseDocumentEntries.mockResolvedValue([]);
       (getIsKnowledgeBaseInstalled as jest.Mock).mockResolvedValue(false);
-      const tool = SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(defaultArgs) as DynamicStructuredTool;
+      const tool = (await SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(
+        defaultArgs
+      )) as DynamicStructuredTool;
 
       const result = await tool.func({ query: 'What is Kibana Security?', product: 'kibana' });
 
@@ -113,7 +119,9 @@ In previous publications,`,
     it('Responds with empty response when no docs and kb is installed', async () => {
       getKnowledgeBaseDocumentEntries.mockResolvedValue([]);
       (getIsKnowledgeBaseInstalled as jest.Mock).mockResolvedValue(true);
-      const tool = SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(defaultArgs) as DynamicStructuredTool;
+      const tool = (await SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool(
+        defaultArgs
+      )) as DynamicStructuredTool;
 
       const result = await tool.func({ query: 'What is Kibana Security?', product: 'kibana' });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.ts
@@ -18,8 +18,11 @@ import {
   knowledgeBaseReference,
 } from '@kbn/elastic-assistant-common/impl/content_references/references';
 import { Document } from 'langchain/document';
+import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
 import { getIsKnowledgeBaseInstalled } from '@kbn/elastic-assistant-plugin/server/routes/helpers';
 import { APP_UI_ID } from '../../../../common';
+
+export type SecurityLabsKnowledgeBaseToolParams = Require<AssistantToolParams, 'kbDataClient'>;
 
 const toolDetails = {
   // note: this description is overwritten when `getTool` is called
@@ -36,15 +39,14 @@ const SECURITY_LABS_BASE_URL = 'https://www.elastic.co/security-labs/';
 export const SECURITY_LABS_KNOWLEDGE_BASE_TOOL: AssistantTool = {
   ...toolDetails,
   sourceRegister: APP_UI_ID,
-  isSupported: (params: AssistantToolParams): params is AssistantToolParams => {
+  isSupported: (params: AssistantToolParams): params is SecurityLabsKnowledgeBaseToolParams => {
     const { kbDataClient, isEnabledKnowledgeBase } = params;
     return isEnabledKnowledgeBase && kbDataClient != null;
   },
-  getTool(params: AssistantToolParams) {
+  async getTool(params: AssistantToolParams) {
     if (!this.isSupported(params)) return null;
 
-    const { kbDataClient, contentReferencesStore } = params as AssistantToolParams;
-    if (kbDataClient == null) return null;
+    const { kbDataClient, contentReferencesStore } = params as SecurityLabsKnowledgeBaseToolParams;
 
     return tool(
       async (input) => {

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -258,6 +258,5 @@
     "@kbn/security-plugin-types-common",
     "@kbn/elastic-assistant-shared-state",
     "@kbn/elastic-assistant-shared-state-plugin",
-    "@kbn/spaces-utils",
   ]
 }

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -258,5 +258,6 @@
     "@kbn/security-plugin-types-common",
     "@kbn/elastic-assistant-shared-state",
     "@kbn/elastic-assistant-shared-state-plugin",
+    "@kbn/spaces-utils",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] [AI assistant ] Fix error where llm.bindTools is not a function. (#225268)](https://github.com/elastic/kibana/pull/225268)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kenneth Kreindler","email":"42113355+KDKHD@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-26T14:22:01Z","message":"[Security Solution] [AI assistant ] Fix error where llm.bindTools is not a function. (#225268)\n\n## Summary\n\nSummarize your PR. If it involves visual changes, include a screenshot\nor gif.\n\nThis PR fixes a bug where the error message \"llm.bindTools is not a\nfunction\" would appear in the Security AI assistant.\n\n![Screenshot 2025-06-25 at 11 05\n25 AM](https://github.com/user-attachments/assets/3e24b857-667c-4be7-b0ac-236d48decd4f)\n\nChanges:\n- Make AssistantTool.getTool return a promise. This means tools can be\ncreated asynchronously. This eliminates the error, as the error stems\nfrom the promise `createLlmInstance()`\n([ref](https://github.com/elastic/kibana/pull/225268/files#diff-69e7fc6c29ce0673d7d33c0472a012ad310fa571487a6b594d2e1378b3e5f246R286))\nnot being awaited.\n- Improve type definition for tools so that we avoid bugs when the\nAssistantTool type changes e.g.\nhttps://github.com/elastic/kibana/pull/225268/files#diff-b603523fee68a791bd3af770b780fc654eb7866c8d2a73192d29fa935c80e541R17\n\n### How to test:\n- Enable AdvancedEsqlGeneration feature flag:\n```yml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['advancedEsqlGeneration']\n```\n- Start Kibana\n- Open the Security AI assistant\n- Ask a question\n- Expect to see a response from the LLM.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"dc24f2068bcaea069cd27d9395282ac384ad9f14","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Security Generative AI","backport:version","v9.1.0","v8.19.0"],"title":"[Security Solution] [AI assistant ] Fix error where llm.bindTools is not a function.","number":225268,"url":"https://github.com/elastic/kibana/pull/225268","mergeCommit":{"message":"[Security Solution] [AI assistant ] Fix error where llm.bindTools is not a function. (#225268)\n\n## Summary\n\nSummarize your PR. If it involves visual changes, include a screenshot\nor gif.\n\nThis PR fixes a bug where the error message \"llm.bindTools is not a\nfunction\" would appear in the Security AI assistant.\n\n![Screenshot 2025-06-25 at 11 05\n25 AM](https://github.com/user-attachments/assets/3e24b857-667c-4be7-b0ac-236d48decd4f)\n\nChanges:\n- Make AssistantTool.getTool return a promise. This means tools can be\ncreated asynchronously. This eliminates the error, as the error stems\nfrom the promise `createLlmInstance()`\n([ref](https://github.com/elastic/kibana/pull/225268/files#diff-69e7fc6c29ce0673d7d33c0472a012ad310fa571487a6b594d2e1378b3e5f246R286))\nnot being awaited.\n- Improve type definition for tools so that we avoid bugs when the\nAssistantTool type changes e.g.\nhttps://github.com/elastic/kibana/pull/225268/files#diff-b603523fee68a791bd3af770b780fc654eb7866c8d2a73192d29fa935c80e541R17\n\n### How to test:\n- Enable AdvancedEsqlGeneration feature flag:\n```yml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['advancedEsqlGeneration']\n```\n- Start Kibana\n- Open the Security AI assistant\n- Ask a question\n- Expect to see a response from the LLM.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"dc24f2068bcaea069cd27d9395282ac384ad9f14"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225268","number":225268,"mergeCommit":{"message":"[Security Solution] [AI assistant ] Fix error where llm.bindTools is not a function. (#225268)\n\n## Summary\n\nSummarize your PR. If it involves visual changes, include a screenshot\nor gif.\n\nThis PR fixes a bug where the error message \"llm.bindTools is not a\nfunction\" would appear in the Security AI assistant.\n\n![Screenshot 2025-06-25 at 11 05\n25 AM](https://github.com/user-attachments/assets/3e24b857-667c-4be7-b0ac-236d48decd4f)\n\nChanges:\n- Make AssistantTool.getTool return a promise. This means tools can be\ncreated asynchronously. This eliminates the error, as the error stems\nfrom the promise `createLlmInstance()`\n([ref](https://github.com/elastic/kibana/pull/225268/files#diff-69e7fc6c29ce0673d7d33c0472a012ad310fa571487a6b594d2e1378b3e5f246R286))\nnot being awaited.\n- Improve type definition for tools so that we avoid bugs when the\nAssistantTool type changes e.g.\nhttps://github.com/elastic/kibana/pull/225268/files#diff-b603523fee68a791bd3af770b780fc654eb7866c8d2a73192d29fa935c80e541R17\n\n### How to test:\n- Enable AdvancedEsqlGeneration feature flag:\n```yml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['advancedEsqlGeneration']\n```\n- Start Kibana\n- Open the Security AI assistant\n- Ask a question\n- Expect to see a response from the LLM.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"dc24f2068bcaea069cd27d9395282ac384ad9f14"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->