### PR TITLE
[Workspace Chrome] Fix integrations grid for new layout

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout-components/application/layout_application.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout-components/application/layout_application.tsx
@@ -31,7 +31,7 @@ export const LayoutApplication = ({
   const overflow = useEuiOverflowScroll('y');
 
   return (
-    <main css={[styles.root, overflow]}>
+    <main css={[styles.root, overflow]} id={'app-main-scroll'}>
       {topBar && <div css={styles.topBar}>{topBar}</div>}
       <div css={[styles.content]}>{children}</div>
       {bottomBar && <div css={styles.bottomBar}>{bottomBar}</div>}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -120,7 +120,9 @@ export const GridColumn = ({
           }
         }}
         scrollElement={
-          scrollElementId ? document.getElementById(scrollElementId) ?? undefined : undefined
+          (scrollElementId && document.getElementById(scrollElementId)) ||
+          document.getElementById('app-main-scroll') ||
+          undefined
         }
       >
         {() => (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -44,7 +44,10 @@ import { SearchBox } from './search_box';
 
 const StickySidebar = styled(EuiFlexItem)`
   position: sticky;
-  top: 120px;
+  top: calc(
+    var(--kbn-application--sticky-headers-offset, 96px) +
+      ${(props) => props.theme.eui.euiSizeL /* 24px */}
+  );
 `;
 
 export interface PackageListGridProps {


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/225263

We're preparing Kibana for new layout (available behind feature flag) and currently addressing obvious bugs that appear in new layout. This PR fixes scroll issue and sticky side menu position for integrations page to work nicely for both and new layout. 

to enable new layout: 
```
feature_flags.overrides:
  core.chrome.layoutType: 'grid'
  core.chrome.layoutDebug: true
```

Ideally needs to be tested in all: 
- [x] old layout + classic nav; 
- [x] old layout + solution nav; 
- [x] new layout + classic nav; 
- [x] new layout + solution nav


**Before** the fix in new layout. Loading on scroll is broken; sticky sidebar position is wrong

https://github.com/user-attachments/assets/86c843b4-afaf-43ca-8df0-d8bf24abab34


**After**

https://github.com/user-attachments/assets/9d51074e-b9f8-45a8-b6be-9392d0ef9764



