### PR TITLE
[ES|QL] Fixes on expandToFitQueryOnMount prop when the query is super long

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -57,6 +57,7 @@ import {
   EDITOR_INITIAL_HEIGHT,
   EDITOR_INITIAL_HEIGHT_INLINE_EDITING,
   RESIZABLE_CONTAINER_INITIAL_HEIGHT,
+  EDITOR_MAX_HEIGHT,
   esqlEditorStyles,
 } from './esql_editor.styles';
 import type { ESQLEditorProps, ESQLEditorDeps, ControlsContext } from './types';
@@ -882,7 +883,11 @@ export const ESQLEditor = memo(function ESQLEditor({
                       const lineCount = editor.getModel()?.getLineCount() || 1;
                       const padding = lineHeight * 1.25; // Extra line at the bottom, plus a bit more to compensate for hidden vertical scrollbars
                       const height = editor.getTopForLineNumber(lineCount + 1) + padding;
-                      if (height > editorHeight) setEditorHeight(height);
+                      if (height > editorHeight && height < EDITOR_MAX_HEIGHT) {
+                        setEditorHeight(height);
+                      } else if (height >= EDITOR_MAX_HEIGHT) {
+                        setEditorHeight(EDITOR_MAX_HEIGHT);
+                      }
                     }
                     editor.onDidLayoutChange((layoutInfoEvent) => {
                       onLayoutChangeRef.current(layoutInfoEvent);


### PR DESCRIPTION
## Summary

Makes sure that if the query is super long wont go above the editor max height

<img width="809" alt="image" src="https://github.com/user-attachments/assets/62775512-df90-4e4d-95d4-4c562953bb94" />





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->