### PR TITLE
[8.19] [ES|QL Controls] Refresh "Values from a query" options on dashboard reload (#225101)

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
@@ -7,10 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import deepEqual from 'react-fast-compare';
-import { BehaviorSubject, combineLatest, map, merge } from 'rxjs';
-import type { ESQLControlVariable, ESQLControlState, EsqlControlType } from '@kbn/esql-types';
-import { ESQLVariableType } from '@kbn/esql-types';
+import { BehaviorSubject, combineLatest, filter, map, merge, switchMap } from 'rxjs';
+import {
+  ESQLControlVariable,
+  ESQLControlState,
+  EsqlControlType,
+  ESQLVariableType,
+} from '@kbn/esql-types';
 import { PublishingSubject, StateComparators } from '@kbn/presentation-publishing';
+import { dataService } from '../../services/kibana_services';
+import { ControlGroupApi } from '../../control_group/types';
+import { getESQLSingleColumnValues } from './utils/get_esql_single_column_values';
 
 function selectedOptionsComparatorFunction(a?: string[], b?: string[]) {
   return deepEqual(a ?? [], b ?? []);
@@ -37,7 +44,10 @@ export const selectionComparators: StateComparators<
   title: 'referenceEquality',
 };
 
-export function initializeESQLControlSelections(initialState: ESQLControlState) {
+export function initializeESQLControlSelections(
+  initialState: ESQLControlState,
+  controlFetch$: ReturnType<ControlGroupApi['controlFetch$']>
+) {
   const availableOptions$ = new BehaviorSubject<string[]>(initialState.availableOptions ?? []);
   const selectedOptions$ = new BehaviorSubject<string[]>(initialState.selectedOptions ?? []);
   const hasSelections$ = new BehaviorSubject<boolean>(false); // hardcoded to false to prevent clear action from appearing.
@@ -55,6 +65,25 @@ export function initializeESQLControlSelections(initialState: ESQLControlState) 
     }
   }
 
+  // For Values From Query controls, update values on dashboard load/reload
+  const fetchSubscription = controlFetch$
+    .pipe(
+      filter(() => controlType$.getValue() === EsqlControlType.VALUES_FROM_QUERY),
+      switchMap(
+        async ({ timeRange }) =>
+          await getESQLSingleColumnValues({
+            query: esqlQuery$.getValue(),
+            search: dataService.search.search,
+            timeRange,
+          })
+      )
+    )
+    .subscribe((result) => {
+      if (getESQLSingleColumnValues.isSuccess(result)) {
+        availableOptions$.next(result.values);
+      }
+    });
+
   // derive ESQL control variable from state.
   const getEsqlVariable = () => ({
     key: variableName$.value,
@@ -64,12 +93,18 @@ export function initializeESQLControlSelections(initialState: ESQLControlState) 
     type: variableType$.value,
   });
   const esqlVariable$ = new BehaviorSubject<ESQLControlVariable>(getEsqlVariable());
-  const subscriptions = combineLatest([variableName$, variableType$, selectedOptions$]).subscribe(
-    () => esqlVariable$.next(getEsqlVariable())
-  );
+  const variableSubscriptions = combineLatest([
+    variableName$,
+    variableType$,
+    selectedOptions$,
+    availableOptions$,
+  ]).subscribe(() => esqlVariable$.next(getEsqlVariable()));
 
   return {
-    cleanup: () => subscriptions.unsubscribe(),
+    cleanup: () => {
+      variableSubscriptions.unsubscribe();
+      fetchSubscription.unsubscribe();
+    },
     api: {
       hasSelections$: hasSelections$ as PublishingSubject<boolean | undefined>,
       esqlVariable$: esqlVariable$ as PublishingSubject<ESQLControlVariable>,

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -37,7 +37,10 @@ export const getESQLControlFactory = (): ControlFactory<ESQLControlState, ESQLCo
     getDisplayName: () => displayName,
     buildControl: async ({ initialState, finalizeApi, uuid, controlGroupApi }) => {
       const defaultControlManager = initializeDefaultControlManager(initialState);
-      const selections = initializeESQLControlSelections(initialState);
+      const selections = initializeESQLControlSelections(
+        initialState,
+        controlGroupApi.controlFetch$(uuid)
+      );
 
       const closeOverlay = () => {
         if (apiHasParentApi(controlGroupApi) && tracksOverlays(controlGroupApi.parentApi)) {

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/utils/get_esql_single_column_values.test.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/utils/get_esql_single_column_values.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { ISearchGeneric } from '@kbn/search-types';
+import {
+  getESQLSingleColumnValues,
+  GetESQLSingleColumnValuesSuccess,
+  GetESQLSingleColumnValuesFailure,
+} from './get_esql_single_column_values';
+
+const mockGetESQLResults = jest.fn();
+jest.mock('@kbn/esql-utils', () => ({
+  getESQLResults: (...args: any[]) => mockGetESQLResults(...args),
+}));
+
+const searchMock = {} as ISearchGeneric;
+
+describe('getESQLSingleColumnValues', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  it('returns only options on success', async () => {
+    mockGetESQLResults.mockResolvedValueOnce({
+      response: {
+        columns: [{ name: 'column1' }],
+        values: [['option1'], ['option2']],
+      },
+    });
+    const result = (await getESQLSingleColumnValues({
+      query: 'FROM index | STATS BY column',
+      search: searchMock,
+    })) as GetESQLSingleColumnValuesSuccess;
+    expect(getESQLSingleColumnValues.isSuccess(result)).toBe(true);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "values": Array [
+          "option1",
+          "option2",
+        ],
+      }
+    `);
+  });
+  it('returns an error when query returns multiple columns', async () => {
+    mockGetESQLResults.mockResolvedValueOnce({
+      response: {
+        columns: [{ name: 'column1' }, { name: 'column2' }],
+        values: [['option1'], ['option2']],
+      },
+    });
+    const result = (await getESQLSingleColumnValues({
+      query: 'FROM index',
+      search: searchMock,
+    })) as GetESQLSingleColumnValuesFailure;
+    expect(getESQLSingleColumnValues.isSuccess(result)).toBe(false);
+    expect('values' in result).toBe(false);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "errors": Array [
+          [Error: Query must return a single column],
+        ],
+      }
+    `);
+  });
+  it('returns an error on a failed query', async () => {
+    mockGetESQLResults.mockRejectedValueOnce('Invalid ES|QL query');
+    const result = (await getESQLSingleColumnValues({
+      query: 'FROM index | EVAL',
+      search: searchMock,
+    })) as GetESQLSingleColumnValuesFailure;
+    expect(getESQLSingleColumnValues.isSuccess(result)).toBe(false);
+    expect('values' in result).toBe(false);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "errors": Array [
+          "Invalid ES|QL query",
+        ],
+      }
+    `);
+  });
+
+  it('passes timeRange successfully', async () => {
+    const timeRange = { from: 'now-10m', to: 'now' };
+    await getESQLSingleColumnValues({
+      query: 'FROM index | STATS BY column',
+      search: searchMock,
+      timeRange,
+    });
+    expect(mockGetESQLResults).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeRange,
+      })
+    );
+  });
+});

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/utils/get_esql_single_column_values.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/utils/get_esql_single_column_values.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ISearchGeneric } from '@kbn/search-types';
+import type { TimeRange } from '@kbn/es-query';
+import { getESQLResults } from '@kbn/esql-utils';
+
+export interface GetESQLSingleColumnValuesSuccess {
+  values: string[];
+}
+
+export interface GetESQLSingleColumnValuesFailure {
+  errors: Error[];
+}
+
+interface GetESQLSingleColumnValuesParams {
+  query: string;
+  search: ISearchGeneric;
+  timeRange?: TimeRange;
+}
+export const getESQLSingleColumnValues = async ({
+  query,
+  search,
+  timeRange,
+}: GetESQLSingleColumnValuesParams): Promise<
+  GetESQLSingleColumnValuesSuccess | GetESQLSingleColumnValuesFailure
+> => {
+  try {
+    const results = await getESQLResults({
+      esqlQuery: query,
+      search,
+      signal: undefined,
+      filter: undefined,
+      dropNullColumns: true,
+      timeRange,
+    });
+    const columns = results.response.columns.map((col) => col.name);
+
+    if (columns.length === 1) {
+      const values = results.response.values
+        .map((value) => value[0])
+        .filter(Boolean)
+        .map((option) => String(option));
+      return { values };
+    }
+
+    return { errors: [new Error('Query must return a single column')] };
+  } catch (e) {
+    return { errors: [e] };
+  }
+};
+
+getESQLSingleColumnValues.isSuccess = (
+  result: unknown
+): result is GetESQLSingleColumnValuesSuccess =>
+  'values' in (result as GetESQLSingleColumnValuesSuccess);

--- a/src/platform/plugins/shared/controls/public/controls/mocks/control_mocks.ts
+++ b/src/platform/plugins/shared/controls/public/controls/mocks/control_mocks.ts
@@ -25,12 +25,18 @@ export const getMockedControlGroupApi = (
   overwriteApi?: Partial<ControlGroupApi>
 ) => {
   const controlStateMap: Record<string, BehaviorSubject<SerializedPanelState<object>>> = {};
+  const controlFetchMap = new Map<string, BehaviorSubject<ControlFetchContext>>();
   return {
     type: CONTROL_GROUP_TYPE,
     parentApi: dashboardApi,
     autoApplySelections$: new BehaviorSubject(true),
     ignoreParentSettings$: new BehaviorSubject(undefined),
-    controlFetch$: () => new BehaviorSubject<ControlFetchContext>({}),
+    controlFetch$: (uuid: string) => {
+      if (!controlFetchMap.has(uuid)) {
+        controlFetchMap.set(uuid, new BehaviorSubject<ControlFetchContext>({}));
+      }
+      return controlFetchMap.get(uuid);
+    },
     allowExpensiveQueries$: new BehaviorSubject(true),
     lastSavedStateForChild$: (childId: string) => controlStateMap[childId] ?? of(undefined),
     getLastSavedStateForChild: (childId: string) => {

--- a/src/platform/plugins/shared/controls/tsconfig.json
+++ b/src/platform/plugins/shared/controls/tsconfig.json
@@ -40,6 +40,8 @@
     "@kbn/std",
     "@kbn/react-hooks",
     "@kbn/esql-types",
+    "@kbn/esql-utils",
+    "@kbn/search-types"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES|QL Controls] Refresh "Values from a query" options on dashboard reload (#225101)](https://github.com/elastic/kibana/pull/225101)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zac Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-30T17:20:21Z","message":"[ES|QL Controls] Refresh \"Values from a query\" options on dashboard reload (#225101)\n\n## Summary\n\nCloses #222198 \n\nFor \"values from a query\" ES|QL controls, attempts to execute the query\nagain on dashboard page load, refresh, timerange change, etc. to get an\nup-to-date list of values.\n\nIf the query execution fails, values cached at the previous edit time\nwill be used.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"215a4bf136c201bdcb0759f137486573309526ae","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","release_note:fix","Team:Presentation","loe:medium","impact:critical","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[ES|QL Controls] Refresh \"Values from a query\" options on dashboard reload","number":225101,"url":"https://github.com/elastic/kibana/pull/225101","mergeCommit":{"message":"[ES|QL Controls] Refresh \"Values from a query\" options on dashboard reload (#225101)\n\n## Summary\n\nCloses #222198 \n\nFor \"values from a query\" ES|QL controls, attempts to execute the query\nagain on dashboard page load, refresh, timerange change, etc. to get an\nup-to-date list of values.\n\nIf the query execution fails, values cached at the previous edit time\nwill be used.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"215a4bf136c201bdcb0759f137486573309526ae"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225891","number":225891,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225101","number":225101,"mergeCommit":{"message":"[ES|QL Controls] Refresh \"Values from a query\" options on dashboard reload (#225101)\n\n## Summary\n\nCloses #222198 \n\nFor \"values from a query\" ES|QL controls, attempts to execute the query\nagain on dashboard page load, refresh, timerange change, etc. to get an\nup-to-date list of values.\n\nIf the query execution fails, values cached at the previous edit time\nwill be used.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"215a4bf136c201bdcb0759f137486573309526ae"}}]}] BACKPORT-->