### PR TITLE
[SO] Messing around with concurrent write

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/fixtures/zdt_base.fixtures.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/fixtures/zdt_base.fixtures.ts
@@ -78,6 +78,7 @@ export const getSampleAType = () => {
   return createType({
     name: 'sample_a',
     mappings: {
+      dynamic: false,
       properties: {
         keyword: { type: 'keyword' },
         boolean: { type: 'boolean' },
@@ -93,6 +94,7 @@ export const getSampleBType = () => {
   return createType({
     name: 'sample_b',
     mappings: {
+      dynamic: false,
       properties: {
         text: { type: 'text' },
         text2: { type: 'text' },

--- a/src/core/server/integration_tests/saved_objects/migrations/zdt_1/conversion_failures.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/zdt_1/conversion_failures.test.ts
@@ -61,7 +61,7 @@ describe('ZDT upgrades - encountering conversion failures', () => {
     });
   });
 
-  describe('when discardCorruptObjects is false', () => {
+  describe.only('when discardCorruptObjects is false', () => {
     it('fails the migration with an explicit message and keep the documents', async () => {
       const { client, runMigrations } = await prepareScenario({
         discardCorruptObjects: false,
@@ -109,7 +109,7 @@ describe('ZDT upgrades - encountering conversion failures', () => {
             type: 'unsafe_transform',
             transformFn: (typeSafeGuard) =>
               typeSafeGuard((doc) => {
-                throw new Error(`error from ${doc.id}`);
+                return { document: { ...doc, attributes: { test : true, ...doc.attributes as any }, } as any };
               }),
           },
         ],
@@ -125,10 +125,7 @@ describe('ZDT upgrades - encountering conversion failures', () => {
             type: 'unsafe_transform',
             transformFn: (typeSafeGuard) =>
               typeSafeGuard((doc) => {
-                if (doc.id === 'b-0') {
-                  throw new Error(`error from ${doc.id}`);
-                }
-                return { document: doc };
+                return { document: { ...doc, attributes: { test : true, ...doc.attributes as any }, } as any };
               }),
           },
         ],


### PR DESCRIPTION
## Summary

Test locally with:

```
yarn test:jest_integration src/core/server/integration_tests/saved_objects/migrations/zdt_1/conversion_failures.test.ts
```


Output looks smth like (test will fail ofc):

```
    OVERWRITING OPERATION [
      { index: { _id: 'sample_a:a-0' } },
      {
        sample_a: { test: true, keyword: 'a_0', boolean: true },
        type: 'sample_a',
        references: [],
        managed: false,
        coreMigrationVersion: '8.8.0',
        typeMigrationVersion: '10.2.0',
        updated_at: '2025-07-03T11:20:33.777Z',
        created_at: '2025-07-03T11:20:33.777Z'
      }
    ]

      at log (src/core/packages/saved-objects/migration-server-internal/src/actions/bulk_overwrite_transformed_documents.ts:61:15)
          at async Promise.all (index 0)

  console.log
    SIMULATING CONCURRENT WRITE BEFORE BULK INDEX! setting keyword to "gonna be lost!" and "test" boolean to false

      at log (src/core/packages/saved-objects/migration-server-internal/src/actions/bulk_overwrite_transformed_documents.ts:68:17)
          at async Promise.all (index 0)

  console.log
    DOC CURRENTLY LOOKS LIKE {
      _index: '.kibana_1',
      _id: 'sample_a:a-0',
      _version: 2,
      _seq_no: 10,
      _primary_term: 1,
      found: true,
      _source: {
        sample_a: { keyword: 'a_0', boolean: true },
        type: 'sample_a',
        references: [],
        managed: false,
        coreMigrationVersion: '8.8.0',
        typeMigrationVersion: '10.1.0',
        updated_at: '2025-07-03T11:20:33.777Z',
        created_at: '2025-07-03T11:20:33.777Z'
      }
    }

      at log (src/core/packages/saved-objects/migration-server-internal/src/actions/bulk_overwrite_transformed_documents.ts:69:17)
          at async Promise.all (index 0)

  console.log
    PARTIAL UPDATE RESULT {
      _index: '.kibana_1',
      _id: 'sample_a:a-0',
      _version: 3,
      result: 'updated',
      forced_refresh: true,
      _shards: { total: 1, successful: 1, failed: 0 },
      _seq_no: 20,
      _primary_term: 1
    }

      at log (src/core/packages/saved-objects/migration-server-internal/src/actions/bulk_overwrite_transformed_documents.ts:70:17)
          at async Promise.all (index 0)

  console.log
    DOC NOW LOOKS LIKE {
      _index: '.kibana_1',
      _id: 'sample_a:a-0',
      _version: 3,
      _seq_no: 20,
      _primary_term: 1,
      found: true,
      _source: {
        sample_a: { keyword: 'gonna be lost!', boolean: true, test: false },
        type: 'sample_a',
        references: [],
        managed: false,
        coreMigrationVersion: '8.8.0',
        typeMigrationVersion: '10.1.0',
        updated_at: '2025-07-03T11:20:33.777Z',
        created_at: '2025-07-03T11:20:33.777Z'
      }
    }

      at log (src/core/packages/saved-objects/migration-server-internal/src/actions/bulk_overwrite_transformed_documents.ts:82:17)
          at async Promise.all (index 0)

  console.log
    POST transforms {
      _index: '.kibana_1',
      _id: 'sample_a:a-0',
      _version: 4,
      _seq_no: 21,
      _primary_term: 1,
      found: true,
      _source: {
        sample_a: { test: true, keyword: 'a_0', boolean: true },
        type: 'sample_a',
        references: [],
        managed: false,
        coreMigrationVersion: '8.8.0',
        typeMigrationVersion: '10.2.0',
        updated_at: '2025-07-03T11:20:33.777Z',
        created_at: '2025-07-03T11:20:33.777Z'
      }
    }

```