### PR TITLE
[SecuritySolution] Fix error shown on Detail Flyout for Risk Contributions under Privileged User

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/columns.tsx
@@ -60,7 +60,7 @@ const getPrivilegedUserColumn = (fieldName: string) => ({
           // Issue to extend SecurityCellActions to support this: https://github.com/elastic/security-team/issues/12712
           fieldName,
           idPrefix: 'privileged-user-monitoring-privileged-user',
-          render: (item) => <UserName userName={item} />,
+          render: (item) => <UserName userName={item} scopeId={SCOPE_ID} />,
           displayCount: 1,
         })
       : getEmptyTagValue(),
@@ -80,7 +80,7 @@ const getTargetUserColumn = (fieldName: string) => ({
           values: isArray(user) ? user : [user],
           fieldName,
           idPrefix: 'privileged-user-monitoring-target-user',
-          render: (item) => <UserName userName={item} />,
+          render: (item) => <UserName userName={item} scopeId={SCOPE_ID} />,
           displayCount: 1,
         })
       : getEmptyTagValue(),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/columns.tsx
@@ -48,6 +48,7 @@ import {
 import { FILTER_ACKNOWLEDGED, FILTER_OPEN } from '../../../../../../common/types';
 import type { CriticalityLevelWithUnassigned } from '../../../../../../common/entity_analytics/asset_criticality/types';
 import { getFormattedAlertStats } from '../../../../../flyout/document_details/shared/components/alert_count_insight';
+import { SCOPE_ID } from '../../constants';
 
 const COLUMN_WIDTHS = { actions: '5%', '@timestamp': '20%', privileged_user: '15%' };
 
@@ -66,7 +67,7 @@ const getPrivilegedUserColumn = (fieldName: string) => ({
           values: isArray(user) ? user : [user],
           fieldName,
           idPrefix: 'privileged-user-monitoring-privileged-user',
-          render: (item) => <UserName userName={item} />,
+          render: (item) => <UserName userName={item} scopeId={SCOPE_ID} />,
           displayCount: 1,
         })
       : getEmptyTagValue(),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_name.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/user_name.tsx
@@ -14,9 +14,11 @@ import { UserPanelKey } from '../../flyout/entity_details/shared/constants';
 
 interface Props {
   userName: string | undefined | null;
+  contextId?: string;
+  scopeId: string;
 }
 
-const UserNameComponent: React.FC<Props> = ({ userName }) => {
+const UserNameComponent: React.FC<Props> = ({ userName, scopeId, contextId }) => {
   const { openFlyout } = useExpandableFlyoutApi();
 
   const openUserDetailsSidePanel = useCallback(
@@ -28,11 +30,13 @@ const UserNameComponent: React.FC<Props> = ({ userName }) => {
           id: UserPanelKey,
           params: {
             userName,
+            contextID: contextId,
+            scopeId,
           },
         },
       });
     },
-    [openFlyout, userName]
+    [contextId, openFlyout, scopeId, userName]
   );
 
   if (!userName) {


### PR DESCRIPTION
## Summary

Fix the error shown on the Detail Flyout for Risk Contributions under Privileged User

The bug happened because we were not providing a `scopeId` for the preview flyout. 
I implemented the quickest fix, which is adding the missing prop to the broken links. However, the flyout should not break due to a missing optional field.


issue: https://github.com/elastic/kibana/issues/226168


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->