### PR TITLE
Add AutoComplete for semantic_text index_options, BBQ quantization

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
@@ -109,15 +109,12 @@ export const mappings = (specService: SpecDefinitionsService) => {
               'freqs',
               'positions',
               'offsets',
-              // dense_vector type
+              // semantic_text type
               {
-                type: {
-                  __one_of: ['int8_hnsw', 'hnsw', 'int4_hnsw', 'flat', 'int8_flat', 'int4_flat'],
-                },
-                m: 16,
-                ef_construction: 100,
-                confidence_interval: 0,
+                dense_vector: DenseVectorIndexOptions
               },
+              // dense_vector type
+              DenseVectorIndexOptions,
             ],
           },
           analyzer: 'standard',
@@ -289,3 +286,12 @@ export const mappings = (specService: SpecDefinitionsService) => {
     },
   });
 };
+
+const DenseVectorIndexOptions = {
+                type: {
+                  __one_of: ['bbq_hnsw', 'bbq_flat', 'int8_hnsw', 'hnsw', 'int4_hnsw', 'flat', 'int8_flat', 'int4_flat'],
+                },
+                m: 16,
+                ef_construction: 100,
+                confidence_interval: 0,
+              };

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
@@ -111,7 +111,7 @@ export const mappings = (specService: SpecDefinitionsService) => {
               'offsets',
               // semantic_text type
               {
-                dense_vector: DenseVectorIndexOptions
+                dense_vector: DenseVectorIndexOptions,
               },
               // dense_vector type
               DenseVectorIndexOptions,
@@ -288,10 +288,19 @@ export const mappings = (specService: SpecDefinitionsService) => {
 };
 
 const DenseVectorIndexOptions = {
-                type: {
-                  __one_of: ['bbq_hnsw', 'bbq_flat', 'int8_hnsw', 'hnsw', 'int4_hnsw', 'flat', 'int8_flat', 'int4_flat'],
-                },
-                m: 16,
-                ef_construction: 100,
-                confidence_interval: 0,
-              };
+  type: {
+    __one_of: [
+      'bbq_hnsw',
+      'bbq_flat',
+      'int8_hnsw',
+      'hnsw',
+      'int4_hnsw',
+      'flat',
+      'int8_flat',
+      'int4_flat',
+    ],
+  },
+  m: 16,
+  ef_construction: 100,
+  confidence_interval: 0,
+};


### PR DESCRIPTION
Adds support for specifying `semantic_text` `index_options`: 
<img width="581" alt="image" src="https://github.com/user-attachments/assets/323148be-e456-45db-83a5-0f16e963fc16" />

And adds BBQ to the list of AutoComplete types: 
<img width="583" alt="image" src="https://github.com/user-attachments/assets/6c57bcb9-a3b2-4291-a005-1a464100d581" />

for both `semantic_text` and `dense_vector`. 

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->