### PR TITLE
Fix deduplication of apm indices pattern

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
@@ -111,7 +111,7 @@ describe('createStaticDataView', () => {
     jest.spyOn(HistoricalAgentData, 'hasHistoricalAgentData').mockResolvedValue(true);
 
     const dataViewService = getMockedDataViewService('apm-*');
-    const expectedDataViewTitle = 'apm-*-transaction-*,apm-*-span-*,apm-*-error-*,apm-*-metrics-*';
+    const expectedDataViewTitle = 'apm-*-error-*,apm-*-metrics-*,apm-*-span-*,apm-*-transaction-*';
 
     await createOrUpdateStaticDataView({
       apmEventClient: apmEventClientMock,
@@ -137,7 +137,7 @@ describe('createStaticDataView', () => {
     jest.spyOn(HistoricalAgentData, 'hasHistoricalAgentData').mockResolvedValue(true);
 
     const dataViewService = getMockedDataViewService(
-      'apm-*-transaction-*,apm-*-span-*,apm-*-error-*,apm-*-metrics-*'
+      'apm-*-error-*,apm-*-metrics-*,apm-*-span-*,apm-*-transaction-*'
     );
 
     await createOrUpdateStaticDataView({

--- a/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.test.ts
@@ -9,23 +9,21 @@ import type { APMIndices } from '@kbn/apm-sources-access-plugin/server';
 import { getApmDataViewIndexPattern } from './get_apm_data_view_index_pattern';
 
 describe('getApmDataViewIndexPattern', () => {
-  it('returns a data view index pattern by combining existing indices', () => {
-    const indexPattern = getApmDataViewIndexPattern({
-      transaction: 'apm-*-transaction-*',
-      span: 'apm-*-span-*',
-      error: 'apm-*-error-*',
-      metric: 'apm-*-metrics-*',
-    } as APMIndices);
-    expect(indexPattern).toBe('apm-*-transaction-*,apm-*-span-*,apm-*-error-*,apm-*-metrics-*');
-  });
-
-  it('removes duplicates', () => {
+  it('combines, sorts and removes duplicates', () => {
     const title = getApmDataViewIndexPattern({
-      transaction: 'apm-*',
-      span: 'apm-*',
-      error: 'apm-*',
-      metric: 'apm-*',
+      error:
+        'remote_cluster:apm-*,remote_cluster:logs-apm*,remote_cluster:logs-*.otel-*,apm-*,logs-apm*,logs-*.otel-*',
+      onboarding: 'remote_cluster:apm-*,apm-*',
+      span: 'remote_cluster:apm-*,remote_cluster:traces-apm*,remote_cluster:traces-*.otel-*,apm-*,traces-apm*,traces-*.otel-*',
+      transaction:
+        'remote_cluster:apm-*,remote_cluster:traces-apm*,remote_cluster:traces-*.otel-*,apm-*,traces-apm*,traces-*.otel-*',
+      metric:
+        'remote_cluster:apm-*,remote_cluster:metrics-apm*,remote_cluster:metrics-*.otel-*,apm-*,metrics-apm*,metrics-*.otel-*',
+      sourcemap: 'remote_cluster:apm-*,apm-*',
     } as APMIndices);
-    expect(title).toBe('apm-*');
+
+    expect(title).toBe(
+      'apm-*,logs-*.otel-*,logs-apm*,metrics-*.otel-*,metrics-apm*,remote_cluster:apm-*,remote_cluster:logs-*.otel-*,remote_cluster:logs-apm*,remote_cluster:metrics-*.otel-*,remote_cluster:metrics-apm*,remote_cluster:traces-*.otel-*,remote_cluster:traces-apm*,traces-*.otel-*,traces-apm*'
+    );
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.test.ts
@@ -26,4 +26,21 @@ describe('getApmDataViewIndexPattern', () => {
       'apm-*,logs-*.otel-*,logs-apm*,metrics-*.otel-*,metrics-apm*,remote_cluster:apm-*,remote_cluster:logs-*.otel-*,remote_cluster:logs-apm*,remote_cluster:metrics-*.otel-*,remote_cluster:metrics-apm*,remote_cluster:traces-*.otel-*,remote_cluster:traces-apm*,traces-*.otel-*,traces-apm*'
     );
   });
+
+  it('handles falsy values', () => {
+    const title = getApmDataViewIndexPattern({
+      error: null,
+      onboarding: undefined,
+      span: '',
+      transaction:
+        'remote_cluster:apm-*,remote_cluster:traces-apm*,remote_cluster:traces-*.otel-*,apm-*,traces-apm*,traces-*.otel-*',
+      metric:
+        'remote_cluster:apm-*,remote_cluster:metrics-apm*,remote_cluster:metrics-*.otel-*,apm-*,metrics-apm*,metrics-*.otel-*',
+      sourcemap: 'remote_cluster:apm-*,apm-*',
+    } as unknown as APMIndices);
+
+    expect(title).toBe(
+      'apm-*,metrics-*.otel-*,metrics-apm*,remote_cluster:apm-*,remote_cluster:metrics-*.otel-*,remote_cluster:metrics-apm*,remote_cluster:traces-*.otel-*,remote_cluster:traces-apm*,traces-*.otel-*,traces-apm*'
+    );
+  });
 });

--- a/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.ts
@@ -9,12 +9,10 @@ import { uniq } from 'lodash';
 import type { APMIndices } from '@kbn/apm-sources-access-plugin/server';
 
 export function getApmDataViewIndexPattern(apmIndices: APMIndices): string {
-  return uniq([
-    ...apmIndices.transaction.split(','),
-    ...apmIndices.span.split(','),
-    ...apmIndices.error.split(','),
-    ...apmIndices.metric.split(','),
-  ])
-    .sort()
-    .join(',');
+  return uniq(
+    [apmIndices.transaction, apmIndices.span, apmIndices.error, apmIndices.metric]
+      .filter(Boolean)
+      .flatMap((index) => index.split(','))
+      .sort()
+  ).join(',');
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/data_view/get_apm_data_view_index_pattern.ts
@@ -8,8 +8,13 @@
 import { uniq } from 'lodash';
 import type { APMIndices } from '@kbn/apm-sources-access-plugin/server';
 
-export function getApmDataViewIndexPattern(apmIndices: APMIndices) {
-  return uniq([apmIndices.transaction, apmIndices.span, apmIndices.error, apmIndices.metric]).join(
-    ','
-  );
+export function getApmDataViewIndexPattern(apmIndices: APMIndices): string {
+  return uniq([
+    ...apmIndices.transaction.split(','),
+    ...apmIndices.span.split(','),
+    ...apmIndices.error.split(','),
+    ...apmIndices.metric.split(','),
+  ])
+    .sort()
+    .join(',');
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/data_view/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/data_view/route.ts
@@ -52,8 +52,8 @@ const dataViewTitleRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/data_view/index_pattern',
   security: { authz: { requiredPrivileges: ['apm'] } },
   handler: async ({ getApmIndices }): Promise<{ apmDataViewIndexPattern: string }> => {
-    const apmIndicies = await getApmIndices();
-    const apmDataViewIndexPattern = getApmDataViewIndexPattern(apmIndicies);
+    const apmIndices = await getApmIndices();
+    const apmDataViewIndexPattern = getApmDataViewIndexPattern(apmIndices);
 
     return { apmDataViewIndexPattern };
   },

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/data_view/static.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/data_view/static.spec.ts
@@ -25,7 +25,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const synthtraceService = getService('synthtrace');
   const logger = getService('log');
   const dataViewPattern =
-    'traces-apm*,apm-*,traces-*.otel-*,logs-apm*,apm-*,logs-*.otel-*,metrics-apm*,apm-*,metrics-*.otel-*';
+    'apm-*,logs-*.otel-*,logs-apm*,metrics-*.otel-*,metrics-apm*,traces-*.otel-*,traces-apm*';
 
   function createDataViewWithWriteUser({ spaceId }: { spaceId: string }) {
     return apmApiClient.writeUser({
@@ -141,7 +141,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           expect(dataView.id).to.be('apm_static_data_view_id_default');
           expect(dataView.name).to.be('APM');
           expect(dataView.title).to.be(
-            'traces-apm*,apm-*,traces-*.otel-*,logs-apm*,apm-*,logs-*.otel-*,metrics-apm*,apm-*,metrics-*.otel-*'
+            'apm-*,logs-*.otel-*,logs-apm*,metrics-*.otel-*,metrics-apm*,traces-*.otel-*,traces-apm*'
           );
         });
       });


### PR DESCRIPTION
## Summary

The indices pattern for APM wasn't correctly deduplicated in server code when creating a Data View. While ES deduplicates an index pattern regardless, the intention of this Kibana code was to deduplicate and it did not.

Created as a byproduct of research into [this SDH](https://github.com/elastic/sdh-apm/issues/1787).