### PR TITLE
[8.19] [Security Solution][Sourcerer] Chore around naming (#225009)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
@@ -30,7 +30,7 @@ export const useCellActionsOptions = (
   >
 ) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const dataView = useDataView(SourcererScopeName.detections);
+  const experimentalDataView = useDataView(SourcererScopeName.detections);
 
   const {
     columns = [],
@@ -41,7 +41,7 @@ export const useCellActionsOptions = (
   } = context ?? {};
   const getFieldSpec = useGetFieldSpec(SourcererScopeName.detections);
   const oldDataViewId = useDataViewId(SourcererScopeName.detections);
-  const dataViewId = newDataViewPickerEnabled ? dataView?.dataView?.id : oldDataViewId;
+  const dataViewId = newDataViewPickerEnabled ? experimentalDataView?.dataView?.id : oldDataViewId;
 
   const cellActionsMetadata = useMemo(
     () => ({ scopeId: tableId, dataViewId }),
@@ -52,7 +52,7 @@ export const useCellActionsOptions = (
       columns.map(
         (column) =>
           (newDataViewPickerEnabled
-            ? dataView.dataView?.fields?.getByName(column.id)?.toSpec()
+            ? experimentalDataView.dataView?.fields?.getByName(column.id)?.toSpec()
             : getFieldSpec(column.id)) ?? {
             name: '',
             type: '', // When type is an empty string all cell actions are incompatible
@@ -60,7 +60,7 @@ export const useCellActionsOptions = (
             searchable: false,
           }
       ),
-    [columns, dataView.dataView?.fields, getFieldSpec, newDataViewPickerEnabled]
+    [columns, experimentalDataView.dataView?.fields, getFieldSpec, newDataViewPickerEnabled]
   );
 
   /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Sourcerer] Chore around naming (#225009)](https://github.com/elastic/kibana/pull/225009)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Luke Gmys","email":"11671118+lgestc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-06-24T09:40:49Z","message":"[Security Solution][Sourcerer] Chore around naming (#225009)\n\n## Summary\n\nJust some chores, did not want to wait for another round of CI checks so\nmade it a separate change. ☮️","sha":"6907186433615e89ae55f21bbc69551bbcae3a93","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Threat Hunting:Investigations","backport:version","v9.1.0","v8.19.0"],"title":"[Security Solution][Sourcerer] Chore around naming","number":225009,"url":"https://github.com/elastic/kibana/pull/225009","mergeCommit":{"message":"[Security Solution][Sourcerer] Chore around naming (#225009)\n\n## Summary\n\nJust some chores, did not want to wait for another round of CI checks so\nmade it a separate change. ☮️","sha":"6907186433615e89ae55f21bbc69551bbcae3a93"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225009","number":225009,"mergeCommit":{"message":"[Security Solution][Sourcerer] Chore around naming (#225009)\n\n## Summary\n\nJust some chores, did not want to wait for another round of CI checks so\nmade it a separate change. ☮️","sha":"6907186433615e89ae55f21bbc69551bbcae3a93"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->