### PR TITLE
[9.1] [Security Solution][Endpoint] Fix automated response actions when spaces is enabled and action can not be sent (#226043)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.test.ts
@@ -182,4 +182,19 @@ describe('When using `getActionDetailsById()', () => {
       })
     );
   });
+
+  it('should not validate against spaces when `bypassSpaceValidation` is `true`', async () => {
+    // @ts-expect-error
+    endpointAppContextService.experimentalFeatures.endpointManagementSpaceAwarenessEnabled = true;
+    (
+      endpointAppContextService.getInternalFleetServices().ensureInCurrentSpace as jest.Mock
+    ).mockResolvedValue(undefined);
+    await getActionDetailsById(endpointAppContextService, 'default', '123', {
+      bypassSpaceValidation: true,
+    });
+
+    expect(
+      endpointAppContextService.getInternalFleetServices().ensureInCurrentSpace
+    ).not.toHaveBeenCalled();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
@@ -27,7 +27,16 @@ import { NotFoundError } from '../../errors';
 export const getActionDetailsById = async <T extends ActionDetails = ActionDetails>(
   endpointService: EndpointAppContextService,
   spaceId: string,
-  actionId: string
+  actionId: string,
+  {
+    bypassSpaceValidation = false,
+  }: Partial<{
+    /**
+     * if `true`, then no space validations will be done on the action retrieved. Default is `false`.
+     * USE IT CAREFULLY!
+     */
+    bypassSpaceValidation: boolean;
+  }> = {}
 ): Promise<T> => {
   let normalizedActionRequest: ReturnType<typeof mapToNormalizedActionRequest> | undefined;
   let actionResponses: FetchActionResponsesResult;
@@ -36,7 +45,7 @@ export const getActionDetailsById = async <T extends ActionDetails = ActionDetai
     // Get both the Action Request(s) and action Response(s)
     const [actionRequestEsDoc, actionResponseResult] = await Promise.all([
       // Get the action request(s)
-      fetchActionRequestById(endpointService, spaceId, actionId),
+      fetchActionRequestById(endpointService, spaceId, actionId, { bypassSpaceValidation }),
 
       // Get all responses
       fetchActionResponses({

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/endpoint/endpoint_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/endpoint/endpoint_actions_client.ts
@@ -195,7 +195,10 @@ export class EndpointActionsClient extends ResponseActionsClientImpl {
       }),
     });
 
-    return this.fetchActionDetails<TResponse>(actionId);
+    // We bypass space validation when retrieving the action details to ensure that if a failed
+    // action was created, and it did not contain the agent policy information (and space is enabled)
+    // we don't trigger an error.
+    return this.fetchActionDetails<TResponse>(actionId, true);
   }
 
   private async dispatchActionViaFleet({

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.test.ts
@@ -293,7 +293,8 @@ describe('ResponseActionsClientImpl base class', () => {
       expect(getActionDetailsByIdMock).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        'one'
+        'one',
+        { bypassSpaceValidation: false }
       );
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
@@ -453,12 +453,20 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
   /**
    * Returns the action details for a given response action id
    * @param actionId
+   * @param bypassSpaceValidation
    * @protected
    */
   protected async fetchActionDetails<T extends ActionDetails = ActionDetails>(
-    actionId: string
+    actionId: string,
+    /**
+     * if `true`, then no space validations will be done on the action retrieved. Default is `false`.
+     * USE IT CAREFULLY!
+     */
+    bypassSpaceValidation: boolean = false
   ): Promise<T> {
-    return getActionDetailsById(this.options.endpointService, this.options.spaceId, actionId);
+    return getActionDetailsById(this.options.endpointService, this.options.spaceId, actionId, {
+      bypassSpaceValidation,
+    });
   }
 
   /**
@@ -612,18 +620,19 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
 
     this.notifyUsage(actionRequest.command);
 
-    // It's possible with Automated Response actions that we could reach this point with
-    // no endpoint IDs in the action request - case where they are no longer enrolled.
-    // In these cases, we don't attempt to build the agent policy info and instead add
-    // the `integration deleted` tag to the action request, which means these are only
-    // visible in the space configured (via ref. data) show orphaned actions
-    const agentPolicyInfo: LogsEndpointAction['agent']['policy'] =
-      isSpacesEnabled && actionRequest.endpoint_ids.length > 0
+    const actionId = actionRequest.actionId || uuidv4();
+    const tags = actionRequest.tags ?? [];
+
+    // With automated response action, it's possible to reach this point and not have any `endpoint_ids`
+    // defined in the action. That's because with automated response actions we always create an
+    // action request, even when there is a failure - like if the agent was un-enrolled in between
+    // the event sent and the detection engine processing that event.
+    const agentPolicyInfo =
+      isSpacesEnabled && actionRequest.endpoint_ids.length
         ? await this.fetchAgentPolicyInfo(actionRequest.endpoint_ids)
         : [];
-    const tags: LogsEndpointAction['tags'] = actionRequest.tags ?? [];
 
-    if (agentPolicyInfo.length === 0) {
+    if (isSpacesEnabled && agentPolicyInfo.length === 0) {
       tags.push(ALLOWED_ACTION_REQUEST_TAGS.integrationPolicyDeleted);
     }
 
@@ -645,7 +654,7 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
         ...(isSpacesEnabled ? { policy: agentPolicyInfo } : {}),
       },
       EndpointActions: {
-        action_id: actionRequest.actionId || uuidv4(),
+        action_id: actionId,
         expiration: getActionRequestExpiration(),
         type: 'INPUT_ACTION',
         input_type: this.agentType,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_request_by_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_request_by_id.test.ts
@@ -124,5 +124,18 @@ describe('fetchActionRequestById() utility', () => {
         'Action [123] not found'
       );
     });
+
+    it('should not validate action against spaces if `bypassSpaceValidation` is true', async () => {
+      (
+        endpointServiceMock.getInternalFleetServices().ensureInCurrentSpace as jest.Mock
+      ).mockResolvedValue(undefined);
+      await fetchActionRequestById(endpointServiceMock, 'default', '123', {
+        bypassSpaceValidation: true,
+      });
+
+      expect(
+        endpointServiceMock.getInternalFleetServices().ensureInCurrentSpace as jest.Mock
+      ).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_request_by_id.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/fetch_action_request_by_id.ts
@@ -25,7 +25,6 @@ import { REF_DATA_KEYS } from '../../../lib/reference_data';
  * @param endpointService
  * @param spaceId
  * @param actionId
- *
  * @throws
  */
 export const fetchActionRequestById = async <
@@ -35,7 +34,16 @@ export const fetchActionRequestById = async <
 >(
   endpointService: EndpointAppContextService,
   spaceId: string,
-  actionId: string
+  actionId: string,
+  {
+    bypassSpaceValidation = false,
+  }: Partial<{
+    /**
+     * if `true`, then no space validations will be done on the action retrieved. Default is `false`.
+     * USE IT CAREFULLY!
+     */
+    bypassSpaceValidation: boolean;
+  }> = {}
 ): Promise<LogsEndpointAction<TParameters, TOutputContent, TMeta>> => {
   const logger = endpointService.createLogger('fetchActionRequestById');
   const searchResponse = await endpointService
@@ -54,7 +62,10 @@ export const fetchActionRequestById = async <
 
   if (!actionRequest) {
     throw new NotFoundError(`Action with id '${actionId}' not found.`);
-  } else if (endpointService.experimentalFeatures.endpointManagementSpaceAwarenessEnabled) {
+  } else if (
+    endpointService.experimentalFeatures.endpointManagementSpaceAwarenessEnabled &&
+    !bypassSpaceValidation
+  ) {
     if (!actionRequest.agent.policy || actionRequest.agent.policy.length === 0) {
       const message = `Response action [${actionId}] missing 'agent.policy' information - unable to determine if response action is accessible for space [${spaceId}]`;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Endpoint] Fix automated response actions when spaces is enabled and action can not be sent (#226043)](https://github.com/elastic/kibana/pull/226043)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-03T13:37:09Z","message":"[Security Solution][Endpoint] Fix automated response actions when spaces is enabled and action can not be sent (#226043)\n\n## Summary\n\nPR fixes the following issue when spaces is enabled:\n\n- When automated response actions are processed, if unable to determine\nthe policy associated with the agent the action is being sent to, we\nshould still create the failed action request (as we did before spaces\nwas enabled)\n- Although this fix creates the action request in failed state, it will\nnot be visible in the UI - both under the alert that triggered it and\nthe action history log - because we are not able to determine access to\nthe action due to not having policy information for the agent.\n- Action failure will tagged as \"orphan\" and thus it will be displayed\nin the action history log in the space that is configured to show orphan\nactions","sha":"765376745e4988519b4ce2e1ef7d1a54c6bcd078","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","backport:version","v9.1.0","v9.2.0"],"title":"[Security Solution][Endpoint] Fix automated response actions when spaces is enabled and action can not be sent","number":226043,"url":"https://github.com/elastic/kibana/pull/226043","mergeCommit":{"message":"[Security Solution][Endpoint] Fix automated response actions when spaces is enabled and action can not be sent (#226043)\n\n## Summary\n\nPR fixes the following issue when spaces is enabled:\n\n- When automated response actions are processed, if unable to determine\nthe policy associated with the agent the action is being sent to, we\nshould still create the failed action request (as we did before spaces\nwas enabled)\n- Although this fix creates the action request in failed state, it will\nnot be visible in the UI - both under the alert that triggered it and\nthe action history log - because we are not able to determine access to\nthe action due to not having policy information for the agent.\n- Action failure will tagged as \"orphan\" and thus it will be displayed\nin the action history log in the space that is configured to show orphan\nactions","sha":"765376745e4988519b4ce2e1ef7d1a54c6bcd078"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226043","number":226043,"mergeCommit":{"message":"[Security Solution][Endpoint] Fix automated response actions when spaces is enabled and action can not be sent (#226043)\n\n## Summary\n\nPR fixes the following issue when spaces is enabled:\n\n- When automated response actions are processed, if unable to determine\nthe policy associated with the agent the action is being sent to, we\nshould still create the failed action request (as we did before spaces\nwas enabled)\n- Although this fix creates the action request in failed state, it will\nnot be visible in the UI - both under the alert that triggered it and\nthe action history log - because we are not able to determine access to\nthe action due to not having policy information for the agent.\n- Action failure will tagged as \"orphan\" and thus it will be displayed\nin the action history log in the space that is configured to show orphan\nactions","sha":"765376745e4988519b4ce2e1ef7d1a54c6bcd078"}}]}] BACKPORT-->