### PR TITLE
[APM] Fix Advanced Settings query parameter

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/storage_explorer/get_storage_explorer_links.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/storage_explorer/get_storage_explorer_links.ts
@@ -20,6 +20,6 @@ export function getStorageExplorerFeedbackHref() {
 
 export function getKibanaAdvancedSettingsHref(core: CoreStart) {
   return core.application.getUrlForApp('management', {
-    path: '/kibana/settings?query=category:(observability)',
+    path: '/kibana/settings?query=categories:(observability)',
   });
 }


### PR DESCRIPTION
closes [#223996](https://github.com/elastic/kibana/issues/223996)

## Summary

Fixes the Advanced Settings link query parameter


### How to test

- Navigate to Applications > Storage Explorer
- Click on the `Kibana advanced settings` in the `Long loading time?` call out



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->