### PR TITLE
[8.19] [Discover] Lens config extension point and hiding x-axis tick labels in patterns profile (#225571)

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
@@ -32,7 +32,7 @@ import type { DiscoverCustomizationId } from '../../../../customizations/customi
 import { RuntimeStateProvider, internalStateActions } from '../../state_management/redux';
 import { dataViewMockWithTimeField } from '@kbn/discover-utils/src/__mocks__';
 import { createContextAwarenessMocks } from '../../../../context_awareness/__mocks__';
-import { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
 
 const { profilesManagerMock: mockProfilesManager } = createContextAwarenessMocks();
 mockProfilesManager.resolveDataSourceProfile({});

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
@@ -31,6 +31,11 @@ import { useDiscoverCustomization } from '../../../../customizations';
 import type { DiscoverCustomizationId } from '../../../../customizations/customization_service';
 import { RuntimeStateProvider, internalStateActions } from '../../state_management/redux';
 import { dataViewMockWithTimeField } from '@kbn/discover-utils/src/__mocks__';
+import { createContextAwarenessMocks } from '../../../../context_awareness/__mocks__';
+import { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+
+const { profilesManagerMock: mockProfilesManager } = createContextAwarenessMocks();
+mockProfilesManager.resolveDataSourceProfile({});
 
 const mockData = dataPluginMock.createStartContract();
 let mockQueryState = {
@@ -51,7 +56,7 @@ jest.mock('../../../../hooks/use_discover_services', () => {
   const originalModule = jest.requireActual('../../../../hooks/use_discover_services');
   return {
     ...originalModule,
-    useDiscoverServices: () => ({ data: mockData }),
+    useDiscoverServices: () => ({ data: mockData, profilesManager: mockProfilesManager }),
   };
 });
 
@@ -435,6 +440,17 @@ describe('useDiscoverHistogram', () => {
         mockHistogramCustomization.withDefaultActions
       );
       expect(hook.result.current.disabledActions).toBeUndefined();
+    });
+  });
+
+  describe('context awareness', () => {
+    it('should modify vis attributes based on profile', async () => {
+      const stateContainer = getStateContainer();
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
+      const modifiedAttributes = hook.result.current.getModifiedVisAttributes?.(
+        {} as TypedLensByValueInput['attributes']
+      );
+      expect(modifiedAttributes).toEqual({ title: 'Modified title' });
     });
   });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -60,6 +60,7 @@ import {
   useInternalStateDispatch,
   useInternalStateSelector,
 } from '../../state_management/redux';
+import { useProfileAccessor } from '../../../../context_awareness';
 
 const EMPTY_ESQL_COLUMNS: DatatableColumn[] = [];
 const EMPTY_FILTERS: Filter[] = [];
@@ -362,6 +363,14 @@ export const useDiscoverHistogram = ({
     [dispatch, stateContainer.savedSearchState]
   );
 
+  const getModifiedVisAttributesAccessor = useProfileAccessor('getModifiedVisAttributes');
+  const getModifiedVisAttributes = useCallback<
+    NonNullable<UnifiedHistogramContainerProps['getModifiedVisAttributes']>
+  >(
+    (attributes) => getModifiedVisAttributesAccessor((params) => params.attributes)({ attributes }),
+    [getModifiedVisAttributesAccessor]
+  );
+
   const breakdownField = useAppStateSelector((state) => state.breakdownField);
 
   const onBreakdownFieldChange = useCallback<
@@ -399,6 +408,7 @@ export const useDiscoverHistogram = ({
     onVisContextChanged: isEsqlMode ? onVisContextChanged : undefined,
     breakdownField,
     onBreakdownFieldChange,
+    getModifiedVisAttributes,
   };
 };
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_default_profile_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_default_profile_state.test.ts
@@ -51,6 +51,35 @@ describe('getDefaultProfileState', () => {
       }).getPreFetchState();
       expect(appState).toEqual(undefined);
     });
+
+    it('should return expected hideChart', () => {
+      let appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          resetId: 'test',
+          columns: false,
+          rowHeight: false,
+          breakdownField: false,
+          hideChart: true,
+        },
+        dataView: dataViewWithTimefieldMock,
+      }).getPreFetchState();
+      expect(appState).toEqual({
+        hideChart: true,
+      });
+      appState = getDefaultProfileState({
+        profilesManager: profilesManagerMock,
+        resetDefaultProfileState: {
+          resetId: 'test',
+          columns: false,
+          rowHeight: false,
+          breakdownField: false,
+          hideChart: false,
+        },
+        dataView: emptyDataView,
+      }).getPreFetchState();
+      expect(appState).toEqual(undefined);
+    });
   });
 
   describe('getPostFetchState', () => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_default_profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_default_profile_state.ts
@@ -44,7 +44,7 @@ export const getDefaultProfileState = ({
         stateUpdate.breakdownField = defaultState.breakdownField;
       }
 
-      if (defaultState.hideChart !== undefined) {
+      if (resetDefaultProfileState.hideChart && defaultState.hideChart !== undefined) {
         stateUpdate.hideChart = defaultState.hideChart;
       }
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
@@ -97,6 +97,7 @@ export const createContextAwarenessMocks = ({
         ],
         rowHeight: 3,
         breakdownField: 'extension',
+        hideChart: true,
       })),
       getAdditionalCellActions: jest.fn((prev) => () => [
         ...prev(),
@@ -113,6 +114,11 @@ export const createContextAwarenessMocks = ({
         ...prev(),
         paginationMode: 'multiPage',
       })),
+      getModifiedVisAttributes: jest.fn((prev) => (params) => {
+        const prevAttributes = prev(params);
+        prevAttributes.title = 'Modified title';
+        return prevAttributes;
+      }),
     },
     resolve: jest.fn(() => ({
       isMatch: true,
@@ -188,7 +194,7 @@ export const createContextAwarenessMocks = ({
     documentProfileServiceMock,
     contextRecordMock,
     contextRecordMock2,
-    profilesManagerMock,
+    profilesManagerMock: profilesManagerMock,
     profileProviderServices,
     ebtManagerMock,
   };

--- a/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
@@ -194,7 +194,7 @@ export const createContextAwarenessMocks = ({
     documentProfileServiceMock,
     contextRecordMock,
     contextRecordMock2,
-    profilesManagerMock: profilesManagerMock,
+    profilesManagerMock,
     profileProviderServices,
     ebtManagerMock,
   };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/patterns/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/patterns/profile.ts
@@ -11,6 +11,7 @@ import { isOfAggregateQueryType } from '@kbn/es-query';
 import { extractCategorizeTokens, getCategorizeColumns, getCategorizeField } from '@kbn/esql-utils';
 import { i18n } from '@kbn/i18n';
 import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
+import type { XYState } from '@kbn/lens-plugin/public';
 import { DataSourceType, isDataSourceType } from '../../../../../common/data_sources';
 import type { DataSourceProfileProvider } from '../../../profiles';
 import { DataSourceCategory } from '../../../profiles';
@@ -103,12 +104,24 @@ export const createPatternDataSourceProfileProvider = (
     getDefaultAppState: (prev) => (params) => {
       return {
         ...prev(params),
-        hideChart: true,
         columns: [
           { name: 'Count', width: 150 },
           { name: 'Pattern', width: undefined },
         ],
       };
+    },
+    getModifiedVisAttributes: (prev) => (params) => {
+      const prevAttributes = prev(params);
+
+      if (prevAttributes.visualizationType === 'lnsXY') {
+        const visualization = prevAttributes.state.visualization as XYState;
+
+        if (visualization.tickLabelsVisibilitySettings) {
+          visualization.tickLabelsVisibilitySettings.x = false;
+        }
+      }
+
+      return prevAttributes;
     },
   },
   resolve: (params) => {

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -23,6 +23,7 @@ import type { OmitIndexSignature } from 'type-fest';
 import type { Trigger } from '@kbn/ui-actions-plugin/public';
 import type { FunctionComponent, PropsWithChildren } from 'react';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
 import type { DiscoverDataSource } from '../../common/data_sources';
 import type { DiscoverAppState } from '../application/main/state_management/discover_app_state_container';
 import type { DiscoverStateContainer } from '../application/main/state_management/discover_state';
@@ -144,6 +145,16 @@ export interface DefaultAppStateExtension {
    * The state for chart visibility toggle
    */
   hideChart?: boolean;
+}
+
+/**
+ * Parameters passed to the modified vis attributes extension
+ */
+export interface ModifiedVisAttributesExtensionParams {
+  /**
+   * The vis attributes to modify
+   */
+  attributes: TypedLensByValueInput['attributes'];
 }
 
 /**
@@ -312,6 +323,18 @@ export interface Profile {
   getDefaultAdHocDataViews: () => Array<
     Omit<DataViewSpec, 'id'> & { id: NonNullable<DataViewSpec['id']> }
   >;
+
+  /**
+   * Chart
+   */
+
+  /**
+   * Allows modifying the default vis attributes used in the Discover chart
+   * @returns The modified vis attributes to use in the chart
+   */
+  getModifiedVisAttributes: (
+    params: ModifiedVisAttributesExtensionParams
+  ) => TypedLensByValueInput['attributes'];
 
   /**
    * Data grid

--- a/src/platform/plugins/shared/unified_histogram/public/__mocks__/lens_vis.ts
+++ b/src/platform/plugins/shared/unified_histogram/public/__mocks__/lens_vis.ts
@@ -34,6 +34,8 @@ export const getLensVisMock = async ({
   allSuggestions,
   isTransformationalESQL,
   table,
+  externalVisContext,
+  getModifiedVisAttributes,
 }: {
   filters: QueryParams['filters'];
   query: QueryParams['query'];
@@ -46,6 +48,8 @@ export const getLensVisMock = async ({
   allSuggestions?: Suggestion[];
   isTransformationalESQL?: boolean;
   table?: Datatable;
+  externalVisContext?: UnifiedHistogramVisContext;
+  getModifiedVisAttributes?: Parameters<LensVisService['update']>[0]['getModifiedVisAttributes'];
 }): Promise<{
   lensService: LensVisService;
   visContext: UnifiedHistogramVisContext | undefined;
@@ -88,9 +92,10 @@ export const getLensVisMock = async ({
     },
     timeInterval,
     breakdownField,
-    externalVisContext: undefined,
+    externalVisContext,
     table,
     onSuggestionContextChange: () => {},
+    getModifiedVisAttributes,
   });
 
   return {

--- a/src/platform/plugins/shared/unified_histogram/public/container/container.tsx
+++ b/src/platform/plugins/shared/unified_histogram/public/container/container.tsx
@@ -54,6 +54,7 @@ export type UnifiedHistogramContainerProps = {
     nextVisContext: UnifiedHistogramVisContext | undefined,
     externalVisContextStatus: UnifiedHistogramExternalVisContextStatus
   ) => void;
+  getModifiedVisAttributes?: UnifiedHistogramLayoutProps['getModifiedVisAttributes'];
 } & Pick<
   UnifiedHistogramLayoutProps,
   | 'services'

--- a/src/platform/plugins/shared/unified_histogram/public/services/lens_vis_service.attributes.test.ts
+++ b/src/platform/plugins/shared/unified_histogram/public/services/lens_vis_service.attributes.test.ts
@@ -741,6 +741,62 @@ describe('LensVisService attributes', () => {
     });
   });
 
+  it('should allow modifying attributes with getModifiedVisAttributes', async () => {
+    const lensVis = await getLensVisMock({
+      filters,
+      query,
+      dataView,
+      timeInterval,
+      breakdownField: undefined,
+      columns: [],
+      isPlainRecord: false,
+      getModifiedVisAttributes: (attributes) => ({
+        ...attributes,
+        title: 'Modified title',
+        visualizationType: 'lnsHeatmap',
+      }),
+    });
+    expect(lensVis.visContext?.attributes).toEqual(
+      expect.objectContaining({
+        title: 'Modified title',
+        visualizationType: 'lnsHeatmap',
+      })
+    );
+  });
+
+  it('should not allow modifying attributes with getModifiedVisAttributes if externalVisContext is applied', async () => {
+    const lensVis = await getLensVisMock({
+      filters,
+      query,
+      dataView,
+      timeInterval,
+      breakdownField: undefined,
+      columns: [],
+      isPlainRecord: false,
+    });
+    const lensVis2 = await getLensVisMock({
+      filters,
+      query,
+      dataView,
+      timeInterval,
+      breakdownField: undefined,
+      columns: [],
+      isPlainRecord: false,
+      externalVisContext: lensVis.visContext,
+      getModifiedVisAttributes: (attributes) => ({
+        ...attributes,
+        title: 'Modified title',
+        visualizationType: 'lnsHeatmap',
+      }),
+    });
+    expect(lensVis2.visContext?.attributes).not.toEqual(
+      expect.objectContaining({
+        title: 'Modified title',
+        visualizationType: 'lnsHeatmap',
+      })
+    );
+  });
+
   it('should return suggestion title', async () => {
     const lensVis = await getLensVisMock({
       filters,

--- a/src/platform/plugins/shared/unified_histogram/public/services/lens_vis_service.ts
+++ b/src/platform/plugins/shared/unified_histogram/public/services/lens_vis_service.ts
@@ -135,6 +135,7 @@ export class LensVisService {
     table,
     onSuggestionContextChange,
     onVisContextChanged,
+    getModifiedVisAttributes,
   }: {
     externalVisContext: UnifiedHistogramVisContext | undefined;
     queryParams: QueryParams;
@@ -148,6 +149,9 @@ export class LensVisService {
       visContext: UnifiedHistogramVisContext | undefined,
       externalVisContextStatus: UnifiedHistogramExternalVisContextStatus
     ) => void;
+    getModifiedVisAttributes?: (
+      attributes: TypedLensByValueInput['attributes']
+    ) => TypedLensByValueInput['attributes'];
   }) => {
     const suggestionState = this.getCurrentSuggestionState({
       externalVisContext,
@@ -163,6 +167,7 @@ export class LensVisService {
       timeInterval,
       breakdownField,
       table,
+      getModifiedVisAttributes,
     });
 
     onSuggestionContextChange(suggestionState.currentSuggestionContext);
@@ -656,6 +661,7 @@ export class LensVisService {
     timeInterval,
     breakdownField,
     table,
+    getModifiedVisAttributes,
   }: {
     currentSuggestionContext: UnifiedHistogramSuggestionContext;
     externalVisContext: UnifiedHistogramVisContext | undefined;
@@ -663,6 +669,9 @@ export class LensVisService {
     timeInterval: string | undefined;
     breakdownField: DataViewField | undefined;
     table: Datatable | undefined;
+    getModifiedVisAttributes?: (
+      attributes: TypedLensByValueInput['attributes']
+    ) => TypedLensByValueInput['attributes'];
   }): {
     externalVisContextStatus: UnifiedHistogramExternalVisContextStatus;
     visContext: UnifiedHistogramVisContext | undefined;
@@ -766,6 +775,13 @@ export class LensVisService {
           table,
         }),
       };
+    }
+
+    if (
+      externalVisContextStatus !== UnifiedHistogramExternalVisContextStatus.applied &&
+      getModifiedVisAttributes
+    ) {
+      visContext.attributes = getModifiedVisAttributes(visContext.attributes);
     }
 
     return {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover] Lens config extension point and hiding x-axis tick labels in patterns profile (#225571)](https://github.com/elastic/kibana/pull/225571)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2025-07-01T14:24:52Z","message":"[Discover] Lens config extension point and hiding x-axis tick labels in patterns profile (#225571)\n\n## Summary\n\nThis PR introduces a `getModifiedVisAttributes` extension point,\nallowing profiles to customize the default Lens chart configuration.\nAdditionally, it updates the patterns data source profile to make use of\nthe extension point in order to hide x-axis tick labels in the XY chart.\nIt also stops hiding the chart by default for the patterns profile.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: James Gowdy <jgowdy@elastic.co>","sha":"b53844fba3aa273b7c1088696383798a576f3f85","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","Project:OneDiscover","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Discover] Lens config extension point and hiding x-axis tick labels in patterns profile","number":225571,"url":"https://github.com/elastic/kibana/pull/225571","mergeCommit":{"message":"[Discover] Lens config extension point and hiding x-axis tick labels in patterns profile (#225571)\n\n## Summary\n\nThis PR introduces a `getModifiedVisAttributes` extension point,\nallowing profiles to customize the default Lens chart configuration.\nAdditionally, it updates the patterns data source profile to make use of\nthe extension point in order to hide x-axis tick labels in the XY chart.\nIt also stops hiding the chart by default for the patterns profile.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: James Gowdy <jgowdy@elastic.co>","sha":"b53844fba3aa273b7c1088696383798a576f3f85"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/226022","number":226022,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225571","number":225571,"mergeCommit":{"message":"[Discover] Lens config extension point and hiding x-axis tick labels in patterns profile (#225571)\n\n## Summary\n\nThis PR introduces a `getModifiedVisAttributes` extension point,\nallowing profiles to customize the default Lens chart configuration.\nAdditionally, it updates the patterns data source profile to make use of\nthe extension point in order to hide x-axis tick labels in the XY chart.\nIt also stops hiding the chart by default for the patterns profile.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: James Gowdy <jgowdy@elastic.co>","sha":"b53844fba3aa273b7c1088696383798a576f3f85"}}]}] BACKPORT-->