### PR TITLE
[POC][Dashboard] Remove editor toolbar and update top nav

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -246,6 +246,14 @@ export const topNavStrings = {
       defaultMessage: 'Create a copy of your dashboard',
     }),
   },
+  add: {
+    label: i18n.translate('dashboard.topNave.addButtonAriaLabel', {
+      defaultMessage: 'add',
+    }),
+    description: i18n.translate('dashboard.topNave.addConfigDescription', {
+      defaultMessage: 'Add content to your dashboard',
+    }),
+  },
 };
 
 export const getControlButtonTitle = () =>

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -8,7 +8,6 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { ViewMode } from '@kbn/presentation-publishing';
 
 export const getDashboardPageTitle = () =>
   i18n.translate('dashboard.dashboardPageTitle', {
@@ -42,19 +41,9 @@ export const dashboardManagedBadge = {
  * @param viewMode {DashboardViewMode} the current mode. If in editing state, prepends 'Editing ' to the title.
  * @returns {string} A title to display to the user based on the above parameters.
  */
-export function getDashboardTitle(
-  title: string | undefined,
-  viewMode: ViewMode,
-  isNew: boolean
-): string {
-  const isEditMode = viewMode === 'edit';
+export function getDashboardTitle(title: string | undefined, isNew: boolean): string {
   const dashboardTitle = isNew || !Boolean(title) ? getNewDashboardTitle() : (title as string);
-  return isEditMode
-    ? i18n.translate('dashboard.strings.dashboardEditTitle', {
-        defaultMessage: 'Editing {title}',
-        values: { title: dashboardTitle },
-      })
-    : dashboardTitle;
+  return dashboardTitle;
 }
 
 export const unsavedChangesBadgeStrings = {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -128,7 +128,6 @@ export const useDashboardMenuItems = ({
         ...topNavStrings.fullScreen,
         id: 'full-screen',
         iconType: 'fullScreen',
-        iconOnly: true,
         testId: 'dashboardFullScreenMode',
         run: () => dashboardApi.setFullScreenMode(true),
         disableButton: disableTopNav,
@@ -172,8 +171,7 @@ export const useDashboardMenuItems = ({
         emphasize: isCreatingNewDashboard,
         id: 'interactive-save',
         testId: 'dashboardInteractiveSaveMenuItem',
-        iconType: lastSavedId ? 'copy' : 'save',
-        iconOnly: !isCreatingNewDashboard,
+        iconType: lastSavedId ? undefined : 'save',
         run: dashboardInteractiveSave,
         label: isCreatingNewDashboard
           ? topNavStrings.quickSave.label
@@ -207,8 +205,6 @@ export const useDashboardMenuItems = ({
       settings: {
         ...topNavStrings.settings,
         id: 'settings',
-        iconType: 'gear',
-        iconOnly: true,
         testId: 'dashboardSettingsButton',
         disableButton: disableTopNav,
         htmlId: 'dashboardSettingsButton',

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -127,7 +127,6 @@ export const useDashboardMenuItems = ({
       fullScreen: {
         ...topNavStrings.fullScreen,
         id: 'full-screen',
-        iconType: 'fullScreen',
         testId: 'dashboardFullScreenMode',
         run: () => dashboardApi.setFullScreenMode(true),
         disableButton: disableTopNav,
@@ -241,8 +240,6 @@ export const useDashboardMenuItems = ({
       ...topNavStrings.resetChanges,
       id: 'reset',
       testId: 'dashboardDiscardChangesMenuItem',
-      iconType: 'editorUndo',
-      iconOnly: true,
       disableButton:
         isResetting ||
         !hasUnsavedChanges ||

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -219,7 +219,6 @@ export const useDashboardMenuItems = ({
         ...topNavStrings.add,
         id: 'add',
         iconType: 'plusInCircle',
-        iconOnly: true,
         testId: 'dashboardAddButton',
         disableButton: disableTopNav,
         run: (anchorElement: HTMLElement) =>

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/_dashboard_listing_strings.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/_dashboard_listing_strings.ts
@@ -129,6 +129,29 @@ export const resetConfirmStrings = {
     }),
 };
 
+export const unsavedChangesConfirmStrings = {
+  getUnsavedChangesTitle: () =>
+    i18n.translate('dashboard.resetChangesConfirmModal.resetChangesTitle', {
+      defaultMessage: 'Unsaved changes',
+    }),
+  getUnsavedChangesSubtitle: () =>
+    i18n.translate('dashboard.discardChangesConfirmModal.discardChangesDescription', {
+      defaultMessage: `You have unsaved changes. Would you like to save or discard your work?`,
+    }),
+  getCancelButtonLabel: () =>
+    i18n.translate('dashboard.unsavedChangesConfirmModal.cancelButtonLabel', {
+      defaultMessage: 'Cancel',
+    }),
+  getDiscardButtonText: () =>
+    i18n.translate('dashboard.unsavedChangesConfirmModal.discardButtonLabel', {
+      defaultMessage: 'Discard',
+    }),
+  getSaveButtonText: () =>
+    i18n.translate('dashboard.unsavedChangesConfirmModal.saveButtonLabel', {
+      defaultMessage: 'Save',
+    }),
+};
+
 export const createConfirmStrings = {
   getCreateTitle: () =>
     i18n.translate('dashboard.createConfirmModal.unsavedChangesTitle', {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/confirm_overlays.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/confirm_overlays.tsx
@@ -25,7 +25,11 @@ import { toMountPoint } from '@kbn/react-kibana-mount';
 
 import { ViewMode } from '@kbn/presentation-publishing';
 import { coreServices } from '../services/kibana_services';
-import { createConfirmStrings, resetConfirmStrings } from './_dashboard_listing_strings';
+import {
+  createConfirmStrings,
+  resetConfirmStrings,
+  unsavedChangesConfirmStrings,
+} from './_dashboard_listing_strings';
 
 export type DiscardOrKeepSelection = 'cancel' | 'discard' | 'keep';
 
@@ -48,9 +52,93 @@ export const confirmDiscardUnsavedChanges = (
     });
 };
 
+export const confirmDiscardOrSaveUnsavedChanges = ({
+  discardCallback,
+  saveCallback,
+  cancelCallback,
+}: {
+  discardCallback: () => void;
+  saveCallback: () => void;
+  cancelCallback?: () => void;
+}) => {
+  const titleId = 'confirmDiscardOrKeepTitle';
+  const descriptionId = 'confirmDiscardOrKeepDescription';
+
+  const session = coreServices.overlays.openModal(
+    toMountPoint(
+      <EuiFocusTrap
+        clickOutsideDisables={true}
+        initialFocus={'.dashboardCreateConfirmContinueButton'}
+      >
+        <EuiOutsideClickDetector onOutsideClick={() => session.close()}>
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={descriptionId}
+          >
+            <EuiModalHeader data-test-subj="dashboardUnsavedChangesCancel">
+              <EuiModalHeaderTitle id={titleId} component="h2">
+                {unsavedChangesConfirmStrings.getUnsavedChangesTitle()}
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+
+            <EuiModalBody>
+              <EuiText>
+                <p id={descriptionId}>{unsavedChangesConfirmStrings.getUnsavedChangesSubtitle()}</p>
+              </EuiText>
+            </EuiModalBody>
+
+            <EuiModalFooter>
+              <EuiButtonEmpty
+                size="s"
+                data-test-subj="dashboard"
+                onClick={() => {
+                  cancelCallback?.();
+                  session.close();
+                }}
+              >
+                {unsavedChangesConfirmStrings.getCancelButtonLabel()}
+              </EuiButtonEmpty>
+              <EuiButtonEmpty
+                color="danger"
+                size="s"
+                data-test-subj="dashboardUnsavedChangesConfirmDiscard"
+                onClick={() => {
+                  discardCallback();
+                  session.close();
+                }}
+              >
+                {unsavedChangesConfirmStrings.getDiscardButtonText()}
+              </EuiButtonEmpty>
+              <EuiButton
+                fill
+                size="s"
+                data-test-subj="dashboardUnsavedChangesConfirmSave"
+                className="dashboardCreateConfirmContinueButton"
+                onClick={() => {
+                  saveCallback();
+                  session.close();
+                }}
+              >
+                {unsavedChangesConfirmStrings.getSaveButtonText()}
+              </EuiButton>
+            </EuiModalFooter>
+          </div>
+        </EuiOutsideClickDetector>
+      </EuiFocusTrap>,
+      coreServices
+    ),
+    {
+      'data-test-subj': 'dashboardCreateConfirmModal',
+      maxWidth: 500,
+    }
+  );
+};
+
 export const confirmCreateWithUnsaved = (
   startBlankCallback: () => void,
-  contineCallback: () => void
+  continueCallback: () => void
 ) => {
   const titleId = 'confirmDiscardOrKeepTitle';
   const descriptionId = 'confirmDiscardOrKeepDescription';
@@ -102,7 +190,7 @@ export const confirmCreateWithUnsaved = (
                 data-test-subj="dashboardCreateConfirmContinue"
                 className="dashboardCreateConfirmContinueButton"
                 onClick={() => {
-                  contineCallback();
+                  continueCallback();
                   session.close();
                 }}
               >

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/show_add_menu.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/show_add_menu.tsx
@@ -76,7 +76,16 @@ const AddMenu = ({ dashboardApi, anchorElement, coreServices }: ShowAddMenuProps
             const overlayRef = coreServices.overlays.openFlyout(
               toMountPoint(
                 React.createElement(function () {
-                  return <AddPanelFlyout dashboardApi={dashboardApi} />;
+                  return (
+                    <AddPanelFlyout
+                      dashboardApi={dashboardApi}
+                      closeFlyout={() => {
+                        dashboardApi.clearOverlays();
+                        overlayRef.close();
+                      }}
+                      ariaLabelledBy="addPanelsFlyout"
+                    />
+                  );
                 }),
                 coreServices
               ),
@@ -84,16 +93,19 @@ const AddMenu = ({ dashboardApi, anchorElement, coreServices }: ShowAddMenuProps
                 size: 'm',
                 maxWidth: 500,
                 paddingSize: 'm',
-                'aria-labelledby': 'addPanelsFlyout',
                 'data-test-subj': 'dashboardPanelSelectionFlyout',
-                onClose() {
-                  dashboardApi.clearOverlays();
-                  overlayRef.close();
-                },
               }
             );
 
             dashboardApi.openOverlay(overlayRef);
+            closePopover();
+          },
+        },
+        {
+          name: 'Add a collapsible section',
+          icon: 'section',
+          onClick: () => {
+            dashboardApi.addNewSection();
             closePopover();
           },
         },

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/show_add_menu.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/show_add_menu.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { EuiContextMenu, EuiWrappingPopover } from '@elastic/eui';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import ReactDOM from 'react-dom';
+import { CoreStart } from '@kbn/core/public';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+import { useStateFromPublishingSubject } from '@kbn/presentation-publishing';
+import { TIME_SLIDER_CONTROL } from '@kbn/controls-plugin/common';
+import { ESQLVariableType, EsqlControlType, apiPublishesESQLVariables } from '@kbn/esql-types';
+import { addFromLibrary } from './add_panel_from_library';
+import { DashboardApi } from '../dashboard_api/types';
+import { executeAddLensPanelAction } from '../dashboard_actions/execute_add_lens_panel_action';
+import { AddPanelFlyout } from '../dashboard_app/top_nav/add_panel_button/components/add_panel_flyout';
+import {
+  getAddControlButtonTitle,
+  getAddESQLControlButtonTitle,
+  getAddTimeSliderControlButtonTitle,
+} from '../dashboard_app/_dashboard_app_strings';
+import { uiActionsService } from '../services/kibana_services';
+
+interface ShowAddMenuProps {
+  dashboardApi: DashboardApi;
+  anchorElement: HTMLElement;
+  coreServices: CoreStart;
+}
+
+const container = document.createElement('div');
+let isOpen = false;
+
+function cleanup() {
+  if (!isOpen) {
+    return;
+  }
+  ReactDOM.unmountComponentAtNode(container);
+  document.body.removeChild(container);
+  isOpen = false;
+}
+
+const AddMenu = ({ dashboardApi, anchorElement, coreServices }: ShowAddMenuProps) => {
+  const onSave = () => {
+    dashboardApi.scrollToTop();
+  };
+  const closePopover = useCallback(() => {
+    anchorElement.focus();
+    cleanup();
+  }, [anchorElement]);
+  const controlGroupApi = useStateFromPublishingSubject(dashboardApi.controlGroupApi$);
+
+  const panels = [
+    {
+      id: 0,
+      items: [
+        {
+          name: 'Create a new visualization',
+          icon: 'lensApp',
+          onClick: async () => {
+            await executeAddLensPanelAction(dashboardApi);
+            closePopover();
+          },
+        },
+        {
+          name: 'Add a panel',
+          icon: 'plusInCircle',
+          onClick: () => {
+            const overlayRef = coreServices.overlays.openFlyout(
+              toMountPoint(
+                React.createElement(function () {
+                  return <AddPanelFlyout dashboardApi={dashboardApi} />;
+                }),
+                coreServices
+              ),
+              {
+                size: 'm',
+                maxWidth: 500,
+                paddingSize: 'm',
+                'aria-labelledby': 'addPanelsFlyout',
+                'data-test-subj': 'dashboardPanelSelectionFlyout',
+                onClose() {
+                  dashboardApi.clearOverlays();
+                  overlayRef.close();
+                },
+              }
+            );
+
+            dashboardApi.openOverlay(overlayRef);
+            closePopover();
+          },
+        },
+        {
+          name: 'Add a control',
+          icon: 'controlsHorizontal',
+          panel: 1,
+        },
+        {
+          name: 'Add from library',
+          icon: 'folderOpen',
+          onClick: () => {
+            addFromLibrary(dashboardApi);
+            closePopover();
+          },
+        },
+      ],
+    },
+    {
+      id: 1,
+      initialFocusedItemIndex: 1,
+      items: [
+        {
+          name: getAddControlButtonTitle(),
+          icon: 'plusInCircle',
+          onClick: () => {
+            controlGroupApi?.openAddDataControlFlyout({ onSave });
+            closePopover();
+          },
+        },
+        {
+          name: getAddTimeSliderControlButtonTitle(),
+          icon: 'timeslider',
+          onClick: async () => {
+            controlGroupApi?.addNewPanel({
+              panelType: TIME_SLIDER_CONTROL,
+              serializedState: {
+                rawState: {
+                  grow: true,
+                  width: 'large',
+                  id: uuidv4(),
+                },
+              },
+            });
+            dashboardApi.scrollToTop();
+            closePopover();
+          },
+        },
+        {
+          name: getAddESQLControlButtonTitle(),
+          icon: 'plusInCircle',
+          onClick: async () => {
+            try {
+              const variablesInParent = apiPublishesESQLVariables(dashboardApi)
+                ? dashboardApi.esqlVariables$.value
+                : [];
+
+              await uiActionsService.getTrigger('ESQL_CONTROL_TRIGGER').exec({
+                queryString: '',
+                variableType: ESQLVariableType.VALUES,
+                controlType: EsqlControlType.VALUES_FROM_QUERY,
+                esqlVariables: variablesInParent,
+                onSaveControl: (controlState) => {
+                  controlGroupApi?.addNewPanel({
+                    panelType: 'esqlControl',
+                    serializedState: {
+                      rawState: {
+                        ...controlState,
+                      },
+                    },
+                  });
+                  dashboardApi.scrollToTop();
+                  closePopover();
+                },
+                onCancelControl: closePopover,
+              });
+            } catch (e) {
+              // eslint-disable-next-line no-console
+              console.error('Error getting ESQL control trigger', e);
+            }
+            closePopover();
+          },
+        },
+      ],
+    },
+  ];
+
+  return (
+    <EuiWrappingPopover
+      isOpen={isOpen}
+      closePopover={closePopover}
+      button={anchorElement}
+      panelPaddingSize="none"
+    >
+      <EuiContextMenu initialPanelId={0} panels={panels} />
+    </EuiWrappingPopover>
+  );
+};
+
+export function ShowAddMenu({ dashboardApi, anchorElement, coreServices }: ShowAddMenuProps) {
+  if (isOpen) {
+    cleanup();
+    return;
+  }
+
+  isOpen = true;
+  document.body.appendChild(container);
+  ReactDOM.render(
+    <KibanaContextProvider services={coreServices}>
+      <AddMenu
+        dashboardApi={dashboardApi}
+        anchorElement={anchorElement}
+        coreServices={coreServices}
+      />
+    </KibanaContextProvider>,
+    container
+  );
+}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/show_add_menu.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/show_add_menu.tsx
@@ -15,7 +15,7 @@ import ReactDOM from 'react-dom';
 import { CoreStart } from '@kbn/core/public';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { useStateFromPublishingSubject } from '@kbn/presentation-publishing';
-import { TIME_SLIDER_CONTROL } from '@kbn/controls-plugin/common';
+import { TIME_SLIDER_CONTROL } from '@kbn/controls-constants';
 import { ESQLVariableType, EsqlControlType, apiPublishesESQLVariables } from '@kbn/esql-types';
 import { addFromLibrary } from './add_panel_from_library';
 import { DashboardApi } from '../dashboard_api/types';
@@ -23,6 +23,7 @@ import { executeAddLensPanelAction } from '../dashboard_actions/execute_add_lens
 import { AddPanelFlyout } from '../dashboard_app/top_nav/add_panel_button/components/add_panel_flyout';
 import {
   getAddControlButtonTitle,
+  getControlButtonTitle,
   getAddESQLControlButtonTitle,
   getAddTimeSliderControlButtonTitle,
 } from '../dashboard_app/_dashboard_app_strings';
@@ -113,6 +114,7 @@ const AddMenu = ({ dashboardApi, anchorElement, coreServices }: ShowAddMenuProps
     },
     {
       id: 1,
+      title: getControlButtonTitle(),
       initialFocusedItemIndex: 1,
       items: [
         {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -52,10 +52,7 @@ import {
 import { getDashboardCapabilities } from '../utils/get_dashboard_capabilities';
 import { getFullEditPath } from '../utils/urls';
 import { DashboardFavoriteButton } from './dashboard_favorite_button';
-import {
-  confirmDiscardOrSaveUnsavedChanges,
-  confirmDiscardUnsavedChanges,
-} from '../dashboard_listing/confirm_overlays';
+import { confirmDiscardOrSaveUnsavedChanges } from '../dashboard_listing/confirm_overlays';
 import { ViewModeToggle } from './view_mode_toggle';
 
 export interface InternalDashboardTopNavProps {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/view_mode_toggle.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/view_mode_toggle.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { ViewMode } from '@kbn/presentation-publishing';
+import { EuiButtonGroup, useEuiTheme } from '@elastic/eui';
+import useMountedState from 'react-use/lib/useMountedState';
+import { DashboardApi } from '../dashboard_api/types';
+import { getDashboardBackupService } from '../services/dashboard_backup_service';
+import {
+  confirmDiscardOrSaveUnsavedChanges,
+  confirmDiscardUnsavedChanges,
+} from '../dashboard_listing/confirm_overlays';
+
+export const ViewModeToggle = ({
+  viewMode,
+  dashboardApi,
+  hasUnsavedChanges,
+  isResetting,
+  setIsResetting,
+}: {
+  viewMode: ViewMode;
+  dashboardApi: DashboardApi;
+  hasUnsavedChanges: boolean;
+  isResetting: boolean;
+  setIsResetting: (isResetting: boolean) => void;
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const isMounted = useMountedState();
+
+  const viewModeOptions: Array<{ id: ViewMode; label: string }> = [
+    { id: 'view', label: 'View' },
+    { id: 'edit', label: 'Edit' },
+  ];
+
+  const switchToEditMode = useCallback(() => {
+    getDashboardBackupService().storeViewMode('edit');
+    dashboardApi.setViewMode('edit');
+    dashboardApi.clearOverlays();
+  }, [dashboardApi]);
+
+  const switchToViewMode = useCallback(() => {
+    dashboardApi.clearOverlays();
+    if (!hasUnsavedChanges) {
+      dashboardApi.setViewMode('view');
+      getDashboardBackupService().storeViewMode('view');
+      return;
+    }
+    confirmDiscardOrSaveUnsavedChanges({
+      discardCallback: async () => {
+        setIsResetting(true);
+        await dashboardApi.asyncResetToLastSavedState();
+        if (isMounted()) {
+          dashboardApi.setViewMode('view');
+          getDashboardBackupService().storeViewMode('view');
+        }
+        setIsResetting(false);
+      },
+      saveCallback: async () => {
+        await dashboardApi.runQuickSave();
+        dashboardApi.clearOverlays();
+
+        if (isMounted()) {
+          dashboardApi.setViewMode('view');
+          getDashboardBackupService().storeViewMode('view');
+        }
+      },
+      cancelCallback: () => {
+        setIsResetting(false);
+        dashboardApi.clearOverlays();
+      },
+    });
+  }, [dashboardApi, hasUnsavedChanges, isMounted, setIsResetting]);
+
+  return (
+    <EuiButtonGroup
+      buttonSize="compressed"
+      legend="This is the toggle for dashboard view mode"
+      type="single"
+      options={viewModeOptions}
+      idSelected={viewMode}
+      onChange={viewMode === 'view' ? switchToEditMode : switchToViewMode}
+      css={{
+        marginLeft: euiTheme.size.s,
+      }}
+    />
+  );
+};

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/view_mode_toggle.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/view_mode_toggle.tsx
@@ -13,10 +13,7 @@ import { EuiButtonGroup, useEuiTheme } from '@elastic/eui';
 import useMountedState from 'react-use/lib/useMountedState';
 import { DashboardApi } from '../dashboard_api/types';
 import { getDashboardBackupService } from '../services/dashboard_backup_service';
-import {
-  confirmDiscardOrSaveUnsavedChanges,
-  confirmDiscardUnsavedChanges,
-} from '../dashboard_listing/confirm_overlays';
+import { confirmDiscardOrSaveUnsavedChanges } from '../dashboard_listing/confirm_overlays';
 
 export const ViewModeToggle = ({
   viewMode,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/view_mode_toggle.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/view_mode_toggle.tsx
@@ -80,6 +80,7 @@ export const ViewModeToggle = ({
       buttonSize="compressed"
       legend="This is the toggle for dashboard view mode"
       type="single"
+      isDisabled={isResetting}
       options={viewModeOptions}
       idSelected={viewMode}
       onChange={viewMode === 'view' ? switchToEditMode : switchToViewMode}


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/192630.
Related to https://github.com/elastic/kibana/issues/217270.

I'm exploring how we can free up space in the top nav in Dashboard and what it'd take to removing the editing toolbar and move all the add panel actions into the top nav. This also includes a few other UX improvements

#### Edit mode
I've removed the editor toolbar and added an add icon button to the top nav. I've also switched all of the top nav actions to icon buttons and leave only the primary action with a button label.

<img width="1071" height="341" alt="Screenshot 2025-07-31 at 11 04 44 AM" src="https://github.com/user-attachments/assets/ed6b1680-ceab-445d-a346-6b47a20d9b2f" />

#### Add panel menu
I've added a collapsible section option to the initial context menu.
Note: This adds an additional click when creating a panel.

<img width="317" height="281" alt="Screenshot 2025-07-31 at 2 32 42 PM" src="https://github.com/user-attachments/assets/9bdcf0dd-4900-4490-92cc-0dd29c9788dd" />


#### View mode switch
![Jul-31-2025 11-03-42](https://github.com/user-attachments/assets/7dfc0e8b-9a9c-4533-8c73-47a2e7bac24b)

#### Unsaved changes modal
This will show when switching to view mode or clicking on the `Unsaved changes` badge. This adds an additional option to save your unsaved changes. 
<img width="544" height="261" alt="Screenshot 2025-07-31 at 11 05 49 AM" src="https://github.com/user-attachments/assets/6b04da02-e41c-4b50-af4e-343115c354fb" />


Note: clicking the `Reset` button will still show the original `Reset changes` confirm modal. 
<img width="469" height="263" alt="Screenshot 2025-07-31 at 11 09 27 AM" src="https://github.com/user-attachments/assets/adc39058-2626-4680-8147-3360b95b464e" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



