### PR TITLE
[9.1] [AI Infra] Fix Observability AI assistant product docs missing multilingual support (#224274)

### DIFF
--- a/packages/kbn-check-mappings-update-cli/current_fields.json
+++ b/packages/kbn-check-mappings-update-cli/current_fields.json
@@ -915,6 +915,7 @@
   ],
   "product-doc-install-status": [
     "index_name",
+    "inference_id",
     "installation_status",
     "last_installation_date",
     "product_name",

--- a/packages/kbn-check-mappings-update-cli/current_mappings.json
+++ b/packages/kbn-check-mappings-update-cli/current_mappings.json
@@ -3042,6 +3042,9 @@
       "index_name": {
         "type": "keyword"
       },
+      "inference_id": {
+        "type": "keyword"
+      },
       "installation_status": {
         "type": "keyword"
       },

--- a/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
@@ -154,7 +154,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "osquery-saved-query": "a8ef11610473e3d1b51a8fdacb2799d8a610818e",
         "policy-settings-protection-updates-note": "c05c4c33a5e5bd1fa153991f300d040ac5d6f38d",
         "privilege-monitoring-status": "4daec76df427409bcd64250f5c23f5ab86c8bac3",
-        "product-doc-install-status": "ee7817c45bf1c41830290c8ef535e726c86f7c19",
+        "product-doc-install-status": "f94e3e5ad2cc933df918f2cd159044c626e01011",
         "query": "1966ccce8e9853018111fb8a1dee500228731d9e",
         "risk-engine-configuration": "533a0a3f2dbef1c95129146ec4d5714de305be1a",
         "rules-settings": "53f94e5ce61f5e75d55ab8adbc1fb3d0937d2e0b",

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/README.md
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/README.md
@@ -8,17 +8,23 @@ Script to build the knowledge base artifacts.
 node scripts/build_product_doc_artifacts.js --stack-version {version} --product-name {product}
 ```
 
+Example:
+
+```
+node scripts/build_product_doc_artifacts.js --product-name=security --stack-version=8.18  --inference-id=.multilingual-e5-small-elasticsearch
+```
+
 ### parameters
 
-#### `stack-version`: 
+#### `stack-version`:
 
 the stack version to generate the artifacts for.
 
-#### `product-name`: 
+#### `product-name`:
 
 (multi-value) the list of products to generate artifacts for.
 
-possible values: 
+possible values:
 - "kibana"
 - "elasticsearch"
 - "observability"
@@ -34,6 +40,11 @@ Defaults to `{REPO_ROOT}/build-kb-artifacts`.
 
 The folder to use for temporary files.
 
+#### inference-id:
+
+The inference endpoint to use to generate the embeddings. If the inference ID provided and is not the ELSER default, the artifacts will be generated with `{artifactName}--{inference-id}.zip`. Note the double dash before inference-id.
+
+
 Defaults to `{REPO_ROOT}/build/temp-kb-artifacts`
 
 #### Cluster infos
@@ -47,3 +58,6 @@ Defaults to `{REPO_ROOT}/build/temp-kb-artifacts`
 `embeddingClusterUrl` / env.KIBANA_EMBEDDING_CLUSTER_URL
 `embeddingClusterUsername` / env.KIBANA_EMBEDDING_CLUSTER_USERNAME
 `embeddingClusterPassword` / env.KIBANA_EMBEDDING_CLUSTER_PASSWORD
+
+- params for the inference endpoint:
+`inferenceId`

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/artifact/mappings.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/artifact/mappings.ts
@@ -6,30 +6,31 @@
  */
 
 import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+import {
+  DEFAULT_ELSER,
+  getSemanticTextMapping,
+  type SemanticTextMapping,
+} from '../tasks/create_index';
 
-export const getArtifactMappings = (inferenceEndpoint: string): MappingTypeMapping => {
+export const getArtifactMappings = (
+  customSemanticTextMapping?: SemanticTextMapping
+): MappingTypeMapping => {
+  const semanticTextMapping = customSemanticTextMapping
+    ? customSemanticTextMapping
+    : getSemanticTextMapping(DEFAULT_ELSER);
   return {
     dynamic: 'strict',
     properties: {
       content_title: { type: 'text' },
-      content_body: {
-        type: 'semantic_text',
-        inference_id: inferenceEndpoint,
-      },
+      content_body: semanticTextMapping,
       product_name: { type: 'keyword' },
       root_type: { type: 'keyword' },
       slug: { type: 'keyword' },
       url: { type: 'keyword' },
       version: { type: 'version' },
       ai_subtitle: { type: 'text' },
-      ai_summary: {
-        type: 'semantic_text',
-        inference_id: inferenceEndpoint,
-      },
-      ai_questions_answered: {
-        type: 'semantic_text',
-        inference_id: inferenceEndpoint,
-      },
+      ai_summary: semanticTextMapping,
+      ai_questions_answered: semanticTextMapping,
       ai_tags: { type: 'keyword' },
     },
   };

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/build_artifacts.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/build_artifacts.ts
@@ -7,8 +7,14 @@
 
 import Path from 'path';
 import { Client, HttpConnection } from '@elastic/elasticsearch';
+import {
+  Client as ElasticsearchClient8,
+  HttpConnection as Elasticsearch8HttpConnection,
+} from 'elasticsearch-8.x';
+
 import { ToolingLog } from '@kbn/tooling-log';
 import type { ProductName } from '@kbn/product-doc-common';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import {
   // checkConnectivity,
   createTargetIndex,
@@ -21,9 +27,10 @@ import {
   processDocuments,
 } from './tasks';
 import type { TaskConfig } from './types';
+import { getSemanticTextMapping } from './tasks/create_index';
 
 const getSourceClient = (config: TaskConfig) => {
-  return new Client({
+  return new ElasticsearchClient8({
     compression: true,
     nodes: [config.sourceClusterUrl],
     sniffOnStart: false,
@@ -31,7 +38,7 @@ const getSourceClient = (config: TaskConfig) => {
       username: config.sourceClusterUsername,
       password: config.sourceClusterPassword,
     },
-    Connection: HttpConnection,
+    Connection: Elasticsearch8HttpConnection,
     requestTimeout: 30_000,
   });
 };
@@ -79,6 +86,7 @@ export const buildArtifacts = async (config: TaskConfig) => {
       sourceClient,
       embeddingClient,
       log,
+      inferenceId: config.inferenceId ?? defaultInferenceEndpoints.ELSER,
     });
   }
 
@@ -93,18 +101,41 @@ const buildArtifact = async ({
   embeddingClient,
   sourceClient,
   log,
+  inferenceId,
 }: {
   productName: ProductName;
   stackVersion: string;
   buildFolder: string;
   targetFolder: string;
-  sourceClient: Client;
+  sourceClient: ElasticsearchClient8;
   embeddingClient: Client;
   log: ToolingLog;
+  inferenceId: string;
 }) => {
-  log.info(`Starting building artifact for product [${productName}] and version [${stackVersion}]`);
+  log.info(
+    `Starting building artifact for product [${productName}] and version [${stackVersion}] with inference id [${inferenceId}]`
+  );
 
-  const targetIndex = getTargetIndexName({ productName, stackVersion });
+  const semanticTextMapping = getSemanticTextMapping(inferenceId);
+
+  log.info(
+    `Detected semantic text mapping for Inference ID ${inferenceId}:\n ${JSON.stringify(
+      semanticTextMapping,
+      null,
+      2
+    )}`
+  );
+
+  const targetIndex = getTargetIndexName({
+    productName,
+    stackVersion,
+    inferenceId: semanticTextMapping?.inference_id,
+  });
+  await deleteIndex({
+    indexName: targetIndex,
+    client: embeddingClient,
+    log,
+  });
 
   let documents = await extractDocumentation({
     client: sourceClient,
@@ -119,6 +150,7 @@ const buildArtifact = async ({
   await createTargetIndex({
     client: embeddingClient,
     indexName: targetIndex,
+    semanticTextMapping,
   });
 
   await indexDocuments({
@@ -142,12 +174,7 @@ const buildArtifact = async ({
     productName,
     stackVersion,
     log,
-  });
-
-  await deleteIndex({
-    indexName: targetIndex,
-    client: embeddingClient,
-    log,
+    semanticTextMapping,
   });
 
   log.info(`Finished building artifact for product [${productName}] and version [${stackVersion}]`);
@@ -156,9 +183,13 @@ const buildArtifact = async ({
 const getTargetIndexName = ({
   productName,
   stackVersion,
+  inferenceId,
 }: {
   productName: string;
   stackVersion: string;
+  inferenceId?: string;
 }) => {
-  return `kb-artifact-builder-${productName}-${stackVersion}`.toLowerCase();
+  return `kb-artifact-builder-${productName}-${stackVersion}${
+    inferenceId ? `-${inferenceId}` : ''
+  }`.toLowerCase();
 };

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/command.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/command.ts
@@ -71,6 +71,10 @@ function options(y: yargs.Argv) {
       demandOption: true,
       default: process.env.KIBANA_EMBEDDING_CLUSTER_PASSWORD,
     })
+    .option('inferenceId', {
+      describe: 'The inference id to use for the artifacts',
+      string: true,
+    })
     .locale('en');
 }
 
@@ -89,6 +93,7 @@ export function runScript() {
         embeddingClusterUrl: argv.embeddingClusterUrl!,
         embeddingClusterUsername: argv.embeddingClusterUsername!,
         embeddingClusterPassword: argv.embeddingClusterPassword!,
+        inferenceId: argv.inferenceId,
       };
 
       return buildArtifacts(taskConfig);

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/create_artifact.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/create_artifact.ts
@@ -15,7 +15,7 @@ import {
 } from '@kbn/product-doc-common';
 import { getArtifactMappings } from '../artifact/mappings';
 import { getArtifactManifest } from '../artifact/manifest';
-import { DEFAULT_ELSER } from './create_index';
+import { DEFAULT_ELSER, SemanticTextMapping } from './create_index';
 
 export const createArtifact = async ({
   productName,
@@ -23,12 +23,14 @@ export const createArtifact = async ({
   buildFolder,
   targetFolder,
   log,
+  semanticTextMapping,
 }: {
   buildFolder: string;
   targetFolder: string;
   productName: ProductName;
   stackVersion: string;
   log: ToolingLog;
+  semanticTextMapping?: SemanticTextMapping;
 }) => {
   log.info(
     `Starting to create artifact from build folder [${buildFolder}] into target [${targetFolder}]`
@@ -36,7 +38,9 @@ export const createArtifact = async ({
 
   const zip = new AdmZip();
 
-  const mappings = getArtifactMappings(DEFAULT_ELSER);
+  const inferenceId = semanticTextMapping?.inference_id || DEFAULT_ELSER;
+
+  const mappings = getArtifactMappings(semanticTextMapping);
   const mappingFileContent = JSON.stringify(mappings, undefined, 2);
   zip.addFile('mappings.json', Buffer.from(mappingFileContent, 'utf-8'));
 
@@ -53,6 +57,7 @@ export const createArtifact = async ({
   const artifactName = getArtifactName({
     productName,
     productVersion: stackVersion,
+    inferenceId,
   });
   zip.writeZip(Path.join(targetFolder, artifactName));
 

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/create_index.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/create_index.ts
@@ -6,43 +6,66 @@
  */
 
 import type { Client } from '@elastic/elasticsearch';
-import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+import { getArtifactMappings } from '../artifact/mappings';
 
 export const DEFAULT_ELSER = '.elser-2-elasticsearch';
+export const DEFAULT_E5_SMALL = '.multilingual-e5-small-elasticsearch';
 
-const mappings: MappingTypeMapping = {
-  dynamic: 'strict',
-  properties: {
-    content_title: { type: 'text' },
-    content_body: {
-      type: 'semantic_text',
-      inference_id: DEFAULT_ELSER,
+interface BaseSemanticTextMapping {
+  type: 'semantic_text';
+  inference_id: string;
+}
+export interface SemanticTextMapping extends BaseSemanticTextMapping {
+  model_settings?: {
+    service?: string;
+    task_type?: string;
+    dimensions?: number;
+    similarity?: string;
+    element_type?: string;
+  };
+}
+
+type SupportedInferenceId = typeof DEFAULT_E5_SMALL | typeof DEFAULT_ELSER;
+const isSupportedInferenceId = (inferenceId: string): inferenceId is SupportedInferenceId => {
+  return inferenceId === DEFAULT_E5_SMALL || inferenceId === DEFAULT_ELSER;
+};
+
+const INFERENCE_ID_TO_SEMANTIC_TEXT_MAPPING: Record<SupportedInferenceId, SemanticTextMapping> = {
+  [DEFAULT_E5_SMALL]: {
+    type: 'semantic_text',
+    inference_id: DEFAULT_E5_SMALL,
+    model_settings: {
+      service: 'elasticsearch',
+      task_type: 'text_embedding',
+      dimensions: 384,
+      similarity: 'cosine',
+      element_type: 'float',
     },
-    product_name: { type: 'keyword' },
-    root_type: { type: 'keyword' },
-    slug: { type: 'keyword' },
-    url: { type: 'keyword' },
-    version: { type: 'version' },
-    ai_subtitle: { type: 'text' },
-    ai_summary: {
-      type: 'semantic_text',
-      inference_id: DEFAULT_ELSER,
-    },
-    ai_questions_answered: {
-      type: 'semantic_text',
-      inference_id: DEFAULT_ELSER,
-    },
-    ai_tags: { type: 'keyword' },
   },
+  [DEFAULT_ELSER]: {
+    type: 'semantic_text',
+    inference_id: DEFAULT_ELSER,
+  },
+};
+export const getSemanticTextMapping = (inferenceId: string): SemanticTextMapping => {
+  if (isSupportedInferenceId(inferenceId)) {
+    return INFERENCE_ID_TO_SEMANTIC_TEXT_MAPPING[inferenceId];
+  }
+  throw new Error(`Semantic text mapping for Inference ID ${inferenceId} not found`);
 };
 
 export const createTargetIndex = async ({
   indexName,
   client,
+  semanticTextMapping,
 }: {
   indexName: string;
   client: Client;
+  semanticTextMapping?: SemanticTextMapping;
 }) => {
+  const mappings = semanticTextMapping
+    ? getArtifactMappings(semanticTextMapping)
+    : getArtifactMappings(getSemanticTextMapping(DEFAULT_ELSER));
   await client.indices.create({
     index: indexName,
     mappings,

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/extract_documentation.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/extract_documentation.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Client } from '@elastic/elasticsearch';
+import { Client as ElasticsearchClient8 } from 'elasticsearch-8.x';
 import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { ProductName } from '@kbn/product-doc-common';
@@ -64,7 +64,7 @@ export const extractDocumentation = async ({
   productName,
   log,
 }: {
-  client: Client;
+  client: ElasticsearchClient8;
   index: string;
   stackVersion: string;
   productName: ProductName;

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/types.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/types.ts
@@ -18,4 +18,5 @@ export interface TaskConfig {
   embeddingClusterUrl: string;
   embeddingClusterUsername: string;
   embeddingClusterPassword: string;
+  inferenceId?: string;
 }

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/tsconfig.json
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/tsconfig.json
@@ -17,5 +17,6 @@
     "@kbn/tooling-log",
     "@kbn/repo-info",
     "@kbn/product-doc-common",
+    "@kbn/inference-common",
   ]
 }

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/inference_endpoints.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/inference_endpoints.ts
@@ -10,6 +10,7 @@
  */
 export const defaultInferenceEndpoints = {
   ELSER: '.elser-2-elasticsearch',
+  ELSER_IN_EIS_INFERENCE_ID: '.elser-v2-elastic',
   MULTILINGUAL_E5_SMALL: '.multilingual-e5-small-elasticsearch',
 } as const;
 

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/kibana.jsonc
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/kibana.jsonc
@@ -6,4 +6,5 @@
   ],
   "group": "platform",
   "visibility": "shared"
+
 }

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/artifact.test.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/artifact.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getArtifactName, parseArtifactName } from './artifact';
+import { getArtifactName, parseArtifactName, DEFAULT_ELSER } from './artifact';
 
 describe('getArtifactName', () => {
   it('builds the name based on the provided product name and version', () => {
@@ -37,6 +37,32 @@ describe('getArtifactName', () => {
       })
     ).toEqual('kb-product-doc-elasticsearch-8.17');
   });
+  it('generates a name with inference id when inference_id is not the ELSER default', () => {
+    expect(
+      getArtifactName({
+        productName: 'kibana',
+        productVersion: '8.16',
+        inferenceId: '.multilingual-e5-small-elasticsearch',
+      })
+    ).toEqual('kb-product-doc-kibana-8.16--.multilingual-e5-small-elasticsearch.zip');
+    expect(
+      getArtifactName({
+        productName: 'kibana',
+        productVersion: '8.16',
+        inferenceId: '.multilingual-e5-small-elasticsearch',
+        excludeExtension: true,
+      })
+    ).toEqual('kb-product-doc-kibana-8.16--.multilingual-e5-small-elasticsearch');
+  });
+  it('generates a name with inference id when inference_id is the ELSER default', () => {
+    expect(
+      getArtifactName({
+        productName: 'kibana',
+        productVersion: '8.16',
+        inferenceId: DEFAULT_ELSER,
+      })
+    ).toEqual('kb-product-doc-kibana-8.16.zip');
+  });
 });
 
 describe('parseArtifactName', () => {
@@ -60,5 +86,23 @@ describe('parseArtifactName', () => {
 
   it('returns undefined if the provided string is not strictly lowercase', () => {
     expect(parseArtifactName('kb-product-doc-Security-8.17')).toEqual(undefined);
+  });
+  it('parses an artifact name with inference id and extension', () => {
+    expect(
+      parseArtifactName('kb-product-doc-kibana-8.16--.multilingual-e5-small-elasticsearch.zip')
+    ).toEqual({
+      productName: 'kibana',
+      productVersion: '8.16',
+      inferenceId: '.multilingual-e5-small-elasticsearch',
+    });
+  });
+  it('parses an artifact name with inference id when it is not the default', () => {
+    expect(
+      parseArtifactName('kb-product-doc-kibana-8.16--.multilingual-e5-small-elasticsearch')
+    ).toEqual({
+      productName: 'kibana',
+      productVersion: '8.16',
+      inferenceId: '.multilingual-e5-small-elasticsearch',
+    });
   });
 });

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/artifact.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/artifact.ts
@@ -9,30 +9,44 @@ import { type ProductName, DocumentationProduct } from './product';
 
 // kb-product-doc-elasticsearch-8.15.zip
 const artifactNameRegexp = /^kb-product-doc-([a-z]+)-([0-9]+\.[0-9]+)(\.zip)?$/;
+const inferenceIdRegexp = /--([a-z0-9.-]+)(\.zip)?$/;
 const allowedProductNames: ProductName[] = Object.values(DocumentationProduct);
+
+export const DEFAULT_ELSER = '.elser-2-elasticsearch';
 
 export const getArtifactName = ({
   productName,
   productVersion,
   excludeExtension = false,
+  inferenceId,
 }: {
   productName: ProductName;
   productVersion: string;
   excludeExtension?: boolean;
+  inferenceId?: string;
 }): string => {
   const ext = excludeExtension ? '' : '.zip';
-  return `kb-product-doc-${productName}-${productVersion}${ext}`.toLowerCase();
+  return `kb-product-doc-${productName}-${productVersion}${
+    inferenceId && inferenceId !== DEFAULT_ELSER ? `--${inferenceId}` : ''
+  }${ext}`.toLowerCase();
 };
 
 export const parseArtifactName = (artifactName: string) => {
-  const match = artifactNameRegexp.exec(artifactName);
+  let name = artifactName.replace(/\.zip$/, '');
+  // First, extract out the inference Id which is prefixed by --
+  const inferenceIdMatch = name.match(inferenceIdRegexp);
+  name = inferenceIdMatch ? name.replace(inferenceIdMatch[0], '') : artifactName;
+
+  const match = name.match(artifactNameRegexp);
   if (match) {
     const productName = match[1].toLowerCase() as ProductName;
     const productVersion = match[2].toLowerCase();
+    const inferenceId = inferenceIdMatch ? inferenceIdMatch[1] : undefined;
     if (allowedProductNames.includes(productName)) {
       return {
         productName,
         productVersion,
+        ...(inferenceId ? { inferenceId } : {}),
       };
     }
   }

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/indices.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/indices.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
+import { isImpliedDefaultElserInferenceId } from './is_default_inference_endpoint';
 import type { ProductName } from './product';
 
 export const productDocIndexPrefix = '.kibana_ai_product_doc';
 export const productDocIndexPattern = `${productDocIndexPrefix}_*`;
 
-export const getProductDocIndexName = (productName: ProductName): string => {
-  return `${productDocIndexPrefix}_${productName.toLowerCase()}`;
+export const getProductDocIndexName = (productName: ProductName, inferenceId?: string): string => {
+  return `${productDocIndexPrefix}_${productName.toLowerCase()}${
+    !isImpliedDefaultElserInferenceId(inferenceId) ? `-${inferenceId}` : ''
+  }`;
 };

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/is_default_inference_endpoint.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/is_default_inference_endpoint.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
+
+/**
+ * Returns true if inferenceId is not provided, or when provided, it is a default ELSER inference ID
+ * @param inferenceId
+ * @returns
+ */
+export const isImpliedDefaultElserInferenceId = (inferenceId: string | null | undefined) => {
+  return (
+    inferenceId === null ||
+    inferenceId === undefined ||
+    inferenceId === defaultInferenceEndpoints.ELSER ||
+    inferenceId === defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID
+  );
+};

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/tsconfig.json
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/tsconfig.json
@@ -13,5 +13,7 @@
   "exclude": [
     "target/**/*"
   ],
-  "kbn_references": []
+  "kbn_references": [
+    "@kbn/inference-common"
+  ]
 }

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_current_inference_id.ts
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_current_inference_id.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useKnowledgeBase } from './use_knowledge_base';
+
+export const useCurrentlyDeployedInferenceId = () => {
+  const knowledgeBase = useKnowledgeBase();
+  return useMemo(
+    () =>
+      knowledgeBase.status.value?.currentInferenceId ??
+      knowledgeBase.status.value?.endpoint?.inference_id,
+    [knowledgeBase.status.value]
+  );
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/product_docs/use_get_product_doc_status.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/product_docs/use_get_product_doc_status.ts
@@ -6,6 +6,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { REACT_QUERY_KEYS } from './const';
 import { useAssistantContext } from '../../../..';
 
@@ -15,7 +16,9 @@ export function useGetProductDocStatus() {
   const { isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery({
     queryKey: [REACT_QUERY_KEYS.GET_PRODUCT_DOC_STATUS],
     queryFn: async () => {
-      return productDocBase.installation.getStatus();
+      return productDocBase.installation.getStatus({
+        inferenceId: defaultInferenceEndpoints.ELSER,
+      });
     },
     keepPreviousData: false,
     refetchOnWindowFocus: false,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/product_docs/use_install_product_doc.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/product_docs/use_install_product_doc.test.ts
@@ -9,6 +9,7 @@ import { waitFor, renderHook } from '@testing-library/react';
 import { useInstallProductDoc } from './use_install_product_doc';
 import { useAssistantContext } from '../../../..';
 import { TestProviders } from '../../../mock/test_providers/test_providers';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
 jest.mock('../../../..', () => ({
   useAssistantContext: jest.fn(),
@@ -39,7 +40,7 @@ describe('useInstallProductDoc', () => {
       wrapper: TestProviders,
     });
 
-    result.current.mutate();
+    result.current.mutate(defaultInferenceEndpoints.ELSER);
     await waitFor(() => result.current.isSuccess);
 
     expect(mockAddSuccess).toHaveBeenCalledWith(
@@ -54,7 +55,7 @@ describe('useInstallProductDoc', () => {
       wrapper: TestProviders,
     });
 
-    result.current.mutate();
+    result.current.mutate(defaultInferenceEndpoints.ELSER);
     await waitFor(() => result.current.isError);
 
     expect(mockAddError).toHaveBeenCalledWith(

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/product_docs/use_install_product_doc.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/product_docs/use_install_product_doc.ts
@@ -11,17 +11,16 @@ import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
 import type { PerformInstallResponse } from '@kbn/product-doc-base-plugin/common/http_api/installation';
 import { REACT_QUERY_KEYS } from './const';
 import { useAssistantContext } from '../../../..';
-
 type ServerError = IHttpFetchError<ResponseErrorBody>;
 
 export function useInstallProductDoc() {
   const { productDocBase, toasts } = useAssistantContext();
   const queryClient = useQueryClient();
 
-  return useMutation<PerformInstallResponse, ServerError, void>(
+  return useMutation<PerformInstallResponse, ServerError, string>(
     [REACT_QUERY_KEYS.INSTALL_PRODUCT_DOC],
-    () => {
-      return productDocBase.installation.install();
+    (inferenceId: string) => {
+      return productDocBase.installation.install({ inferenceId });
     },
     {
       onSuccess: () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/product_documentation/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/product_documentation/index.test.tsx
@@ -9,6 +9,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ProductDocumentationManagement } from '.';
 import * as i18n from './translations';
 import { useInstallProductDoc } from '../../api/product_docs/use_install_product_doc';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
 jest.mock('../../api/product_docs/use_install_product_doc');
 jest.mock('../../api/product_docs/use_get_product_doc_status');
@@ -26,12 +27,22 @@ describe('ProductDocumentationManagement', () => {
   });
 
   it('renders install button when not installed', () => {
-    render(<ProductDocumentationManagement status="uninstalled" />);
+    render(
+      <ProductDocumentationManagement
+        status="uninstalled"
+        inferenceId={defaultInferenceEndpoints.ELSER}
+      />
+    );
     expect(screen.getByText(i18n.INSTALL)).toBeInTheDocument();
   });
 
   it('does not render anything when already installed', () => {
-    const { container } = render(<ProductDocumentationManagement status="installed" />);
+    const { container } = render(
+      <ProductDocumentationManagement
+        status="installed"
+        inferenceId={defaultInferenceEndpoints.ELSER}
+      />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -41,7 +52,12 @@ describe('ProductDocumentationManagement', () => {
       isLoading: false,
       isSuccess: false,
     });
-    const { container } = render(<ProductDocumentationManagement status="installing" />);
+    const { container } = render(
+      <ProductDocumentationManagement
+        status="installing"
+        inferenceId={defaultInferenceEndpoints.ELSER}
+      />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -51,7 +67,12 @@ describe('ProductDocumentationManagement', () => {
       isLoading: true,
       isSuccess: false,
     });
-    render(<ProductDocumentationManagement status="uninstalled" />);
+    render(
+      <ProductDocumentationManagement
+        status="uninstalled"
+        inferenceId={defaultInferenceEndpoints.ELSER}
+      />
+    );
     expect(screen.getByTestId('installing')).toBeInTheDocument();
     expect(screen.getByText(i18n.INSTALLING)).toBeInTheDocument();
   });
@@ -63,7 +84,12 @@ describe('ProductDocumentationManagement', () => {
       isSuccess: true,
     });
     mockInstallProductDoc.mockResolvedValueOnce({});
-    render(<ProductDocumentationManagement status="uninstalled" />);
+    render(
+      <ProductDocumentationManagement
+        status="uninstalled"
+        inferenceId={defaultInferenceEndpoints.ELSER}
+      />
+    );
     expect(screen.queryByText(i18n.INSTALL)).not.toBeInTheDocument();
   });
 
@@ -74,7 +100,12 @@ describe('ProductDocumentationManagement', () => {
       isSuccess: false,
     });
     mockInstallProductDoc.mockRejectedValueOnce(new Error('Installation failed'));
-    render(<ProductDocumentationManagement status="uninstalled" />);
+    render(
+      <ProductDocumentationManagement
+        status="uninstalled"
+        inferenceId={defaultInferenceEndpoints.ELSER}
+      />
+    );
     fireEvent.click(screen.getByText(i18n.INSTALL));
     await waitFor(() => expect(screen.getByText(i18n.INSTALL)).toBeInTheDocument());
   });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/product_documentation/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/product_documentation/index.tsx
@@ -21,7 +21,8 @@ import * as i18n from './translations';
 
 export const ProductDocumentationManagement = React.memo<{
   status?: InstallationStatus;
-}>(({ status }) => {
+  inferenceId: string;
+}>(({ status, inferenceId }) => {
   const {
     mutateAsync: installProductDoc,
     isSuccess: isInstalled,
@@ -29,8 +30,8 @@ export const ProductDocumentationManagement = React.memo<{
   } = useInstallProductDoc();
 
   const onClickInstall = useCallback(() => {
-    installProductDoc();
-  }, [installProductDoc]);
+    installProductDoc(inferenceId);
+  }, [installProductDoc, inferenceId]);
 
   const content = useMemo(() => {
     if (isInstalling) {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
@@ -32,6 +32,7 @@ import { css } from '@emotion/react';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
 import useAsync from 'react-use/lib/useAsync';
 import { useSearchParams } from 'react-router-dom-v5-compat';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { useKnowledgeBaseUpdater } from '../../assistant/settings/use_settings_updater/use_knowledge_base_updater';
 import { ProductDocumentationManagement } from '../../assistant/settings/product_documentation';
 import { KnowledgeBaseTour } from '../../tour/knowledge_base';
@@ -338,7 +339,10 @@ export const KnowledgeBaseSettingsManagement: React.FC<Params> = React.memo(({ d
 
   return (
     <>
-      <ProductDocumentationManagement status={kbStatus?.product_documentation_status} />
+      <ProductDocumentationManagement
+        status={kbStatus?.product_documentation_status}
+        inferenceId={defaultInferenceEndpoints.ELSER}
+      />
       <EuiPanel hasShadow={false} hasBorder paddingSize="l">
         <EuiText size={'m'}>
           <FormattedMessage

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/tsconfig.json
@@ -44,5 +44,6 @@
     "@kbn/datemath",
     "@kbn/alerts-ui-shared",
     "@kbn/deeplinks-security",
+    "@kbn/inference-common",
   ]
 }

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc_status.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc_status.ts
@@ -9,13 +9,13 @@ import { useQuery } from '@tanstack/react-query';
 import { REACT_QUERY_KEYS } from '../constants';
 import { useKibana } from './use_kibana';
 
-export function useGetProductDocStatus() {
+export function useGetProductDocStatus(inferenceId: string | undefined) {
   const { productDocBase } = useKibana().services;
 
   const { isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery({
-    queryKey: [REACT_QUERY_KEYS.GET_PRODUCT_DOC_STATUS],
+    queryKey: [REACT_QUERY_KEYS.GET_PRODUCT_DOC_STATUS, inferenceId],
     queryFn: async () => {
-      return productDocBase!.installation.getStatus();
+      return productDocBase!.installation.getStatus({ inferenceId });
     },
     keepPreviousData: false,
     refetchOnWindowFocus: false,

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_install_product_doc.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_install_product_doc.ts
@@ -20,11 +20,10 @@ export function useInstallProductDoc() {
     notifications: { toasts },
   } = useKibana().services;
   const queryClient = useQueryClient();
-
-  return useMutation<PerformInstallResponse, ServerError, void>(
+  return useMutation<PerformInstallResponse, ServerError, string>(
     [REACT_QUERY_KEYS.INSTALL_PRODUCT_DOC],
-    () => {
-      return productDocBase!.installation.install();
+    (inferenceId: string) => {
+      return productDocBase!.installation.install({ inferenceId });
     },
     {
       onSuccess: () => {

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_uninstall_product_doc.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_uninstall_product_doc.ts
@@ -21,10 +21,10 @@ export function useUninstallProductDoc() {
   } = useKibana().services;
   const queryClient = useQueryClient();
 
-  return useMutation<UninstallResponse, ServerError, void>(
+  return useMutation<UninstallResponse, ServerError, string>(
     [REACT_QUERY_KEYS.UNINSTALL_PRODUCT_DOC],
-    () => {
-      return productDocBase!.installation.uninstall();
+    (inferenceId: string) => {
+      return productDocBase!.installation.uninstall({ inferenceId });
     },
     {
       onSuccess: () => {

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useKnowledgeBase } from '@kbn/ai-assistant';
 import { useKibana } from '../../../hooks/use_kibana';
 import { useGetProductDocStatus } from '../../../hooks/use_get_product_doc_status';
 import { useInstallProductDoc } from '../../../hooks/use_install_product_doc';
@@ -26,22 +27,29 @@ import { useUninstallProductDoc } from '../../../hooks/use_uninstall_product_doc
 export function ProductDocEntry() {
   const { overlays } = useKibana().services;
 
-  const [isInstalled, setInstalled] = useState<boolean>(true);
+  const knowledgeBase = useKnowledgeBase();
+  const selectedInferenceId: string | undefined = knowledgeBase.status.value?.currentInferenceId;
+
+  const [isInstalled, setInstalled] = useState<boolean>(false);
   const [isInstalling, setInstalling] = useState<boolean>(false);
 
   const { mutateAsync: installProductDoc } = useInstallProductDoc();
   const { mutateAsync: uninstallProductDoc } = useUninstallProductDoc();
-  const { status, isLoading: isStatusLoading } = useGetProductDocStatus();
+  const { status, isLoading: isStatusLoading } = useGetProductDocStatus(selectedInferenceId);
 
   useEffect(() => {
+    if (isStatusLoading) return;
     if (status) {
-      setInstalled(status.overall === 'installed');
+      setInstalled(status.overall === 'installed' && status.inferenceId === selectedInferenceId);
     }
-  }, [status]);
+  }, [selectedInferenceId, status, isStatusLoading]);
 
   const onClickInstall = useCallback(() => {
+    if (!selectedInferenceId) {
+      throw new Error('Inference ID is required to install product documentation');
+    }
     setInstalling(true);
-    installProductDoc().then(
+    installProductDoc(selectedInferenceId).then(
       () => {
         setInstalling(false);
         setInstalled(true);
@@ -51,7 +59,7 @@ export function ProductDocEntry() {
         setInstalled(false);
       }
     );
-  }, [installProductDoc]);
+  }, [installProductDoc, selectedInferenceId]);
 
   const onClickUninstall = useCallback(() => {
     overlays
@@ -72,18 +80,18 @@ export function ProductDocEntry() {
         }
       )
       .then((confirmed) => {
-        if (confirmed) {
-          uninstallProductDoc().then(() => {
+        if (confirmed && selectedInferenceId) {
+          uninstallProductDoc(selectedInferenceId).then(() => {
             setInstalling(false);
             setInstalled(false);
           });
         }
       });
-  }, [overlays, uninstallProductDoc]);
+  }, [overlays, uninstallProductDoc, selectedInferenceId]);
 
   const content = useMemo(() => {
     if (isStatusLoading) {
-      return <></>;
+      return <EuiLoadingSpinner size="m" />;
     }
     if (isInstalling) {
       return (

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
@@ -48,6 +48,11 @@ describe('SettingsTab', () => {
           basePath: { prepend: prependMock },
         },
         productDocBase: undefined,
+        notifications: {
+          toasts: {
+            add: jest.fn(),
+          },
+        },
       },
     });
     useKnowledgeBaseMock.mockReturnValue({

--- a/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/plugin.ts
@@ -7,6 +7,7 @@
 
 import type { Logger } from '@kbn/logging';
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import type { LlmTasksConfig } from './config';
 import type {
   LlmTasksPluginSetup,
@@ -41,7 +42,9 @@ export class LlmTasksPlugin
     const { inference, productDocBase } = startDependencies;
     return {
       retrieveDocumentationAvailable: async () => {
-        const docBaseStatus = await startDependencies.productDocBase.management.getStatus();
+        const docBaseStatus = await startDependencies.productDocBase.management.getStatus({
+          inferenceId: defaultInferenceEndpoints.ELSER,
+        });
         return docBaseStatus.status === 'installed';
       },
       retrieveDocumentation: (options) => {

--- a/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/tasks/retrieve_documentation/retrieve_documentation.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/tasks/retrieve_documentation/retrieve_documentation.test.ts
@@ -16,6 +16,7 @@ const truncateMock = truncate as jest.MockedFn<typeof truncate>;
 const countTokensMock = countTokens as jest.MockedFn<typeof countTokens>;
 
 import { summarizeDocument } from './summarize_document';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 jest.mock('./summarize_document');
 const summarizeDocumentMock = summarizeDocument as jest.MockedFn<typeof summarizeDocument>;
 
@@ -65,6 +66,7 @@ describe('retrieveDocumentation', () => {
       max: 5,
       connectorId: '.my-connector',
       functionCalling: 'simulated',
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
 
     expect(result).toEqual({
@@ -78,6 +80,7 @@ describe('retrieveDocumentation', () => {
       products: ['kibana'],
       max: 5,
       highlights: 4,
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
   });
 
@@ -92,6 +95,7 @@ describe('retrieveDocumentation', () => {
       max: 5,
       connectorId: '.my-connector',
       functionCalling: 'simulated',
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
 
     expect(searchDocAPI).toHaveBeenCalledTimes(1);
@@ -100,6 +104,7 @@ describe('retrieveDocumentation', () => {
       products: ['kibana'],
       max: 5,
       highlights: 0,
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
   });
 
@@ -127,6 +132,7 @@ describe('retrieveDocumentation', () => {
       connectorId: '.my-connector',
       maxDocumentTokens: 100,
       tokenReductionStrategy: 'highlight',
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
 
     expect(result.documents.length).toEqual(3);
@@ -162,6 +168,7 @@ describe('retrieveDocumentation', () => {
       connectorId: '.my-connector',
       maxDocumentTokens: 100,
       tokenReductionStrategy: 'truncate',
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
 
     expect(result.documents.length).toEqual(3);
@@ -201,6 +208,7 @@ describe('retrieveDocumentation', () => {
       connectorId: '.my-connector',
       maxDocumentTokens: 100,
       tokenReductionStrategy: 'summarize',
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
 
     expect(result.documents.length).toEqual(3);
@@ -230,6 +238,7 @@ describe('retrieveDocumentation', () => {
       connectorId: '.my-connector',
       maxDocumentTokens: 100,
       tokenReductionStrategy: 'summarize',
+      inferenceId: defaultInferenceEndpoints.ELSER,
     });
 
     expect(result).toEqual({

--- a/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/tasks/retrieve_documentation/retrieve_documentation.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/tasks/retrieve_documentation/retrieve_documentation.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Logger } from '@kbn/logging';
-import type { OutputAPI } from '@kbn/inference-common';
+import { type OutputAPI } from '@kbn/inference-common';
 import type { ProductDocSearchAPI, DocSearchResult } from '@kbn/product-doc-base-plugin/server';
 import { truncate, count as countTokens } from '../../utils/tokens';
 import type { RetrieveDocumentationAPI } from './types';
@@ -30,6 +30,7 @@ export const retrieveDocumentation =
     connectorId,
     products,
     functionCalling,
+    inferenceId,
     max = MAX_DOCUMENTS_DEFAULT,
     maxDocumentTokens = MAX_TOKENS_DEFAULT,
     tokenReductionStrategy = 'highlight',
@@ -65,6 +66,7 @@ export const retrieveDocumentation =
         products,
         max,
         highlights,
+        inferenceId,
       });
 
       log.debug(`searching with term=[${searchTerm}] returned ${results.length} documents`);

--- a/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/tasks/retrieve_documentation/types.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/tasks/retrieve_documentation/types.ts
@@ -58,6 +58,10 @@ export interface RetrieveDocumentationParams {
    * Optional functionCalling parameter to pass down to the inference APIs.
    */
   functionCalling?: FunctionCallingMode;
+  /**
+   * Inferece ID to route the request to the right index to perform the search.
+   */
+  inferenceId: string;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/common/http_api/installation.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/common/http_api/installation.ts
@@ -13,14 +13,20 @@ export const INSTALL_ALL_API_PATH = '/internal/product_doc_base/install';
 export const UNINSTALL_ALL_API_PATH = '/internal/product_doc_base/uninstall';
 
 export interface InstallationStatusResponse {
+  inferenceId: string;
   overall: InstallationStatus;
   perProducts: Record<ProductName, ProductInstallState>;
 }
 
 export interface PerformInstallResponse {
   installed: boolean;
+  failureReason?: string;
 }
 
 export interface UninstallResponse {
   success: boolean;
+}
+
+export interface ProductDocInstallParams {
+  inferenceId: string | undefined;
 }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/common/install_status.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/common/install_status.ts
@@ -20,9 +20,11 @@ export interface ProductDocInstallStatus {
   lastInstallationDate: Date | undefined;
   lastInstallationFailureReason: string | undefined;
   indexName?: string;
+  inferenceId?: string;
 }
 
 export interface ProductInstallState {
   status: InstallationStatus;
   version?: string;
+  failureReason?: string;
 }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/plugin.tsx
@@ -16,6 +16,10 @@ import type {
 } from './types';
 import { InstallationService } from './services/installation';
 
+interface ProductDocInstallServiceParams {
+  inferenceId: string;
+}
+
 export class ProductDocBasePlugin
   implements
     Plugin<
@@ -42,9 +46,11 @@ export class ProductDocBasePlugin
 
     return {
       installation: {
-        getStatus: () => installationService.getInstallationStatus(),
-        install: () => installationService.install(),
-        uninstall: () => installationService.uninstall(),
+        getStatus: (params: ProductDocInstallServiceParams) =>
+          installationService.getInstallationStatus(params),
+        install: (params: ProductDocInstallServiceParams) => installationService.install(params),
+        uninstall: (params: ProductDocInstallServiceParams) =>
+          installationService.uninstall(params),
       },
     };
   }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/services/installation/installation_service.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/services/installation/installation_service.test.ts
@@ -12,6 +12,9 @@ import {
   INSTALL_ALL_API_PATH,
   UNINSTALL_ALL_API_PATH,
 } from '../../../common/http_api/installation';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
+
+const inferenceId = defaultInferenceEndpoints.ELSER;
 
 describe('InstallationService', () => {
   let http: ReturnType<typeof httpServiceMock.createSetupContract>;
@@ -24,16 +27,31 @@ describe('InstallationService', () => {
 
   describe('#getInstallationStatus', () => {
     it('calls the endpoint with the right parameters', async () => {
-      await service.getInstallationStatus();
+      await service.getInstallationStatus({ inferenceId });
       expect(http.get).toHaveBeenCalledTimes(1);
-      expect(http.get).toHaveBeenCalledWith(INSTALLATION_STATUS_API_PATH);
+      expect(http.get).toHaveBeenCalledWith(INSTALLATION_STATUS_API_PATH, {
+        query: {
+          inferenceId,
+        },
+      });
     });
     it('returns the value from the server', async () => {
       const expected = { stubbed: true };
       http.get.mockResolvedValue(expected);
 
-      const response = await service.getInstallationStatus();
+      const response = await service.getInstallationStatus({ inferenceId });
       expect(response).toEqual(expected);
+    });
+    it('calls the endpoint with the right parameters for different inference IDs', async () => {
+      await service.getInstallationStatus({
+        inferenceId: defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL,
+      });
+      expect(http.get).toHaveBeenCalledTimes(1);
+      expect(http.get).toHaveBeenCalledWith(INSTALLATION_STATUS_API_PATH, {
+        query: {
+          inferenceId: defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL,
+        },
+      });
     });
   });
   describe('#install', () => {
@@ -42,37 +60,68 @@ describe('InstallationService', () => {
     });
 
     it('calls the endpoint with the right parameters', async () => {
-      await service.install();
+      await service.install({ inferenceId });
       expect(http.post).toHaveBeenCalledTimes(1);
-      expect(http.post).toHaveBeenCalledWith(INSTALL_ALL_API_PATH);
+      expect(http.post).toHaveBeenCalledWith(INSTALL_ALL_API_PATH, {
+        body: JSON.stringify({
+          inferenceId,
+        }),
+      });
+    });
+    it('calls the endpoint with the right parameters for different inference IDs', async () => {
+      await service.install({
+        inferenceId: defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL,
+      });
+      expect(http.post).toHaveBeenCalledTimes(1);
+      expect(http.post).toHaveBeenCalledWith(INSTALL_ALL_API_PATH, {
+        body: JSON.stringify({
+          inferenceId: defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL,
+        }),
+      });
     });
     it('returns the value from the server', async () => {
       const expected = { installed: true };
       http.post.mockResolvedValue(expected);
 
-      const response = await service.install();
+      const response = await service.install({ inferenceId });
       expect(response).toEqual(expected);
     });
     it('throws when the server returns installed: false', async () => {
       const expected = { installed: false };
       http.post.mockResolvedValue(expected);
 
-      await expect(service.install()).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Installation did not complete successfully"`
+      await expect(service.install({ inferenceId })).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Installation did not complete successfully."`
       );
     });
   });
   describe('#uninstall', () => {
     it('calls the endpoint with the right parameters', async () => {
-      await service.uninstall();
+      await service.uninstall({ inferenceId });
       expect(http.post).toHaveBeenCalledTimes(1);
-      expect(http.post).toHaveBeenCalledWith(UNINSTALL_ALL_API_PATH);
+      expect(http.post).toHaveBeenCalledWith(UNINSTALL_ALL_API_PATH, {
+        body: JSON.stringify({
+          inferenceId,
+        }),
+      });
     });
+    it('calls the endpoint with the right parameters for different inference IDs', async () => {
+      await service.uninstall({
+        inferenceId: defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL,
+      });
+      expect(http.post).toHaveBeenCalledTimes(1);
+      expect(http.post).toHaveBeenCalledWith(UNINSTALL_ALL_API_PATH, {
+        body: JSON.stringify({
+          inferenceId: defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL,
+        }),
+      });
+    });
+
     it('returns the value from the server', async () => {
       const expected = { stubbed: true };
       http.post.mockResolvedValue(expected);
 
-      const response = await service.uninstall();
+      const response = await service.uninstall({ inferenceId });
       expect(response).toEqual(expected);
     });
   });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/services/installation/installation_service.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/services/installation/installation_service.ts
@@ -6,6 +6,7 @@
  */
 
 import type { HttpSetup } from '@kbn/core-http-browser';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import {
   INSTALLATION_STATUS_API_PATH,
   INSTALL_ALL_API_PATH,
@@ -22,19 +23,42 @@ export class InstallationService {
     this.http = http;
   }
 
-  async getInstallationStatus(): Promise<InstallationStatusResponse> {
-    return await this.http.get<InstallationStatusResponse>(INSTALLATION_STATUS_API_PATH);
+  async getInstallationStatus(params: {
+    inferenceId: string;
+  }): Promise<InstallationStatusResponse> {
+    const inferenceId = params?.inferenceId ?? defaultInferenceEndpoints.ELSER;
+
+    const response = await this.http.get<InstallationStatusResponse>(INSTALLATION_STATUS_API_PATH, {
+      query: { inferenceId },
+    });
+
+    return response;
   }
 
-  async install(): Promise<PerformInstallResponse> {
-    const response = await this.http.post<PerformInstallResponse>(INSTALL_ALL_API_PATH);
+  async install(params: { inferenceId: string }): Promise<PerformInstallResponse> {
+    const inferenceId = params?.inferenceId ?? defaultInferenceEndpoints.ELSER;
+
+    const response = await this.http.post<PerformInstallResponse>(INSTALL_ALL_API_PATH, {
+      body: JSON.stringify({ inferenceId }),
+    });
+
     if (!response.installed) {
-      throw new Error('Installation did not complete successfully');
+      throw new Error(
+        `Installation did not complete successfully.${
+          response.failureReason ? `\n${response.failureReason}` : ''
+        }`
+      );
     }
     return response;
   }
 
-  async uninstall(): Promise<UninstallResponse> {
-    return await this.http.post<UninstallResponse>(UNINSTALL_ALL_API_PATH);
+  async uninstall(params: { inferenceId: string }): Promise<UninstallResponse> {
+    const inferenceId = params?.inferenceId ?? defaultInferenceEndpoints.ELSER;
+
+    const response = await this.http.post<UninstallResponse>(UNINSTALL_ALL_API_PATH, {
+      body: JSON.stringify({ inferenceId }),
+    });
+
+    return response;
   }
 }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/services/installation/types.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/public/services/installation/types.ts
@@ -9,10 +9,11 @@ import type {
   InstallationStatusResponse,
   PerformInstallResponse,
   UninstallResponse,
+  ProductDocInstallParams,
 } from '../../../common/http_api/installation';
 
 export interface InstallationAPI {
-  getStatus(): Promise<InstallationStatusResponse>;
-  install(): Promise<PerformInstallResponse>;
-  uninstall(): Promise<UninstallResponse>;
+  getStatus(params: ProductDocInstallParams): Promise<InstallationStatusResponse>;
+  install(params: ProductDocInstallParams): Promise<PerformInstallResponse>;
+  uninstall(params: ProductDocInstallParams): Promise<UninstallResponse>;
 }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/plugin.ts
@@ -10,6 +10,7 @@ import type { Logger } from '@kbn/logging';
 import { getDataPath } from '@kbn/utils';
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import { SavedObjectsClient } from '@kbn/core/server';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { productDocInstallStatusSavedObjectTypeName } from '../common/consts';
 import type { ProductDocBaseConfig } from './config';
 import {
@@ -76,7 +77,10 @@ export class ProductDocBasePlugin
     const soClient = new SavedObjectsClient(
       core.savedObjects.createInternalRepository([productDocInstallStatusSavedObjectTypeName])
     );
-    const productDocClient = new ProductDocInstallClient({ soClient });
+    const productDocClient = new ProductDocInstallClient({
+      soClient,
+      log: this.logger,
+    });
 
     const packageInstaller = new PackageInstaller({
       esClient: core.elasticsearch.client.asInternalUser,
@@ -110,7 +114,7 @@ export class ProductDocBasePlugin
       taskManager,
     };
 
-    documentationManager.update().catch((err) => {
+    documentationManager.update({ inferenceId: defaultInferenceEndpoints.ELSER }).catch((err) => {
       this.logger.error(`Error scheduling product documentation update task: ${err.message}`);
     });
 

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/saved_objects/product_doc_install.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/saved_objects/product_doc_install.ts
@@ -7,6 +7,7 @@
 
 import type { SavedObjectsType } from '@kbn/core/server';
 import type { ProductName } from '@kbn/product-doc-common';
+import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
 import { productDocInstallStatusSavedObjectTypeName } from '../../common/consts';
 import type { InstallationStatus } from '../../common/install_status';
 
@@ -22,7 +23,18 @@ export interface ProductDocInstallStatusAttributes {
   last_installation_date?: number;
   last_installation_failure_reason?: string;
   index_name?: string;
+  inference_id?: string;
 }
+const modelVersion1: SavedObjectsModelVersion = {
+  changes: [
+    {
+      type: 'mappings_addition',
+      addedMappings: {
+        inference_id: { type: 'keyword' },
+      },
+    },
+  ],
+};
 
 export const productDocInstallStatusSavedObjectType: SavedObjectsType<ProductDocInstallStatusAttributes> =
   {
@@ -37,10 +49,11 @@ export const productDocInstallStatusSavedObjectType: SavedObjectsType<ProductDoc
         installation_status: { type: 'keyword' },
         last_installation_date: { type: 'date' },
         index_name: { type: 'keyword' },
+        inference_id: { type: 'keyword' },
       },
     },
     management: {
       importableAndExportable: false,
     },
-    modelVersions: {},
+    modelVersions: { '1': modelVersion1 },
   };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/model_conversion.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/model_conversion.ts
@@ -22,5 +22,6 @@ export const soToModel = (
       ? new Date(so.attributes.last_installation_date)
       : undefined,
     lastInstallationFailureReason: so.attributes.last_installation_failure_reason,
+    inferenceId: so.attributes.inference_id,
   };
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.test.ts
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import type { SavedObjectsFindResult } from '@kbn/core/server';
+import type { Logger, SavedObjectsFindResult } from '@kbn/core/server';
 import { DocumentationProduct } from '@kbn/product-doc-common';
 import type { ProductDocInstallStatusAttributes as TypeAttributes } from '../../saved_objects';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { ProductDocInstallClient } from './product_doc_install_service';
+import { loggingSystemMock } from '@kbn/core/public/mocks';
 
+const inferenceId = '.elser-2-elasticsearch';
 const createObj = (attrs: TypeAttributes): SavedObjectsFindResult<TypeAttributes> => {
   return {
     id: attrs.product_name,
@@ -24,10 +26,12 @@ const createObj = (attrs: TypeAttributes): SavedObjectsFindResult<TypeAttributes
 describe('ProductDocInstallClient', () => {
   let soClient: ReturnType<typeof savedObjectsClientMock.create>;
   let service: ProductDocInstallClient;
+  let log: Logger;
 
   beforeEach(() => {
     soClient = savedObjectsClientMock.create();
-    service = new ProductDocInstallClient({ soClient });
+    log = loggingSystemMock.createLogger();
+    service = new ProductDocInstallClient({ soClient, log });
   });
 
   describe('getInstallationStatus', () => {
@@ -50,7 +54,7 @@ describe('ProductDocInstallClient', () => {
         page: 1,
       });
 
-      const installStatus = await service.getInstallationStatus();
+      const installStatus = await service.getInstallationStatus({ inferenceId });
 
       expect(Object.keys(installStatus).sort()).toEqual(Object.keys(DocumentationProduct).sort());
       expect(installStatus.kibana).toEqual({

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.ts
@@ -8,74 +8,130 @@
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { ProductName, DocumentationProduct } from '@kbn/product-doc-common';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
+import type { Logger } from '@kbn/logging';
+import { isImpliedDefaultElserInferenceId } from '@kbn/product-doc-common/src/is_default_inference_endpoint';
 import type { ProductInstallState } from '../../../common/install_status';
 import { productDocInstallStatusSavedObjectTypeName as typeName } from '../../../common/consts';
 import type { ProductDocInstallStatusAttributes as TypeAttributes } from '../../saved_objects';
 
 export class ProductDocInstallClient {
   private soClient: SavedObjectsClientContract;
+  private log: Logger;
 
-  constructor({ soClient }: { soClient: SavedObjectsClientContract }) {
+  constructor({ soClient, log }: { soClient: SavedObjectsClientContract; log: Logger }) {
     this.soClient = soClient;
+    this.log = log;
   }
 
-  async getInstallationStatus(): Promise<Record<ProductName, ProductInstallState>> {
-    const response = await this.soClient.find<TypeAttributes>({
+  async getPreviouslyInstalledInferenceIds(): Promise<string[]> {
+    const query = {
       type: typeName,
       perPage: 100,
-    });
+    };
+    const response = await this.soClient.find<TypeAttributes>(query);
+    const inferenceIds = new Set(
+      response?.saved_objects.map(
+        (so) => so.attributes?.inference_id ?? defaultInferenceEndpoints.ELSER
+      )
+    );
+    return Array.from(inferenceIds);
+  }
 
+  async getInstallationStatus({
+    inferenceId,
+  }: {
+    inferenceId: string;
+  }): Promise<Record<ProductName, ProductInstallState>> {
+    const query = {
+      type: typeName,
+      perPage: 100,
+    };
     const installStatus = Object.values(DocumentationProduct).reduce((memo, product) => {
       memo[product] = { status: 'uninstalled' };
       return memo;
     }, {} as Record<ProductName, ProductInstallState>);
+    try {
+      const response = await this.soClient.find<TypeAttributes>(query);
+      const savedObjects = isImpliedDefaultElserInferenceId(inferenceId)
+        ? response?.saved_objects.filter((so) =>
+            isImpliedDefaultElserInferenceId(so.attributes.inference_id)
+          )
+        : response?.saved_objects.filter((so) => so.attributes.inference_id === inferenceId);
 
-    response.saved_objects.forEach(({ attributes }) => {
-      installStatus[attributes.product_name as ProductName] = {
-        status: attributes.installation_status,
-        version: attributes.product_version,
-      };
-    });
+      savedObjects?.forEach(({ attributes }) => {
+        installStatus[attributes.product_name as ProductName] = {
+          status: attributes.installation_status,
+          version: attributes.product_version,
+          ...(attributes.last_installation_failure_reason
+            ? { failureReason: attributes.last_installation_failure_reason }
+            : {}),
+        };
+      });
 
-    return installStatus;
+      return installStatus;
+    } catch (error) {
+      this.log.error(
+        `An error occurred getting installation status saved object for inferenceId [${inferenceId}]
+        Query: ${JSON.stringify(query, null, 2)}`,
+        error
+      );
+      return installStatus;
+    }
   }
 
-  async setInstallationStarted(fields: { productName: ProductName; productVersion: string }) {
-    const { productName, productVersion } = fields;
-    const objectId = getObjectIdFromProductName(productName);
+  async setInstallationStarted(fields: {
+    productName: ProductName;
+    productVersion: string;
+    inferenceId: string | undefined;
+  }) {
+    const { productName, productVersion, inferenceId } = fields;
+    const objectId = getObjectIdFromProductName(productName, inferenceId);
     const attributes = {
       product_name: productName,
       product_version: productVersion,
       installation_status: 'installing' as const,
       last_installation_failure_reason: '',
+      inference_id: inferenceId,
     };
     await this.soClient.update<TypeAttributes>(typeName, objectId, attributes, {
       upsert: attributes,
     });
   }
 
-  async setInstallationSuccessful(productName: ProductName, indexName: string) {
-    const objectId = getObjectIdFromProductName(productName);
+  async setInstallationSuccessful(
+    productName: ProductName,
+    indexName: string,
+    inferenceId: string | undefined
+  ) {
+    const objectId = getObjectIdFromProductName(productName, inferenceId);
     await this.soClient.update<TypeAttributes>(typeName, objectId, {
       installation_status: 'installed',
       index_name: indexName,
+      inference_id: inferenceId,
     });
   }
 
-  async setInstallationFailed(productName: ProductName, failureReason: string) {
-    const objectId = getObjectIdFromProductName(productName);
+  async setInstallationFailed(
+    productName: ProductName,
+    failureReason: string,
+    inferenceId: string | undefined
+  ) {
+    const objectId = getObjectIdFromProductName(productName, inferenceId);
     await this.soClient.update<TypeAttributes>(typeName, objectId, {
       installation_status: 'error',
       last_installation_failure_reason: failureReason,
+      inference_id: inferenceId,
     });
   }
 
-  async setUninstalled(productName: ProductName) {
-    const objectId = getObjectIdFromProductName(productName);
+  async setUninstalled(productName: ProductName, inferenceId: string | undefined) {
+    const objectId = getObjectIdFromProductName(productName, inferenceId);
     try {
       await this.soClient.update<TypeAttributes>(typeName, objectId, {
         installation_status: 'uninstalled',
         last_installation_failure_reason: '',
+        inference_id: inferenceId,
       });
     } catch (e) {
       if (!SavedObjectsErrorHelpers.isNotFoundError(e)) {
@@ -85,5 +141,7 @@ export class ProductDocInstallClient {
   }
 }
 
-const getObjectIdFromProductName = (productName: ProductName) =>
-  `kb-product-doc-${productName}-status`.toLowerCase();
+const getObjectIdFromProductName = (productName: ProductName, inferenceId: string | undefined) => {
+  const inferenceIdPart = !isImpliedDefaultElserInferenceId(inferenceId) ? `-${inferenceId}` : '';
+  return `kb-product-doc-${productName}${inferenceIdPart}-status`.toLowerCase();
+};

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/service.mock.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/service.mock.ts
@@ -16,6 +16,7 @@ const createInstallClientMock = (): InstallClientMock => {
     setInstallationSuccessful: jest.fn(),
     setInstallationFailed: jest.fn(),
     setUninstalled: jest.fn(),
+    getPreviouslyInstalledInferenceIds: jest.fn().mockResolvedValue([]),
   } as unknown as InstallClientMock;
 };
 

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_manager/doc_manager.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_manager/doc_manager.test.ts
@@ -20,6 +20,7 @@ import {
   getTaskStatus,
   waitUntilTaskCompleted,
 } from '../../tasks';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
 const scheduleInstallAllTaskMock = scheduleInstallAllTask as jest.MockedFn<
   typeof scheduleInstallAllTask
@@ -35,6 +36,7 @@ const waitUntilTaskCompletedMock = waitUntilTaskCompleted as jest.MockedFn<
 >;
 const getTaskStatusMock = getTaskStatus as jest.MockedFn<typeof getTaskStatus>;
 
+const DEFAULT_INFERENCE_ID = defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL;
 describe('DocumentationManager', () => {
   let logger: MockedLogger;
   let taskManager: ReturnType<typeof taskManagerMock.createStart>;
@@ -85,19 +87,20 @@ describe('DocumentationManager', () => {
     });
 
     it('calls `scheduleInstallAllTask`', async () => {
-      await docManager.install({});
+      await docManager.install({ inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(scheduleInstallAllTaskMock).toHaveBeenCalledTimes(1);
       expect(scheduleInstallAllTaskMock).toHaveBeenCalledWith({
         taskManager,
         logger,
+        inferenceId: DEFAULT_INFERENCE_ID,
       });
 
       expect(waitUntilTaskCompletedMock).not.toHaveBeenCalled();
     });
 
     it('calls waitUntilTaskCompleted if wait=true', async () => {
-      await docManager.install({ wait: true });
+      await docManager.install({ wait: true, inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(scheduleInstallAllTaskMock).toHaveBeenCalledTimes(1);
       expect(waitUntilTaskCompletedMock).toHaveBeenCalledTimes(1);
@@ -108,7 +111,7 @@ describe('DocumentationManager', () => {
         kibana: { status: 'installed' },
       } as Awaited<ReturnType<ProductDocInstallClient['getInstallationStatus']>>);
 
-      await docManager.install({ wait: true });
+      await docManager.install({ wait: true, inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(scheduleInstallAllTaskMock).not.toHaveBeenCalled();
       expect(waitUntilTaskCompletedMock).not.toHaveBeenCalled();
@@ -120,7 +123,12 @@ describe('DocumentationManager', () => {
       const auditLog = auditService.withoutRequest;
       auditService.asScoped = jest.fn(() => auditLog);
 
-      await docManager.install({ force: false, wait: false, request });
+      await docManager.install({
+        force: false,
+        wait: false,
+        request,
+        inferenceId: DEFAULT_INFERENCE_ID,
+      });
 
       expect(auditLog.log).toHaveBeenCalledTimes(1);
       expect(auditLog.log).toHaveBeenCalledWith({
@@ -140,7 +148,7 @@ describe('DocumentationManager', () => {
       );
 
       await expect(
-        docManager.install({ force: false, wait: false })
+        docManager.install({ force: false, wait: false, inferenceId: DEFAULT_INFERENCE_ID })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Elastic documentation requires an enterprise license"`
       );
@@ -157,19 +165,20 @@ describe('DocumentationManager', () => {
     });
 
     it('calls `scheduleEnsureUpToDateTask`', async () => {
-      await docManager.update({});
+      await docManager.update({ inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(scheduleEnsureUpToDateTaskMock).toHaveBeenCalledTimes(1);
       expect(scheduleEnsureUpToDateTaskMock).toHaveBeenCalledWith({
         taskManager,
         logger,
+        inferenceId: DEFAULT_INFERENCE_ID,
       });
 
       expect(waitUntilTaskCompletedMock).not.toHaveBeenCalled();
     });
 
     it('calls waitUntilTaskCompleted if wait=true', async () => {
-      await docManager.update({ wait: true });
+      await docManager.update({ wait: true, inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(scheduleEnsureUpToDateTaskMock).toHaveBeenCalledTimes(1);
       expect(waitUntilTaskCompletedMock).toHaveBeenCalledTimes(1);
@@ -181,7 +190,7 @@ describe('DocumentationManager', () => {
       const auditLog = auditService.withoutRequest;
       auditService.asScoped = jest.fn(() => auditLog);
 
-      await docManager.update({ wait: false, request });
+      await docManager.update({ wait: false, request, inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(auditLog.log).toHaveBeenCalledTimes(1);
       expect(auditLog.log).toHaveBeenCalledWith({
@@ -206,19 +215,20 @@ describe('DocumentationManager', () => {
     });
 
     it('calls `scheduleUninstallAllTask`', async () => {
-      await docManager.uninstall({});
+      await docManager.uninstall({ inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(scheduleUninstallAllTaskMock).toHaveBeenCalledTimes(1);
       expect(scheduleUninstallAllTaskMock).toHaveBeenCalledWith({
         taskManager,
         logger,
+        inferenceId: DEFAULT_INFERENCE_ID,
       });
 
       expect(waitUntilTaskCompletedMock).not.toHaveBeenCalled();
     });
 
     it('calls waitUntilTaskCompleted if wait=true', async () => {
-      await docManager.uninstall({ wait: true });
+      await docManager.uninstall({ wait: true, inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(scheduleUninstallAllTaskMock).toHaveBeenCalledTimes(1);
       expect(waitUntilTaskCompletedMock).toHaveBeenCalledTimes(1);
@@ -230,7 +240,7 @@ describe('DocumentationManager', () => {
       const auditLog = auditService.withoutRequest;
       auditService.asScoped = jest.fn(() => auditLog);
 
-      await docManager.uninstall({ wait: false, request });
+      await docManager.uninstall({ wait: false, request, inferenceId: DEFAULT_INFERENCE_ID });
 
       expect(auditLog.log).toHaveBeenCalledTimes(1);
       expect(auditLog.log).toHaveBeenCalledWith({

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_manager/types.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_manager/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
-import type { InstallationStatus } from '../../../common/install_status';
+import type { InstallationStatus, ProductInstallState } from '../../../common/install_status';
 
 /**
  * APIs to manage the product documentation.
@@ -30,8 +30,9 @@ export interface DocumentationManagerAPI {
   uninstall(options?: DocUninstallOptions): Promise<void>;
   /**
    * Returns the overall installation status of the documentation.
+   * @param inferenceId - The inference ID to get the status for.
    */
-  getStatus(): Promise<DocGetStatusResponse>;
+  getStatus({ inferenceId }: { inferenceId: string }): Promise<DocGetStatusResponse>;
 }
 
 /**
@@ -39,6 +40,7 @@ export interface DocumentationManagerAPI {
  */
 export interface DocGetStatusResponse {
   status: InstallationStatus;
+  installStatus?: Record<string, ProductInstallState>;
 }
 
 /**
@@ -61,6 +63,10 @@ export interface DocInstallOptions {
    * Defaults to `false`
    */
   wait?: boolean;
+  /**
+   * If provided, the docs will be installed with the model indicated by Inference ID
+   */
+  inferenceId: string;
 }
 
 /**
@@ -78,6 +84,10 @@ export interface DocUninstallOptions {
    * Defaults to `false`
    */
   wait?: boolean;
+  /**
+   * If provided, the docs will be uninstalled with the model indicated by Inference ID
+   */
+  inferenceId: string;
 }
 
 /**
@@ -95,4 +105,8 @@ export interface DocUpdateOptions {
    * Defaults to `false`
    */
   wait?: boolean;
+  /**
+   * If provided, the docs will be updated with the model indicated by Inference ID
+   */
+  inferenceId: string;
 }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.ts
@@ -16,7 +16,7 @@ import {
   fetchArtifactVersionsMock,
   ensureDefaultElserDeployedMock,
 } from './package_installer.test.mocks';
-
+import { cloneDeep } from 'lodash';
 import {
   getArtifactName,
   getProductDocIndexName,
@@ -29,6 +29,7 @@ import { installClientMock } from '../doc_install_status/service.mock';
 import type { ProductInstallState } from '../../../common/install_status';
 import { PackageInstaller } from './package_installer';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
+import { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 
 const artifactsFolder = '/lost';
 const artifactRepositoryUrl = 'https://repository.com';
@@ -86,7 +87,15 @@ describe('PackageInstaller', () => {
       };
       openZipArchiveMock.mockResolvedValue(zipArchive);
 
-      const mappings = Symbol('mappings');
+      const mappings = {
+        properties: {
+          semantic: {
+            inference_id: '.elser',
+            type: 'semantic_text',
+            model_settings: {},
+          },
+        },
+      };
       loadMappingFileMock.mockResolvedValue(mappings);
 
       await packageInstaller.installPackage({ productName: 'kibana', productVersion: '8.16' });
@@ -114,10 +123,11 @@ describe('PackageInstaller', () => {
       expect(loadManifestFileMock).toHaveBeenCalledWith(zipArchive);
 
       expect(createIndexMock).toHaveBeenCalledTimes(1);
+      const modifiedMappings = cloneDeep(mappings);
+      modifiedMappings.properties.semantic.inference_id = defaultInferenceEndpoints.ELSER;
       expect(createIndexMock).toHaveBeenCalledWith({
-        elserInferenceId: defaultInferenceEndpoints.ELSER,
         indexName,
-        mappings,
+        mappings: modifiedMappings,
         manifestVersion: TEST_FORMAT_VERSION,
         esClient,
         log: logger,
@@ -125,16 +135,20 @@ describe('PackageInstaller', () => {
 
       expect(populateIndexMock).toHaveBeenCalledTimes(1);
       expect(populateIndexMock).toHaveBeenCalledWith({
-        elserInferenceId: defaultInferenceEndpoints.ELSER,
         indexName,
         archive: zipArchive,
         manifestVersion: TEST_FORMAT_VERSION,
+        inferenceId: defaultInferenceEndpoints.ELSER,
         esClient,
         log: logger,
       });
 
       expect(productDocClient.setInstallationSuccessful).toHaveBeenCalledTimes(1);
-      expect(productDocClient.setInstallationSuccessful).toHaveBeenCalledWith('kibana', indexName);
+      expect(productDocClient.setInstallationSuccessful).toHaveBeenCalledWith(
+        'kibana',
+        indexName,
+        defaultInferenceEndpoints.ELSER
+      );
 
       expect(zipArchive.close).toHaveBeenCalledTimes(1);
 
@@ -166,7 +180,16 @@ describe('PackageInstaller', () => {
       });
 
       await expect(
-        packageInstaller.installPackage({ productName: 'kibana', productVersion: '8.16' })
+        packageInstaller.installPackage({
+          productName: 'kibana',
+          productVersion: '8.16',
+          customInference: {
+            inference_id: defaultInferenceEndpoints.ELSER,
+            task_type: 'text_embedding' as InferenceTaskType,
+            service: 'elser',
+            service_settings: {},
+          },
+        })
       ).rejects.toThrowError();
 
       expect(productDocClient.setInstallationSuccessful).not.toHaveBeenCalled();
@@ -181,7 +204,8 @@ describe('PackageInstaller', () => {
       expect(productDocClient.setInstallationFailed).toHaveBeenCalledTimes(1);
       expect(productDocClient.setInstallationFailed).toHaveBeenCalledWith(
         'kibana',
-        'something bad'
+        'something bad',
+        defaultInferenceEndpoints.ELSER
       );
     });
   });
@@ -195,7 +219,7 @@ describe('PackageInstaller', () => {
         elasticsearch: ['8.15'],
       });
 
-      await packageInstaller.installAll({});
+      await packageInstaller.installAll({ inferenceId: defaultInferenceEndpoints.ELSER });
 
       expect(packageInstaller.installPackage).toHaveBeenCalledTimes(2);
 
@@ -226,7 +250,7 @@ describe('PackageInstaller', () => {
 
       jest.spyOn(packageInstaller, 'installPackage');
 
-      await packageInstaller.ensureUpToDate({});
+      await packageInstaller.ensureUpToDate({ inferenceId: defaultInferenceEndpoints.ELSER });
 
       expect(packageInstaller.installPackage).toHaveBeenCalledTimes(1);
       expect(packageInstaller.installPackage).toHaveBeenCalledWith({
@@ -249,7 +273,7 @@ describe('PackageInstaller', () => {
       );
 
       expect(productDocClient.setUninstalled).toHaveBeenCalledTimes(1);
-      expect(productDocClient.setUninstalled).toHaveBeenCalledWith('kibana');
+      expect(productDocClient.setUninstalled).toHaveBeenCalledWith('kibana', undefined);
     });
   });
 

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
@@ -14,6 +14,9 @@ import {
   type ProductName,
 } from '@kbn/product-doc-common';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
+import { cloneDeep } from 'lodash';
+import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
+import { i18n } from '@kbn/i18n';
 import type { ProductDocInstallClient } from '../doc_install_status';
 import {
   downloadToDisk,
@@ -22,6 +25,7 @@ import {
   loadManifestFile,
   ensureDefaultElserDeployed,
   type ZipArchive,
+  ensureInferenceDeployed,
 } from './utils';
 import { majorMinor, latestVersion } from './utils/semver';
 import {
@@ -30,6 +34,7 @@ import {
   createIndex,
   populateIndex,
 } from './steps';
+import { overrideInferenceSettings } from './steps/create_index';
 
 interface PackageInstallerOpts {
   artifactsFolder: string;
@@ -48,7 +53,7 @@ export class PackageInstaller {
   private readonly productDocClient: ProductDocInstallClient;
   private readonly artifactRepositoryUrl: string;
   private readonly currentVersion: string;
-  private readonly elserInferenceId?: string;
+  private readonly elserInferenceId: string;
 
   constructor({
     artifactsFolder,
@@ -68,16 +73,29 @@ export class PackageInstaller {
     this.elserInferenceId = elserInferenceId || defaultInferenceEndpoints.ELSER;
   }
 
+  private async getInferenceInfo(inferenceId?: string) {
+    if (!inferenceId) {
+      return;
+    }
+    const inferenceEndpoints = await this.esClient.inference.get({
+      inference_id: inferenceId,
+    });
+    return Array.isArray(inferenceEndpoints.endpoints) && inferenceEndpoints.endpoints.length > 0
+      ? inferenceEndpoints.endpoints[0]
+      : undefined;
+  }
   /**
    * Make sure that the currently installed doc packages are up to date.
    * Will not upgrade products that are not already installed
    */
-  async ensureUpToDate({}: {}) {
+  async ensureUpToDate(params: { inferenceId: string }) {
+    const { inferenceId } = params;
+    const inferenceInfo = await this.getInferenceInfo(inferenceId);
     const [repositoryVersions, installStatuses] = await Promise.all([
       fetchArtifactVersions({
         artifactRepositoryUrl: this.artifactRepositoryUrl,
       }),
-      this.productDocClient.getInstallationStatus(),
+      this.productDocClient.getInstallationStatus({ inferenceId }),
     ]);
 
     const toUpdate: Array<{
@@ -105,15 +123,19 @@ export class PackageInstaller {
       await this.installPackage({
         productName,
         productVersion,
+        customInference: inferenceInfo,
       });
     }
   }
 
-  async installAll({}: {}) {
+  async installAll(params: { inferenceId?: string } = {}) {
+    const { inferenceId } = params;
     const repositoryVersions = await fetchArtifactVersions({
       artifactRepositoryUrl: this.artifactRepositoryUrl,
     });
     const allProducts = Object.values(DocumentationProduct) as ProductName[];
+    const inferenceInfo = await this.getInferenceInfo(inferenceId);
+
     for (const productName of allProducts) {
       const availableVersions = repositoryVersions[productName];
       if (!availableVersions || !availableVersions.length) {
@@ -125,6 +147,7 @@ export class PackageInstaller {
       await this.installPackage({
         productName,
         productVersion: selectedVersion,
+        customInference: inferenceInfo,
       });
     }
   }
@@ -132,32 +155,53 @@ export class PackageInstaller {
   async installPackage({
     productName,
     productVersion,
+    customInference,
   }: {
     productName: ProductName;
     productVersion: string;
+    customInference?: InferenceInferenceEndpointInfo;
   }) {
+    const inferenceId = customInference?.inference_id ?? this.elserInferenceId;
+
     this.log.info(
-      `Starting installing documentation for product [${productName}] and version [${productVersion}]`
+      `Starting installing documentation for product [${productName}] and version [${productVersion}] with inference ID [${inferenceId}]`
     );
 
     productVersion = majorMinor(productVersion);
 
-    await this.uninstallPackage({ productName });
+    await this.uninstallPackage({ productName, inferenceId });
 
     let zipArchive: ZipArchive | undefined;
     try {
       await this.productDocClient.setInstallationStarted({
         productName,
         productVersion,
+        inferenceId,
       });
 
-      if (this.elserInferenceId === defaultInferenceEndpoints.ELSER) {
+      if (customInference && customInference?.inference_id !== this.elserInferenceId) {
+        if (customInference?.task_type !== 'text_embedding') {
+          throw new Error(
+            `Inference [${inferenceId}]'s task type ${customInference?.task_type} is not supported. Please use a model with task type 'text_embedding'.`
+          );
+        }
+        await ensureInferenceDeployed({
+          client: this.esClient,
+          inferenceId,
+        });
+      }
+
+      if (!customInference || customInference?.inference_id === this.elserInferenceId) {
         await ensureDefaultElserDeployed({
           client: this.esClient,
         });
       }
 
-      const artifactFileName = getArtifactName({ productName, productVersion });
+      const artifactFileName = getArtifactName({
+        productName,
+        productVersion,
+        inferenceId: customInference?.inference_id ?? this.elserInferenceId,
+      });
       const artifactUrl = `${this.artifactRepositoryUrl}/${artifactFileName}`;
       const artifactPath = `${this.artifactsFolder}/${artifactFileName}`;
 
@@ -165,7 +209,6 @@ export class PackageInstaller {
       await downloadToDisk(artifactUrl, artifactPath);
 
       zipArchive = await openZipArchive(artifactPath);
-
       validateArtifactArchive(zipArchive);
 
       const [manifest, mappings] = await Promise.all([
@@ -174,14 +217,16 @@ export class PackageInstaller {
       ]);
 
       const manifestVersion = manifest.formatVersion;
-      const indexName = getProductDocIndexName(productName);
+      const indexName = getProductDocIndexName(productName, customInference?.inference_id);
+
+      const modifiedMappings = cloneDeep(mappings);
+      overrideInferenceSettings(modifiedMappings, inferenceId!);
 
       await createIndex({
         indexName,
-        mappings,
+        mappings: modifiedMappings, // Mappings will be overridden by the inference ID and inference type
         manifestVersion,
         esClient: this.esClient,
-        elserInferenceId: this.elserInferenceId,
         log: this.log,
       });
 
@@ -191,27 +236,45 @@ export class PackageInstaller {
         archive: zipArchive,
         esClient: this.esClient,
         log: this.log,
-        elserInferenceId: this.elserInferenceId,
+        inferenceId,
       });
-      await this.productDocClient.setInstallationSuccessful(productName, indexName);
+      await this.productDocClient.setInstallationSuccessful(productName, indexName, inferenceId);
 
       this.log.info(
         `Documentation installation successful for product [${productName}] and version [${productVersion}]`
       );
     } catch (e) {
+      let message = e.message;
+      if (message.includes('End of central directory record signature not found.')) {
+        message = i18n.translate('aiInfra.productDocBase.packageInstaller.noArtifactAvailable', {
+          values: {
+            productName,
+            productVersion,
+            inferenceId,
+          },
+          defaultMessage:
+            'No documentation artifact available for product [{productName}]/[{productVersion}] for Inference ID [{inferenceId}]. Please select a different model or contact your administrator.',
+        });
+      }
       this.log.error(
-        `Error during documentation installation of product [${productName}]/[${productVersion}] : ${e.message}`
+        `Error during documentation installation of product [${productName}]/[${productVersion}] : ${message}`
       );
 
-      await this.productDocClient.setInstallationFailed(productName, e.message);
+      await this.productDocClient.setInstallationFailed(productName, message, inferenceId);
       throw e;
     } finally {
       zipArchive?.close();
     }
   }
 
-  async uninstallPackage({ productName }: { productName: ProductName }) {
-    const indexName = getProductDocIndexName(productName);
+  async uninstallPackage({
+    productName,
+    inferenceId,
+  }: {
+    productName: ProductName;
+    inferenceId?: string;
+  }) {
+    const indexName = getProductDocIndexName(productName, inferenceId);
     await this.esClient.indices.delete(
       {
         index: indexName,
@@ -219,13 +282,14 @@ export class PackageInstaller {
       { ignore: [404] }
     );
 
-    await this.productDocClient.setUninstalled(productName);
+    await this.productDocClient.setUninstalled(productName, inferenceId);
   }
 
-  async uninstallAll() {
+  async uninstallAll(params: { inferenceId?: string } = {}) {
+    const { inferenceId } = params;
     const allProducts = Object.values(DocumentationProduct);
     for (const productName of allProducts) {
-      await this.uninstallPackage({ productName });
+      await this.uninstallPackage({ productName, inferenceId });
     }
   }
 }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/steps/create_index.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/steps/create_index.ts
@@ -8,7 +8,7 @@
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { MappingTypeMapping, MappingProperty } from '@elastic/elasticsearch/lib/api/types';
-import { internalElserInferenceId } from '../../../../common/consts';
+import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import { isLegacySemanticTextVersion } from '../utils';
 
 export const createIndex = async ({
@@ -17,20 +17,16 @@ export const createIndex = async ({
   manifestVersion,
   mappings,
   log,
-  elserInferenceId = internalElserInferenceId,
 }: {
   esClient: ElasticsearchClient;
   indexName: string;
   manifestVersion: string;
   mappings: MappingTypeMapping;
   log: Logger;
-  elserInferenceId?: string;
 }) => {
   log.debug(`Creating index ${indexName}`);
 
   const legacySemanticText = isLegacySemanticTextVersion(manifestVersion);
-
-  overrideInferenceId(mappings, elserInferenceId);
 
   await esClient.indices.create({
     index: indexName,
@@ -43,13 +39,23 @@ export const createIndex = async ({
   });
 };
 
-const overrideInferenceId = (mappings: MappingTypeMapping, inferenceId: string) => {
+export const overrideInferenceSettings = (
+  mappings: MappingTypeMapping,
+  inferenceId: string,
+  modelSettingsToOverride?: object
+) => {
   const recursiveOverride = (current: MappingTypeMapping | MappingProperty) => {
-    if ('type' in current && current.type === 'semantic_text') {
+    if (isPopulatedObject(current, ['type']) && current.type === 'semantic_text') {
       current.inference_id = inferenceId;
+      if (modelSettingsToOverride) {
+        // @ts-expect-error - model_settings is not typed, but exists for semantic_text field
+        current.model_settings = modelSettingsToOverride;
+      }
     }
-    if ('properties' in current && current.properties) {
-      for (const prop of Object.values(current.properties)) {
+    if (isPopulatedObject(current, ['properties'])) {
+      for (const prop of Object.values(
+        current.properties as Record<string, MappingTypeMapping | MappingProperty>
+      )) {
         recursiveOverride(prop);
       }
     }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/steps/populate_index.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/steps/populate_index.ts
@@ -19,14 +19,14 @@ export const populateIndex = async ({
   manifestVersion,
   archive,
   log,
-  elserInferenceId,
+  inferenceId = internalElserInferenceId,
 }: {
   esClient: ElasticsearchClient;
   indexName: string;
   manifestVersion: string;
   archive: ZipArchive;
   log: Logger;
-  elserInferenceId?: string;
+  inferenceId?: string;
 }) => {
   log.debug(`Starting populating index ${indexName}`);
 
@@ -43,7 +43,7 @@ export const populateIndex = async ({
       esClient,
       contentBuffer,
       legacySemanticText,
-      elserInferenceId,
+      inferenceId,
     });
   }
 
@@ -56,12 +56,14 @@ const indexContentFile = async ({
   esClient,
   legacySemanticText,
   elserInferenceId = internalElserInferenceId,
+  inferenceId,
 }: {
   indexName: string;
   contentBuffer: Buffer;
   esClient: ElasticsearchClient;
   legacySemanticText: boolean;
   elserInferenceId?: string;
+  inferenceId?: string;
 }) => {
   const fileContent = contentBuffer.toString('utf-8');
   const lines = fileContent.split('\n');
@@ -75,7 +77,7 @@ const indexContentFile = async ({
     .map((doc) =>
       rewriteInferenceId({
         document: doc,
-        inferenceId: elserInferenceId,
+        inferenceId: inferenceId ?? elserInferenceId,
         legacySemanticText,
       })
     );

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/ensure_default_elser_deployed.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/ensure_default_elser_deployed.ts
@@ -8,12 +8,26 @@
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
-export const ensureDefaultElserDeployed = async ({ client }: { client: ElasticsearchClient }) => {
+export const ensureInferenceDeployed = async ({
+  client,
+  inferenceId,
+}: {
+  client: ElasticsearchClient;
+  inferenceId?: string;
+}) => {
+  if (!inferenceId) return;
   await client.inference.inference(
     {
-      inference_id: defaultInferenceEndpoints.ELSER,
+      inference_id: inferenceId,
       input: 'I just want to call the API to force the model to download and allocate',
     },
     { requestTimeout: 10 * 60 * 1000 }
   );
+};
+
+export const ensureDefaultElserDeployed = async ({ client }: { client: ElasticsearchClient }) => {
+  await ensureInferenceDeployed({
+    client,
+    inferenceId: defaultInferenceEndpoints.ELSER,
+  });
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/index.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/index.ts
@@ -8,5 +8,8 @@
 export { downloadToDisk } from './download';
 export { openZipArchive, type ZipArchive } from './zip_archive';
 export { loadManifestFile, loadMappingFile } from './archive_accessors';
-export { ensureDefaultElserDeployed } from './ensure_default_elser_deployed';
+export {
+  ensureDefaultElserDeployed,
+  ensureInferenceDeployed,
+} from './ensure_default_elser_deployed';
 export { isLegacySemanticTextVersion } from './manifest_versions';

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/search_service.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/search_service.test.ts
@@ -11,6 +11,7 @@ import { SearchService } from './search_service';
 import { getIndicesForProductNames } from './utils';
 
 import { performSearch } from './perform_search';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 jest.mock('./perform_search');
 const performSearchMock = performSearch as jest.MockedFn<typeof performSearch>;
 
@@ -32,7 +33,7 @@ describe('SearchService', () => {
   });
 
   describe('#search', () => {
-    it('calls `performSearch` with the right parameters', async () => {
+    it('calls `performSearch` with the right default parameters', async () => {
       await service.search({
         query: 'What is Kibana?',
         products: ['kibana'],
@@ -45,7 +46,62 @@ describe('SearchService', () => {
         searchQuery: 'What is Kibana?',
         size: 42,
         highlights: 3,
-        index: getIndicesForProductNames(['kibana']),
+        index: getIndicesForProductNames(['kibana'], undefined),
+        client: esClient,
+      });
+    });
+    it('calls `performSearch` with the right default index name for ELSER inference', async () => {
+      await service.search({
+        query: 'What is Kibana?',
+        products: ['kibana'],
+        max: 42,
+        highlights: 3,
+        inferenceId: defaultInferenceEndpoints.ELSER,
+      });
+
+      expect(performSearchMock).toHaveBeenCalledTimes(1);
+      expect(performSearchMock).toHaveBeenCalledWith({
+        searchQuery: 'What is Kibana?',
+        size: 42,
+        highlights: 3,
+        index: [`.kibana_ai_product_doc_kibana`],
+        client: esClient,
+      });
+    });
+
+    it('calls `performSearch` with the right default index name for ELSER EIS inference ID', async () => {
+      await service.search({
+        query: 'What is Kibana?',
+        products: ['kibana'],
+        max: 42,
+        highlights: 3,
+        inferenceId: defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID,
+      });
+
+      expect(performSearchMock).toHaveBeenCalledTimes(1);
+      expect(performSearchMock).toHaveBeenCalledWith({
+        searchQuery: 'What is Kibana?',
+        size: 42,
+        highlights: 3,
+        index: [`.kibana_ai_product_doc_kibana`],
+        client: esClient,
+      });
+    });
+    it('reroutes `performSearch` to multilingual index when inference ID is E5 small', async () => {
+      await service.search({
+        query: 'What is Kibana?',
+        products: ['kibana'],
+        max: 42,
+        highlights: 3,
+        inferenceId: defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL,
+      });
+
+      expect(performSearchMock).toHaveBeenCalledTimes(1);
+      expect(performSearchMock).toHaveBeenCalledWith({
+        searchQuery: 'What is Kibana?',
+        size: 42,
+        highlights: 3,
+        index: [`.kibana_ai_product_doc_kibana-${defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL}`],
         client: esClient,
       });
     });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/search_service.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/search_service.ts
@@ -21,13 +21,14 @@ export class SearchService {
   }
 
   async search(options: DocSearchOptions): Promise<DocSearchResponse> {
-    const { query, max = 3, highlights = 3, products } = options;
-    this.log.debug(`performing search - query=[${query}]`);
+    const { query, max = 3, highlights = 3, products, inferenceId } = options;
+    const index = getIndicesForProductNames(products, inferenceId);
+    this.log.debug(`performing search - query=[${query}] at index=[${index}] `);
     const results = await performSearch({
       searchQuery: query,
       size: max,
       highlights,
-      index: getIndicesForProductNames(products),
+      index,
       client: this.esClient,
     });
 

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/types.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/types.ts
@@ -19,6 +19,8 @@ export interface DocSearchOptions {
   highlights?: number;
   /** optional list of products to filter search */
   products?: ProductName[];
+  /** optional inference ID to filter search */
+  inferenceId?: string;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/utils/get_indices_for_product_names.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/utils/get_indices_for_product_names.test.ts
@@ -7,16 +7,44 @@
 
 import { productDocIndexPattern, getProductDocIndexName } from '@kbn/product-doc-common';
 import { getIndicesForProductNames } from './get_indices_for_product_names';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
 describe('getIndicesForProductNames', () => {
   it('returns the index pattern when product names are not specified', () => {
-    expect(getIndicesForProductNames(undefined)).toEqual(productDocIndexPattern);
-    expect(getIndicesForProductNames([])).toEqual(productDocIndexPattern);
+    expect(getIndicesForProductNames(undefined, undefined)).toEqual(productDocIndexPattern);
+    expect(getIndicesForProductNames([], undefined)).toEqual(productDocIndexPattern);
   });
   it('returns individual index names when product names are specified', () => {
     expect(getIndicesForProductNames(['kibana', 'elasticsearch'])).toEqual([
       getProductDocIndexName('kibana'),
       getProductDocIndexName('elasticsearch'),
+    ]);
+  });
+  it('returns individual index names when ELSER EIS is specified', () => {
+    expect(getIndicesForProductNames(['kibana', 'elasticsearch'], '.elser-v2-elastic')).toEqual([
+      getProductDocIndexName('kibana'),
+      getProductDocIndexName('elasticsearch'),
+    ]);
+  });
+  it('returns individual index names when ELSER is specified', () => {
+    expect(
+      getIndicesForProductNames(['kibana', 'elasticsearch'], defaultInferenceEndpoints.ELSER)
+    ).toEqual([getProductDocIndexName('kibana'), getProductDocIndexName('elasticsearch')]);
+  });
+
+  it('returns the index pattern when inferenceId is specified', () => {
+    expect(
+      getIndicesForProductNames(
+        ['kibana', 'elasticsearch'],
+        defaultInferenceEndpoints.MULTILINGUAL_E5_SMALL
+      )
+    ).toEqual([
+      '.kibana_ai_product_doc_kibana-.multilingual-e5-small-elasticsearch',
+      '.kibana_ai_product_doc_elasticsearch-.multilingual-e5-small-elasticsearch',
+    ]);
+    expect(getIndicesForProductNames(['kibana', 'elasticsearch'], '.anyInferenceId')).toEqual([
+      '.kibana_ai_product_doc_kibana-.anyInferenceId',
+      '.kibana_ai_product_doc_elasticsearch-.anyInferenceId',
     ]);
   });
 });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/utils/get_indices_for_product_names.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/search/utils/get_indices_for_product_names.ts
@@ -12,10 +12,11 @@ import {
 } from '@kbn/product-doc-common';
 
 export const getIndicesForProductNames = (
-  productNames: ProductName[] | undefined
+  productNames: ProductName[] | undefined,
+  inferenceId?: string
 ): string | string[] => {
   if (!productNames || !productNames.length) {
     return productDocIndexPattern;
   }
-  return productNames.map(getProductDocIndexName);
+  return productNames.map((productName) => getProductDocIndexName(productName, inferenceId));
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/tasks/index.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/tasks/index.ts
@@ -24,6 +24,14 @@ export const registerTaskDefinitions = ({
 };
 
 export { scheduleEnsureUpToDateTask, ENSURE_DOC_UP_TO_DATE_TASK_ID } from './ensure_up_to_date';
-export { scheduleInstallAllTask, INSTALL_ALL_TASK_ID } from './install_all';
-export { scheduleUninstallAllTask, UNINSTALL_ALL_TASK_ID } from './uninstall_all';
+export {
+  scheduleInstallAllTask,
+  INSTALL_ALL_TASK_ID,
+  INSTALL_ALL_TASK_ID_MULTILINGUAL,
+} from './install_all';
+export {
+  scheduleUninstallAllTask,
+  UNINSTALL_ALL_TASK_ID,
+  UNINSTALL_ALL_TASK_ID_MULTILINGUAL,
+} from './uninstall_all';
 export { waitUntilTaskCompleted, getTaskStatus } from './utils';

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/tasks/install_all.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/tasks/install_all.ts
@@ -10,11 +10,13 @@ import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
+import { isImpliedDefaultElserInferenceId } from '@kbn/product-doc-common/src/is_default_inference_endpoint';
 import type { InternalServices } from '../types';
 import { isTaskCurrentlyRunningError } from './utils';
 
 export const INSTALL_ALL_TASK_TYPE = 'ProductDocBase:InstallAll';
 export const INSTALL_ALL_TASK_ID = 'ProductDocBase:InstallAll';
+export const INSTALL_ALL_TASK_ID_MULTILINGUAL = 'ProductDocBase:InstallAllMultilingual';
 
 export const registerInstallAllTaskDefinition = ({
   getServices,
@@ -25,14 +27,15 @@ export const registerInstallAllTaskDefinition = ({
 }) => {
   taskManager.registerTaskDefinitions({
     [INSTALL_ALL_TASK_TYPE]: {
-      title: 'Install all product documentation artifacts',
+      title: `Install all product documentation artifacts ${INSTALL_ALL_TASK_TYPE}`,
       timeout: '10m',
       maxAttempts: 3,
       createTaskRunner: (context) => {
+        const inferenceId = context.taskInstance?.params?.inferenceId;
         return {
           async run() {
             const { packageInstaller } = getServices();
-            return packageInstaller.installAll({});
+            return packageInstaller.installAll({ inferenceId });
           },
         };
       },
@@ -44,27 +47,32 @@ export const registerInstallAllTaskDefinition = ({
 export const scheduleInstallAllTask = async ({
   taskManager,
   logger,
+  inferenceId,
 }: {
   taskManager: TaskManagerStartContract;
   logger: Logger;
+  inferenceId: string;
 }) => {
+  const taskId = isImpliedDefaultElserInferenceId(inferenceId)
+    ? INSTALL_ALL_TASK_ID
+    : INSTALL_ALL_TASK_ID_MULTILINGUAL;
   try {
     await taskManager.ensureScheduled({
-      id: INSTALL_ALL_TASK_ID,
+      id: taskId,
       taskType: INSTALL_ALL_TASK_TYPE,
-      params: {},
+      params: { inferenceId },
       state: {},
       scope: ['productDoc'],
     });
 
-    await taskManager.runSoon(INSTALL_ALL_TASK_ID);
+    await taskManager.runSoon(taskId);
 
-    logger.info(`Task ${INSTALL_ALL_TASK_ID} scheduled to run soon`);
+    logger.info(`Task ${taskId} scheduled to run soon`);
   } catch (e) {
     if (!isTaskCurrentlyRunningError(e)) {
       throw e;
     }
   }
 
-  return INSTALL_ALL_TASK_ID;
+  return taskId;
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/tsconfig.json
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/tsconfig.json
@@ -27,5 +27,7 @@
     "@kbn/task-manager-plugin",
     "@kbn/inference-common",
     "@kbn/core-security-server",
+    "@kbn/ml-is-populated-object",
+    "@kbn/i18n"
   ]
 }

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/index.ts
@@ -60,3 +60,5 @@ export const plugin = async (ctx: PluginInitializerContext<ObservabilityAIAssist
   const { ObservabilityAIAssistantPlugin } = await import('./plugin');
   return new ObservabilityAIAssistantPlugin(ctx);
 };
+
+export { getInferenceIdFromWriteIndex } from './service/knowledge_base_service/get_inference_id_from_write_index';

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/documentation.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/documentation.ts
@@ -7,6 +7,8 @@
 
 import { DocumentationProduct } from '@kbn/product-doc-common';
 import { FunctionVisibility } from '@kbn/observability-ai-assistant-plugin/common';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
+import { getInferenceIdFromWriteIndex } from '@kbn/observability-ai-assistant-plugin/server';
 import type { FunctionRegistrationParameters } from '.';
 
 export const RETRIEVE_DOCUMENTATION_NAME = 'retrieve_elastic_doc';
@@ -64,6 +66,12 @@ export async function registerDocumentationFunction({
       } as const,
     },
     async ({ arguments: { query, product }, connectorId, simulateFunctionCalling }) => {
+      const esClient = (await resources.context.core).elasticsearch.client;
+
+      const inferenceId =
+        (await getInferenceIdFromWriteIndex(esClient, resources.logger)) ??
+        defaultInferenceEndpoints.ELSER;
+
       const response = await llmTasks!.retrieveDocumentation({
         searchTerm: query,
         products: product ? [product] : undefined,
@@ -71,6 +79,7 @@ export async function registerDocumentationFunction({
         connectorId,
         request: resources.request,
         functionCalling: simulateFunctionCalling ? 'simulated' : 'auto',
+        inferenceId,
       });
 
       return {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/field_maps_configuration.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/field_maps_configuration.ts
@@ -7,7 +7,6 @@
 import { FieldMap } from '@kbn/data-stream-adapter';
 
 export const ASSISTANT_ELSER_INFERENCE_ID = 'elastic-security-ai-assistant-elser2';
-export const ELASTICSEARCH_ELSER_INFERENCE_ID = '.elser-2-elasticsearch';
 
 export const knowledgeBaseFieldMap: FieldMap = {
   // Base fields

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
@@ -38,6 +38,7 @@ import { map } from 'lodash';
 import { InstallationStatus } from '@kbn/product-doc-base-plugin/common/install_status';
 import type { TrainedModelsProvider } from '@kbn/ml-plugin/server/shared_services/providers';
 import { getMlNodeCount } from '@kbn/ml-plugin/server/lib/node_utils';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { AIAssistantDataClient, AIAssistantDataClientParams } from '..';
 import { GetElser } from '../../types';
 import {
@@ -68,10 +69,7 @@ import {
   loadSecurityLabs,
   getSecurityLabsDocsCount,
 } from '../../lib/langchain/content_loaders/security_labs_loader';
-import {
-  ASSISTANT_ELSER_INFERENCE_ID,
-  ELASTICSEARCH_ELSER_INFERENCE_ID,
-} from './field_maps_configuration';
+import { ASSISTANT_ELSER_INFERENCE_ID } from './field_maps_configuration';
 import { BulkOperationError } from '../../lib/data_stream/documents_data_writer';
 import { AUDIT_OUTCOME, KnowledgeBaseAuditAction, knowledgeBaseAuditEvent } from './audit_events';
 import { findDocuments } from '../find';
@@ -849,7 +847,7 @@ export const getInferenceEndpointId = async ({ esClient }: { esClient: Elasticse
   }
 
   // Fallback to the default inference endpoint
-  return ELASTICSEARCH_ELSER_INFERENCE_ID;
+  return defaultInferenceEndpoints.ELSER;
 };
 
 /**

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/helpers.ts
@@ -13,6 +13,7 @@ import { DeleteByQueryRequest } from '@elastic/elasticsearch/lib/api/types';
 import { i18n } from '@kbn/i18n';
 import { ProductDocBaseStartContract } from '@kbn/product-doc-base-plugin/server';
 import type { Logger } from '@kbn/logging';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { getResourceName } from '.';
 import { knowledgeBaseIngestPipeline } from '../ai_assistant_data_clients/knowledge_base/ingest_pipeline';
 import { GetElser } from '../types';
@@ -154,12 +155,17 @@ export const ensureProductDocumentationInstalled = async ({
   logger: Logger;
 }) => {
   try {
-    const { status } = await productDocManager.getStatus();
+    const { status } = await productDocManager.getStatus({
+      inferenceId: defaultInferenceEndpoints.ELSER,
+    });
     if (status !== 'installed') {
       logger.debug(`Installing product documentation for AIAssistantService`);
       setIsProductDocumentationInProgress(true);
       try {
-        await productDocManager.install({ wait: true });
+        await productDocManager.install({
+          wait: true,
+          inferenceId: defaultInferenceEndpoints.ELSER,
+        });
         logger.debug(`Successfully installed product documentation for AIAssistantService`);
       } catch (e) {
         logger.warn(`Failed to install product documentation for AIAssistantService: ${e.message}`);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts
@@ -27,6 +27,7 @@ import { omit, some } from 'lodash';
 import { InstallationStatus } from '@kbn/product-doc-base-plugin/common/install_status';
 import { TrainedModelsProvider } from '@kbn/ml-plugin/server/shared_services/providers';
 import { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { alertSummaryFieldsFieldMap } from '../ai_assistant_data_clients/alert_summary/field_maps_configuration';
 import { attackDiscoveryFieldMap } from '../lib/attack_discovery/persistence/field_maps_configuration/field_maps_configuration';
 import { defendInsightsFieldMap } from '../lib/defend_insights/persistence/field_maps_configuration';
@@ -49,7 +50,6 @@ import { assistantAnonymizationFieldsFieldMap } from '../ai_assistant_data_clien
 import { AIAssistantDataClient } from '../ai_assistant_data_clients';
 import {
   ASSISTANT_ELSER_INFERENCE_ID,
-  ELASTICSEARCH_ELSER_INFERENCE_ID,
   knowledgeBaseFieldMap,
 } from '../ai_assistant_data_clients/knowledge_base/field_maps_configuration';
 import {
@@ -290,7 +290,7 @@ export class AIAssistantService {
           type: 'semantic_text',
           array: false,
           required: false,
-          ...(targetInferenceEndpointId !== ELASTICSEARCH_ELSER_INFERENCE_ID
+          ...(targetInferenceEndpointId !== defaultInferenceEndpoints.ELSER
             ? { inference_id: targetInferenceEndpointId }
             : {}),
         },
@@ -374,7 +374,7 @@ export class AIAssistantService {
       if (isUsingDedicatedInferenceEndpoint) {
         this.knowledgeBaseDataStream = await this.rolloverDataStream(
           ASSISTANT_ELSER_INFERENCE_ID,
-          ELASTICSEARCH_ELSER_INFERENCE_ID
+          defaultInferenceEndpoints.ELSER
         );
       } else {
         // We need to make sure that the data stream is created with the correct mappings
@@ -542,7 +542,9 @@ export class AIAssistantService {
   }
 
   public async getProductDocumentationStatus(): Promise<InstallationStatus> {
-    const status = await this.productDocManager?.getStatus();
+    const status = await this.productDocManager?.getStatus({
+      inferenceId: defaultInferenceEndpoints.ELSER,
+    });
 
     if (!status) {
       return 'uninstalled';

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/config_schema.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/config_schema.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 import { schema } from '@kbn/config-schema';
-import { ELASTICSEARCH_ELSER_INFERENCE_ID } from './ai_assistant_data_clients/knowledge_base/field_maps_configuration';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
 export interface ConfigSchema {
   elserInferenceId: string;
   responseTimeout: number;
 }
 export const configSchema = schema.object({
-  elserInferenceId: schema.string({ defaultValue: ELASTICSEARCH_ELSER_INFERENCE_ID }),
+  elserInferenceId: schema.string({ defaultValue: defaultInferenceEndpoints.ELSER }),
   responseTimeout: schema.number({
     defaultValue: 10 * 60 * 1000, // 10 minutes
   }),

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.test.ts
@@ -25,7 +25,7 @@ import {
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { appendAssistantMessageToConversation, langChainExecute } from './helpers';
 import { getPrompt } from '../lib/prompt';
-import { ELASTICSEARCH_ELSER_INFERENCE_ID } from '../ai_assistant_data_clients/knowledge_base/field_maps_configuration';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
 const license = licensingMock.createLicenseMock();
 const actionsClient = actionsClientMock.create();
@@ -132,7 +132,7 @@ const mockResponse = {
   error: jest.fn().mockImplementation((x) => x),
 };
 const mockConfig = {
-  elserInferenceId: ELASTICSEARCH_ELSER_INFERENCE_ID,
+  elserInferenceId: defaultInferenceEndpoints.ELSER,
   responseTimeout: 1000,
 };
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/register_routes.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/register_routes.test.ts
@@ -52,7 +52,7 @@ import { deleteAttackDiscoverySchedulesRoute } from './attack_discovery/schedule
 import { findAttackDiscoverySchedulesRoute } from './attack_discovery/schedules/find';
 import { disableAttackDiscoverySchedulesRoute } from './attack_discovery/schedules/disable';
 import { enableAttackDiscoverySchedulesRoute } from './attack_discovery/schedules/enable';
-import { ELASTICSEARCH_ELSER_INFERENCE_ID } from '../ai_assistant_data_clients/knowledge_base/field_maps_configuration';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 
 jest.mock('./alert_summary/find_route');
 const findAlertSummaryRouteMock = findAlertSummaryRoute as jest.Mock;
@@ -136,7 +136,7 @@ const enableAttackDiscoverySchedulesRouteMock = enableAttackDiscoverySchedulesRo
 describe('registerRoutes', () => {
   const loggerMock = loggingSystemMock.createLogger();
   let server: ReturnType<typeof serverMock.create>;
-  const config = { elserInferenceId: ELASTICSEARCH_ELSER_INFERENCE_ID, responseTimeout: 60000 };
+  const config = { elserInferenceId: defaultInferenceEndpoints.ELSER, responseTimeout: 60000 };
 
   beforeEach(async () => {
     jest.clearAllMocks();

--- a/x-pack/solutions/security/plugins/elastic_assistant/tsconfig.json
+++ b/x-pack/solutions/security/plugins/elastic_assistant/tsconfig.json
@@ -88,7 +88,8 @@
     "@kbn/ai-security-labs-content",
     "@kbn/inference-langchain",
     "@kbn/security-solution-features",
-    "@kbn/core-http-server-mocks"
+    "@kbn/core-http-server-mocks",
+    "@kbn/inference-common"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.test.ts
@@ -22,6 +22,8 @@ import type {
 } from '@kbn/elastic-assistant-common';
 import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 
+const DEFAULT_INFERENCE_ID = '.elser-2-elasticsearch';
+
 describe('ProductDocumentationTool', () => {
   const chain = {} as RetrievalQAChain;
   const esClient = {
@@ -97,6 +99,7 @@ describe('ProductDocumentationTool', () => {
         connectorId: 'fake-connector',
         request,
         functionCalling: 'auto',
+        inferenceId: DEFAULT_INFERENCE_ID,
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.ts
@@ -16,6 +16,7 @@ import {
 import type { ContentReferencesStore } from '@kbn/elastic-assistant-common';
 import type { RetrieveDocumentationResultDoc } from '@kbn/llm-tasks-plugin/server';
 import type { Require } from '@kbn/elastic-assistant-plugin/server/types';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { APP_UI_ID } from '../../../../common';
 
 export type ProductDocumentationToolParams = Require<
@@ -53,6 +54,7 @@ export const PRODUCT_DOCUMENTATION_TOOL: AssistantTool = {
           connectorId,
           request,
           functionCalling: 'auto',
+          inferenceId: defaultInferenceEndpoints.ELSER,
         });
 
         const enrichedDocuments = response.documents.map(enrichDocument(contentReferencesStore));

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -18,6 +18,8 @@ import { chatComplete } from '../../utils/conversation';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
 import { installProductDoc, uninstallProductDoc } from '../../utils/product_doc_base';
 
+const DEFAULT_INFERENCE_ID = '.elser-2-elasticsearch';
+
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
   const log = getService('log');
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
@@ -93,7 +95,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         connectorId = await observabilityAIAssistantAPIClient.createProxyActionConnector({
           port: llmProxy.getPort(),
         });
-        await installProductDoc(supertest);
+        await installProductDoc(supertest, DEFAULT_INFERENCE_ID);
 
         void llmProxy.interceptWithFunctionRequest({
           name: 'retrieve_elastic_doc',
@@ -118,7 +120,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
 
       after(async () => {
-        await uninstallProductDoc(supertest);
+        await uninstallProductDoc(supertest, DEFAULT_INFERENCE_ID);
         llmProxy.close();
         await observabilityAIAssistantAPIClient.deleteActionConnector({
           actionId: connectorId,

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/product_doc_base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/product_doc_base.ts
@@ -12,20 +12,26 @@ import {
 
 import type SuperTest from 'supertest';
 
-export async function installProductDoc(supertest: SuperTest.Agent) {
+export async function installProductDoc(supertest: SuperTest.Agent, inferenceId: string) {
   return supertest
     .post('/internal/product_doc_base/install')
     .set(ELASTIC_HTTP_VERSION_HEADER, '1')
     .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
     .set('kbn-xsrf', 'foo')
+    .send({
+      inferenceId,
+    })
     .expect(200);
 }
 
-export async function uninstallProductDoc(supertest: SuperTest.Agent) {
+export async function uninstallProductDoc(supertest: SuperTest.Agent, inferenceId: string) {
   return supertest
     .post('/internal/product_doc_base/uninstall')
     .set(ELASTIC_HTTP_VERSION_HEADER, '1')
     .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
     .set('kbn-xsrf', 'foo')
+    .send({
+      inferenceId,
+    })
     .expect(200);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[AI Infra] Fix Observability AI assistant product docs missing multilingual support (#224274)](https://github.com/elastic/kibana/pull/224274)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Quynh Nguyen (Quinn)","email":"43350163+qn895@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-03T09:53:13Z","message":"[AI Infra] Fix Observability AI assistant product docs missing multilingual support (#224274)\n\n## Summary\n\nThis PR fixes https://github.com/elastic/kibana/issues/222176, and\nrewired the productDoc installation process to accept an `inferenceId`\nargument to the productDocBase installation API. It:\n\n- Allows for concurrent installation of the product docs with two\ndifferent models: The default ELSER and the multilingual E5. Kibana will\nonly install the one the user needs, but has capacity for other models\nif user needs both of them (i.e. ELSER for Security AI Assistant and\nmultilingual E5 for Observability AI Assistant).\n \n- Modifies the script that generates the artifacts to also allows\ninferenceId to be passed in.\n\n```\nnode scripts/build_product_doc_artifacts.js --product-name=security --stack-version=8.18  --inference-id=.multilingual-e5-small-elasticsearch\n```\n\n- In parallel with this PR, deploys the public multilingual product doc\nartifacts for 8.18\n- It modifies the installation logic to append the inferenceId's to the\ntarget index name's (to distinguish it from the ELSER default) and\ndefine the mapping of the target index to use the E5's model_settings\n- Surfaces up error if there's an error with the installation \n\n\t\nFor example, if there's no corresponding artifact available, or if the\nartifact fails to fetch. Before:\n\n\n![image](https://github.com/user-attachments/assets/ac9fe8db-a34e-4e67-8471-56e8f4520fdd)\n\n\n\t\n\tAfter, it will prompt the user: \n\n\n![image](https://github.com/user-attachments/assets/ff18c6bd-0c20-4227-aac7-913a3032a31f)\n\n\n## Note for Reviewers:\n\n- **kibana-core**: Saved object 'product-doc-install-status' was updated\nto add a new field `inference_id`\n\n- **Security Gen AI**: With the newly required inferenceId parameter to\nthe installation endpoints, by default it will use ELSER\n'.elser-2-elasticsearch'\n\n- **Observability AI Assistant**: There are 2 at least todos remaining:\n1) Make to sure pass the inferenceId to the retrieveDocumentation so\nthat it reroutes to the right index\nhttps://github.com/elastic/kibana/pull/224274/files#diff-e393e350cf2449f8b756cad947fc8a902fddf6e6b30f1363750d469fc7d81b61R74\n2) Handle the change in inference model selection for Product Doc. Here\nthis is triggering an update to the product doc installation when user\nclicks Update model:\nhttps://github.com/elastic/kibana/pull/224274/files#diff-7d84fc1bf3106fe3b0cb357c800faefc1b96b853beeb74711f1c3c623ae901b9R151\n\n- ### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Dima Arnautov <dmitrii.arnautov@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4ff731dcccaf9f60c5ef49ae014ed96800bacbe7","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug",":ml","release_note:skip","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[AI Infra] Fix Observability AI assistant product docs missing multilingual support","number":224274,"url":"https://github.com/elastic/kibana/pull/224274","mergeCommit":{"message":"[AI Infra] Fix Observability AI assistant product docs missing multilingual support (#224274)\n\n## Summary\n\nThis PR fixes https://github.com/elastic/kibana/issues/222176, and\nrewired the productDoc installation process to accept an `inferenceId`\nargument to the productDocBase installation API. It:\n\n- Allows for concurrent installation of the product docs with two\ndifferent models: The default ELSER and the multilingual E5. Kibana will\nonly install the one the user needs, but has capacity for other models\nif user needs both of them (i.e. ELSER for Security AI Assistant and\nmultilingual E5 for Observability AI Assistant).\n \n- Modifies the script that generates the artifacts to also allows\ninferenceId to be passed in.\n\n```\nnode scripts/build_product_doc_artifacts.js --product-name=security --stack-version=8.18  --inference-id=.multilingual-e5-small-elasticsearch\n```\n\n- In parallel with this PR, deploys the public multilingual product doc\nartifacts for 8.18\n- It modifies the installation logic to append the inferenceId's to the\ntarget index name's (to distinguish it from the ELSER default) and\ndefine the mapping of the target index to use the E5's model_settings\n- Surfaces up error if there's an error with the installation \n\n\t\nFor example, if there's no corresponding artifact available, or if the\nartifact fails to fetch. Before:\n\n\n![image](https://github.com/user-attachments/assets/ac9fe8db-a34e-4e67-8471-56e8f4520fdd)\n\n\n\t\n\tAfter, it will prompt the user: \n\n\n![image](https://github.com/user-attachments/assets/ff18c6bd-0c20-4227-aac7-913a3032a31f)\n\n\n## Note for Reviewers:\n\n- **kibana-core**: Saved object 'product-doc-install-status' was updated\nto add a new field `inference_id`\n\n- **Security Gen AI**: With the newly required inferenceId parameter to\nthe installation endpoints, by default it will use ELSER\n'.elser-2-elasticsearch'\n\n- **Observability AI Assistant**: There are 2 at least todos remaining:\n1) Make to sure pass the inferenceId to the retrieveDocumentation so\nthat it reroutes to the right index\nhttps://github.com/elastic/kibana/pull/224274/files#diff-e393e350cf2449f8b756cad947fc8a902fddf6e6b30f1363750d469fc7d81b61R74\n2) Handle the change in inference model selection for Product Doc. Here\nthis is triggering an update to the product doc installation when user\nclicks Update model:\nhttps://github.com/elastic/kibana/pull/224274/files#diff-7d84fc1bf3106fe3b0cb357c800faefc1b96b853beeb74711f1c3c623ae901b9R151\n\n- ### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Dima Arnautov <dmitrii.arnautov@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4ff731dcccaf9f60c5ef49ae014ed96800bacbe7"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224274","number":224274,"mergeCommit":{"message":"[AI Infra] Fix Observability AI assistant product docs missing multilingual support (#224274)\n\n## Summary\n\nThis PR fixes https://github.com/elastic/kibana/issues/222176, and\nrewired the productDoc installation process to accept an `inferenceId`\nargument to the productDocBase installation API. It:\n\n- Allows for concurrent installation of the product docs with two\ndifferent models: The default ELSER and the multilingual E5. Kibana will\nonly install the one the user needs, but has capacity for other models\nif user needs both of them (i.e. ELSER for Security AI Assistant and\nmultilingual E5 for Observability AI Assistant).\n \n- Modifies the script that generates the artifacts to also allows\ninferenceId to be passed in.\n\n```\nnode scripts/build_product_doc_artifacts.js --product-name=security --stack-version=8.18  --inference-id=.multilingual-e5-small-elasticsearch\n```\n\n- In parallel with this PR, deploys the public multilingual product doc\nartifacts for 8.18\n- It modifies the installation logic to append the inferenceId's to the\ntarget index name's (to distinguish it from the ELSER default) and\ndefine the mapping of the target index to use the E5's model_settings\n- Surfaces up error if there's an error with the installation \n\n\t\nFor example, if there's no corresponding artifact available, or if the\nartifact fails to fetch. Before:\n\n\n![image](https://github.com/user-attachments/assets/ac9fe8db-a34e-4e67-8471-56e8f4520fdd)\n\n\n\t\n\tAfter, it will prompt the user: \n\n\n![image](https://github.com/user-attachments/assets/ff18c6bd-0c20-4227-aac7-913a3032a31f)\n\n\n## Note for Reviewers:\n\n- **kibana-core**: Saved object 'product-doc-install-status' was updated\nto add a new field `inference_id`\n\n- **Security Gen AI**: With the newly required inferenceId parameter to\nthe installation endpoints, by default it will use ELSER\n'.elser-2-elasticsearch'\n\n- **Observability AI Assistant**: There are 2 at least todos remaining:\n1) Make to sure pass the inferenceId to the retrieveDocumentation so\nthat it reroutes to the right index\nhttps://github.com/elastic/kibana/pull/224274/files#diff-e393e350cf2449f8b756cad947fc8a902fddf6e6b30f1363750d469fc7d81b61R74\n2) Handle the change in inference model selection for Product Doc. Here\nthis is triggering an update to the product doc installation when user\nclicks Update model:\nhttps://github.com/elastic/kibana/pull/224274/files#diff-7d84fc1bf3106fe3b0cb357c800faefc1b96b853beeb74711f1c3c623ae901b9R151\n\n- ### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Dima Arnautov <dmitrii.arnautov@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4ff731dcccaf9f60c5ef49ae014ed96800bacbe7"}}]}] BACKPORT-->