### PR TITLE
chore(security, tests): Add testCategory to cookie and shard missing tests

### DIFF
--- a/x-pack/test/security_api_integration/session_cookie.config.ts
+++ b/x-pack/test/security_api_integration/session_cookie.config.ts
@@ -7,6 +7,7 @@
 
 import { resolve } from 'path';
 
+import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 import { services } from './services';
@@ -17,6 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xPackAPITestsConfig = await readConfigFile(require.resolve('../api_integration/config.ts'));
 
   return {
+    testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
     testFiles: [resolve(__dirname, './tests/session_cookie')],
     services,
     servers: xPackAPITestsConfig.get('servers'),

--- a/x-pack/test/security_api_integration/session_shard_missing.config.ts
+++ b/x-pack/test/security_api_integration/session_shard_missing.config.ts
@@ -7,6 +7,7 @@
 
 import { resolve } from 'path';
 
+import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 import { services } from './services';
@@ -22,6 +23,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const testEndpointsPlugin = resolve(__dirname, '../security_functional/plugins/test_endpoints');
 
   return {
+    testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
     testFiles: [resolve(__dirname, './tests/session_shard_missing')],
     services,
     servers: xPackAPITestsConfig.get('servers'),


### PR DESCRIPTION
## Summary

Add testCategory for Session Cookies and Session Index shard missing FTR tests to improve visibility into test runs. 


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->