### PR TITLE
Use elasticsearch.query logger instead of debugESCall

### DIFF
--- a/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
@@ -201,10 +201,6 @@ export const instrumentEsQueryAndDeprecationLogger = ({
     const customLoggerName = event?.meta?.request?.options?.context?.requesterPlugin as
       | string
       | undefined;
-    // if (event?.meta.request.params.path.includes('/_count')) {
-    //   console.log(JSON.stringify(event, null, 2));
-    //   console.log(customLoggerName);
-    // }
 
     const customLogger = customLoggerName ? queryLogger.get(customLoggerName) : queryLogger;
     const level = customLoggerName ? 'info' : 'debug';

--- a/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
@@ -203,12 +203,12 @@ export const instrumentEsQueryAndDeprecationLogger = ({
       | ElasticsearchRequestLoggingOptions
       | undefined;
 
-    const { loggerName, level = 'debug' } = requestLoggingOptions || {};
+    const { loggerName } = requestLoggingOptions || {};
     const customLogger = loggerName ? logger.get('query', loggerName) : queryLogger;
 
     // we could check this once and not subscribe to response events if both are disabled,
     // but then we would not be supporting hot reload of the logging configuration.
-    const logQuery = customLogger.isLevelEnabled(level);
+    const logQuery = customLogger.isLevelEnabled('debug');
     const logDeprecation = deprecationLogger.isLevelEnabled('debug');
 
     if (error && isMaximumResponseSizeExceededError(error)) {
@@ -221,7 +221,7 @@ export const instrumentEsQueryAndDeprecationLogger = ({
 
       if (logQuery) {
         const meta = getEcsResponseLog(event, bytes);
-        customLogger[level](queryMsg, meta);
+        customLogger.debug(queryMsg, meta);
       }
 
       if (logDeprecation && event.warnings && event.warnings.filter(isEsWarning).length > 0) {

--- a/src/core/packages/elasticsearch/server/index.ts
+++ b/src/core/packages/elasticsearch/server/index.ts
@@ -9,6 +9,7 @@
 
 export type {
   ElasticsearchClient,
+  ElasticsearchRequestLoggingOptions,
   IScopedClusterClient,
   IClusterClient,
   ICustomClusterClient,

--- a/src/core/packages/elasticsearch/server/src/client/client.ts
+++ b/src/core/packages/elasticsearch/server/src/client/client.ts
@@ -18,3 +18,20 @@ export type ElasticsearchClient = Omit<
   Client,
   'connectionPool' | 'serializer' | 'extend' | 'close' | 'diagnostic'
 >;
+
+/**
+ * Options for configuring per-request logging.
+ *
+ * @public
+ */
+export interface ElasticsearchRequestLoggingOptions {
+  /**
+   * The logger to use for logging requests. It results in the logger `elasticsearch.query.<loggerName>`.
+   * This allows grouping logs by the logger name, and using different configurations for each logger.
+   */
+  loggerName: string;
+  /**
+   * The level at which to log the request.
+   */
+  level: 'debug' | 'info';
+}

--- a/src/core/packages/elasticsearch/server/src/client/client.ts
+++ b/src/core/packages/elasticsearch/server/src/client/client.ts
@@ -26,7 +26,7 @@ export type ElasticsearchClient = Omit<
  */
 export interface ElasticsearchRequestLoggingOptions {
   /**
-   * The logger to use for logging requests. It results in the logger `elasticsearch.query.<loggerName>`.
+   * The logger name to use for logging requests. It results in the logger name `elasticsearch.query.<loggerName>`.
    * This allows grouping logs by the logger name, and using different configurations for each logger.
    */
   loggerName: string;

--- a/src/core/packages/elasticsearch/server/src/client/client.ts
+++ b/src/core/packages/elasticsearch/server/src/client/client.ts
@@ -30,8 +30,4 @@ export interface ElasticsearchRequestLoggingOptions {
    * This allows grouping logs by the logger name, and using different configurations for each logger.
    */
   loggerName: string;
-  /**
-   * The level at which to log the request.
-   */
-  level: 'debug' | 'info';
 }

--- a/src/core/packages/elasticsearch/server/src/client/index.ts
+++ b/src/core/packages/elasticsearch/server/src/client/index.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { ElasticsearchClient } from './client';
+export type { ElasticsearchClient, ElasticsearchRequestLoggingOptions } from './client';
 export type { IClusterClient, ICustomClusterClient } from './cluster_client';
 export type { ScopeableRequest, FakeRequest } from './scopeable_request';
 export type { IScopedClusterClient } from './scoped_cluster_client';

--- a/src/core/packages/logging/server/src/contracts.ts
+++ b/src/core/packages/logging/server/src/contracts.ts
@@ -20,7 +20,7 @@ export interface LoggingServiceSetup {
    * Customizes the logging config for the plugin's context.
    *
    * @remarks
-   * Assumes that that the `context` property of the individual `logger` items emitted by `config$`
+   * Assumes that the `context` property of the individual `logger` items emitted by `config$`
    * are relative to the plugin's logging context (defaults to `plugins.<plugin_id>`).
    *
    * @example

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -110,6 +110,7 @@ export type {
   FakeRequest,
   ScopeableRequest,
   ElasticsearchClient,
+  ElasticsearchRequestLoggingOptions,
   IClusterClient,
   ICustomClusterClient,
   ElasticsearchClientConfig,

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
@@ -168,7 +168,7 @@ describe('tlsRuleExecutor', () => {
             }),
           }),
         }),
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
     });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
@@ -168,7 +168,7 @@ describe('tlsRuleExecutor', () => {
             }),
           }),
         }),
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
     });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
@@ -109,7 +109,7 @@ describe('SyntheticsEsClient', () => {
           index: 'synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
       expect(result).toEqual({
         body: {},
@@ -137,7 +137,7 @@ describe('SyntheticsEsClient', () => {
           index: 'synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
     });
   });
@@ -150,7 +150,10 @@ describe('SyntheticsEsClient', () => {
 
       const result = await syntheticsEsClient.count(mockCountParams);
 
-      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, { meta: true });
+      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
+        meta: true,
+        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+      });
       expect(result).toEqual({
         indices: 'synthetics-*',
         result: {
@@ -173,7 +176,10 @@ describe('SyntheticsEsClient', () => {
       esClient.count.mockRejectedValueOnce(mockError);
 
       await expect(syntheticsEsClient.count(mockCountParams)).rejects.toThrow(mockError);
-      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, { meta: true });
+      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
+        meta: true,
+        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+      });
     });
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
@@ -109,7 +109,7 @@ describe('SyntheticsEsClient', () => {
           index: 'synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
       expect(result).toEqual({
         body: {},
@@ -137,7 +137,7 @@ describe('SyntheticsEsClient', () => {
           index: 'synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
     });
   });
@@ -152,7 +152,7 @@ describe('SyntheticsEsClient', () => {
 
       expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
         meta: true,
-        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+        context: { loggingOptions: { loggerName: 'synthetics' } },
       });
       expect(result).toEqual({
         indices: 'synthetics-*',
@@ -178,7 +178,7 @@ describe('SyntheticsEsClient', () => {
       await expect(syntheticsEsClient.count(mockCountParams)).rejects.toThrow(mockError);
       expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
         meta: true,
-        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+        context: { loggingOptions: { loggerName: 'synthetics' } },
       });
     });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
@@ -82,14 +82,19 @@ export class SyntheticsEsClient {
 
     let esRequestStatus: RequestStatus = RequestStatus.PENDING;
 
+    const isInspectorEnabled = await this.getInspectEnabled();
     try {
-      res = await this.baseESClient.search(esParams, { meta: true });
+      res = await this.baseESClient.search(esParams, {
+        meta: true,
+        context: {
+          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+        },
+      });
       esRequestStatus = RequestStatus.OK;
     } catch (e) {
       esError = e;
       esRequestStatus = RequestStatus.ERROR;
     }
-    const isInspectorEnabled = await this.getInspectEnabled();
     if ((isInspectorEnabled || this.isDev) && this.request) {
       this.inspectableEsQueries.push(
         getInspectResponse({
@@ -182,13 +187,18 @@ export class SyntheticsEsClient {
     const esParams = { index: SYNTHETICS_INDEX_PATTERN, ...params };
     const startTime = process.hrtime();
 
+    const isInspectorEnabled = await this.getInspectEnabled();
+
     try {
-      res = await this.baseESClient.count(esParams, { meta: true });
+      res = await this.baseESClient.count(esParams, {
+        meta: true,
+        context: {
+          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+        },
+      });
     } catch (e) {
       esError = e;
     }
-
-    const isInspectorEnabled = await this.getInspectEnabled();
 
     if (isInspectorEnabled && this.request) {
       debugESCall({

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
@@ -9,8 +9,9 @@ import {
   SearchSearchRequestBody,
   MsearchMultisearchHeader,
 } from '@elastic/elasticsearch/lib/api/types';
-import {
+import type {
   ElasticsearchClient,
+  ElasticsearchRequestLoggingOptions,
   SavedObjectsClientContract,
   KibanaRequest,
   CoreRequestHandlerContext,
@@ -87,7 +88,7 @@ export class SyntheticsEsClient {
       res = await this.baseESClient.search(esParams, {
         meta: true,
         context: {
-          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
         },
       });
       esRequestStatus = RequestStatus.OK;
@@ -193,7 +194,7 @@ export class SyntheticsEsClient {
       res = await this.baseESClient.count(esParams, {
         meta: true,
         context: {
-          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
         },
       });
     } catch (e) {
@@ -287,3 +288,12 @@ export function debugESCall({
 export const isTestUser = (server: SyntheticsServerSetup) => {
   return server.config.service?.username === 'localKibanaIntegrationTestsUser';
 };
+
+function getElasticsearchRequestLoggingOptions(
+  isInspectorEnabled?: boolean
+): ElasticsearchRequestLoggingOptions {
+  return {
+    loggerName: 'synthetics',
+    level: isInspectorEnabled ? 'info' : 'debug',
+  };
+}

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
@@ -82,11 +82,12 @@ export class SyntheticsEsClient {
     let esRequestStatus: RequestStatus = RequestStatus.PENDING;
 
     const isInspectorEnabled = await this.getInspectEnabled();
+
     try {
       res = await this.baseESClient.search(esParams, {
         meta: true,
         context: {
-          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
+          loggingOptions: getElasticsearchRequestLoggingOptions(),
         },
       });
       esRequestStatus = RequestStatus.OK;
@@ -94,6 +95,7 @@ export class SyntheticsEsClient {
       esError = e;
       esRequestStatus = RequestStatus.ERROR;
     }
+
     if ((isInspectorEnabled || this.isDev) && this.request) {
       this.inspectableEsQueries.push(
         getInspectResponse({
@@ -175,13 +177,11 @@ export class SyntheticsEsClient {
 
     const esParams = { index: SYNTHETICS_INDEX_PATTERN, ...params };
 
-    const isInspectorEnabled = await this.getInspectEnabled();
-
     try {
       res = await this.baseESClient.count(esParams, {
         meta: true,
         context: {
-          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
+          loggingOptions: getElasticsearchRequestLoggingOptions(),
         },
       });
     } catch (e) {
@@ -228,11 +228,8 @@ export const isTestUser = (server: SyntheticsServerSetup) => {
   return server.config.service?.username === 'localKibanaIntegrationTestsUser';
 };
 
-function getElasticsearchRequestLoggingOptions(
-  isInspectorEnabled?: boolean
-): ElasticsearchRequestLoggingOptions {
+function getElasticsearchRequestLoggingOptions(): ElasticsearchRequestLoggingOptions {
   return {
     loggerName: 'synthetics',
-    level: isInspectorEnabled ? 'info' : 'debug',
   };
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
@@ -214,6 +214,12 @@ describe('getNetworkEvents', () => {
             "track_total_hits": true,
           },
           Object {
+            "context": Object {
+              "loggingOptions": Object {
+                "level": "debug",
+                "loggerName": "synthetics",
+              },
+            },
             "meta": true,
           },
         ],

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
@@ -216,7 +216,6 @@ describe('getNetworkEvents', () => {
           Object {
             "context": Object {
               "loggingOptions": Object {
-                "level": "debug",
                 "loggerName": "synthetics",
               },
             },

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.test.ts
@@ -43,7 +43,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*',
           ...mockSearchParams,
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
       expect(result).toEqual({
         body: {},
@@ -71,7 +71,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*',
           ...mockSearchParams,
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
     });
   });
@@ -84,7 +84,10 @@ describe('UptimeEsClient', () => {
 
       const result = await uptimeEsClient.count(mockCountParams);
 
-      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, { meta: true });
+      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
+        meta: true,
+        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+      });
       expect(result).toEqual({
         indices: 'heartbeat-*',
         result: {
@@ -107,7 +110,10 @@ describe('UptimeEsClient', () => {
       esClient.count.mockRejectedValueOnce(mockError);
 
       await expect(uptimeEsClient.count(mockCountParams)).rejects.toThrow(mockError);
-      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, { meta: true });
+      expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
+        meta: true,
+        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+      });
     });
   });
 
@@ -160,7 +166,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*,synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
     });
     it('appends synthetics-* in index for legacy alerts when settings are never saved', async () => {
@@ -189,7 +195,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*,synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
     });
     it('does not append synthetics-* to index for stack version 8.10.0 or later', async () => {
@@ -216,7 +222,7 @@ describe('UptimeEsClient', () => {
             match_all: {},
           },
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
 
       uptimeEsClient = new UptimeEsClient(savedObjectsClient, esClient, {
@@ -236,7 +242,7 @@ describe('UptimeEsClient', () => {
             match_all: {},
           },
         },
-        { meta: true }
+        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
       );
     });
   });

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.test.ts
@@ -43,7 +43,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
       expect(result).toEqual({
         body: {},
@@ -71,7 +71,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
     });
   });
@@ -86,7 +86,7 @@ describe('UptimeEsClient', () => {
 
       expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
         meta: true,
-        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+        context: { loggingOptions: { loggerName: 'synthetics' } },
       });
       expect(result).toEqual({
         indices: 'heartbeat-*',
@@ -112,7 +112,7 @@ describe('UptimeEsClient', () => {
       await expect(uptimeEsClient.count(mockCountParams)).rejects.toThrow(mockError);
       expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
         meta: true,
-        context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+        context: { loggingOptions: { loggerName: 'synthetics' } },
       });
     });
   });
@@ -166,7 +166,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*,synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
     });
     it('appends synthetics-* in index for legacy alerts when settings are never saved', async () => {
@@ -195,7 +195,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*,synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
     });
     it('does not append synthetics-* to index for stack version 8.10.0 or later', async () => {
@@ -222,7 +222,7 @@ describe('UptimeEsClient', () => {
             match_all: {},
           },
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
 
       uptimeEsClient = new UptimeEsClient(savedObjectsClient, esClient, {
@@ -242,7 +242,7 @@ describe('UptimeEsClient', () => {
             match_all: {},
           },
         },
-        { meta: true, context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
       );
     });
   });

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
@@ -13,7 +13,6 @@ import {
   SavedObjectsErrorHelpers,
   type ElasticsearchRequestLoggingOptions,
 } from '@kbn/core/server';
-import chalk from 'chalk';
 import type { estypes } from '@elastic/elasticsearch';
 import type { ESSearchResponse } from '@kbn/es-types';
 import { RequestStatus } from '@kbn/inspector-plugin/common';
@@ -101,7 +100,6 @@ export class UptimeEsClient {
     await this.initSettings();
 
     const esParams = { index: index ?? this.heartbeatIndices, ...params };
-    const startTime = process.hrtime();
 
     const startTimeNow = Date.now();
 
@@ -134,15 +132,6 @@ export class UptimeEsClient {
         })
       );
     }
-    if (isInspectorEnabled && this.request) {
-      debugESCall({
-        startTime,
-        request: this.request,
-        esError,
-        operationName: 'search',
-        params: esParams,
-      });
-    }
 
     if (esError) {
       throw esError;
@@ -157,7 +146,6 @@ export class UptimeEsClient {
     await this.initSettings();
 
     const esParams = { index: this.heartbeatIndices, ...params };
-    const startTime = process.hrtime();
 
     const isInspectorEnabled = await this.getInspectEnabled();
 
@@ -170,16 +158,6 @@ export class UptimeEsClient {
       });
     } catch (e) {
       esError = e;
-    }
-
-    if (isInspectorEnabled && this.request) {
-      debugESCall({
-        startTime,
-        request: this.request,
-        esError,
-        operationName: 'count',
-        params: esParams,
-      });
     }
 
     if (esError) {
@@ -259,44 +237,6 @@ export const shouldAppendSyntheticsIndex = (stackVersion?: string) => {
 
 export function createEsParams<T extends estypes.SearchRequest>(params: T): T {
   return params;
-}
-
-/* eslint-disable no-console */
-
-function formatObj(obj: Record<string, any>) {
-  return JSON.stringify(obj);
-}
-
-export function debugESCall({
-  operationName,
-  params,
-  request,
-  esError,
-  startTime,
-}: {
-  operationName: string;
-  params: Record<string, any>;
-  request: KibanaRequest;
-  esError: any;
-  startTime: [number, number];
-}) {
-  const highlightColor = esError ? 'bgRed' : 'inverse';
-  const diff = process.hrtime(startTime);
-  const duration = `${Math.round(diff[0] * 1000 + diff[1] / 1e6)}ms`;
-  const routeInfo = `${request.route.method.toUpperCase()} ${request.route.path}`;
-
-  console.log(chalk.bold[highlightColor](`=== Debug: ${routeInfo} (${duration}) ===`));
-
-  if (operationName === 'search') {
-    console.log(`GET ${params.index}/_${operationName}`);
-    console.log(formatObj(params.body));
-  } else {
-    console.log(chalk.bold('ES operation:'), operationName);
-
-    console.log(chalk.bold('ES query:'));
-    console.log(formatObj(params));
-  }
-  console.log(`\n`);
 }
 
 function getElasticsearchRequestLoggingOptions(

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
@@ -11,6 +11,7 @@ import {
   KibanaRequest,
   CoreRequestHandlerContext,
   SavedObjectsErrorHelpers,
+  type ElasticsearchRequestLoggingOptions,
 } from '@kbn/core/server';
 import chalk from 'chalk';
 import type { estypes } from '@elastic/elasticsearch';
@@ -112,7 +113,7 @@ export class UptimeEsClient {
       res = await this.baseESClient.search(esParams, {
         meta: true,
         context: {
-          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
         },
       });
       esRequestStatus = RequestStatus.OK;
@@ -164,7 +165,7 @@ export class UptimeEsClient {
       res = await this.baseESClient.count(esParams, {
         meta: true,
         context: {
-          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
         },
       });
     } catch (e) {
@@ -296,4 +297,13 @@ export function debugESCall({
     console.log(formatObj(params));
   }
   console.log(`\n`);
+}
+
+function getElasticsearchRequestLoggingOptions(
+  isInspectorEnabled?: boolean
+): ElasticsearchRequestLoggingOptions {
+  return {
+    loggerName: 'synthetics',
+    level: isInspectorEnabled ? 'info' : 'debug',
+  };
 }

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
@@ -106,8 +106,15 @@ export class UptimeEsClient {
 
     let esRequestStatus: RequestStatus = RequestStatus.PENDING;
 
+    const isInspectorEnabled = await this.getInspectEnabled();
+
     try {
-      res = await this.baseESClient.search(esParams, { meta: true });
+      res = await this.baseESClient.search(esParams, {
+        meta: true,
+        context: {
+          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+        },
+      });
       esRequestStatus = RequestStatus.OK;
     } catch (e) {
       esError = e;
@@ -126,7 +133,6 @@ export class UptimeEsClient {
         })
       );
     }
-    const isInspectorEnabled = await this.getInspectEnabled();
     if (isInspectorEnabled && this.request) {
       debugESCall({
         startTime,
@@ -152,13 +158,18 @@ export class UptimeEsClient {
     const esParams = { index: this.heartbeatIndices, ...params };
     const startTime = process.hrtime();
 
+    const isInspectorEnabled = await this.getInspectEnabled();
+
     try {
-      res = await this.baseESClient.count(esParams, { meta: true });
+      res = await this.baseESClient.count(esParams, {
+        meta: true,
+        context: {
+          requesterPlugin: isInspectorEnabled ? 'synthetics' : undefined,
+        },
+      });
     } catch (e) {
       esError = e;
     }
-
-    const isInspectorEnabled = await this.getInspectEnabled();
 
     if (isInspectorEnabled && this.request) {
       debugESCall({

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
@@ -105,13 +105,11 @@ export class UptimeEsClient {
 
     let esRequestStatus: RequestStatus = RequestStatus.PENDING;
 
-    const isInspectorEnabled = await this.getInspectEnabled();
-
     try {
       res = await this.baseESClient.search(esParams, {
         meta: true,
         context: {
-          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
+          loggingOptions: getElasticsearchRequestLoggingOptions(),
         },
       });
       esRequestStatus = RequestStatus.OK;
@@ -147,13 +145,11 @@ export class UptimeEsClient {
 
     const esParams = { index: this.heartbeatIndices, ...params };
 
-    const isInspectorEnabled = await this.getInspectEnabled();
-
     try {
       res = await this.baseESClient.count(esParams, {
         meta: true,
         context: {
-          loggingOptions: getElasticsearchRequestLoggingOptions(isInspectorEnabled),
+          loggingOptions: getElasticsearchRequestLoggingOptions(),
         },
       });
     } catch (e) {
@@ -239,11 +235,8 @@ export function createEsParams<T extends estypes.SearchRequest>(params: T): T {
   return params;
 }
 
-function getElasticsearchRequestLoggingOptions(
-  isInspectorEnabled?: boolean
-): ElasticsearchRequestLoggingOptions {
+function getElasticsearchRequestLoggingOptions(): ElasticsearchRequestLoggingOptions {
   return {
     loggerName: 'synthetics',
-    level: isInspectorEnabled ? 'info' : 'debug',
   };
 }

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_details.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_details.test.ts.snap
@@ -56,6 +56,12 @@ Array [
     "size": 0,
   },
   Object {
+    "context": Object {
+      "loggingOptions": Object {
+        "level": "debug",
+        "loggerName": "synthetics",
+      },
+    },
     "meta": true,
   },
 ]
@@ -105,6 +111,12 @@ Array [
     ],
   },
   Object {
+    "context": Object {
+      "loggingOptions": Object {
+        "level": "debug",
+        "loggerName": "synthetics",
+      },
+    },
     "meta": true,
   },
 ]

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_details.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_details.test.ts.snap
@@ -58,7 +58,6 @@ Array [
   Object {
     "context": Object {
       "loggingOptions": Object {
-        "level": "debug",
         "loggerName": "synthetics",
       },
     },
@@ -113,7 +112,6 @@ Array [
   Object {
     "context": Object {
       "loggingOptions": Object {
-        "level": "debug",
         "loggerName": "synthetics",
       },
     },

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_duration.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_duration.test.ts.snap
@@ -70,6 +70,12 @@ Array [
     "size": 0,
   },
   Object {
+    "context": Object {
+      "loggingOptions": Object {
+        "level": "debug",
+        "loggerName": "synthetics",
+      },
+    },
     "meta": true,
   },
 ]

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_duration.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_duration.test.ts.snap
@@ -72,7 +72,6 @@ Array [
   Object {
     "context": Object {
       "loggingOptions": Object {
-        "level": "debug",
         "loggerName": "synthetics",
       },
     },

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_certs.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_certs.test.ts
@@ -254,6 +254,12 @@ describe('getCerts', () => {
             ],
           },
           Object {
+            "context": Object {
+              "loggingOptions": Object {
+                "level": "debug",
+                "loggerName": "synthetics",
+              },
+            },
             "meta": true,
           },
         ],

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_certs.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_certs.test.ts
@@ -256,7 +256,6 @@ describe('getCerts', () => {
           Object {
             "context": Object {
               "loggingOptions": Object {
-                "level": "debug",
                 "loggerName": "synthetics",
               },
             },

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_latest_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_latest_monitor.test.ts
@@ -105,6 +105,9 @@ describe('getLatestMonitor', () => {
     expect(result.timestamp).toBe('123456');
     expect(result.monitor).not.toBeFalsy();
     expect(result?.monitor?.id).toBe('testMonitor');
-    expect(mockEsClient.search).toHaveBeenCalledWith(expectedGetLatestSearchParams, { meta: true });
+    expect(mockEsClient.search).toHaveBeenCalledWith(expectedGetLatestSearchParams, {
+      meta: true,
+      context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+    });
   });
 });

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_latest_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_latest_monitor.test.ts
@@ -107,7 +107,7 @@ describe('getLatestMonitor', () => {
     expect(result?.monitor?.id).toBe('testMonitor');
     expect(mockEsClient.search).toHaveBeenCalledWith(expectedGetLatestSearchParams, {
       meta: true,
-      context: { loggingOptions: { level: 'debug', loggerName: 'synthetics' } },
+      context: { loggingOptions: { loggerName: 'synthetics' } },
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.test.ts
@@ -857,6 +857,12 @@ describe('monitor availability', () => {
             "size": 0,
           },
           Object {
+            "context": Object {
+              "loggingOptions": Object {
+                "level": "debug",
+                "loggerName": "synthetics",
+              },
+            },
             "meta": true,
           },
         ]

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.test.ts
@@ -859,7 +859,6 @@ describe('monitor availability', () => {
           Object {
             "context": Object {
               "loggingOptions": Object {
-                "level": "debug",
                 "loggerName": "synthetics",
               },
             },

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_network_events.test.ts
@@ -214,6 +214,12 @@ describe('getNetworkEvents', () => {
             "track_total_hits": true,
           },
           Object {
+            "context": Object {
+              "loggingOptions": Object {
+                "level": "debug",
+                "loggerName": "synthetics",
+              },
+            },
             "meta": true,
           },
         ],

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_network_events.test.ts
@@ -216,7 +216,6 @@ describe('getNetworkEvents', () => {
           Object {
             "context": Object {
               "loggingOptions": Object {
-                "level": "debug",
                 "loggerName": "synthetics",
               },
             },

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_pings.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_pings.test.ts
@@ -164,6 +164,12 @@ describe('getAll', () => {
           ],
         },
         Object {
+          "context": Object {
+            "loggingOptions": Object {
+              "level": "debug",
+              "loggerName": "synthetics",
+            },
+          },
           "meta": true,
         },
       ]
@@ -224,6 +230,12 @@ describe('getAll', () => {
           ],
         },
         Object {
+          "context": Object {
+            "loggingOptions": Object {
+              "level": "debug",
+              "loggerName": "synthetics",
+            },
+          },
           "meta": true,
         },
       ]
@@ -284,6 +296,12 @@ describe('getAll', () => {
           ],
         },
         Object {
+          "context": Object {
+            "loggingOptions": Object {
+              "level": "debug",
+              "loggerName": "synthetics",
+            },
+          },
           "meta": true,
         },
       ]
@@ -349,6 +367,12 @@ describe('getAll', () => {
           ],
         },
         Object {
+          "context": Object {
+            "loggingOptions": Object {
+              "level": "debug",
+              "loggerName": "synthetics",
+            },
+          },
           "meta": true,
         },
       ]
@@ -455,6 +479,12 @@ describe('getAll', () => {
           ],
         },
         Object {
+          "context": Object {
+            "loggingOptions": Object {
+              "level": "debug",
+              "loggerName": "synthetics",
+            },
+          },
           "meta": true,
         },
       ]

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_pings.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_pings.test.ts
@@ -166,7 +166,6 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "level": "debug",
               "loggerName": "synthetics",
             },
           },
@@ -232,7 +231,6 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "level": "debug",
               "loggerName": "synthetics",
             },
           },
@@ -298,7 +296,6 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "level": "debug",
               "loggerName": "synthetics",
             },
           },
@@ -369,7 +366,6 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "level": "debug",
               "loggerName": "synthetics",
             },
           },
@@ -481,7 +477,6 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "level": "debug",
               "loggerName": "synthetics",
             },
           },


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/210156

This PR explores the option of ES request callers being able to provide a `requesterPlugin` (name TBD), so that our ES logger logs the queries for them.

```
[2025-06-27T03:15:01.647+02:00][INFO ][elasticsearch.query.synthetics] 200 - 95.0B
POST /heartbeat-*/_count?terminate_after=1
{"query":{"range":{"@timestamp":{"gte":"now-7d/d","lte":"now/d"}}}}
```

cc @maryam-saeidi @rudolf 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


