### PR TITLE
fix chat display with `prefers-reduce-motion`

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
@@ -104,6 +104,7 @@ const fadeInAnimation = keyframes`
 const animClassName = (euiTheme: UseEuiTheme['euiTheme']) => css`
   height: 100%;
   ${euiCanAnimate} {
+    opacity: 0;
     animation: ${fadeInAnimation} ${euiTheme.animation.normal} ${euiTheme.animation.bounce}
       ${euiTheme.animation.normal} forwards;
   }

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
@@ -103,7 +103,6 @@ const fadeInAnimation = keyframes`
 
 const animClassName = (euiTheme: UseEuiTheme['euiTheme']) => css`
   height: 100%;
-  opacity: 0;
   ${euiCanAnimate} {
     animation: ${fadeInAnimation} ${euiTheme.animation.normal} ${euiTheme.animation.bounce}
       ${euiTheme.animation.normal} forwards;


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/225846,
Closes https://github.com/elastic/obs-ai-assistant-team/issues/307

To see the bug Enable the "Reduce Motion" setting on your device.
On MacBook: System Settings → Accessibility → Display → Reduce motion





<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->