### PR TITLE
[Cloud Security] Fixing CSPM Findings sanity tests

### DIFF
--- a/x-pack/solutions/security/test/cloud_security_posture_functional/cloud_tests/findings_sanity.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/cloud_tests/findings_sanity.ts
@@ -21,8 +21,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     before(async () => {
       findings = pageObjects.findings;
       latestFindingsTable = pageObjects.findings.latestFindingsTable;
+
       await findings.navigateToLatestFindingsPage();
-      await findings.waitForPluginInitialized();
+      await pageObjects.header.waitUntilLoadingHasFinished();
     });
 
     describe('Findings - Querying data', () => {


### PR DESCRIPTION
## Summary

This pull request modifies the `before` hook in the `findings_sanity.ts` test file to improve the initialization process for testing the "Findings" functionality. The changes ensure better synchronization by replacing the plugin initialization check with a header loading completion check.

Test initialization improvements:

* [`x-pack/solutions/security/test/cloud_security_posture_functional/cloud_tests/findings_sanity.ts`](diffhunk://#diff-1ad371d35ebdfa9781717b68c801201cb84275af3757a65cca8cf7ba50f741b5R24-R26): Replaced `findings.waitForPluginInitialized()` with `pageObjects.header.waitUntilLoadingHasFinished()` to ensure tests wait for the header to finish loading instead of relying on plugin initialization. Also added a call to `findings.navigateToLatestFindingsPage()` for navigation setup.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
    - **The Flaky Test Runner cannot be used for sanity tests because we use a deployed environment.**
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->