### PR TITLE
[OAS] Remove doc version

### DIFF
--- a/oas_docs/kibana.info.serverless.yaml
+++ b/oas_docs/kibana.info.serverless.yaml
@@ -27,6 +27,7 @@ info:
 
     This documentation is derived from the `main` branch of the [kibana](https://github.com/elastic/kibana) repository.
     It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+  version: '' # Leave empty
   x-doc-license:
     name: Attribution-NonCommercial-NoDerivatives 4.0 International
     url: https://creativecommons.org/licenses/by-nc-nd/4.0/

--- a/oas_docs/kibana.info.serverless.yaml
+++ b/oas_docs/kibana.info.serverless.yaml
@@ -8,14 +8,14 @@ info:
     and must include all of the necessary information for Kibana to fulfill the
     request. API requests return JSON output, which is a format that is
     machine-readable and works well for automation.
-    
+
     To interact with Kibana APIs, use the following operations:
-    
+
     - GET: Fetches the information.
     - POST: Adds new information.
     - PUT: Updates the existing information.
     - DELETE: Removes the information.
-    
+
     You can prepend any Kibana API endpoint with `kbn:` and run the request in
     **Dev Tools → Console**. For example:
 
@@ -24,14 +24,13 @@ info:
     ```
 
     ## Documentation source and versions
-    
+
     This documentation is derived from the `main` branch of the [kibana](https://github.com/elastic/kibana) repository.
     It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
-  version: "1.0.2"
   x-doc-license:
     name: Attribution-NonCommercial-NoDerivatives 4.0 International
     url: https://creativecommons.org/licenses/by-nc-nd/4.0/
-  contact: 
+  contact:
     name: Kibana Team
   x-feedbackLink:
     label: Feedback

--- a/oas_docs/kibana.info.yaml
+++ b/oas_docs/kibana.info.yaml
@@ -33,7 +33,6 @@ info:
     It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
 
     This documentation contains work-in-progress information for future Elastic Stack releases.
-  version: '1.0.2'
   x-doc-license:
     name: Attribution-NonCommercial-NoDerivatives 4.0 International
     url: https://creativecommons.org/licenses/by-nc-nd/4.0/

--- a/oas_docs/kibana.info.yaml
+++ b/oas_docs/kibana.info.yaml
@@ -33,6 +33,7 @@ info:
     It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
 
     This documentation contains work-in-progress information for future Elastic Stack releases.
+  version: '' # Leave empty
   x-doc-license:
     name: Attribution-NonCommercial-NoDerivatives 4.0 International
     url: https://creativecommons.org/licenses/by-nc-nd/4.0/

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -29,7 +29,7 @@ info:
     This documentation is derived from the `main` branch of the [kibana](https://github.com/elastic/kibana) repository.
     It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
   title: Kibana Serverless APIs
-  version: 1.0.2
+  version: ''
   x-doc-license:
     name: Attribution-NonCommercial-NoDerivatives 4.0 International
     url: https://creativecommons.org/licenses/by-nc-nd/4.0/

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -35,7 +35,7 @@ info:
 
     This documentation contains work-in-progress information for future Elastic Stack releases.
   title: Kibana APIs
-  version: 1.0.2
+  version: ''
   x-doc-license:
     name: Attribution-NonCommercial-NoDerivatives 4.0 International
     url: https://creativecommons.org/licenses/by-nc-nd/4.0/


### PR DESCRIPTION
## Summary

Per the title. This conforms with ES API docs as rendered on our docs sites: https://www.elastic.co/docs/api/doc/elasticsearch/


<img width="327" alt="Screenshot 2025-06-26 at 17 14 51" src="https://github.com/user-attachments/assets/82f2bda0-e846-4865-bf77-7ffad1f0090a" />



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->