### PR TITLE
[Logs Essential] Disable annotations routes and UI !!

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu.tsx
@@ -24,6 +24,8 @@ export function HeaderMenu(): React.ReactElement | null {
     OBSERVABILITY_ONBOARDING_LOCATOR
   );
   const href = onboardingLocator?.useUrl({});
+  const { pricing } = useKibana().services;
+  const isCompleteOverviewEnabled = pricing.isFeatureAvailable('observability:complete_overview');
 
   const { appMountParameters } = usePluginContext();
 
@@ -35,14 +37,16 @@ export function HeaderMenu(): React.ReactElement | null {
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>
           <EuiHeaderLinks gutterSize="xs">
-            <EuiHeaderLink
-              color="primary"
-              href={http.basePath.prepend('/app/observability/annotations')}
-            >
-              {i18n.translate('xpack.observability.home.annotations', {
-                defaultMessage: 'Annotations',
-              })}
-            </EuiHeaderLink>
+            {isCompleteOverviewEnabled && (
+              <EuiHeaderLink
+                color="primary"
+                href={http.basePath.prepend('/app/observability/annotations')}
+              >
+                {i18n.translate('xpack.observability.home.annotations', {
+                  defaultMessage: 'Annotations',
+                })}
+              </EuiHeaderLink>
+            )}
             <EuiHeaderLink color="primary" href={href}>
               {i18n.translate('xpack.observability.home.addData', {
                 defaultMessage: 'Add data',

--- a/x-pack/solutions/observability/plugins/observability/public/routes/routes.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/routes/routes.tsx
@@ -83,6 +83,20 @@ const completeRoutes = {
     params: {},
     exact: true,
   },
+  [ANNOTATIONS_PATH]: {
+    handler: () => {
+      return <AnnotationsPage />;
+    },
+    params: {},
+    exact: true,
+  },
+  [EXPLORATORY_VIEW_PATH]: {
+    handler: () => {
+      return <SimpleRedirect to="/" redirectToApp="exploratory-view" />;
+    },
+    params: {},
+    exact: true,
+  },
   [CASES_PATH]: {
     handler: () => {
       return <CasesPage />;
@@ -108,13 +122,6 @@ const routes = {
   [ALERTS_PATH]: {
     handler: () => {
       return <AlertsPage />;
-    },
-    params: {},
-    exact: true,
-  },
-  [EXPLORATORY_VIEW_PATH]: {
-    handler: () => {
-      return <SimpleRedirect to="/" redirectToApp="exploratory-view" />;
     },
     params: {},
     exact: true,
@@ -192,13 +199,6 @@ const routes = {
   [OLD_SLO_EDIT_PATH]: {
     handler: () => {
       return <SimpleRedirect to="/:sloId" redirectToApp="slo" />;
-    },
-    params: {},
-    exact: true,
-  },
-  [ANNOTATIONS_PATH]: {
-    handler: () => {
-      return <AnnotationsPage />;
     },
     params: {},
     exact: true,

--- a/x-pack/solutions/observability/plugins/observability/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/plugin.ts
@@ -104,18 +104,6 @@ export class ObservabilityPlugin
 
     core.pricing.registerProductFeatures(OBSERVABILITY_TIERED_FEATURES);
 
-    if (config.annotations.enabled) {
-      annotationsApiPromise = bootstrapAnnotations({
-        core,
-        index: config.annotations.index,
-        context: this.initContext,
-      }).catch((err) => {
-        const logger = this.initContext.logger.get('annotations');
-        logger.warn(err);
-        throw err;
-      });
-    }
-
     const { ruleDataService } = plugins.ruleRegistry;
 
     core.savedObjects.registerType(threshold);
@@ -126,6 +114,21 @@ export class ObservabilityPlugin
     });
 
     void core.getStartServices().then(([coreStart, pluginStart]) => {
+      const isCompleteOverviewEnabled = coreStart.pricing.isFeatureAvailable(
+        'observability:complete_overview'
+      );
+
+      if (config.annotations.enabled && isCompleteOverviewEnabled) {
+        annotationsApiPromise = bootstrapAnnotations({
+          core,
+          index: config.annotations.index,
+          context: this.initContext,
+        }).catch((err) => {
+          const logger = this.initContext.logger.get('annotations');
+          logger.warn(err);
+          throw err;
+        });
+      }
       registerRoutes({
         core,
         dependencies: {

--- a/x-pack/test_serverless/api_integration/test_suites/observability/logs_essentials_only/connector_and_rules.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/logs_essentials_only/connector_and_rules.ts
@@ -62,5 +62,17 @@ export default function ({ getService }: FtrProviderContext) {
         'datasetQuality.degradedDocs',
       ]);
     });
+
+    it('does not register annotations API', async () => {
+      await supertestAdminWithCookieCredentials
+        .post('/api/observability/annotation')
+        .send({})
+        .set(svlCommonApi.getInternalRequestHeader())
+        .expect(404, {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Not Found',
+        });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Disable annotations routes and UI !!

Run kibana with

```
yarn es serverless --projectType oblt --serverless.observability.tier=logs_essentials -E xpack.ml.enabled=false
yarn serverless-oblt --pricing.tiers.products='[{"name":"observability","tier":"logs_essentials"}]'
```

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->