### PR TITLE
[HTTP] Minimize `...` spreads in object assignments

### DIFF
--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -558,15 +558,14 @@ export class HttpServer {
 
       executionContext?.setRequestId(requestId);
 
-      request.app = {
-        ...(request.app ?? {}),
-        requestId,
-        requestUuid: uuidv4(),
-        measureElu: stop,
-        // Kibana stores trace.id until https://github.com/elastic/apm-agent-nodejs/issues/2353 is resolved
-        // The current implementation of the APM agent ends a request transaction before "response" log is emitted.
-        traceId: apm.currentTraceIds['trace.id'],
-      } as KibanaRequestState;
+      const app: KibanaRequestState = request.app as KibanaRequestState;
+      app.requestId = requestId;
+      app.requestUuid = uuidv4();
+      app.measureElu = stop;
+      // Kibana stores trace.id until https://github.com/elastic/apm-agent-nodejs/issues/2353 is resolved
+      // The current implementation of the APM agent ends a request transaction before "response" log is emitted.
+      app.traceId = apm.currentTraceIds['trace.id'];
+
       return responseToolkit.continue;
     });
   }

--- a/src/core/packages/http/server-internal/src/lifecycle_handlers.ts
+++ b/src/core/packages/http/server-internal/src/lifecycle_handlers.ts
@@ -119,7 +119,7 @@ export const createCustomHeadersPreResponseHandler = (config: HttpConfig): OnPre
   };
 
   return (request, response, toolkit) => {
-    return toolkit.next({ headers: { ...additionalHeaders } });
+    return toolkit.next({ headers: additionalHeaders });
   };
 };
 
@@ -137,7 +137,7 @@ export const createDeprecationWarningHeaderPreResponseHandler = (
         kibanaVersion
       ),
     };
-    return toolkit.next({ headers: { ...additionalHeaders } });
+    return toolkit.next({ headers: additionalHeaders });
   };
 };
 


### PR DESCRIPTION
## Summary

Hoping for some perf improvement here, since `Object.assign` (or merging objects through `...`) is usually more CPU intensive than direct property assignment.

### Scalability tests

- APIs Capacity: https://buildkite.com/elastic/kibana-apis-capacity-testing/builds/7254/
- Single User Performance: https://buildkite.com/elastic/kibana-single-user-performance/builds/16940/
- Scalability benchmarking: https://buildkite.com/elastic/kibana-scalability-benchmarking/builds/1043/


### Checklist

- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




