### PR TITLE
[ResponseOps][Reporting] Add callout to scheduled reports flyout when no supported report type is available

### DIFF
--- a/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_flyout_share_wrapper.test.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_flyout_share_wrapper.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  ScheduledReportFlyoutShareWrapper,
+  ScheduledReportMenuItem,
+} from './scheduled_report_flyout_share_wrapper';
+import { useShareTypeContext } from '@kbn/share-plugin/public';
+import { ScheduledReportFlyoutContent } from './scheduled_report_flyout_content';
+
+jest.mock('./scheduled_report_flyout_content');
+jest.mocked(ScheduledReportFlyoutContent).mockReturnValue(<div data-test-subj="flyoutContent" />);
+
+jest.mock('@kbn/share-plugin/public');
+const mockUseShareTypeContext = jest.mocked(useShareTypeContext).mockReturnValue({
+  objectType: 'dashboard',
+  shareMenuItems: [
+    { config: { exportType: 'printablePdfV2', label: 'PDF' } },
+    { config: { exportType: 'csv_searchsource', label: 'CSV' } },
+  ],
+});
+
+const mockApiClient = {} as any;
+const mockReportingServices = { serviceFromReporting: {} } as any;
+const mockSharingData = { title: 'Test Report' } as any;
+const mockOnClose = jest.fn();
+
+const defaultProps: ScheduledReportMenuItem = {
+  apiClient: mockApiClient,
+  services: mockReportingServices,
+  sharingData: mockSharingData,
+  onClose: mockOnClose,
+};
+
+describe('ScheduledReportFlyoutShareWrapper', () => {
+  const mockUseKibana = jest.fn();
+  jest.mock('@kbn/reporting-public', () => ({
+    ...jest.requireActual('@kbn/reporting-public'),
+    useKibana: mockUseKibana,
+  }));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKibana.mockReturnValue({ services: { otherService: {} } });
+  });
+
+  it('should render ScheduledReportFlyoutContent if at least one compatible report type is available', () => {
+    render(<ScheduledReportFlyoutShareWrapper {...defaultProps} />);
+    expect(screen.getByTestId('flyoutContent')).toBeInTheDocument();
+  });
+
+  it('should render null if reporting services are missing', () => {
+    const { container } = render(
+      // @ts-expect-error Testing missing services
+      <ScheduledReportFlyoutShareWrapper {...defaultProps} services={{}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should show a warning CallOut if no report type is supported for scheduling', () => {
+    mockUseShareTypeContext.mockReturnValue({
+      shareMenuItems: [],
+      objectType: 'test',
+    });
+    render(<ScheduledReportFlyoutShareWrapper {...defaultProps} />);
+    expect(screen.getByText('Scheduled reports are not supported here yet')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_flyout_share_wrapper.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_flyout_share_wrapper.tsx
@@ -5,17 +5,20 @@
  * 2.0.
  */
 
-import { useShareTypeContext } from '@kbn/share-plugin/public';
 import React, { useMemo } from 'react';
+import { EuiCallOut, EuiFlyoutBody } from '@elastic/eui';
+import { useShareTypeContext } from '@kbn/share-plugin/public';
 import { ReportingAPIClient, useKibana } from '@kbn/reporting-public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { ReportingSharingData } from '@kbn/reporting-public/share/share_context_menu';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { isEmpty } from 'lodash';
 import { supportedReportTypes } from '../report_params';
 import { queryClient } from '../../query_client';
 import type { ReportingPublicPluginStartDependencies } from '../../plugin';
 import { ScheduledReportFlyoutContent } from './scheduled_report_flyout_content';
 import { ReportTypeId } from '../../types';
+import * as i18n from '../translations';
 
 export interface ScheduledReportMenuItem {
   apiClient: ReportingAPIClient;
@@ -56,8 +59,22 @@ export const ScheduledReportFlyoutShareWrapper = ({
     [sharingData]
   );
 
-  if (!services) {
+  if (isEmpty(reportingServices)) {
     return null;
+  }
+
+  if (!availableReportTypes || availableReportTypes.length === 0) {
+    return (
+      <EuiFlyoutBody>
+        <EuiCallOut
+          title={i18n.SCHEDULED_REPORT_NO_REPORT_TYPES_TITLE}
+          color="warning"
+          iconType="warning"
+        >
+          <p>{i18n.SCHEDULED_REPORT_NO_REPORT_TYPES_MESSAGE}</p>
+        </EuiCallOut>
+      </EuiFlyoutBody>
+    );
   }
 
   return (

--- a/x-pack/platform/plugins/private/reporting/public/management/report_params.ts
+++ b/x-pack/platform/plugins/private/reporting/public/management/report_params.ts
@@ -18,6 +18,7 @@ const reportParamsProviders = {
   pngV2: getPngReportParams,
   printablePdfV2: getPdfReportParams,
   csv_searchsource: getCsvReportParams,
+  csv_v2: getCsvReportParams,
 } as const;
 
 export const supportedReportTypes = Object.keys(reportParamsProviders) as ReportTypeId[];

--- a/x-pack/platform/plugins/private/reporting/public/management/translations.ts
+++ b/x-pack/platform/plugins/private/reporting/public/management/translations.ts
@@ -268,6 +268,20 @@ export const SCHEDULED_REPORT_FORM_FAILURE_TOAST_MESSAGE = i18n.translate(
   }
 );
 
+export const SCHEDULED_REPORT_NO_REPORT_TYPES_TITLE = i18n.translate(
+  'xpack.reporting.scheduledReportingForm.noReportTypesTitle',
+  {
+    defaultMessage: 'Scheduled reports are not supported here yet',
+  }
+);
+
+export const SCHEDULED_REPORT_NO_REPORT_TYPES_MESSAGE = i18n.translate(
+  'xpack.reporting.scheduledReportingForm.noReportTypesMessage',
+  {
+    defaultMessage: 'Report types in this page are not supported for scheduled reports yet.',
+  }
+);
+
 export const CANNOT_LOAD_REPORTING_HEALTH_TITLE = i18n.translate(
   'xpack.reporting.scheduledReportingForm.cannotLoadReportingHealthTitle',
   {

--- a/x-pack/platform/plugins/private/reporting/public/types.ts
+++ b/x-pack/platform/plugins/private/reporting/public/types.ts
@@ -51,7 +51,7 @@ export interface JobSummarySet {
   failed?: JobSummary[];
 }
 
-export type ReportTypeId = 'pngV2' | 'printablePdfV2' | 'csv_searchsource';
+export type ReportTypeId = 'pngV2' | 'printablePdfV2' | 'csv_searchsource' | 'csv_v2';
 
 export interface ScheduledReport {
   title: string;


### PR DESCRIPTION
## 📄 Summary

- Adds a callout to the Scheduled reports flyout when none of the available report types is supported for scheduling to avoid showing the flyout with an empty type selector
- Adds `csv_v2` to the list of supported report types

<details>
<summary>

## 🧪 Verification steps

</summary>

### No supported report type for scheduling
- If you don't have data in Kibana, navigate to Home > Try sample data and activate a sample data set
- Create a role (and relative test user) with access to some ES indices, a license != `basic` and privilege for Visualize Library without subfeature privilege for scheduling PDF and PNG reports:
    <img width="723" alt="image" src="https://github.com/user-attachments/assets/7e413a51-8d14-4b3b-af9d-24f82e6f9ea6" />
- Log in with the unprivileged user and navigate to `Analytics > Visualize Library`, then create a visualization of type Lens
- Drag any field in the lens UX so that the  ⬇️ (Export) menu in the toolbar becomes clickable and click it
- Click on `Schedule export`
- Check that the flyout shows a warning callout for unsupported report types

#### csv_v2 support
- Log in as an admin or user with access to Discover
- Navigate to Discover, toggle ES|QL mode
- Open the ⬇️ (Export) menu in the toolbar
- Click on `Schedule export`
- Check that the `CSV` option is available and scheduling works correctly

</details>

<details>

<summary>

## 🐞 Known issues

</summary>

The CallOut for missing report types is a temporary solution until we can hide the schedule button altogether (this requires changes in the SharedUX share menu API)

</details>

<details>

<summary>

## 📷 Screenshots

</summary>

Warning CallOut
![image](https://github.com/user-attachments/assets/dd1eaf2e-22d7-451f-b6bd-4b57ad05d664)


</details>

## 🔗 References

Refs #225606

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->