### PR TITLE
[Cloud Security] handle error object and missing vulnerability field in vulnerability document.

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_right/header.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_right/header.tsx
@@ -183,9 +183,9 @@ export const FindingsVulnerabilityFlyoutHeader = ({
                     <EuiFlexItem>
                       <b>Data source</b>
                       <EuiSpacer size="s" />
-                      {vulnerability.data_source?.URL ? (
+                      {vulnerability?.data_source?.URL ? (
                         <EuiLink href={vulnerability.data_source?.URL} target="_blank">
-                          {vulnerability.data_source.ID}
+                          {vulnerability?.data_source?.ID}
                         </EuiLink>
                       ) : (
                         <EuiText>{EMPTY_VALUE}</EuiText>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
@@ -332,7 +332,7 @@ const getDetailsList = (
         </h1>
       </EuiTitle>
     ),
-    description: vulnerabilityData.vulnerability.id ? (
+    description: vulnerabilityData.vulnerability?.id ? (
       <VulnerabilityDetectionRuleCounter vulnerabilityRecord={vulnerabilityData} />
     ) : (
       EMPTY_VALUE
@@ -363,7 +363,7 @@ const getDetailsList = (
         </h1>
       </EuiTitle>
     ),
-    description: vulnerabilityData.vulnerability.published_date ? (
+    description: vulnerabilityData.vulnerability?.published_date ? (
       <FormattedMessage
         id="xpack.csp.findings.vulnerabilityFindingsFlyout.overviewTab.publishedDateText"
         defaultMessage="{date}"


### PR DESCRIPTION
## Summary

This PR closes the following [issue](https://github.com/elastic/kibana/issues/226692).




<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->