### PR TITLE
[Oblt Logs Essentials] Replace CTA links in k8s OTel onboarding flow

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -27,6 +27,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { css } from '@emotion/react';
 import { usePerformanceContext } from '@kbn/ebt-tools';
+import { type LogsLocatorParams, LOGS_LOCATOR_ID } from '@kbn/logs-shared-plugin/common';
 import { ObservabilityOnboardingPricingFeature } from '../../../../common/pricing_features';
 import { type ObservabilityOnboardingAppServices } from '../../..';
 import { EmptyPrompt } from '../shared/empty_prompt';
@@ -57,6 +58,7 @@ export const OtelKubernetesPanel: React.FC = () => {
   } = useKibana<ObservabilityOnboardingAppServices>();
   const apmLocator = share.url.locators.get('APM_LOCATOR');
   const dashboardLocator = share.url.locators.get(DASHBOARD_APP_LOCATOR);
+  const logsLocator = share.url.locators.get<LogsLocatorParams>(LOGS_LOCATOR_ID);
   const theme = useEuiTheme();
   const { onPageReady } = usePerformanceContext();
   const metricsOnboardingEnabled = usePricingFeature(
@@ -383,12 +385,17 @@ kubectl describe pod <myapp-pod-name> -n my-namespace`}
             children: data ? (
               <>
                 <p>
-                  {i18n.translate(
-                    'xpack.observability_onboarding.otelKubernetesPanel.onceYourKubernetesInfrastructureLabel',
-                    {
-                      defaultMessage:
-                        'Analyze your Kubernetes cluster’s health and monitor your container workloads.',
-                    }
+                  {metricsOnboardingEnabled && (
+                    <FormattedMessage
+                      id="xpack.observability_onboarding.otelKubernetesPanel.onceYourKubernetesInfrastructureLabel"
+                      defaultMessage="Analyze your Kubernetes cluster’s health and monitor your container workloads."
+                    />
+                  )}
+                  {!metricsOnboardingEnabled && (
+                    <FormattedMessage
+                      id="xpack.observability_onboarding.logsEssentials.otelKubernetesPanel.onceYourKubernetesInfrastructureLabel"
+                      defaultMessage="After running the previous command, come back and view your data."
+                    />
                   )}
                 </p>
                 <EuiSpacer />
@@ -399,43 +406,64 @@ kubectl describe pod <myapp-pod-name> -n my-namespace`}
                   integration="kubernetes_otel"
                   newTab={false}
                   isLoading={false}
-                  actionLinks={[
-                    {
-                      id: CLUSTER_OVERVIEW_DASHBOARD_ID,
-                      title: i18n.translate(
-                        'xpack.observability_onboarding.otelKubernetesPanel.monitoringCluster',
-                        {
-                          defaultMessage: 'Check your Kubernetes cluster health:',
-                        }
-                      ),
-                      label: i18n.translate(
-                        'xpack.observability_onboarding.otelKubernetesPanel.exploreDashboard',
-                        {
-                          defaultMessage: 'Explore Kubernetes Cluster Dashboard',
-                        }
-                      ),
-                      href:
-                        dashboardLocator?.getRedirectUrl({
-                          dashboardId: CLUSTER_OVERVIEW_DASHBOARD_ID,
-                        }) ?? '',
-                    },
-                    {
-                      id: 'services',
-                      title: i18n.translate(
-                        'xpack.observability_onboarding.otelKubernetesPanel.servicesTitle',
-                        {
-                          defaultMessage: 'Check your application services:',
-                        }
-                      ),
-                      label: i18n.translate(
-                        'xpack.observability_onboarding.otelKubernetesPanel.servicesLabel',
-                        {
-                          defaultMessage: 'Explore Service Inventory',
-                        }
-                      ),
-                      href: apmLocator?.getRedirectUrl({ serviceName: undefined }) ?? '',
-                    },
-                  ]}
+                  actionLinks={
+                    metricsOnboardingEnabled
+                      ? [
+                          {
+                            id: CLUSTER_OVERVIEW_DASHBOARD_ID,
+                            title: i18n.translate(
+                              'xpack.observability_onboarding.otelKubernetesPanel.monitoringCluster',
+                              {
+                                defaultMessage: 'Check your Kubernetes cluster health:',
+                              }
+                            ),
+                            label: i18n.translate(
+                              'xpack.observability_onboarding.otelKubernetesPanel.exploreDashboard',
+                              {
+                                defaultMessage: 'Explore Kubernetes Cluster Dashboard',
+                              }
+                            ),
+                            href:
+                              dashboardLocator?.getRedirectUrl({
+                                dashboardId: CLUSTER_OVERVIEW_DASHBOARD_ID,
+                              }) ?? '',
+                          },
+                          {
+                            id: 'services',
+                            title: i18n.translate(
+                              'xpack.observability_onboarding.otelKubernetesPanel.servicesTitle',
+                              {
+                                defaultMessage: 'Check your application services:',
+                              }
+                            ),
+                            label: i18n.translate(
+                              'xpack.observability_onboarding.otelKubernetesPanel.servicesLabel',
+                              {
+                                defaultMessage: 'Explore Service Inventory',
+                              }
+                            ),
+                            href: apmLocator?.getRedirectUrl({ serviceName: undefined }) ?? '',
+                          },
+                        ]
+                      : [
+                          {
+                            id: 'logs',
+                            title: i18n.translate(
+                              'xpack.observability_onboarding.otelKubernetesPanel.logsTitle',
+                              {
+                                defaultMessage: 'View and analyze your logs:',
+                              }
+                            ),
+                            label: i18n.translate(
+                              'xpack.observability_onboarding.otelKubernetesPanel.logsLabel',
+                              {
+                                defaultMessage: 'Explore logs',
+                              }
+                            ),
+                            href: logsLocator?.getRedirectUrl({}) ?? '',
+                          },
+                        ]
+                  }
                 />
               </>
             ) : (


### PR DESCRIPTION
This change replaces CTAs in the Kubernetes OTel onboarding flow to point users to Discover instead of metrics dashboard or APM as those won't be available in Logs Essentials tier.

![CleanShot 2025-07-07 at 16 35 27@2x](https://github.com/user-attachments/assets/57bcf6ef-339a-4a42-873f-100f5cf232be)
