### PR TITLE
[Discover] Return namespaces from update (#212574)

### DIFF
--- a/src/platform/plugins/shared/data/server/query/route_handler_context.test.ts
+++ b/src/platform/plugins/shared/data/server/query/route_handler_context.test.ts
@@ -220,34 +220,74 @@ describe('saved query route handler context', () => {
   });
 
   describe('update', function () {
-    it('should update a saved object for the given attributes', async () => {
-      const mockResponse: SavedObject<InternalSavedQueryAttributes> = {
-        id: 'foo',
-        type: 'query',
-        attributes: internalSavedQueryAttributes,
-        references: [],
-      };
+    beforeEach(() => {
       mockSavedObjectsClient.find.mockResolvedValue({
         total: 0,
         page: 0,
         per_page: 0,
         saved_objects: [],
       });
-      mockSavedObjectsClient.update.mockResolvedValue(mockResponse);
+    });
 
-      const response = await context.update('foo', savedQueryAttributes);
-
-      expect(mockSavedObjectsClient.update).toHaveBeenCalledWith(
-        'query',
-        'foo',
-        { ...internalSavedQueryAttributes, timefilter: null },
-        {
+    describe('when the saved query does not have namespaces', () => {
+      it('should update a saved object for the given attributes', async () => {
+        // Given
+        const mockResponse: SavedObject<InternalSavedQueryAttributes> = {
+          id: 'foo',
+          type: 'query',
+          attributes: internalSavedQueryAttributes,
           references: [],
-        }
-      );
-      expect(response).toEqual({
-        id: 'foo',
-        attributes: savedQueryAttributes,
+        };
+        mockSavedObjectsClient.update.mockResolvedValue(mockResponse);
+
+        // When
+        const response = await context.update('foo', savedQueryAttributes);
+
+        // Then
+        expect(mockSavedObjectsClient.update).toHaveBeenCalledWith(
+          'query',
+          'foo',
+          { ...internalSavedQueryAttributes, timefilter: null },
+          {
+            references: [],
+          }
+        );
+        expect(response).toEqual({
+          id: 'foo',
+          attributes: savedQueryAttributes,
+        });
+      });
+    });
+
+    describe('when the saved query has namespaces', () => {
+      it('should update a saved object for the given attributes', async () => {
+        // Given
+        const mockResponse: SavedObject<InternalSavedQueryAttributes> = {
+          id: 'foo',
+          type: 'query',
+          attributes: internalSavedQueryAttributes,
+          references: [],
+          namespaces: ['default'],
+        };
+        mockSavedObjectsClient.update.mockResolvedValue(mockResponse);
+
+        // When
+        const response = await context.update('foo', savedQueryAttributes);
+
+        // Then
+        expect(mockSavedObjectsClient.update).toHaveBeenCalledWith(
+          'query',
+          'foo',
+          { ...internalSavedQueryAttributes, timefilter: null },
+          {
+            references: [],
+          }
+        );
+        expect(response).toEqual({
+          id: 'foo',
+          attributes: savedQueryAttributes,
+          namespaces: ['default'],
+        });
       });
     });
 

--- a/src/platform/plugins/shared/data/server/query/route_handler_context.ts
+++ b/src/platform/plugins/shared/data/server/query/route_handler_context.ts
@@ -179,7 +179,7 @@ export async function registerSavedQueryRouteHandlerContext(context: RequestHand
     // TODO: Handle properly
     if (savedObject.error) throw internal(savedObject.error.message);
 
-    return injectReferences({ id, attributes, references });
+    return injectReferences({ id, attributes, references, namespaces: savedObject.namespaces });
   };
 
   const getSavedQuery = async (id: string): Promise<SavedQueryRestResponse> => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/212574

Right now the update response doesn't return namespaces. The typing of the query assumes it's always going to be there so we have to return it when we update the query.

Server response
--
| Before | After |
|--------|------|
| ![image](https://github.com/user-attachments/assets/c089c7fb-acc9-412f-9553-aff759e81df2) | ![image](https://github.com/user-attachments/assets/73a231ba-1390-4527-9dbe-5c117d4e6e84) |

---

Before

https://github.com/user-attachments/assets/8fd760c1-733d-42ac-9bf8-2bb9259aa23d


After

https://github.com/user-attachments/assets/e38586c8-78db-4093-ae8b-0f7310665308


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->