### PR TITLE
[Discover] Don't change selected document when resizing flyout with keyboard (#225447)

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -158,6 +158,13 @@ export function UnifiedDocViewerFlyout({
         return;
       }
 
+      const isResizableButton =
+        (ev.target as HTMLElement).getAttribute('data-test-subj') === 'euiResizableButton';
+      if (isResizableButton) {
+        // ignore events triggered when the resizable button is focused
+        return;
+      }
+
       if (ev.key === keys.ARROW_LEFT || ev.key === keys.ARROW_RIGHT) {
         ev.preventDefault();
         ev.stopPropagation();

--- a/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
@@ -518,6 +518,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
         });
 
+        it('should not navigate between documents with arrow keys when resizable button is focused', async () => {
+          await dataGrid.clickRowToggle({ defaultTabId: false });
+          await discover.isShowingDocViewer();
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-0`);
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+          await testSubjects.click('euiResizableButton');
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+        });
+
         it('should close the flyout with the escape key', async () => {
           await dataGrid.clickRowToggle({ defaultTabId: false });
           expect(await discover.isShowingDocViewer()).to.be(true);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/225447

Adds a new rule to not let the event bubble up to the main table so it doesn't change the selected document when the user is resizing the table via keyboard.

Before
------
https://github.com/user-attachments/assets/417169fa-f2fc-4a5f-9782-09c84ccdb339


After
------
https://github.com/user-attachments/assets/3794e982-c767-4fda-b432-8ca167f9250d




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->