### PR TITLE
[Search] fix: start page skip goes to homepage

### DIFF
--- a/x-pack/solutions/search/packages/shared-ui/src/constants.ts
+++ b/x-pack/solutions/search/packages/shared-ui/src/constants.ts
@@ -6,3 +6,4 @@
  */
 
 export const WORKFLOW_LOCALSTORAGE_KEY = 'search_onboarding_workflow';
+export const GLOBAL_EMPTY_STATE_SKIP_KEY = 'search_onboarding_global_empty_state_skip';

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_indices_status_query.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_indices_status_query.ts
@@ -17,7 +17,8 @@ import { useKibana } from '../use_kibana';
 const DEFAULT_INDICES_POLLING_INTERVAL = 15 * 1000;
 
 export const useIndicesStatusQuery = (
-  pollingInterval = DEFAULT_INDICES_POLLING_INTERVAL
+  pollingInterval = DEFAULT_INDICES_POLLING_INTERVAL,
+  enabled = true
 ): UseQueryResult<IndicesStatusResponse> => {
   const { http } = useKibana().services;
 
@@ -28,5 +29,6 @@ export const useIndicesStatusQuery = (
     retry: true,
     queryKey: [QueryKeys.FetchSearchIndicesStatus],
     queryFn: () => http.get<IndicesStatusResponse>(GET_STATUS_ROUTE),
+    enabled,
   });
 };

--- a/x-pack/solutions/search/plugins/search_homepage/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_homepage/tsconfig.json
@@ -31,7 +31,8 @@
     "@kbn/core-http-server",
     "@kbn/search-navigation",
     "@kbn/logging",
-    "@kbn/core-elasticsearch-server"
+    "@kbn/core-elasticsearch-server",
+    "@kbn/search-shared-ui"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/search/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -8,7 +8,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import { WorkflowId } from '@kbn/search-shared-ui';
+import { SEARCH_HOMEPAGE } from '@kbn/deeplinks-search';
+import { GLOBAL_EMPTY_STATE_SKIP_KEY, WorkflowId } from '@kbn/search-shared-ui';
 import type { IndicesStatusResponse } from '../../../common';
 
 import { AnalyticsEvents } from '../../analytics/constants';
@@ -95,7 +96,8 @@ export const ElasticsearchStart: React.FC<ElasticsearchStartProps> = () => {
     [usageTracker, formState, setFormState]
   );
   const onClose = useCallback(() => {
-    application.navigateToApp('elasticsearchIndexManagement');
+    localStorage.setItem(GLOBAL_EMPTY_STATE_SKIP_KEY, 'true');
+    application.navigateToApp(SEARCH_HOMEPAGE);
   }, [application]);
 
   return (

--- a/x-pack/test/functional/page_objects/search_start.ts
+++ b/x-pack/test/functional/page_objects/search_start.ts
@@ -33,6 +33,11 @@ export function SearchStartProvider({ getService }: FtrProviderContext) {
         );
       });
     },
+    async expectToBeOnSearchHomepagePage() {
+      await retry.tryForTime(60 * 1000, async () => {
+        expect(await browser.getCurrentUrl()).contain('/app/elasticsearch/home');
+      });
+    },
     async expectToBeOnMLFileUploadPage() {
       await retry.tryForTime(60 * 1000, async () => {
         expect(await browser.getCurrentUrl()).contain('/app/ml/filedatavisualizer');
@@ -131,6 +136,9 @@ export function SearchStartProvider({ getService }: FtrProviderContext) {
         /^https?\:\/\/.*\/app\/management\/kibana\/spaces\/create/
       );
       expect(await testSubjects.getAttribute('createO11ySpaceBtn', 'target')).equal('_blank');
+    },
+    async clearSkipEmptyStateStorageFlag() {
+      await browser.removeLocalStorageItem('search_onboarding_global_empty_state_skip');
     },
   };
 }

--- a/x-pack/test/functional_search/tests/search_start.ts
+++ b/x-pack/test/functional_search/tests/search_start.ts
@@ -46,6 +46,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       // Clean up space created
       await cleanUp();
       await deleteAllTestIndices();
+      await searchStart.clearSkipEmptyStateStorageFlag();
     });
 
     describe('Developer rights', function () {
@@ -117,18 +118,19 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await searchStart.expectAnalyzeLogsIntegrationLink();
         await searchStart.expectCreateO11ySpaceBtn();
       });
+
       it('should have close button', async () => {
         await searchStart.expectToBeOnStartPage();
         await searchStart.expectCloseCreateIndexButtonExists();
         await searchStart.clickCloseCreateIndexButton();
-        await searchStart.expectToBeOnIndexListPage();
+        await searchStart.expectToBeOnSearchHomepagePage();
       });
 
       it('should have skip button', async () => {
         await searchStart.expectToBeOnStartPage();
         await searchStart.expectSkipButtonExists();
         await searchStart.clickSkipButton();
-        await searchStart.expectToBeOnIndexListPage();
+        await searchStart.expectToBeOnSearchHomepagePage();
       });
     });
   });

--- a/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
@@ -33,6 +33,11 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
         );
       });
     },
+    async expectToBeOnSearchHomepagePage() {
+      await retry.tryForTime(60 * 1000, async () => {
+        expect(await browser.getCurrentUrl()).contain('/app/elasticsearch/home');
+      });
+    },
     async expectToBeOnMLFileUploadPage() {
       await retry.tryForTime(60 * 1000, async () => {
         expect(await browser.getCurrentUrl()).contain('/app/ml/filedatavisualizer');
@@ -126,6 +131,10 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
     async expectAPIKeyFormNotAvailable() {
       await testSubjects.missingOrFail('apiKeyHasNotBeenGenerated');
       await testSubjects.missingOrFail('apiKeyHasBeenGenerated');
+    },
+
+    async clearSkipEmptyStateStorageFlag() {
+      await browser.removeLocalStorageItem('search_onboarding_global_empty_state_skip');
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
@@ -34,6 +34,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
       after(async () => {
         await deleteAllTestIndices();
+        await pageObjects.svlSearchElasticsearchStartPage.clearSkipEmptyStateStorageFlag();
       });
       beforeEach(async () => {
         await deleteAllTestIndices();
@@ -196,13 +197,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnStartPage();
         await pageObjects.svlSearchElasticsearchStartPage.expectCloseCreateIndexButtonExists();
         await pageObjects.svlSearchElasticsearchStartPage.clickCloseCreateIndexButton();
-        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnIndexListPage();
+        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnSearchHomepagePage();
       });
       it('should have skip button', async () => {
         await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnStartPage();
         await pageObjects.svlSearchElasticsearchStartPage.expectSkipButtonExists();
         await pageObjects.svlSearchElasticsearchStartPage.clickSkipButton();
-        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnIndexListPage();
+        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnSearchHomepagePage();
       });
     });
     describe('viewer', function () {


### PR DESCRIPTION
## Summary

Updated the Search empty state start page to redirect to the homepage now that it has shipped. Additionally if the user closes the start page I added a localstorage key to disable the redirect on the homepage when the user clicks skip or close so that we can take them back to the homepage.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->