### PR TITLE
[Dashboard] Skip fallback for no references

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/dashboard_saved_object/migrations/migrate_extract_panel_references/dashboard_container_references.ts
+++ b/src/platform/plugins/shared/dashboard/server/dashboard_saved_object/migrations/migrate_extract_panel_references/dashboard_container_references.ts
@@ -51,8 +51,7 @@ export const createInject = (
 
       for (const [key, panel] of Object.entries(workingState.panels)) {
         workingState.panels[key] = { ...panel };
-        const filteredReferences = getReferencesForPanelId(key, references);
-        const panelReferences = filteredReferences.length === 0 ? references : filteredReferences;
+        const panelReferences = getReferencesForPanelId(key, references) ?? [];
 
         /**
          * Inject saved object ID back into the explicit input.


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/225118

The above issue was mostly fixed by [this PR](https://github.com/elastic/kibana/pull/223149), but it seemed prudent to stop sending _all_ dashboard references to any panels that don't have references, just in case there is a similar error like Lens / ESQL panels where all given references are persisted.

This shouldn't cause any failures as since 7.11 all panels with references have extracted them with the proper prefix.