### PR TITLE
[Connectors UI] Fix API key scopes

### DIFF
--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/api_key_panel.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/api_key_panel.tsx
@@ -71,15 +71,12 @@ export const ApiKeyPanel: React.FC<ApiKeyPanelProps> = ({ connector }) => {
                 name: `${connector.index_name}-connector`,
                 role_descriptors: {
                   [`${connector.index_name}-connector-role`]: {
-                    cluster: ['monitor'],
+                    cluster: ['monitor', 'manage_connector'],
                     index: [
                       {
                         names: [
                           connector.index_name,
-                          connector.index_name.replace(
-                            /^(?:search-)?(.*)$/,
-                            '.search-acl-filter-$1'
-                          ),
+                          `.search-acl-filter-${connector.index_name}`,
                           `${CONNECTORS_INDEX}*`,
                         ],
                         privileges: ['all'],


### PR DESCRIPTION
## Summary

Fix scopes in generated API key to use with connector. This bug affected only serverless

1. Include `manage_connector` in cluster level privilege
2. Fix weird replace logic in line with how acl index pattern works: https://github.com/elastic/connectors/blob/main/connectors/protocol/connectors.py#L1137

Manually tested that it works

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



