### PR TITLE
[9.1] [Attack Discovery][Scheduling] Cases support followup 1 (#225452)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.test.tsx
@@ -19,6 +19,7 @@ import { useGetAllCaseConfigurations } from '../../../containers/configure/use_g
 import { useGetAllCaseConfigurationsResponse } from '../../configure_cases/__mock__';
 import { templatesConfigurationMock } from '../../../containers/mock';
 import * as utils from '../../../containers/configure/utils';
+import { ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/elastic-assistant-common';
 
 jest.mock('@kbn/alerts-ui-shared/src/common/hooks/use_alerts_data_view');
 jest.mock('../../../common/lib/kibana/use_application');
@@ -72,6 +73,7 @@ describe('CasesParamsFields renders', () => {
     // Workaround for timeout via https://github.com/testing-library/user-event/issues/833#issuecomment-1171452841
     user = userEvent.setup({
       advanceTimers: jest.advanceTimersByTime,
+      pointerEventsCheck: 0,
     });
     useApplicationMock.mockReturnValueOnce({ appId: 'management' });
     useAlertsDataViewMock.mockReturnValue({
@@ -395,6 +397,69 @@ describe('CasesParamsFields renders', () => {
       await user.click(await screen.findByTestId('reopen-case'));
 
       expect(editAction.mock.calls[0][1].reopenClosedCases).toEqual(true);
+    });
+  });
+
+  describe('Attack Discovery', () => {
+    it('does not render `group by` component', async () => {
+      const newProps = {
+        ...defaultProps,
+        ruleTypeId: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+      };
+      render(<CasesParamsFields {...newProps} />);
+
+      expect(screen.queryByTestId('group-by-alert-field-combobox')).not.toBeInTheDocument();
+    });
+
+    it('does not render `time window` component', async () => {
+      const newProps = {
+        ...defaultProps,
+        ruleTypeId: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+      };
+      render(<CasesParamsFields {...newProps} />);
+
+      expect(screen.queryByTestId('time-window-size-input')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('time-window-unit-select')).not.toBeInTheDocument();
+    });
+
+    it('does not render `reopen case` component', async () => {
+      const newProps = {
+        ...defaultProps,
+        ruleTypeId: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+      };
+      render(<CasesParamsFields {...newProps} />);
+
+      expect(screen.queryByTestId('reopen-case')).not.toBeInTheDocument();
+    });
+
+    it('renders disabled `template selector` component', async () => {
+      const newProps = {
+        ...defaultProps,
+        ruleTypeId: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+      };
+      render(<CasesParamsFields {...newProps} />);
+
+      const templateSelectorComponent = await screen.findByTestId('create-case-template-select');
+
+      expect(templateSelectorComponent).toBeInTheDocument();
+      expect(templateSelectorComponent).toBeDisabled();
+    });
+
+    it('shows attack discovery explanation tooltip', async () => {
+      const newProps = {
+        ...defaultProps,
+        ruleTypeId: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+      };
+      render(<CasesParamsFields {...newProps} />);
+
+      await user.hover(await screen.findByTestId('create-case-template-select'));
+
+      expect(await screen.findByTestId('case-action-attack-discovery-tooltip')).toBeTruthy();
+      expect(
+        await screen.findByText(
+          'Attack Discovery Schedules fully manage Case actions, automatically filling in all fields for new Cases.'
+        )
+      ).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.tsx
@@ -188,8 +188,26 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
     [editSubActionProperty]
   );
 
-  const groupByComponent = useMemo(() => {
+  if (isAttackDiscoveryRuleType) {
     return (
+      <EuiToolTip
+        data-test-subj="case-action-attack-discovery-tooltip"
+        content={i18n.ATTACK_DISCOVERY_TEMPLATE_TOOLTIP}
+      >
+        <TemplateSelector
+          key={currentConfiguration.id}
+          isLoading={isLoadingCaseConfiguration}
+          templates={[defaultTemplate, ...currentConfiguration.templates]}
+          onTemplateChange={onTemplateChange}
+          initialTemplate={selectedTemplate}
+          isDisabled={true}
+        />
+      </EuiToolTip>
+    );
+  }
+
+  return (
+    <>
       <EuiFlexGroup>
         <EuiFlexItem grow={true}>
           <EuiFormRow fullWidth label={i18n.GROUP_BY_ALERT} labelAppend={OptionalFieldLabel}>
@@ -207,71 +225,54 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
           </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
-    );
-  }, [loadingAlertDataViews, onChangeComboBox, options, selectedOptions]);
-
-  const timeWindowComponent = useMemo(() => {
-    return (
-      <>
-        <EuiFormRow
-          fullWidth
-          id="timeWindow"
-          error={errors.timeWindow as string[]}
-          isInvalid={
-            errors.timeWindow !== undefined &&
-            Number(errors.timeWindow.length) > 0 &&
-            timeWindow !== undefined
-          }
-        >
-          <EuiFlexGroup alignItems="flexEnd" gutterSize="s">
-            <EuiFlexItem grow={4}>
-              <EuiFieldNumber
-                prepend={i18n.TIME_WINDOW}
-                data-test-subj="time-window-size-input"
-                value={timeWindowSize}
-                min={1}
-                step={1}
-                onChange={(e) => {
-                  handleTimeWindowChange('timeWindowSize', e.target.value);
-                }}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem grow={3}>
-              <EuiSelect
-                fullWidth
-                data-test-subj="time-window-unit-select"
-                value={timeWindowUnit}
-                onChange={(e) => {
-                  handleTimeWindowChange('timeWindowUnit', e.target.value);
-                }}
-                options={getTimeUnitOptions(timeWindowSize)}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFormRow>
-        <EuiSpacer size="s" />
-        {showTimeWindowWarning && (
-          <EuiCallOut
-            data-test-subj="show-time-window-warning"
-            title={i18n.TIME_WINDOW_WARNING}
-            color="warning"
-            iconType="alert"
-            size="s"
-          />
-        )}
-      </>
-    );
-  }, [
-    errors.timeWindow,
-    handleTimeWindowChange,
-    showTimeWindowWarning,
-    timeWindow,
-    timeWindowSize,
-    timeWindowUnit,
-  ]);
-
-  const templateSelectorComponent = useMemo(() => {
-    return (
+      <EuiSpacer size="m" />
+      <EuiFormRow
+        fullWidth
+        id="timeWindow"
+        error={errors.timeWindow as string[]}
+        isInvalid={
+          errors.timeWindow !== undefined &&
+          Number(errors.timeWindow.length) > 0 &&
+          timeWindow !== undefined
+        }
+      >
+        <EuiFlexGroup alignItems="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={4}>
+            <EuiFieldNumber
+              prepend={i18n.TIME_WINDOW}
+              data-test-subj="time-window-size-input"
+              value={timeWindowSize}
+              min={1}
+              step={1}
+              onChange={(e) => {
+                handleTimeWindowChange('timeWindowSize', e.target.value);
+              }}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={3}>
+            <EuiSelect
+              fullWidth
+              data-test-subj="time-window-unit-select"
+              value={timeWindowUnit}
+              onChange={(e) => {
+                handleTimeWindowChange('timeWindowUnit', e.target.value);
+              }}
+              options={getTimeUnitOptions(timeWindowSize)}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFormRow>
+      <EuiSpacer size="s" />
+      {showTimeWindowWarning && (
+        <EuiCallOut
+          data-test-subj="show-time-window-warning"
+          title={i18n.TIME_WINDOW_WARNING}
+          color="warning"
+          iconType="alert"
+          size="s"
+        />
+      )}
+      <EuiSpacer size="m" />
       <EuiFlexGroup>
         <EuiFlexItem grow={true}>
           <TemplateSelector
@@ -280,23 +281,10 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
             templates={[defaultTemplate, ...currentConfiguration.templates]}
             onTemplateChange={onTemplateChange}
             initialTemplate={selectedTemplate}
-            isDisabled={isAttackDiscoveryRuleType}
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-    );
-  }, [
-    currentConfiguration.id,
-    currentConfiguration.templates,
-    defaultTemplate,
-    isAttackDiscoveryRuleType,
-    isLoadingCaseConfiguration,
-    onTemplateChange,
-    selectedTemplate,
-  ]);
-
-  const reopenClosedCasesComponent = useMemo(() => {
-    return (
+      <EuiSpacer size="m" />
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiCheckbox
@@ -310,26 +298,6 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-    );
-  }, [editSubActionProperty, index, reopenClosedCases]);
-
-  if (isAttackDiscoveryRuleType) {
-    return (
-      <EuiToolTip content={i18n.ATTACK_DISCOVERY_TEMPLATE_TOOLTIP}>
-        {templateSelectorComponent}
-      </EuiToolTip>
-    );
-  }
-
-  return (
-    <>
-      {groupByComponent}
-      <EuiSpacer size="m" />
-      {timeWindowComponent}
-      <EuiSpacer size="m" />
-      {templateSelectorComponent}
-      <EuiSpacer size="m" />
-      {reopenClosedCasesComponent}
     </>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Attack Discovery][Scheduling] Cases support followup 1 (#225452)](https://github.com/elastic/kibana/pull/225452)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2025-06-26T19:31:35Z","message":"[Attack Discovery][Scheduling] Cases support followup 1 (#225452)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nThese changes addresses the review comment from my previous PR\nhttps://github.com/elastic/kibana/pull/222827/files/36ed6b38c1efbb742378cb6cf68782cc0962b528#r2150081638\n\nInitially I broke up rendered component into multiple memoized\nsub-sections. Reverting that back and adding tests coverage for the new\nfunctionality - Case actions UI for the Attack Discovery rule type:\n* Hidden `group by` component\n* Hidden `time window` component\n* Hidden `reopen case` component\n* Disabled `template selector` component\n* Tooltip explaining why we disabled the `template selector` component","sha":"d38801034a3f72d9a92039b168cbb11b38c37e69","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Team:Security Generative AI","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Attack Discovery][Scheduling] Cases support followup 1","number":225452,"url":"https://github.com/elastic/kibana/pull/225452","mergeCommit":{"message":"[Attack Discovery][Scheduling] Cases support followup 1 (#225452)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nThese changes addresses the review comment from my previous PR\nhttps://github.com/elastic/kibana/pull/222827/files/36ed6b38c1efbb742378cb6cf68782cc0962b528#r2150081638\n\nInitially I broke up rendered component into multiple memoized\nsub-sections. Reverting that back and adding tests coverage for the new\nfunctionality - Case actions UI for the Attack Discovery rule type:\n* Hidden `group by` component\n* Hidden `time window` component\n* Hidden `reopen case` component\n* Disabled `template selector` component\n* Tooltip explaining why we disabled the `template selector` component","sha":"d38801034a3f72d9a92039b168cbb11b38c37e69"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225452","number":225452,"mergeCommit":{"message":"[Attack Discovery][Scheduling] Cases support followup 1 (#225452)\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\nThese changes addresses the review comment from my previous PR\nhttps://github.com/elastic/kibana/pull/222827/files/36ed6b38c1efbb742378cb6cf68782cc0962b528#r2150081638\n\nInitially I broke up rendered component into multiple memoized\nsub-sections. Reverting that back and adding tests coverage for the new\nfunctionality - Case actions UI for the Attack Discovery rule type:\n* Hidden `group by` component\n* Hidden `time window` component\n* Hidden `reopen case` component\n* Disabled `template selector` component\n* Tooltip explaining why we disabled the `template selector` component","sha":"d38801034a3f72d9a92039b168cbb11b38c37e69"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225543","number":225543,"state":"MERGED","mergeCommit":{"sha":"ab209c1cf3b5a86c67c21695b82a22765bc54799","message":"[8.19] [Attack Discovery][Scheduling] Cases support followup 1 (#225452) (#225543)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Attack Discovery][Scheduling] Cases support followup 1\n(#225452)](https://github.com/elastic/kibana/pull/225452)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ievgen Sorokopud <ievgen.sorokopud@elastic.co>"}},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->