### PR TITLE
[Security Solution] [Detections] remove skip for whole suite, only skips individual failing test

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
@@ -2206,10 +2206,11 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload(packetBeatPath);
       });
 
-      it.skip('should handle shard failures and include warning in logs for query that is not aggregating', async () => {
+      it('should handle shard failures and include warning in logs for query that is not aggregating', async () => {
         const doc1 = { agent: { name: 'test-1' } };
         await indexEnhancedDocuments({
           documents: [doc1],
+          interval: ['2020-10-28T06:00:00.000Z', '2020-10-28T06:10:00.000Z'],
           id: uuidv4(),
         });
 

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
@@ -65,7 +65,6 @@ export default ({ getService }: FtrProviderContext) => {
    */
   const internalIdPipe = (id: string) => `| where id=="${id}"`;
 
-  // Failing: See https://github.com/elastic/kibana/issues/224699
   describe('@ess @serverless ES|QL rule type', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/security_solution/ecs_compliant');

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
@@ -66,7 +66,7 @@ export default ({ getService }: FtrProviderContext) => {
   const internalIdPipe = (id: string) => `| where id=="${id}"`;
 
   // Failing: See https://github.com/elastic/kibana/issues/224699
-  describe.skip('@ess @serverless ES|QL rule type', () => {
+  describe('@ess @serverless ES|QL rule type', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/security_solution/ecs_compliant');
     });
@@ -2206,7 +2206,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload(packetBeatPath);
       });
 
-      it('should handle shard failures and include warning in logs for query that is not aggregating', async () => {
+      it.skip('should handle shard failures and include warning in logs for query that is not aggregating', async () => {
         const doc1 = { agent: { name: 'test-1' } };
         await indexEnhancedDocuments({
           documents: [doc1],


### PR DESCRIPTION
Ref: https://github.com/elastic/kibana/issues/224699




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->