### PR TITLE
[Obs AI Assistant] Fix the EIS callout being cut off for large font sizes

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_flyout.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_flyout.tsx
@@ -172,6 +172,7 @@ export function ChatFlyout({
           'xpack.aiAssistant.chatFlyout.euiFlyoutResizable.aiAssistantLabel',
           { defaultMessage: 'AI Assistant Chat Flyout' }
         )}
+        data-test-subj="aiAssistantChatFlyout"
         className={flyoutClassName}
         closeButtonProps={{
           css: {

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_flyout.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_flyout.tsx
@@ -172,7 +172,6 @@ export function ChatFlyout({
           'xpack.aiAssistant.chatFlyout.euiFlyoutResizable.aiAssistantLabel',
           { defaultMessage: 'AI Assistant Chat Flyout' }
         )}
-        data-test-subj="aiAssistantChatFlyout"
         className={flyoutClassName}
         closeButtonProps={{
           css: {

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_header.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_header.tsx
@@ -27,6 +27,7 @@ import {
   getElasticManagedLlmConnector,
   ElasticLlmCalloutKey,
   useElasticLlmCalloutDismissed,
+  useObservabilityAIAssistantFlyoutStateContext,
 } from '@kbn/observability-ai-assistant-plugin/public';
 import { ChatActionsMenu } from './chat_actions_menu';
 import type { UseGenAIConnectorsResult } from '../hooks/use_genai_connectors';
@@ -120,27 +121,7 @@ export function ChatHeader({
     false
   );
 
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
-
-  useEffect(() => {
-    // Check if the AI Assistant flyout is open
-    const checkFlyoutContext = () => {
-      const aiAssistantFlyout = document.querySelector('[data-test-subj="aiAssistantChatFlyout"]');
-      if (aiAssistantFlyout) {
-        setIsFlyoutOpen(true);
-      } else {
-        setIsFlyoutOpen(false);
-      }
-    };
-
-    checkFlyoutContext();
-
-    // Set up a mutation observer to detect when flyouts are added/removed
-    const observer = new MutationObserver(checkFlyoutContext);
-    observer.observe(document.body, { childList: true, subtree: true });
-
-    return () => observer.disconnect();
-  }, []);
+  const { isFlyoutOpen } = useObservabilityAIAssistantFlyoutStateContext();
 
   return (
     <EuiPanel

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_header.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_header.tsx
@@ -120,6 +120,28 @@ export function ChatHeader({
     false
   );
 
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+
+  useEffect(() => {
+    // Check if the AI Assistant flyout is open
+    const checkFlyoutContext = () => {
+      const aiAssistantFlyout = document.querySelector('[data-test-subj="aiAssistantChatFlyout"]');
+      if (aiAssistantFlyout) {
+        setIsFlyoutOpen(true);
+      } else {
+        setIsFlyoutOpen(false);
+      }
+    };
+
+    checkFlyoutContext();
+
+    // Set up a mutation observer to detect when flyouts are added/removed
+    const observer = new MutationObserver(checkFlyoutContext);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <EuiPanel
       borderRadius="none"
@@ -281,11 +303,10 @@ export function ChatHeader({
               ) : null}
 
               <EuiFlexItem grow={false}>
-                {!!elasticManagedLlm && !tourCalloutDismissed ? (
-                  <ElasticLlmTourCallout
-                    zIndex={isConversationApp ? 999 : undefined}
-                    dismissTour={() => setTourCalloutDismissed(true)}
-                  >
+                {!!elasticManagedLlm &&
+                !tourCalloutDismissed &&
+                !(isConversationApp && isFlyoutOpen) ? (
+                  <ElasticLlmTourCallout dismissTour={() => setTourCalloutDismissed(true)}>
                     <ChatActionsMenu connectors={connectors} disabled={licenseInvalid} />
                   </ElasticLlmTourCallout>
                 ) : (

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/context/observability_ai_assistant_flyout_state_context.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/context/observability_ai_assistant_flyout_state_context.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext } from 'react';
+
+interface FlyoutStateContextValue {
+  isFlyoutOpen: boolean;
+}
+
+const FlyoutStateContext = createContext<FlyoutStateContextValue | undefined>(undefined);
+
+interface FlyoutStateProviderProps {
+  children: React.ReactNode;
+  isFlyoutOpen: boolean;
+}
+
+export function ObservabilityAIAssistantFlyoutStateProvider({
+  children,
+  isFlyoutOpen,
+}: FlyoutStateProviderProps) {
+  return (
+    <FlyoutStateContext.Provider value={{ isFlyoutOpen }}>{children}</FlyoutStateContext.Provider>
+  );
+}
+
+export function useObservabilityAIAssistantFlyoutStateContext(): FlyoutStateContextValue {
+  const context = useContext(FlyoutStateContext);
+  if (context === undefined) {
+    // Return default value when not within provider
+    return { isFlyoutOpen: false };
+  }
+  return context;
+}

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/index.ts
@@ -135,3 +135,10 @@ export {
   useElasticLlmCalloutDismissed,
   ElasticLlmCalloutKey,
 } from './hooks/use_elastic_llm_callout_dismissed';
+
+export { useFlyoutState } from './hooks/use_flyout_state';
+
+export {
+  ObservabilityAIAssistantFlyoutStateProvider,
+  useObservabilityAIAssistantFlyoutStateContext,
+} from './context/observability_ai_assistant_flyout_state_context';

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/index.ts
@@ -136,8 +136,6 @@ export {
   ElasticLlmCalloutKey,
 } from './hooks/use_elastic_llm_callout_dismissed';
 
-export { useFlyoutState } from './hooks/use_flyout_state';
-
 export {
   ObservabilityAIAssistantFlyoutStateProvider,
   useObservabilityAIAssistantFlyoutStateContext,

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/routes/conversations/conversation_view_with_props.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/routes/conversations/conversation_view_with_props.tsx
@@ -6,14 +6,21 @@
  */
 
 import React from 'react';
-import { ConversationView } from '@kbn/ai-assistant';
+import { ConversationView, FlyoutPositionMode } from '@kbn/ai-assistant';
+import { ObservabilityAIAssistantFlyoutStateProvider } from '@kbn/observability-ai-assistant-plugin/public';
 import { useObservabilityAIAssistantParams } from '../../hooks/use_observability_ai_assistant_params';
 import { useObservabilityAIAssistantRouter } from '../../hooks/use_observability_ai_assistant_router';
+import { useLocalStorage } from '../../hooks/use_local_storage';
 
 export function ConversationViewWithProps() {
   const { path } = useObservabilityAIAssistantParams('/conversations/*');
   const conversationId = 'conversationId' in path ? path.conversationId : undefined;
   const observabilityAIAssistantRouter = useObservabilityAIAssistantRouter();
+
+  const [flyoutSettings] = useLocalStorage('observabilityAIAssistant.flyoutSettings', {
+    mode: FlyoutPositionMode.OVERLAY,
+    isOpen: false,
+  });
 
   function navigateToConversation(nextConversationId?: string) {
     if (nextConversationId) {
@@ -29,18 +36,20 @@ export function ConversationViewWithProps() {
   }
 
   return (
-    <ConversationView
-      conversationId={conversationId}
-      navigateToConversation={navigateToConversation}
-      newConversationHref={observabilityAIAssistantRouter.link('/conversations/new')}
-      getConversationHref={(id: string) =>
-        observabilityAIAssistantRouter.link(`/conversations/{conversationId}`, {
-          path: {
-            conversationId: id,
-          },
-        })
-      }
-      scopes={['observability']}
-    />
+    <ObservabilityAIAssistantFlyoutStateProvider isFlyoutOpen={flyoutSettings.isOpen}>
+      <ConversationView
+        conversationId={conversationId}
+        navigateToConversation={navigateToConversation}
+        newConversationHref={observabilityAIAssistantRouter.link('/conversations/new')}
+        getConversationHref={(id: string) =>
+          observabilityAIAssistantRouter.link(`/conversations/{conversationId}`, {
+            path: {
+              conversationId: id,
+            },
+          })
+        }
+        scopes={['observability']}
+      />
+    </ObservabilityAIAssistantFlyoutStateProvider>
   );
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/226611

## Summary

### Problem
For large font sizes, the Elastic Managed LLM callout is being cut off at the top when the user is in the AI Assistant page.
This happens because the z-index of the callout is conflicting with the z-index of the Kibana header as the z-index of the callout was reduced to not overlap with the chat flyout when it's open.

<img width="708" height="225" alt="Image" src="https://github.com/user-attachments/assets/d0818e78-75fc-4fac-aea8-decb4e1a1adf" />

### Solution
Use the flyout open/closed state from local storage in the flyout context and wrap the AI Assistant page with this context so that all components within the page would have this information. If the flyout is open when on the page, hide the EIS callout on the page to avoid overlaps with the flyout.

![image](https://github.com/user-attachments/assets/9a5b51cd-9e66-4136-b099-3f0b5a692b16)

https://github.com/user-attachments/assets/92aa048d-cb7a-4fb9-be93-18d80756e029

## Testing instructions
1. Enable EIS locally using the instructions in https://github.com/elastic/kibana/pull/215475
2. Increase the font size in Kibana on your browser
3. Check whether the EIS callout is being correctly rendered when you are on the AI Assistant page (without the callout being cut off).
4. Check whether the EIS callout is being rendered correctly in the flyout and contextual insights as well.

Code contribution models (to update tests): Claude Sonnet 4

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->