### PR TITLE
[DOCS][Stack connectors][8.19] Default Gemini model bump for UI docs

### DIFF
--- a/docs/management/connectors/action-types/gemini.asciidoc
+++ b/docs/management/connectors/action-types/gemini.asciidoc
@@ -31,7 +31,7 @@ Name::      The name of the connector.
 API URL::   The {gemini} request URL.
 Project ID:: The project which has Vertex AI endpoint enabled.
 Region:: The GCP region where the Vertex AI endpoint enabled.
-Default model:: The GAI model for {gemini} to use. Current support is for the Google Gemini models, defaulting to gemini-1.5-pro-002. The model can be set on a per request basis by including a "model" parameter alongside the request body.
+Default model:: The GAI model for {gemini} to use. Current support is for the Google Gemini models, defaulting to gemini-2.5-pro. The model can be set on a per request basis by including a "model" parameter alongside the request body.
 Credentials JSON:: The GCP service account JSON file for authentication.
 
 [float]

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -360,7 +360,7 @@ The default model to use for requests, which varies by connector:
 +
 --
 * For an <<bedrock-action-type,{bedrock} connector>>, current support is for the Anthropic Claude models. Defaults to `anthropic.claude-3-5-sonnet-20240620-v1:0`.
-* For a <<gemini-action-type,{gemini} connector>>, current support is for the Gemini models. Defaults to `gemini-1.5-pro-002`.
+* For a <<gemini-action-type,{gemini} connector>>, current support is for the Gemini models. Defaults to `gemini-2.5-pro`.
 * For a <<openai-action-type,OpenAI connector>>, it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`.
 --
 


### PR DESCRIPTION
## Summary
Bumps default Gemini model from `gemini-1.5-pro-002` to `gemini-2.5-pro` for the 8.19 docs.

Related to https://github.com/elastic/kibana/pull/225917. Corresponding 9.1 and Serverless docs are being updated via https://github.com/elastic/kibana/pull/226045.

## Previews:
- [Google Gemini connector and action | Connector configuration](https://kibana_bk_226048.docs-preview.app.elstc.co/guide/en/kibana/8.x/gemini-action-type.html#gemini-connector-configuration) - Updated the description for the **Default model** field.
- [Alerting and action settings | Preconfigured connector settings](https://kibana_bk_226048.docs-preview.app.elstc.co/guide/en/kibana/8.x/alert-action-settings-kb.html#preconfigured-connector-settings) - Updated the description for the `xpack.actions.preconfigured.<connector-id>.config.defaultModel` field.
