### PR TITLE
[DOCS][8.18 & 8.19] Removes tech preview label from `alertuuid` action var

### DIFF
--- a/docs/user/alerting/action-variables.asciidoc
+++ b/docs/user/alerting/action-variables.asciidoc
@@ -111,7 +111,7 @@ If the rule's action frequency is not a summary of alerts, it passes the followi
 `alert.consecutiveMatches`:: The number of consecutive runs that meet the rule conditions.
 `alert.flapping`:: A flag on the alert that indicates whether the alert status is changing repeatedly.
 `alert.id`:: The ID of the alert that scheduled the action.
-`alert.uuid`:: A universally unique identifier for the alert. While the alert is active, the UUID value remains unchanged each time the rule runs. preview:[]
+`alert.uuid`:: A universally unique identifier for the alert. While the alert is active, the UUID value remains unchanged each time the rule runs.
 
 [float]
 [[defining-rules-actions-variable-context]]


### PR DESCRIPTION
## Summary

Removed the tech preview label from the `alertuuid` action variable, as per request from @ymao1. 

Corresponding 9.x and Serverless docs updated via: https://github.com/elastic/docs-content/pull/2011


