### PR TITLE
[EDR Workflows] Hardcode agent version in Osquery cypress

### DIFF
--- a/x-pack/solutions/security/test/osquery_cypress/utils.ts
+++ b/x-pack/solutions/security/test/osquery_cypress/utils.ts
@@ -130,7 +130,7 @@ export const addIntegrationToAgentPolicy = async (
  * Check if the given version string is a valid artifact version
  * @param version Version string
  */
-const isValidArtifactVersion = (version: string) => !!version.match(/^\d+\.\d+\.\d+(-SNAPSHOT)?$/);
+// const isValidArtifactVersion = (version: string) => !!version.match(/^\d+\.\d+\.\d+(-SNAPSHOT)?$/);
 
 /**
  * Returns the Agent version that is available for install (will check `artifacts-api.elastic.co/v1/versions`)

--- a/x-pack/solutions/security/test/osquery_cypress/utils.ts
+++ b/x-pack/solutions/security/test/osquery_cypress/utils.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import axios from 'axios';
-import semver from 'semver';
-import { map } from 'lodash';
 import { PackagePolicy, CreatePackagePolicyResponse, API_VERSIONS } from '@kbn/fleet-plugin/common';
-import { kibanaPackageJson } from '@kbn/repo-info';
 import { KbnClient } from '@kbn/test';
 import {
   GetEnrollmentAPIKeysResponse,
@@ -17,7 +13,6 @@ import {
 } from '@kbn/fleet-plugin/common/types';
 import { ToolingLog } from '@kbn/tooling-log';
 import chalk from 'chalk';
-import pRetry from 'p-retry';
 
 export const DEFAULT_HEADERS = Object.freeze({
   'x-elastic-internal-product': 'security-solution',
@@ -143,45 +138,52 @@ const isValidArtifactVersion = (version: string) => !!version.match(/^\d+\.\d+\.
  * @param kbnClient
  * @param log
  */
+//
+// export const getLatestAvailableAgentVersion = async (
+//   kbnClient: KbnClient,
+//   log: ToolingLog
+// ): Promise<string> => {
+//   let currentVersion: string;
+//
+//   try {
+//     const kbnStatus = await kbnClient.status.get();
+//     currentVersion = kbnStatus.version.number;
+//   } catch {
+//     log.warning(chalk.bold('Failed to get Kibana version, using package.json version'));
+//     currentVersion = kibanaPackageJson.version;
+//   }
+//
+//   const agentVersions = await pRetry(
+//     async () => {
+//       const response = await axios.get('https://artifacts-api.elastic.co/v1/versions');
+//       return map(
+//         response.data.versions.filter(isValidArtifactVersion),
+//         (version) => version.split('-SNAPSHOT')[0]
+//       );
+//     },
+//     {
+//       retries: 6,
+//     }
+//   ).catch(() => null);
+//
+//   if (!agentVersions) {
+//     log.warning(
+//       chalk.bold('Failed to get agent versions from artifacts-api, using package.json version')
+//     );
+//   }
+//
+//   const version = agentVersions
+//     ? semver.maxSatisfying(agentVersions, `<=${currentVersion}`)
+//     : currentVersion;
+//
+//   return `${version}-SNAPSHOT`;
+// };
 
 export const getLatestAvailableAgentVersion = async (
   kbnClient: KbnClient,
   log: ToolingLog
 ): Promise<string> => {
-  let currentVersion: string;
-
-  try {
-    const kbnStatus = await kbnClient.status.get();
-    currentVersion = kbnStatus.version.number;
-  } catch {
-    log.warning(chalk.bold('Failed to get Kibana version, using package.json version'));
-    currentVersion = kibanaPackageJson.version;
-  }
-
-  const agentVersions = await pRetry(
-    async () => {
-      const response = await axios.get('https://artifacts-api.elastic.co/v1/versions');
-      return map(
-        response.data.versions.filter(isValidArtifactVersion),
-        (version) => version.split('-SNAPSHOT')[0]
-      );
-    },
-    {
-      retries: 6,
-    }
-  ).catch(() => null);
-
-  if (!agentVersions) {
-    log.warning(
-      chalk.bold('Failed to get agent versions from artifacts-api, using package.json version')
-    );
-  }
-
-  const version = agentVersions
-    ? semver.maxSatisfying(agentVersions, `<=${currentVersion}`)
-    : currentVersion;
-
-  return `${version}-SNAPSHOT`;
+  return `9.1.0-SNAPSHOT`;
 };
 
 export const generateRandomString = (length: number) => {

--- a/x-pack/solutions/security/test/tsconfig.json
+++ b/x-pack/solutions/security/test/tsconfig.json
@@ -47,6 +47,5 @@
     "@kbn/es",
     "@kbn/cypress-test-helper",
     "@kbn/fleet-plugin",
-    "@kbn/repo-info",
   ]
 }


### PR DESCRIPTION
We're seeing problems on CI where agent version is higher than fleet server version: https://elastic.slack.com/archives/C01CM17B483/p1751322585779329 

This PR is a temporary solution to unblock PR pipelines, after merging this we should think of a long term approach to guarding from this kind of issues.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->