### PR TITLE
[8.19] [Response Ops][Reporting][Task Manager] Allow setting dtstart in rrule schedule - schema changes only for intermediate release (#224979)

### DIFF
--- a/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
@@ -173,7 +173,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "synthetics-private-location": "8cecc9e4f39637d2f8244eb7985c0690ceab24be",
         "synthetics-privates-locations": "f53d799d5c9bc8454aaa32c6abc99a899b025d5c",
         "tag": "e2544392fe6563e215bb677abc8b01c2601ef2dc",
-        "task": "fd81cc235a5c7f64e9487e47f1ef73b3b6bfbe98",
+        "task": "d84ed32d1853a79961447944193193f54ad570b6",
         "telemetry": "7b00bcf1c7b4f6db1192bb7405a6a63e78b699fd",
         "threshold-explorer-view": "175306806f9fc8e13fcc1c8953ec4ba89bda1b70",
         "ui-metric": "d227284528fd19904e9d972aea0a13716fc5fe24",

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/schedule_request_handler.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/schedule_request_handler.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 
 import { schema } from '@kbn/config-schema';
 import { isEmpty, omit } from 'lodash';
-import { RruleSchedule, scheduleRruleSchema } from '@kbn/task-manager-plugin/server';
+import { RruleSchedule, scheduleRruleSchemaV1 } from '@kbn/task-manager-plugin/server';
 import { SavedObjectsUtils } from '@kbn/core/server';
 import { IKibanaResponse } from '@kbn/core/server';
 import { RawNotification } from '../../../saved_objects/scheduled_report/schemas/latest';
@@ -34,7 +34,7 @@ const MAX_ALLOWED_EMAILS = 30;
 const validation = {
   params: schema.object({ exportType: schema.string({ minLength: 2 }) }),
   body: schema.object({
-    schedule: scheduleRruleSchema,
+    schedule: scheduleRruleSchemaV1,
     notification: schema.maybe(rawNotificationSchema),
     jobParams: schema.string(),
   }),

--- a/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/model_versions.ts
+++ b/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/model_versions.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SavedObjectsModelVersionMap } from '@kbn/core-saved-objects-server';
-import { rawScheduledReportSchemaV1 } from './schemas';
+import { rawScheduledReportSchemaV1, rawScheduledReportSchemaV2 } from './schemas';
 
 export const scheduledReportModelVersions: SavedObjectsModelVersionMap = {
   '1': {
@@ -14,6 +14,13 @@ export const scheduledReportModelVersions: SavedObjectsModelVersionMap = {
     schemas: {
       forwardCompatibility: rawScheduledReportSchemaV1.extends({}, { unknowns: 'ignore' }),
       create: rawScheduledReportSchemaV1,
+    },
+  },
+  '2': {
+    changes: [],
+    schemas: {
+      forwardCompatibility: rawScheduledReportSchemaV2.extends({}, { unknowns: 'ignore' }),
+      create: rawScheduledReportSchemaV2,
     },
   },
 };

--- a/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/schemas/latest.ts
+++ b/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/schemas/latest.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TypeOf } from '@kbn/config-schema';
-import type { rawNotificationSchema, rawScheduledReportSchema } from './v1';
+import type { rawNotificationSchema, rawScheduledReportSchema } from './v2';
 
 export type RawNotification = TypeOf<typeof rawNotificationSchema>;
 export type RawScheduledReport = TypeOf<typeof rawScheduledReportSchema>;

--- a/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/schemas/v1.ts
+++ b/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/schemas/v1.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { scheduleRruleSchema } from '@kbn/task-manager-plugin/server';
+import { scheduleRruleSchemaV1 } from '@kbn/task-manager-plugin/server';
 
 const rawLayoutIdSchema = schema.oneOf([
   schema.literal('preserve_layout'),
@@ -52,6 +52,6 @@ export const rawScheduledReportSchema = schema.object({
   migrationVersion: schema.maybe(schema.string()),
   notification: schema.maybe(rawNotificationSchema),
   payload: schema.string(),
-  schedule: scheduleRruleSchema,
+  schedule: scheduleRruleSchemaV1,
   title: schema.string(),
 });

--- a/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/schemas/v2.ts
+++ b/x-pack/platform/plugins/private/reporting/server/saved_objects/scheduled_report/schemas/v2.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { scheduleRruleSchemaV2 } from '@kbn/task-manager-plugin/server';
+import { rawScheduledReportSchema as rawScheduledReportSchemaV1 } from './v1';
+export * from './v1';
+
+export const rawScheduledReportSchema = rawScheduledReportSchemaV1.extends({
+  schedule: scheduleRruleSchemaV2,
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/index.ts
@@ -25,7 +25,7 @@ export type {
 } from './task';
 
 export { Frequency, Weekday } from '@kbn/rrule';
-export { scheduleRruleSchema } from './saved_objects';
+export { scheduleRruleSchemaV1, scheduleRruleSchemaV2 } from './saved_objects';
 
 export type { RruleSchedule } from './task';
 export { TaskStatus, TaskPriority, TaskCost } from './task';

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/index.ts
@@ -14,7 +14,7 @@ import { getOldestIdleActionTask } from '../queries/oldest_idle_action_task';
 import { TASK_MANAGER_INDEX } from '../constants';
 import { backgroundTaskNodeModelVersions, taskModelVersions } from './model_versions';
 
-export { scheduleRruleSchema } from './schemas/task';
+export { scheduleRruleSchemaV1, scheduleRruleSchemaV2 } from './schemas/rrule';
 
 export const TASK_SO_NAME = 'task';
 export const BACKGROUND_TASK_NODE_SO_NAME = 'background-task-node';

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_model_versions.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_model_versions.ts
@@ -12,6 +12,7 @@ import {
   taskSchemaV3,
   taskSchemaV4,
   taskSchemaV5,
+  taskSchemaV6,
 } from '../schemas/task';
 
 // IMPORTANT!!!
@@ -82,6 +83,13 @@ export const taskModelVersions: SavedObjectsModelVersionMap = {
     schemas: {
       forwardCompatibility: taskSchemaV5.extends({}, { unknowns: 'ignore' }),
       create: taskSchemaV5,
+    },
+  },
+  '6': {
+    changes: [],
+    schemas: {
+      forwardCompatibility: taskSchemaV6.extends({}, { unknowns: 'ignore' }),
+      create: taskSchemaV6,
     },
   },
 };

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/index.ts
@@ -5,5 +5,11 @@
  * 2.0.
  */
 
-export { rawScheduledReportSchema as rawScheduledReportSchemaV1 } from './v1';
-export { rawScheduledReportSchema as rawScheduledReportSchemaV2 } from './v2';
+export {
+  rruleSchedule as rruleScheduleV1,
+  scheduleRruleSchema as scheduleRruleSchemaV1,
+} from './v1';
+export {
+  rruleSchedule as rruleScheduleV2,
+  scheduleRruleSchema as scheduleRruleSchemaV2,
+} from './v2';

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v1.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v1.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 import { Frequency } from '@kbn/rrule';
 import moment from 'moment-timezone';
 
-function validateTimezone(timezone: string) {
+export function validateTimezone(timezone: string) {
   if (moment.tz.zone(timezone) != null) {
     return;
   }
@@ -36,7 +36,7 @@ const validateRecurrenceByWeekday = (array: string[]) => {
   }
 };
 
-const rruleCommon = schema.object({
+export const rruleCommon = schema.object({
   freq: schema.oneOf([
     schema.literal(0),
     schema.literal(1),
@@ -57,15 +57,21 @@ const rruleCommon = schema.object({
   tzid: schema.string({ validate: validateTimezone, defaultValue: 'UTC' }),
 });
 
-const byminute = schema.maybe(schema.arrayOf(schema.number({ min: 0, max: 59 }), { minSize: 1 }));
-const byhour = schema.maybe(schema.arrayOf(schema.number({ min: 0, max: 23 }), { minSize: 1 }));
-const byweekday = schema.maybe(
+export const byminute = schema.maybe(
+  schema.arrayOf(schema.number({ min: 0, max: 59 }), { minSize: 1 })
+);
+export const byhour = schema.maybe(
+  schema.arrayOf(schema.number({ min: 0, max: 23 }), { minSize: 1 })
+);
+export const byweekday = schema.maybe(
   schema.arrayOf(schema.string(), {
     minSize: 1,
     validate: validateRecurrenceByWeekday,
   })
 );
-const bymonthday = schema.maybe(schema.arrayOf(schema.number({ min: 1, max: 31 }), { minSize: 1 }));
+export const bymonthday = schema.maybe(
+  schema.arrayOf(schema.number({ min: 1, max: 31 }), { minSize: 1 })
+);
 
 const rruleMonthly = rruleCommon.extends({
   freq: schema.literal(Frequency.MONTHLY),
@@ -92,3 +98,6 @@ const rruleDaily = rruleCommon.extends({
 });
 
 export const rruleSchedule = schema.oneOf([rruleMonthly, rruleWeekly, rruleDaily]);
+export const scheduleRruleSchema = schema.object({
+  rrule: rruleSchedule,
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v2.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/rrule/v2.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { Frequency } from '@kbn/rrule';
+import { byhour, byminute, byweekday, bymonthday, rruleCommon as rruleCommonV1 } from './v1';
+
+const validateStartDate = (date: string) => {
+  const parsedValue = Date.parse(date);
+  if (isNaN(parsedValue)) return `Invalid date: ${date}`;
+  return;
+};
+
+const rruleCommon = rruleCommonV1.extends({
+  dtstart: schema.maybe(schema.string({ validate: validateStartDate })),
+});
+
+const rruleMonthly = rruleCommon.extends({
+  freq: schema.literal(Frequency.MONTHLY),
+  byhour,
+  byminute,
+  byweekday,
+  bymonthday,
+});
+
+const rruleWeekly = rruleCommon.extends({
+  freq: schema.literal(Frequency.WEEKLY),
+  byhour,
+  byminute,
+  byweekday,
+  bymonthday: schema.never(),
+});
+
+const rruleDaily = rruleCommon.extends({
+  freq: schema.literal(Frequency.DAILY),
+  byhour,
+  byminute,
+  byweekday,
+  bymonthday: schema.never(),
+});
+
+export const rruleSchedule = schema.oneOf([rruleMonthly, rruleWeekly, rruleDaily]);
+export const scheduleRruleSchema = schema.object({
+  rrule: rruleSchedule,
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { isInterval } from '../../lib/intervals';
-import { rruleSchedule } from './rrule';
+import { scheduleRruleSchemaV1, scheduleRruleSchemaV2 } from './rrule';
 
 export function validateDuration(duration: string) {
   if (!isInterval(duration)) {
@@ -59,10 +59,6 @@ export const scheduleIntervalSchema = schema.object({
   interval: schema.string({ validate: validateDuration }),
 });
 
-export const scheduleRruleSchema = schema.object({
-  rrule: rruleSchedule,
-});
-
 export const taskSchemaV4 = taskSchemaV3.extends({
   apiKey: schema.maybe(schema.string()),
   userScope: schema.maybe(
@@ -75,5 +71,9 @@ export const taskSchemaV4 = taskSchemaV3.extends({
 });
 
 export const taskSchemaV5 = taskSchemaV4.extends({
-  schedule: schema.maybe(schema.oneOf([scheduleIntervalSchema, scheduleRruleSchema])),
+  schedule: schema.maybe(schema.oneOf([scheduleIntervalSchema, scheduleRruleSchemaV1])),
+});
+
+export const taskSchemaV6 = taskSchemaV5.extends({
+  schedule: schema.maybe(schema.oneOf([scheduleIntervalSchema, scheduleRruleSchemaV2])),
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Reporting][Task Manager] Allow setting dtstart in rrule schedule - schema changes only for intermediate release (#224979)](https://github.com/elastic/kibana/pull/224979)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-06-27T14:05:28Z","message":"[Response Ops][Reporting][Task Manager] Allow setting dtstart in rrule schedule - schema changes only for intermediate release (#224979)\n\n## Summary\n\nThis PR contains the schema changes needed to support using `dtstart` in\ntask manager rrule schedules. This is meant for intermediate release and\nthen the changes will be used in this PR:\nhttps://github.com/elastic/kibana/pull/224948\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f43138c059047b5a73ea8fabbc976ed2fc09a6b9","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Reporting:Framework","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Response Ops][Reporting][Task Manager] Allow setting dtstart in rrule schedule - schema changes only for intermediate release","number":224979,"url":"https://github.com/elastic/kibana/pull/224979","mergeCommit":{"message":"[Response Ops][Reporting][Task Manager] Allow setting dtstart in rrule schedule - schema changes only for intermediate release (#224979)\n\n## Summary\n\nThis PR contains the schema changes needed to support using `dtstart` in\ntask manager rrule schedules. This is meant for intermediate release and\nthen the changes will be used in this PR:\nhttps://github.com/elastic/kibana/pull/224948\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f43138c059047b5a73ea8fabbc976ed2fc09a6b9"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225645","number":225645,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224979","number":224979,"mergeCommit":{"message":"[Response Ops][Reporting][Task Manager] Allow setting dtstart in rrule schedule - schema changes only for intermediate release (#224979)\n\n## Summary\n\nThis PR contains the schema changes needed to support using `dtstart` in\ntask manager rrule schedules. This is meant for intermediate release and\nthen the changes will be used in this PR:\nhttps://github.com/elastic/kibana/pull/224948\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f43138c059047b5a73ea8fabbc976ed2fc09a6b9"}}]}] BACKPORT-->