### PR TITLE
Enable the test skipped test

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
@@ -67,7 +67,7 @@ describe('getNextRunAt', () => {
   test('should use the rrule with a fixed time when it is given to calculate the next runAt (same day)', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-06-30T10:00:00.000Z'));
-    const now = new Date('2025-06-30T10:00:00.000Z');
+    const now = new Date();
     const testStart = new Date(now.getTime() - 500);
     const testRunAt = new Date(now.getTime() - 1000);
     const nextRunAt = getNextRunAt(
@@ -94,8 +94,8 @@ describe('getNextRunAt', () => {
 
   test('should use the rrule with a fixed time when it is given to calculate the next runAt (next day)', () => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-30T10:00:00.000Z'));
-    const now = new Date('2025-06-30T13:00:00.000Z');
+    jest.setSystemTime(new Date('2025-06-30T13:00:00.000Z'));
+    const now = new Date();
     const testStart = new Date(now.getTime() - 500);
     const testRunAt = new Date(now.getTime() - 1000);
     const nextRunAt = getNextRunAt(

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
@@ -11,8 +11,7 @@ import { getNextRunAt } from './get_next_run_at';
 import { loggerMock } from '@kbn/logging-mocks';
 const mockLogger = loggerMock.create();
 
-// Failing: See https://github.com/elastic/kibana/issues/225833
-describe.skip('getNextRunAt', () => {
+describe('getNextRunAt', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
Fixes: #225833

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->