### PR TITLE
[8.12] [Docs] Adds link to default_field index setting to Discover docs (#226629)

### DIFF
--- a/docs/user/discover.asciidoc
+++ b/docs/user/discover.asciidoc
@@ -190,6 +190,7 @@ To search all fields, enter a simple string in the query bar.
 [role="screenshot"]
 image:images/discover-search-field.png[Search field in Discover]
 
+NOTE: Free text searches that don't specify a field may not return expected results depending on how the {ref}/index-modules.html#index-query-default-field[`index.query.default_field` index setting] is configured for the indices matching the current data view.
 
 To search particular fields and
 build more complex queries, use the <<kuery-query,Kibana Query language>>.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.15` to `8.12`:
 - [[Docs] Adds link to default_field index setting to Discover docs (#226629)](https://github.com/elastic/kibana/pull/226629)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2025-07-04T17:50:53Z","message":"[Docs] Adds link to default_field index setting to Discover docs (#226629)\n\nBackport of https://github.com/elastic/kibana/pull/225129 but from a\nfresh PR since the content had moved in that version","sha":"f7a9d9784e8d7f8d4923dfcb9768da4e6d31b4c7","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","backport","docs"],"title":"[Docs] Adds link to default_field index setting to Discover docs","number":226629,"url":"https://github.com/elastic/kibana/pull/226629","mergeCommit":{"message":"[Docs] Adds link to default_field index setting to Discover docs (#226629)\n\nBackport of https://github.com/elastic/kibana/pull/225129 but from a\nfresh PR since the content had moved in that version","sha":"f7a9d9784e8d7f8d4923dfcb9768da4e6d31b4c7"}},"sourceBranch":"8.15","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->