### PR TITLE
Revert "[CI] Trigger backport when `v*` labels are added (#225511)"

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -10,33 +10,23 @@ jobs:
     name: 'Label and Backport'
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.merged == true && (
-        github.event.action == 'closed' || (
-          github.event.action == 'labeled' && (
-            github.event.label.name == 'backport:prev-minor' ||
-            github.event.label.name == 'backport:prev-major' ||
-            github.event.label.name == 'backport:current-major' ||
-            github.event.label.name == 'backport:all-open' ||
-            github.event.label.name == 'backport:version' ||
-            github.event.label.name == 'auto-backport'
-          )
-        ) || (
-          github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'backport:version') && (
-            startsWith(github.event.label.name,'v7') ||
-            startsWith(github.event.label.name,'v8') ||
-            startsWith(github.event.label.name,'v9')
-          )
-        ) || (
-          github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip' && (
-            contains(github.event.pull_request.labels.*.name, 'backport:prev-minor') ||
-            contains(github.event.pull_request.labels.*.name, 'backport:prev-major') ||
-            contains(github.event.pull_request.labels.*.name, 'backport:current-major') ||
-            contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
-            contains(github.event.pull_request.labels.*.name, 'backport:version') ||
-            contains(github.event.pull_request.labels.*.name, 'auto-backport')
-          )
-        )
-      )
+      github.event.pull_request.merged == true &&
+        (github.event.action == 'closed' ||
+          (github.event.action == 'labeled' &&
+            (github.event.label.name == 'backport:prev-minor' ||
+              github.event.label.name == 'backport:prev-major' ||
+              github.event.label.name == 'backport:current-major' ||
+              github.event.label.name == 'backport:all-open' ||
+              github.event.label.name == 'backport:version' ||
+              github.event.label.name == 'auto-backport')) ||
+          (github.event.action == 'unlabeled' &&
+            github.event.label.name == 'backport:skip' &&
+            (contains(github.event.pull_request.labels.*.name, 'backport:prev-minor') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:prev-major') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:current-major') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:version') ||
+              contains(github.event.pull_request.labels.*.name, 'auto-backport'))))
     steps:
       - name: Checkout Actions
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary 
This reverts commit 780310b78500fafb476c259dcf7df5758b8a91f1.

The reason for the revert: the previous way (although not responding to _every_ valid event, e.g.: new label arriving when `backport:version` is already present) less sensitive, and thus not generating multiple backport runs when several labels were changed. Example case: https://github.com/elastic/kibana/pull/225821 - the events +`backport:version`, +`v9.1.0`, -`backport:skip` all generated a run on the backport action in this order. Ultimately, we got a single PR, but it's noise, and might be confusing for developers.
