### PR TITLE
[streams] fix lifecycle tests assertion

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/lifecycle.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/lifecycle.ts
@@ -49,10 +49,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     for (const dataStream of dataStreams.data_streams) {
       if (isDslLifecycle(expectedLifecycle)) {
         expect(dataStream.lifecycle?.data_retention).to.eql(expectedLifecycle.dsl.data_retention);
-        expect(dataStream.indices.every((index) => !index.ilm_policy)).to.eql(
-          true,
-          'backing indices should not specify an ilm_policy'
-        );
+        expect(
+          dataStream.indices.every((index) => index.managed_by === 'Data stream lifecycle')
+        ).to.eql(true, 'backing indices should be managed by DSL');
+
         if (!isServerless) {
           expect(dataStream.prefer_ilm).to.eql(
             false,
@@ -71,15 +71,17 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(dataStream.ilm_policy).to.eql(expectedLifecycle.ilm.policy);
         expect(
           dataStream.indices.every(
-            (index) => index.prefer_ilm && index.ilm_policy === expectedLifecycle.ilm.policy
+            (index) =>
+              index.prefer_ilm &&
+              index.ilm_policy === expectedLifecycle.ilm.policy &&
+              index.managed_by === 'Index Lifecycle Management'
           )
-        ).to.eql(true, 'backing indices should specify prefer_ilm and ilm_policy');
+        ).to.eql(true, 'backing indices should be managed by ILM');
       }
     }
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/225196
-  describe.skip('Lifecycle', () => {
+  describe('Lifecycle', () => {
     before(async () => {
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
       await enableStreams(apiClient);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/225196

https://github.com/elastic/elasticsearch/pull/129677 changed the behavior of null values passed to the `_data_stream/_settings` api. Before that change a null value was considered an actual value and would override the template settings. After the change a null value unsets any data stream overrides and falls back to the index template settings. When we update a stream to use DSL we update index.lifecycle.name to null and our tests expects this setting to be null but is now the value set on the index template.

The test failure does not indicate a bug, the expected lifecycle is still effective because the behaviour is dictated by prefer_ilm which we override in any cases





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->