### PR TITLE
[Security Solution][Detection Engine] unskip ES|QL FTR tests

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
@@ -65,8 +65,7 @@ export default ({ getService }: FtrProviderContext) => {
    */
   const internalIdPipe = (id: string) => `| where id=="${id}"`;
 
-  // Failing: See https://github.com/elastic/kibana/issues/224699
-  describe.skip('@ess @serverless ES|QL rule type', () => {
+  describe('@ess @serverless ES|QL rule type', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/security_solution/ecs_compliant');
     });
@@ -2190,7 +2189,8 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    describe('shard failures', () => {
+    // Failing: See https://github.com/elastic/kibana/issues/224699
+    describe.skip('shard failures', () => {
       const config = getService('config');
       const isServerless = config.get('serverless');
       const dataPathBuilder = new EsArchivePathBuilder(isServerless);


### PR DESCRIPTION
## Summary

 - unskips the whole set of ES|QL FTR tests
 - skips instead failing shards tests https://github.com/elastic/kibana/issues/224699
 - previous fix https://github.com/elastic/kibana/pull/225542 (cc: @dhurley14 did not help)


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->