### PR TITLE
[dashboard] avoid 5 second delay in functional tests when calling onDashboardLandingPage

### DIFF
--- a/src/platform/test/functional/page_objects/dashboard_page.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page.ts
@@ -199,7 +199,8 @@ export class DashboardPageObject extends FtrService {
    */
   public async onDashboardLandingPage() {
     this.log.debug(`onDashboardLandingPage`);
-    return await this.listingTable.onListingPage('dashboard');
+    const currentUrl = await this.browser.getCurrentUrl();
+    return currentUrl.includes('dashboards#/list');
   }
 
   public async expectExistsDashboardLandingPage() {


### PR DESCRIPTION
The current implementation of `onDashboardLandingPage` calls `this.listingTable.onListingPage('dashboard')`. `onListingPage` is inlined below for reference. The problem with this implementation is that when the test is not on the listing page, there is a 5000 milliseconds delay checking for the existence of a never-gonna-be-there element.

```
public async onListingPage(appName: AppName) {
    return await this.testSubjects.exists(`${appName}LandingPage`, {
      timeout: 5000,
    });
  }
```

`onDashboardLandingPage` is used 20 times, while `onDashboardLandingPage` is called in `gotoDashboardLandingPage`, which is used 137 times. A majority of these calls occur when the test is on `dashboards#/view` so the tests delay 5 seconds on these calls. Needless to say, our tests waste a lot of time determining if they are on the listing page.

One case study is src/platform/test/functional/apps/dashboard/group1/dashboard_unsaved_listing.ts, which calls `gotoDashboardLandingPage` 11 times. Before this change, this test takes 4 minutes to run. With this change, this test takes 3 minutes to run which lines up with our expection that 11 x 5 seconds is about one minute.

The PR resolves the issue by checking the URL instead of the DOM. This way, the test instantly knows if its on the landing page without any delays.

Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8504. Ran src/platform/test/functional/apps/dashboard/group1/config.ts, which includes dashboard_unsaved_listing.ts, to ensure this change is not flaky.

I also ran the flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8506 as a control to see how long it takes without these changes. The runs where 2 to 3 minutes faster with the changes.

Control - no changes to `onDashboardLandingPage`
<img width="408" alt="Screenshot 2025-07-01 at 4 45 04 PM" src="https://github.com/user-attachments/assets/58acc42c-241c-4005-b564-c114ff6b7b15" />

With changes to `onDashboardLandingPage`
<img width="348" alt="Screenshot 2025-07-01 at 4 45 44 PM" src="https://github.com/user-attachments/assets/45ed8cde-e78c-4be6-a6b4-e9d95626a681" />



<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->