### PR TITLE
[8.17] [Discover] Don't change selected document when resizing flyout with keyboard (#225447) (#225594)

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -146,6 +146,19 @@ export function UnifiedDocViewerFlyout({
         return;
       }
 
+      const isTabButton = (ev.target as HTMLElement).getAttribute('role') === 'tab';
+      if (isTabButton) {
+        // ignore events triggered when the tab buttons are focused
+        return;
+      }
+
+      const isResizableButton =
+        (ev.target as HTMLElement).getAttribute('data-test-subj') === 'euiResizableButton';
+      if (isResizableButton) {
+        // ignore events triggered when the resizable button is focused
+        return;
+      }
+
       if (ev.key === keys.ARROW_LEFT || ev.key === keys.ARROW_RIGHT) {
         ev.preventDefault();
         ev.stopPropagation();

--- a/test/functional/apps/discover/group3/_doc_viewer.ts
+++ b/test/functional/apps/discover/group3/_doc_viewer.ts
@@ -501,6 +501,28 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-2`);
         });
 
+        it('should not navigate between documents with arrow keys when the tabs are focused', async () => {
+          await dataGrid.clickRowToggle({ defaultTabId: false });
+          await discover.isShowingDocViewer();
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-0`);
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+          await testSubjects.click('docViewerTab-doc_view_source');
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+        });
+
+        it('should not navigate between documents with arrow keys when resizable button is focused', async () => {
+          await dataGrid.clickRowToggle({ defaultTabId: false });
+          await discover.isShowingDocViewer();
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-0`);
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+          await testSubjects.click('euiResizableButton');
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+        });
+
         it('should close the flyout with the escape key', async () => {
           await dataGrid.clickRowToggle({ defaultTabId: false });
           expect(await discover.isShowingDocViewer()).to.be(true);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Discover] Don't change selected document when resizing flyout with keyboard (#225447) (#225594)](https://github.com/elastic/kibana/pull/225594)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alejandro García Parrondo","email":"31973472+AlexGPlay@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-04T06:34:21Z","message":"[Discover] Don't change selected document when resizing flyout with keyboard (#225447) (#225594)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/225447\n\nAdds a new rule to not let the event bubble up to the main table so it\ndoesn't change the selected document when the user is resizing the table\nvia keyboard.\n\nBefore\n------\n\nhttps://github.com/user-attachments/assets/417169fa-f2fc-4a5f-9782-09c84ccdb339\n\n\nAfter\n------\n\nhttps://github.com/user-attachments/assets/3794e982-c767-4fda-b432-8ca167f9250d\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"6447ece451734804a02c929dc93c71728a309954","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:all-open","Feature:UnifiedDocViewer","v9.2.0"],"title":"[Discover] Don't change selected document when resizing flyout with keyboard (#225447)","number":225594,"url":"https://github.com/elastic/kibana/pull/225594","mergeCommit":{"message":"[Discover] Don't change selected document when resizing flyout with keyboard (#225447) (#225594)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/225447\n\nAdds a new rule to not let the event bubble up to the main table so it\ndoesn't change the selected document when the user is resizing the table\nvia keyboard.\n\nBefore\n------\n\nhttps://github.com/user-attachments/assets/417169fa-f2fc-4a5f-9782-09c84ccdb339\n\n\nAfter\n------\n\nhttps://github.com/user-attachments/assets/3794e982-c767-4fda-b432-8ca167f9250d\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"6447ece451734804a02c929dc93c71728a309954"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225594","number":225594,"mergeCommit":{"message":"[Discover] Don't change selected document when resizing flyout with keyboard (#225447) (#225594)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/225447\n\nAdds a new rule to not let the event bubble up to the main table so it\ndoesn't change the selected document when the user is resizing the table\nvia keyboard.\n\nBefore\n------\n\nhttps://github.com/user-attachments/assets/417169fa-f2fc-4a5f-9782-09c84ccdb339\n\n\nAfter\n------\n\nhttps://github.com/user-attachments/assets/3794e982-c767-4fda-b432-8ca167f9250d\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"6447ece451734804a02c929dc93c71728a309954"}},{"url":"https://github.com/elastic/kibana/pull/226514","number":226514,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/226515","number":226515,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/226516","number":226516,"branch":"9.0","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/226517","number":226517,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->