### PR TITLE
[8.18] [ResponseOps][Alerting] Bound recursion when injecting analyzed wildcards (#223545)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/constants.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+export const MAX_QUERIES = 20000;

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/inject_analyze_wildcard.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/inject_analyze_wildcard.ts
@@ -5,26 +5,38 @@
  * 2.0.
  */
 
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { MAX_QUERIES } from './constants';
 
 export const injectAnalyzeWildcard = (query: QueryDslQueryContainer): void => {
   if (!query) {
     return;
   }
 
-  if (Array.isArray(query)) {
-    return query.forEach((child) => injectAnalyzeWildcard(child));
-  }
+  let queriesCount = 0;
+  const stack: QueryDslQueryContainer[] = [query];
 
-  if (typeof query === 'object') {
-    Object.entries(query).forEach(([key, value]) => {
-      if (key !== 'query_string') {
-        return injectAnalyzeWildcard(value);
-      }
+  while (stack.length > 0) {
+    queriesCount = queriesCount + 1;
 
-      if (typeof value.query === 'string' && value.query.includes('*')) {
-        value.analyze_wildcard = true;
+    if (queriesCount > MAX_QUERIES) {
+      throw new Error('Query is too deeply nested');
+    }
+
+    const current = stack.pop();
+
+    if (Array.isArray(current)) {
+      for (const child of current) {
+        stack.push(child);
       }
-    });
+    } else if (typeof current === 'object' && current !== null) {
+      for (const [key, value] of Object.entries(current)) {
+        if (key !== 'query_string') {
+          stack.push(value);
+        } else if (typeof value.query === 'string' && value.query.includes('*')) {
+          value.analyze_wildcard = true;
+        }
+      }
+    }
   }
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ResponseOps][Alerting] Bound recursion when injecting analyzed wildcards (#223545)](https://github.com/elastic/kibana/pull/223545)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2025-07-01T09:34:43Z","message":"[ResponseOps][Alerting] Bound recursion when injecting analyzed wildcards (#223545)\n\nCloses https://github.com/elastic/kibana/issues/223524\n\n## Summary\n\n- Refactored `injectAnalyzeWildcard` function to replace unbounded\nrecursion with a bounded, iterative approach using a stack.\n\nTo test the changes, please follow the steps provided\n[here](https://github.com/elastic/kibana/pull/194777).","sha":"99f58ac8e830b7cd0be4b3398516f916ac9159cb","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0","v9.2.0","v8.18.4","v8.17.9"],"title":"[ResponseOps][Alerting] Bound recursion when injecting analyzed wildcards","number":223545,"url":"https://github.com/elastic/kibana/pull/223545","mergeCommit":{"message":"[ResponseOps][Alerting] Bound recursion when injecting analyzed wildcards (#223545)\n\nCloses https://github.com/elastic/kibana/issues/223524\n\n## Summary\n\n- Refactored `injectAnalyzeWildcard` function to replace unbounded\nrecursion with a bounded, iterative approach using a stack.\n\nTo test the changes, please follow the steps provided\n[here](https://github.com/elastic/kibana/pull/194777).","sha":"99f58ac8e830b7cd0be4b3398516f916ac9159cb"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225963","number":225963,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/225962","number":225962,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223545","number":223545,"mergeCommit":{"message":"[ResponseOps][Alerting] Bound recursion when injecting analyzed wildcards (#223545)\n\nCloses https://github.com/elastic/kibana/issues/223524\n\n## Summary\n\n- Refactored `injectAnalyzeWildcard` function to replace unbounded\nrecursion with a bounded, iterative approach using a stack.\n\nTo test the changes, please follow the steps provided\n[here](https://github.com/elastic/kibana/pull/194777).","sha":"99f58ac8e830b7cd0be4b3398516f916ac9159cb"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->