### PR TITLE
[Cloud Security] fix vulnerablity flyout resource table displayed package fields

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/test_subjects.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/test_subjects.ts
@@ -30,3 +30,4 @@ export const VULNERABILITY_OVERVIEW_TAB_ID_MORE_BTN = 'vulnerability-overview-ta
 export const VULNERABILITY_OVERVIEW_TAB_ID_LESS_BTN = 'vulnerability-overview-tab-id-more-less';
 export const VULNERABILITY_OVERVIEW_PUBLISHED_DATE = 'vulnerability-overview-tab-published-date';
 export const VULNERABILITY_EMPTY_VALUE = 'vulnerability-empty-value';
+export const VULNERABILITY_RESOURCE_TABLE = 'vulnerability-resource-table';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_flyout.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_flyout.test.tsx
@@ -19,6 +19,7 @@ import {
   VULNERABILITY_HEADER_REFERENCE_LINK,
   VULNERABILITY_OVERVIEW_TAB_ID_LESS_BTN,
   VULNERABILITY_OVERVIEW_TAB_ID_MORE_BTN,
+  VULNERABILITY_RESOURCE_TABLE,
   VULNERABILITY_SCORES_FLYOUT,
 } from '../test_subjects';
 import { EMPTY_VALUE } from '../../configurations/findings_flyout/findings_flyout';
@@ -179,6 +180,28 @@ describe('<VulnerabilityFindingFlyout/>', () => {
       getAllByText(mockVulnerabilityHit.vulnerability?.cvss?.ghsa?.V3Score?.toString() as string);
       getAllByText(mockVulnerabilityHit.package.name as string);
       getAllByText(mockVulnerabilityHit.package.fixed_version as string);
+    });
+
+    it('shows resource information in a table with correct fields', () => {
+      const { getByTestId } = render(
+        <TestProvider>
+          <VulnerabilityOverviewTab vulnerabilityRecord={mockVulnerabilityHit} />
+        </TestProvider>
+      );
+
+      const resourceTable = getByTestId(VULNERABILITY_RESOURCE_TABLE);
+      expect(resourceTable).toBeInTheDocument();
+
+      // Check that all resource fields are displayed in the table
+      const tableContent = resourceTable.textContent;
+      expect(tableContent).toContain('ID');
+      expect(tableContent).toContain(mockVulnerabilityHit.resource?.id);
+      expect(tableContent).toContain('Name');
+      expect(tableContent).toContain(mockVulnerabilityHit.resource?.name);
+      expect(tableContent).toContain('Package');
+      expect(tableContent).toContain(mockVulnerabilityHit.package.name);
+      expect(tableContent).toContain('Version');
+      expect(tableContent).toContain(mockVulnerabilityHit.package.version);
     });
 
     it('Overview Tab with Qualys vulnerability renders multiple CVEs', async () => {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
@@ -48,6 +48,7 @@ import { VulnerabilityDetectionRuleCounter } from './vulnerability_detection_rul
 import { CopyButton } from '../../../components/copy_button';
 import { columns, convertObjectToArray } from '../../configurations/findings_flyout/overview_tab';
 import { VulnerabilityIdContent } from './vulnerability_id_content';
+import { VULNERABILITY_RESOURCE_TABLE } from '../test_subjects';
 
 const cvssVendors: Record<string, Vendor> = {
   nvd: 'NVD',
@@ -294,12 +295,13 @@ const getResourceList = (vulnerabilityData: CspVulnerabilityFinding) => [
       <EuiPanel>
         <EuiPanel hasBorder>
           <EuiBasicTable
+            data-test-subj={VULNERABILITY_RESOURCE_TABLE}
             items={
               convertObjectToArray({
                 ID: vulnerabilityData?.resource?.id,
                 Name: vulnerabilityData?.resource?.name,
                 Package: vulnerabilityData?.package?.name,
-                Version: vulnerabilityData?.package?.fixed_version,
+                Version: vulnerabilityData?.package?.version,
               }) || []
             }
             rowHeader="Field"


### PR DESCRIPTION
## Summary

This PR fix the following [issue](https://github.com/elastic/kibana/issues/226325).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->