### PR TITLE
[fix] Fixing accidental lint issue

### DIFF
--- a/.buildkite/scripts/pipelines/chromium_linux_build/issue_feedback/transform_path_file.test.ts
+++ b/.buildkite/scripts/pipelines/chromium_linux_build/issue_feedback/transform_path_file.test.ts
@@ -57,7 +57,6 @@ const runnerOptions = {
 };
 
 describe('transform_path_file', () => {
-
   it('throws an error if options are missing', () => {
     expect(() => {
       applyTransform(pathFileTransform, {}, pathFileContents, runnerOptions);


### PR DESCRIPTION
## Summary
I took an edit suggestion in https://github.com/elastic/kibana/pull/226133 and I didn't run it through the linting, it caused a lint issue when merged. This PR fixes that extra linebreak
