### PR TITLE
[onechat] Separate builtIn tools from ESQL tools in the UI

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/base_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/base_tools.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiBadgeGroup,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiFlexGroup,
+  EuiHorizontalRule,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { ToolDescriptor } from '@kbn/onechat-common';
+import React from 'react';
+import { useOnechatBaseTools } from '../../hooks/use_tools';
+import { truncateAtNewline } from '../../utils/truncate_at_newline';
+
+const columns: Array<EuiBasicTableColumn<ToolDescriptor>> = [
+  {
+    field: 'id',
+    name: i18n.translate('xpack.onechat.tools.toolIdLabel', { defaultMessage: 'Tool' }),
+    valign: 'top',
+    render: (id: string) => (
+      <EuiText size="s">
+        <strong>{id}</strong>
+      </EuiText>
+    ),
+  },
+  {
+    field: 'description',
+    name: i18n.translate('xpack.onechat.tools.toolDescriptionLabel', {
+      defaultMessage: 'Description',
+    }),
+    width: '60%',
+    valign: 'top',
+    render: (description: string) => {
+      return <EuiText size="s">{truncateAtNewline(description)}</EuiText>;
+    },
+  },
+  {
+    field: 'meta.tags',
+    name: i18n.translate('xpack.onechat.tools.tagsLabel', {
+      defaultMessage: 'Tags',
+    }),
+    width: '15%',
+    valign: 'top',
+    render: (tags: string[]) => {
+      return (
+        <EuiBadgeGroup>
+          {tags.map((tag) => (
+            <EuiBadge key={tag} color="primary">
+              {tag}
+            </EuiBadge>
+          ))}
+        </EuiBadgeGroup>
+      );
+    },
+  },
+];
+
+export const OnechatBaseTools: React.FC = () => {
+  const { tools, isLoading, error } = useOnechatBaseTools();
+  const errorMessage = error
+    ? i18n.translate('xpack.onechat.tools.listToolsErrorMessage', {
+        defaultMessage: 'Failed to fetch tools',
+      })
+    : undefined;
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiTitle size="s">
+        <h2>
+          {i18n.translate('xpack.onechat.tools.baseToolsTitle', { defaultMessage: 'Base Tools' })}
+        </h2>
+      </EuiTitle>
+      <EuiText component="p" size="s">
+        {i18n.translate('xpack.onechat.tools.baseToolsDescription', {
+          defaultMessage: 'Out-of-the-box tools ready for use in your chat experience.',
+        })}
+      </EuiText>
+      <EuiHorizontalRule margin="xs" />
+      <EuiBasicTable
+        loading={isLoading}
+        columns={columns}
+        items={tools}
+        itemId="id"
+        error={errorMessage}
+      />
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql_tools.tsx
@@ -5,17 +5,21 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiBadgeGroup, EuiBasicTable, EuiBasicTableColumn, EuiText } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiBadgeGroup,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiFlexGroup,
+  EuiHorizontalRule,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ToolDescriptor } from '@kbn/onechat-common';
 import React from 'react';
-import { useOnechatTools } from '../../hooks/use_tools';
-
-const parseToolDescription = (description: string): string => {
-  // Truncate at newline
-  const [truncatedDescription] = description.split('\n');
-  return truncatedDescription;
-};
+import { useOnechatEsqlTools } from '../../hooks/use_tools';
+import { truncateAtNewline } from '../../utils/truncate_at_newline';
 
 const columns: Array<EuiBasicTableColumn<ToolDescriptor>> = [
   {
@@ -36,7 +40,7 @@ const columns: Array<EuiBasicTableColumn<ToolDescriptor>> = [
     width: '60%',
     valign: 'top',
     render: (description: string) => {
-      return <EuiText size="s">{parseToolDescription(description)}</EuiText>;
+      return <EuiText size="s">{truncateAtNewline(description)}</EuiText>;
     },
   },
   {
@@ -60,8 +64,8 @@ const columns: Array<EuiBasicTableColumn<ToolDescriptor>> = [
   },
 ];
 
-export const OnechatToolsTable: React.FC = () => {
-  const { tools, isLoading, error } = useOnechatTools();
+export const OnechatEsqlTools: React.FC = () => {
+  const { tools, isLoading, error } = useOnechatEsqlTools();
   const errorMessage = error
     ? i18n.translate('xpack.onechat.tools.listToolsErrorMessage', {
         defaultMessage: 'Failed to fetch tools',
@@ -69,15 +73,33 @@ export const OnechatToolsTable: React.FC = () => {
     : undefined;
 
   return (
-    <EuiBasicTable
-      loading={isLoading}
-      columns={columns}
-      items={tools}
-      itemId="id"
-      noItemsMessage={i18n.translate('xpack.onechat.tools.noToolsMessage', {
-        defaultMessage: 'No tools found',
-      })}
-      error={errorMessage}
-    />
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiTitle size="s">
+        <h2>
+          {i18n.translate('xpack.onechat.tools.esqlToolsTitle', { defaultMessage: 'ES|QL Tools' })}
+        </h2>
+      </EuiTitle>
+      <EuiText component="p" size="s">
+        {i18n.translate('xpack.onechat.tools.esqlToolsDescription', {
+          defaultMessage: 'Define your own custom tools using ES|QL queries.',
+        })}
+      </EuiText>
+      <EuiHorizontalRule margin="xs" />
+      {tools.length > 0 ? (
+        <EuiBasicTable
+          loading={isLoading}
+          columns={columns}
+          items={tools}
+          itemId="id"
+          error={errorMessage}
+        />
+      ) : (
+        <EuiText component="p" size="s" textAlign="center" color="subdued">
+          {i18n.translate('xpack.onechat.tools.noEsqlToolsMessage', {
+            defaultMessage: "It looks like you don't have any ES|QL tools defined yet.",
+          })}
+        </EuiText>
+      )}
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
+import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import React from 'react';
-import { OnechatToolsTable } from './tools_table';
+import { OnechatBaseTools } from './base_tools';
+import { OnechatEsqlTools } from './esql_tools';
+
 export const OnechatTools = () => {
   return (
     <KibanaPageTemplate>
@@ -22,7 +25,9 @@ export const OnechatTools = () => {
         })}
       />
       <KibanaPageTemplate.Section>
-        <OnechatToolsTable />
+        <OnechatEsqlTools />
+        <EuiSpacer size="xl" />
+        <OnechatBaseTools />
       </KibanaPageTemplate.Section>
     </KibanaPageTemplate>
   );

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_tools.ts
@@ -6,6 +6,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { useOnechatServices } from './use_onechat_service';
 
 export const useOnechatTools = () => {
@@ -17,4 +18,21 @@ export const useOnechatTools = () => {
   });
 
   return { tools: data?.tools ?? [], isLoading, error };
+};
+
+export const useOnechatBaseTools = () => {
+  const { tools, ...rest } = useOnechatTools();
+
+  const baseTools = useMemo(
+    () => tools.filter((tool) => tool.meta.providerId === 'builtIn'),
+    [tools]
+  );
+  return { tools: baseTools, ...rest };
+};
+
+export const useOnechatEsqlTools = () => {
+  const { tools, ...rest } = useOnechatTools();
+
+  const esqlTools = useMemo(() => tools.filter((tool) => tool.meta.providerId === 'esql'), [tools]);
+  return { tools: esqlTools, ...rest };
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/truncate_at_newline.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/truncate_at_newline.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { truncateAtNewline } from './truncate_at_newline';
+
+describe('truncateAtNewline', () => {
+  it('should truncate a string at the first newline character', () => {
+    const input = 'Hello\nWorld';
+    const expected = 'Hello';
+    expect(truncateAtNewline(input)).toBe(expected);
+  });
+
+  it('should return the original string if no newline character is present', () => {
+    const input = 'Hello World';
+    expect(truncateAtNewline(input)).toBe(input);
+  });
+
+  it('should handle strings with multiple newline characters', () => {
+    const input = 'Hello\nWorld\nAgain';
+    const expected = 'Hello';
+    expect(truncateAtNewline(input)).toBe(expected);
+  });
+
+  it('should handle an empty string', () => {
+    const input = '';
+    expect(truncateAtNewline(input)).toBe('');
+  });
+
+  it('should handle a string that starts with a newline', () => {
+    const input = '\nHelloWorld';
+    expect(truncateAtNewline(input)).toBe('');
+  });
+
+  it('should handle a string with only a newline character', () => {
+    const input = '\n';
+    expect(truncateAtNewline(input)).toBe('');
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/truncate_at_newline.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/truncate_at_newline.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Truncates a string at the first newline character.
+ * If no newline character is present, the original string is returned.
+ *
+ * @param str The string to truncate.
+ * @returns The truncated string, or an empty string if the input is null or undefined.
+ */
+export const truncateAtNewline = (str: string): string => {
+  if (!str) {
+    return '';
+  }
+  const [truncated] = str.split('\n');
+  return truncated;
+};


### PR DESCRIPTION
## Summary

This PR separates the ES|QL tools from the built-in tools on the tools page.

![Screenshot 2025-06-30 at 1 21 56 PM](https://github.com/user-attachments/assets/c2992bdd-962a-4f8d-ba4f-402b5f069362)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



