### PR TITLE
[Cloud Security] Refactor hard coded Findings filter fields in CSPM benchmark dashboard's

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -209,6 +209,16 @@ export const VULNERABILITY_GROUPING_OPTIONS = {
   CVE: VULNERABILITY_FIELDS.VULNERABILITY_ID,
 } as const;
 
+export const FINDINGS_FILTER_OPTIONS = {
+  CLOUD_PROVIDER: 'cloud.provider',
+  NAMESPACE: 'data_stream.namespace',
+  RULE_BENCHMARK_ID: 'rule.benchmark.id',
+  RULE_BENCHMARK_POSTURE_TYPE: 'rule.benchmark.posture_type',
+  RULE_BENCHMARK_VERSION: 'rule.benchmark.version',
+  RESULT_EVALUATION: 'result.evaluation',
+  RULE_SECTION: 'rule.section',
+} as const;
+
 /*
  * ECS schema unique field to describe the event
  * https://www.elastic.co/guide/en/ecs/current/ecs-event.html

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.test.tsx
@@ -10,6 +10,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { AccountsEvaluatedWidget } from './accounts_evaluated_widget';
 import { BenchmarkData } from '../../common/types_old';
 import { TestProvider } from '../test/test_provider';
+import { FINDINGS_FILTER_OPTIONS, FINDINGS_GROUPING_OPTIONS } from '../common/constants';
 
 const mockNavToFindings = jest.fn();
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_navigate_findings', () => ({
@@ -44,8 +45,8 @@ describe('AccountsEvaluatedWidget', () => {
 
     expect(mockNavToFindings).toHaveBeenCalledWith(
       {
-        'cloud.provider': 'aws',
-        'rule.benchmark.posture_type': 'cspm',
+        [FINDINGS_FILTER_OPTIONS.CLOUD_PROVIDER]: 'aws',
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_POSTURE_TYPE]: 'cspm',
       },
       ['cloud.account.id']
     );
@@ -66,11 +67,11 @@ describe('AccountsEvaluatedWidget', () => {
 
     expect(mockNavToFindings).toHaveBeenCalledWith(
       {
-        'data_stream.namespace': 'test-namespace',
-        'cloud.provider': 'aws',
-        'rule.benchmark.posture_type': 'cspm',
+        [FINDINGS_FILTER_OPTIONS.NAMESPACE]: 'test-namespace',
+        [FINDINGS_FILTER_OPTIONS.CLOUD_PROVIDER]: 'aws',
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_POSTURE_TYPE]: 'cspm',
       },
-      ['cloud.account.id']
+      [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]
     );
   });
 
@@ -85,9 +86,9 @@ describe('AccountsEvaluatedWidget', () => {
 
     expect(mockNavToFindings).toHaveBeenCalledWith(
       {
-        'rule.benchmark.id': 'cis_k8s',
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_ID]: 'cis_k8s',
       },
-      ['orchestrator.cluster.id']
+      [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID]
     );
   });
 
@@ -106,10 +107,10 @@ describe('AccountsEvaluatedWidget', () => {
 
     expect(mockNavToFindings).toHaveBeenCalledWith(
       {
-        'rule.benchmark.id': 'cis_k8s',
-        'data_stream.namespace': 'test-namespace',
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_ID]: 'cis_k8s',
+        [FINDINGS_FILTER_OPTIONS.NAMESPACE]: 'test-namespace',
       },
-      ['orchestrator.cluster.id']
+      [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID]
     );
   });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.test.tsx
@@ -48,29 +48,6 @@ describe('AccountsEvaluatedWidget', () => {
         [FINDINGS_FILTER_OPTIONS.CLOUD_PROVIDER]: 'aws',
         [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_POSTURE_TYPE]: 'cspm',
       },
-      ['cloud.account.id']
-    );
-  });
-
-  it('calls navToFindingsByCloudProvider when a benchmark with provider and namespace is clicked', () => {
-    const { getByText } = render(
-      <TestProvider>
-        <AccountsEvaluatedWidget
-          activeNamespace="test-namespace"
-          benchmarkAssets={benchmarkAssets}
-          benchmarkAbbreviateAbove={999}
-        />
-      </TestProvider>
-    );
-
-    fireEvent.click(getByText('10'));
-
-    expect(mockNavToFindings).toHaveBeenCalledWith(
-      {
-        [FINDINGS_FILTER_OPTIONS.NAMESPACE]: 'test-namespace',
-        [FINDINGS_FILTER_OPTIONS.CLOUD_PROVIDER]: 'aws',
-        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_POSTURE_TYPE]: 'cspm',
-      },
       [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]
     );
   });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
@@ -14,7 +14,7 @@ import { CIS_AWS, CIS_GCP, CIS_AZURE, CIS_K8S, CIS_EKS } from '../../common/cons
 import { CISBenchmarkIcon } from './cis_benchmark_icon';
 import { CompactFormattedNumber } from './compact_formatted_number';
 import { BenchmarkData } from '../../common/types_old';
-import { FINDINGS_GROUPING_OPTIONS } from '../common/constants';
+import { FINDINGS_GROUPING_OPTIONS, FINDINGS_FILTER_OPTIONS } from '../common/constants';
 
 // order in array will determine order of appearance in the dashboard
 const benchmarks = [
@@ -67,11 +67,13 @@ export const AccountsEvaluatedWidget = ({
     navToFindings(
       activeNamespace
         ? {
-            'data_stream.namespace': activeNamespace,
-            'cloud.provider': provider,
-            'rule.benchmark.posture_type': CSPM_POLICY_TEMPLATE,
+            [FINDINGS_FILTER_OPTIONS.NAMESPACE]: activeNamespace,
+            [FINDINGS_FILTER_OPTIONS.CLOUD_PROVIDER]: provider,
           }
-        : { 'cloud.provider': provider, 'rule.benchmark.posture_type': CSPM_POLICY_TEMPLATE },
+        : {
+            [FINDINGS_FILTER_OPTIONS.CLOUD_PROVIDER]: provider,
+            [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_POSTURE_TYPE]: CSPM_POLICY_TEMPLATE,
+          },
       [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]
     );
   };
@@ -80,10 +82,10 @@ export const AccountsEvaluatedWidget = ({
     navToFindings(
       activeNamespace
         ? {
-            'data_stream.namespace': activeNamespace,
-            'rule.benchmark.id': cisBenchmark,
+            [FINDINGS_FILTER_OPTIONS.NAMESPACE]: activeNamespace,
+            [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_ID]: cisBenchmark,
           }
-        : { 'rule.benchmark.id': cisBenchmark },
+        : { [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_ID]: cisBenchmark },
       [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID]
     );
   };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
@@ -67,7 +67,7 @@ export const AccountsEvaluatedWidget = ({
     navToFindings(
       activeNamespace
         ? {
-            [`${FINDINGS_GROUPING_OPTIONS.NAMESPACE}`]: activeNamespace,
+            'data_stream.namespace': activeNamespace,
             'cloud.provider': provider,
             'rule.benchmark.posture_type': CSPM_POLICY_TEMPLATE,
           }
@@ -80,7 +80,7 @@ export const AccountsEvaluatedWidget = ({
     navToFindings(
       activeNamespace
         ? {
-            [`${FINDINGS_GROUPING_OPTIONS.NAMESPACE}`]: activeNamespace,
+            'data_stream.namespace': activeNamespace,
             'rule.benchmark.id': cisBenchmark,
           }
         : { 'rule.benchmark.id': cisBenchmark },

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.test.tsx
@@ -10,6 +10,7 @@ import { render } from '@testing-library/react';
 import { TestProvider } from '../../../test/test_provider';
 import { BenchmarkDetailsBox } from './benchmark_details_box';
 import { getBenchmarkMockData } from '../mock';
+import { FINDINGS_FILTER_OPTIONS } from '../../../common/constants';
 
 const mockNavToFindings = jest.fn();
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_navigate_findings', () => ({
@@ -36,9 +37,9 @@ describe('BenchmarkDetailsBox', () => {
 
     expect(mockNavToFindings).toHaveBeenCalledWith(
       {
-        'data_stream.namespace': 'test-namespace',
-        'rule.benchmark.id': 'cis_aws',
-        'rule.benchmark.version': '1.2.3',
+        [FINDINGS_FILTER_OPTIONS.NAMESPACE]: 'test-namespace',
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_ID]: 'cis_aws',
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_VERSION]: '1.2.3',
       },
       ['cloud.account.id']
     );

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -25,6 +25,7 @@ import { RULE_FAILED, RULE_PASSED } from '../../../../common/constants';
 import {
   LOCAL_STORAGE_DASHBOARD_BENCHMARK_SORT_KEY,
   FINDINGS_GROUPING_OPTIONS,
+  FINDINGS_FILTER_OPTIONS,
 } from '../../../common/constants';
 import { dashboardColumnsGrow, getPolicyTemplateQuery } from './summary_section';
 import {
@@ -41,13 +42,13 @@ export const getBenchmarkIdQuery = (
 ): NavFilter => {
   return activeNamespace
     ? {
-        'rule.benchmark.id': benchmark.meta.benchmarkId,
-        'rule.benchmark.version': benchmark.meta.benchmarkVersion,
-        'data_stream.namespace': activeNamespace,
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_ID]: benchmark.meta.benchmarkId,
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_VERSION]: benchmark.meta.benchmarkVersion,
+        [FINDINGS_FILTER_OPTIONS.NAMESPACE]: activeNamespace,
       }
     : {
-        'rule.benchmark.id': benchmark.meta.benchmarkId,
-        'rule.benchmark.version': benchmark.meta.benchmarkVersion,
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_ID]: benchmark.meta.benchmarkId,
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_VERSION]: benchmark.meta.benchmarkVersion,
       };
 };
 
@@ -81,7 +82,7 @@ export const BenchmarksSection = ({
       {
         ...getPolicyTemplateQuery(dashboardType, activeNamespace),
         ...getBenchmarkIdQuery(benchmark, activeNamespace),
-        'result.evaluation': evaluation,
+        [FINDINGS_FILTER_OPTIONS.RESULT_EVALUATION]: evaluation,
       },
       groupBy
     );
@@ -95,8 +96,8 @@ export const BenchmarksSection = ({
       {
         ...getPolicyTemplateQuery(dashboardType, activeNamespace),
         ...getBenchmarkIdQuery(benchmark, activeNamespace),
-        'rule.section': ruleSection,
-        'result.evaluation': resultEvaluation,
+        [FINDINGS_FILTER_OPTIONS.RULE_SECTION]: ruleSection,
+        [FINDINGS_FILTER_OPTIONS.RESULT_EVALUATION]: resultEvaluation,
       },
       [FINDINGS_GROUPING_OPTIONS.NONE]
     );

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -43,7 +43,7 @@ export const getBenchmarkIdQuery = (
     ? {
         'rule.benchmark.id': benchmark.meta.benchmarkId,
         'rule.benchmark.version': benchmark.meta.benchmarkVersion,
-        [`${FINDINGS_GROUPING_OPTIONS.NAMESPACE}`]: activeNamespace,
+        'data_stream.namespace': activeNamespace,
       }
     : {
         'rule.benchmark.id': benchmark.meta.benchmarkId,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -32,7 +32,7 @@ import type {
 import { RisksTable } from '../compliance_charts/risks_table';
 import { RULE_FAILED, RULE_PASSED } from '../../../../common/constants';
 import { AccountsEvaluatedWidget } from '../../../components/accounts_evaluated_widget';
-import { FINDINGS_GROUPING_OPTIONS } from '../../../common/constants';
+import { FINDINGS_GROUPING_OPTIONS, FINDINGS_FILTER_OPTIONS } from '../../../common/constants';
 
 export const dashboardColumnsGrow: Record<string, EuiFlexItemProps['grow']> = {
   first: 3,
@@ -46,11 +46,11 @@ export const getPolicyTemplateQuery = (
 ): NavFilter =>
   activeNamespace
     ? {
-        'rule.benchmark.posture_type': policyTemplate,
-        'data_stream.namespace': activeNamespace,
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_POSTURE_TYPE]: policyTemplate,
+        [FINDINGS_FILTER_OPTIONS.NAMESPACE]: activeNamespace,
       }
     : {
-        'rule.benchmark.posture_type': policyTemplate,
+        [FINDINGS_FILTER_OPTIONS.RULE_BENCHMARK_POSTURE_TYPE]: policyTemplate,
       };
 
 export const SummarySection = ({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -47,7 +47,7 @@ export const getPolicyTemplateQuery = (
   activeNamespace
     ? {
         'rule.benchmark.posture_type': policyTemplate,
-        [`${FINDINGS_GROUPING_OPTIONS.NAMESPACE}`]: activeNamespace,
+        'data_stream.namespace': activeNamespace,
       }
     : {
         'rule.benchmark.posture_type': policyTemplate,


### PR DESCRIPTION
## Summary


This pull request introduces a new constant, `FINDINGS_FILTER_OPTIONS`, to centralize filter keys used throughout the Cloud Security Posture plugin. The changes replace hardcoded filter keys with references to this constant across multiple components and tests, improving maintainability and consistency.

### Introduction of `FINDINGS_FILTER_OPTIONS`:

* Added `FINDINGS_FILTER_OPTIONS` to `constants.ts` to centralize filter keys such as `CLOUD_PROVIDER`, `NAMESPACE`, `RULE_BENCHMARK_ID`, and others. This ensures a single source of truth for filter key definitions.

### Refactoring in components:

* Updated `AccountsEvaluatedWidget` to replace hardcoded filter keys with `FINDINGS_FILTER_OPTIONS`
* Updated `BenchmarksSection` to use `FINDINGS_FILTER_OPTIONS`
* Updated `SummarySection` to use `FINDINGS_FILTER_OPTIONS

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->