### PR TITLE
[8.18] [OpenAI Connector] Get `http` info from config url, not proxyUrl (#225541)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
@@ -81,7 +81,7 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
       this.url
     );
 
-      const isHttps = this.url.toLowerCase().startsWith('https');
+    const isHttps = this.url.toLowerCase().startsWith('https');
 
     this.openAI =
       this.config.apiProvider === OpenAiProviderType.AzureAi

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
@@ -81,9 +81,7 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
       this.url
     );
 
-    const isHttps = (this.configurationUtilities.getProxySettings()?.proxyUrl ?? this.url)
-      .toLowerCase()
-      .startsWith('https');
+      const isHttps = this.url.toLowerCase().startsWith('https');
 
     this.openAI =
       this.config.apiProvider === OpenAiProviderType.AzureAi


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[OpenAI Connector] Get `http` info from config url, not proxyUrl (#225541)](https://github.com/elastic/kibana/pull/225541)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Steph Milovic","email":"stephanie.milovic@elastic.co"},"sourceCommit":{"committedDate":"2025-06-26T22:16:32Z","message":"[OpenAI Connector] Get `http` info from config url, not proxyUrl (#225541)","sha":"4543f3e25d362f2791df6b92be6ebfc9bd23375a","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Security Generative AI","v9.1.0","v9.2.0","v8.18.4","v9.0.4"],"title":"[OpenAI Connector] Get `http` info from config url, not proxyUrl","number":225541,"url":"https://github.com/elastic/kibana/pull/225541","mergeCommit":{"message":"[OpenAI Connector] Get `http` info from config url, not proxyUrl (#225541)","sha":"4543f3e25d362f2791df6b92be6ebfc9bd23375a"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225541","number":225541,"mergeCommit":{"message":"[OpenAI Connector] Get `http` info from config url, not proxyUrl (#225541)","sha":"4543f3e25d362f2791df6b92be6ebfc9bd23375a"}},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->