### PR TITLE
Remove globby in favor of fast-glob

### DIFF
--- a/.buildkite/package-lock.json
+++ b/.buildkite/package-lock.json
@@ -11,7 +11,7 @@
         "@octokit/rest": "^18.10.0",
         "adm-zip": "^0.5.16",
         "axios": "^1.8.3",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "js-yaml": "^4.1.0",
         "minimatch": "^5.0.1",
         "minimist": "^1.2.8",
@@ -1155,14 +1155,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1585,17 +1577,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1652,15 +1633,16 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -1888,25 +1870,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1930,14 +1893,6 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/imurmurhash": {
@@ -2661,14 +2616,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -3048,14 +2995,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/source-map": {
@@ -4324,11 +4263,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -4630,14 +4564,6 @@
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true
     },
-    "dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "requires": {
-        "path-type": "^4.0.0"
-      }
-    },
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4675,15 +4601,15 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       }
     },
     "fastq": {
@@ -4830,19 +4756,6 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
-    "globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "requires": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4860,11 +4773,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -5379,11 +5287,6 @@
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       }
     },
-    "path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-    },
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -5626,11 +5529,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true
-    },
-    "slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -13,7 +13,7 @@
     "@octokit/rest": "^18.10.0",
     "adm-zip": "^0.5.16",
     "axios": "^1.8.3",
-    "globby": "^11.1.0",
+    "fast-glob": "^3.3.2",
     "js-yaml": "^4.1.0",
     "minimatch": "^5.0.1",
     "minimist": "^1.2.8",

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -9,7 +9,7 @@
 
 import * as Fs from 'fs';
 
-import * as globby from 'globby';
+import * as fastGlob from 'fast-glob';
 import minimatch from 'minimatch';
 
 import { load as loadYaml } from 'js-yaml';
@@ -284,7 +284,7 @@ export async function pickTestGroupRunOrder() {
   if (!ftrConfigsIncluded) ftrConfigsByQueue.clear();
 
   const jestUnitConfigs = LIMIT_CONFIG_TYPE.includes('unit')
-    ? globby.sync(['**/jest.config.js', '!**/__fixtures__/**'], {
+    ? fastGlob.sync(['**/jest.config.js', '!**/__fixtures__/**'], {
         cwd: process.cwd(),
         absolute: false,
         ignore: DISABLED_JEST_CONFIGS,
@@ -292,7 +292,7 @@ export async function pickTestGroupRunOrder() {
     : [];
 
   const jestIntegrationConfigs = LIMIT_CONFIG_TYPE.includes('integration')
-    ? globby.sync(['**/jest.integration.config.js', '!**/__fixtures__/**'], {
+    ? fastGlob.sync(['**/jest.integration.config.js', '!**/__fixtures__/**'], {
         cwd: process.cwd(),
         absolute: false,
         ignore: DISABLED_JEST_CONFIGS,

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@types/react": "~18.2.0",
     "@types/react-dom": "~18.2.0",
     "@xstate5/react/**/xstate": "^5.19.2",
-    "globby/fast-glob": "^3.3.2",
     "pkce-challenge": "3.1.0"
   },
   "dependencies": {
@@ -1222,7 +1221,6 @@
     "get-port": "^5.0.0",
     "getopts": "^2.2.5",
     "getos": "^3.1.0",
-    "globby": "^11.1.0",
     "google-auth-library": "^9.10.0",
     "gpt-tokenizer": "^2.6.2",
     "handlebars": "4.7.8",

--- a/packages/kbn-docs-utils/src/mdx/get_all_doc_file_ids.ts
+++ b/packages/kbn-docs-utils/src/mdx/get_all_doc_file_ids.ts
@@ -9,14 +9,14 @@
 
 import Fsp from 'fs/promises';
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { asyncMapWithLimit } from '@kbn/std';
 import Yaml from 'js-yaml';
 
 const FM_SEP_RE = /^---$/m;
 
 export async function getAllDocFileIds(outputDir: string) {
-  const paths = await globby(['**/*.mdx'], {
+  const paths = await fastGlob(['**/*.mdx'], {
     cwd: outputDir,
     absolute: true,
     unique: true,

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/failed_tests_reporter_cli.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/failed_tests_reporter_cli.ts
@@ -13,7 +13,7 @@ import { REPO_ROOT } from '@kbn/repo-info';
 import { run } from '@kbn/dev-cli-runner';
 import { createFailError, createFlagError } from '@kbn/dev-cli-errors';
 import { CiStatsReporter } from '@kbn/ci-stats-reporter';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import normalize from 'normalize-path';
 import { getFailures } from './get_failures';
 import { GithubApi } from './github_api';
@@ -92,7 +92,7 @@ run(
         normalize(Path.resolve(p))
       );
       log.info('Searching for reports at', patterns);
-      const reportPaths = await globby(patterns, {
+      const reportPaths = await fastGlob(patterns, {
         absolute: true,
       });
 

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
@@ -9,7 +9,7 @@
 
 import Path from 'path';
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import fs from 'fs';
 import { createHash } from 'crypto';
 import { ToolingLog } from '@kbn/tooling-log';
@@ -27,7 +27,7 @@ export async function generateScoutTestFailureArtifacts({
 }) {
   log.info('Searching for Scout test failure reports');
 
-  const dirs = await globby(SCOUT_TEST_FAILURE_DIR_PATTERN, {
+  const dirs = await fastGlob(SCOUT_TEST_FAILURE_DIR_PATTERN, {
     onlyDirectories: true,
   });
 

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
@@ -11,7 +11,7 @@ import Path from 'path';
 import Fs from 'fs';
 import { createHash } from 'crypto';
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { ToolingLog } from '@kbn/tooling-log';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { escape } from 'he';
@@ -77,7 +77,7 @@ function getAllScreenshots(log: ToolingLog) {
 }
 function findAllScreenshots(log: ToolingLog) {
   try {
-    return globby
+    return fastGlob
       .sync(
         [
           'src/platform/test/functional/**/screenshots/failure/*.png',

--- a/packages/kbn-generate/src/commands/package_command.ts
+++ b/packages/kbn-generate/src/commands/package_command.ts
@@ -12,7 +12,7 @@ import Path from 'path';
 
 import inquirer from 'inquirer';
 import normalizePath from 'normalize-path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { ESLint } from 'eslint';
 
 import { REPO_ROOT } from '@kbn/repo-info';
@@ -182,7 +182,7 @@ export const PackageCommand: GenerateCommand = {
       }
     }
 
-    const templateFiles = await globby('**/*', {
+    const templateFiles = await fastGlob('**/*', {
       cwd: PKG_TEMPLATE_DIR,
       absolute: false,
       dot: true,

--- a/packages/kbn-optimizer/src/optimizer/optimizer_built_paths.ts
+++ b/packages/kbn-optimizer/src/optimizer/optimizer_built_paths.ts
@@ -8,13 +8,13 @@
  */
 
 import Path from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 import { ascending } from '../common';
 
 export async function getOptimizerBuiltPaths() {
   return (
-    await globby(
+    await fastGlob(
       [
         '**/*',
         '!**/{__fixtures__,__snapshots__,integration_tests,audit_bundle_dependencies,node}/**',

--- a/packages/kbn-plugin-generator/src/integration_tests/generate_plugin.test.ts
+++ b/packages/kbn-plugin-generator/src/integration_tests/generate_plugin.test.ts
@@ -13,7 +13,7 @@ import del from 'del';
 import execa from 'execa';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { createAbsolutePathSerializer } from '@kbn/jest-serializers';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 const GENERATED_DIR = Path.resolve(REPO_ROOT, `plugins`);
 
@@ -33,7 +33,7 @@ it('generates a plugin', async () => {
     buffer: true,
   });
 
-  const paths = await globby('**/*', {
+  const paths = await fastGlob('**/*', {
     cwd: GENERATED_DIR,
     absolute: true,
     dot: true,
@@ -71,7 +71,7 @@ it('generates a plugin without UI', async () => {
     buffer: true,
   });
 
-  const paths = await globby('**/*', {
+  const paths = await fastGlob('**/*', {
     cwd: GENERATED_DIR,
     absolute: true,
     dot: true,
@@ -104,7 +104,7 @@ it('generates a plugin without server plugin', async () => {
     buffer: true,
   });
 
-  const paths = await globby('**/*', {
+  const paths = await fastGlob('**/*', {
     cwd: GENERATED_DIR,
     absolute: true,
     dot: true,

--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -15,7 +15,7 @@ import { REPO_ROOT } from '@kbn/repo-info';
 import { createStripAnsiSerializer, createReplaceSerializer } from '@kbn/jest-serializers';
 import extract from 'extract-zip';
 import del from 'del';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import loadJsonFile from 'load-json-file';
 
 const PLUGIN_DIR = Path.resolve(REPO_ROOT, 'plugins/foo_test_plugin');
@@ -84,7 +84,7 @@ it('builds a generated plugin into a viable archive', async () => {
 
   await extract(PLUGIN_ARCHIVE, { dir: TMP_DIR });
 
-  const files = await globby(['**/*'], { cwd: TMP_DIR, dot: true });
+  const files = await fastGlob(['**/*'], { cwd: TMP_DIR, dot: true });
   files.sort((a, b) => a.localeCompare(b));
 
   expect(files).toMatchInlineSnapshot(`

--- a/renovate.json
+++ b/renovate.json
@@ -2856,25 +2856,6 @@
       "enabled": true
     },
     {
-      "groupName": "globby",
-      "matchDepNames": [
-        "globby"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "backport:all-open",
-        "release_note:skip"
-      ],
-      "minimumReleaseAge": "7 days",
-      "enabled": true
-    },
-    {
       "groupName": "ignore",
       "matchDepNames": [
         "ignore"

--- a/src/cli_plugin/install/download.test.js
+++ b/src/cli_plugin/install/download.test.js
@@ -13,7 +13,7 @@ import http from 'http';
 
 import sinon from 'sinon';
 import nock from 'nock';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import del from 'del';
 
 import { Logger } from '../../cli/logger';
@@ -34,12 +34,12 @@ describe('kibana cli', function () {
     const logger = new Logger(settings);
 
     function expectWorkingPathEmpty() {
-      const files = globby.sync('**/*', { cwd: testWorkingPath, onlyFiles: false });
+      const files = fastGlob.sync('**/*', { cwd: testWorkingPath, onlyFiles: false });
       expect(files).toEqual([]);
     }
 
     function expectWorkingPathNotEmpty() {
-      const files = globby.sync('**/*', { cwd: testWorkingPath, onlyFiles: false });
+      const files = fastGlob.sync('**/*', { cwd: testWorkingPath, onlyFiles: false });
       const expected = ['archive.part'];
 
       expect(files.sort()).toEqual(expected.sort());

--- a/src/cli_plugin/install/pack.test.js
+++ b/src/cli_plugin/install/pack.test.js
@@ -11,7 +11,7 @@ import Fs from 'fs';
 import { join } from 'path';
 
 import sinon from 'sinon';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import del from 'del';
 
 import { Logger } from '../../cli/logger';
@@ -72,7 +72,7 @@ describe('kibana cli', function () {
         await getPackData(settings, logger);
         await extract(settings, logger);
 
-        expect(globby.sync('**/*', { cwd: testWorkingPath, onlyFiles: false }).sort())
+        expect(fastGlob.sync('**/*', { cwd: testWorkingPath, onlyFiles: false }).sort())
           .toMatchInlineSnapshot(`
           Array [
             "archive.part",

--- a/src/cli_plugin/install/zip.test.js
+++ b/src/cli_plugin/install/zip.test.js
@@ -12,7 +12,7 @@ import os from 'os';
 import fs from 'fs';
 
 import del from 'del';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 import { analyzeArchive, extractArchive } from './zip';
 
@@ -55,7 +55,7 @@ describe('kibana cli', function () {
         const archive = path.resolve(repliesPath, 'test_plugin.zip');
         await extractArchive(archive, tempPath, 'kibana/test-plugin');
 
-        expect(globby.sync('**/*', { cwd: tempPath, onlyFiles: false })).toMatchInlineSnapshot(`
+        expect(fastGlob.sync('**/*', { cwd: tempPath, onlyFiles: false })).toMatchInlineSnapshot(`
           Array [
             "bin",
             "kibana.json",
@@ -78,7 +78,7 @@ describe('kibana cli', function () {
 
         await extractArchive(archivePath, tempPath, 'kibana/test-plugin/bin');
 
-        expect(globby.sync('**/*', { cwd: tempPath, onlyFiles: false })).toMatchInlineSnapshot(`
+        expect(fastGlob.sync('**/*', { cwd: tempPath, onlyFiles: false })).toMatchInlineSnapshot(`
           Array [
             "executable",
             "not-executable",

--- a/src/cli_plugin/remove/remove.test.js
+++ b/src/cli_plugin/remove/remove.test.js
@@ -11,7 +11,7 @@ import { join } from 'path';
 import { writeFileSync, existsSync, mkdirSync } from 'fs';
 
 import sinon from 'sinon';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import del from 'del';
 
 import { Logger } from '../../cli/logger';
@@ -83,7 +83,7 @@ describe('kibana cli', function () {
       mkdirSync(join(pluginDir, 'bar'), { recursive: true });
 
       remove(settings, logger);
-      const files = globby.sync('**/*', { cwd: pluginDir, onlyFiles: false });
+      const files = fastGlob.sync('**/*', { cwd: pluginDir, onlyFiles: false });
       const expected = ['bar'];
       expect(files.sort()).toEqual(expected.sort());
     });

--- a/src/core/packages/i18n/server-internal/src/get_translation_paths.test.mocks.ts
+++ b/src/core/packages/i18n/server-internal/src/get_translation_paths.test.mocks.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export const globbyMock = jest.fn();
-jest.doMock('globby', () => globbyMock);
+export const fastGlobMock = jest.fn();
+jest.doMock('fast-glob', () => fastGlobMock);
 
 export const readFileMock = jest.fn();
 jest.doMock('fs/promises', () => ({

--- a/src/core/packages/i18n/server-internal/src/get_translation_paths.test.ts
+++ b/src/core/packages/i18n/server-internal/src/get_translation_paths.test.ts
@@ -8,35 +8,35 @@
  */
 
 import { resolve, join } from 'path';
-import { globbyMock, readFileMock } from './get_translation_paths.test.mocks';
+import { fastGlobMock, readFileMock } from './get_translation_paths.test.mocks';
 import { getTranslationPaths } from './get_translation_paths';
 
 describe('getTranslationPaths', () => {
   beforeEach(() => {
-    globbyMock.mockReset();
+    fastGlobMock.mockReset();
     readFileMock.mockReset();
 
-    globbyMock.mockResolvedValue([]);
+    fastGlobMock.mockResolvedValue([]);
     readFileMock.mockResolvedValue('{}');
   });
 
-  it('calls `globby` with the correct parameters', async () => {
+  it('calls `fast-glob` with the correct parameters', async () => {
     getTranslationPaths({ cwd: '/some/cwd', nested: false });
 
-    expect(globbyMock).toHaveBeenCalledTimes(1);
-    expect(globbyMock).toHaveBeenCalledWith('.i18nrc.json', { cwd: '/some/cwd', dot: true });
+    expect(fastGlobMock).toHaveBeenCalledTimes(1);
+    expect(fastGlobMock).toHaveBeenCalledWith('.i18nrc.json', { cwd: '/some/cwd', dot: true });
 
-    globbyMock.mockClear();
+    fastGlobMock.mockClear();
 
     await getTranslationPaths({ cwd: '/other/cwd', nested: true });
 
-    expect(globbyMock).toHaveBeenCalledTimes(1);
-    expect(globbyMock).toHaveBeenCalledWith('*/.i18nrc.json', { cwd: '/other/cwd', dot: true });
+    expect(fastGlobMock).toHaveBeenCalledTimes(1);
+    expect(fastGlobMock).toHaveBeenCalledWith('*/.i18nrc.json', { cwd: '/other/cwd', dot: true });
   });
 
-  it('calls `readFile` for each entry returned by `globby`', async () => {
+  it('calls `readFile` for each entry returned by `fast-glob`', async () => {
     const entries = [join('pathA', '.i18nrc.json'), join('pathB', '.i18nrc.json')];
-    globbyMock.mockResolvedValue(entries);
+    fastGlobMock.mockResolvedValue(entries);
 
     const cwd = '/kibana-extra';
 
@@ -50,7 +50,7 @@ describe('getTranslationPaths', () => {
 
   it('returns the absolute path to the translation files', async () => {
     const entries = ['.i18nrc.json'];
-    globbyMock.mockResolvedValue(entries);
+    fastGlobMock.mockResolvedValue(entries);
 
     const i18nFileContent = {
       translations: ['translations/en.json', 'translations/fr.json'],
@@ -68,7 +68,7 @@ describe('getTranslationPaths', () => {
   });
 
   it('throws if i18nrc parsing fails', async () => {
-    globbyMock.mockResolvedValue(['.i18nrc.json']);
+    fastGlobMock.mockResolvedValue(['.i18nrc.json']);
     readFileMock.mockRejectedValue(new Error('error parsing file'));
 
     await expect(

--- a/src/core/packages/i18n/server-internal/src/get_translation_paths.ts
+++ b/src/core/packages/i18n/server-internal/src/get_translation_paths.ts
@@ -8,7 +8,7 @@
  */
 
 import { resolve, dirname } from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { readFile } from 'fs/promises';
 
 interface I18NRCFileStructure {
@@ -19,7 +19,7 @@ const I18N_RC = '.i18nrc.json';
 
 export async function getTranslationPaths({ cwd, nested }: { cwd: string; nested: boolean }) {
   const glob = nested ? `*/${I18N_RC}` : I18N_RC;
-  const entries = await globby(glob, { cwd, dot: true });
+  const entries = await fastGlob(glob, { cwd, dot: true });
   const translationPaths: string[] = [];
 
   for (const entry of entries) {

--- a/src/dev/build/lib/fs.ts
+++ b/src/dev/build/lib/fs.ts
@@ -17,7 +17,7 @@ import { createGunzip } from 'zlib';
 import { inspect } from 'util';
 
 import archiver from 'archiver';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import cpy from 'cpy';
 import del from 'del';
 import * as tar from 'tar';
@@ -178,7 +178,7 @@ export async function copyAll(
   // we must update access and modified file times after the file copy
   // has completed, otherwise the copy action can effect modify times.
   if (time) {
-    const copiedDirectories = await globby(select, {
+    const copiedDirectories = await fastGlob(select, {
       cwd: destination,
       dot,
       onlyDirectories: true,

--- a/src/dev/build/tasks/bin/copy_bin_scripts_task.ts
+++ b/src/dev/build/tasks/bin/copy_bin_scripts_task.ts
@@ -10,7 +10,7 @@
 import Mustache from 'mustache';
 import { join } from 'path';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { copyAll, Task } from '../../lib';
 
 export const CopyBinScripts: Task = {
@@ -27,7 +27,7 @@ export const CopyBinScripts: Task = {
           select: ['*.bat'],
         });
       } else {
-        globby
+        fastGlob
           .sync(['*'], {
             ignore: ['*.bat'],
             cwd: scriptsSrc,

--- a/src/dev/build/tasks/copy_legacy_source_task.ts
+++ b/src/dev/build/tasks/copy_legacy_source_task.ts
@@ -10,7 +10,7 @@
 import { resolve } from 'path';
 
 import { getPackages } from '@kbn/repo-packages';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import Piscina from 'piscina';
 
 import { Task } from '../lib';
@@ -55,9 +55,9 @@ export const CopyLegacySource: Task = {
       filename: resolve(__dirname, 'copy_source_worker.js'),
     });
 
-    const globbyOptions = { cwd: config.resolveFromRepo('.') };
+    const fastGlobOptions = { cwd: config.resolveFromRepo('.') };
     const promises = [];
-    for await (const source of globby.stream(select, globbyOptions)) {
+    for await (const source of fastGlob.stream(select, fastGlobOptions)) {
       promises.push(piscina.run({ source }));
     }
     await Promise.all(promises);

--- a/src/dev/build/tasks/create_cdn_assets_task.ts
+++ b/src/dev/build/tasks/create_cdn_assets_task.ts
@@ -17,7 +17,7 @@ import { getKibanaTranslationFiles, supportedLocale } from '@kbn/core-i18n-serve
 import { i18n, i18nLoader } from '@kbn/i18n';
 
 import del from 'del';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 import { mkdirp, compressTar, Task, copyAll, write } from '../lib';
 
@@ -34,7 +34,7 @@ export const CreateCdnAssets: Task = {
     await del(assets);
     await mkdirp(assets);
 
-    const plugins = globby.sync([`${buildSource}/node_modules/@kbn/**/*/kibana.jsonc`]);
+    const plugins = fastGlob.sync([`${buildSource}/node_modules/@kbn/**/*/kibana.jsonc`]);
 
     // translation files
     const pluginPaths = plugins.map((plugin) => resolve(dirname(plugin)));

--- a/src/dev/build/tasks/generate_packages_optimized_assets.ts
+++ b/src/dev/build/tasks/generate_packages_optimized_assets.ts
@@ -21,7 +21,7 @@ import gulpTerser from 'gulp-terser';
 import { ToolingLog } from '@kbn/tooling-log';
 import terser from 'terser';
 import vfs from 'vinyl-fs';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import del from 'del';
 import zlib from 'zlib';
 
@@ -101,7 +101,7 @@ const getCategory = (relative: string) => {
 
 function categorizeAssets(assetDirs: string[]) {
   const assets = assetDirs.flatMap((assetDir) =>
-    globby
+    fastGlob
       .sync(['**/*'], {
         cwd: assetDir,
         ignore: ['*-manifest.json', '*.gz', '*.br'],

--- a/src/dev/build/tasks/package_json/find_used_dependencies.ts
+++ b/src/dev/build/tasks/package_json/find_used_dependencies.ts
@@ -8,7 +8,7 @@
  */
 
 import Path from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { ImportResolver } from '@kbn/import-resolver';
 import { ImportLocator } from '@kbn/import-locator';
 import { readPackageMap, Package, PluginPackage } from '@kbn/repo-packages';
@@ -49,7 +49,7 @@ export async function findUsedDependencies(
             ? Path.resolve(repoRoot, p.normalizedRepoRelativeDir, 'server/index.js')
             : []
         ),
-        ...(await globby(
+        ...(await fastGlob(
           [
             // main code entries
             'src/cli*/dist.js',

--- a/src/dev/build/tasks/write_sha_sums_task.ts
+++ b/src/dev/build/tasks/write_sha_sums_task.ts
@@ -8,7 +8,7 @@
  */
 
 import path from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 import { getFileHash, write, GlobalTask } from '../lib';
 
@@ -17,7 +17,7 @@ export const WriteShaSums: GlobalTask = {
   description: 'Writing sha1sums of archives and packages in target directory',
 
   async run(config) {
-    const artifacts = await globby(['*.zip', '*.tar.gz', '*.deb', '*.rpm'], {
+    const artifacts = await fastGlob(['*.zip', '*.tar.gz', '*.deb', '*.rpm'], {
       cwd: config.resolveFromTarget('.'),
       absolute: true,
     });

--- a/src/dev/buildkite_migration/rewrite_buildkite_agent_rules.ts
+++ b/src/dev/buildkite_migration/rewrite_buildkite_agent_rules.ts
@@ -11,12 +11,13 @@ import fs from 'fs';
 import { readFile, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import yaml from 'js-yaml';
 
 import { run } from '@kbn/dev-cli-runner';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { ToolingLog } from '@kbn/tooling-log';
+import { readGitignore } from '../globs';
 
 interface BuildkiteStepFull {
   agents: { queue: string };
@@ -81,10 +82,11 @@ run(
   async ({ log, flags, flagsReader }) => {
     const filterExpressions = flagsReader.getPositionals();
 
-    const paths = await globby('.buildkite/**/*.yml', {
+    const gitignore = readGitignore(REPO_ROOT);
+    const paths = await fastGlob('.buildkite/**/*.yml', {
       cwd: REPO_ROOT,
       onlyFiles: true,
-      gitignore: true,
+      ignore: [...gitignore],
     });
 
     const pathsFiltered =

--- a/src/dev/code_coverage/ingest_coverage/team_assignment/enumeration_helpers.js
+++ b/src/dev/code_coverage/ingest_coverage/team_assignment/enumeration_helpers.js
@@ -8,21 +8,21 @@
  */
 
 import { statSync } from 'fs';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { left, right, tryCatch } from '../either';
 import { taMark } from '../utils';
 
 export const push = (xs) => (x) => xs.push(x);
 export const pathExists = (x) => tryCatch(() => statSync(x)).fold(left, right);
 export const isDir = (x) => statSync(x).isDirectory();
-export const prokGlob = (x) => globby.sync(x);
+export const prokGlob = (x) => fastGlob.sync(x);
 export const trim = (ROOT) => (x) => x.replace(`${ROOT}/`, '');
 export const isFileAllowed = (x) => /.(j|t)(s|sx)$/gm.test(x);
 export const isRejectedDir = (x) =>
   /node_modules|__tests__|__fixture__|__fixtures__|build\//gm.test(x);
 export const globExpands = (x) => Boolean(prokGlob(x).length);
 export const tryPath = (x) => {
-  const isAGlob = globby.hasMagic(x);
+  const isAGlob = fastGlob.hasMagic(x);
 
   if (isAGlob) return globExpands(x) ? right(x) : left(x);
 

--- a/src/dev/globs.js
+++ b/src/dev/globs.js
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import fs from 'fs';
+import path from 'path';
 import minimatch from 'minimatch';
 
 export function matchesAnyGlob(path, globs) {
@@ -15,4 +17,17 @@ export function matchesAnyGlob(path, globs) {
       dot: true,
     })
   );
+}
+
+export function readGitignore(rootPath) {
+  const gitignorePath = path.join(rootPath, '.gitignore');
+  try {
+    return fs
+      .readFileSync(gitignorePath, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim() && !line.startsWith('#'))
+      .map((line) => line.trim());
+  } catch (error) {
+    return [];
+  }
 }

--- a/src/dev/i18n_tools/utils/glob_namespace.ts
+++ b/src/dev/i18n_tools/utils/glob_namespace.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import path from 'path';
 
 export interface Options {
@@ -31,7 +31,7 @@ export async function globTranslationFiles(fileRoot: string, options: Options = 
     .concat(additionalIgnore)
     .map((i) => `!${i}`);
 
-  const entries = await globby(['*.{js,jsx,ts,tsx}', ...ignore], {
+  const entries = await fastGlob(['*.{js,jsx,ts,tsx}', ...ignore], {
     cwd: fileRoot,
     baseNameMatch: true,
     markDirectories: mark,

--- a/src/dev/notice/bundled_notices.js
+++ b/src/dev/notice/bundled_notices.js
@@ -10,11 +10,11 @@
 import { resolve } from 'path';
 import { readFile } from 'fs/promises';
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 export async function getBundledNotices(packageDirectory) {
   const pattern = resolve(packageDirectory, '*{LICENSE,NOTICE}*');
-  const paths = await globby(pattern);
+  const paths = await fastGlob(pattern);
   return Promise.all(
     paths.map(async (path) => ({
       path,

--- a/src/dev/notice/generate_notice_from_source.ts
+++ b/src/dev/notice/generate_notice_from_source.ts
@@ -9,7 +9,7 @@
 
 import { readFile } from 'fs/promises';
 import { relative } from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 import { ToolingLog } from '@kbn/tooling-log';
 
@@ -51,7 +51,7 @@ export async function generateNoticeFromSource({ productName, directory, log }: 
 
   log.info(`Searching ${directory} for multi-line comments starting with @notice`);
 
-  const files = globby.stream(select, {
+  const files = fastGlob.stream(select, {
     cwd: directory,
     followSymbolicLinks: false,
     absolute: true,

--- a/src/dev/run_prettier_topology_check.ts
+++ b/src/dev/run_prettier_topology_check.ts
@@ -7,22 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import path from 'path';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { createFailError } from '@kbn/dev-cli-errors';
 import { run } from '@kbn/dev-cli-runner';
+import { readGitignore } from './globs';
 
 function listPaths(filePaths: string[]) {
   return filePaths.map((filePath: string) => ` - ${filePath}`).join('\n');
 }
 
 run(async ({ log }) => {
-  const filePaths = await globby('**/.prettierrc*', {
+  const gitignore = readGitignore(REPO_ROOT);
+  const filePaths = await fastGlob('**/.prettierrc*', {
     cwd: REPO_ROOT,
     onlyFiles: true,
-    gitignore: true,
     ignore: [
+      ...gitignore,
       // the gitignore: true option makes sure that we don't
       // include files from node_modules in the result, but it still
       // loads all of the files from node_modules before filtering

--- a/src/platform/packages/private/kbn-telemetry-tools/src/tools/extract_collectors.ts
+++ b/src/platform/packages/private/kbn-telemetry-tools/src/tools/extract_collectors.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import * as path from 'path';
 import { parseUsageCollection } from './ts_parser';
 import { TelemetryRC } from './config';
@@ -17,7 +17,7 @@ export async function getProgramPaths({
   root,
   exclude,
 }: Pick<TelemetryRC, 'root' | 'exclude'>): Promise<string[]> {
-  const filePaths = await globby(
+  const filePaths = await fastGlob(
     [
       '**/*.ts',
       '!**/node_modules/**',

--- a/src/platform/packages/shared/kbn-es-archiver/src/actions/edit.ts
+++ b/src/platform/packages/shared/kbn-es-archiver/src/actions/edit.ts
@@ -11,7 +11,7 @@ import { relative } from 'path';
 import Fs from 'fs';
 import { createGunzip, createGzip, constants } from 'zlib';
 import { promisify } from 'util';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { ToolingLog } from '@kbn/tooling-log';
 import { createPromiseFromStreams } from '@kbn/utils';
 
@@ -27,7 +27,7 @@ export async function editAction({
   handler: () => Promise<any>;
 }) {
   const archives = (
-    await globby('**/*.gz', {
+    await fastGlob('**/*.gz', {
       cwd: path,
       absolute: true,
     })

--- a/src/platform/packages/shared/kbn-es/src/utils/find_most_recently_changed.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/find_most_recently_changed.test.ts
@@ -31,7 +31,7 @@ jest.mock('fs', () => ({
   }),
 }));
 
-jest.mock('globby', () => ({
+jest.mock('fast-glob', () => ({
   sync: jest.fn().mockImplementation(() => {
     return ['/data/oldest.yml', '/data/newest.yml', '/data/middle.yml'];
   }),

--- a/src/platform/packages/shared/kbn-es/src/utils/find_most_recently_changed.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/find_most_recently_changed.ts
@@ -9,7 +9,7 @@
 
 import path from 'path';
 import fs from 'fs';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 /**
  *  Find the most recently modified file that matches the pattern pattern
@@ -21,7 +21,7 @@ export function findMostRecentlyChanged(pattern: string) {
 
   const ctime = (p: string) => fs.statSync(p).ctime.getTime();
 
-  return globby
+  return fastGlob
     .sync(pattern, { onlyFiles: false })
     .sort((a, b) => ctime(a) - ctime(b))
     .pop();

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/utils/remove_files_by_glob.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/utils/remove_files_by_glob.ts
@@ -8,7 +8,7 @@
  */
 
 import fs from 'fs/promises';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { resolve } from 'path';
 
 /**
@@ -18,7 +18,7 @@ import { resolve } from 'path';
  * @param globPattern files pattern to remove
  */
 export async function removeFilesByGlob(path: string, globPattern: string): Promise<void> {
-  const filesToRemove = await globby([resolve(path, globPattern)]);
+  const filesToRemove = await fastGlob([resolve(path, globPattern)]);
 
   await Promise.all(filesToRemove.map((fileName) => fs.unlink(fileName)));
 }

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/utils/resolve_globs.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/utils/resolve_globs.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { resolve } from 'path';
 
 export async function resolveGlobs(globs: string[]): Promise<string[]> {
   const normalizedGlobs = globs.map((glob) => resolve(glob));
-  const filePaths = await globby(normalizedGlobs);
+  const filePaths = await fastGlob(normalizedGlobs);
 
   return filePaths;
 }

--- a/src/platform/packages/shared/kbn-openapi-generator/src/lib/remove_gen_artifacts.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/lib/remove_gen_artifacts.ts
@@ -8,7 +8,7 @@
  */
 
 import fs from 'fs/promises';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { resolve } from 'path';
 
 /**
@@ -17,7 +17,7 @@ import { resolve } from 'path';
  * @param folderPath target directory
  */
 export async function removeGenArtifacts(folderPath: string) {
-  const artifactsPath = await globby([resolve(folderPath, './**/*.gen.ts')]);
+  const artifactsPath = await fastGlob([resolve(folderPath, './**/*.gen.ts')]);
 
   await Promise.all(artifactsPath.map((artifactPath) => fs.unlink(artifactPath)));
 }

--- a/src/platform/packages/shared/kbn-openapi-generator/src/openapi_generator.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/openapi_generator.ts
@@ -12,7 +12,7 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
 import chalk from 'chalk';
 import fs from 'fs/promises';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { resolve } from 'path';
 import { fixEslint } from './lib/fix_eslint';
 import { formatOutput } from './lib/format_output';
@@ -52,7 +52,7 @@ export const generate = async (config: GeneratorConfig) => {
 
   console.log(`👀  Searching for source files`);
   const sourceFilesGlob = resolve(rootDir, sourceGlob);
-  const schemaPaths = await globby([sourceFilesGlob]);
+  const schemaPaths = await fastGlob([sourceFilesGlob]);
 
   console.log(`🕵️‍♀️   Found ${schemaPaths.length} schemas, parsing`);
   let parsedSources: ParsedSource[] = await Promise.all(

--- a/src/platform/packages/shared/kbn-openapi-generator/src/openapi_linter.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/openapi_linter.ts
@@ -10,7 +10,7 @@
 /* eslint-disable no-console */
 
 import { resolve } from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import execa from 'execa';
 import chalk from 'chalk';
 import { REPO_ROOT } from '@kbn/repo-info';
@@ -24,7 +24,7 @@ export const lint = async (config: LinterConfig) => {
   const { rootDir, sourceGlob } = config;
 
   const sourceFilesGlob = resolve(rootDir, sourceGlob);
-  const schemaPaths = await globby([sourceFilesGlob]);
+  const schemaPaths = await fastGlob([sourceFilesGlob]);
 
   console.log(chalk.bold(`Linting API route schemas`));
 

--- a/src/platform/packages/shared/kbn-test/src/es/test_es_cluster.ts
+++ b/src/platform/packages/shared/kbn-test/src/es/test_es_cluster.ts
@@ -11,7 +11,7 @@ import Path from 'path';
 import { format } from 'url';
 import del from 'del';
 import { v4 as uuidv4 } from 'uuid';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import createArchiver from 'archiver';
 import Fs from 'fs';
 import { pipeline } from 'stream/promises';
@@ -351,10 +351,13 @@ export function createTestEsCluster<
     }
 
     async captureDebugFiles() {
-      const debugFiles = await globby([`**/hs_err_pid*.log`, `**/replay_pid*.log`, `**/*.hprof`], {
-        cwd: config.installPath,
-        absolute: true,
-      });
+      const debugFiles = await fastGlob(
+        [`**/hs_err_pid*.log`, `**/replay_pid*.log`, `**/*.hprof`],
+        {
+          cwd: config.installPath,
+          absolute: true,
+        }
+      );
 
       if (!debugFiles.length) {
         log.info('[es] no debug files found, assuming es did not write any');

--- a/src/platform/packages/shared/kbn-test/src/find_test_plugin_paths.ts
+++ b/src/platform/packages/shared/kbn-test/src/find_test_plugin_paths.ts
@@ -8,12 +8,12 @@
  */
 
 import Path from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 
 export function findTestPluginPaths(dirs: string | string[]) {
   return (Array.isArray(dirs) ? dirs : [dirs])
     .flatMap((dir) =>
-      globby.sync('*/kibana.jsonc', {
+      fastGlob.sync('*/kibana.jsonc', {
         cwd: dir,
         absolute: true,
         onlyFiles: true,

--- a/src/platform/plugins/private/vis_types/timelion/server/lib/load_functions.js
+++ b/src/platform/plugins/private/vis_types/timelion/server/lib/load_functions.js
@@ -8,7 +8,7 @@
  */
 
 import _ from 'lodash';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import processFunctionDefinition from './process_function_definition';
 
 export default function (directory) {
@@ -18,7 +18,7 @@ export default function (directory) {
 
   // Get a list of all files and use the filename as the object key
   const files = _.map(
-    globby
+    fastGlob
       .sync('../' + directory + '/*.js', { cwd: __dirname })
       .filter((filename) => !filename.includes('.test')),
     function (file) {
@@ -29,7 +29,7 @@ export default function (directory) {
 
   // Get a list of all directories with an index.js, use the directory name as the key in the object
   const directories = _.chain(
-    globby.sync('../' + directory + '/*/index.js', {
+    fastGlob.sync('../' + directory + '/*/index.js', {
       cwd: __dirname,
     })
   )

--- a/src/platform/plugins/shared/console/server/services/spec_definitions_service.test.ts
+++ b/src/platform/plugins/shared/console/server/services/spec_definitions_service.test.ts
@@ -7,13 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import fs from 'fs';
 import { SpecDefinitionsService } from '.';
 import type { EndpointDefinition, EndpointsAvailability } from '../../common/types';
 
 const mockReadFileSync = jest.spyOn(fs, 'readFileSync');
-const mockGlobbySync = jest.spyOn(globby, 'sync');
+const mockFastGlobSync = jest.spyOn(fastGlob, 'sync');
 const mockJsLoadersGetter = jest.fn();
 
 jest.mock('../lib', () => {
@@ -56,7 +56,7 @@ describe('SpecDefinitionsService', () => {
   });
   beforeEach(() => {
     // mock the function that lists files in the definitions folders
-    mockGlobbySync.mockImplementation(() => []);
+    mockFastGlobSync.mockImplementation(() => []);
     // mock the function that reads files
     mockReadFileSync.mockImplementation(() => '');
     // mock the function that returns the list of js definitions loaders
@@ -111,7 +111,7 @@ describe('SpecDefinitionsService', () => {
   });
 
   it('loads generated endpoints definition', () => {
-    mockGlobbySync.mockImplementation((pattern) => {
+    mockFastGlobSync.mockImplementation((pattern) => {
       if (pattern.includes('generated')) {
         return ['/generated/endpoint1.json', '/generated/endpoint2.json'];
       }
@@ -153,7 +153,7 @@ describe('SpecDefinitionsService', () => {
   });
 
   it('overrides an endpoint if override file is present', () => {
-    mockGlobbySync.mockImplementation((pattern) => {
+    mockFastGlobSync.mockImplementation((pattern) => {
       if (pattern.includes('generated')) {
         return ['/generated/endpoint1.json', '/generated/endpoint2.json'];
       }
@@ -213,7 +213,7 @@ describe('SpecDefinitionsService', () => {
   });
 
   it('loads manual definitions if any', () => {
-    mockGlobbySync.mockImplementation((pattern) => {
+    mockFastGlobSync.mockImplementation((pattern) => {
       if (pattern.includes('manual')) {
         return ['manual_endpoint.json'];
       }
@@ -241,7 +241,7 @@ describe('SpecDefinitionsService', () => {
   });
 
   it("manual definitions don't override generated files even when the same endpoint name is used", () => {
-    mockGlobbySync.mockImplementation((pattern) => {
+    mockFastGlobSync.mockImplementation((pattern) => {
       if (pattern.includes('generated')) {
         return ['generated_endpoint.json'];
       }
@@ -282,7 +282,7 @@ describe('SpecDefinitionsService', () => {
   });
 
   it('filters out endpoints not available in stack', () => {
-    mockGlobbySync.mockImplementation((pattern) => {
+    mockFastGlobSync.mockImplementation((pattern) => {
       if (pattern.includes('generated')) {
         return ['/generated/endpoint1.json', '/generated/endpoint2.json'];
       }
@@ -324,7 +324,7 @@ describe('SpecDefinitionsService', () => {
   });
 
   it('filters out endpoints not available in serverless', () => {
-    mockGlobbySync.mockImplementation((pattern) => {
+    mockFastGlobSync.mockImplementation((pattern) => {
       if (pattern.includes('generated')) {
         return ['/generated/endpoint1.json', '/generated/endpoint2.json'];
       }

--- a/src/platform/plugins/shared/console/server/services/spec_definitions_service.ts
+++ b/src/platform/plugins/shared/console/server/services/spec_definitions_service.ts
@@ -8,10 +8,10 @@
  */
 
 import _, { merge } from 'lodash';
-import globby from 'globby';
 import { basename, join } from 'path';
 import normalizePath from 'normalize-path';
 import { readFileSync } from 'fs';
+import { fastGlob } from 'fast-glob';
 
 import { EndpointDefinition, EndpointDescription, EndpointsAvailability } from '../../common/types';
 import {
@@ -104,13 +104,13 @@ export class SpecDefinitionsService {
 
   private loadJSONDefinitionsFiles() {
     // we need to normalize paths otherwise they don't work on windows, see https://github.com/elastic/kibana/issues/151032
-    const generatedFiles = globby.sync(
+    const generatedFiles = fastGlob.sync(
       normalizePath(join(AUTOCOMPLETE_DEFINITIONS_FOLDER, GENERATED_SUBFOLDER, '*.json'))
     );
-    const overrideFiles = globby.sync(
+    const overrideFiles = fastGlob.sync(
       normalizePath(join(AUTOCOMPLETE_DEFINITIONS_FOLDER, OVERRIDES_SUBFOLDER, '*.json'))
     );
-    const manualFiles = globby.sync(
+    const manualFiles = fastGlob.sync(
       normalizePath(join(AUTOCOMPLETE_DEFINITIONS_FOLDER, MANUAL_SUBFOLDER, '*.json'))
     );
 

--- a/x-pack/dev-tools/api_debug/index.js
+++ b/x-pack/dev-tools/api_debug/index.js
@@ -6,14 +6,14 @@
  */
 
 import { resolve } from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { bold } from 'chalk';
 import { argv } from 'yargs';
 import { requestFromApi } from './request_from_api';
 
 async function listFiles() {
   const pattern = resolve(__dirname, './apis/*/index.js');
-  const files = await globby(pattern);
+  const files = await fastGlob(pattern);
   files.forEach((file) => {
     const { name, description } = require(file); // eslint-disable-line import/no-dynamic-require
     console.log('    ' + bold(`node ${argv.$0} ${name}`));

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/fields/field.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/fields/field.test.ts
@@ -8,7 +8,7 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { load } from 'js-yaml';
 
 import { getField, processFields, processFieldsWithWildcard } from './field';
@@ -27,7 +27,7 @@ expect.addSnapshotSerializer({
 
 test('tests loading fields.yml', () => {
   // Find all .yml files to run tests on
-  const files = globby.sync(path.join(__dirname, '/tests/*.yml'));
+  const files = fastGlob.sync(path.join(__dirname, '/tests/*.yml'));
   for (const file of files) {
     const fieldsYML = readFileSync(file, 'utf-8');
     const fields: Field[] = load(fieldsYML);

--- a/x-pack/solutions/observability/test/api_integration/profiling/tests/index.ts
+++ b/x-pack/solutions/observability/test/api_integration/profiling/tests/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import path from 'path';
 import { FtrProviderContext } from '../common/ftr_provider_context';
 
@@ -31,7 +31,7 @@ export default function profilingApiIntegrationTests({
   // FLAKY: https://github.com/elastic/kibana/issues/169841
   describe.skip('Profiling API tests', function () {
     const filePattern = getGlobPattern();
-    const tests = globby.sync(filePattern, { cwd });
+    const tests = fastGlob.sync(filePattern, { cwd });
 
     if (envGrepFiles) {
       // eslint-disable-next-line no-console

--- a/x-pack/solutions/observability/test/apm_api_integration/tests/index.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import path from 'path';
 import { FtrProviderContext } from '../common/ftr_provider_context';
 
@@ -32,7 +32,7 @@ export default function apmApiIntegrationTests({ getService, loadTestFile }: Ftr
   // Failing: See https://github.com/elastic/kibana/issues/176948
   describe('APM API tests', function () {
     const filePattern = getGlobPattern();
-    const tests = globby.sync(filePattern, { cwd });
+    const tests = fastGlob.sync(filePattern, { cwd });
 
     if (envGrepFiles) {
       // eslint-disable-next-line no-console

--- a/x-pack/solutions/security/plugins/elastic_assistant/scripts/encode_security_labs_content_script.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/scripts/encode_security_labs_content_script.ts
@@ -10,7 +10,7 @@
 import * as fs from 'fs/promises';
 
 import * as path from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { existsSync } from 'fs';
 import {
   ENCODED_FILE_MICROMATCH_PATTERN,
@@ -30,7 +30,7 @@ export const deleteFilesByPattern = async ({
 }): Promise<void> => {
   try {
     console.log(`Deleting files matching pattern "${pattern}" in directory "${directoryPath}"`);
-    const files = await globby(pattern, { cwd: directoryPath });
+    const files = await fastGlob(pattern, { cwd: directoryPath });
 
     if (files.length === 0) {
       console.log(`No files found matching pattern "${pattern}" in directory "${directoryPath}".`);
@@ -72,7 +72,7 @@ export const encodeSecurityLabsContent = async () => {
     pattern: ENCODED_FILE_MICROMATCH_PATTERN,
   });
 
-  const files = await globby(PLAIN_TEXT_FILE_MICROMATCH_PATTERN, {
+  const files = await fastGlob(PLAIN_TEXT_FILE_MICROMATCH_PATTERN, {
     cwd: SECURITY_LABS_DIR,
   });
   files.forEach((file) => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/scripts/generate_security_ai_prompts_script.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/scripts/generate_security_ai_prompts_script.ts
@@ -11,7 +11,7 @@ import { Prompt } from '@kbn/security-ai-prompts';
 import * as fs from 'fs/promises';
 import { existsSync, mkdirSync } from 'fs';
 import * as path from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { v4 as uuidv4 } from 'uuid';
 
 import { localPrompts } from '../server/lib/prompt/local_prompt_object';
@@ -43,7 +43,7 @@ export const deleteFilesByPattern = async ({
 }): Promise<void> => {
   try {
     console.log(`Deleting files matching pattern "${pattern}" in directory "${directoryPath}"`);
-    const files = await globby(pattern, { cwd: directoryPath });
+    const files = await fastGlob(pattern, { cwd: directoryPath });
 
     if (files.length === 0) {
       console.log(`No files found matching pattern "${pattern}" in directory "${directoryPath}".`);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/knowledge_base/security_labs.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/knowledge_base/security_labs.test.ts
@@ -8,7 +8,7 @@
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import {
   decryptSecurityLabsContent,
   ENCODED_FILE_MICROMATCH_PATTERN,
@@ -19,10 +19,10 @@ const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 describe('Security labs content', () => {
   const directoryPath = path.join(__dirname, 'security_labs');
-  const plainTextFiles: string[] = globby.sync(PLAIN_TEXT_FILE_MICROMATCH_PATTERN, {
+  const plainTextFiles: string[] = fastGlob.sync(PLAIN_TEXT_FILE_MICROMATCH_PATTERN, {
     cwd: directoryPath,
   });
-  const encodedFiles: string[] = globby.sync(ENCODED_FILE_MICROMATCH_PATTERN, {
+  const encodedFiles: string[] = fastGlob.sync(ENCODED_FILE_MICROMATCH_PATTERN, {
     cwd: directoryPath,
   });
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/encoded_security_labs_content_loader.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/encoded_security_labs_content_loader.test.ts
@@ -8,11 +8,11 @@
 import { DirectoryLoader } from 'langchain/document_loaders/fs/directory';
 import { EncodedSecurityLabsContentLoader } from './encoded_security_labs_content_loader';
 import path, { resolve } from 'path';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { PLAIN_TEXT_FILE_MICROMATCH_PATTERN } from '@kbn/ai-security-labs-content';
 
 const directoryPath = path.join(__dirname, '../../../knowledge_base/security_labs');
-const plainTextFiles: string[] = globby.sync(PLAIN_TEXT_FILE_MICROMATCH_PATTERN, {
+const plainTextFiles: string[] = fastGlob.sync(PLAIN_TEXT_FILE_MICROMATCH_PATTERN, {
   cwd: directoryPath,
 });
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/security_labs_loader.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/security_labs_loader.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import { Logger } from '@kbn/core/server';
 import { DirectoryLoader } from 'langchain/document_loaders/fs/directory';
 import { resolve } from 'path';
@@ -73,7 +73,7 @@ export const loadSecurityLabs = async (
 
 export const getSecurityLabsDocsCount = async ({ logger }: { logger: Logger }): Promise<number> => {
   try {
-    return await globby(ENCODED_FILE_MICROMATCH_PATTERN, {
+    return await fastGlob(ENCODED_FILE_MICROMATCH_PATTERN, {
       cwd: resolve(__dirname, '../../../knowledge_base/security_labs'),
     }).then((files) => files.length);
   } catch (e) {

--- a/x-pack/solutions/security/plugins/security_solution/scripts/junit_transformer/junit_transformer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/junit_transformer/junit_transformer.ts
@@ -19,7 +19,7 @@ run(command, {
     string: ['pathPattern', 'rootDirectory', 'reportName'],
     boolean: ['writeInPlace'],
     help: `
-        --pathPattern      Required, glob passed to globby to select files to operate on
+        --pathPattern      Required, glob passed to fast-glob to select files to operate on
         --rootDirectory    Required, path of the kibana repo. Used to calcuate the file path of each spec file relative to the Kibana repo
         --reportName       Required, used as a prefix for the classname. Eventually shows up in the title of flaky test Github issues
         --writeInPlace     Defaults to false. If passed, rewrite the file in place with transformations. If false, the script will pass the transformed XML as a string to stdout

--- a/x-pack/solutions/security/plugins/security_solution/scripts/junit_transformer/lib.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/junit_transformer/lib.ts
@@ -15,7 +15,7 @@ import { relative } from 'path';
 import * as t from 'io-ts';
 import { isLeft } from 'fp-ts/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import del from 'del';
 
 // Function to remove specific fields from an XML object in order to
@@ -192,7 +192,7 @@ export async function command({ flags, log }: CommandArgs) {
   // and remove duplicated reports.
   const xmlResultFiles: string[] = [];
 
-  for (const path of await globby(flags.pathPattern)) {
+  for (const path of await fastGlob(flags.pathPattern)) {
     // Read the file
     const source: string = await fs.readFile(path, 'utf8');
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -8,7 +8,7 @@
 import { run } from '@kbn/dev-cli-runner';
 import yargs from 'yargs';
 import _ from 'lodash';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import pMap from 'p-map';
 import { withProcRunner } from '@kbn/dev-proc-runner';
 import cypress from 'cypress';
@@ -125,7 +125,7 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
 
       const concreteFilePaths = isGrepReturnedFilePaths
         ? grepSpecPattern // use the returned concrete file paths
-        : globby.sync(
+        : fastGlob.sync(
             specPattern,
             excludeSpecPattern
               ? {

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
@@ -8,7 +8,7 @@
 import { run } from '@kbn/dev-cli-runner';
 import yargs from 'yargs';
 import _ from 'lodash';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import pMap from 'p-map';
 import { ToolingLog } from '@kbn/tooling-log';
 import { withProcRunner } from '@kbn/dev-proc-runner';
@@ -424,7 +424,7 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
 
       const concreteFilePaths = isGrepReturnedFilePaths
         ? grepSpecPattern // use the returned concrete file paths
-        : globby.sync(specPattern); // convert the glob pattern to concrete file paths
+        : fastGlob.sync(specPattern); // convert the glob pattern to concrete file paths
 
       const files = retrieveIntegrations(concreteFilePaths);
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_playwright/playwright.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_playwright/playwright.ts
@@ -8,7 +8,7 @@
 import { run } from '@kbn/dev-cli-runner';
 import yargs from 'yargs';
 import _ from 'lodash';
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import pMap from 'p-map';
 import { withProcRunner } from '@kbn/dev-proc-runner';
 import path from 'path';
@@ -77,7 +77,7 @@ ${JSON.stringify(playwrightConfigFile, null, 2)}
       const specConfig = playwrightConfigFile.testMatch;
       const specArg = argv.spec;
       const specPattern = specArg ?? specConfig;
-      const files = retrieveIntegrations(globby.sync(specPattern));
+      const files = retrieveIntegrations(fastGlob.sync(specPattern));
       const esPorts: number[] = [9200, 9220];
       const kibanaPorts: number[] = [5601, 5620];
       const fleetServerPorts: number[] = [8220];

--- a/x-pack/test/dataset_quality_api_integration/tests/index.ts
+++ b/x-pack/test/dataset_quality_api_integration/tests/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import path from 'path';
 import { FtrProviderContext } from '../common/ftr_provider_context';
 
@@ -29,7 +29,7 @@ export default function datasetQualityApiIntegrationTests({
 
   describe('Dataset quality API tests', function () {
     const filePattern = getGlobPattern();
-    const tests = globby.sync(filePattern, { cwd });
+    const tests = fastGlob.sync(filePattern, { cwd });
 
     if (envGrepFiles) {
       // eslint-disable-next-line no-console

--- a/x-pack/test/observability_ai_assistant_functional/tests/index.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import path from 'path';
 import { createUsersAndRoles } from '../common/users/create_users_and_roles';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
@@ -18,7 +18,7 @@ export default function observabilityAIAssistantFunctionalTests({
 }: FtrProviderContext) {
   describe('Observability AI Assistant Functional tests', function () {
     const filePattern = '**/*.spec.ts';
-    const tests = globby.sync(filePattern, { cwd });
+    const tests = fastGlob.sync(filePattern, { cwd });
 
     // Creates roles and users before running tests
     before(async () => {

--- a/x-pack/test/observability_onboarding_api_integration/tests/index.ts
+++ b/x-pack/test/observability_onboarding_api_integration/tests/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import globby from 'globby';
+import fastGlob from 'fast-glob';
 import path from 'path';
 import { FtrProviderContext } from '../common/ftr_provider_context';
 
@@ -29,7 +29,7 @@ export default function observabilityApiIntegrationTests({
 
   describe('Observability onboarding API tests', function () {
     const filePattern = getGlobPattern();
-    const tests = globby.sync(filePattern, { cwd });
+    const tests = fastGlob.sync(filePattern, { cwd });
 
     if (envGrepFiles) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
This pull request replaces the `globby` library with `fast-glob` across multiple files in the codebase to improve performance and maintain consistency. The changes involve updating dependencies, modifying import statements, and replacing function calls. Additionally, the `package-lock.json` and `package.json` files have been updated to reflect the removal of `globby` and the addition of `fast-glob`.

### Dependency Updates:
* [`.buildkite/package-lock.json`](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL14-R14): Removed `globby` and related dependencies such as `array-union`, `dir-glob`, `ignore`, `path-type`, and `slash`. Updated `fast-glob` to version `3.3.3`. [[1]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL14-R14) [[2]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL1158-L1165) [[3]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL1588-L1598) [[4]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL1655-R1645) [[5]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL1891-L1909) [[6]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL1935-L1942) [[7]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL2664-L2671) [[8]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL3053-L3060) [[9]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL4327-L4331) [[10]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL4633-L4640) [[11]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL4678-R4612) [[12]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL4833-L4845) [[13]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL4864-L4868) [[14]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL5382-L5386) [[15]](diffhunk://#diff-46800ab176461f82a970b28ab2defb74ded6cafa600d2cbcb047c5f0c2c0fc3eL5630-L5634)
* [`.buildkite/package.json`](diffhunk://#diff-795a7c88469fb3e6f82ba4ee20c888f7be1062a43676185b0f2044a3c9d4cd20L16-R16): Replaced `globby` with `fast-glob` in dependencies.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L106): Removed `globby` from dependencies. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L106) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1225)

### Code Updates:
* [`.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts`](diffhunk://#diff-b094f1eb1ec69146aec5f6f7d719bc73fe351b83f4efc74ec9af9686ec75e756L12-R12): Replaced `globby` with `fast-glob` for file matching in `pickTestGroupRunOrder`. [[1]](diffhunk://#diff-b094f1eb1ec69146aec5f6f7d719bc73fe351b83f4efc74ec9af9686ec75e756L12-R12) [[2]](diffhunk://#diff-b094f1eb1ec69146aec5f6f7d719bc73fe351b83f4efc74ec9af9686ec75e756L287-R295)
* [`packages/kbn-docs-utils/src/mdx/get_all_doc_file_ids.ts`](diffhunk://#diff-1ed79405f0cafed5542820255d1b93e6b25e08c139e935c39ffb35d1ba9aec47L12-R19): Updated `globby` to `fast-glob` for retrieving `.mdx` files.
* [`packages/kbn-failed-test-reporter-cli/failed_tests_reporter/failed_tests_reporter_cli.ts`](diffhunk://#diff-bb801c18fd2e1a3a36a3b39fbf02c1abe337c46c201ad5a01239a9d2501d4b56L16-R16): Switched `globby` to `fast-glob` for searching report files. [[1]](diffhunk://#diff-bb801c18fd2e1a3a36a3b39fbf02c1abe337c46c201ad5a01239a9d2501d4b56L16-R16) [[2]](diffhunk://#diff-bb801c18fd2e1a3a36a3b39fbf02c1abe337c46c201ad5a01239a9d2501d4b56L95-R95)
* [`packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts`](diffhunk://#diff-ff06d8e4eeece7bd960bdaa25a0797bb802154c452af3402ef893a5f64db0e19L12-R12): Changed `globby` to `fast-glob` for locating directories. [[1]](diffhunk://#diff-ff06d8e4eeece7bd960bdaa25a0797bb802154c452af3402ef893a5f64db0e19L12-R12) [[2]](diffhunk://#diff-ff06d8e4eeece7bd960bdaa25a0797bb802154c452af3402ef893a5f64db0e19L30-R30)
* [`packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts`](diffhunk://#diff-bd52789213faa4c3c5685670228a635a0a7c752d4132e532b8036b60b9f8e185L14-R14): Replaced `globby` with `fast-glob` for screenshot discovery. [[1]](diffhunk://#diff-bd52789213faa4c3c5685670228a635a0a7c752d4132e532b8036b60b9f8e185L14-R14) [[2]](diffhunk://#diff-bd52789213faa4c3c5685670228a635a0a7c752d4132e532b8036b60b9f8e185L80-R80)
* [`packages/kbn-generate/src/commands/package_command.ts`](diffhunk://#diff-13fa30edd23a92ed7fc144c55eae98a8ec62802523b1d6bbfd4d0a5e1a8c7461L15-R15): Updated `globby` to `fast-glob` for template file matching. [[1]](diffhunk://#diff-13fa30edd23a92ed7fc144c55eae98a8ec62802523b1d6bbfd4d0a5e1a8c7461L15-R15) [[2]](diffhunk://#diff-13fa30edd23a92ed7fc144c55eae98a8ec62802523b1d6bbfd4d0a5e1a8c7461L185-R185)
* [`packages/kbn-optimizer/src/optimizer/optimizer_built_paths.ts`](diffhunk://#diff-c72762ace73120e21aface8e36a309a008bc2b1501041477abef81084f5863b6L11-R17): Replaced `globby` with `fast-glob` for optimizer paths.
* [`packages/kbn-plugin-generator/src/integration_tests/generate_plugin.test.ts`](diffhunk://#diff-7614d60c4db8470d6b17964637815af18d1b46f05d37367e6b0522f1e83d6b87L16-R16): Switched `globby` to `fast-glob` for integration test file matching.