### PR TITLE
[Dashboards as code] Remove schema.maybe from perPage parameter

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
@@ -206,17 +206,15 @@ export function registerAPIRoutes({
               min: 1,
               defaultValue: 1,
             }),
-            perPage: schema.maybe(
-              schema.number({
-                meta: {
-                  description:
-                    'The number of dashboards to display on each page (max 1000). Default is "20".',
-                },
-                defaultValue: 20,
-                min: 1,
-                max: 1000,
-              })
-            ),
+            perPage: schema.number({
+              meta: {
+                description:
+                  'The number of dashboards to display on each page (max 1000). Default is "20".',
+              },
+              defaultValue: 20,
+              min: 1,
+              max: 1000,
+            }),
           }),
         },
         response: {


### PR DESCRIPTION
Fixes #225559

## Summary

Remove `schema.maybe` from `perPage` query attribute on Dashboard listing endpoint.

When a property has `schema.maybe` and a `defaultValue`, the assigned `defaultValue` is not used and the property falls back to undefined. This was not previously detected, because the saved objects client applies a per page limit of 20 if the setting is undefined.





