### PR TITLE
[Streams] [Streamlang] Add base / core types

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-streamlang/tsconfig.json
@@ -13,5 +13,9 @@
   "exclude": [
     "target/**/*"
   ],
-  "kbn_references": []
+  "kbn_references": [
+    "@kbn/zod",
+    "@kbn/zod-helpers",
+    "@kbn/streams-schema",
+  ]
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/conditions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/conditions.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { NonEmptyString } from '@kbn/zod-helpers';
+import { createIsNarrowSchema } from '@kbn/streams-schema';
+
+const stringOrNumberOrBoolean = z.union([z.string(), z.number(), z.boolean()]);
+
+export interface ShorthandBinaryFilterCondition {
+  field: string;
+  eq?: string | number | boolean;
+  neq?: string | number | boolean;
+  lt?: string | number | boolean;
+  lte?: string | number | boolean;
+  gt?: string | number | boolean;
+  gte?: string | number | boolean;
+  contains?: string | number | boolean;
+  startsWith?: string | number | boolean;
+  endsWith?: string | number | boolean;
+}
+
+// Shorthand binary: field + one of the operator keys
+export const shorthandBinaryFilterConditionSchema = z
+  .object({
+    field: NonEmptyString,
+    eq: stringOrNumberOrBoolean.optional(),
+    neq: stringOrNumberOrBoolean.optional(),
+    lt: stringOrNumberOrBoolean.optional(),
+    lte: stringOrNumberOrBoolean.optional(),
+    gt: stringOrNumberOrBoolean.optional(),
+    gte: stringOrNumberOrBoolean.optional(),
+    contains: stringOrNumberOrBoolean.optional(),
+    startsWith: stringOrNumberOrBoolean.optional(),
+    endsWith: stringOrNumberOrBoolean.optional(),
+  })
+  .refine(
+    (obj) =>
+      // At least one operator must be present
+      Object.keys(obj).some((key) =>
+        ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'contains', 'startsWith', 'endsWith'].includes(key)
+      ),
+    { message: 'At least one operator must be specified' }
+  );
+
+export interface ShorthandUnaryFilterCondition {
+  field: string;
+  exists?: true;
+  notExists?: true;
+}
+
+// Shorthand unary: field + exists or notExists
+export const shorthandUnaryFilterConditionSchema = z
+  .object({
+    field: NonEmptyString,
+    exists: z.literal(true).optional(),
+    notExists: z.literal(true).optional(),
+  })
+  .refine((obj) => obj.exists === true || obj.notExists === true, {
+    message: 'Must specify exists: true or notExists: true',
+  });
+
+export type FilterCondition = ShorthandBinaryFilterCondition | ShorthandUnaryFilterCondition;
+
+export const filterConditionSchema = z.union([
+  shorthandBinaryFilterConditionSchema,
+  shorthandUnaryFilterConditionSchema,
+]);
+
+export interface AndCondition {
+  and: Condition[];
+}
+
+export interface OrCondition {
+  or: Condition[];
+}
+
+export interface AlwaysCondition {
+  always: {};
+}
+
+export interface NeverCondition {
+  never: {};
+}
+
+export type Condition =
+  | FilterCondition
+  | AndCondition
+  | OrCondition
+  | NeverCondition
+  | AlwaysCondition;
+
+export const conditionSchema: z.Schema<Condition> = z.lazy(() =>
+  z.union([
+    filterConditionSchema,
+    andConditionSchema,
+    orConditionSchema,
+    neverConditionSchema,
+    alwaysConditionSchema,
+  ])
+);
+
+export const andConditionSchema = z.object({ and: z.array(conditionSchema) });
+export const orConditionSchema = z.object({ or: z.array(conditionSchema) });
+export const neverConditionSchema = z.object({ never: z.strictObject({}) });
+export const alwaysConditionSchema = z.object({ always: z.strictObject({}) });
+
+export const isBinaryFilterCondition = createIsNarrowSchema(
+  conditionSchema,
+  shorthandBinaryFilterConditionSchema
+);
+export const isUnaryFilterCondition = createIsNarrowSchema(
+  conditionSchema,
+  shorthandUnaryFilterConditionSchema
+);
+export const isFilterCondition = createIsNarrowSchema(conditionSchema, filterConditionSchema);
+
+export const isAndCondition = createIsNarrowSchema(conditionSchema, andConditionSchema);
+export const isOrCondition = createIsNarrowSchema(conditionSchema, orConditionSchema);
+export const isNeverCondition = createIsNarrowSchema(conditionSchema, neverConditionSchema);
+export const isAlwaysCondition = createIsNarrowSchema(conditionSchema, alwaysConditionSchema);
+
+export const isCondition = createIsNarrowSchema(z.unknown(), conditionSchema);

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
@@ -1,0 +1,340 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { NonEmptyString } from '@kbn/zod-helpers';
+import { createIsNarrowSchema } from '@kbn/streams-schema';
+import {
+  ElasticsearchProcessorType,
+  elasticsearchProcessorTypes,
+} from './ingest_pipeline_processors';
+import { Condition, conditionSchema } from '../conditions';
+
+/**
+ * Base processor
+ */
+export interface ProcessorBase {
+  description?: string;
+  ignore_failure?: boolean;
+}
+
+const processorBaseSchema = z.object({
+  description: z.optional(z.string()),
+  ignore_failure: z.optional(z.boolean()),
+});
+
+/**
+ * Base with where
+ */
+export interface ProcessorBaseWithWhere extends ProcessorBase {
+  where?: Condition;
+}
+
+const processorBaseWithWhereSchema = processorBaseSchema.extend({
+  where: z.optional(conditionSchema),
+});
+
+/* Manual ingest pipeline processor */
+
+// Not 100% accurate, but close enough for our use case to provide minimal safety
+// without having to check all details
+export type ElasticsearchProcessor = Partial<Record<ElasticsearchProcessorType, unknown>>;
+
+export interface ManualIngestPipelineProcessor extends ProcessorBaseWithWhere {
+  action: 'manual_ingest_pipeline';
+  processors: ElasticsearchProcessor[];
+  ignore_failure?: boolean;
+  tag?: string;
+  on_failure?: Array<Record<string, unknown>>;
+}
+
+export const manualIngestPipelineProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('manual_ingest_pipeline'),
+  processors: z.array(z.record(z.enum(elasticsearchProcessorTypes), z.unknown())),
+  tag: z.optional(z.string()),
+  on_failure: z.optional(z.array(z.record(z.unknown()))),
+}) satisfies z.Schema<ManualIngestPipelineProcessor>;
+
+/**
+ * Grok processor
+ */
+export interface GrokProcessor extends ProcessorBaseWithWhere {
+  action: 'grok';
+  field: string;
+  patterns: string[];
+  pattern_definitions?: Record<string, string>;
+  ignore_missing?: boolean;
+}
+
+export const grokProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('grok'),
+  field: NonEmptyString,
+  patterns: z.array(NonEmptyString).nonempty(),
+  pattern_definitions: z.optional(z.record(z.string())),
+  ignore_missing: z.optional(z.boolean()),
+}) satisfies z.Schema<GrokProcessor>;
+
+/**
+ * Dissect processor
+ */
+
+export interface DissectProcessor extends ProcessorBaseWithWhere {
+  action: 'dissect';
+  field: string;
+  pattern: string;
+  append_separator?: string;
+  ignore_missing?: boolean;
+}
+
+export const dissectProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('dissect'),
+  field: NonEmptyString,
+  pattern: NonEmptyString,
+  append_separator: z.optional(NonEmptyString),
+  ignore_missing: z.optional(z.boolean()),
+}) satisfies z.Schema<DissectProcessor>;
+
+/**
+ * Date processor
+ */
+
+export interface DateProcessor extends ProcessorBaseWithWhere {
+  action: 'date';
+  field: string;
+  formats: string[];
+  locale?: string;
+  target_field?: string;
+  timezone?: string;
+  output_format?: string;
+}
+
+export const dateProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('date'),
+  field: NonEmptyString,
+  formats: z.array(NonEmptyString),
+  locale: z.optional(NonEmptyString),
+  target_field: z.optional(NonEmptyString),
+  timezone: z.optional(NonEmptyString),
+  output_format: z.optional(NonEmptyString),
+}) satisfies z.Schema<DateProcessor>;
+
+/**
+ * KV processor
+ */
+
+export interface KvProcessor extends ProcessorBaseWithWhere {
+  action: 'kv';
+  field: string;
+  field_split: string;
+  value_split: string;
+  target_field?: string;
+  include_keys?: string[];
+  exclude_keys?: string[];
+  ignore_missing?: boolean;
+  prefix?: string;
+  trim_key?: string;
+  trim_value?: string;
+  strip_brackets?: boolean;
+}
+
+export const kvProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('kv'),
+  field: NonEmptyString,
+  // These aren't NonEmptyString on purpose as a space (for example) can be a valid use case here.
+  field_split: z.string(),
+  value_split: z.string(),
+  target_field: z.optional(NonEmptyString),
+  include_keys: z.optional(z.array(NonEmptyString)),
+  exclude_keys: z.optional(z.array(NonEmptyString)),
+  ignore_missing: z.optional(z.boolean()),
+  prefix: z.optional(NonEmptyString),
+  trim_key: z.optional(NonEmptyString),
+  trim_value: z.optional(NonEmptyString),
+  strip_brackets: z.optional(z.boolean()),
+}) satisfies z.Schema<KvProcessor>;
+
+/**
+ * GeoIP processor
+ */
+
+export interface GeoIpProcessor {
+  action: 'geoip';
+  field: string;
+  target_field?: string;
+  database_file?: string;
+  properties?: string[];
+  ignore_missing?: boolean;
+  first_only?: boolean;
+}
+
+export const geoIpProcessorSchema = z.object({
+  action: z.literal('geoip'),
+  field: NonEmptyString,
+  target_field: z.optional(NonEmptyString),
+  database_file: z.optional(NonEmptyString),
+  properties: z.optional(z.array(NonEmptyString)),
+  ignore_missing: z.optional(z.boolean()),
+  first_only: z.optional(z.boolean()),
+}) satisfies z.Schema<GeoIpProcessor>;
+
+/**
+ * Rename processor
+ */
+
+export interface RenameProcessor extends ProcessorBaseWithWhere {
+  action: 'rename';
+  field: string;
+  target_field: string;
+  ignore_missing?: boolean;
+  override?: boolean;
+}
+
+export const renameProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('rename'),
+  field: NonEmptyString,
+  target_field: NonEmptyString,
+  ignore_missing: z.optional(z.boolean()),
+  override: z.optional(z.boolean()),
+}) satisfies z.Schema<RenameProcessor>;
+
+/**
+ * Set processor
+ */
+
+export interface SetProcessor extends ProcessorBaseWithWhere {
+  action: 'set';
+  field: string;
+  value: string;
+  override?: boolean;
+  ignore_empty_value?: boolean;
+  media_type?: string;
+}
+
+export const setProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('set'),
+  field: NonEmptyString,
+  value: NonEmptyString,
+  override: z.optional(z.boolean()),
+  ignore_empty_value: z.optional(z.boolean()),
+  media_type: z.optional(z.string()),
+}) satisfies z.Schema<SetProcessor>;
+
+/**
+ * URL Decode processor
+ */
+
+export interface UrlDecodeProcessor extends ProcessorBaseWithWhere {
+  action: 'urldecode';
+  field: string;
+  target_field?: string;
+  ignore_missing?: boolean;
+}
+
+export const urlDecodeProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('urldecode'),
+  field: NonEmptyString,
+  target_field: z.optional(NonEmptyString),
+  ignore_missing: z.optional(z.boolean()),
+}) satisfies z.Schema<UrlDecodeProcessor>;
+
+/**
+ * User agent processor
+ */
+
+export interface UserAgentProcessor {
+  action: 'user_agent';
+  field: string;
+  target_field?: string;
+  regex_file?: string;
+  properties?: string[];
+  ignore_missing?: boolean;
+}
+
+export const userAgentProcessorSchema = z.object({
+  action: z.literal('user_agent'),
+  field: NonEmptyString,
+  target_field: z.optional(NonEmptyString),
+  regex_file: z.optional(NonEmptyString),
+  properties: z.optional(z.array(NonEmptyString)),
+  ignore_missing: z.optional(z.boolean()),
+}) satisfies z.Schema<UserAgentProcessor>;
+
+export type StreamlangProcessorDefinition =
+  | DateProcessor
+  | DissectProcessor
+  | GrokProcessor
+  | KvProcessor
+  | GeoIpProcessor
+  | RenameProcessor
+  | SetProcessor
+  | ManualIngestPipelineProcessor
+  | UrlDecodeProcessor
+  | UserAgentProcessor;
+
+export type ProcessorDefinitionWithId = StreamlangProcessorDefinition & { id: string };
+
+export const streamlangProcessorSchema = z.discriminatedUnion('action', [
+  grokProcessorSchema,
+  dissectProcessorSchema,
+  dateProcessorSchema,
+  kvProcessorSchema,
+  geoIpProcessorSchema,
+  renameProcessorSchema,
+  setProcessorSchema,
+  manualIngestPipelineProcessorSchema,
+  urlDecodeProcessorSchema,
+  userAgentProcessorSchema,
+]);
+
+export const processorWithIdDefinitionSchema: z.ZodType<ProcessorDefinitionWithId> = z.union([
+  dateProcessorSchema.merge(z.object({ id: z.string() })),
+  dissectProcessorSchema.merge(z.object({ id: z.string() })),
+  grokProcessorSchema.merge(z.object({ id: z.string() })),
+  manualIngestPipelineProcessorSchema.merge(z.object({ id: z.string() })),
+  kvProcessorSchema.merge(z.object({ id: z.string() })),
+  geoIpProcessorSchema.merge(z.object({ id: z.string() })),
+  renameProcessorSchema.merge(z.object({ id: z.string() })),
+  setProcessorSchema.merge(z.object({ id: z.string() })),
+  urlDecodeProcessorSchema.merge(z.object({ id: z.string() })),
+  userAgentProcessorSchema.merge(z.object({ id: z.string() })),
+]);
+
+export const isGrokProcessorDefinition = createIsNarrowSchema(
+  streamlangProcessorSchema,
+  grokProcessorSchema
+);
+
+export const isDissectProcessorDefinition = createIsNarrowSchema(
+  streamlangProcessorSchema,
+  dissectProcessorSchema
+);
+
+export const isDateProcessorDefinition = createIsNarrowSchema(
+  streamlangProcessorSchema,
+  dateProcessorSchema
+);
+
+/**
+ * ProcessorType is the union of all possible 'action' values
+ */
+export type ProcessorType = StreamlangProcessorDefinition['action'];
+
+/**
+ * Get all processor types as a string array (derived from the Zod schema)
+ */
+export const processorTypes: ProcessorType[] = (
+  streamlangProcessorSchema._def.options as Array<z.ZodObject<any, any, any, any, any>>
+).map((schema) => schema.shape.action.value) as ProcessorType[];
+
+/**
+ * Get the processor type (action) from a processor definition
+ */
+export function getProcessorType<TProcessorDefinition extends StreamlangProcessorDefinition>(
+  processor: TProcessorDefinition
+): ProcessorType {
+  return processor.action;
+}

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
+
+export type ElasticsearchProcessorType = keyof IngestProcessorContainer;
+
+const ensureFullProcessorTypeList = <T extends readonly ElasticsearchProcessorType[]>(
+  types: ElasticsearchProcessorType extends T[number]
+    ? T
+    : `Missing elements from union: "${Exclude<ElasticsearchProcessorType, T[number]>}"`
+) => types as T;
+
+export const elasticsearchProcessorTypes = ensureFullProcessorTypeList([
+  'append',
+  'attachment',
+  'bytes',
+  'circle',
+  'community_id',
+  'convert',
+  'csv',
+  'date',
+  'date_index_name',
+  'dissect',
+  'dot_expander',
+  'drop',
+  'enrich',
+  'fail',
+  'fingerprint',
+  'foreach',
+  'ip_location',
+  'geo_grid',
+  'geoip',
+  'grok',
+  'gsub',
+  'html_strip',
+  'inference',
+  'join',
+  'json',
+  'kv',
+  'lowercase',
+  'network_direction',
+  'pipeline',
+  'redact',
+  'registered_domain',
+  'remove',
+  'rename',
+  'reroute',
+  'script',
+  'set',
+  'set_security_user',
+  'sort',
+  'split',
+  'terminate',
+  'trim',
+  'uppercase',
+  'urldecode',
+  'uri_parts',
+  'user_agent',
+] as const);

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/streamlang.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/streamlang.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { Condition, conditionSchema } from './conditions';
+import { StreamlangProcessorDefinition, streamlangProcessorSchema } from './processors';
+
+// Recursive schema for ConditionWithSteps
+export const conditionWithStepsSchema: z.ZodType<ConditionWithSteps> = z.lazy(() =>
+  z.intersection(
+    conditionSchema,
+    z.object({
+      steps: z.array(streamlangStepSchema),
+    })
+  )
+);
+
+export type ConditionWithSteps = Condition & { steps: StreamlangStep[] };
+
+/**
+ * Nested where block (recursive)
+ */
+export interface StreamlangWhereBlock {
+  where: ConditionWithSteps;
+}
+
+/**
+ * Zod schema for a where block
+ */
+export const streamlangWhereBlockSchema: z.ZodType<StreamlangWhereBlock> = z.object({
+  where: conditionWithStepsSchema,
+});
+
+/**
+ * A step can be either a processor or a where block (optionally recursive)
+ */
+export type StreamlangStep = StreamlangProcessorDefinition | StreamlangWhereBlock;
+export const streamlangStepSchema: z.ZodType<StreamlangStep> = z.lazy(() =>
+  z.union([streamlangProcessorSchema, streamlangWhereBlockSchema])
+);
+
+/**
+ * Streamlang DSL Root Type
+ */
+export interface StreamlangDSL {
+  steps: StreamlangStep[];
+}
+
+/**
+ * Zod schema for the Streamlang DSL root
+ */
+export const streamlangDSLSchema = z.object({
+  steps: z.array(streamlangStepSchema),
+});

--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -66,7 +66,7 @@ export {
   flattenRecord,
   recursiveRecord,
 } from './src/shared/record_types';
-export { isSchema } from './src/shared/type_guards';
+export { isSchema, createIsNarrowSchema } from './src/shared/type_guards';
 
 export {
   isChildOf,


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/kibana/issues/224421.

Adds various base / core types for Streamlang. As mentioned in the issue this will not (yet) be a perfect representation of the end product (e.g. processor types will eventually be reduced down to a schema representation that fits the support matrix, types will change with the transpilation code / extension of the conditions code etc), however this is a best effort at keeping PR sizes down.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->