### PR TITLE
[ES|QL] Expand to fit the query on editor mount

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -745,6 +745,7 @@ export const QueryBarTopRow = React.memo(
             errors={props.textBasedLanguageModeErrors}
             warning={props.textBasedLanguageModeWarning}
             detectedTimestamp={detectedTimestamp}
+            expandToFitQueryOnMount
             onTextLangQuerySubmit={async () =>
               onSubmit({
                 query: queryRef.current,


### PR DESCRIPTION
## Summary

Enabling the expand to fit query on mount in Discover



![meow](https://github.com/user-attachments/assets/49bd8dc2-cadc-4b58-82d3-eb12f0eb24a1)



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->