### PR TITLE
[DOCS][Stack connectors][9.1 & Serv] Default Gemini model bump for UI docs

### DIFF
--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -493,7 +493,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
        * In {{serverless-full}}, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`.
        * In {{stack}} 9.0, the default is `anthropic.claude-3-5-sonnet-20240620-v1:0`.
        * In {{stack}} 9.1 and later, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`. {applies_to}`stack: planned 9.1`
-    * For a [{{gemini}} connector](/reference/connectors-kibana/gemini-action-type.md), current support is for the Gemini models. Defaults to `gemini-1.5-pro-002`.
+    * For a [{{gemini}} connector](/reference/connectors-kibana/gemini-action-type.md), current support is for the Gemini models. Defaults to `gemini-2.5-pro`.
     * For a [OpenAI connector](/reference/connectors-kibana/openai-action-type.md), it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`.
 
     Data type: `string`

--- a/docs/reference/connectors-kibana/gemini-action-type.md
+++ b/docs/reference/connectors-kibana/gemini-action-type.md
@@ -37,7 +37,7 @@ Region
 :   The GCP region where the Vertex AI endpoint enabled.
 
 Default model
-:   The GAI model for {{gemini}} to use. Current support is for the Google Gemini models, defaulting to gemini-1.5-pro-002. The model can be set on a per request basis by including a "model" parameter alongside the request body.
+:   The GAI model for {{gemini}} to use. Current support is for the Google Gemini models, defaulting to gemini-2.5-pro. The model can be set on a per request basis by including a "model" parameter alongside the request body.
 
 Credentials JSON
 :   The GCP service account JSON file for authentication.

--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -1140,7 +1140,7 @@ groups:
             * In {{serverless-full}}, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`.
             * In {{stack}} 9.0, the default is `anthropic.claude-3-5-sonnet-20240620-v1:0`.
             * In {{stack}} 9.1 and later, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`. {applies_to}`stack: planned 9.1`
-          * For a [{{gemini}} connector](/kibana/docs/reference/connectors-kibana/gemini-action-type.md), current support is for the Gemini models. Defaults to `gemini-1.5-pro-002`.
+          * For a [{{gemini}} connector](/kibana/docs/reference/connectors-kibana/gemini-action-type.md), current support is for the Gemini models. Defaults to `gemini-2.5-pro`.
           * For a [OpenAI connector](/kibana/docs/reference/connectors-kibana/openai-action-type.md), it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`.
         # state: deprecated/hidden/tech-preview
         # deprecation_details: ""


### PR DESCRIPTION
## Summary
Bumps default Gemini model from `gemini-1.5-pro-002` to `gemini-2.5-pro` for the 9.1 and Serverless docs.

Related to https://github.com/elastic/kibana/pull/225917. Corresponding 8.19 docs are being updated via https://github.com/elastic/kibana/pull/226048.

## Previews:
- [Google Gemini connector and action | Connector configuration](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/226045/reference/connectors-kibana/gemini-action-type#gemini-connector-configuration) - Updated the description for the **Default model** field.
- [Alerting and action settings | Preconfigured connector settings](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/226045/reference/configuration-reference/alerting-settings#preconfigured-connector-settings): Updated the description for the `xpack.actions.preconfigured.<connector-id>.config.defaultModel` field.



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->