### PR TITLE
[Cloud Security] fix misconfiguration and vulnerability flyout UI issues

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/overview_tab.tsx
@@ -18,9 +18,16 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
 import React, { useMemo } from 'react';
-import type { EuiDescriptionListProps, EuiAccordionProps, EuiBasicTableColumn } from '@elastic/eui';
+import type {
+  EuiDescriptionListProps,
+  EuiAccordionProps,
+  EuiBasicTableColumn,
+  EuiThemeComputed,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
   CDR_MISCONFIGURATIONS_INDEX_PATTERN,
@@ -82,9 +89,21 @@ const renderTableField = (value: string) => {
     return <EuiText size="xs">{EMPTY_VALUE}</EuiText>;
   }
 
-  return Array.isArray(value) ? (
-    <MultiValueCellPopover<unknown> items={value} field="" object={{}} renderItem={renderValue} />
-  ) : (
+  if (Array.isArray(value)) {
+    return (
+      <MultiValueCellPopover<unknown>
+        items={value}
+        field=""
+        object={{}}
+        renderItem={renderValue}
+        {...(value.length === 1
+          ? { firstItemRenderer: (item) => <TruncatedCopyableText textToCopy={item} /> }
+          : {})}
+      />
+    );
+  }
+
+  return (
     <>
       <TruncatedCopyableText textToCopy={value} />
     </>
@@ -138,40 +157,74 @@ const getResourceList = (data: CspFinding) => [
 const getDetailsList = (
   data: CspFinding,
   ruleFlyoutLink?: string,
-  discoverDataViewLink?: string
+  discoverDataViewLink?: string,
+  euiTheme?: EuiThemeComputed<{}>
 ) => [
   {
     title: (
-      <>
-        <EuiFlexGroup direction="row" gutterSize="m">
-          <EuiFlexItem>
-            {i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.ruleDescription', {
-              defaultMessage: 'Rule Description',
-            })}
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiLink href={ruleFlyoutLink} target="_blank" css={{ textAlign: 'right' }}>
-              <EuiIcon type="expand" />
-              {i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.showRuleDetails', {
-                defaultMessage: 'Show rule details',
+      <EuiFlexGroup direction="row" gutterSize="m" css={{ marginBottom: euiTheme?.size.xs }}>
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h1>
+              {i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.ruleDescription', {
+                defaultMessage: 'Rule Description',
               })}
-            </EuiLink>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </>
+            </h1>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h1>
+              <div
+                css={{
+                  textAlign: 'right',
+                  display: 'flex',
+                  gap: euiTheme?.size.s,
+                  alignItems: 'center',
+                  justifyContent: 'flex-end',
+                  marginBottom: euiTheme?.size.xs,
+                }}
+              >
+                <EuiIcon type="expand" color="primary" />
+                <EuiLink href={ruleFlyoutLink} target="_blank" external={false}>
+                  {i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.showRuleDetails', {
+                    defaultMessage: 'Show rule details',
+                  })}
+                </EuiLink>
+              </div>
+            </h1>
+          </EuiTitle>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     ),
-    description: data.rule?.description ? <EuiText>{data.rule?.description}</EuiText> : EMPTY_VALUE,
+    description: data.rule?.description ? (
+      <EuiText size="s">{data.rule?.description}</EuiText>
+    ) : (
+      EMPTY_VALUE
+    ),
   },
   {
-    title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.alertsTitle', {
-      defaultMessage: 'Alerts',
-    }),
+    title: (
+      <EuiTitle size="xxs" css={{ marginBottom: euiTheme?.size.xs }}>
+        <h1>
+          {i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.alertsTitle', {
+            defaultMessage: 'Alerts',
+          })}
+        </h1>
+      </EuiTitle>
+    ),
     description: <FindingsDetectionRuleCounter finding={data} />,
   },
   {
-    title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.dataViewTitle', {
-      defaultMessage: 'Data View',
-    }),
+    title: (
+      <EuiTitle size="xxs" css={{ marginBottom: euiTheme?.size.xs }}>
+        <h1>
+          {i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.dataViewTitle', {
+            defaultMessage: 'Data View',
+          })}
+        </h1>
+      </EuiTitle>
+    ),
     description: discoverDataViewLink ? (
       <EuiLink href={discoverDataViewLink}>{CDR_MISCONFIGURATIONS_INDEX_PATTERN}</EuiLink>
     ) : (
@@ -229,6 +282,7 @@ export const OverviewTab = ({
 }) => {
   const { discover } = useKibana<CoreStart & CspClientPluginStartDeps>().services;
   const cdrMisconfigurationsDataView = useDataView(CDR_MISCONFIGURATIONS_DATA_VIEW_ID_PREFIX);
+  const { euiTheme } = useEuiTheme();
 
   // link will navigate to our dataview in discover, filtered by the data source of the finding
   const discoverDataViewLink = useMemo(
@@ -265,7 +319,7 @@ export const OverviewTab = ({
             defaultMessage: 'About',
           }),
           id: 'detailsAccordion',
-          listItems: getDetailsList(data, ruleFlyoutLink, discoverDataViewLink),
+          listItems: getDetailsList(data, ruleFlyoutLink, discoverDataViewLink, euiTheme),
         },
         {
           initialIsOpen: true,
@@ -294,7 +348,7 @@ export const OverviewTab = ({
             listItems: getEvidenceList(data),
           },
       ].filter(truthy),
-    [data, discoverDataViewLink, hasEvidence, ruleFlyoutLink]
+    [data, discoverDataViewLink, euiTheme, hasEvidence, ruleFlyoutLink]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_right/header.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_right/header.tsx
@@ -93,22 +93,20 @@ export const FindingsVulnerabilityFlyoutHeader = ({
             href={referenceLink}
             target="_blank"
             color="primary"
-            css={{
-              fontWeight: euiTheme.font.weight.semiBold,
-            }}
+            css={css`
+              display: flex;
+              align-items: center;
+              svg {
+                width: ${euiTheme.base}px;
+                height: ${euiTheme.base}px;
+              }
+            `}
           >
             {id}
           </EuiLink>
         </EuiText>
       ) : (
-        <EuiText
-          css={css`
-            font-weight: ${euiTheme.font.weight.semiBold} !important;
-          `}
-          data-test-subj={VULNERABILITY_HEADER_ID}
-        >
-          {id}
-        </EuiText>
+        <EuiText data-test-subj={VULNERABILITY_HEADER_ID}>{id}</EuiText>
       );
     };
 
@@ -121,10 +119,10 @@ export const FindingsVulnerabilityFlyoutHeader = ({
       >
         <EuiFlexItem grow={false}>
           <EuiTitle
-            size="m"
+            size="s"
             css={css`
-              line-height: 32px;
-              font-weight: bold;
+              font-weight: ${euiTheme.font.weight.semiBold};
+              line-height: ${euiTheme.size.xl};
             `}
           >
             {renderVulnerabilityId()}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_title.tsx
@@ -67,7 +67,7 @@ export const FlyoutTitle: FC<FlyoutTitleProps> = memo(
 
     const titleComponent = useMemo(() => {
       return (
-        <EuiTitle size="s" data-test-subj={`${dataTestSubj}Text`}>
+        <EuiTitle size="m" data-test-subj={`${dataTestSubj}Text`}>
           <EuiTextColor color={isLink ? euiTheme.colors.textPrimary : undefined}>
             <span>{title}</span>
           </EuiTextColor>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_title.tsx
@@ -67,7 +67,7 @@ export const FlyoutTitle: FC<FlyoutTitleProps> = memo(
 
     const titleComponent = useMemo(() => {
       return (
-        <EuiTitle size="m" data-test-subj={`${dataTestSubj}Text`}>
+        <EuiTitle size="s" data-test-subj={`${dataTestSubj}Text`}>
           <EuiTextColor color={isLink ? euiTheme.colors.textPrimary : undefined}>
             <span>{title}</span>
           </EuiTextColor>


### PR DESCRIPTION
## Summary
This PR fixes the following issues:

1. misconfiguration and vulnerability expandable flyout title and sub title font size should be as specified in the [design](https://www.figma.com/design/MimidTyvcOa19Xq9IzrbaS/Expandable-Flyout---Findings?node-id=989-178616&m=dev).
2. fix 'About' section in misconfiguration tab - fix sub titles sizes and spacing, remove link icon from 'show rule details' text.
3. fix Resource table rendering to handle properly package fields with array of single item - copy icon should be rendered in this case.




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] misconfiguration and vulnerability expandable flyout title and sub title font size should be as specified in the [design](https://www.figma.com/design/MimidTyvcOa19Xq9IzrbaS/Expandable-Flyout---Findings?node-id=989-178616&m=dev).

### Screenshot

**title and sub title fix**
![image](https://github.com/user-attachments/assets/ccb9e56a-2720-42e6-9903-f043fd8ba701)

![image](https://github.com/user-attachments/assets/adf09a47-2392-44e1-a15b-becce2b3a83e)

![image](https://github.com/user-attachments/assets/b28108e9-e624-47da-b1c2-e3322b8c97f1)

![image](https://github.com/user-attachments/assets/b8ddea87-7e3d-4127-b59f-a845f3528c9c)

**vulnerability flyout - overview tab resource section fix **
![image](https://github.com/user-attachments/assets/15a1a63b-f358-460d-99cc-7519f7d512f4)

**misconfiguration flyout - about section spacing and font size issues fix**
![image](https://github.com/user-attachments/assets/fa91badf-4ba4-43c1-82cb-15177cf5fe34)



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->