### PR TITLE
[ES|QL] fix: don't let clear ESQL control type

### DIFF
--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/shared_form_components.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/shared_form_components.tsx
@@ -130,6 +130,7 @@ export function ControlType({
             fullWidth
             isDisabled={isDisabled}
             compressed
+            isClearable={false}
             data-test-subj="esqlControlTypeDropdown"
             inputPopoverProps={{
               'data-test-subj': 'esqlControlTypeInputPopover',


### PR DESCRIPTION
## Summary
When attempting to clear the control type an uncaught error occurs.
```
shared_form_components.tsx:56 Uncaught TypeError: Cannot read properties of undefined (reading 'key')
    at shared_form_components.tsx:56:1
```

As the type is mandatory, make the select un-clearable.

<img width="581" alt="image" src="https://github.com/user-attachments/assets/e7b10080-0886-4a03-b8eb-4b8cca597294" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->