### PR TITLE
[Unzyme] `src/core/packages/mount-utils` :shipit:

### DIFF
--- a/src/core/packages/mount-utils/browser-internal/src/mount.test.tsx
+++ b/src/core/packages/mount-utils/browser-internal/src/mount.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { MountWrapper, mountReactNode } from './mount';
 
 describe('MountWrapper', () => {
@@ -21,8 +21,8 @@ describe('MountWrapper', () => {
       return () => {};
     };
     const wrapper = <MountWrapper mount={mountPoint} />;
-    const container = mount(wrapper);
-    expect(container.html()).toMatchInlineSnapshot(
+    const container = render(wrapper);
+    expect(container.container.innerHTML).toMatchInlineSnapshot(
       `"<div class=\\"kbnMountWrapper\\"><p class=\\"bar\\">hello</p></div>"`
     );
   });
@@ -37,14 +37,13 @@ describe('MountWrapper', () => {
     };
 
     const wrapper = <MountWrapper mount={mountPoint} />;
-    const container = mount(wrapper);
-    expect(container.html()).toMatchInlineSnapshot(
+    const container = render(wrapper);
+    expect(container.container.innerHTML).toMatchInlineSnapshot(
       `"<div class=\\"kbnMountWrapper\\"><p>initial</p></div>"`
     );
 
     el.textContent = 'changed';
-    container.update();
-    expect(container.html()).toMatchInlineSnapshot(
+    expect(container.container.innerHTML).toMatchInlineSnapshot(
       `"<div class=\\"kbnMountWrapper\\"><p>changed</p></div>"`
     );
   });
@@ -52,8 +51,8 @@ describe('MountWrapper', () => {
   it('can render a detached react component', () => {
     const mountPoint = mountReactNode(<span>detached</span>);
     const wrapper = <MountWrapper mount={mountPoint} />;
-    const container = mount(wrapper);
-    expect(container.html()).toMatchInlineSnapshot(
+    const container = render(wrapper);
+    expect(container.container.innerHTML).toMatchInlineSnapshot(
       `"<div class=\\"kbnMountWrapper\\"><span>detached</span></div>"`
     );
   });
@@ -61,8 +60,8 @@ describe('MountWrapper', () => {
   it('accepts a className prop to override default className', () => {
     const mountPoint = mountReactNode(<span>detached</span>);
     const wrapper = <MountWrapper mount={mountPoint} className="customClass" />;
-    const container = mount(wrapper);
-    expect(container.html()).toMatchInlineSnapshot(
+    const container = render(wrapper);
+    expect(container.container.innerHTML).toMatchInlineSnapshot(
       `"<div class=\\"customClass\\"><span>detached</span></div>"`
     );
   });


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/224000

Moved to react testing library. Tests pass but I'm getting this warning now:

```
Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot
```

When I tried to move to createRoot it caused other issues so I'm not sure how to continue or if we should ignore the warning 🤔 @Dosant 

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->