### PR TITLE
[Controls] Hide Select All checkbox from single select controls

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_action_bar.test.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_action_bar.test.tsx
@@ -56,7 +56,7 @@ const renderComponent = ({
   );
 };
 
-const getSelectAllCheckbox = () => screen.getByRole('checkbox', { name: /Select all/i });
+const getSelectAllCheckbox = () => screen.queryByRole('checkbox', { name: /Select all/i });
 
 const getSearchInput = () => screen.getByRole('searchbox', { name: /Filter suggestions/i });
 
@@ -91,6 +91,16 @@ describe('Options list popover', () => {
 
     expect(getSelectAllCheckbox()).toBeEnabled();
     expect(getSelectAllCheckbox()).not.toBeChecked();
+  });
+
+  test('hides "Select all" checkbox if the control only allows single selections', async () => {
+    const contextMock = getOptionsListContextMock();
+    contextMock.componentApi.setTotalCardinality(80);
+    contextMock.componentApi.setAvailableOptions(take(allOptions, 10));
+    contextMock.componentApi.setSingleSelect(true);
+    renderComponent(contextMock);
+
+    expect(getSelectAllCheckbox()).not.toBeInTheDocument();
   });
 
   test('Select all is checked when all available options are selected ', async () => {

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_action_bar.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_action_bar.tsx
@@ -88,6 +88,7 @@ export const OptionsListPopoverActionBar = ({
     allowExpensiveQueries,
     availableOptions = [],
     dataLoading,
+    singleSelect,
   ] = useBatchedPublishingSubjects(
     componentApi.searchTechnique$,
     componentApi.searchStringValid$,
@@ -97,7 +98,8 @@ export const OptionsListPopoverActionBar = ({
     componentApi.fieldName$,
     componentApi.parentApi.allowExpensiveQueries$,
     componentApi.availableOptions$,
-    componentApi.dataLoading$
+    componentApi.dataLoading$,
+    componentApi.singleSelect$
   );
 
   const compatibleSearchTechniques = useMemo(() => {
@@ -188,38 +190,40 @@ export const OptionsListPopoverActionBar = ({
               </EuiFlexItem>
             </>
           )}
-          <EuiFlexItem grow={false}>
-            <EuiToolTip
-              content={
-                hasTooManyOptions
-                  ? OptionsListStrings.popover.getMaximumBulkSelectionTooltip()
-                  : undefined
-              }
-            >
-              <EuiCheckbox
-                checked={areAllSelected}
-                id={`optionsList-control-selectAll-checkbox-${componentApi.uuid}`}
-                // indeterminate={selectedOptions.length > 0 && !areAllSelected}
-                disabled={isBulkSelectDisabled}
-                data-test-subj="optionsList-control-selectAll"
-                onChange={() => {
-                  if (areAllSelected) {
-                    handleBulkAction(componentApi.deselectAll);
-                    setAllSelected(false);
-                  } else {
-                    handleBulkAction(componentApi.selectAll);
-                    setAllSelected(true);
-                  }
-                }}
-                css={styles.selectAllCheckbox}
-                label={
-                  <EuiText size="xs">
-                    {OptionsListStrings.popover.getSelectAllButtonLabel()}
-                  </EuiText>
+          {!singleSelect && (
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={
+                  hasTooManyOptions
+                    ? OptionsListStrings.popover.getMaximumBulkSelectionTooltip()
+                    : undefined
                 }
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
+              >
+                <EuiCheckbox
+                  checked={areAllSelected}
+                  id={`optionsList-control-selectAll-checkbox-${componentApi.uuid}`}
+                  // indeterminate={selectedOptions.length > 0 && !areAllSelected}
+                  disabled={isBulkSelectDisabled}
+                  data-test-subj="optionsList-control-selectAll"
+                  onChange={() => {
+                    if (areAllSelected) {
+                      handleBulkAction(componentApi.deselectAll);
+                      setAllSelected(false);
+                    } else {
+                      handleBulkAction(componentApi.selectAll);
+                      setAllSelected(true);
+                    }
+                  }}
+                  css={styles.selectAllCheckbox}
+                  label={
+                    <EuiText size="xs">
+                      {OptionsListStrings.popover.getSelectAllButtonLabel()}
+                    </EuiText>
+                  }
+                />
+              </EuiToolTip>
+            </EuiFlexItem>
+          )}
           <EuiFlexItem grow={true}>
             <EuiFlexGroup
               gutterSize="xs"


### PR DESCRIPTION
## Summary

Controls configured to only allow a single selection
<img width="278" alt="Screenshot 2025-07-02 at 3 55 32 PM" src="https://github.com/user-attachments/assets/193680b6-082e-4b89-b847-5803fe6c4cb6" />

Would still display a Select All checkbox and allow the user to select multiple options this way
<img width="460" alt="Screenshot 2025-07-02 at 3 53 32 PM" src="https://github.com/user-attachments/assets/7d384015-63db-4a76-9449-35c377280e46" />

This PR hides Select All if the single selection option is chosen:
<img width="459" alt="Screenshot 2025-07-02 at 3 53 42 PM" src="https://github.com/user-attachments/assets/01eae209-d358-4e94-a6e2-6c1d9fb60aa1" />


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->