### PR TITLE
[9.1] [Response Ops][Reporting] Fixing timestamp override for scheduled CSV reports (#224757)

### DIFF
--- a/src/platform/packages/private/kbn-generate-csv/src/lib/override_time_range.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/lib/override_time_range.test.ts
@@ -1,0 +1,609 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { overrideTimeRange } from './override_time_range';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+
+const mockLogger = loggingSystemMock.createLogger();
+
+describe('overrideTimeRange', () => {
+  it('should return modified time range filter', () => {
+    const filter = {
+      meta: {
+        field: '@timestamp',
+        index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+        params: {},
+      },
+      query: {
+        range: {
+          '@timestamp': {
+            format: 'strict_date_optional_time',
+            gte: '2025-01-01T19:38:24.286Z',
+            lte: '2025-01-01T20:03:24.286Z',
+          },
+        },
+      },
+    };
+
+    const updated = overrideTimeRange({
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toEqual([
+      {
+        meta: {
+          field: '@timestamp',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            '@timestamp': {
+              format: 'strict_date_optional_time',
+              gte: '2025-06-18T19:30:00.000Z',
+              lte: '2025-06-18T19:55:00.000Z',
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should return modified time range in filter array', () => {
+    const filter = [
+      {
+        meta: {
+          field: '@timestamp',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            '@timestamp': {
+              format: 'strict_date_optional_time',
+              gte: '2025-01-01T19:38:24.286Z',
+              lte: '2025-01-01T20:03:24.286Z',
+            },
+          },
+        },
+      },
+    ];
+
+    const updated = overrideTimeRange({
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toEqual([
+      {
+        meta: {
+          field: '@timestamp',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            '@timestamp': {
+              format: 'strict_date_optional_time',
+              gte: '2025-06-18T19:30:00.000Z',
+              lte: '2025-06-18T19:55:00.000Z',
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should return modified time range in the filter array when timestamp field is not @timestamp', () => {
+    const filter = [
+      {
+        meta: {
+          field: 'event.start',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            'event.start': {
+              format: 'strict_date_optional_time',
+              gte: '2025-01-01T19:38:24.286Z',
+              lte: '2025-01-01T20:03:24.286Z',
+            },
+          },
+        },
+      },
+    ];
+
+    const updated = overrideTimeRange({
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toEqual([
+      {
+        meta: {
+          field: 'event.start',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            'event.start': {
+              format: 'strict_date_optional_time',
+              gte: '2025-06-18T19:30:00.000Z',
+              lte: '2025-06-18T19:55:00.000Z',
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should maintain the same filter order', () => {
+    const filter = [
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'event.action',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'event.action',
+          negate: false,
+          params: ['a', 'b', 'c'],
+          type: 'phrases',
+          value: ['a', 'b', 'c'],
+        },
+        query: {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                match_phrase: {
+                  'event.action': 'a',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'b',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'c',
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        meta: {
+          field: 'event.start',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            'event.start': {
+              format: 'strict_date_optional_time',
+              gte: '2025-01-01T19:38:24.286Z',
+              lte: '2025-01-01T20:03:24.286Z',
+            },
+          },
+        },
+      },
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'another.range.field',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'another.range.field',
+          negate: false,
+          params: {
+            gte: '0',
+            lt: '10',
+          },
+          type: 'range',
+          value: {
+            gte: '0',
+            lt: '10',
+          },
+        },
+        query: {
+          range: {
+            'another.range.field': {
+              gte: '0',
+              lt: '10',
+            },
+          },
+        },
+      },
+    ];
+
+    const updated = overrideTimeRange({
+      // @ts-expect-error
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toEqual([
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'event.action',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'event.action',
+          negate: false,
+          params: ['a', 'b', 'c'],
+          type: 'phrases',
+          value: ['a', 'b', 'c'],
+        },
+        query: {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                match_phrase: {
+                  'event.action': 'a',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'b',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'c',
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        meta: {
+          field: 'event.start',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            'event.start': {
+              format: 'strict_date_optional_time',
+              gte: '2025-06-18T19:30:00.000Z',
+              lte: '2025-06-18T19:55:00.000Z',
+            },
+          },
+        },
+      },
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'another.range.field',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'another.range.field',
+          negate: false,
+          params: {
+            gte: '0',
+            lt: '10',
+          },
+          type: 'range',
+          value: {
+            gte: '0',
+            lt: '10',
+          },
+        },
+        query: {
+          range: {
+            'another.range.field': {
+              gte: '0',
+              lt: '10',
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should return modified time range in the filter array range filters are present', () => {
+    const filter = [
+      {
+        meta: {
+          field: 'event.start',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            'event.start': {
+              format: 'strict_date_optional_time',
+              gte: '2025-01-01T19:38:24.286Z',
+              lte: '2025-01-01T20:03:24.286Z',
+            },
+          },
+        },
+      },
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'event.action',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'event.action',
+          negate: false,
+          params: ['a', 'b', 'c'],
+          type: 'phrases',
+          value: ['a', 'b', 'c'],
+        },
+        query: {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                match_phrase: {
+                  'event.action': 'a',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'b',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'c',
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'another.range.field',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'another.range.field',
+          negate: false,
+          params: {
+            gte: '0',
+            lt: '10',
+          },
+          type: 'range',
+          value: {
+            gte: '0',
+            lt: '10',
+          },
+        },
+        query: {
+          range: {
+            'another.range.field': {
+              gte: '0',
+              lt: '10',
+            },
+          },
+        },
+      },
+    ];
+
+    const updated = overrideTimeRange({
+      // @ts-expect-error
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toEqual([
+      {
+        meta: {
+          field: 'event.start',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            'event.start': {
+              format: 'strict_date_optional_time',
+              gte: '2025-06-18T19:30:00.000Z',
+              lte: '2025-06-18T19:55:00.000Z',
+            },
+          },
+        },
+      },
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'event.action',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'event.action',
+          negate: false,
+          params: ['a', 'b', 'c'],
+          type: 'phrases',
+          value: ['a', 'b', 'c'],
+        },
+        query: {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                match_phrase: {
+                  'event.action': 'a',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'b',
+                },
+              },
+              {
+                match_phrase: {
+                  'event.action': 'c',
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        $state: {
+          store: 'appState',
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          field: 'another.range.field',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          key: 'another.range.field',
+          negate: false,
+          params: {
+            gte: '0',
+            lt: '10',
+          },
+          type: 'range',
+          value: {
+            gte: '0',
+            lt: '10',
+          },
+        },
+        query: {
+          range: {
+            'another.range.field': {
+              gte: '0',
+              lt: '10',
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should return undefined if unexpected time filter found', () => {
+    const filter = [
+      {
+        meta: {
+          field: 'event.start',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            'another.field': {
+              format: 'strict_date_optional_time',
+              gte: '2025-01-01T19:38:24.286Z',
+              lte: '2025-01-01T20:03:24.286Z',
+            },
+          },
+        },
+      },
+    ];
+
+    const updated = overrideTimeRange({
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toBeUndefined();
+  });
+
+  it('should return undefined if no meta field found', () => {
+    const filter = [
+      {
+        query: {
+          range: {
+            '@timestamp': {
+              format: 'strict_date_optional_time',
+              gte: '2025-01-01T19:38:24.286Z',
+              lte: '2025-01-01T20:03:24.286Z',
+            },
+          },
+        },
+      },
+    ];
+
+    const updated = overrideTimeRange({
+      // @ts-expect-error missing meta field
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+    });
+    expect(updated).toBeUndefined();
+  });
+
+  it('should return undefined if invalid time', () => {
+    const filter = [
+      {
+        meta: {
+          field: '@timestamp',
+          index: '0bde9920-4ade-4c19-8043-368aa37f1dae',
+          params: {},
+        },
+        query: {
+          range: {
+            '@timestamp': {
+              format: 'strict_date_optional_time',
+              gte: 'foo',
+              lte: 'bar',
+            },
+          },
+        },
+      },
+    ];
+
+    const updated = overrideTimeRange({
+      currentFilters: filter,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toBeUndefined();
+  });
+
+  it('should return undefined for undefined filters', () => {
+    const updated = overrideTimeRange({
+      currentFilters: undefined,
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toBeUndefined();
+  });
+
+  it('should return undefined for empty filters', () => {
+    const updated = overrideTimeRange({
+      currentFilters: [],
+      forceNow: '2025-06-18T19:55:00.000Z',
+      logger: mockLogger,
+    });
+    expect(updated).toBeUndefined();
+  });
+});

--- a/src/platform/packages/private/kbn-generate-csv/src/lib/override_time_range.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/lib/override_time_range.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Filter } from '@kbn/es-query';
+import { set } from '@kbn/safer-lodash-set';
+import type { Logger } from '@kbn/core/server';
+import { cloneDeep, get, has, isArray } from 'lodash';
+
+const getTimeFieldAccessorString = (metaField: string): string => `query.range['${metaField}']`;
+const getTimeFields = (filter: Filter) => {
+  const metaField = get(filter, 'meta.field');
+  if (metaField) {
+    const timeFieldAccessorString = getTimeFieldAccessorString(metaField);
+    const timeFormat = get(filter, `${timeFieldAccessorString}.format`);
+    const timeGte = get(filter, `${timeFieldAccessorString}.gte`);
+    const timeLte = get(filter, `${timeFieldAccessorString}.lte`);
+
+    return { metaField, timeFormat, timeGte, timeLte };
+  }
+
+  return {};
+};
+
+const isValidDateTime = (dateString: string): boolean => {
+  const date = Date.parse(dateString);
+  return !isNaN(date) && date > 0;
+};
+
+interface OverrideTimeRangeOpts {
+  currentFilters: Filter[] | Filter | undefined;
+  forceNow: string;
+  logger: Logger;
+}
+export const overrideTimeRange = ({
+  currentFilters,
+  forceNow,
+  logger,
+}: OverrideTimeRangeOpts): Filter[] | undefined => {
+  if (!currentFilters) {
+    return;
+  }
+
+  const filters = isArray(currentFilters) ? currentFilters : [currentFilters];
+  if (filters.length === 0) {
+    return;
+  }
+
+  // Looking for filters with this format which indicate a time range:
+  //   {
+  //     "meta": {
+  //         "field": <timeFieldName>,
+  //         "index": <indexId>,
+  //         "params": {}
+  //     },
+  //     "query": {
+  //         "range": {
+  //             <timeFieldName>: {
+  //                 "format": "strict_date_optional_time",
+  //                 "gte": "2025-06-18T18:29:53.537Z",
+  //                 "lte": "2025-06-18T18:54:53.537Z"
+  //             }
+  //         }
+  //     }
+  // }
+  const timeFilterIndex = filters.findIndex((filter) => {
+    if (has(filter, '$state')) {
+      return false;
+    }
+
+    const {
+      timeFormat: maybeTimeFieldFormat,
+      timeGte: maybeTimeFieldGte,
+      timeLte: maybeTimeFieldLte,
+    } = getTimeFields(filter);
+
+    if (maybeTimeFieldFormat && maybeTimeFieldGte && maybeTimeFieldLte) {
+      return isValidDateTime(maybeTimeFieldGte) && isValidDateTime(maybeTimeFieldLte);
+    }
+    return false;
+  });
+
+  if (timeFilterIndex >= 0) {
+    try {
+      const timeFilter = cloneDeep(filters[timeFilterIndex]);
+      const { metaField, timeGte, timeLte } = getTimeFields(timeFilter);
+      if (metaField) {
+        const timeGteMs = Date.parse(timeGte);
+        const timeLteMs = Date.parse(timeLte);
+        const timeDiffMs = timeLteMs - timeGteMs;
+        const newLte = Date.parse(forceNow);
+        const newGte = newLte - timeDiffMs;
+
+        const timeFieldAccessorString = getTimeFieldAccessorString(metaField);
+        set(timeFilter, `${timeFieldAccessorString}.gte`, new Date(newGte).toISOString());
+        set(timeFilter, `${timeFieldAccessorString}.lte`, forceNow);
+
+        filters.splice(timeFilterIndex, 1, timeFilter);
+        return filters;
+      }
+    } catch (error) {
+      logger.warn(`Error calculating updated time range: ${error.message}`);
+    }
+  }
+};

--- a/src/platform/packages/private/kbn-generate-csv/src/lib/search_cursor_pit.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/lib/search_cursor_pit.ts
@@ -124,6 +124,8 @@ export class SearchCursorPit extends SearchCursor {
       throw new Error('Could not retrieve the search body!');
     }
 
+    this.logger.debug(() => `Executing search with body: ${JSON.stringify(searchBody)}`);
+
     const response = await this.searchWithPit(searchBody);
 
     if (!response) {

--- a/src/platform/packages/private/kbn-generate-csv/tsconfig.json
+++ b/src/platform/packages/private/kbn-generate-csv/tsconfig.json
@@ -32,5 +32,6 @@
     "@kbn/search-types",
     "@kbn/task-manager-plugin",
     "@kbn/esql-utils",
+    "@kbn/safer-lodash-set",
   ]
 }

--- a/src/platform/packages/private/kbn-generate-csv/types.ts
+++ b/src/platform/packages/private/kbn-generate-csv/types.ts
@@ -17,5 +17,6 @@ export interface JobParamsCSV {
   browserTimezone?: string;
   searchSource: SerializedSearchSourceFields;
   columns?: string[];
+  forceNow?: string;
   pagingStrategy?: CsvPagingStrategy;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Response Ops][Reporting] Fixing timestamp override for scheduled CSV reports (#224757)](https://github.com/elastic/kibana/pull/224757)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-06-26T19:40:46Z","message":"[Response Ops][Reporting] Fixing timestamp override for scheduled CSV reports (#224757)\n\n## Summary\n\nPDF, PNG and ES|QL CSV reports all use a relative date range based on\n`now` so when we generate recurring exports, we override `now` with a\n`forceNow` parameter. Non ES|QL CSV reports use a `SearchSource` with a\nfixed time range, even when a relative time range is set in Discover.\n\nThis PR updates the CSV search source report generation to override the\nfixed time range for recurring scheduled exports.\n\n## To Verify\n\n- create a dataview (trying creating one using a field other than\n`@timestamp` as the time field)\n- populate the dataview with some data\n- schedule a CSV export and verify that the eventual CSV report has data\nin the correct time range\n- may be faster to schedule via the API to get a report generated\nfaster.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9f6eb0a0cb7408a614335773240e3b360c9eceee","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Reporting:Framework","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Response Ops][Reporting] Fixing timestamp override for scheduled CSV reports","number":224757,"url":"https://github.com/elastic/kibana/pull/224757","mergeCommit":{"message":"[Response Ops][Reporting] Fixing timestamp override for scheduled CSV reports (#224757)\n\n## Summary\n\nPDF, PNG and ES|QL CSV reports all use a relative date range based on\n`now` so when we generate recurring exports, we override `now` with a\n`forceNow` parameter. Non ES|QL CSV reports use a `SearchSource` with a\nfixed time range, even when a relative time range is set in Discover.\n\nThis PR updates the CSV search source report generation to override the\nfixed time range for recurring scheduled exports.\n\n## To Verify\n\n- create a dataview (trying creating one using a field other than\n`@timestamp` as the time field)\n- populate the dataview with some data\n- schedule a CSV export and verify that the eventual CSV report has data\nin the correct time range\n- may be faster to schedule via the API to get a report generated\nfaster.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9f6eb0a0cb7408a614335773240e3b360c9eceee"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224757","number":224757,"mergeCommit":{"message":"[Response Ops][Reporting] Fixing timestamp override for scheduled CSV reports (#224757)\n\n## Summary\n\nPDF, PNG and ES|QL CSV reports all use a relative date range based on\n`now` so when we generate recurring exports, we override `now` with a\n`forceNow` parameter. Non ES|QL CSV reports use a `SearchSource` with a\nfixed time range, even when a relative time range is set in Discover.\n\nThis PR updates the CSV search source report generation to override the\nfixed time range for recurring scheduled exports.\n\n## To Verify\n\n- create a dataview (trying creating one using a field other than\n`@timestamp` as the time field)\n- populate the dataview with some data\n- schedule a CSV export and verify that the eventual CSV report has data\nin the correct time range\n- may be faster to schedule via the API to get a report generated\nfaster.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9f6eb0a0cb7408a614335773240e3b360c9eceee"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225544","number":225544,"state":"MERGED","mergeCommit":{"sha":"c54b691f4c236d5cf9953c5d7c405f693e34642d","message":"[8.19] [Response Ops][Reporting] Fixing timestamp override for scheduled CSV reports (#224757) (#225544)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Response Ops][Reporting] Fixing timestamp override for scheduled CSV\nreports (#224757)](https://github.com/elastic/kibana/pull/224757)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ying Mao <ying.mao@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->