### PR TITLE
[Synthetics / WIP] Introduce subfeature for managing monitors

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_settings_context.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_settings_context.tsx
@@ -103,6 +103,8 @@ export const SyntheticsSettingsContextProvider: React.FC<PropsWithChildren<Synth
   const canSave = (application?.capabilities.uptime.save ?? false) as boolean;
   const canManagePrivateLocations = (application?.capabilities.uptime.canManagePrivateLocations ??
     false) as boolean;
+  const canManageSyntheticsTests = (application?.capabilities.uptime.canManageSyntheticsTests ??
+    false) as boolean;
 
   const value = useMemo(() => {
     return {
@@ -118,6 +120,7 @@ export const SyntheticsSettingsContextProvider: React.FC<PropsWithChildren<Synth
       dateRangeEnd: dateRangeEnd ?? DATE_RANGE_END,
       isServerless,
       canManagePrivateLocations,
+      canManageSyntheticsTests,
     };
   }, [
     darkMode,
@@ -132,6 +135,7 @@ export const SyntheticsSettingsContextProvider: React.FC<PropsWithChildren<Synth
     commonlyUsedRanges,
     isServerless,
     canManagePrivateLocations,
+    canManageSyntheticsTests,
   ]);
 
   return <SyntheticsSettingsContext.Provider value={value} children={children} />;

--- a/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
@@ -34,6 +34,7 @@ import { syntheticsApiKeyObjectType } from './saved_objects/service_api_key';
 
 export const PRIVATE_LOCATION_WRITE_API = 'private-location-write';
 export const SYNTHETICS_TEST_WRITE_API = 'synthetics-test-write';
+export const MONITOR_WRITE_API = 'monitor-write';
 
 const ruleTypes = [...UPTIME_RULE_TYPE_IDS, ...SYNTHETICS_RULE_TYPE_IDS];
 
@@ -48,7 +49,7 @@ const elasticManagedLocationsEnabledPrivilege: SubFeaturePrivilegeGroupConfig = 
     {
       id: 'elastic_managed_locations_enabled',
       name: i18n.translate('xpack.synthetics.features.elasticManagedLocations.label', {
-        defaultMessage: 'Managed locations enabled',
+        defaultMessage: 'Use elastic managed locations',
       }),
       includeIn: 'all',
       savedObject: {
@@ -79,21 +80,21 @@ const canManagePrivateLocationsPrivilege: SubFeaturePrivilegeGroupConfig = {
   ],
 };
 
-const canManageSyntheticsTestsPrivilege: SubFeaturePrivilegeGroupConfig = {
+const canManageSyntheticsMonitorsPrivilege: SubFeaturePrivilegeGroupConfig = {
   groupType: 'independent' as SubFeaturePrivilegeGroupType,
   privileges: [
     {
-      id: 'can_manage_synthetics_tests',
-      name: i18n.translate('xpack.synthetics.features.canManageSyntheticsTests', {
-        defaultMessage: 'Can manage tests',
+      id: 'can_manage_synthetics_monitors',
+      name: i18n.translate('xpack.synthetics.features.canManageSyntheticsMonitors', {
+        defaultMessage: 'Can manage monitors',
       }),
       includeIn: 'all',
-      api: [SYNTHETICS_TEST_WRITE_API],
+      api: [MONITOR_WRITE_API],
       savedObject: {
-        all: [],
+        all: [legacySyntheticsMonitorTypeSingle, syntheticsMonitorSavedObjectType],
         read: [],
       },
-      ui: ['canManageSyntheticsTests'],
+      ui: ['monitor:save'],
     },
   ],
 };
@@ -118,15 +119,18 @@ export const syntheticsFeature = {
       savedObject: {
         all: [
           syntheticsSettingsObjectType,
-          legacySyntheticsMonitorTypeSingle,
-          syntheticsMonitorSavedObjectType,
           syntheticsApiKeyObjectType,
           syntheticsParamType,
 
           // uptime settings object is also registered here since feature is shared between synthetics and uptime
           uptimeSettingsObjectType,
         ],
-        read: [privateLocationSavedObjectName, legacyPrivateLocationsSavedObjectName],
+        read: [
+          legacySyntheticsMonitorTypeSingle,
+          syntheticsMonitorSavedObjectType,
+          privateLocationSavedObjectName,
+          legacyPrivateLocationsSavedObjectName,
+        ],
       },
       alerting: {
         rule: {
@@ -175,6 +179,15 @@ export const syntheticsFeature = {
   },
   subFeatures: [
     {
+      name: i18n.translate('xpack.synthetics.features.app.monitors', {
+        defaultMessage: 'Synthetics monitors',
+      }),
+      description: i18n.translate('xpack.synthetics.features.app.monitorsDescription', {
+        defaultMessage: 'This feature allows you to modify monitors for synthetics.',
+      }),
+      privilegeGroups: [canManageSyntheticsMonitorsPrivilege],
+    },
+    {
       name: i18n.translate('xpack.synthetics.features.app.elastic', {
         defaultMessage: 'Elastic managed locations',
       }),
@@ -193,15 +206,6 @@ export const syntheticsFeature = {
           'This feature allows you to manage your private locations, for example adding, or deleting them.',
       }),
       privilegeGroups: [canManagePrivateLocationsPrivilege],
-    },
-    {
-      name: i18n.translate('xpack.synthetics.features.app.tests', {
-        defaultMessage: 'Synthetics tests',
-      }),
-      description: i18n.translate('xpack.synthetics.features.app.testsDescription', {
-        defaultMessage: 'This feature allows you to modify tests for synthetics monitors.',
-      }),
-      privilegeGroups: [canManageSyntheticsTestsPrivilege],
     },
   ],
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/feature.ts
@@ -33,6 +33,7 @@ import {
 import { syntheticsApiKeyObjectType } from './saved_objects/service_api_key';
 
 export const PRIVATE_LOCATION_WRITE_API = 'private-location-write';
+export const SYNTHETICS_TEST_WRITE_API = 'synthetics-test-write';
 
 const ruleTypes = [...UPTIME_RULE_TYPE_IDS, ...SYNTHETICS_RULE_TYPE_IDS];
 
@@ -47,7 +48,7 @@ const elasticManagedLocationsEnabledPrivilege: SubFeaturePrivilegeGroupConfig = 
     {
       id: 'elastic_managed_locations_enabled',
       name: i18n.translate('xpack.synthetics.features.elasticManagedLocations.label', {
-        defaultMessage: 'Enabled',
+        defaultMessage: 'Managed locations enabled',
       }),
       includeIn: 'all',
       savedObject: {
@@ -65,7 +66,7 @@ const canManagePrivateLocationsPrivilege: SubFeaturePrivilegeGroupConfig = {
     {
       id: 'can_manage_private_locations',
       name: i18n.translate('xpack.synthetics.features.canManagePrivateLocations', {
-        defaultMessage: 'Can manage',
+        defaultMessage: 'Can manage private locations',
       }),
       includeIn: 'all',
       api: [PRIVATE_LOCATION_WRITE_API],
@@ -74,6 +75,25 @@ const canManagePrivateLocationsPrivilege: SubFeaturePrivilegeGroupConfig = {
         read: [],
       },
       ui: ['canManagePrivateLocations'],
+    },
+  ],
+};
+
+const canManageSyntheticsTestsPrivilege: SubFeaturePrivilegeGroupConfig = {
+  groupType: 'independent' as SubFeaturePrivilegeGroupType,
+  privileges: [
+    {
+      id: 'can_manage_synthetics_tests',
+      name: i18n.translate('xpack.synthetics.features.canManageSyntheticsTests', {
+        defaultMessage: 'Can manage tests',
+      }),
+      includeIn: 'all',
+      api: [SYNTHETICS_TEST_WRITE_API],
+      savedObject: {
+        all: [],
+        read: [],
+      },
+      ui: ['canManageSyntheticsTests'],
     },
   ],
 };
@@ -173,6 +193,15 @@ export const syntheticsFeature = {
           'This feature allows you to manage your private locations, for example adding, or deleting them.',
       }),
       privilegeGroups: [canManagePrivateLocationsPrivilege],
+    },
+    {
+      name: i18n.translate('xpack.synthetics.features.app.tests', {
+        defaultMessage: 'Synthetics tests',
+      }),
+      description: i18n.translate('xpack.synthetics.features.app.testsDescription', {
+        defaultMessage: 'This feature allows you to modify tests for synthetics monitors.',
+      }),
+      privilegeGroups: [canManageSyntheticsTestsPrivilege],
     },
   ],
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -21,11 +21,13 @@ import { SyntheticsRestApiRouteFactory } from '../types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { normalizeAPIConfig, validateMonitor } from './monitor_validation';
 import { mapSavedObjectToMonitor } from './formatters/saved_object_to_monitor';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const addSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.SYNTHETICS_MONITORS,
   validate: {},
+  requiredPrivileges: [MONITOR_WRITE_API],
   validation: {
     request: {
       body: schema.any(),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_integration.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_integration.ts
@@ -7,10 +7,12 @@
 import { schema } from '@kbn/config-schema';
 import { SyntheticsRestApiRouteFactory } from '../types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const deletePackagePolicyRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'DELETE',
   path: SYNTHETICS_API_URLS.DELETE_PACKAGE_POLICY,
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {
     params: schema.object({
       packagePolicyId: schema.string({ minLength: 1, maxLength: 1024 }),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
@@ -10,6 +10,7 @@ import { DeleteMonitorAPI } from './services/delete_monitor_api';
 import { SyntheticsRestApiRouteFactory } from '../types';
 import { DeleteParamsResponse } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const deleteSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory<
   DeleteParamsResponse[],
@@ -19,6 +20,7 @@ export const deleteSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory<
 > = () => ({
   method: 'DELETE',
   path: SYNTHETICS_API_URLS.SYNTHETICS_MONITORS + '/{id?}',
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {},
   validation: {
     request: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -36,12 +36,14 @@ import {
 } from '../telemetry/monitor_upgrade_sender';
 import { formatSecrets } from '../../synthetics_service/utils/secrets';
 import { mapSavedObjectToMonitor } from './formatters/saved_object_to_monitor';
+import { MONITOR_WRITE_API } from '../../feature';
 
 // Simplify return promise type and type it with runtime_types
 export const editSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'PUT',
   path: SYNTHETICS_API_URLS.SYNTHETICS_MONITORS + '/{monitorId}',
   validate: {},
+  requiredPrivileges: [MONITOR_WRITE_API],
   validation: {
     request: {
       params: schema.object({

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
@@ -15,10 +15,12 @@ import { DEFAULT_FIELDS } from '../../../common/constants/monitor_defaults';
 import { validateMonitor } from './monitor_validation';
 import { getPrivateLocationsForMonitor } from './add_monitor/utils';
 import { AddEditMonitorAPI } from './add_monitor/add_monitor_api';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const inspectSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.SYNTHETICS_MONITOR_INSPECT,
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {
     body: schema.any(),
     query: schema.object({

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
@@ -17,12 +17,14 @@ import { ProjectMonitor } from '../../../../common/runtime_types';
 
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { ProjectMonitorFormatter } from '../../../synthetics_service/project_monitor/project_monitor_formatter';
+import { MONITOR_WRITE_API } from '../../../feature';
 
 const MAX_PAYLOAD_SIZE = 1048576 * 100; // 50MiB
 
 export const addSyntheticsProjectMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'PUT',
   path: SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE,
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {
     query: schema.object({
       // primarily used for testing purposes, to specify the type of saved object

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
@@ -13,10 +13,12 @@ import { ConfigKey, EncryptedSyntheticsMonitorAttributes } from '../../../../com
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { getSavedObjectKqlFilter } from '../../common';
 import { validateSpaceId } from '../services/validate_space_id';
+import { MONITOR_WRITE_API } from '../../../feature';
 
 export const deleteSyntheticsMonitorProjectRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'DELETE',
   path: SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE,
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {
     body: schema.object({
       monitors: schema.arrayOf(schema.string()),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/pings/journey_screenshot_blocks.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/pings/journey_screenshot_blocks.ts
@@ -9,10 +9,12 @@ import { schema } from '@kbn/config-schema';
 import { getJourneyScreenshotBlocks } from '../../queries/get_journey_screenshot_blocks';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { SyntheticsRestApiRouteFactory } from '../types';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const createJourneyScreenshotBlocksRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.JOURNEY_SCREENSHOT_BLOCKS,
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {
     body: schema.object({
       hashes: schema.arrayOf(schema.string()),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/dynamic_settings.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/dynamic_settings.ts
@@ -22,6 +22,7 @@ export const createGetDynamicSettingsRoute: SyntheticsRestApiRouteFactory<
   method: 'GET',
   path: SYNTHETICS_API_URLS.DYNAMIC_SETTINGS,
   validate: false,
+
   handler: async ({ savedObjectsClient }) => {
     const dynamicSettingsAttributes: DynamicSettingsAttributes = await getSyntheticsDynamicSettings(
       savedObjectsClient

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../common/runtime_types';
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { MONITOR_WRITE_API } from '../../../feature';
 
 const ParamsObjectSchema = schema.object({
   key: schema.string({
@@ -36,6 +37,7 @@ export const addSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
 > = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.PARAMS,
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {},
   validation: {
     request: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/delete_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/delete_param.ts
@@ -12,6 +12,7 @@ import { SyntheticsRestApiRouteFactory } from '../../types';
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { DeleteParamsResponse } from '../../../../common/runtime_types';
+import { MONITOR_WRITE_API } from '../../../feature';
 
 export const deleteSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
   DeleteParamsResponse[],
@@ -21,6 +22,7 @@ export const deleteSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
 > = () => ({
   method: 'DELETE',
   path: SYNTHETICS_API_URLS.PARAMS + '/{id?}',
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {},
   validation: {
     request: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/delete_params_bulk.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/delete_params_bulk.ts
@@ -11,6 +11,7 @@ import { SyntheticsRestApiRouteFactory } from '../../types';
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { DeleteParamsResponse } from '../../../../common/runtime_types';
+import { MONITOR_WRITE_API } from '../../../feature';
 
 export const deleteSyntheticsParamsBulkRoute: SyntheticsRestApiRouteFactory<
   DeleteParamsResponse[],
@@ -20,6 +21,7 @@ export const deleteSyntheticsParamsBulkRoute: SyntheticsRestApiRouteFactory<
 > = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.PARAMS + '/_bulk_delete',
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {},
   validation: {
     request: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -14,6 +14,7 @@ import { SyntheticsRestApiRouteFactory } from '../../types';
 import { SyntheticsParamRequest, SyntheticsParams } from '../../../../common/runtime_types';
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { MONITOR_WRITE_API } from '../../../feature';
 
 const RequestParamsSchema = schema.object({
   id: schema.string(),
@@ -28,6 +29,7 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
   method: 'PUT',
   path: SYNTHETICS_API_URLS.PARAMS + '/{id}',
   validate: {},
+  requiredPrivileges: [MONITOR_WRITE_API],
   validation: {
     request: {
       params: RequestParamsSchema,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/enablement.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/enablement.ts
@@ -12,6 +12,7 @@ import {
   getAPIKeyForSyntheticsService,
   getSyntheticsEnablement,
 } from '../../synthetics_service/get_api_key';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const getSyntheticsEnablementRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'PUT',
@@ -62,6 +63,7 @@ export const getSyntheticsEnablementRoute: SyntheticsRestApiRouteFactory = () =>
 export const disableSyntheticsRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'DELETE',
   path: SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT,
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {},
   handler: async ({
     response,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
@@ -12,10 +12,12 @@ import { SyntheticsRestApiRouteFactory } from '../types';
 import { ConfigKey, MonitorFields } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { validateMonitor } from '../monitor_cruds/monitor_validation';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const runOnceSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.RUN_ONCE_MONITOR + '/{monitorId}',
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {
     body: schema.any(),
     params: schema.object({

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -15,10 +15,12 @@ import { ConfigKey, MonitorFields } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { getPrivateLocationsForMonitor } from '../monitor_cruds/add_monitor/utils';
 import { getMonitorNotFoundResponse } from './service_errors';
+import { MONITOR_WRITE_API } from '../../feature';
 
 export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse> = () => ({
   method: 'POST',
   path: SYNTHETICS_API_URLS.TRIGGER_MONITOR + '/{monitorId}',
+  requiredPrivileges: [MONITOR_WRITE_API],
   validate: {
     params: schema.object({
       monitorId: schema.string({ minLength: 1, maxLength: 1024 }),


### PR DESCRIPTION
WIP for #225630

- Because `uptime-write` is written to all PUT, POST, and DEL routes dynamically, this is treated as the universal edit role for the synthetics api and ideally should not be modified
- A new privilege has been added to specific synthetics routes. Some tweaking may be required. The dynamic settings route was excluded due to mapping error thrown at runtime.
- The "save" ui privilege is part of the core synthetics feature and cannot be moved to the new monitors subfeature, as this is shared with other features in Kibana. **This privilege is also widely used throughout synthetics to determine whether or not a user can modify anything in the plugin. It will be necessary to change the conditions under which a user can modify monitors (canSave) to look for the new capability instead of just save**
