### PR TITLE
[8.19] Free up space for CI

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -44,3 +44,4 @@ fi
 
 # Clear the cache after installation
 rm -rf ./.yarn-local-mirror
+yarn cache clean


### PR DESCRIPTION
## Summary
We're still getting a few ENOSPC errors through unit-tests. After some digging, it seems the yarn download cache is still ripe for cleaning with ~4gb of space. This should be clearing us for a bit. However, this costs ~20s after bootstrap to clean, and might slow down the kibana build step, where the cache might be needed.
<img width="1108" alt="Screenshot 2025-07-01 at 15 37 55" src="https://github.com/user-attachments/assets/88bcf912-3358-4fe9-8798-e56d441a9cf4" />

It frees up significant space (~4g) that should be enough for any litter generated by typecheck or jest. It doesn't change build time significantly.
