### PR TITLE
Changed failsOnMKI to skipCloud at synthetics API test suite for multispace monitors

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/legacy_and_multispace_monitor_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/legacy_and_multispace_monitor_api.ts
@@ -19,7 +19,7 @@ import { getFixtureJson } from './helpers/get_fixture_json';
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('LegacyAndMultiSpaceMonitorAPI', function () {
     // Fails on MKI, see https://github.com/elastic/kibana/issues/225431
-    this.tags(['failsOnMKI']);
+    this.tags(['skipCloud']);
 
     const supertest = getService('supertestWithoutAuth');
     const kibanaServer = getService('kibanaServer');


### PR DESCRIPTION
### Summary 

Changed `failsOnMKI` to `skipCloud` at synthetics API test suite for multispace monitors.
Same issue on ECH -> https://github.com/elastic/kibana/issues/225431

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->