### PR TITLE
[ES|QL] Adds a tooltip at the quick reference icon

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
@@ -16,6 +16,7 @@ import {
   EuiCode,
   EuiButtonIcon,
   EuiButtonEmpty,
+  EuiToolTip,
 } from '@elastic/eui';
 import { Interpolation, Theme, css } from '@emotion/react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -305,13 +306,20 @@ export const EditorFooter = memo(function EditorFooter({
                     />
                   )}
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="documentation"
-                      onClick={toggleLanguageComponent}
-                      aria-label={i18n.translate('esqlEditor.query.documentationAriaLabel', {
-                        defaultMessage: 'Open documentation',
+                    <EuiToolTip
+                      position="top"
+                      content={i18n.translate('esqlEditor.query.quickReferenceLabel', {
+                        defaultMessage: 'Quick reference',
                       })}
-                    />
+                    >
+                      <EuiButtonIcon
+                        iconType="documentation"
+                        onClick={toggleLanguageComponent}
+                        aria-label={i18n.translate('esqlEditor.query.documentationAriaLabel', {
+                          defaultMessage: 'Open documentation',
+                        })}
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                   <KeyboardShortcuts />
                 </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Adds a tooltip at the Quick reference icon, all the other icons have one already

<img width="426" alt="image" src="https://github.com/user-attachments/assets/667703cf-c85a-4b27-853e-696d5927f9a3" />



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->