### PR TITLE
[Discover] Fix font size in a single document/flyover popover

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_value.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_value.tsx
@@ -16,6 +16,7 @@ import {
   EuiTextColor,
   EuiToolTip,
   useResizeObserver,
+  euiFontSize,
   type UseEuiTheme,
 } from '@elastic/eui';
 import React, { Fragment, useCallback, useState } from 'react';
@@ -200,8 +201,11 @@ export const TableFieldValue = ({
 };
 
 const componentStyles = {
-  docViewerValue: ({ euiTheme }: UseEuiTheme) =>
-    css({
+  docViewerValue: (themeContext: UseEuiTheme) => {
+    const { euiTheme } = themeContext;
+    const { fontSize } = euiFontSize(themeContext, 's');
+
+    return css({
       wordBreak: 'break-all',
       wordWrap: 'break-word',
       whiteSpace: 'pre-wrap',
@@ -209,9 +213,10 @@ const componentStyles = {
       verticalAlign: 'top',
 
       '.euiDataGridRowCell__popover &': {
-        fontSize: `${euiTheme.font.scale.s}rem`,
+        fontSize,
       },
-    }),
+    });
+  },
   docViewerValueHighlighted: ({ euiTheme }: UseEuiTheme) =>
     css({
       fontWeight: euiTheme.font.weight.bold,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_value.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_value.tsx
@@ -209,7 +209,7 @@ const componentStyles = {
       verticalAlign: 'top',
 
       '.euiDataGridRowCell__popover &': {
-        fontSize: euiTheme.font.scale.s,
+        fontSize: `${euiTheme.font.scale.s}rem`,
       },
     }),
   docViewerValueHighlighted: ({ euiTheme }: UseEuiTheme) =>


### PR DESCRIPTION
## Summary

Closes #226217

This PR fixes too small text.

Before:
![image](https://github.com/user-attachments/assets/52a89b5f-a426-4934-b861-619e8d0bb483)

After:
<img width="525" alt="Screenshot 2025-07-02 at 18 09 31" src="https://github.com/user-attachments/assets/5f5e9e55-a86d-4d92-abf2-c500f5aeb2ce" />



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->