### PR TITLE
Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute·ts - alerting api integration security and spaces enabled - Group 2 Connectors execute no_kibana_privileges at space1 should log api key information from execute request

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
@@ -1706,6 +1706,7 @@ describe('Event log', () => {
       ...mockUser,
       authentication_type: 'api_key',
       api_key: {
+        managed_by: 'elasticsearch',
         id: '456',
         name: 'test api key',
       },

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -551,7 +551,13 @@ export class ActionExecutor {
           event.user = event.user || {};
           event.user.name = currentUser?.username;
           event.user.id = currentUser?.profile_uid;
-          event.kibana!.user_api_key = currentUser?.api_key;
+          if (currentUser?.api_key) {
+            event.kibana!.user_api_key = {
+              name: currentUser.api_key?.name,
+              id: currentUser.api_key?.id,
+            };
+          }
+
           set(
             event,
             'kibana.action.execution.usage.request_body_bytes',

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute.ts
@@ -24,8 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
 
   const authorizationIndex = '.kibana-test-authorization';
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/224987
-  describe.skip('execute', () => {
+  describe('execute', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     before(async () => {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/224987

## Summary

This test was failing the ES snapshot promotion pipeline. See in the logs:

```
[00:04:15]             â”‚ proc [kbn-ui] [2025-06-26T17:44:06.841+00:00][WARN ][plugins.eventLog] invalid event logged: [kibana.user_api_key.managed_by]: definition for this key is missing; {"@timestamp":"2025-06-26T17:44:06.840Z","event":{"provider":"actions","action":"execute","kind":"action","start":"2025-06-26T17:44:06.762Z","end":"2025-06-26T17:44:06.840Z","duration":"78000000","outcome":"success"},"kibana":{"saved_objects":[{"rel":"primary","type":"action","id":"c4a64b3b-e5f5-4ffc-a58c-98584b6b5e59","type_id":"test.index-record","namespace":"space1"}],"space_ids":["space1"],"action":{"name":"My Connector","id":"c4a64b3b-e5f5-4ffc-a58c-98584b6b5e59","type_id":"test.index-record","execution":{"uuid":"ecbbf89f-729a-416c-a711-05b0a1e27de6","source":"http_request","usage":{"request_body_bytes":0}}},"user_api_key":{"managed_by":"elasticsearch","name":"test user managed key","id":"r1RWrZcB4HDiQQlB8SOM"},"server_uuid":"5b2de169-2785-441b-ae8c-186a1936b17d","version":"9.1.0"},"user":{"name":"elastic"},"message":"action executed: test.index-record:c4a64b3b-e5f5-4ffc-a58c-98584b6b5e59: My Connector","ecs":{"version":"1.8.0"}}) {"service":{"node":{"roles":["ui"]}}}
```

So it looks like the `api_key` information now returns a `managed_by` field which we were copying over to the event log but was not accepted by the event log schema. Updated the code to only copy over the `name` and `id` field to address this. Can open a followup issue to see if we want to copy over the `managed_by` field.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->