### PR TITLE
create ingest pipeline for cnvm

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -40,8 +40,10 @@ export const initializeCspIndices = async (
   latestFindingsIndexAutoCreated: boolean,
   logger: Logger
 ) => {
-  await createPipelineIfNotExists(esClient, scorePipelineIngestConfig, logger);
-
+  await Promise.allSettled([
+    createPipelineIfNotExists(esClient, scorePipelineIngestConfig, logger),
+    createPipelineIfNotExists(esClient, latestFindingsPipelineIngestConfig, logger),
+  ]);
   const [createVulnerabilitiesLatestIndexPromise, createBenchmarkScoreIndexPromise] =
     await Promise.allSettled([
       createLatestIndex(
@@ -62,7 +64,6 @@ export const initializeCspIndices = async (
 
   if (!latestFindingsIndexAutoCreated) {
     try {
-      await createPipelineIfNotExists(esClient, latestFindingsPipelineIngestConfig, logger);
       await createLatestIndex(
         esClient,
         latestIndexConfigs.findings,


### PR DESCRIPTION
sloves:
- https://github.com/elastic/kibana/issues/226037
## Bug fix
Remove the condition for creating the Cloud Security ingest pipeline, as it is used by CNVM in all versions.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->