### PR TITLE
Avoid Upgrade Assistant not to load if ML is disabled

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/helpers/http_requests.ts
@@ -133,6 +133,9 @@ const registerHttpRequestMockHelpers = (
   const setLoadMlUpgradeModeResponse = (response?: object, error?: ResponseError) =>
     mockResponse('GET', `${API_BASE_PATH}/ml_upgrade_mode`, response, error);
 
+  const setLoadMlEnabledResponse = (response?: { mlEnabled: boolean }, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/ml_enabled`, response, error);
+
   const setSystemIndicesMigrationResponse = (response?: object, error?: ResponseError) =>
     mockResponse('POST', `${API_BASE_PATH}/system_indices_migration`, response, error);
 
@@ -166,6 +169,7 @@ const registerHttpRequestMockHelpers = (
     setStartReindexingResponse,
     setReindexStatusResponse,
     setLoadMlUpgradeModeResponse,
+    setLoadMlEnabledResponse,
     setGetUpgradeStatusResponse,
     setLoadRemoteClustersResponse,
     setLoadNodeDiskSpaceResponse,

--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
@@ -10,8 +10,10 @@ import { OverviewTestBed, setupOverviewPage } from './overview.helpers';
 
 describe('Overview Page', () => {
   let testBed: OverviewTestBed;
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
+
   beforeEach(async () => {
-    testBed = await setupOverviewPage(setupEnvironment().httpSetup);
+    testBed = await setupOverviewPage(httpSetup);
     testBed.component.update();
   });
 
@@ -27,6 +29,31 @@ describe('Overview Page', () => {
       const { exists } = testBed;
 
       expect(exists('documentationLink')).toBe(true);
+    });
+  });
+
+  describe('Machine Learning callout', () => {
+    test('Shows ML disabled callout when ML is disabled', async () => {
+      httpRequestsMockHelpers.setLoadMlEnabledResponse({ mlEnabled: false });
+
+      testBed = await setupOverviewPage(httpSetup);
+      testBed.component.update();
+
+      const { exists, find } = testBed;
+
+      expect(exists('mlDisabledCallout')).toBe(true);
+      expect(find('mlDisabledCallout').text()).toContain('Machine Learning is disabled');
+    });
+
+    test('Does not show ML disabled callout when ML is enabled', async () => {
+      httpRequestsMockHelpers.setLoadMlEnabledResponse({ mlEnabled: true });
+
+      testBed = await setupOverviewPage(httpSetup);
+      testBed.component.update();
+
+      const { exists } = testBed;
+
+      expect(exists('mlDisabledCallout')).toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/ml_callout/ml_callout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/ml_callout/ml_callout.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useAppContext } from '../../../app_context';
+
+export const MachineLearningDisabledCallout: React.FunctionComponent = () => {
+  const {
+    services: { api },
+  } = useAppContext();
+
+  const [mlEnabled, setMlEnabled] = useState<boolean>(true);
+
+  useEffect(() => {
+    api.getMLEnabled().then(({ data }) => {
+      setMlEnabled(data.mlEnabled);
+    });
+  }, [api]);
+
+  return (
+    !mlEnabled && (
+      <>
+        <EuiSpacer size="s" />
+        <EuiCallOut
+          title={
+            <FormattedMessage
+              id="xpack.upgradeAssistant.overview.mlCallout.title"
+              defaultMessage="Machine Learning is disabled"
+            />
+          }
+          color="warning"
+          iconType="warning"
+          data-test-subj="mlDisabledCallout"
+        >
+          <FormattedMessage
+            id="xpack.upgradeAssistant.overview.mlCallout.description"
+            defaultMessage="Machine Learning is disabled in your cluster. Upgrade Assistant will not be able to check for any Machine Learning deprecations or issues. Please enable Machine Learning in your cluster to use this feature."
+          />
+        </EuiCallOut>
+      </>
+    )
+  );
+};

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/overview.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/overview.tsx
@@ -31,6 +31,7 @@ import { getFixIssuesStep } from './fix_issues_step';
 import { getUpgradeStep } from './upgrade_step';
 import { getMigrateSystemIndicesStep } from './migrate_system_indices';
 import { getLogsStep } from './logs_step';
+import { MachineLearningDisabledCallout } from './ml_callout/ml_callout';
 
 type OverviewStep = 'backup' | 'migrate_system_indices' | 'fix_issues' | 'logs';
 
@@ -112,6 +113,7 @@ export const Overview = withRouter(({ history }: RouteComponentProps) => {
               }}
             />
           </EuiText>
+          <MachineLearningDisabledCallout />
         </EuiPageHeader>
         <EuiSpacer size="l" />
         <EuiSteps

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/lib/api.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/lib/api.ts
@@ -305,6 +305,12 @@ export class ApiService {
       },
     });
   }
+  public async getMLEnabled() {
+    return await this.sendRequest({
+      path: `${API_BASE_PATH}/ml_enabled`,
+      method: 'get',
+    });
+  }
 
   public useLoadRemoteClusters() {
     return this.useRequest<string[]>({

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
@@ -116,8 +116,9 @@ const normalizeEsResponse = (migrationsResponse: EsDeprecations) => {
     }
   );
 
-  const mlSettingsDeprecations = migrationsResponse.ml_settings.map((depractionData) =>
-    createBaseDeprecation(depractionData, { deprecationType: 'ml_settings' })
+  // If xpack.ml.enabled is set to false, ML settings key won't be pressent https://github.com/elastic/sdh-kibana/issues/5541
+  const mlSettingsDeprecations = (migrationsResponse.ml_settings || []).map((deprecationData) =>
+    createBaseDeprecation(deprecationData, { deprecationType: 'ml_settings' })
   );
   const nodeSettingsDeprecations = migrationsResponse.node_settings.map((depractionData) =>
     createBaseDeprecation(depractionData, { deprecationType: 'node_settings' })

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_enabled_cluster.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_enabled_cluster.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { handleEsError } from '../shared_imports';
+import { createMockRouter, MockRouter, routeHandlerContextMock } from './__mocks__/routes.mock';
+import { createRequestMock } from './__mocks__/request.mock';
+import { registerMLEnabledRoute } from './ml_enabled_cluster';
+
+jest.mock('../lib/es_version_precheck', () => ({
+  versionCheckHandlerWrapper: (a: any) => a,
+}));
+
+describe('ML enabled cluster API', () => {
+  let mockRouter: MockRouter;
+  let routeDependencies: any;
+
+  beforeEach(() => {
+    mockRouter = createMockRouter();
+    routeDependencies = {
+      router: mockRouter,
+      lib: { handleEsError },
+    };
+    registerMLEnabledRoute(routeDependencies);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('GET /api/upgrade_assistant/ml_enabled', () => {
+    it('returns 200 status with mlEnabled true when ML is enabled', async () => {
+      (
+        routeHandlerContextMock.core.elasticsearch.client.asCurrentUser.cluster
+          .getSettings as jest.Mock
+      ).mockResolvedValue({
+        defaults: {
+          xpack: {
+            ml: {
+              enabled: 'true',
+            },
+          },
+        },
+      });
+
+      const resp = await routeDependencies.router.getHandler({
+        method: 'get',
+        pathPattern: '/api/upgrade_assistant/ml_enabled',
+      })(routeHandlerContextMock, createRequestMock(), kibanaResponseFactory);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.payload).toEqual({
+        mlEnabled: true,
+      });
+    });
+
+    it('returns 200 status with mlEnabled false when ML is disabled', async () => {
+      (
+        routeHandlerContextMock.core.elasticsearch.client.asCurrentUser.cluster
+          .getSettings as jest.Mock
+      ).mockResolvedValue({
+        defaults: {
+          xpack: {
+            ml: {
+              enabled: 'false',
+            },
+          },
+        },
+      });
+
+      const resp = await routeDependencies.router.getHandler({
+        method: 'get',
+        pathPattern: '/api/upgrade_assistant/ml_enabled',
+      })(routeHandlerContextMock, createRequestMock(), kibanaResponseFactory);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.payload).toEqual({
+        mlEnabled: false,
+      });
+    });
+
+    it('returns 200 status with mlEnabled false when ML settings are missing', async () => {
+      (
+        routeHandlerContextMock.core.elasticsearch.client.asCurrentUser.cluster
+          .getSettings as jest.Mock
+      ).mockResolvedValue({
+        defaults: {},
+      });
+
+      const resp = await routeDependencies.router.getHandler({
+        method: 'get',
+        pathPattern: '/api/upgrade_assistant/ml_enabled',
+      })(routeHandlerContextMock, createRequestMock(), kibanaResponseFactory);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.payload).toEqual({
+        mlEnabled: false,
+      });
+    });
+
+    it('handles Elasticsearch errors properly', async () => {
+      (
+        routeHandlerContextMock.core.elasticsearch.client.asCurrentUser.cluster
+          .getSettings as jest.Mock
+      ).mockRejectedValue(new Error('Elasticsearch error'));
+
+      await expect(
+        routeDependencies.router.getHandler({
+          method: 'get',
+          pathPattern: '/api/upgrade_assistant/ml_enabled',
+        })(routeHandlerContextMock, createRequestMock(), kibanaResponseFactory)
+      ).rejects.toThrow('Elasticsearch error');
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_enabled_cluster.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/ml_enabled_cluster.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { API_BASE_PATH } from '../../common/constants';
+import { versionCheckHandlerWrapper } from '../lib/es_version_precheck';
+import { RouteDependencies } from '../types';
+
+export function registerMLEnabledRoute({ router, lib: { handleEsError } }: RouteDependencies) {
+  router.get(
+    {
+      path: `${API_BASE_PATH}/ml_enabled`,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Relies on es client for authorization',
+        },
+      },
+      validate: false,
+    },
+    versionCheckHandlerWrapper(async ({ core }, request, response) => {
+      try {
+        const {
+          elasticsearch: { client },
+        } = await core;
+
+        const settingsResponse = await client.asCurrentUser.cluster.getSettings({
+          include_defaults: true,
+        });
+
+        const mlEnabled = settingsResponse.defaults?.xpack?.ml?.enabled;
+        return response.ok({
+          body: {
+            mlEnabled: mlEnabled === 'true',
+          },
+        });
+      } catch (error) {
+        return handleEsError({ error, response });
+      }
+    })
+  );
+}

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/register_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/register_routes.ts
@@ -24,6 +24,7 @@ import { registerClusterSettingsRoute } from './cluster_settings';
 import { registerMigrateDataStreamRoutes } from './migrate_data_streams';
 import { registerUpdateIndexRoute } from './update_index';
 import { registerEnterpriseSearchDeprecationRoutes } from '../lib/enterprise_search/enterprise_search_deprecations_routes';
+import { registerMLEnabledRoute } from './ml_enabled_cluster';
 
 export function registerRoutes(dependencies: RouteDependencies, getWorker: () => ReindexWorker) {
   registerAppRoutes(dependencies);
@@ -42,6 +43,8 @@ export function registerRoutes(dependencies: RouteDependencies, getWorker: () =>
   registerRemoteClustersRoute(dependencies);
   registerNodeDiskSpaceRoute(dependencies);
   registerClusterSettingsRoute(dependencies);
+  // Route to check if ML is enabled in the cluster
+  registerMLEnabledRoute(dependencies);
 
   // Data streams reindexing
   registerMigrateDataStreamRoutes(dependencies);


### PR DESCRIPTION
Fixes https://github.com/elastic/sdh-kibana/issues/5541

## Summary
When the user had `xpack.ml.enabled` set to false, the ES deprecation list was throwing the error `Cannot read properties of undefined (reading 'map')`. This was caused because UA was expecting to always receive an ML array in the migration deprecation response.

![Screenshot 2025-06-27 at 13 43 38](https://github.com/user-attachments/assets/d8a05d07-bd1c-4627-b7ca-9e6b6ccc90ca)

This PR makes the ES list not to fail when the user has this disabled. However, I wasn't able to test what would happen if the cluster contains ML deprecations but the setting is set to false and the user upgrades it and then enables it again. For that reason, at least for the moment, this PR also introduces a callout informing of this feature to be disabled:


<img width="1247" alt="Screenshot 2025-06-27 at 13 34 52" src="https://github.com/user-attachments/assets/30c57495-d9eb-4824-9e76-9ad25a08bd6b" />





Also, this way, if some migration for ML fails, the user is informed of the root cause. For instance, for System indices:

<img width="1049" alt="Screenshot 2025-06-27 at 13 35 31" src="https://github.com/user-attachments/assets/196f39a5-f791-4e5f-b766-c2a4767acbfe" />

### How to test
* Follow the instructions in https://github.com/elastic/kibana-team/issues/1521. Use the data folder named `data_qaf_7.17.zip`. This contains ML deprecations.
* Run ES and Kibana as usual for Upgrade Assistant. Verify that the callout is not present.
* Run ES for UA but adding the flag `-E xpack.ml.enabled=false` and Kibana as usual. 
* Verify the plugin loads.
* Verify the Es deprecation list does not contain ML deprecations.
* Verify that the callout is present.

