### PR TITLE
[8.19] [Incident management] Suggested dashboards are returned only for custom threshold alerts (#224458)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/services/alert_data.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/services/alert_data.ts
@@ -6,9 +6,7 @@
  */
 
 import { omit } from 'lodash';
-import { CustomThresholdParams } from '@kbn/response-ops-rule-params/custom_threshold';
 import type { AlertsClient } from '@kbn/rule-registry-plugin/server';
-import { DataViewSpec } from '@kbn/response-ops-rule-params/common';
 import {
   ALERT_RULE_PARAMETERS,
   ALERT_RULE_TYPE_ID,
@@ -16,6 +14,43 @@ import {
   OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
   fields as TECHNICAL_ALERT_FIELDS,
 } from '@kbn/rule-data-utils';
+import { CustomThresholdParams } from '@kbn/response-ops-rule-params/custom_threshold';
+import { DataViewSpec } from '@kbn/response-ops-rule-params/common';
+import {
+  isSuggestedDashboardsValidRuleTypeId,
+  SuggestedDashboardsValidRuleTypeIds,
+} from './helpers';
+
+// TS will make sure that if we add a new supported rule type id we had the corresponding function to get the relevant rule fields
+const getRelevantRuleFieldsMap: Record<
+  SuggestedDashboardsValidRuleTypeIds,
+  (ruleParams: { [key: string]: unknown }) => Set<string>
+> = {
+  [OBSERVABILITY_THRESHOLD_RULE_TYPE_ID]: (customThresholdParams) => {
+    const relevantFields = new Set<string>();
+    const metrics = (customThresholdParams as CustomThresholdParams).criteria[0].metrics;
+    metrics.forEach((metric) => {
+      // The property "field" is of type string | never but it collapses to just string
+      // We should probably avoid typing field as never and just omit it from the type to avoid situations like this one
+      if ('field' in metric) relevantFields.add(metric.field);
+    });
+    return relevantFields;
+  },
+};
+
+const getRuleQueryIndexMap: Record<
+  SuggestedDashboardsValidRuleTypeIds,
+  (ruleParams: { [key: string]: unknown }) => string | null
+> = {
+  [OBSERVABILITY_THRESHOLD_RULE_TYPE_ID]: (customThresholdParams) => {
+    const {
+      searchConfiguration: { index },
+    } = customThresholdParams as CustomThresholdParams;
+    if (typeof index === 'object') return (index as DataViewSpec)?.id || null;
+    if (typeof index === 'string') return index;
+    return null;
+  },
+};
 
 export class AlertData {
   constructor(private alert: Awaited<ReturnType<AlertsClient['get']>>) {}
@@ -30,23 +65,14 @@ export class AlertData {
 
   getRelevantRuleFields(): Set<string> {
     const ruleParameters = this.getRuleParameters();
-    const relevantFields = new Set<string>();
     if (!ruleParameters) {
       throw new Error('No rule parameters found');
     }
-    switch (this.getRuleTypeId()) {
-      case OBSERVABILITY_THRESHOLD_RULE_TYPE_ID:
-        const customThresholdParams = ruleParameters as CustomThresholdParams;
-        const metrics = customThresholdParams.criteria[0].metrics;
-        metrics.forEach((metric) => {
-          if (metric.field) {
-            relevantFields.add(metric.field);
-          }
-        });
-        return relevantFields;
-      default:
-        return relevantFields;
-    }
+    const ruleTypeId = this.getRuleTypeId();
+
+    return isSuggestedDashboardsValidRuleTypeId(ruleTypeId)
+      ? getRelevantRuleFieldsMap[ruleTypeId](ruleParameters)
+      : new Set<string>();
   }
 
   getRelevantAADFields(): string[] {
@@ -76,17 +102,10 @@ export class AlertData {
     if (!ruleParameters) {
       throw new Error('No rule parameters found');
     }
-    switch (ruleTypeId) {
-      case OBSERVABILITY_THRESHOLD_RULE_TYPE_ID:
-        const customThresholdParams = ruleParameters as CustomThresholdParams;
-        if (typeof customThresholdParams.searchConfiguration.index === 'object')
-          return (customThresholdParams.searchConfiguration.index as DataViewSpec)?.id || null;
-        if (typeof customThresholdParams.searchConfiguration.index === 'string')
-          return customThresholdParams.searchConfiguration.index;
-        return null;
-      default:
-        return null;
-    }
+
+    return isSuggestedDashboardsValidRuleTypeId(ruleTypeId)
+      ? getRuleQueryIndexMap[ruleTypeId](ruleParameters)
+      : null;
   }
 
   getRuleTypeId(): string | undefined {

--- a/x-pack/solutions/observability/plugins/observability/server/services/helpers.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/services/helpers.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+
+const SUGGESTED_DASHBOARDS_VALID_RULE_TYPE_IDS = [OBSERVABILITY_THRESHOLD_RULE_TYPE_ID] as const;
+
+export type SuggestedDashboardsValidRuleTypeIds =
+  (typeof SUGGESTED_DASHBOARDS_VALID_RULE_TYPE_IDS)[number];
+
+export const isSuggestedDashboardsValidRuleTypeId = (
+  ruleTypeId?: string
+): ruleTypeId is SuggestedDashboardsValidRuleTypeIds => {
+  return (
+    ruleTypeId !== undefined &&
+    Object.values<string>(SUGGESTED_DASHBOARDS_VALID_RULE_TYPE_IDS).includes(ruleTypeId)
+  );
+};

--- a/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.ts
@@ -22,6 +22,7 @@ import type {
 } from '@kbn/observability-schema';
 import type { InvestigateAlertsClient } from './investigate_alerts_client';
 import type { AlertData } from './alert_data';
+import { isSuggestedDashboardsValidRuleTypeId } from './helpers';
 
 type Dashboard = SavedObjectsFindResult<DashboardAttributes>;
 export class RelatedDashboardsClient {
@@ -71,6 +72,8 @@ export class RelatedDashboardsClient {
 
   private async fetchSuggestedDashboards(): Promise<SuggestedDashboard[]> {
     const alert = this.checkAlert();
+    if (!isSuggestedDashboardsValidRuleTypeId(alert.getRuleTypeId())) return [];
+
     const allSuggestedDashboards = new Set<SuggestedDashboard>();
     const relevantDashboardsById = new Map<string, SuggestedDashboard>();
     const index = this.getRuleQueryIndex();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Incident management] Suggested dashboards are returned only for custom threshold alerts (#224458)](https://github.com/elastic/kibana/pull/224458)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-06-30T10:00:01Z","message":"[Incident management] Suggested dashboards are returned only for custom threshold alerts (#224458)\n\nSuggested dashboards should return only for custom threshold alerts at\nthe moment, we'll return an empty array for all the other rule type ids.\n\nWith this refactor whenever we want to add a new rule type id TS will\nmake sure we also add a `getRelevantRuleFields` and a\n`getRuleQueryIndex` for the new rule type id.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"85c8d521c105e5caf7d171dcccc6a874b947a0ce","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management","v9.2.0"],"title":"[Incident management] Suggested dashboards are returned only for custom threshold alerts","number":224458,"url":"https://github.com/elastic/kibana/pull/224458","mergeCommit":{"message":"[Incident management] Suggested dashboards are returned only for custom threshold alerts (#224458)\n\nSuggested dashboards should return only for custom threshold alerts at\nthe moment, we'll return an empty array for all the other rule type ids.\n\nWith this refactor whenever we want to add a new rule type id TS will\nmake sure we also add a `getRelevantRuleFields` and a\n`getRuleQueryIndex` for the new rule type id.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"85c8d521c105e5caf7d171dcccc6a874b947a0ce"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225792","number":225792,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224458","number":224458,"mergeCommit":{"message":"[Incident management] Suggested dashboards are returned only for custom threshold alerts (#224458)\n\nSuggested dashboards should return only for custom threshold alerts at\nthe moment, we'll return an empty array for all the other rule type ids.\n\nWith this refactor whenever we want to add a new rule type id TS will\nmake sure we also add a `getRelevantRuleFields` and a\n`getRuleQueryIndex` for the new rule type id.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"85c8d521c105e5caf7d171dcccc6a874b947a0ce"}}]}] BACKPORT-->