### PR TITLE
[8.19] [Security Solution][Sourcerer] Replace unnecessary useDataViewSpec calls (#224831)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
@@ -39,7 +39,7 @@ import { useSourcererDataView } from '../../sourcerer/containers';
 import { useDiscoverState } from '../../timelines/components/timeline/tabs/esql/use_discover_state';
 import { useKibana } from '../../common/lib/kibana';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
-import { useDataViewSpec } from '../../data_view_manager/hooks/use_data_view_spec';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 
 export interface SendToTimelineButtonProps {
   asEmptyButton: boolean;
@@ -67,10 +67,10 @@ export const SendToTimelineButton: FC<PropsWithChildren<SendToTimelineButtonProp
   const { dataViewId: oldTimelineDataViewId } = useSourcererDataView(SourcererScopeName.timeline);
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataViewSpec } = useDataViewSpec(SourcererScopeName.timeline);
+  const { dataView } = useDataView(SourcererScopeName.timeline);
 
   const timelineDataViewId = newDataViewPickerEnabled
-    ? dataViewSpec?.id ?? null
+    ? dataView?.id ?? null
     : oldTimelineDataViewId;
 
   const { setDiscoverAppState } = useDiscoverState();

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { DataViewPicker } from '.';
-import { useDataViewSpec } from '../../hooks/use_data_view_spec';
+import { useDataView } from '../../hooks/use_data_view';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, DataViewManagerScopeName } from '../../constants';
 import { sharedDataViewManagerSlice } from '../../redux/slices';
 import { useDispatch } from 'react-redux';
@@ -24,8 +24,8 @@ jest.mock('../../../common/utils/global_query_string', () => ({
   useUpdateUrlParam: jest.fn(),
 }));
 
-jest.mock('../../hooks/use_data_view_spec', () => ({
-  useDataViewSpec: jest.fn(),
+jest.mock('../../hooks/use_data_view', () => ({
+  useDataView: jest.fn(),
 }));
 
 jest.mock('../../hooks/use_select_data_view', () => ({
@@ -79,11 +79,11 @@ describe('DataViewPicker', () => {
   beforeEach(() => {
     jest.mocked(useUpdateUrlParam).mockReturnValue(jest.fn());
 
-    jest.mocked(useDataViewSpec).mockReturnValue({
-      dataViewSpec: {
+    jest.mocked(useDataView).mockReturnValue({
+      dataView: {
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
         name: 'Default Security Data View',
-      },
+      } as unknown as DataView,
       status: 'ready',
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -14,15 +14,15 @@ import type { SourcererUrlState } from '../../../sourcerer/store/model';
 import { useUpdateUrlParam } from '../../../common/utils/global_query_string';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { useKibana } from '../../../common/lib/kibana';
-import { useDataViewSpec } from '../../hooks/use_data_view_spec';
 import { sharedStateSelector } from '../../redux/selectors';
 import { sharedDataViewManagerSlice } from '../../redux/slices';
 import { useSelectDataView } from '../../hooks/use_select_data_view';
 import { DataViewManagerScopeName } from '../../constants';
 import { useManagedDataViews } from '../../hooks/use_managed_data_views';
 import { useSavedDataViews } from '../../hooks/use_saved_data_views';
-import { LOADING } from './translations';
+import { DEFAULT_SECURITY_DATA_VIEW, LOADING } from './translations';
 import { DATA_VIEW_PICKER_TEST_ID } from './constants';
+import { useDataView } from '../../hooks/use_data_view';
 
 interface DataViewPickerProps {
   /**
@@ -55,7 +55,7 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
   const closeDataViewEditor = useRef<() => void | undefined>();
   const closeFieldEditor = useRef<() => void | undefined>();
 
-  const { dataViewSpec, status } = useDataViewSpec(scope);
+  const { dataView, status } = useDataView(scope);
 
   const { adhocDataViews: adhocDataViewSpecs, defaultDataViewId } =
     useSelector(sharedStateSelector);
@@ -69,7 +69,7 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
   const isDefaultSourcerer = scope === DataViewManagerScopeName.default;
   const updateUrlParam = useUpdateUrlParam<SourcererUrlState>(URL_PARAM_KEY.sourcerer);
 
-  const dataViewId = dataViewSpec?.id;
+  const dataViewId = dataView?.id;
 
   // NOTE: this function is called in response to user interaction with the picker,
   // hence - it is the only place where we should update the url param for the data view selection.
@@ -154,10 +154,16 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
       return { label: LOADING };
     }
 
+    if (dataView?.id === defaultDataViewId) {
+      return {
+        label: DEFAULT_SECURITY_DATA_VIEW,
+      };
+    }
+
     return {
-      label: dataViewSpec?.name || dataViewSpec?.id || 'Data view',
+      label: dataView?.name || dataView?.id || 'Data view',
     };
-  }, [dataViewSpec?.name, dataViewSpec?.id, status]);
+  }, [dataView?.id, dataView?.name, defaultDataViewId, status]);
 
   return (
     <div data-test-subj={DATA_VIEW_PICKER_TEST_ID}>

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
@@ -6,15 +6,29 @@
  */
 
 import { useMemo } from 'react';
-import { DataViewManagerScopeName } from '../constants';
 import { useDataView } from './use_data_view';
+import type { DataViewSpec, SharedDataViewSelectionState } from '../redux/types';
+import { DataViewManagerScopeName } from '../constants';
+
+export interface UseDataViewSpecResult {
+  /**
+   * DataViewSpec object for the current dataView
+   */
+  dataViewSpec: DataViewSpec;
+  /**
+   * Status of the dataView (can be the following values: 'pristine' | 'loading' | 'error' | 'ready')
+   */
+  status: SharedDataViewSelectionState['status'];
+}
 
 /**
- * Returns data view selection for given scopeName
+ * Returns an object with the dataViewSpec and status values for the given scopeName.
+ * IMPORTANT: If fields are not required, make sure to pass `includeFields = false`.
  */
 export const useDataViewSpec = (
-  scopeName: DataViewManagerScopeName = DataViewManagerScopeName.default
-) => {
+  scopeName: DataViewManagerScopeName = DataViewManagerScopeName.default,
+  includeFields = true
+): UseDataViewSpecResult => {
   const { dataView, status } = useDataView(scopeName);
 
   return useMemo(() => {
@@ -30,6 +44,6 @@ export const useDataViewSpec = (
       };
     }
 
-    return { status, dataViewSpec: dataView?.toSpec?.() };
-  }, [dataView, status]);
+    return { dataViewSpec: dataView?.toSpec?.(includeFields), status };
+  }, [dataView, includeFields, status]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
@@ -21,11 +21,11 @@ import { defaultUdtHeaders } from '../components/timeline/body/column_headers/de
 import { timelineDefaults } from '../store/defaults';
 import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
 import { DataViewManagerScopeName } from '../../data_view_manager/constants';
-import { useDataViewSpec } from '../../data_view_manager/hooks/use_data_view_spec';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 import { sourcererActions, sourcererSelectors } from '../../sourcerer/store';
 import { SourcererScopeName } from '../../sourcerer/store/model';
 import { useEnableExperimental } from '../../common/hooks/use_experimental_features';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 
 export interface UseCreateTimelineParams {
   /**
@@ -59,14 +59,12 @@ export const useCreateTimeline = ({
   ) ?? { id: '', patternList: [] };
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
-  const { dataViewSpec: experimentalDataViewSpec } = useDataViewSpec(
-    DataViewManagerScopeName.default
-  );
+  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.default);
   const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.default);
 
   const dataViewId = useMemo(
-    () => (newDataViewPickerEnabled ? experimentalDataViewSpec.id ?? '' : oldDataViewId),
-    [experimentalDataViewSpec.id, newDataViewPickerEnabled, oldDataViewId]
+    () => (newDataViewPickerEnabled ? experimentalDataView?.id ?? '' : oldDataViewId),
+    [experimentalDataView?.id, newDataViewPickerEnabled, oldDataViewId]
   );
   const selectedPatterns = useMemo(
     () => (newDataViewPickerEnabled ? experimentalSelectedPatterns : oldSelectedPatterns),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Sourcerer] Replace unnecessary useDataViewSpec calls (#224831)](https://github.com/elastic/kibana/pull/224831)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Luke Gmys","email":"11671118+lgestc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-02T12:14:35Z","message":"[Security Solution][Sourcerer] Replace unnecessary useDataViewSpec calls (#224831)\n\n## Summary\n\nAs useDataViewSpec uses are expensive (due to toSpec method in the data\nview implementation), this PR\nadds in an optional switch to the hook and actually replaces it where we\nonly need the data view id and not the full spec.\n\n### Testing\n\nSet the FF,\n\n```\nxpack.securitySolution.enableExperimental: ['newDataViewPickerEnabled']\n```\n\nverify that the app still works correctly (timelines)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"711ab70b3770addcba8fa66b28af65ceda11e5e3","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:version","9.1 candidate","v9.1.0","v8.19.0","v9.2.0"],"title":"[Security Solution][Sourcerer] Replace unnecessary useDataViewSpec calls","number":224831,"url":"https://github.com/elastic/kibana/pull/224831","mergeCommit":{"message":"[Security Solution][Sourcerer] Replace unnecessary useDataViewSpec calls (#224831)\n\n## Summary\n\nAs useDataViewSpec uses are expensive (due to toSpec method in the data\nview implementation), this PR\nadds in an optional switch to the hook and actually replaces it where we\nonly need the data view id and not the full spec.\n\n### Testing\n\nSet the FF,\n\n```\nxpack.securitySolution.enableExperimental: ['newDataViewPickerEnabled']\n```\n\nverify that the app still works correctly (timelines)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"711ab70b3770addcba8fa66b28af65ceda11e5e3"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/226183","number":226183,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224831","number":224831,"mergeCommit":{"message":"[Security Solution][Sourcerer] Replace unnecessary useDataViewSpec calls (#224831)\n\n## Summary\n\nAs useDataViewSpec uses are expensive (due to toSpec method in the data\nview implementation), this PR\nadds in an optional switch to the hook and actually replaces it where we\nonly need the data view id and not the full spec.\n\n### Testing\n\nSet the FF,\n\n```\nxpack.securitySolution.enableExperimental: ['newDataViewPickerEnabled']\n```\n\nverify that the app still works correctly (timelines)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"711ab70b3770addcba8fa66b28af65ceda11e5e3"}}]}] BACKPORT-->