### PR TITLE
Fix - Failing test: Chrome X-Pack Observability UI Functional Tests.x-pack/test/observability_functional/apps/observability/pages/alerts/index·ts - ObservabilityApp Observability alerts > Alerts table Filtering Autocompletion works

### DIFF
--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
@@ -76,9 +76,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
     },
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/217739
-  // Failing: See https://github.com/elastic/kibana/issues/217739
-  describe.skip('Observability alerts >', function () {
+  describe('Observability alerts >', function () {
     this.tags('includeFirefox');
     const testSubjects = getService('testSubjects');
     const retry = getService('retry');
@@ -231,7 +229,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
               const titleText = await (
                 await observability.alerts.common.getAlertsFlyoutTitle()
               ).getVisibleText();
-              expect(titleText).to.contain('APM Failed Transaction Rate (one)');
+              expect(titleText).to.contain('Failed transaction rate threshold breached');
             });
           });
 


### PR DESCRIPTION
## Summary

It fixes #217739 



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->