### PR TITLE
[onechat] avoid unhandled promise rejection during agent execution

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/chat/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/chat/run_chat_agent.ts
@@ -42,7 +42,7 @@ export const runChatAgent: RunChatAgentFn = async (
     nextInput,
     previousRounds: conversation,
   });
-  const agentGraph = await createAgentGraph({
+  const agentGraph = createAgentGraph({
     logger,
     chatModel: model.chatModel,
     tools: langchainTools,
@@ -73,8 +73,11 @@ export const runChatAgent: RunChatAgentFn = async (
     shareReplay()
   );
 
-  events$.subscribe((event) => {
-    events.emit(event);
+  events$.subscribe({
+    next: (event) => events.emit(event),
+    error: () => {
+      // error will be handled by function return, we just need to trap here
+    },
   });
 
   const round = await extractRound(events$);

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/planner/run_planner_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/planner/run_planner_agent.ts
@@ -79,8 +79,11 @@ export const runPlannerAgent: RunPlannerAgentFn = async (
     shareReplay()
   );
 
-  events$.subscribe((event) => {
-    events.emit(event);
+  events$.subscribe({
+    next: (event) => events.emit(event),
+    error: () => {
+      // error will be handled by function return, we just need to trap here
+    },
   });
 
   const round = await extractRound(events$);

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/reasoning/run_reasoning_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/reasoning/run_reasoning_agent.ts
@@ -74,8 +74,11 @@ export const runReasoningAgent: RunChatAgentFn = async (
     shareReplay()
   );
 
-  events$.subscribe((event) => {
-    events.emit(event);
+  events$.subscribe({
+    next: (event) => events.emit(event),
+    error: () => {
+      // error will be handled by function return, we just need to trap here
+    },
   });
 
   const round = await extractRound(events$);

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/researcher/run_researcher_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/researcher/run_researcher_agent.ts
@@ -79,8 +79,11 @@ export const runResearcherAgent: RunResearcherAgentFn = async (
     shareReplay()
   );
 
-  events$.subscribe((event) => {
-    events.emit(event);
+  events$.subscribe({
+    next: (event) => events.emit(event),
+    error: () => {
+      // error will be handled by function return, we just need to trap here
+    },
   });
 
   const round = await extractRound(events$);


### PR DESCRIPTION
## Summary

Fix a bug which was causing errors occurring during agent graph execution to be considered unhandled, which was causing process termination in dev mode.


