### PR TITLE
[9.1] [A11y] Add labels to control inputs (#221639)

### DIFF
--- a/src/platform/plugins/shared/controls/public/control_group/components/control_panel.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/components/control_panel.tsx
@@ -98,6 +98,7 @@ export const ControlPanel = <ApiType extends DefaultControlApi = DefaultControlA
   const isEditable = viewMode === 'edit';
   const controlWidth = width ?? DEFAULT_CONTROL_WIDTH;
   const controlGrow = grow ?? DEFAULT_CONTROL_GROW;
+  const controlLabel = isTwoLine ? panelTitle || defaultPanelTitle || '...' : undefined;
   const hasRoundedBorders = !api?.CustomPrependComponent && !isEditable && isTwoLine;
   const shouldHideComponent = Boolean(blockingError);
 
@@ -135,7 +136,9 @@ export const ControlPanel = <ApiType extends DefaultControlApi = DefaultControlA
         <EuiFormRow
           data-test-subj="control-frame-title"
           fullWidth
-          label={isTwoLine ? panelTitle || defaultPanelTitle || '...' : undefined}
+          label={controlLabel}
+          id={`control-title-${uuid}`}
+          aria-label={`Control for ${controlLabel}`}
         >
           <EuiFormControlLayout
             fullWidth

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/components/range_slider_control.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/components/range_slider_control.tsx
@@ -23,31 +23,33 @@ import { RangeSliderStrings } from '../range_slider_strings';
 import { rangeSliderControlStyles } from './range_slider.styles';
 
 interface Props {
-  fieldFormatter?: (value: string) => string;
+  compressed: boolean;
+  controlPanelClassName?: string;
   isInvalid: boolean;
   isLoading: boolean;
+  fieldName: string;
   max: number | undefined;
   min: number | undefined;
-  onChange: (value: RangeValue | undefined) => void;
   step: number;
-  value: RangeValue | undefined;
   uuid: string;
-  controlPanelClassName?: string;
-  compressed: boolean;
+  value: RangeValue | undefined;
+  fieldFormatter?: (value: string) => string;
+  onChange: (value: RangeValue | undefined) => void;
 }
 
 export const RangeSliderControl: FC<Props> = ({
-  fieldFormatter,
+  compressed,
+  controlPanelClassName,
   isInvalid,
   isLoading,
+  fieldName,
   max,
   min,
-  onChange,
   step,
-  value,
   uuid,
-  controlPanelClassName,
-  compressed,
+  value,
+  fieldFormatter,
+  onChange,
 }: Props) => {
   const rangeSliderRef = useRef<EuiDualRangeProps | null>(null);
 
@@ -141,10 +143,14 @@ export const RangeSliderControl: FC<Props> = ({
       inputValue,
       testSubj,
       placeholder,
+      ariaLabel,
+      id,
     }: {
       inputValue: string;
       testSubj: string;
       placeholder: string;
+      ariaLabel: string;
+      id: string;
     }) => {
       return {
         isInvalid: undefined, // disabling this prop to handle our own validation styling
@@ -155,9 +161,12 @@ export const RangeSliderControl: FC<Props> = ({
           isInvalid ? styles.fieldNumbers.invalid : styles.fieldNumbers.valid,
         ],
         className: 'rangeSliderAnchor__fieldNumber',
-        'data-test-subj': `rangeSlider__${testSubj}`,
         value: inputValue === placeholder ? '' : inputValue,
         title: !isInvalid && step ? '' : undefined, // overwrites native number input validation error when the value falls between two steps
+        'data-test-subj': `rangeSlider__${testSubj}`,
+        'aria-label': ariaLabel,
+        'aria-labelledby': `control-title-${id}`,
+        id: `controls-range-slider-${id}`,
       };
     },
     [isInvalid, step, styles]
@@ -168,16 +177,20 @@ export const RangeSliderControl: FC<Props> = ({
       inputValue: displayedValue[0],
       testSubj: 'lowerBoundFieldNumber',
       placeholder: String(min ?? -Infinity),
+      ariaLabel: RangeSliderStrings.control.getLowerBoundAriaLabel(fieldName),
+      id: uuid,
     });
-  }, [getCommonInputProps, min, displayedValue]);
+  }, [getCommonInputProps, displayedValue, min, fieldName, uuid]);
 
   const maxInputProps = useMemo(() => {
     return getCommonInputProps({
       inputValue: displayedValue[1],
       testSubj: 'upperBoundFieldNumber',
       placeholder: String(max ?? Infinity),
+      ariaLabel: RangeSliderStrings.control.getUpperBoundAriaLabel(fieldName),
+      id: uuid,
     });
-  }, [getCommonInputProps, max, displayedValue]);
+  }, [getCommonInputProps, displayedValue, max, fieldName, uuid]);
 
   return (
     <span

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
@@ -236,16 +236,25 @@ export const getRangesliderControlFactory = (): DataControlFactory<
       return {
         api,
         Component: ({ className: controlPanelClassName }) => {
-          const [dataLoading, fieldFormatter, max, min, selectionHasNoResults, step, value] =
-            useBatchedPublishingSubjects(
-              dataLoading$,
-              dataControlManager.api.fieldFormatter,
-              max$,
-              min$,
-              selectionHasNoResults$,
-              step$,
-              selections.value$
-            );
+          const [
+            dataLoading,
+            fieldFormatter,
+            max,
+            min,
+            selectionHasNoResults,
+            step,
+            value,
+            fieldName,
+          ] = useBatchedPublishingSubjects(
+            dataLoading$,
+            dataControlManager.api.fieldFormatter,
+            max$,
+            min$,
+            selectionHasNoResults$,
+            step$,
+            selections.value$,
+            dataControlManager.api.fieldName$
+          );
 
           useEffect(() => {
             return () => {
@@ -260,6 +269,7 @@ export const getRangesliderControlFactory = (): DataControlFactory<
           return (
             <RangeSliderControl
               controlPanelClassName={controlPanelClassName}
+              fieldName={fieldName}
               fieldFormatter={fieldFormatter}
               isInvalid={Boolean(value) && selectionHasNoResults}
               isLoading={typeof dataLoading === 'boolean' ? dataLoading : false}

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/range_slider_strings.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/range_slider_strings.ts
@@ -19,6 +19,16 @@ export const RangeSliderStrings = {
       i18n.translate('controls.rangeSlider.control.invalidSelectionWarningLabel', {
         defaultMessage: 'Selected range returns no results.',
       }),
+    getLowerBoundAriaLabel: (fieldName: string) =>
+      i18n.translate('controls.rangeSlider.control.lowerBoundAriaLabel', {
+        defaultMessage: 'Range slider lower bound for {fieldName}',
+        values: { fieldName },
+      }),
+    getUpperBoundAriaLabel: (fieldName: string) =>
+      i18n.translate('controls.rangeSlider.control.lowerBoundAriaLabel', {
+        defaultMessage: 'Range slider upper bound for {fieldName}',
+        values: { fieldName },
+      }),
   },
   editor: {
     getStepTitle: () =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[A11y] Add labels to control inputs (#221639)](https://github.com/elastic/kibana/pull/221639)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Catherine Liu","email":"catherine.liu@elastic.co"},"sourceCommit":{"committedDate":"2025-06-26T21:54:03Z","message":"[A11y] Add labels to control inputs (#221639)\n\n## Summary\n\nCloses #183202.\nCloses #220687.\n\nThis adds aria-labels to the number fields on the range slider control.\n\n<img width=\"704\" alt=\"Screenshot 2025-05-27 at 8 10 38 AM\"\nsrc=\"https://github.com/user-attachments/assets/ffeb1b98-6765-41ab-abd3-bff2ce176cda\"\n/>\n\n<img width=\"413\" alt=\"Screenshot 2025-05-27 at 8 04 59 AM\"\nsrc=\"https://github.com/user-attachments/assets/e899b1f9-6290-463f-9213-2e0a456fa677\"\n/>\n\nThis also adds an aria-label to the search filter at the top of the\noptions list popover.\n\n<img width=\"2559\" alt=\"Screenshot 2025-06-02 at 7 23 53 AM\"\nsrc=\"https://github.com/user-attachments/assets/47e870dc-55c2-40bd-b461-a16022691810\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>","sha":"f7dad16597d9d29b312b877a4cb8c9e9bdf4f5ac","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","Team:Presentation","loe:small","release_note:skip","impact:high","backport missing","ci:cloud-deploy","backport:version","a11y","v9.1.0","v8.19.0","v9.0.1"],"title":"[A11y] Add labels to control inputs","number":221639,"url":"https://github.com/elastic/kibana/pull/221639","mergeCommit":{"message":"[A11y] Add labels to control inputs (#221639)\n\n## Summary\n\nCloses #183202.\nCloses #220687.\n\nThis adds aria-labels to the number fields on the range slider control.\n\n<img width=\"704\" alt=\"Screenshot 2025-05-27 at 8 10 38 AM\"\nsrc=\"https://github.com/user-attachments/assets/ffeb1b98-6765-41ab-abd3-bff2ce176cda\"\n/>\n\n<img width=\"413\" alt=\"Screenshot 2025-05-27 at 8 04 59 AM\"\nsrc=\"https://github.com/user-attachments/assets/e899b1f9-6290-463f-9213-2e0a456fa677\"\n/>\n\nThis also adds an aria-label to the search filter at the top of the\noptions list popover.\n\n<img width=\"2559\" alt=\"Screenshot 2025-06-02 at 7 23 53 AM\"\nsrc=\"https://github.com/user-attachments/assets/47e870dc-55c2-40bd-b461-a16022691810\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>","sha":"f7dad16597d9d29b312b877a4cb8c9e9bdf4f5ac"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221639","number":221639,"mergeCommit":{"message":"[A11y] Add labels to control inputs (#221639)\n\n## Summary\n\nCloses #183202.\nCloses #220687.\n\nThis adds aria-labels to the number fields on the range slider control.\n\n<img width=\"704\" alt=\"Screenshot 2025-05-27 at 8 10 38 AM\"\nsrc=\"https://github.com/user-attachments/assets/ffeb1b98-6765-41ab-abd3-bff2ce176cda\"\n/>\n\n<img width=\"413\" alt=\"Screenshot 2025-05-27 at 8 04 59 AM\"\nsrc=\"https://github.com/user-attachments/assets/e899b1f9-6290-463f-9213-2e0a456fa677\"\n/>\n\nThis also adds an aria-label to the search filter at the top of the\noptions list popover.\n\n<img width=\"2559\" alt=\"Screenshot 2025-06-02 at 7 23 53 AM\"\nsrc=\"https://github.com/user-attachments/assets/47e870dc-55c2-40bd-b461-a16022691810\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>","sha":"f7dad16597d9d29b312b877a4cb8c9e9bdf4f5ac"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->