### PR TITLE
[Security Assistant] Re-add telemetry params to default assistant graph

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/graph.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/graph.ts
@@ -89,7 +89,7 @@ export const getDefaultAssistantGraph = ({
       )
       .addNode(NodeType.GENERATE_CHAT_TITLE, async (state: AgentState) => {
         const model = await createLlmInstance();
-        return generateChatTitle({ ...nodeParams, state, model, telemetry });
+        return generateChatTitle({ ...nodeParams, state, model, telemetryParams, telemetry });
       })
       .addNode(NodeType.PERSIST_CONVERSATION_CHANGES, (state: AgentState) =>
         persistConversationChanges({
@@ -109,7 +109,14 @@ export const getDefaultAssistantGraph = ({
         })
       )
       .addNode(NodeType.TOOLS, (state: AgentState) =>
-        executeTools({ ...nodeParams, config: { signal }, state, tools, telemetry })
+        executeTools({
+          ...nodeParams,
+          config: { signal },
+          state,
+          tools,
+          telemetryParams,
+          telemetry,
+        })
       )
       .addNode(NodeType.RESPOND, async (state: AgentState) => {
         const model = await createLlmInstance();


### PR DESCRIPTION
## Summary

This PR restores the `telemetryParams` property to a few nodes on the default chain. It was unintentionally removed during conflict resolution in a previous [PR](https://github.com/elastic/kibana/pull/220273/files). This change ensures those nodes receive the correct telemetry parameters again.



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->