### PR TITLE
[9.0] [a11y][ml] fix screen reader not reading tooltip p-value (#224666)

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_points_table.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_points_table.tsx
@@ -8,9 +8,7 @@
 import {
   EuiBadge,
   EuiEmptyPrompt,
-  EuiIcon,
   EuiInMemoryTable,
-  EuiToolTip,
   type DefaultItemAction,
   type EuiBasicTableColumn,
 } from '@elastic/eui';
@@ -181,21 +179,15 @@ export const ChangePointsTable: FC<ChangePointsTableProps> = ({
       id: 'pValue',
       'data-test-subj': 'aiopsChangePointPValue',
       field: 'p_value',
-      name: (
-        <EuiToolTip
-          content={i18n.translate('xpack.aiops.changePointDetection.pValueTooltip', {
-            defaultMessage:
-              'Indicates how extreme the change is. Lower values indicate greater change.',
-          })}
-        >
-          <span>
-            {i18n.translate('xpack.aiops.changePointDetection.pValueLabel', {
-              defaultMessage: 'p-value',
-            })}
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
-          </span>
-        </EuiToolTip>
-      ),
+      name: i18n.translate('xpack.aiops.changePointDetection.pValueColumn', {
+        defaultMessage: 'p-value',
+      }),
+      nameTooltip: {
+        content: i18n.translate('xpack.aiops.changePointDetection.pValueTooltip', {
+          defaultMessage:
+            'Indicates how extreme the change is. Lower values indicate greater change.',
+        }),
+      },
       sortable: true,
       truncateText: false,
       render: (pValue: ChangePointAnnotation['p_value']) => pValue.toPrecision(3),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[a11y][ml] fix screen reader not reading tooltip p-value (#224666)](https://github.com/elastic/kibana/pull/224666)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paulina Shakirova","email":"paulina.shakirova@elastic.co"},"sourceCommit":{"committedDate":"2025-06-26T15:16:10Z","message":"[a11y][ml] fix screen reader not reading tooltip p-value (#224666)\n\n## Summary\nThis PR fixes [[ML] Change point detection: p-value tooltip is not\nannounced because lack of\nfocus](https://github.com/elastic/kibana/issues/216545) issue.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b0704474f0f8fef1dfd83054c2085f1be1f6ca39","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","backport:prev-major","a11y","v9.1.0"],"title":"[a11y][ml] fix screen reader not reading tooltip p-value","number":224666,"url":"https://github.com/elastic/kibana/pull/224666","mergeCommit":{"message":"[a11y][ml] fix screen reader not reading tooltip p-value (#224666)\n\n## Summary\nThis PR fixes [[ML] Change point detection: p-value tooltip is not\nannounced because lack of\nfocus](https://github.com/elastic/kibana/issues/216545) issue.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b0704474f0f8fef1dfd83054c2085f1be1f6ca39"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224666","number":224666,"mergeCommit":{"message":"[a11y][ml] fix screen reader not reading tooltip p-value (#224666)\n\n## Summary\nThis PR fixes [[ML] Change point detection: p-value tooltip is not\nannounced because lack of\nfocus](https://github.com/elastic/kibana/issues/216545) issue.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b0704474f0f8fef1dfd83054c2085f1be1f6ca39"}}]}] BACKPORT-->