### PR TITLE
[Telemetry] Add EBT for alert details and case details page visits

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -343,3 +343,8 @@ export const OBSERVABLE_TYPES_BUILTIN = [
 ];
 
 export const OBSERVABLE_TYPES_BUILTIN_KEYS = OBSERVABLE_TYPES_BUILTIN.map(({ key }) => key);
+
+/**
+ * EBT events
+ */
+export const CASE_PAGE_VIEW_EVENT_TYPE = 'case_page_view';

--- a/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AnalyticsServiceSetup } from '@kbn/core/public';
-import { CASE_PAGE_VIEW_EVENT_TYPE } from '../../../common/constants';
+import { CASE_PAGE_VIEW_EVENT_TYPE } from '../../common/constants';
 
 export const registerAnalytics = ({
   analyticsService,

--- a/x-pack/platform/plugins/shared/cases/public/components/analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/analytics/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceSetup } from '@kbn/core/public';
+import { CASE_PAGE_VIEW_EVENT_TYPE } from '../../../common/constants';
+
+export const registerAnalytics = ({
+  analyticsService,
+}: {
+  analyticsService: AnalyticsServiceSetup;
+}) => {
+  analyticsService.registerEventType({
+    eventType: CASE_PAGE_VIEW_EVENT_TYPE,
+    schema: {
+      owner: {
+        type: 'keyword',
+        _meta: {
+          description: 'The solution ID (owner) that rendered the Cases page',
+          optional: false,
+        },
+      },
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/index.tsx
@@ -17,6 +17,7 @@ import { useCasesContext } from '../cases_context/use_cases_context';
 import { generateCaseViewPath, useCaseViewParams } from '../../common/navigation';
 import { CaseViewPage } from './case_view_page';
 import type { CaseViewProps } from './types';
+import { useCasePageViewEbt } from './use_case_page_view_ebt';
 
 export const CaseViewLoading = () => (
   <EuiFlexGroup gutterSize="none" justifyContent="center" alignItems="center">
@@ -40,6 +41,7 @@ export const CaseView = React.memo(
     const { spaces: spacesApi } = useKibana().services;
     const { detailName: caseId } = useCaseViewParams();
     const { basePath } = useCasesContext();
+    useCasePageViewEbt();
 
     const { data, isLoading, isError, refetch } = useGetCase(caseId);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_page_view_ebt.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_page_view_ebt.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useCasePageViewEbt } from './use_case_page_view_ebt';
+import { CASE_PAGE_VIEW_EVENT_TYPE } from '../../../common/constants';
+
+// Mocks
+jest.mock('../../common/lib/kibana', () => ({
+  useKibana: jest.fn(),
+}));
+
+jest.mock('../cases_context/use_cases_context', () => ({
+  useCasesContext: jest.fn(),
+}));
+
+jest.mock('../../files', () => ({
+  isRegisteredOwner: jest.fn().mockReturnValue(true),
+}));
+
+import { useKibana } from '../../common/lib/kibana';
+import { useCasesContext } from '../cases_context/use_cases_context';
+
+const getMockServices = (reportEvent: jest.Mock) => ({
+  services: {
+    analytics: {
+      reportEvent,
+    },
+  },
+});
+
+describe('useCasePageViewEbt', () => {
+  it('reports analytics event with valid owner', () => {
+    const reportEvent = jest.fn();
+    (useKibana as jest.Mock).mockReturnValue(getMockServices(reportEvent));
+    (useCasesContext as jest.Mock).mockReturnValue({ owner: ['observability'] });
+
+    renderHook(() => useCasePageViewEbt());
+
+    expect(reportEvent).toHaveBeenCalledWith(CASE_PAGE_VIEW_EVENT_TYPE, {
+      owner: 'observability',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_page_view_ebt.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_page_view_ebt.test.tsx
@@ -7,7 +7,9 @@
 
 import { renderHook } from '@testing-library/react';
 import { useCasePageViewEbt } from './use_case_page_view_ebt';
-import { CASE_PAGE_VIEW_EVENT_TYPE } from '../../../common/constants';
+import { CASE_PAGE_VIEW_EVENT_TYPE, OBSERVABILITY_OWNER } from '../../../common/constants';
+import { useKibana } from '../../common/lib/kibana';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 // Mocks
 jest.mock('../../common/lib/kibana', () => ({
@@ -17,13 +19,6 @@ jest.mock('../../common/lib/kibana', () => ({
 jest.mock('../cases_context/use_cases_context', () => ({
   useCasesContext: jest.fn(),
 }));
-
-jest.mock('../../files', () => ({
-  isRegisteredOwner: jest.fn().mockReturnValue(true),
-}));
-
-import { useKibana } from '../../common/lib/kibana';
-import { useCasesContext } from '../cases_context/use_cases_context';
 
 const getMockServices = (reportEvent: jest.Mock) => ({
   services: {
@@ -37,12 +32,24 @@ describe('useCasePageViewEbt', () => {
   it('reports analytics event with valid owner', () => {
     const reportEvent = jest.fn();
     (useKibana as jest.Mock).mockReturnValue(getMockServices(reportEvent));
-    (useCasesContext as jest.Mock).mockReturnValue({ owner: ['observability'] });
+    (useCasesContext as jest.Mock).mockReturnValue({ owner: [OBSERVABILITY_OWNER] });
 
     renderHook(() => useCasePageViewEbt());
 
     expect(reportEvent).toHaveBeenCalledWith(CASE_PAGE_VIEW_EVENT_TYPE, {
-      owner: 'observability',
+      owner: OBSERVABILITY_OWNER,
+    });
+  });
+
+  it('reports analytics event with invalid owner', () => {
+    const reportEvent = jest.fn();
+    (useKibana as jest.Mock).mockReturnValue(getMockServices(reportEvent));
+    (useCasesContext as jest.Mock).mockReturnValue({ owner: ['invalid'] });
+
+    renderHook(() => useCasePageViewEbt());
+
+    expect(reportEvent).toHaveBeenCalledWith(CASE_PAGE_VIEW_EVENT_TYPE, {
+      owner: 'unknown',
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_page_view_ebt.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_page_view_ebt.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useEffect } from 'react';
+
+import { CASE_PAGE_VIEW_EVENT_TYPE } from '../../../common/constants';
+import { useKibana } from '../../common/lib/kibana';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import { isRegisteredOwner } from '../../files';
+
+export const useCasePageViewEbt = () => {
+  const { analytics } = useKibana().services;
+  const { owner } = useCasesContext();
+
+  useEffect(() => {
+    analytics.reportEvent(CASE_PAGE_VIEW_EVENT_TYPE, {
+      owner: owner[0] && isRegisteredOwner(owner[0]) ? owner[0] : 'unknown',
+    });
+  }, [analytics, owner]);
+};

--- a/x-pack/platform/plugins/shared/cases/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.test.ts
@@ -22,6 +22,7 @@ import type { CasesPublicStartDependencies, CasesPublicSetupDependencies } from 
 import { CasesUiPlugin } from './plugin';
 import { ALLOWED_MIME_TYPES } from '../common/constants/mime_types';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
+import { CASE_PAGE_VIEW_EVENT_TYPE } from '../common/constants';
 
 function getConfig(overrides = {}) {
   return {
@@ -100,6 +101,17 @@ describe('Cases Ui Plugin', () => {
           },
         }
     `);
+    });
+
+    it('registers cases page view event type', async () => {
+      plugin.setup(coreSetup, pluginsSetup);
+
+      expect(coreSetup.analytics.registerEventType).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: CASE_PAGE_VIEW_EVENT_TYPE,
+          schema: expect.objectContaining({ owner: expect.objectContaining({ type: 'keyword' }) }),
+        })
+      );
     });
 
     it('should register kibana feature when stack is enabled', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.ts
@@ -12,7 +12,7 @@ import { createBrowserHistory } from 'history';
 
 import { KibanaServices } from './common/lib/kibana';
 import type { CasesUiConfigType } from '../common/ui/types';
-import { APP_ID, APP_PATH, CASE_PAGE_VIEW_EVENT_TYPE } from '../common/constants';
+import { APP_ID, APP_PATH } from '../common/constants';
 import { APP_TITLE, APP_DESC } from './common/translations';
 import { useCasesAddToExistingCaseModal } from './components/all_cases/selector_modal/use_cases_add_to_existing_case_modal';
 import { useCasesAddToNewCaseFlyout } from './components/create/flyout/use_cases_add_to_new_case_flyout';
@@ -38,6 +38,7 @@ import type {
   CasesPublicStartDependencies,
 } from './types';
 import { registerSystemActions } from './components/system_actions';
+import { registerAnalytics } from './components/analytics';
 
 /**
  * @public
@@ -117,18 +118,7 @@ export class CasesUiPlugin
 
     registerSystemActions(plugins.triggersActionsUi);
 
-    core.analytics.registerEventType({
-      eventType: CASE_PAGE_VIEW_EVENT_TYPE,
-      schema: {
-        owner: {
-          type: 'keyword',
-          _meta: {
-            description: 'The solution ID (owner) that rendered the Cases page',
-            optional: false,
-          },
-        },
-      },
-    });
+    registerAnalytics({ analyticsService: core.analytics });
 
     return {
       attachmentFramework: {

--- a/x-pack/platform/plugins/shared/cases/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.ts
@@ -12,7 +12,7 @@ import { createBrowserHistory } from 'history';
 
 import { KibanaServices } from './common/lib/kibana';
 import type { CasesUiConfigType } from '../common/ui/types';
-import { APP_ID, APP_PATH } from '../common/constants';
+import { APP_ID, APP_PATH, CASE_PAGE_VIEW_EVENT_TYPE } from '../common/constants';
 import { APP_TITLE, APP_DESC } from './common/translations';
 import { useCasesAddToExistingCaseModal } from './components/all_cases/selector_modal/use_cases_add_to_existing_case_modal';
 import { useCasesAddToNewCaseFlyout } from './components/create/flyout/use_cases_add_to_new_case_flyout';
@@ -116,6 +116,19 @@ export class CasesUiPlugin
     }
 
     registerSystemActions(plugins.triggersActionsUi);
+
+    core.analytics.registerEventType({
+      eventType: CASE_PAGE_VIEW_EVENT_TYPE,
+      schema: {
+        owner: {
+          type: 'keyword',
+          _meta: {
+            description: 'The solution ID (owner) that rendered the Cases page',
+            optional: false,
+          },
+        },
+      },
+    });
 
     return {
       attachmentFramework: {

--- a/x-pack/platform/plugins/shared/cases/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.ts
@@ -38,7 +38,7 @@ import type {
   CasesPublicStartDependencies,
 } from './types';
 import { registerSystemActions } from './components/system_actions';
-import { registerAnalytics } from './components/analytics';
+import { registerAnalytics } from './analytics';
 
 /**
  * @public

--- a/x-pack/solutions/observability/plugins/observability/public/hooks/use_alert_details_page_view_ebt.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/hooks/use_alert_details_page_view_ebt.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useAlertDetailsPageViewEbt } from './use_alert_details_page_view_ebt';
+import { useKibana } from '../utils/kibana_react';
+
+jest.mock('../utils/kibana_react', () => ({
+  useKibana: jest.fn(),
+}));
+
+describe('useAlertDetailsPageViewEbt', () => {
+  const getServices = (reportAlertDetailsPageView: jest.Mock) => ({
+    services: { telemetryClient: { reportAlertDetailsPageView } },
+  });
+
+  it('fires event when ruleType provided', () => {
+    const reportAlertDetailsPageView = jest.fn();
+    (useKibana as jest.Mock).mockReturnValue(getServices(reportAlertDetailsPageView));
+
+    renderHook(() => useAlertDetailsPageViewEbt({ ruleType: 'logs.alert.document.count' }));
+
+    expect(reportAlertDetailsPageView).toHaveBeenCalledWith('logs.alert.document.count');
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/hooks/use_alert_details_page_view_ebt.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/hooks/use_alert_details_page_view_ebt.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Telemetry hook for alert details page view in Observability.
+ */
+
+import { useEffect } from 'react';
+import { useKibana } from '../utils/kibana_react';
+
+export const useAlertDetailsPageViewEbt = ({ ruleType }: { ruleType?: string }) => {
+  const { telemetryClient } = useKibana().services;
+
+  useEffect(() => {
+    if (ruleType) {
+      telemetryClient.reportAlertDetailsPageView(ruleType);
+    }
+  }, [ruleType, telemetryClient]);
+};

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.test.tsx
@@ -27,6 +27,7 @@ import { kibanaStartMock } from '../../utils/kibana_react.mock';
 import { render } from '../../utils/test_helper';
 import { AlertDetails } from './alert_details';
 import { alertDetail, alertWithNoData } from './mock/alert';
+import { createTelemetryClientMock } from '../../services/telemetry/telemetry_client.mock';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -107,6 +108,7 @@ const mockKibana = () => {
       theme: {},
       dashboard: {},
       spaces: mockSpaces,
+      telemetryClient: createTelemetryClientMock(),
     },
   });
 };

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -63,6 +63,7 @@ import { AlertSubtitle } from './components/alert_subtitle';
 import { ProximalAlertsCallout } from './proximal_alerts_callout';
 import { useTabId } from './hooks/use_tab_id';
 import { useRelatedDashboards } from './hooks/use_related_dashboards';
+import { useAlertDetailsPageViewEbt } from '../../hooks/use_alert_details_page_view_ebt';
 
 interface AlertDetailsPathParams {
   alertId: string;
@@ -110,6 +111,8 @@ export function AlertDetails() {
   const { rule, refetch } = useFetchRule({
     ruleId: ruleId || '',
   });
+
+  useAlertDetailsPageViewEbt({ ruleType: rule?.ruleTypeId });
 
   const onSuccessAddSuggestedDashboard = useCallback(async () => {
     await Promise.all([refetchRelatedDashboards(), refetch()]);

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_client.mock.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_client.mock.ts
@@ -9,4 +9,5 @@ import type { ITelemetryClient } from './types';
 
 export const createTelemetryClientMock = (): jest.Mocked<ITelemetryClient> => ({
   reportRelatedAlertsLoaded: jest.fn(),
+  reportAlertDetailsPageView: jest.fn(),
 });

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_client.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_client.ts
@@ -16,4 +16,10 @@ export class TelemetryClient implements ITelemetryClient {
       count,
     });
   }
+
+  reportAlertDetailsPageView(ruleType: string): void {
+    this.analytics.reportEvent(TelemetryEventTypes.ALERT_DETAILS_PAGE_VIEW, {
+      rule_type: ruleType,
+    });
+  }
 }

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_events.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/telemetry_events.ts
@@ -20,4 +20,17 @@ const relatedAlertsLoaded: TelemetryEvent = {
   },
 };
 
-export const events: TelemetryEvent[] = [relatedAlertsLoaded];
+const alertDetailsPageView: TelemetryEvent = {
+  eventType: TelemetryEventTypes.ALERT_DETAILS_PAGE_VIEW,
+  schema: {
+    rule_type: {
+      type: 'keyword' as const,
+      _meta: {
+        description: 'Rule type ID of the alert whose details page was viewed',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const events: TelemetryEvent[] = [relatedAlertsLoaded, alertDetailsPageView];

--- a/x-pack/solutions/observability/plugins/observability/public/services/telemetry/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/services/telemetry/types.ts
@@ -11,19 +11,31 @@ export type TelemetryServiceStart = ITelemetryClient;
 
 export interface ITelemetryClient {
   reportRelatedAlertsLoaded(count: number): void;
+  reportAlertDetailsPageView(ruleType: string): void;
 }
 
 export enum TelemetryEventTypes {
   RELATED_ALERTS_LOADED = 'Related Alerts Loaded',
+  ALERT_DETAILS_PAGE_VIEW = 'Alert Details Page View',
 }
 
-export interface TelemetryEvent {
+interface RelatedAlertsLoadedParams {
+  count: number;
+}
+interface RelatedAlertsLoadedEvent {
   eventType: TelemetryEventTypes.RELATED_ALERTS_LOADED;
   schema: RootSchema<RelatedAlertsLoadedParams>;
 }
 
-export interface RelatedAlertsLoadedParams {
-  count: number;
+interface AlertDetailsPageViewParams {
+  rule_type: string;
 }
 
-export type TelemetryEventParams = RelatedAlertsLoadedParams;
+interface AlertDetailsPageViewEvent {
+  eventType: TelemetryEventTypes.ALERT_DETAILS_PAGE_VIEW;
+  schema: RootSchema<AlertDetailsPageViewParams>;
+}
+
+export type TelemetryEvent = AlertDetailsPageViewEvent | RelatedAlertsLoadedEvent;
+
+export type TelemetryEventParams = RelatedAlertsLoadedParams | AlertDetailsPageViewParams;


### PR DESCRIPTION
This PR closes #216490 


https://github.com/user-attachments/assets/b8d0bcd5-59a1-43dd-a5db-fa3932b347e6

**Acceptance criteria:**
Add custom events to capture following telemetry:

- Visits to alert detail pages, custom event should include rule type ✅
- Visits to the case page ✅