### PR TITLE
[Security Assistant] Starter prompt telemetry!

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/starter_prompts.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/starter_prompts.test.tsx
@@ -81,7 +81,7 @@ const mockResponse = [
 const testProps = {
   setUserPrompt: jest.fn(),
 };
-
+const mockReportAssistantStarterPrompt = jest.fn();
 jest.mock('../../..', () => {
   return {
     useFindPrompts: jest.fn(),
@@ -89,12 +89,18 @@ jest.mock('../../..', () => {
       assistantAvailability: {
         isAssistantEnabled: true,
       },
+      assistantTelemetry: {
+        reportAssistantStarterPrompt: mockReportAssistantStarterPrompt,
+      },
       http: { fetch: {} },
     }),
   };
 });
 
 describe('StarterPrompts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('should return an empty array if no prompts are provided', () => {
     expect(getAllPromptIds(promptGroups)).toEqual([
       'starterPromptTitle1',
@@ -157,5 +163,17 @@ describe('StarterPrompts', () => {
     );
     fireEvent.click(getByTestId('starterPromptPrompt2 from API yall'));
     expect(testProps.setUserPrompt).toHaveBeenCalledWith('starterPromptPrompt2 from API yall');
+  });
+  it('calls reportAssistantStarterPrompt with prompt title when a prompt is selected', () => {
+    (useFindPrompts as jest.Mock).mockReturnValue({ data: { prompts: mockResponse } });
+    const { getByTestId } = render(
+      <TestProviders>
+        <StarterPrompts {...testProps} />
+      </TestProviders>
+    );
+    fireEvent.click(getByTestId('starterPromptPrompt2 from API yall'));
+    expect(mockReportAssistantStarterPrompt).toHaveBeenCalledWith({
+      promptTitle: 'starterPromptTitle2 from API yall',
+    });
   });
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/starter_prompts.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/starter_prompts.tsx
@@ -68,6 +68,7 @@ export const promptGroups = [
 export const StarterPrompts: React.FC<Props> = ({ connectorId, setUserPrompt }) => {
   const {
     assistantAvailability: { isAssistantEnabled },
+    assistantTelemetry,
     http,
     toasts,
   } = useAssistantContext();
@@ -93,11 +94,21 @@ export const StarterPrompts: React.FC<Props> = ({ connectorId, setUserPrompt }) 
     return formatPromptGroups(actualPrompts);
   }, [actualPrompts]);
 
-  const onSelectPrompt = useCallback(
-    (prompt: string) => {
-      setUserPrompt(prompt);
+  const trackPrompt = useCallback(
+    (promptTitle: string) => {
+      assistantTelemetry?.reportAssistantStarterPrompt({
+        promptTitle,
+      });
     },
-    [setUserPrompt]
+    [assistantTelemetry]
+  );
+
+  const onSelectPrompt = useCallback(
+    (prompt: string, title: string) => {
+      setUserPrompt(prompt);
+      trackPrompt(title);
+    },
+    [setUserPrompt, trackPrompt]
   );
 
   return (
@@ -109,7 +120,7 @@ export const StarterPrompts: React.FC<Props> = ({ connectorId, setUserPrompt }) 
             hasShadow={false}
             hasBorder
             data-test-subj={prompt}
-            onClick={() => onSelectPrompt(prompt)}
+            onClick={() => onSelectPrompt(prompt, title)}
             className={starterPromptInnerClassName}
           >
             <EuiSpacer size="s" />

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.test.tsx
@@ -15,6 +15,7 @@ const assistantTelemetry = {
   reportAssistantInvoked,
   reportAssistantMessageSent: () => {},
   reportAssistantQuickPrompt: () => {},
+  reportAssistantStarterPrompt: () => {},
   reportAssistantSettingToggled: () => {},
 };
 describe('AssistantOverlay', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx
@@ -53,6 +53,7 @@ export interface AssistantTelemetry {
     isEnabledKnowledgeBase: boolean;
   }) => void;
   reportAssistantQuickPrompt: (params: { promptTitle: string }) => void;
+  reportAssistantStarterPrompt: (params: { promptTitle: string }) => void;
   reportAssistantSettingToggled: (params: {
     assistantStreamingEnabled?: boolean;
     alertsCountUpdated?: boolean;

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/common/lib/telemetry/events/ai_assistant/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/common/lib/telemetry/events/ai_assistant/types.ts
@@ -11,6 +11,7 @@ export enum AssistantEventTypes {
   AssistantInvoked = 'Assistant Invoked',
   AssistantMessageSent = 'Assistant Message Sent',
   AssistantQuickPrompt = 'Assistant Quick Prompt',
+  AssistantStarterPrompt = 'Assistant Starter Prompt',
   AssistantSettingToggled = 'Assistant Setting Toggled',
 }
 
@@ -30,6 +31,10 @@ export interface ReportAssistantQuickPromptParams {
   promptTitle: string;
 }
 
+export interface ReportAssistantStarterPromptParams {
+  promptTitle: string;
+}
+
 export interface ReportAssistantSettingToggledParams {
   alertsCountUpdated?: boolean;
   assistantStreamingEnabled?: boolean;
@@ -39,6 +44,7 @@ export interface AssistantTelemetryEventsMap {
   [AssistantEventTypes.AssistantInvoked]: ReportAssistantInvokedParams;
   [AssistantEventTypes.AssistantMessageSent]: ReportAssistantMessageSentParams;
   [AssistantEventTypes.AssistantQuickPrompt]: ReportAssistantQuickPromptParams;
+  [AssistantEventTypes.AssistantStarterPrompt]: ReportAssistantStarterPromptParams;
   [AssistantEventTypes.AssistantSettingToggled]: ReportAssistantSettingToggledParams;
 }
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/use_assistant_telemetry/index.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/use_assistant_telemetry/index.test.tsx
@@ -43,6 +43,7 @@ const trackingFns = [
   { name: 'reportAssistantInvoked', eventType: AssistantEventTypes.AssistantInvoked },
   { name: 'reportAssistantMessageSent', eventType: AssistantEventTypes.AssistantMessageSent },
   { name: 'reportAssistantQuickPrompt', eventType: AssistantEventTypes.AssistantQuickPrompt },
+  { name: 'reportAssistantStarterPrompt', eventType: AssistantEventTypes.AssistantStarterPrompt },
 ];
 
 describe('useAssistantTelemetry', () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/use_assistant_telemetry/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/use_assistant_telemetry/index.tsx
@@ -13,6 +13,7 @@ import {
   ReportAssistantInvokedParams,
   ReportAssistantMessageSentParams,
   ReportAssistantQuickPromptParams,
+  ReportAssistantStarterPromptParams,
   ReportAssistantSettingToggledParams,
 } from '../../common/lib/telemetry/events/ai_assistant/types';
 
@@ -45,6 +46,8 @@ export const useAssistantTelemetry = (): AssistantTelemetry => {
         reportTelemetry({ eventType: AssistantEventTypes.AssistantMessageSent, params }),
       reportAssistantQuickPrompt: (params: ReportAssistantQuickPromptParams) =>
         reportTelemetry({ eventType: AssistantEventTypes.AssistantQuickPrompt, params }),
+      reportAssistantStarterPrompt: (params: ReportAssistantStarterPromptParams) =>
+        reportTelemetry({ eventType: AssistantEventTypes.AssistantStarterPrompt, params }),
       reportAssistantSettingToggled: (params: ReportAssistantSettingToggledParams) =>
         telemetry.reportEvent(AssistantEventTypes.AssistantSettingToggled, params),
     }),


### PR DESCRIPTION
## Summary

Adds a new `ebt-kibana-browser` event type of `Assistant Starter Prompt` that reuses the same `promptTitle` parameter as the `Assistant Quick Prompt`. Since the starter prompts are always defined by us, there is no user data to mask and no need for "Custom" entries like we have for quick prompts.

We're tracking when the starter prompts are clicked, not when they are sent.

### To test
1. have the feature flag enabled: `feature_flags.overrides.elasticAssistant.starterPromptsEnabled: true`
2. Do some clicking of the starter prompts. Keep track of how many times you click each prompt.
3. Wait ~1 hour (or more) for your events to show on the telemetry instance
4. Check this dashboard for your events: https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/r/s/eLwM5. Ensure the counts match up with what you tracked.

<img width="317" alt="Screenshot 2025-07-02 at 8 16 18 AM" src="https://github.com/user-attachments/assets/f580559a-2eed-472e-bc56-e3f835000b10" />





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->