### PR TITLE
[Inference] Fallback to kibana.dev.yml for connector config

### DIFF
--- a/src/platform/packages/private/kbn-gen-ai-functional-testing/README.md
+++ b/src/platform/packages/private/kbn-gen-ai-functional-testing/README.md
@@ -30,7 +30,45 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 }
 ```
 
-then the `getAvailableConnectors` can be used during the test suite to retrieve the list of LLM connectors.
+### Connector configuration sources
+
+`@kbn/gen-ai-functional-testing` can discover connectors from two different sources:
+
+1. **CI / automated runs** – set the environment variable  
+   `KIBANA_TESTING_AI_CONNECTORS` with the base-64-encoded JSON payload that you
+   want to feed into `xpack.actions.preconfigured`. This is what the Buildkite
+   pipeline does.
+2. **Local developer machines** – if the environment variable is **not** set and
+   the process is **not** running in CI (`process.env.CI` is undefined), the
+   package falls back to reading `config/kibana.dev.yml` in the repo root and
+   extracts the `xpack.actions.preconfigured` section. This lets you keep your
+   personal connector secrets out of env vars.
+
+If the env var is missing **and** the code is executing in CI, an error is
+thrown to avoid silent mis-configuration.
+
+### Typical workflow
+
+1. **Local development**  
+   Add your connector definition to `config/kibana.dev.yml`:
+
+   ```yaml
+   xpack.actions.preconfigured:
+     my-gpt-4o:
+       name: GPT-4o Azure
+       actionTypeId: .gen-ai
+       config:
+         apiUrl: https://.../chat/completions?api-version=2025-01-01-preview
+         apiProvider: Azure OpenAI
+       secrets:
+         apiKey: <YOUR_KEY>
+   ```
+
+2. **CI**  
+   Generate the same YAML as JSON, base-64 encode it and export as
+   `KIBANA_TESTING_AI_CONNECTORS` before running the FTR suite.
+
+If one of these sources is available, the `getAvailableConnectors` can be used during the test suite to retrieve the list of LLM connectors.
 
 For example to run some predefined test suite against all exposed LLM connectors:
 

--- a/src/platform/packages/private/kbn-gen-ai-functional-testing/src/connectors.ts
+++ b/src/platform/packages/private/kbn-gen-ai-functional-testing/src/connectors.ts
@@ -8,6 +8,11 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import Path from 'path';
+import Fs from 'fs';
+import { load } from 'js-yaml';
+import { mapValues } from 'lodash';
+import { REPO_ROOT } from '@kbn/repo-info';
 
 /**
  * The environment variable that is used by the CI to load the connectors configuration
@@ -20,7 +25,7 @@ const connectorsSchema = schema.recordOf(
     name: schema.string(),
     actionTypeId: schema.string(),
     config: schema.recordOf(schema.string(), schema.any()),
-    secrets: schema.recordOf(schema.string(), schema.any()),
+    secrets: schema.maybe(schema.recordOf(schema.string(), schema.any())),
   })
 );
 
@@ -28,28 +33,79 @@ export interface AvailableConnector {
   name: string;
   actionTypeId: string;
   config: Record<string, unknown>;
-  secrets: Record<string, unknown>;
+  secrets?: Record<string, unknown>;
 }
 
 export interface AvailableConnectorWithId extends AvailableConnector {
   id: string;
 }
 
-const loadConnectors = (): Record<string, AvailableConnector> => {
-  const envValue = process.env[AI_CONNECTORS_VAR_ENV];
-  if (!envValue) {
+/**
+ * Try to read the connectors configuration from the local `config/kibana.dev.yml`
+ * file. This allows developers to define `xpack.actions.preconfigured` connectors
+ * in their local Kibana config without having to set the `KIBANA_TESTING_AI_CONNECTORS`
+ * environment variable.
+ */
+const getConnectorsFromKibanaDevYml = (): Record<string, AvailableConnector> => {
+  try {
+    const configDir = Path.join(REPO_ROOT, './config');
+
+    const kibanaDevConfigPath = Path.join(configDir, 'kibana.dev.yml');
+
+    const configPath = Fs.existsSync(kibanaDevConfigPath) ? kibanaDevConfigPath : undefined;
+
+    if (!configPath) {
+      return {};
+    }
+
+    const parsedConfig = (load(Fs.readFileSync(configPath, 'utf8')) || {}) as Record<
+      string,
+      unknown
+    >;
+
+    const preconfiguredConnectors = (parsedConfig['xpack.actions.preconfigured'] || {}) as Record<
+      string,
+      AvailableConnector
+    >;
+
+    return mapValues(preconfiguredConnectors, ({ actionTypeId, config, name, secrets }) => {
+      // make sure we don't send in any additional properties
+      return {
+        actionTypeId,
+        config,
+        name,
+        secrets,
+      };
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`Unable to read connectors from Kibana config file: ${(err as Error).message}`);
     return {};
   }
+};
 
-  let connectors: Record<string, AvailableConnector>;
-  try {
-    connectors = JSON.parse(Buffer.from(envValue, 'base64').toString('utf-8'));
-  } catch (e) {
-    throw new Error(
-      `Error trying to parse value from KIBANA_AI_CONNECTORS environment variable: ${e.message}`
-    );
+const loadConnectors = (): Record<string, AvailableConnector> => {
+  const envValue = process.env[AI_CONNECTORS_VAR_ENV];
+  if (envValue) {
+    let connectors: Record<string, AvailableConnector>;
+    try {
+      connectors = JSON.parse(Buffer.from(envValue, 'base64').toString('utf-8'));
+    } catch (e) {
+      throw new Error(
+        `Error trying to parse value from ${AI_CONNECTORS_VAR_ENV} environment variable: ${
+          (e as Error).message
+        }`
+      );
+    }
+    return connectorsSchema.validate(connectors);
   }
-  return connectorsSchema.validate(connectors);
+
+  // don't attempt to read from kibana.dev.yml on CI
+  if (process.env.CI) {
+    throw new Error(`Can't read connectors, env variable ${AI_CONNECTORS_VAR_ENV} is not set`);
+  }
+
+  return connectorsSchema.validate(getConnectorsFromKibanaDevYml());
 };
 
 /**


### PR DESCRIPTION
Currently, connectors for the Inference integration tests need to be defined as base64 encoded strings. This PR adds a fallback option for local development that will simply read the connectors from config/kibana.dev.yml which is good enough in most cases.

Notes: 
- Bootstrapped simple implementation iterated on it, generated docs w/ Windsurf & o3: https://windsurf.com/conversation-share/d393cf63-82cb-4d55-99ce-7f603e218160

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->