### PR TITLE
🌊 Streams: small fixes

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/utils.ts
@@ -116,7 +116,9 @@ export function getUpsertWiredFields(
   return { ...originalFieldDefinition, ...simulationMappedFieldDefinition };
 }
 
-export const spawnDataSource = <TAssignArgs extends AssignArgs<any, any, any, any>>(
+export const spawnDataSource = <
+  TAssignArgs extends AssignArgs<StreamEnrichmentContextType, any, any, any>
+>(
   dataSource: EnrichmentDataSource,
   assignArgs: TAssignArgs
 ) => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@kbn/streams-schema';
 import React from 'react';
 import { DISCOVER_APP_LOCATOR, DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
+import { LocatorPublic } from '@kbn/share-plugin/public';
 import { css } from '@emotion/react';
 import { useKibana } from '../../hooks/use_kibana';
 
@@ -146,6 +147,16 @@ export function DiscoverBadgeButton({
     return null;
   }
 
+  return <DiscoverBadgeButtonInner discoverLocator={discoverLocator} esqlQuery={esqlQuery} />;
+}
+
+function DiscoverBadgeButtonInner({
+  discoverLocator,
+  esqlQuery,
+}: {
+  discoverLocator: LocatorPublic<DiscoverAppLocatorParams>;
+  esqlQuery: string;
+}) {
   const discoverLink = discoverLocator.useUrl({
     query: {
       esql: esqlQuery,


### PR DESCRIPTION
This PR fixes two very small things I noticed while working with the code:
* `spawnDataSource` wasn't typed at all - it accesses the context but it was just any, which is dangerous when refactoring
* rules of hooks were violated in the discover badge