### PR TITLE
[Streams 🌊] Reset query value for SearchBar if one is not specified

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_search_bar/uncontrolled_streams_app_bar.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_search_bar/uncontrolled_streams_app_bar.tsx
@@ -23,6 +23,7 @@ export function UncontrolledStreamsAppSearchBar(props: UncontrolledStreamsAppSea
       submitButtonStyle="iconOnly"
       displayStyle="inPage"
       disableQueryLanguageSwitcher
+      query={undefined}
       {...props}
     />
   );


### PR DESCRIPTION
## 📓 Summary

Closes #225668 

Given the stateful nature of the unified search bar, when a `query` property is not specified, it restores the saved value in the session, which coming from ESQL Discover was an `esql` query. 
Since we want want to use queries for the searchbar only when explicitly specified, passing an explicit default value of undefined to the searchbar tells the internal of unified search bar to not restore the previous value.

https://github.com/user-attachments/assets/7525d950-4ce3-481e-bc45-13fe0edb79ad



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->