### PR TITLE
fix(slo): Hide actions for read-only user

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_table.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_table.tsx
@@ -97,6 +97,7 @@ export function SloManagementTable() {
       description: i18n.translate('xpack.slo.item.actions.clone', {
         defaultMessage: 'Clone',
       }),
+      enabled: () => !!permissions?.hasAllWriteRequested,
       'data-test-subj': 'sloActionsClone',
       onClick: (slo: SLODefinitionResponse) => triggerAction({ item: slo, type: 'clone' }),
     },
@@ -299,7 +300,7 @@ export function SloManagementTable() {
         pagination={pagination}
         onChange={onTableChange}
         loading={isLoading}
-        selection={selection}
+        selection={permissions?.hasAllWriteRequested ? selection : undefined}
       />
     </EuiPanel>
   );


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/226258

This PR hides the bulk menu and disable the clone action for readonly users on the SLO management page.

### Testing

1. Create some SLOs
2. Create a read only user, logged in
3. Go to the SLO management page
4. Assert every actions are disabled
5. Assert bulk actions are not available

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->