### PR TITLE
[Fleet] Fix string escaping 

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/security/uninstall_token_service/index.ts
@@ -242,7 +242,7 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
   private prepareExactPolicyIdQuery(policyId: string | undefined): string | undefined {
     if (!policyId) return undefined;
     // Escape special characters but don't add wildcards for exact matching
-    return policyId.replace(new RegExp(/[@#&*+()\[\]{}|.?~"<]/, 'g'), '\\$&');
+    return this.prepareSearchString(policyId, /[@#&*+()\[\]{}|.?~"<]/, '');
   }
   private prepareRegexpQuery(str: string | undefined): string | undefined {
     return this.prepareSearchString(str, /[@#&*+()[\]{}|.?~"<]/, '.*');


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/1767

Fixes a string escaping flaw in the regex, switched to using the built in function that safely escapes special characters


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A




<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->