### PR TITLE
[OpenAI Connector] Get `http` info from config url, not proxyUrl

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
@@ -87,9 +87,7 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
       const defaultHeaders = { ...this.headers };
       let defaultQuery: Record<string, string> | undefined;
 
-      const isHttps = (this.configurationUtilities.getProxySettings()?.proxyUrl ?? this.url)
-        .toLowerCase()
-        .startsWith('https');
+      const isHttps = this.url.toLowerCase().startsWith('https');
 
       if (
         this.provider === OpenAiProviderType.Other &&


### PR DESCRIPTION
## Summary

We need to base the `httpAgent` off of the config url, not the proxy. See this comment for more information: https://github.com/elastic/kibana/pull/224130#discussion_r2152632806

I already did this fix in 8.19 when i had a backport that had conflicts on this line
