### PR TITLE
Added privileged user monitoring docs link

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -478,6 +478,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
         riskScorePrerequisites: `${ELASTIC_DOCS}solutions/security/advanced-entity-analytics/entity-risk-scoring-requirements`,
         entityRiskScoring: `${ELASTIC_DOCS}solutions/security/advanced-entity-analytics/entity-risk-scoring`,
         assetCriticality: `${ELASTIC_DOCS}solutions/security/advanced-entity-analytics/asset-criticality`,
+        privilegedUserMonitoring: `${ELASTIC_DOCS}solutions/security/advanced-entity-analytics/privileged-user-monitoring`,
       },
       detectionEngineOverview: `${ELASTIC_DOCS}solutions/security/detect-and-alert`,
       aiAssistant: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -337,6 +337,7 @@ export interface DocLinks {
       readonly riskScorePrerequisites: string;
       readonly entityRiskScoring: string;
       readonly assetCriticality: string;
+      readonly privilegedUserMonitoring: string;
     };
     readonly detectionEngineOverview: string;
     readonly signalsMigrationApi: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/onboarding_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/onboarding_panel.tsx
@@ -21,6 +21,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { AddDataSourcePanel } from './components/add_data_source';
 import privilegedUserMonitoringOnboardingPageIllustration from '../../../common/images/information_light.png';
+import { useKibana } from '../../../common/lib/kibana';
 
 interface PrivilegedUserMonitoringOnboardingPanelProps {
   onComplete: (userCount: number) => void;
@@ -29,6 +30,8 @@ interface PrivilegedUserMonitoringOnboardingPanelProps {
 export const PrivilegedUserMonitoringOnboardingPanel = ({
   onComplete,
 }: PrivilegedUserMonitoringOnboardingPanelProps) => {
+  const { docLinks } = useKibana().services;
+
   return (
     <EuiPanel paddingSize="none">
       <EuiPanel paddingSize="xl" color="subdued" hasShadow={false} hasBorder={false}>
@@ -84,10 +87,11 @@ export const PrivilegedUserMonitoringOnboardingPanel = ({
                         defaultMessage="Want to learn more?"
                       />
                       <EuiLink
-                        css={{ color: '#FF007F' }} // TODO DELETE THIS WHEN THE HREF LINK IS READY
                         external={true}
                         data-test-subj="learnMoreLink"
-                        href="??????" // TODO Add Link to docs
+                        href={
+                          docLinks?.links.securitySolution.entityAnalytics.privilegedUserMonitoring
+                        }
                         target="_blank"
                       >
                         <FormattedMessage


### PR DESCRIPTION
# Overview

Adds the documentation link to the Privileged user monitoring page

# How to test

1. Pull this code down
2. Navigate to Security->Entity Analytics->Privileged user monitoring
3. Note that the documentation link is no longer pink, and that it links out to a placeholder page (found [here](https://www.elastic.co/docs/solutions/security/advanced-entity-analytics/privileged-user-monitoring))


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->