### PR TITLE
[FIX] Flaky test - Field list new fields in background handling

### DIFF
--- a/src/platform/test/functional/apps/discover/group4/_field_list_new_fields.ts
+++ b/src/platform/test/functional/apps/discover/group4/_field_list_new_fields.ts
@@ -90,7 +90,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await retry.waitFor('the new record was found', async () => {
         await queryBar.submitQuery();
         await unifiedFieldList.waitUntilSidebarHasLoaded();
-        return (await discover.getHitCountInt()) === 2;
+        return (
+          (await discover.getHitCountInt()) === 2 &&
+          (await unifiedFieldList.getSidebarSectionFieldCount('available')) === 3
+        );
       });
 
       expect(await unifiedFieldList.getSidebarSectionFieldNames('available')).to.eql([


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/kibana/issues/222364
fixes https://github.com/elastic/kibana/issues/222365

This is a very slightly flaky test. Run the tests more than 40 times and could not reproduce the failure, this test has only failed 3 times in the last year.
<img width="1423" alt="image" src="https://github.com/user-attachments/assets/afa9ac89-dcb7-4061-b0a7-209d15a00b91" />

### Possible cause of the flakynes
The test waits until discover has the new document and then checks the fieldNames in the sidebar, it might happen (very weirdly?) that the unifiedFieldList don't manage to update before the test assertion.

Added an extra check to only assert the new fields if the field count in the sidenav has been updated.


### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
 https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8520




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->