### PR TITLE
[Data Views][QOL] Add hasMatchedIndices method to DataView

### DIFF
--- a/src/platform/plugins/shared/data_views/common/data_views/abstract_data_views.ts
+++ b/src/platform/plugins/shared/data_views/common/data_views/abstract_data_views.ts
@@ -560,4 +560,12 @@ export abstract class AbstractDataView {
     const clonedFieldAttrs = cloneDeep(Object.fromEntries(this.fieldAttrs.entries()));
     return new Map(Object.entries(clonedFieldAttrs));
   };
+
+  /**
+   * Checks if there are any matched indices.
+   * @returns True if there are matched indices, false otherwise.
+   */
+  hasMatchedIndices() {
+    return !!this.matchedIndices.length;
+  }
 }

--- a/src/platform/plugins/shared/data_views/common/data_views/data_views.test.ts
+++ b/src/platform/plugins/shared/data_views/common/data_views/data_views.test.ts
@@ -385,7 +385,7 @@ describe('IndexPatterns', () => {
     expect((await indexPatterns.get(id)).fields.length).toBe(1);
   });
 
-  test('existing indices, so dataView.matchedIndices.length equals 1 ', async () => {
+  test('existing indices, so dataView.matchedIndices.length equals 1 and hasMatchedIndices() returns true', async () => {
     const id = '1';
     setDocsourcePayload(id, {
       id: 'foo',
@@ -396,9 +396,10 @@ describe('IndexPatterns', () => {
     });
     const dataView = await indexPatterns.get(id);
     expect(dataView.matchedIndices.length).toBe(1);
+    expect(dataView.hasMatchedIndices()).toBe(true);
   });
 
-  test('missing indices, so dataView.matchedIndices.length equals 0 ', async () => {
+  test('missing indices, so dataView.matchedIndices.length equals 0 and hasMatchedIndices() returns false', async () => {
     const id = '1';
     setDocsourcePayload(id, {
       id: 'foo',
@@ -412,6 +413,7 @@ describe('IndexPatterns', () => {
     });
     const dataView = await indexPatterns.get(id);
     expect(dataView.matchedIndices.length).toBe(0);
+    expect(dataView.hasMatchedIndices()).toBe(false);
   });
 
   test('savedObjectCache pre-fetches title, type, typeMeta', async () => {


### PR DESCRIPTION
## Summary

This PR adds "hasMatchedIndices" method to `DataView`, so that we can avoid repetitive `!!dv.matchedIndices.length` around the app.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->