### PR TITLE
[Serverless build] Include `oblt` tier config files

### DIFF
--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -57,6 +57,7 @@ export const CreateArchivesSources: Task = {
               select: [
                 'serverless.yml',
                 'serverless.{chat,es,oblt,security}.yml',
+                'serverless.oblt.{logs_essentials,complete}.yml',
                 'serverless.security.{search_ai_lake,essentials,complete}.yml',
               ],
             }


### PR DESCRIPTION
## Summary

Adding `oblt` product tiers' config files to the build archives, so that they make it to the docker images.

### Question to reviewers

What backporting strategy should we follow for these changes?


