### PR TITLE
[8.17] [Fleet] Fix agentless policy deletion unenroll agents (#216513)

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy_update.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_update.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { agentPolicyUpdateEventHandler } from './agent_policy_update';
+import { createAppContextStartContractMock } from '../mocks';
+import { appContextService } from './app_context';
+import { getAgentById, getAgentPolicyForAgent, getAgentsByKuery } from './agents';
+
+jest.mock('./agents/crud', () => ({
+  ...jest.requireActual('./agents/crud'),
+  getAgentsByKuery: jest.fn(),
+  getAgentById: jest.fn(),
+  getAgentPolicyForAgent: jest.fn(),
+}));
+jest.mock('./api_keys');
+
+describe('agentPolicyUpdateEventHandler', () => {
+  describe('deleted', () => {
+    it('should unenroll agentless agents', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      appContextService.start(createAppContextStartContractMock());
+
+      jest
+        .mocked(getAgentsByKuery)
+        .mockResolvedValueOnce({
+          agents: [{ id: 'agent1' }],
+        } as any)
+        .mockResolvedValueOnce({
+          agents: [],
+        } as any);
+      jest.mocked(getAgentById).mockResolvedValue({
+        id: 'agent1',
+      } as any);
+      jest.mocked(getAgentPolicyForAgent).mockResolvedValue({
+        supports_agentless: true,
+      } as any);
+      await agentPolicyUpdateEventHandler(esClient, 'deleted', 'test1');
+
+      expect(esClient.update).toBeCalledWith(
+        expect.objectContaining({
+          id: 'agent1',
+          doc: expect.objectContaining({
+            unenrollment_started_at: expect.anything(),
+          }),
+        })
+      );
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/agent_policy_update.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_update.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
-import { agentPolicyUpdateEventHandler } from './agent_policy_update';
+
 import { createAppContextStartContractMock } from '../mocks';
+
+import { agentPolicyUpdateEventHandler } from './agent_policy_update';
 import { appContextService } from './app_context';
 import { getAgentById, getAgentPolicyForAgent, getAgentsByKuery } from './agents';
 
@@ -44,9 +46,11 @@ describe('agentPolicyUpdateEventHandler', () => {
       expect(esClient.update).toBeCalledWith(
         expect.objectContaining({
           id: 'agent1',
-          doc: expect.objectContaining({
-            unenrollment_started_at: expect.anything(),
-          }),
+          body: {
+            doc: expect.objectContaining({
+              unenrollment_started_at: expect.anything(),
+            }),
+          },
         })
       );
     });

--- a/x-pack/plugins/fleet/server/services/agents/update.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update.ts
@@ -31,7 +31,9 @@ export async function unenrollForAgentPolicyId(
       hasMore = false;
     }
     for (const agent of agents) {
-      await unenrollAgent(soClient, esClient, agent.id);
+      await unenrollAgent(soClient, esClient, agent.id, {
+        skipAgentlessValidation: true,
+      });
     }
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Fleet] Fix agentless policy deletion unenroll agents (#216513)](https://github.com/elastic/kibana/pull/216513)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-04-01T14:40:13Z","message":"[Fleet] Fix agentless policy deletion unenroll agents (#216513)","sha":"f578f401d464c800fe6772325a7ed5722f54f3e1","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","Team:Fleet","backport:prev-minor","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3"],"title":"[Fleet] Fix agentless policy deletion unenroll agents","number":216513,"url":"https://github.com/elastic/kibana/pull/216513","mergeCommit":{"message":"[Fleet] Fix agentless policy deletion unenroll agents (#216513)","sha":"f578f401d464c800fe6772325a7ed5722f54f3e1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216513","number":216513,"mergeCommit":{"message":"[Fleet] Fix agentless policy deletion unenroll agents (#216513)","sha":"f578f401d464c800fe6772325a7ed5722f54f3e1"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/221925","number":221925,"state":"MERGED","mergeCommit":{"sha":"7116f26bb2b4a01fb338b72cac5a773c8e2e44c1","message":"[9.0] [Fleet] Fix agentless policy deletion unenroll agents (#216513) (#221925)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Fleet] Fix agentless policy deletion unenroll agents\n(#216513)](https://github.com/elastic/kibana/pull/216513)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/221921","number":221921,"state":"MERGED","mergeCommit":{"sha":"bb25e91d83cc3985c0630098ba9ef76c79843ae1","message":"[8.18] [Fleet] Fix agentless policy deletion unenroll agents (#216513) (#221921)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Fleet] Fix agentless policy deletion unenroll agents\n(#216513)](https://github.com/elastic/kibana/pull/216513)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/221922","number":221922,"branch":"8.19","state":"MERGED","mergeCommit":{"sha":"001f86c9fcbb48db83c5ee00d8152a02121c822a","message":"[8.19] [Fleet] Fix agentless policy deletion unenroll agents (#216513) (#221922)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Fleet] Fix agentless policy deletion unenroll agents\n(#216513)](https://github.com/elastic/kibana/pull/216513)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}}]}] BACKPORT-->