### PR TITLE
[ES|QL] Moves fork validation in one place

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -230,19 +230,10 @@ function validateCommand(
     messages.push(...commandDefinition.methods.validate(command, ast, context));
   }
 
+  // ToDo: Move this to the commands registry
   switch (commandDefinition.name) {
     case 'join':
       break;
-    case 'fork': {
-      for (const arg of command.args.flat()) {
-        if (!Array.isArray(arg) && arg.type === 'query') {
-          // all the args should be commands
-          arg.commands.forEach((subCommand) => {
-            messages.push(...validateCommand(subCommand, references, ast, currentCommandIndex));
-          });
-        }
-      }
-    }
     default: {
       // Now validate arguments
       for (const arg of command.args) {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -233,6 +233,7 @@ function validateCommand(
   // ToDo: Move this to the commands registry
   switch (commandDefinition.name) {
     case 'join':
+    case 'fork':
       break;
     default: {
       // Now validate arguments


### PR DESCRIPTION
## Summary

As a follow up of the registry, I move the entire fork validation code into the registry




