### PR TITLE
[Discover] Dataview Picker - Update dropdown minimum width

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.styles.ts
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.styles.ts
@@ -11,8 +11,7 @@ import type { EuiThemeComputed } from '@elastic/eui';
 import { calculateWidthFromEntries } from '@kbn/calculate-width-from-char-count';
 import { DataViewListItemEnhanced } from './dataview_list';
 
-const MIN_WIDTH = 300;
-const MAX_MOBILE_WIDTH = 350;
+const DEFAULT_WIDTH = 350;
 
 export const changeDataViewStyles = ({
   fullWidth,
@@ -27,7 +26,7 @@ export const changeDataViewStyles = ({
 }) => {
   return {
     trigger: {
-      maxWidth: fullWidth ? undefined : MIN_WIDTH,
+      maxWidth: fullWidth ? undefined : DEFAULT_WIDTH,
       backgroundColor: theme.colors.backgroundBasePlain,
       border: `${theme.border.width.thin} solid ${theme.colors.borderBasePlain}`,
       borderTopLeftRadius: 0,
@@ -35,8 +34,8 @@ export const changeDataViewStyles = ({
     },
     popoverContent: {
       width: calculateWidthFromEntries(dataViewsList, ['name', 'id'], {
-        minWidth: MIN_WIDTH,
-        ...(isMobile && { maxWidth: MAX_MOBILE_WIDTH }),
+        minWidth: DEFAULT_WIDTH,
+        ...(isMobile && { maxWidth: DEFAULT_WIDTH }),
       }),
     },
   };


### PR DESCRIPTION
## Summary

This PR modifies the minimum width of the data view picker drop down. The width calculation does not factor in `Managed` badge, in the case of security data views (we always have them present), the text is truncated. Slightly increase the width to improve presentation.

|Before|After|
|------|------|
|![image](https://github.com/user-attachments/assets/547f85de-2012-41e3-97ad-8ba9c97e917d)| ![image](https://github.com/user-attachments/assets/9ffdf241-dc28-4c79-a247-8dbf08ad2544)|

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->