### PR TITLE
[9.0] [Security Solution] Fix time duration normalization at rule schedule for day units (#224083)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-utils/src/time_duration/time_duration.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-utils/src/time_duration/time_duration.ts
@@ -12,6 +12,7 @@
  * - 5s
  * - 3m
  * - 7h
+ * - 9d
  */
 export class TimeDuration {
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.tsx
@@ -168,7 +168,7 @@ export function ScheduleItemField({
   );
 }
 
-const DEFAULT_TIME_DURATION_UNITS = ['s', 'm', 'h'];
+const DEFAULT_TIME_DURATION_UNITS = ['s', 'm', 'h', 'd'];
 
 function saturate(input: number, minValue: number, maxValue: number): number {
   return Math.max(minValue, Math.min(input, maxValue));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Fix time duration normalization at rule schedule for day units (#224083)](https://github.com/elastic/kibana/pull/224083)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-06-20T14:42:42Z","message":"[Security Solution] Fix time duration normalization at rule schedule for day units (#224083)\n\n**Addresses:** https://github.com/elastic/kibana/issues/223446\n\n## Summary\n\nThis PR fixes an issue when time duration normalized to day(s) is shown as 0 seconds. The fix is performed by allowing using days time unit at rule schedule.\n\n## Details\n\nThe issue happens when rule schedule's look-back gets normalized to day(s). The reason is that look-backs input doesn't support Days time unit. It leads to inability to parse the value and displaying the default value which is 0 seconds.\n\nRule schedule is shown to the users as rule `interval` and `look-back` while rule's SO saves the schedule by using three fields `interval`, `from` and `to`. Where `look-back` represents a logical value calculated as `lookback` = `to` - `from` - `interval`. Taking that into account it's becomes harder to maintain the original time duration unit value during prebuilt rules upgrade workflow (See https://github.com/elastic/kibana/pull/204317 for more details).\n\nThe easiest way to fix this issue is to allow Days time unit in rule schedule inputs. On top of that 24 hours are always 1 day making hours the largest simply convertible time unit. The PR allows hours in rule schedule.\n\n**Before:**\n\nhttps://github.com/user-attachments/assets/4f2038f1-4a6a-4a88-b86e-381a5b717605\n\n**After:**\n\nhttps://github.com/user-attachments/assets/74875bf2-9341-425f-a35f-c8b088c1ef6a","sha":"a013929fda4dbae08b52d8258c37cb4c144a83f5","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Rule Creation","Feature:Rule Edit","backport:version","v9.1.0","v8.19.0"],"title":"[Security Solution] Fix time duration normalization at rule schedule for day units","number":224083,"url":"https://github.com/elastic/kibana/pull/224083","mergeCommit":{"message":"[Security Solution] Fix time duration normalization at rule schedule for day units (#224083)\n\n**Addresses:** https://github.com/elastic/kibana/issues/223446\n\n## Summary\n\nThis PR fixes an issue when time duration normalized to day(s) is shown as 0 seconds. The fix is performed by allowing using days time unit at rule schedule.\n\n## Details\n\nThe issue happens when rule schedule's look-back gets normalized to day(s). The reason is that look-backs input doesn't support Days time unit. It leads to inability to parse the value and displaying the default value which is 0 seconds.\n\nRule schedule is shown to the users as rule `interval` and `look-back` while rule's SO saves the schedule by using three fields `interval`, `from` and `to`. Where `look-back` represents a logical value calculated as `lookback` = `to` - `from` - `interval`. Taking that into account it's becomes harder to maintain the original time duration unit value during prebuilt rules upgrade workflow (See https://github.com/elastic/kibana/pull/204317 for more details).\n\nThe easiest way to fix this issue is to allow Days time unit in rule schedule inputs. On top of that 24 hours are always 1 day making hours the largest simply convertible time unit. The PR allows hours in rule schedule.\n\n**Before:**\n\nhttps://github.com/user-attachments/assets/4f2038f1-4a6a-4a88-b86e-381a5b717605\n\n**After:**\n\nhttps://github.com/user-attachments/assets/74875bf2-9341-425f-a35f-c8b088c1ef6a","sha":"a013929fda4dbae08b52d8258c37cb4c144a83f5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/224083","number":224083,"mergeCommit":{"message":"[Security Solution] Fix time duration normalization at rule schedule for day units (#224083)\n\n**Addresses:** https://github.com/elastic/kibana/issues/223446\n\n## Summary\n\nThis PR fixes an issue when time duration normalized to day(s) is shown as 0 seconds. The fix is performed by allowing using days time unit at rule schedule.\n\n## Details\n\nThe issue happens when rule schedule's look-back gets normalized to day(s). The reason is that look-backs input doesn't support Days time unit. It leads to inability to parse the value and displaying the default value which is 0 seconds.\n\nRule schedule is shown to the users as rule `interval` and `look-back` while rule's SO saves the schedule by using three fields `interval`, `from` and `to`. Where `look-back` represents a logical value calculated as `lookback` = `to` - `from` - `interval`. Taking that into account it's becomes harder to maintain the original time duration unit value during prebuilt rules upgrade workflow (See https://github.com/elastic/kibana/pull/204317 for more details).\n\nThe easiest way to fix this issue is to allow Days time unit in rule schedule inputs. On top of that 24 hours are always 1 day making hours the largest simply convertible time unit. The PR allows hours in rule schedule.\n\n**Before:**\n\nhttps://github.com/user-attachments/assets/4f2038f1-4a6a-4a88-b86e-381a5b717605\n\n**After:**\n\nhttps://github.com/user-attachments/assets/74875bf2-9341-425f-a35f-c8b088c1ef6a","sha":"a013929fda4dbae08b52d8258c37cb4c144a83f5"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/224716","number":224716,"state":"MERGED","mergeCommit":{"sha":"0163914af918d1ee0181d731224f00e14cadc4db","message":"[8.19] [Security Solution] Fix time duration normalization at rule schedule for day units (#224083) (#224716)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Fix time duration normalization at rule schedule\nfor day units (#224083)](https://github.com/elastic/kibana/pull/224083)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/225424","number":225424,"branch":"8.18","state":"OPEN"}]}] BACKPORT-->