### PR TITLE
Use mocked date for getNextRun

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
@@ -65,6 +65,8 @@ describe('getNextRunAt', () => {
   });
 
   test('should use the rrule with a fixed time when it is given to calculate the next runAt (same day)', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-06-30T10:00:00.000Z'));
     const now = new Date('2025-06-30T10:00:00.000Z');
     const testStart = new Date(now.getTime() - 500);
     const testRunAt = new Date(now.getTime() - 1000);
@@ -87,9 +89,12 @@ describe('getNextRunAt', () => {
     );
     const expectedNextRunAt = new Date('2025-06-30T12:15:59.500Z');
     expect(nextRunAt).toEqual(expectedNextRunAt);
+    jest.useRealTimers();
   });
 
   test('should use the rrule with a fixed time when it is given to calculate the next runAt (next day)', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-06-30T10:00:00.000Z'));
     const now = new Date('2025-06-30T13:00:00.000Z');
     const testStart = new Date(now.getTime() - 500);
     const testRunAt = new Date(now.getTime() - 1000);
@@ -112,6 +117,7 @@ describe('getNextRunAt', () => {
     );
     const expectedNextRunAt = new Date('2025-07-01T12:15:59.500Z');
     expect(nextRunAt).toEqual(expectedNextRunAt);
+    jest.useRealTimers();
   });
 
   test('should use the rrule with a basic interval time when it is given to calculate the next runAt', () => {


### PR DESCRIPTION
Fixes: #220501

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->