### PR TITLE
Add `ci:project-deploy-log_essentials`

### DIFF
--- a/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
+++ b/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
@@ -5,7 +5,7 @@ env:
 
 steps:
   - group: 'Notify if missing labels'
-    if: "build.env('GITHUB_PR_LABELS') !~ /ci:project-deploy-(elasticsearch|observability|security)/"
+    if: "build.env('GITHUB_PR_LABELS') !~ /ci:project-deploy-(elasticsearch|observability|log_essentials|security)/"
 
     steps:
       - command: |
@@ -22,7 +22,7 @@ steps:
         timeout_in_minutes: 5
 
   - group: 'Project Deployment'
-    if: "build.env('GITHUB_PR_LABELS') =~ /ci:project-deploy-(elasticsearch|observability|security)/"
+    if: "build.env('GITHUB_PR_LABELS') =~ /ci:project-deploy-(elasticsearch|observability|log_essentials|security)/"
 
     steps:
       - command: .buildkite/scripts/lifecycle/pre_build.sh

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -178,6 +178,7 @@ const getPipeline = (filename: string, removeSteps = true) => {
     if (
       GITHUB_PR_LABELS.includes('ci:project-deploy-elasticsearch') ||
       GITHUB_PR_LABELS.includes('ci:project-deploy-observability') ||
+      GITHUB_PR_LABELS.includes('ci:project-deploy-log_essentials') ||
       GITHUB_PR_LABELS.includes('ci:project-deploy-security')
     ) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/deploy_project.yml'));

--- a/.buildkite/scripts/steps/cloud/purge_projects.ts
+++ b/.buildkite/scripts/steps/cloud/purge_projects.ts
@@ -102,7 +102,9 @@ async function purgeProjects() {
     } else if (
       !Boolean(
         pullRequest.labels.filter((label: any) =>
-          /^ci:project-deploy-(elasticsearch|security|observability)$/.test(label.name)
+          /^ci:project-deploy-(elasticsearch|observability|log_essentials|security)$/.test(
+            label.name
+          )
         ).length
       )
     ) {

--- a/.buildkite/scripts/steps/serverless/deploy.sh
+++ b/.buildkite/scripts/steps/serverless/deploy.sh
@@ -9,6 +9,7 @@ KIBANA_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless:pr-$BUILDKITE_PULL_R
 
 deploy() {
   PROJECT_TYPE=$1
+  PRODUCT_TIER=$2
   # BOOKMARK - List of Kibana solutions
   case $PROJECT_TYPE in
     elasticsearch)
@@ -22,11 +23,19 @@ deploy() {
     ;;
   esac
 
-  PROJECT_NAME="kibana-pr-$BUILDKITE_PULL_REQUEST-$PROJECT_TYPE"
+  PRODUCT_TIER_JSON_ENTRY=""
+  PRODUCT_TIER_NAME=""
+  if [ -n "${PRODUCT_TIER:-}" ]; then
+    PRODUCT_TIER_JSON_ENTRY='"product_tier": "'"$PRODUCT_TIER"'",'
+    PRODUCT_TIER_NAME="-$PRODUCT_TIER"
+  fi
+
+  PROJECT_NAME="kibana-pr-$BUILDKITE_PULL_REQUEST-$PROJECT_TYPE$PRODUCT_TIER_NAME"
   VAULT_KEY_NAME="$PROJECT_NAME"
   is_pr_with_label "ci:project-persist-deployment" && PROJECT_NAME="keep_$PROJECT_NAME"
   PROJECT_CREATE_CONFIGURATION='{
     "name": "'"$PROJECT_NAME"'",
+    '"$PRODUCT_TIER_JSON_ENTRY"'
     "region_id": "aws-eu-west-1",
     "overrides": {
         "kibana": {
@@ -36,6 +45,7 @@ deploy() {
   }'
   PROJECT_UPDATE_CONFIGURATION='{
     "name": "'"$PROJECT_NAME"'",
+    '"$PRODUCT_TIER_JSON_ENTRY"'
     "overrides": {
         "kibana": {
             "docker_image": "'"$KIBANA_IMAGE"'"
@@ -161,6 +171,7 @@ EOF
 
 is_pr_with_label "ci:project-deploy-elasticsearch" && deploy "elasticsearch"
 is_pr_with_label "ci:project-deploy-security" && deploy "security"
+is_pr_with_label "ci:project-deploy-log_essentials" && deploy "observability" "logs_essentials"
 if is_pr_with_label "ci:project-deploy-observability" ; then
   # Only deploy observability if the PR is targeting main
   if [[ "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" == "main" ]]; then

--- a/dev_docs/tutorials/ci.mdx
+++ b/dev_docs/tutorials/ci.mdx
@@ -103,6 +103,10 @@ Create or update a serverless Elasticsearch project on Elastic Cloud QA.
 
 Create or update a serverless Observability project on Elastic Cloud QA.
 
+#### `ci:project-deploy-log_essentials`
+
+Create or update a serverless Observability project (in the Log Essentials tier) on Elastic Cloud QA.
+
 #### `ci:project-deploy-security`
 
 Create or update a serverless Security project on Elastic Cloud QA.


### PR DESCRIPTION
## Summary

Adds the label `ci:project-deploy-log_essentials` that deploys an Observability project with the product tier `log_essentials`.

Inspired by https://github.com/elastic/kibana/pull/219071

### Checklist

Check the PR satisfies following conditions. 

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


