### PR TITLE
[AI Infra] Fix product doc artifact name parsing 

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/artifact.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/artifact.ts
@@ -7,9 +7,6 @@
 
 import { type ProductName, DocumentationProduct } from './product';
 
-// kb-product-doc-elasticsearch-8.15.zip
-const artifactNameRegexp = /^kb-product-doc-([a-z]+)-([0-9]+\.[0-9]+)(\.zip)?$/;
-const inferenceIdRegexp = /--([a-z0-9.-]+)(\.zip)?$/;
 const allowedProductNames: ProductName[] = Object.values(DocumentationProduct);
 
 export const DEFAULT_ELSER = '.elser-2-elasticsearch';
@@ -32,22 +29,29 @@ export const getArtifactName = ({
 };
 
 export const parseArtifactName = (artifactName: string) => {
-  let name = artifactName.replace(/\.zip$/, '');
-  // First, extract out the inference Id which is prefixed by --
-  const inferenceIdMatch = name.match(inferenceIdRegexp);
-  name = inferenceIdMatch ? name.replace(inferenceIdMatch[0], '') : artifactName;
+  // drop ".zip" (if any)
+  let name = artifactName.endsWith('.zip') ? artifactName.slice(0, -4) : artifactName;
 
-  const match = name.match(artifactNameRegexp);
-  if (match) {
-    const productName = match[1].toLowerCase() as ProductName;
-    const productVersion = match[2].toLowerCase();
-    const inferenceId = inferenceIdMatch ? inferenceIdMatch[1] : undefined;
-    if (allowedProductNames.includes(productName)) {
-      return {
-        productName,
-        productVersion,
-        ...(inferenceId ? { inferenceId } : {}),
-      };
-    }
+  // pull off the final  "--<inferenceId>" (if present)
+  let inferenceId: string | undefined;
+  const lastDashDash = name.lastIndexOf('--');
+  if (lastDashDash !== -1) {
+    inferenceId = name.slice(lastDashDash + 2);
+    name = name.slice(0, lastDashDash); // strip it for the base match
   }
+
+  // match the main pattern kb-product-doc-<product>-<version>
+  const match = name.match(/^kb-product-doc-([a-z]+)-([0-9]+\.[0-9]+)$/);
+  if (!match) return;
+
+  const productName = match[1].toLowerCase() as ProductName;
+  const productVersion = match[2].toLowerCase();
+
+  if (!allowedProductNames.includes(productName)) return;
+
+  return {
+    productName,
+    productVersion,
+    ...(inferenceId ? { inferenceId } : {}),
+  };
 };


### PR DESCRIPTION
## Summary

Replaces the regular expression implementation for parsing product documentation artifact names.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->