### PR TITLE
[Obs-UX-Management] Replace usages of EuiErrorBoundary in the exploratory view plugin 

### DIFF
--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/index.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/embeddable/index.tsx
@@ -9,12 +9,12 @@ import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import type { AnalyticsServiceSetup, CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { EuiErrorBoundary } from '@elastic/eui';
 import styled from '@emotion/styled';
 import { DataView } from '@kbn/data-views-plugin/common';
 import { FormulaPublicApi } from '@kbn/lens-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { useFetcher } from '@kbn/observability-shared-plugin/public';
+import { KibanaErrorBoundary } from '@kbn/shared-ux-error-boundary';
 import { useAppDataView } from './use_app_data_view';
 import type { ExploratoryViewPublicPluginsStart } from '../../../..';
 import type { ExploratoryEmbeddableProps, ExploratoryEmbeddableComponentProps } from './embeddable';
@@ -128,7 +128,7 @@ export function getExploratoryViewEmbeddable(
     }
 
     return (
-      <EuiErrorBoundary>
+      <KibanaErrorBoundary>
         <KibanaContextProvider services={services}>
           <Wrapper customHeight={props.customHeight} data-test-subj={props.dataTestSubj}>
             <ExploratoryViewEmbeddable
@@ -142,7 +142,7 @@ export function getExploratoryViewEmbeddable(
             />
           </Wrapper>
         </KibanaContextProvider>
-      </EuiErrorBoundary>
+      </KibanaErrorBoundary>
     );
   };
 }

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/obsv_exploratory_view.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/obsv_exploratory_view.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react';
-import { EuiErrorBoundary } from '@elastic/eui';
+import { KibanaErrorBoundary } from '@kbn/shared-ux-error-boundary';
 import { getAlertsSingleMetricConfig } from './configurations/alerts_configs/single_metric_config';
 import { getAlertsKPIConfig } from './configurations/alerts_configs/kpi_over_time_config';
 import { DataTypes, DataTypesLabels } from './labels';
@@ -111,9 +111,8 @@ export const obsvReportConfigMap = {
 
 export function ObservabilityExploratoryView(props: { startServices: StartServices }) {
   const { appMountParameters } = usePluginContext();
-
   return (
-    <EuiErrorBoundary>
+    <KibanaErrorBoundary>
       <ExploratoryViewContextProvider
         reportTypes={reportTypesList}
         dataTypes={dataTypes}
@@ -124,6 +123,6 @@ export function ObservabilityExploratoryView(props: { startServices: StartServic
       >
         <ExploratoryViewPage />
       </ExploratoryViewContextProvider>
-    </EuiErrorBoundary>
+    </KibanaErrorBoundary>
   );
 }

--- a/x-pack/solutions/observability/plugins/exploratory_view/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/exploratory_view/tsconfig.json
@@ -45,7 +45,8 @@
     "@kbn/core-analytics-browser",
     "@kbn/expressions-plugin",
     "@kbn/ebt-tools",
-    "@kbn/config-schema"
+    "@kbn/config-schema",
+    "@kbn/shared-ux-error-boundary"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

If fixes [#4566](https://github.com/elastic/observability-dev/issues/4566)

<img width="1447" alt="Screenshot 2025-07-01 at 13 09 39" src="https://github.com/user-attachments/assets/c62e77da-f87a-4b35-8726-2e23156da8f0" />
