### PR TITLE
[Attack Discovery][Scheduling] Use triple braces by default for the URL and markdown fields

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/message_variables.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/message_variables.test.ts
@@ -15,49 +15,82 @@ describe('getMessageVariables', () => {
   it('should return `context.attack.alertIds` action variable', () => {
     const variables = getMessageVariables().context;
     expect(variables).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'attack.alertIds' })])
+      expect.arrayContaining([{ description: expect.anything(), name: 'attack.alertIds' }])
     );
   });
 
   it('should return `context.attack.detailsMarkdown` action variable', () => {
     const variables = getMessageVariables().context;
     expect(variables).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'attack.detailsMarkdown' })])
+      expect.arrayContaining([
+        {
+          description: expect.anything(),
+          name: 'attack.detailsMarkdown',
+          useWithTripleBracesInTemplates: true,
+        },
+      ])
     );
   });
 
   it('should return `context.attack.summaryMarkdown` action variable', () => {
     const variables = getMessageVariables().context;
     expect(variables).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'attack.summaryMarkdown' })])
+      expect.arrayContaining([
+        {
+          description: expect.anything(),
+          name: 'attack.summaryMarkdown',
+          useWithTripleBracesInTemplates: true,
+        },
+      ])
     );
   });
 
   it('should return `context.attack.title` action variable', () => {
     const variables = getMessageVariables().context;
     expect(variables).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'attack.title' })])
+      expect.arrayContaining([{ description: expect.anything(), name: 'attack.title' }])
     );
   });
 
   it('should return `context.attack.timestamp` action variable', () => {
     const variables = getMessageVariables().context;
     expect(variables).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'attack.timestamp' })])
+      expect.arrayContaining([{ description: expect.anything(), name: 'attack.timestamp' }])
     );
   });
 
   it('should return `context.attack.entitySummaryMarkdown` action variable', () => {
     const variables = getMessageVariables().context;
     expect(variables).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'attack.entitySummaryMarkdown' })])
+      expect.arrayContaining([
+        {
+          description: expect.anything(),
+          name: 'attack.entitySummaryMarkdown',
+          useWithTripleBracesInTemplates: true,
+        },
+      ])
     );
   });
 
   it('should return `context.attack.mitreAttackTactics` action variable', () => {
     const variables = getMessageVariables().context;
     expect(variables).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'attack.mitreAttackTactics' })])
+      expect.arrayContaining([
+        { description: expect.anything(), name: 'attack.mitreAttackTactics' },
+      ])
+    );
+  });
+
+  it('should return `context.attack.detailsUrl` action variable', () => {
+    const variables = getMessageVariables().context;
+    expect(variables).toEqual(
+      expect.arrayContaining([
+        {
+          description: expect.anything(),
+          name: 'attack.detailsUrl',
+          useWithTripleBracesInTemplates: true,
+        },
+      ])
     );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/message_variables.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/message_variables.ts
@@ -31,6 +31,7 @@ export const getMessageVariables = (): ActionVariables => {
               'Details of the attack with bulleted markdown that always uses special syntax for field names and values from the source data',
           }
         ),
+        useWithTripleBracesInTemplates: true,
       },
       {
         name: 'attack.summaryMarkdown',
@@ -40,6 +41,7 @@ export const getMessageVariables = (): ActionVariables => {
             defaultMessage: 'A markdown summary of attack discovery, using the same syntax',
           }
         ),
+        useWithTripleBracesInTemplates: true,
       },
       {
         name: 'attack.title',
@@ -68,6 +70,7 @@ export const getMessageVariables = (): ActionVariables => {
               'A short (no more than a sentence) summary of the attack discovery featuring only the host.name and user.name fields (when they are applicable), using the same syntax',
           }
         ),
+        useWithTripleBracesInTemplates: true,
       },
       {
         name: 'attack.mitreAttackTactics',
@@ -86,6 +89,7 @@ export const getMessageVariables = (): ActionVariables => {
             defaultMessage: 'A link to the attack discovery details',
           }
         ),
+        useWithTripleBracesInTemplates: true,
       },
     ],
   };


### PR DESCRIPTION
## Summary

According to the [mustache syntax](https://github.com/janl/mustache.js?tab=readme-ov-file#variables), all variables are HTML-escaped by default. If we want to render unescaped HTML, we should use the triple mustache: `{{{name}}}`.

There are a few attack discovery variables in the action's context that we would like to render as unescaped HTML to preserve the URL and markdown structure. Those variable should be added using triple mustache by default from the action's "Add variable" menu:

<img width="379" alt="Screenshot 2025-06-30 at 11 55 08" src="https://github.com/user-attachments/assets/6ca19adb-2b17-4eaf-b4f7-c94d0674c7fc" />

### Variables that use triple mustache

- `context.attack.detailsMarkdown`
- `context.attack.summaryMarkdown`
- `context.attack.entitySummaryMarkdown`
- `context.attack.detailsUrl`

### Screenshots

**Using double mustache**:

<img width="1547" alt="Screenshot 2025-06-30 at 12 08 54" src="https://github.com/user-attachments/assets/f1e86d0f-14fb-4041-be8b-d96cd208a5a9" />

**Using triple mustache**:

<img width="1547" alt="Screenshot 2025-06-30 at 12 08 41" src="https://github.com/user-attachments/assets/627a1b74-8c2c-44c0-8d0f-8be17ca61482" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->