### PR TITLE
[9.0] [Dashboard][Controls] Do not recommend adhoc dataviews (#225705)

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/publishes_data_views.ts
@@ -10,6 +10,10 @@
 import { DataView } from '@kbn/data-views-plugin/common';
 import { PublishingSubject } from '../publishing_subject';
 
+/**
+ * This API publishes a list of data views that it uses. Note that this should not contain any
+ * ad-hoc data views.
+ */
 export interface PublishesDataViews {
   dataViews$: PublishingSubject<DataView[] | undefined>;
 }

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -413,11 +413,6 @@ export const getOptionsListControlFactory = (): DataControlFactory<
               singleSelectSubscription.unsubscribe();
               validSearchStringSubscription.unsubscribe();
               hasSelectionsSubscription.unsubscribe();
-<<<<<<< HEAD
-=======
-              selectionsSubscription.unsubscribe();
-              errorsSubscription.unsubscribe();
->>>>>>> f48e8142750 ([Dashboard][Controls] Do not recommend adhoc dataviews (#225705))
             };
           }, []);
 

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -189,7 +189,7 @@ export const getOptionsListControlFactory = (): DataControlFactory<
         stateManager,
         controlFetch$: (onReload: () => void) => controlGroupApi.controlFetch$(uuid, onReload),
       }).subscribe((result) => {
-        // if there was an error during fetch, set blocking error and return early
+        // if there was an error during fetch, set suggestion load error and return early
         if (Object.hasOwn(result, 'error')) {
           dataControl.api.setBlockingError((result as { error: Error }).error);
           return;
@@ -413,6 +413,11 @@ export const getOptionsListControlFactory = (): DataControlFactory<
               singleSelectSubscription.unsubscribe();
               validSearchStringSubscription.unsubscribe();
               hasSelectionsSubscription.unsubscribe();
+<<<<<<< HEAD
+=======
+              selectionsSubscription.unsubscribe();
+              errorsSubscription.unsubscribe();
+>>>>>>> f48e8142750 ([Dashboard][Controls] Do not recommend adhoc dataviews (#225705))
             };
           }, []);
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/data_views_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/data_views_manager.ts
@@ -43,7 +43,10 @@ export function initializeDataViewsManager(
   const dataViewsSubscription = combineLatest([controlGroupDataViewsPipe, childDataViewsPipe])
     .pipe(
       switchMap(async ([controlGroupDataViews, childDataViews]) => {
-        const allDataViews = [...(controlGroupDataViews ?? []), ...childDataViews];
+        const allDataViews = [...(controlGroupDataViews ?? []), ...childDataViews].filter(
+          (dataView) => dataView.isPersisted()
+        );
+
         if (allDataViews.length === 0) {
           try {
             const defaultDataView = await dataService.dataViews.getDefaultDataView();

--- a/src/platform/plugins/shared/data_views/common/data_views/abstract_data_views.ts
+++ b/src/platform/plugins/shared/data_views/common/data_views/abstract_data_views.ts
@@ -235,6 +235,9 @@ export abstract class AbstractDataView {
     this.originalSavedObjectBody = this.getAsSavedObjectBody();
   };
 
+  /**
+   * Returns true if the data view is persisted, and false if the dataview is adhoc.
+   */
   isPersisted() {
     return typeof this.version === 'string';
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Dashboard][Controls] Do not recommend adhoc dataviews (#225705)](https://github.com/elastic/kibana/pull/225705)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Devon Thomson","email":"devon.thomson@elastic.co"},"sourceCommit":{"committedDate":"2025-07-02T19:45:45Z","message":"[Dashboard][Controls] Do not recommend adhoc dataviews (#225705)\n\nStops the Dashboard from placing adhoc data views into its published data views list. This fixes a bug where Dashboard would recommend an adhoc data view as the most relevant data view when creating a control.","sha":"f48e8142750669651933711e87f57ff26bb8210b","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Presentation","loe:small","impact:critical","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.0.4"],"title":"[Dashboard][Controls] Do not recommend adhoc dataviews","number":225705,"url":"https://github.com/elastic/kibana/pull/225705","mergeCommit":{"message":"[Dashboard][Controls] Do not recommend adhoc dataviews (#225705)\n\nStops the Dashboard from placing adhoc data views into its published data views list. This fixes a bug where Dashboard would recommend an adhoc data view as the most relevant data view when creating a control.","sha":"f48e8142750669651933711e87f57ff26bb8210b"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/226297","number":226297,"state":"MERGED","mergeCommit":{"sha":"88593381d369a55eff0620015fb75d844e558188","message":"[9.1] [Dashboard][Controls] Do not recommend adhoc dataviews (#225705) (#226297)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Dashboard][Controls] Do not recommend adhoc dataviews\n(#225705)](https://github.com/elastic/kibana/pull/225705)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Devon Thomson <devon.thomson@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/226296","number":226296,"state":"MERGED","mergeCommit":{"sha":"7a30084256088d181e483760178d9d2cbc3ab65a","message":"[8.19] [Dashboard][Controls] Do not recommend adhoc dataviews (#225705) (#226296)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Dashboard][Controls] Do not recommend adhoc dataviews\n(#225705)](https://github.com/elastic/kibana/pull/225705)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Devon Thomson <devon.thomson@elastic.co>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225705","number":225705,"mergeCommit":{"message":"[Dashboard][Controls] Do not recommend adhoc dataviews (#225705)\n\nStops the Dashboard from placing adhoc data views into its published data views list. This fixes a bug where Dashboard would recommend an adhoc data view as the most relevant data view when creating a control.","sha":"f48e8142750669651933711e87f57ff26bb8210b"}},{"branch":"9.0","label":"v9.0.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->