### PR TITLE
[8.18] remove yarn caches after bootstrap

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -42,3 +42,6 @@ if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
   check_for_changed_files 'yarn kbn bootstrap'
 fi
 
+# Clear the cache after installation
+rm -rf ./.yarn-local-mirror
+yarn cache clean


### PR DESCRIPTION
## Summary
... to free up space on CI, and prevent `ENOSPC` errors.

Backport of https://github.com/elastic/kibana/pull/225999 + https://github.com/elastic/kibana/pull/225605