### PR TITLE
[8.17] Test fix: Close popover before clicking on the tab (#226116)

### DIFF
--- a/x-pack/test/functional/apps/infra/node_details.ts
+++ b/x-pack/test/functional/apps/infra/node_details.ts
@@ -141,9 +141,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     await pageObjects.header.waitUntilLoadingHasFinished();
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/192891
-  // Failing: See https://github.com/elastic/kibana/issues/192891
-  describe.skip('Node Details', () => {
+  describe('Node Details', () => {
     let synthEsClient: InfraSynthtraceEsClient;
     before(async () => {
       synthEsClient = await getInfraSynthtraceEsClient(esClient);
@@ -654,7 +652,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       describe('Overview Tab', () => {
         before(async () => {
-          await pageObjects.assetDetails.clickOverviewTab();
+          // Close the metric popover if it is open
+          await browser.pressKeys(browser.keys.ESCAPE);
+          const overviewTab = await pageObjects.assetDetails.getOverviewTab();
+          // Use clickMouseButton to ensure the tab is visible
+          await overviewTab.clickMouseButton();
         });
 
         [
@@ -861,7 +863,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         describe('Metadata Tab', () => {
           before(async () => {
-            await pageObjects.assetDetails.clickMetadataTab();
+            // Close the metric popover if it is open
+            await browser.pressKeys(browser.keys.ESCAPE);
+            const metadataTab = await pageObjects.assetDetails.getMetadataTab();
+            // Use clickMouseButton to ensure the tab is visible
+            await metadataTab.clickMouseButton();
           });
 
           it('should show metadata table', async () => {

--- a/x-pack/test/functional/page_objects/asset_details.ts
+++ b/x-pack/test/functional/page_objects/asset_details.ts
@@ -176,6 +176,10 @@ export function AssetDetailsProvider({ getService }: FtrProviderContext) {
     },
 
     // Metadata
+    async getMetadataTab() {
+      return testSubjects.find('infraAssetDetailsMetadataTab');
+    },
+
     async clickMetadataTab() {
       return testSubjects.click('infraAssetDetailsMetadataTab');
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Test fix: Close popover before clicking on the tab (#226116)](https://github.com/elastic/kibana/pull/226116)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-07-03T08:16:20Z","message":"Test fix: Close popover before clicking on the tab (#226116)\n\nCloses #225181\n\n## Summary\n\nThis PR tries to fix a failing test by closing all popovers that cover\nthe tab button using the escape key.","sha":"d5f6e40ef663b7a3bab5858b4b5eaa4506c5f691","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.1.0","v8.19.0","v9.2.0"],"title":"Test fix: Close popover before clicking on the tab","number":226116,"url":"https://github.com/elastic/kibana/pull/226116","mergeCommit":{"message":"Test fix: Close popover before clicking on the tab (#226116)\n\nCloses #225181\n\n## Summary\n\nThis PR tries to fix a failing test by closing all popovers that cover\nthe tab button using the escape key.","sha":"d5f6e40ef663b7a3bab5858b4b5eaa4506c5f691"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/226347","number":226347,"state":"MERGED","mergeCommit":{"sha":"eea43c24d9c9d6fbc22cc57b4b1f2f79df152711","message":"[9.1] Test fix: Close popover before clicking on the tab (#226116) (#226347)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [Test fix: Close popover before clicking on the tab\n(#226116)](https://github.com/elastic/kibana/pull/226116)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/226346","number":226346,"state":"MERGED","mergeCommit":{"sha":"4ffa18c085a42439614dc367b8210cd1f8f78db8","message":"[8.19] Test fix: Close popover before clicking on the tab (#226116) (#226346)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [Test fix: Close popover before clicking on the tab\n(#226116)](https://github.com/elastic/kibana/pull/226116)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226116","number":226116,"mergeCommit":{"message":"Test fix: Close popover before clicking on the tab (#226116)\n\nCloses #225181\n\n## Summary\n\nThis PR tries to fix a failing test by closing all popovers that cover\nthe tab button using the escape key.","sha":"d5f6e40ef663b7a3bab5858b4b5eaa4506c5f691"}}]}] BACKPORT-->