### PR TITLE
[Dashboards as code] Publish OpenAPI specifications for unstable APIs

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -76,6 +76,7 @@ tags:
     x-displayName: Connectors
   - description: Dashboards APIs enable you to manage and interact with Kibana dashboards.
     name: dashboards
+    x-displayName: Dashboards
   - name: Data streams
   - description: Data view APIs enable you to manage data views, formerly known as Kibana index patterns.
     name: data views

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -74,6 +74,8 @@ tags:
       description: Connector documentation
       url: https://www.elastic.co/docs/reference/kibana/connectors-kibana
     x-displayName: Connectors
+  - description: Dashboards APIs enable you to manage and interact with Kibana dashboards.
+    name: dashboards
   - name: Data streams
   - description: Data view APIs enable you to manage data views, formerly known as Kibana index patterns.
     name: data views
@@ -6336,6 +6338,2643 @@ paths:
       summary: List asset criticality records
       tags:
         - Security Entity Analytics API
+  /api/dashboards/dashboard:
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard
+      parameters:
+        - description: The page number to return. Default is "1".
+          in: query
+          name: page
+          required: false
+          schema:
+            default: 1
+            minimum: 1
+            type: number
+        - description: The number of dashboards to display on each page (max 1000). Default is "20".
+          in: query
+          name: perPage
+          required: false
+          schema:
+            maximum: 1000
+            minimum: 1
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  items:
+                    items:
+                      additionalProperties: true
+                      type: object
+                      properties:
+                        attributes:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            description:
+                              default: ''
+                              description: A short description.
+                              type: string
+                            tags:
+                              items:
+                                description: An array of tags applied to this dashboard
+                                type: string
+                              type: array
+                            timeRestore:
+                              default: false
+                              description: Whether to restore time upon viewing this dashboard
+                              type: boolean
+                            title:
+                              description: A human-readable title for the dashboard
+                              type: string
+                          required:
+                            - title
+                        createdAt:
+                          type: string
+                        createdBy:
+                          type: string
+                        error:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            error:
+                              type: string
+                            message:
+                              type: string
+                            metadata:
+                              additionalProperties: true
+                              type: object
+                              properties: {}
+                            statusCode:
+                              type: number
+                          required:
+                            - error
+                            - message
+                            - statusCode
+                        id:
+                          type: string
+                        managed:
+                          type: boolean
+                        namespaces:
+                          items:
+                            type: string
+                          type: array
+                        originId:
+                          type: string
+                        references:
+                          items:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - name
+                              - type
+                              - id
+                          type: array
+                        type:
+                          type: string
+                        updatedAt:
+                          type: string
+                        updatedBy:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                        - id
+                        - type
+                        - attributes
+                        - references
+                    type: array
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+      summary: Get a list of dashboards
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+  /api/dashboards/dashboard/{dashboardId}:
+    delete:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: delete-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses: {}
+      summary: Delete a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard-id
+      parameters:
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                  meta:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      aliasPurpose:
+                        enum:
+                          - savedObjectConversion
+                          - savedObjectImport
+                        type: string
+                      aliasTargetId:
+                        type: string
+                      outcome:
+                        enum:
+                          - exactMatch
+                          - aliasMatch
+                          - conflict
+                        type: string
+                    required:
+                      - outcome
+                required:
+                  - item
+                  - meta
+      summary: Get a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    post:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: post-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ''
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  'y':
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - 'y'
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  'y':
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - 'y'
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+                spaces:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - attributes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Create a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    put:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: put-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ''
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  'y':
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - 'y'
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  'y':
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - 'y'
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+              required:
+                - attributes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Update an existing dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
   /api/data_views:
     get:
       operationId: getAllDataViewsDefault

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -90,6 +90,7 @@ tags:
     x-displayName: Connectors
   - description: Dashboards APIs enable you to manage and interact with Kibana dashboards.
     name: dashboards
+    x-displayName: Dashboards
   - name: Data streams
   - description: Data view APIs enable you to manage data views, formerly known as Kibana index patterns.
     name: data views

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -88,6 +88,8 @@ tags:
       description: Connector documentation
       url: https://www.elastic.co/docs/reference/kibana/connectors-kibana
     x-displayName: Connectors
+  - description: Dashboards APIs enable you to manage and interact with Kibana dashboards.
+    name: dashboards
   - name: Data streams
   - description: Data view APIs enable you to manage data views, formerly known as Kibana index patterns.
     name: data views
@@ -7878,6 +7880,2643 @@ paths:
       summary: Get case tags
       tags:
         - cases
+  /api/dashboards/dashboard:
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard
+      parameters:
+        - description: The page number to return. Default is "1".
+          in: query
+          name: page
+          required: false
+          schema:
+            default: 1
+            minimum: 1
+            type: number
+        - description: The number of dashboards to display on each page (max 1000). Default is "20".
+          in: query
+          name: perPage
+          required: false
+          schema:
+            maximum: 1000
+            minimum: 1
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  items:
+                    items:
+                      additionalProperties: true
+                      type: object
+                      properties:
+                        attributes:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            description:
+                              default: ''
+                              description: A short description.
+                              type: string
+                            tags:
+                              items:
+                                description: An array of tags applied to this dashboard
+                                type: string
+                              type: array
+                            timeRestore:
+                              default: false
+                              description: Whether to restore time upon viewing this dashboard
+                              type: boolean
+                            title:
+                              description: A human-readable title for the dashboard
+                              type: string
+                          required:
+                            - title
+                        createdAt:
+                          type: string
+                        createdBy:
+                          type: string
+                        error:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            error:
+                              type: string
+                            message:
+                              type: string
+                            metadata:
+                              additionalProperties: true
+                              type: object
+                              properties: {}
+                            statusCode:
+                              type: number
+                          required:
+                            - error
+                            - message
+                            - statusCode
+                        id:
+                          type: string
+                        managed:
+                          type: boolean
+                        namespaces:
+                          items:
+                            type: string
+                          type: array
+                        originId:
+                          type: string
+                        references:
+                          items:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - name
+                              - type
+                              - id
+                          type: array
+                        type:
+                          type: string
+                        updatedAt:
+                          type: string
+                        updatedBy:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                        - id
+                        - type
+                        - attributes
+                        - references
+                    type: array
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+      summary: Get a list of dashboards
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+  /api/dashboards/dashboard/{dashboardId}:
+    delete:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: delete-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses: {}
+      summary: Delete a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard-id
+      parameters:
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                  meta:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      aliasPurpose:
+                        enum:
+                          - savedObjectConversion
+                          - savedObjectImport
+                        type: string
+                      aliasTargetId:
+                        type: string
+                      outcome:
+                        enum:
+                          - exactMatch
+                          - aliasMatch
+                          - conflict
+                        type: string
+                    required:
+                      - outcome
+                required:
+                  - item
+                  - meta
+      summary: Get a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    post:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: post-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ''
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  'y':
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - 'y'
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  'y':
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - 'y'
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+                spaces:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - attributes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Create a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    put:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: put-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ''
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  'y':
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - 'y'
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  'y':
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - 'y'
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+              required:
+                - attributes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Update an existing dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
   /api/data_views:
     get:
       operationId: getAllDataViewsDefault

--- a/oas_docs/overlays/kibana.overlays.serverless.yaml
+++ b/oas_docs/overlays/kibana.overlays.serverless.yaml
@@ -22,6 +22,10 @@ actions:
       description: >
         Streams is a new and experimental way to manage your data in Kibana. The API is currently not considered stable and can change at any point.
       x-displayName: "Streams"
+  - target: '$.tags[?(@.name=="dashboards")]'
+    description: Change displayName
+    update:
+      x-displayName: "Dashboards"
   - target: '$.tags[?(@.name=="data views")]'
     description: Change displayName
     update:

--- a/oas_docs/overlays/kibana.overlays.yaml
+++ b/oas_docs/overlays/kibana.overlays.yaml
@@ -42,6 +42,10 @@ actions:
       description: >
         Streams is a new and experimental way to manage your data in Kibana (currently experimental - expect changes).
       x-displayName: "Streams"
+  - target: '$.tags[?(@.name=="dashboards")]'
+    description: Change displayName
+    update:
+      x-displayName: "Dashboards"
   - target: '$.tags[?(@.name=="data views")]'
     description: Change displayName
     update:

--- a/oas_docs/scripts/merge_ess_oas.js
+++ b/oas_docs/scripts/merge_ess_oas.js
@@ -17,6 +17,7 @@ const { REPO_ROOT } = require('@kbn/repo-info');
       `${REPO_ROOT}/oas_docs/bundle.json`,
       `${REPO_ROOT}/x-pack/platform/plugins/shared/alerting/docs/openapi/bundled.yaml`,
       `${REPO_ROOT}/x-pack/platform/plugins/shared/cases/docs/openapi/bundled.yaml`,
+      `${REPO_ROOT}/src/platform/plugins/shared/dashboard/docs/openapi/bundled.yaml`,
       `${REPO_ROOT}/src/platform/plugins/shared/data_views/docs/openapi/bundled.yaml`,
       `${REPO_ROOT}/x-pack/platform/plugins/shared/features/docs/openapi/feature_apis.yaml`,
       `${REPO_ROOT}/x-pack/platform/plugins/shared/ml/common/openapi/ml_apis.yaml`,

--- a/oas_docs/scripts/merge_serverless_oas.js
+++ b/oas_docs/scripts/merge_serverless_oas.js
@@ -15,6 +15,7 @@ const { REPO_ROOT } = require('@kbn/repo-info');
   await merge({
     sourceGlobs: [
       `${REPO_ROOT}/oas_docs/bundle.serverless.json`,
+      `${REPO_ROOT}/src/platform/plugins/shared/dashboard/docs/openapi/bundled.yaml`,
       `${REPO_ROOT}/src/platform/plugins/shared/data_views/docs/openapi/bundled.yaml`,
       `${REPO_ROOT}/x-pack/platform/plugins/shared/ml/common/openapi/ml_apis_serverless.yaml`,
       `${REPO_ROOT}/x-pack/platform/plugins/shared/task_manager/docs/openapi/bundled_serverless.yaml`,

--- a/src/platform/plugins/shared/dashboard/docs/openapi/README.md
+++ b/src/platform/plugins/shared/dashboard/docs/openapi/README.md
@@ -1,0 +1,23 @@
+# OpenAPI (Experimental)
+
+The current self-contained spec file is available as `bundled.json` or `bundled.yaml` and can be used for online tools like those found at <https://openapi.tools/>.
+This spec is experimental and may be incomplete or change later.
+
+A guide about the openApi specification can be found at [https://swagger.io/docs/specification/about/](https://swagger.io/docs/specification/about/).
+
+## The `openapi` folder
+
+- `entrypoint.yaml` is the overview file which pulls together all the paths and components.
+- [Paths](paths/README.md): Defines each endpoint. A path can have one operation per http method.
+- [Components](components/README.md): Defines reusable components.
+
+## Tools
+
+Generate the `bundled` files by running the following commands:
+
+```bash
+npx @redocly/cli bundle entrypoint.yaml --output bundled.yaml --ext yaml
+npx @redocly/cli bundle entrypoint.yaml --output bundled.json --ext json
+```
+
+Then join these files with the rest of the Kibana APIs per `oas_docs/README.md`

--- a/src/platform/plugins/shared/dashboard/docs/openapi/bundled.json
+++ b/src/platform/plugins/shared/dashboard/docs/openapi/bundled.json
@@ -1,0 +1,3721 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Dashboards (unstable)",
+    "description": "The Dashboards API allows you to manage and interact with Kibana dashboards.\nYou can create, update, delete, and retrieve dashboards programmatically.\n",
+    "version": "0.1",
+    "contact": {
+      "name": "Kibana Presentation Team"
+    },
+    "license": {
+      "name": "Elastic License 2.0",
+      "url": "https://www.elastic.co/licensing/elastic-license"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://{kibana_url}",
+      "variables": {
+        "kibana_url": {
+          "default": "localhost:5601"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "dashboards",
+      "description": "Dashboards APIs enable you to manage and interact with Kibana dashboards."
+    }
+  ],
+  "paths": {
+    "/api/dashboards/dashboard": {
+      "get": {
+        "description": "This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.",
+        "operationId": "get-dashboards-dashboard",
+        "parameters": [
+          {
+            "description": "The page number to return. Default is \"1\".",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "description": "The number of dashboards to display on each page (max 1000). Default is \"20\".",
+            "in": "query",
+            "name": "perPage",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": true,
+                        "type": "object",
+                        "properties": {
+                          "attributes": {
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "description": {
+                                "default": "",
+                                "description": "A short description.",
+                                "type": "string"
+                              },
+                              "tags": {
+                                "items": {
+                                  "description": "An array of tags applied to this dashboard",
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "timeRestore": {
+                                "default": false,
+                                "description": "Whether to restore time upon viewing this dashboard",
+                                "type": "boolean"
+                              },
+                              "title": {
+                                "description": "A human-readable title for the dashboard",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "title"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "createdBy": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "error": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": true,
+                                "type": "object",
+                                "properties": {}
+                              },
+                              "statusCode": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "error",
+                              "message",
+                              "statusCode"
+                            ]
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "managed": {
+                            "type": "boolean"
+                          },
+                          "namespaces": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "originId": {
+                            "type": "string"
+                          },
+                          "references": {
+                            "items": {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "type",
+                                "id"
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "updatedBy": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "attributes",
+                          "references"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get a list of dashboards",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Unstable (Do not use)"
+      }
+    },
+    "/api/dashboards/dashboard/{dashboardId}": {
+      "delete": {
+        "description": "This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.",
+        "operationId": "delete-dashboards-dashboard-id",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "A unique identifier for the dashboard.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Delete a dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Unstable (Do not use)"
+      },
+      "get": {
+        "description": "This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.",
+        "operationId": "get-dashboards-dashboard-id",
+        "parameters": [
+          {
+            "description": "A unique identifier for the dashboard.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "additionalProperties": true,
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "controlGroupInput": {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "autoApplySelections": {
+                                  "default": true,
+                                  "description": "Show apply selections button in controls.",
+                                  "type": "boolean"
+                                },
+                                "chainingSystem": {
+                                  "default": "HIERARCHICAL",
+                                  "description": "The chaining strategy for multiple controls. For example, \"HIERARCHICAL\" or \"NONE\".",
+                                  "enum": [
+                                    "NONE",
+                                    "HIERARCHICAL"
+                                  ],
+                                  "type": "string"
+                                },
+                                "controls": {
+                                  "default": [],
+                                  "description": "An array of control panels and their state in the control group.",
+                                  "items": {
+                                    "additionalProperties": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "controlConfig": {
+                                        "additionalProperties": {},
+                                        "type": "object"
+                                      },
+                                      "grow": {
+                                        "default": false,
+                                        "description": "Expand width of the control panel to fit available space.",
+                                        "type": "boolean"
+                                      },
+                                      "id": {
+                                        "description": "The unique ID of the control.",
+                                        "type": "string"
+                                      },
+                                      "order": {
+                                        "description": "The order of the control panel in the control group.",
+                                        "type": "number"
+                                      },
+                                      "type": {
+                                        "description": "The type of the control panel.",
+                                        "type": "string"
+                                      },
+                                      "width": {
+                                        "default": "medium",
+                                        "description": "Minimum width of the control panel in the control group.",
+                                        "enum": [
+                                          "small",
+                                          "medium",
+                                          "large"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "order"
+                                    ]
+                                  },
+                                  "type": "array"
+                                },
+                                "enhancements": {
+                                  "additionalProperties": {},
+                                  "type": "object"
+                                },
+                                "ignoreParentSettings": {
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "ignoreFilters": {
+                                      "default": false,
+                                      "description": "Ignore global filters in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreQuery": {
+                                      "default": false,
+                                      "description": "Ignore the global query bar in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreTimerange": {
+                                      "default": false,
+                                      "description": "Ignore the global time range in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreValidations": {
+                                      "default": false,
+                                      "description": "Ignore validations in controls.",
+                                      "type": "boolean"
+                                    }
+                                  }
+                                },
+                                "labelPosition": {
+                                  "default": "oneLine",
+                                  "description": "Position of the labels for controls. For example, \"oneLine\", \"twoLine\".",
+                                  "enum": [
+                                    "oneLine",
+                                    "twoLine"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "ignoreParentSettings"
+                              ]
+                            },
+                            "description": {
+                              "default": "",
+                              "description": "A short description.",
+                              "type": "string"
+                            },
+                            "kibanaSavedObjectMeta": {
+                              "additionalProperties": false,
+                              "default": {},
+                              "description": "A container for various metadata",
+                              "type": "object",
+                              "properties": {
+                                "searchSource": {
+                                  "additionalProperties": true,
+                                  "type": "object",
+                                  "properties": {
+                                    "filter": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "A filter for the search source.",
+                                        "type": "object",
+                                        "properties": {
+                                          "$state": {
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "store": {
+                                                "description": "Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').",
+                                                "enum": [
+                                                  "appState",
+                                                  "globalState"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "store"
+                                            ]
+                                          },
+                                          "meta": {
+                                            "additionalProperties": true,
+                                            "type": "object",
+                                            "properties": {
+                                              "alias": {
+                                                "nullable": true,
+                                                "type": "string"
+                                              },
+                                              "controlledBy": {
+                                                "type": "string"
+                                              },
+                                              "disabled": {
+                                                "type": "boolean"
+                                              },
+                                              "field": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "index": {
+                                                "type": "string"
+                                              },
+                                              "isMultiIndex": {
+                                                "type": "boolean"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "negate": {
+                                                "type": "boolean"
+                                              },
+                                              "params": {},
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "params"
+                                            ]
+                                          },
+                                          "query": {
+                                            "additionalProperties": {},
+                                            "type": "object"
+                                          }
+                                        },
+                                        "required": [
+                                          "meta"
+                                        ]
+                                      },
+                                      "type": "array"
+                                    },
+                                    "query": {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "language": {
+                                          "description": "The query language such as KQL or Lucene.",
+                                          "type": "string"
+                                        },
+                                        "query": {
+                                          "anyOf": [
+                                            {
+                                              "description": "A text-based query such as Kibana Query Language (KQL) or Lucene query language.",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "additionalProperties": {},
+                                              "type": "object"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "query",
+                                        "language"
+                                      ]
+                                    },
+                                    "sort": {
+                                      "items": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "enum": [
+                                                "asc",
+                                                "desc"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "format": {
+                                                  "type": "string"
+                                                },
+                                                "order": {
+                                                  "enum": [
+                                                    "asc",
+                                                    "desc"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "order"
+                                              ]
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "numeric_type": {
+                                                  "enum": [
+                                                    "double",
+                                                    "long",
+                                                    "date",
+                                                    "date_nanos"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "order": {
+                                                  "enum": [
+                                                    "asc",
+                                                    "desc"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "order"
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "options": {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "hidePanelTitles": {
+                                  "default": false,
+                                  "description": "Hide the panel titles in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncColors": {
+                                  "default": true,
+                                  "description": "Synchronize colors between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncCursor": {
+                                  "default": true,
+                                  "description": "Synchronize cursor position between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncTooltips": {
+                                  "default": true,
+                                  "description": "Synchronize tooltips between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "useMargins": {
+                                  "default": true,
+                                  "description": "Show margins between panels in the dashboard layout.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "panels": {
+                              "default": [],
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "h": {
+                                            "default": 15,
+                                            "description": "The height of the panel in grid units",
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "i": {
+                                            "type": "string"
+                                          },
+                                          "w": {
+                                            "default": 24,
+                                            "description": "The width of the panel in grid units",
+                                            "maximum": 48,
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "x": {
+                                            "description": "The x coordinate of the panel in grid units",
+                                            "type": "number"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the panel in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "x",
+                                          "y",
+                                          "i"
+                                        ]
+                                      },
+                                      "id": {
+                                        "description": "The saved object id for by reference panels",
+                                        "type": "string"
+                                      },
+                                      "panelConfig": {
+                                        "additionalProperties": true,
+                                        "type": "object",
+                                        "properties": {}
+                                      },
+                                      "panelIndex": {
+                                        "type": "string"
+                                      },
+                                      "panelRefName": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "description": "The title of the panel",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "The embeddable type",
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "deprecated": true,
+                                        "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "panelConfig",
+                                      "type",
+                                      "gridData",
+                                      "panelIndex"
+                                    ]
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "collapsed": {
+                                        "description": "The collapsed state of the section.",
+                                        "type": "boolean"
+                                      },
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "i": {
+                                            "type": "string"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the section in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "y",
+                                          "i"
+                                        ]
+                                      },
+                                      "panels": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "gridData": {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "h": {
+                                                  "default": 15,
+                                                  "description": "The height of the panel in grid units",
+                                                  "minimum": 1,
+                                                  "type": "number"
+                                                },
+                                                "i": {
+                                                  "type": "string"
+                                                },
+                                                "w": {
+                                                  "default": 24,
+                                                  "description": "The width of the panel in grid units",
+                                                  "maximum": 48,
+                                                  "minimum": 1,
+                                                  "type": "number"
+                                                },
+                                                "x": {
+                                                  "description": "The x coordinate of the panel in grid units",
+                                                  "type": "number"
+                                                },
+                                                "y": {
+                                                  "description": "The y coordinate of the panel in grid units",
+                                                  "type": "number"
+                                                }
+                                              },
+                                              "required": [
+                                                "x",
+                                                "y",
+                                                "i"
+                                              ]
+                                            },
+                                            "id": {
+                                              "description": "The saved object id for by reference panels",
+                                              "type": "string"
+                                            },
+                                            "panelConfig": {
+                                              "additionalProperties": true,
+                                              "type": "object",
+                                              "properties": {}
+                                            },
+                                            "panelIndex": {
+                                              "type": "string"
+                                            },
+                                            "panelRefName": {
+                                              "type": "string"
+                                            },
+                                            "title": {
+                                              "description": "The title of the panel",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "The embeddable type",
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "deprecated": true,
+                                              "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "panelConfig",
+                                            "type",
+                                            "gridData",
+                                            "panelIndex"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "title": {
+                                        "description": "The title of the section.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "title",
+                                      "gridData",
+                                      "panels"
+                                    ]
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "refreshInterval": {
+                              "additionalProperties": false,
+                              "description": "A container for various refresh interval settings",
+                              "type": "object",
+                              "properties": {
+                                "display": {
+                                  "deprecated": true,
+                                  "description": "A human-readable string indicating the refresh frequency. No longer used.",
+                                  "type": "string"
+                                },
+                                "pause": {
+                                  "description": "Whether the refresh interval is set to be paused while viewing the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "section": {
+                                  "deprecated": true,
+                                  "description": "No longer used.",
+                                  "type": "number"
+                                },
+                                "value": {
+                                  "description": "A numeric value indicating refresh frequency in milliseconds.",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "pause",
+                                "value"
+                              ]
+                            },
+                            "tags": {
+                              "items": {
+                                "description": "An array of tags applied to this dashboard",
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "timeFrom": {
+                              "description": "An ISO string indicating when to restore time from",
+                              "type": "string"
+                            },
+                            "timeRestore": {
+                              "default": false,
+                              "description": "Whether to restore time upon viewing this dashboard",
+                              "type": "boolean"
+                            },
+                            "timeTo": {
+                              "description": "An ISO string indicating when to restore time from",
+                              "type": "string"
+                            },
+                            "title": {
+                              "description": "A human-readable title for the dashboard",
+                              "type": "string"
+                            },
+                            "version": {
+                              "deprecated": true,
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "title",
+                            "options"
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "createdBy": {
+                          "type": "string"
+                        },
+                        "error": {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "metadata": {
+                              "additionalProperties": true,
+                              "type": "object",
+                              "properties": {}
+                            },
+                            "statusCode": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "error",
+                            "message",
+                            "statusCode"
+                          ]
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "managed": {
+                          "type": "boolean"
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "originId": {
+                          "type": "string"
+                        },
+                        "references": {
+                          "items": {
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "type",
+                              "id"
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        },
+                        "updatedBy": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes",
+                        "references"
+                      ]
+                    },
+                    "meta": {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "aliasPurpose": {
+                          "enum": [
+                            "savedObjectConversion",
+                            "savedObjectImport"
+                          ],
+                          "type": "string"
+                        },
+                        "aliasTargetId": {
+                          "type": "string"
+                        },
+                        "outcome": {
+                          "enum": [
+                            "exactMatch",
+                            "aliasMatch",
+                            "conflict"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "outcome"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "item",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get a dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Unstable (Do not use)"
+      },
+      "post": {
+        "description": "This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.",
+        "operationId": "post-dashboards-dashboard-id",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "A unique identifier for the dashboard.",
+            "in": "path",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": {
+                  "attributes": {
+                    "additionalProperties": false,
+                    "type": "object",
+                    "properties": {
+                      "controlGroupInput": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                          "autoApplySelections": {
+                            "default": true,
+                            "description": "Show apply selections button in controls.",
+                            "type": "boolean"
+                          },
+                          "chainingSystem": {
+                            "default": "HIERARCHICAL",
+                            "description": "The chaining strategy for multiple controls. For example, \"HIERARCHICAL\" or \"NONE\".",
+                            "enum": [
+                              "NONE",
+                              "HIERARCHICAL"
+                            ],
+                            "type": "string"
+                          },
+                          "controls": {
+                            "default": [],
+                            "description": "An array of control panels and their state in the control group.",
+                            "items": {
+                              "additionalProperties": true,
+                              "type": "object",
+                              "properties": {
+                                "controlConfig": {
+                                  "additionalProperties": {},
+                                  "type": "object"
+                                },
+                                "grow": {
+                                  "default": false,
+                                  "description": "Expand width of the control panel to fit available space.",
+                                  "type": "boolean"
+                                },
+                                "id": {
+                                  "description": "The unique ID of the control.",
+                                  "type": "string"
+                                },
+                                "order": {
+                                  "description": "The order of the control panel in the control group.",
+                                  "type": "number"
+                                },
+                                "type": {
+                                  "description": "The type of the control panel.",
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "default": "medium",
+                                  "description": "Minimum width of the control panel in the control group.",
+                                  "enum": [
+                                    "small",
+                                    "medium",
+                                    "large"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "order"
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          "enhancements": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "ignoreParentSettings": {
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "ignoreFilters": {
+                                "default": false,
+                                "description": "Ignore global filters in controls.",
+                                "type": "boolean"
+                              },
+                              "ignoreQuery": {
+                                "default": false,
+                                "description": "Ignore the global query bar in controls.",
+                                "type": "boolean"
+                              },
+                              "ignoreTimerange": {
+                                "default": false,
+                                "description": "Ignore the global time range in controls.",
+                                "type": "boolean"
+                              },
+                              "ignoreValidations": {
+                                "default": false,
+                                "description": "Ignore validations in controls.",
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "labelPosition": {
+                            "default": "oneLine",
+                            "description": "Position of the labels for controls. For example, \"oneLine\", \"twoLine\".",
+                            "enum": [
+                              "oneLine",
+                              "twoLine"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "ignoreParentSettings"
+                        ]
+                      },
+                      "description": {
+                        "default": "",
+                        "description": "A short description.",
+                        "type": "string"
+                      },
+                      "kibanaSavedObjectMeta": {
+                        "additionalProperties": false,
+                        "default": {},
+                        "description": "A container for various metadata",
+                        "type": "object",
+                        "properties": {
+                          "searchSource": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "properties": {
+                              "filter": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "A filter for the search source.",
+                                  "type": "object",
+                                  "properties": {
+                                    "$state": {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "store": {
+                                          "description": "Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').",
+                                          "enum": [
+                                            "appState",
+                                            "globalState"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "store"
+                                      ]
+                                    },
+                                    "meta": {
+                                      "additionalProperties": true,
+                                      "type": "object",
+                                      "properties": {
+                                        "alias": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "controlledBy": {
+                                          "type": "string"
+                                        },
+                                        "disabled": {
+                                          "type": "boolean"
+                                        },
+                                        "field": {
+                                          "type": "string"
+                                        },
+                                        "group": {
+                                          "type": "string"
+                                        },
+                                        "index": {
+                                          "type": "string"
+                                        },
+                                        "isMultiIndex": {
+                                          "type": "boolean"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "negate": {
+                                          "type": "boolean"
+                                        },
+                                        "params": {},
+                                        "type": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "params"
+                                      ]
+                                    },
+                                    "query": {
+                                      "additionalProperties": {},
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "meta"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "query": {
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "language": {
+                                    "description": "The query language such as KQL or Lucene.",
+                                    "type": "string"
+                                  },
+                                  "query": {
+                                    "anyOf": [
+                                      {
+                                        "description": "A text-based query such as Kibana Query Language (KQL) or Lucene query language.",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "additionalProperties": {},
+                                        "type": "object"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "query",
+                                  "language"
+                                ]
+                              },
+                              "sort": {
+                                "items": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "enum": [
+                                          "asc",
+                                          "desc"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "format": {
+                                            "type": "string"
+                                          },
+                                          "order": {
+                                            "enum": [
+                                              "asc",
+                                              "desc"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "order"
+                                        ]
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "numeric_type": {
+                                            "enum": [
+                                              "double",
+                                              "long",
+                                              "date",
+                                              "date_nanos"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "order": {
+                                            "enum": [
+                                              "asc",
+                                              "desc"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "order"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "options": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                          "hidePanelTitles": {
+                            "default": false,
+                            "description": "Hide the panel titles in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "syncColors": {
+                            "default": true,
+                            "description": "Synchronize colors between related panels in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "syncCursor": {
+                            "default": true,
+                            "description": "Synchronize cursor position between related panels in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "syncTooltips": {
+                            "default": true,
+                            "description": "Synchronize tooltips between related panels in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "useMargins": {
+                            "default": true,
+                            "description": "Show margins between panels in the dashboard layout.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "panels": {
+                        "default": [],
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "gridData": {
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "h": {
+                                      "default": 15,
+                                      "description": "The height of the panel in grid units",
+                                      "minimum": 1,
+                                      "type": "number"
+                                    },
+                                    "i": {
+                                      "description": "The unique identifier of the panel",
+                                      "type": "string"
+                                    },
+                                    "w": {
+                                      "default": 24,
+                                      "description": "The width of the panel in grid units",
+                                      "maximum": 48,
+                                      "minimum": 1,
+                                      "type": "number"
+                                    },
+                                    "x": {
+                                      "description": "The x coordinate of the panel in grid units",
+                                      "type": "number"
+                                    },
+                                    "y": {
+                                      "description": "The y coordinate of the panel in grid units",
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "x",
+                                    "y"
+                                  ]
+                                },
+                                "id": {
+                                  "description": "The saved object id for by reference panels",
+                                  "type": "string"
+                                },
+                                "panelConfig": {
+                                  "additionalProperties": true,
+                                  "type": "object",
+                                  "properties": {}
+                                },
+                                "panelIndex": {
+                                  "description": "The unique ID of the panel.",
+                                  "type": "string"
+                                },
+                                "panelRefName": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "description": "The title of the panel",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "The embeddable type",
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "deprecated": true,
+                                  "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "panelConfig",
+                                "type",
+                                "gridData"
+                              ]
+                            },
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "collapsed": {
+                                  "description": "The collapsed state of the section.",
+                                  "type": "boolean"
+                                },
+                                "gridData": {
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "i": {
+                                      "description": "The unique identifier of the section",
+                                      "type": "string"
+                                    },
+                                    "y": {
+                                      "description": "The y coordinate of the section in grid units",
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "y"
+                                  ]
+                                },
+                                "panels": {
+                                  "default": [],
+                                  "description": "The panels that belong to the section.",
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "h": {
+                                            "default": 15,
+                                            "description": "The height of the panel in grid units",
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "i": {
+                                            "description": "The unique identifier of the panel",
+                                            "type": "string"
+                                          },
+                                          "w": {
+                                            "default": 24,
+                                            "description": "The width of the panel in grid units",
+                                            "maximum": 48,
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "x": {
+                                            "description": "The x coordinate of the panel in grid units",
+                                            "type": "number"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the panel in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "x",
+                                          "y"
+                                        ]
+                                      },
+                                      "id": {
+                                        "description": "The saved object id for by reference panels",
+                                        "type": "string"
+                                      },
+                                      "panelConfig": {
+                                        "additionalProperties": true,
+                                        "type": "object",
+                                        "properties": {}
+                                      },
+                                      "panelIndex": {
+                                        "description": "The unique ID of the panel.",
+                                        "type": "string"
+                                      },
+                                      "panelRefName": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "description": "The title of the panel",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "The embeddable type",
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "deprecated": true,
+                                        "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "panelConfig",
+                                      "type",
+                                      "gridData"
+                                    ]
+                                  },
+                                  "type": "array"
+                                },
+                                "title": {
+                                  "description": "The title of the section.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "title",
+                                "gridData"
+                              ]
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      "refreshInterval": {
+                        "additionalProperties": false,
+                        "description": "A container for various refresh interval settings",
+                        "type": "object",
+                        "properties": {
+                          "display": {
+                            "deprecated": true,
+                            "description": "A human-readable string indicating the refresh frequency. No longer used.",
+                            "type": "string"
+                          },
+                          "pause": {
+                            "description": "Whether the refresh interval is set to be paused while viewing the dashboard.",
+                            "type": "boolean"
+                          },
+                          "section": {
+                            "deprecated": true,
+                            "description": "No longer used.",
+                            "type": "number"
+                          },
+                          "value": {
+                            "description": "A numeric value indicating refresh frequency in milliseconds.",
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "pause",
+                          "value"
+                        ]
+                      },
+                      "tags": {
+                        "items": {
+                          "description": "An array of tags applied to this dashboard",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "timeFrom": {
+                        "description": "An ISO string indicating when to restore time from",
+                        "type": "string"
+                      },
+                      "timeRestore": {
+                        "default": false,
+                        "description": "Whether to restore time upon viewing this dashboard",
+                        "type": "boolean"
+                      },
+                      "timeTo": {
+                        "description": "An ISO string indicating when to restore time from",
+                        "type": "string"
+                      },
+                      "title": {
+                        "description": "A human-readable title for the dashboard",
+                        "type": "string"
+                      },
+                      "version": {
+                        "deprecated": true,
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "title",
+                      "options"
+                    ]
+                  },
+                  "references": {
+                    "items": {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "type",
+                        "id"
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "spaces": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "attributes"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "additionalProperties": true,
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "controlGroupInput": {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "autoApplySelections": {
+                                  "default": true,
+                                  "description": "Show apply selections button in controls.",
+                                  "type": "boolean"
+                                },
+                                "chainingSystem": {
+                                  "default": "HIERARCHICAL",
+                                  "description": "The chaining strategy for multiple controls. For example, \"HIERARCHICAL\" or \"NONE\".",
+                                  "enum": [
+                                    "NONE",
+                                    "HIERARCHICAL"
+                                  ],
+                                  "type": "string"
+                                },
+                                "controls": {
+                                  "default": [],
+                                  "description": "An array of control panels and their state in the control group.",
+                                  "items": {
+                                    "additionalProperties": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "controlConfig": {
+                                        "additionalProperties": {},
+                                        "type": "object"
+                                      },
+                                      "grow": {
+                                        "default": false,
+                                        "description": "Expand width of the control panel to fit available space.",
+                                        "type": "boolean"
+                                      },
+                                      "id": {
+                                        "description": "The unique ID of the control.",
+                                        "type": "string"
+                                      },
+                                      "order": {
+                                        "description": "The order of the control panel in the control group.",
+                                        "type": "number"
+                                      },
+                                      "type": {
+                                        "description": "The type of the control panel.",
+                                        "type": "string"
+                                      },
+                                      "width": {
+                                        "default": "medium",
+                                        "description": "Minimum width of the control panel in the control group.",
+                                        "enum": [
+                                          "small",
+                                          "medium",
+                                          "large"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "order"
+                                    ]
+                                  },
+                                  "type": "array"
+                                },
+                                "enhancements": {
+                                  "additionalProperties": {},
+                                  "type": "object"
+                                },
+                                "ignoreParentSettings": {
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "ignoreFilters": {
+                                      "default": false,
+                                      "description": "Ignore global filters in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreQuery": {
+                                      "default": false,
+                                      "description": "Ignore the global query bar in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreTimerange": {
+                                      "default": false,
+                                      "description": "Ignore the global time range in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreValidations": {
+                                      "default": false,
+                                      "description": "Ignore validations in controls.",
+                                      "type": "boolean"
+                                    }
+                                  }
+                                },
+                                "labelPosition": {
+                                  "default": "oneLine",
+                                  "description": "Position of the labels for controls. For example, \"oneLine\", \"twoLine\".",
+                                  "enum": [
+                                    "oneLine",
+                                    "twoLine"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "ignoreParentSettings"
+                              ]
+                            },
+                            "description": {
+                              "default": "",
+                              "description": "A short description.",
+                              "type": "string"
+                            },
+                            "kibanaSavedObjectMeta": {
+                              "additionalProperties": false,
+                              "default": {},
+                              "description": "A container for various metadata",
+                              "type": "object",
+                              "properties": {
+                                "searchSource": {
+                                  "additionalProperties": true,
+                                  "type": "object",
+                                  "properties": {
+                                    "filter": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "A filter for the search source.",
+                                        "type": "object",
+                                        "properties": {
+                                          "$state": {
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "store": {
+                                                "description": "Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').",
+                                                "enum": [
+                                                  "appState",
+                                                  "globalState"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "store"
+                                            ]
+                                          },
+                                          "meta": {
+                                            "additionalProperties": true,
+                                            "type": "object",
+                                            "properties": {
+                                              "alias": {
+                                                "nullable": true,
+                                                "type": "string"
+                                              },
+                                              "controlledBy": {
+                                                "type": "string"
+                                              },
+                                              "disabled": {
+                                                "type": "boolean"
+                                              },
+                                              "field": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "index": {
+                                                "type": "string"
+                                              },
+                                              "isMultiIndex": {
+                                                "type": "boolean"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "negate": {
+                                                "type": "boolean"
+                                              },
+                                              "params": {},
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "params"
+                                            ]
+                                          },
+                                          "query": {
+                                            "additionalProperties": {},
+                                            "type": "object"
+                                          }
+                                        },
+                                        "required": [
+                                          "meta"
+                                        ]
+                                      },
+                                      "type": "array"
+                                    },
+                                    "query": {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "language": {
+                                          "description": "The query language such as KQL or Lucene.",
+                                          "type": "string"
+                                        },
+                                        "query": {
+                                          "anyOf": [
+                                            {
+                                              "description": "A text-based query such as Kibana Query Language (KQL) or Lucene query language.",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "additionalProperties": {},
+                                              "type": "object"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "query",
+                                        "language"
+                                      ]
+                                    },
+                                    "sort": {
+                                      "items": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "enum": [
+                                                "asc",
+                                                "desc"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "format": {
+                                                  "type": "string"
+                                                },
+                                                "order": {
+                                                  "enum": [
+                                                    "asc",
+                                                    "desc"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "order"
+                                              ]
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "numeric_type": {
+                                                  "enum": [
+                                                    "double",
+                                                    "long",
+                                                    "date",
+                                                    "date_nanos"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "order": {
+                                                  "enum": [
+                                                    "asc",
+                                                    "desc"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "order"
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "options": {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "hidePanelTitles": {
+                                  "default": false,
+                                  "description": "Hide the panel titles in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncColors": {
+                                  "default": true,
+                                  "description": "Synchronize colors between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncCursor": {
+                                  "default": true,
+                                  "description": "Synchronize cursor position between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncTooltips": {
+                                  "default": true,
+                                  "description": "Synchronize tooltips between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "useMargins": {
+                                  "default": true,
+                                  "description": "Show margins between panels in the dashboard layout.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "panels": {
+                              "default": [],
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "h": {
+                                            "default": 15,
+                                            "description": "The height of the panel in grid units",
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "i": {
+                                            "type": "string"
+                                          },
+                                          "w": {
+                                            "default": 24,
+                                            "description": "The width of the panel in grid units",
+                                            "maximum": 48,
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "x": {
+                                            "description": "The x coordinate of the panel in grid units",
+                                            "type": "number"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the panel in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "x",
+                                          "y",
+                                          "i"
+                                        ]
+                                      },
+                                      "id": {
+                                        "description": "The saved object id for by reference panels",
+                                        "type": "string"
+                                      },
+                                      "panelConfig": {
+                                        "additionalProperties": true,
+                                        "type": "object",
+                                        "properties": {}
+                                      },
+                                      "panelIndex": {
+                                        "type": "string"
+                                      },
+                                      "panelRefName": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "description": "The title of the panel",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "The embeddable type",
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "deprecated": true,
+                                        "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "panelConfig",
+                                      "type",
+                                      "gridData",
+                                      "panelIndex"
+                                    ]
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "collapsed": {
+                                        "description": "The collapsed state of the section.",
+                                        "type": "boolean"
+                                      },
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "i": {
+                                            "type": "string"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the section in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "y",
+                                          "i"
+                                        ]
+                                      },
+                                      "panels": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "gridData": {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "h": {
+                                                  "default": 15,
+                                                  "description": "The height of the panel in grid units",
+                                                  "minimum": 1,
+                                                  "type": "number"
+                                                },
+                                                "i": {
+                                                  "type": "string"
+                                                },
+                                                "w": {
+                                                  "default": 24,
+                                                  "description": "The width of the panel in grid units",
+                                                  "maximum": 48,
+                                                  "minimum": 1,
+                                                  "type": "number"
+                                                },
+                                                "x": {
+                                                  "description": "The x coordinate of the panel in grid units",
+                                                  "type": "number"
+                                                },
+                                                "y": {
+                                                  "description": "The y coordinate of the panel in grid units",
+                                                  "type": "number"
+                                                }
+                                              },
+                                              "required": [
+                                                "x",
+                                                "y",
+                                                "i"
+                                              ]
+                                            },
+                                            "id": {
+                                              "description": "The saved object id for by reference panels",
+                                              "type": "string"
+                                            },
+                                            "panelConfig": {
+                                              "additionalProperties": true,
+                                              "type": "object",
+                                              "properties": {}
+                                            },
+                                            "panelIndex": {
+                                              "type": "string"
+                                            },
+                                            "panelRefName": {
+                                              "type": "string"
+                                            },
+                                            "title": {
+                                              "description": "The title of the panel",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "The embeddable type",
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "deprecated": true,
+                                              "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "panelConfig",
+                                            "type",
+                                            "gridData",
+                                            "panelIndex"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "title": {
+                                        "description": "The title of the section.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "title",
+                                      "gridData",
+                                      "panels"
+                                    ]
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "refreshInterval": {
+                              "additionalProperties": false,
+                              "description": "A container for various refresh interval settings",
+                              "type": "object",
+                              "properties": {
+                                "display": {
+                                  "deprecated": true,
+                                  "description": "A human-readable string indicating the refresh frequency. No longer used.",
+                                  "type": "string"
+                                },
+                                "pause": {
+                                  "description": "Whether the refresh interval is set to be paused while viewing the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "section": {
+                                  "deprecated": true,
+                                  "description": "No longer used.",
+                                  "type": "number"
+                                },
+                                "value": {
+                                  "description": "A numeric value indicating refresh frequency in milliseconds.",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "pause",
+                                "value"
+                              ]
+                            },
+                            "tags": {
+                              "items": {
+                                "description": "An array of tags applied to this dashboard",
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "timeFrom": {
+                              "description": "An ISO string indicating when to restore time from",
+                              "type": "string"
+                            },
+                            "timeRestore": {
+                              "default": false,
+                              "description": "Whether to restore time upon viewing this dashboard",
+                              "type": "boolean"
+                            },
+                            "timeTo": {
+                              "description": "An ISO string indicating when to restore time from",
+                              "type": "string"
+                            },
+                            "title": {
+                              "description": "A human-readable title for the dashboard",
+                              "type": "string"
+                            },
+                            "version": {
+                              "deprecated": true,
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "title",
+                            "options"
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "createdBy": {
+                          "type": "string"
+                        },
+                        "error": {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "metadata": {
+                              "additionalProperties": true,
+                              "type": "object",
+                              "properties": {}
+                            },
+                            "statusCode": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "error",
+                            "message",
+                            "statusCode"
+                          ]
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "managed": {
+                          "type": "boolean"
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "originId": {
+                          "type": "string"
+                        },
+                        "references": {
+                          "items": {
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "type",
+                              "id"
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        },
+                        "updatedBy": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes",
+                        "references"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "item"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Create a dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Unstable (Do not use)"
+      },
+      "put": {
+        "description": "This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.",
+        "operationId": "put-dashboards-dashboard-id",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "A unique identifier for the dashboard.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": {
+                  "attributes": {
+                    "additionalProperties": false,
+                    "type": "object",
+                    "properties": {
+                      "controlGroupInput": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                          "autoApplySelections": {
+                            "default": true,
+                            "description": "Show apply selections button in controls.",
+                            "type": "boolean"
+                          },
+                          "chainingSystem": {
+                            "default": "HIERARCHICAL",
+                            "description": "The chaining strategy for multiple controls. For example, \"HIERARCHICAL\" or \"NONE\".",
+                            "enum": [
+                              "NONE",
+                              "HIERARCHICAL"
+                            ],
+                            "type": "string"
+                          },
+                          "controls": {
+                            "default": [],
+                            "description": "An array of control panels and their state in the control group.",
+                            "items": {
+                              "additionalProperties": true,
+                              "type": "object",
+                              "properties": {
+                                "controlConfig": {
+                                  "additionalProperties": {},
+                                  "type": "object"
+                                },
+                                "grow": {
+                                  "default": false,
+                                  "description": "Expand width of the control panel to fit available space.",
+                                  "type": "boolean"
+                                },
+                                "id": {
+                                  "description": "The unique ID of the control.",
+                                  "type": "string"
+                                },
+                                "order": {
+                                  "description": "The order of the control panel in the control group.",
+                                  "type": "number"
+                                },
+                                "type": {
+                                  "description": "The type of the control panel.",
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "default": "medium",
+                                  "description": "Minimum width of the control panel in the control group.",
+                                  "enum": [
+                                    "small",
+                                    "medium",
+                                    "large"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "order"
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          "enhancements": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "ignoreParentSettings": {
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "ignoreFilters": {
+                                "default": false,
+                                "description": "Ignore global filters in controls.",
+                                "type": "boolean"
+                              },
+                              "ignoreQuery": {
+                                "default": false,
+                                "description": "Ignore the global query bar in controls.",
+                                "type": "boolean"
+                              },
+                              "ignoreTimerange": {
+                                "default": false,
+                                "description": "Ignore the global time range in controls.",
+                                "type": "boolean"
+                              },
+                              "ignoreValidations": {
+                                "default": false,
+                                "description": "Ignore validations in controls.",
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "labelPosition": {
+                            "default": "oneLine",
+                            "description": "Position of the labels for controls. For example, \"oneLine\", \"twoLine\".",
+                            "enum": [
+                              "oneLine",
+                              "twoLine"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "ignoreParentSettings"
+                        ]
+                      },
+                      "description": {
+                        "default": "",
+                        "description": "A short description.",
+                        "type": "string"
+                      },
+                      "kibanaSavedObjectMeta": {
+                        "additionalProperties": false,
+                        "default": {},
+                        "description": "A container for various metadata",
+                        "type": "object",
+                        "properties": {
+                          "searchSource": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "properties": {
+                              "filter": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "A filter for the search source.",
+                                  "type": "object",
+                                  "properties": {
+                                    "$state": {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "store": {
+                                          "description": "Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').",
+                                          "enum": [
+                                            "appState",
+                                            "globalState"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "store"
+                                      ]
+                                    },
+                                    "meta": {
+                                      "additionalProperties": true,
+                                      "type": "object",
+                                      "properties": {
+                                        "alias": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "controlledBy": {
+                                          "type": "string"
+                                        },
+                                        "disabled": {
+                                          "type": "boolean"
+                                        },
+                                        "field": {
+                                          "type": "string"
+                                        },
+                                        "group": {
+                                          "type": "string"
+                                        },
+                                        "index": {
+                                          "type": "string"
+                                        },
+                                        "isMultiIndex": {
+                                          "type": "boolean"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "negate": {
+                                          "type": "boolean"
+                                        },
+                                        "params": {},
+                                        "type": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "params"
+                                      ]
+                                    },
+                                    "query": {
+                                      "additionalProperties": {},
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "meta"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "query": {
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "language": {
+                                    "description": "The query language such as KQL or Lucene.",
+                                    "type": "string"
+                                  },
+                                  "query": {
+                                    "anyOf": [
+                                      {
+                                        "description": "A text-based query such as Kibana Query Language (KQL) or Lucene query language.",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "additionalProperties": {},
+                                        "type": "object"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "query",
+                                  "language"
+                                ]
+                              },
+                              "sort": {
+                                "items": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "enum": [
+                                          "asc",
+                                          "desc"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "format": {
+                                            "type": "string"
+                                          },
+                                          "order": {
+                                            "enum": [
+                                              "asc",
+                                              "desc"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "order"
+                                        ]
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "numeric_type": {
+                                            "enum": [
+                                              "double",
+                                              "long",
+                                              "date",
+                                              "date_nanos"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "order": {
+                                            "enum": [
+                                              "asc",
+                                              "desc"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "order"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "options": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                          "hidePanelTitles": {
+                            "default": false,
+                            "description": "Hide the panel titles in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "syncColors": {
+                            "default": true,
+                            "description": "Synchronize colors between related panels in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "syncCursor": {
+                            "default": true,
+                            "description": "Synchronize cursor position between related panels in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "syncTooltips": {
+                            "default": true,
+                            "description": "Synchronize tooltips between related panels in the dashboard.",
+                            "type": "boolean"
+                          },
+                          "useMargins": {
+                            "default": true,
+                            "description": "Show margins between panels in the dashboard layout.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "panels": {
+                        "default": [],
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "gridData": {
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "h": {
+                                      "default": 15,
+                                      "description": "The height of the panel in grid units",
+                                      "minimum": 1,
+                                      "type": "number"
+                                    },
+                                    "i": {
+                                      "description": "The unique identifier of the panel",
+                                      "type": "string"
+                                    },
+                                    "w": {
+                                      "default": 24,
+                                      "description": "The width of the panel in grid units",
+                                      "maximum": 48,
+                                      "minimum": 1,
+                                      "type": "number"
+                                    },
+                                    "x": {
+                                      "description": "The x coordinate of the panel in grid units",
+                                      "type": "number"
+                                    },
+                                    "y": {
+                                      "description": "The y coordinate of the panel in grid units",
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "x",
+                                    "y"
+                                  ]
+                                },
+                                "id": {
+                                  "description": "The saved object id for by reference panels",
+                                  "type": "string"
+                                },
+                                "panelConfig": {
+                                  "additionalProperties": true,
+                                  "type": "object",
+                                  "properties": {}
+                                },
+                                "panelIndex": {
+                                  "description": "The unique ID of the panel.",
+                                  "type": "string"
+                                },
+                                "panelRefName": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "description": "The title of the panel",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "The embeddable type",
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "deprecated": true,
+                                  "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "panelConfig",
+                                "type",
+                                "gridData"
+                              ]
+                            },
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "collapsed": {
+                                  "description": "The collapsed state of the section.",
+                                  "type": "boolean"
+                                },
+                                "gridData": {
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "i": {
+                                      "description": "The unique identifier of the section",
+                                      "type": "string"
+                                    },
+                                    "y": {
+                                      "description": "The y coordinate of the section in grid units",
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "y"
+                                  ]
+                                },
+                                "panels": {
+                                  "default": [],
+                                  "description": "The panels that belong to the section.",
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "h": {
+                                            "default": 15,
+                                            "description": "The height of the panel in grid units",
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "i": {
+                                            "description": "The unique identifier of the panel",
+                                            "type": "string"
+                                          },
+                                          "w": {
+                                            "default": 24,
+                                            "description": "The width of the panel in grid units",
+                                            "maximum": 48,
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "x": {
+                                            "description": "The x coordinate of the panel in grid units",
+                                            "type": "number"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the panel in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "x",
+                                          "y"
+                                        ]
+                                      },
+                                      "id": {
+                                        "description": "The saved object id for by reference panels",
+                                        "type": "string"
+                                      },
+                                      "panelConfig": {
+                                        "additionalProperties": true,
+                                        "type": "object",
+                                        "properties": {}
+                                      },
+                                      "panelIndex": {
+                                        "description": "The unique ID of the panel.",
+                                        "type": "string"
+                                      },
+                                      "panelRefName": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "description": "The title of the panel",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "The embeddable type",
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "deprecated": true,
+                                        "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "panelConfig",
+                                      "type",
+                                      "gridData"
+                                    ]
+                                  },
+                                  "type": "array"
+                                },
+                                "title": {
+                                  "description": "The title of the section.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "title",
+                                "gridData"
+                              ]
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      "refreshInterval": {
+                        "additionalProperties": false,
+                        "description": "A container for various refresh interval settings",
+                        "type": "object",
+                        "properties": {
+                          "display": {
+                            "deprecated": true,
+                            "description": "A human-readable string indicating the refresh frequency. No longer used.",
+                            "type": "string"
+                          },
+                          "pause": {
+                            "description": "Whether the refresh interval is set to be paused while viewing the dashboard.",
+                            "type": "boolean"
+                          },
+                          "section": {
+                            "deprecated": true,
+                            "description": "No longer used.",
+                            "type": "number"
+                          },
+                          "value": {
+                            "description": "A numeric value indicating refresh frequency in milliseconds.",
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "pause",
+                          "value"
+                        ]
+                      },
+                      "tags": {
+                        "items": {
+                          "description": "An array of tags applied to this dashboard",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "timeFrom": {
+                        "description": "An ISO string indicating when to restore time from",
+                        "type": "string"
+                      },
+                      "timeRestore": {
+                        "default": false,
+                        "description": "Whether to restore time upon viewing this dashboard",
+                        "type": "boolean"
+                      },
+                      "timeTo": {
+                        "description": "An ISO string indicating when to restore time from",
+                        "type": "string"
+                      },
+                      "title": {
+                        "description": "A human-readable title for the dashboard",
+                        "type": "string"
+                      },
+                      "version": {
+                        "deprecated": true,
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "title",
+                      "options"
+                    ]
+                  },
+                  "references": {
+                    "items": {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "type",
+                        "id"
+                      ]
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "attributes"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "additionalProperties": true,
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "controlGroupInput": {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "autoApplySelections": {
+                                  "default": true,
+                                  "description": "Show apply selections button in controls.",
+                                  "type": "boolean"
+                                },
+                                "chainingSystem": {
+                                  "default": "HIERARCHICAL",
+                                  "description": "The chaining strategy for multiple controls. For example, \"HIERARCHICAL\" or \"NONE\".",
+                                  "enum": [
+                                    "NONE",
+                                    "HIERARCHICAL"
+                                  ],
+                                  "type": "string"
+                                },
+                                "controls": {
+                                  "default": [],
+                                  "description": "An array of control panels and their state in the control group.",
+                                  "items": {
+                                    "additionalProperties": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "controlConfig": {
+                                        "additionalProperties": {},
+                                        "type": "object"
+                                      },
+                                      "grow": {
+                                        "default": false,
+                                        "description": "Expand width of the control panel to fit available space.",
+                                        "type": "boolean"
+                                      },
+                                      "id": {
+                                        "description": "The unique ID of the control.",
+                                        "type": "string"
+                                      },
+                                      "order": {
+                                        "description": "The order of the control panel in the control group.",
+                                        "type": "number"
+                                      },
+                                      "type": {
+                                        "description": "The type of the control panel.",
+                                        "type": "string"
+                                      },
+                                      "width": {
+                                        "default": "medium",
+                                        "description": "Minimum width of the control panel in the control group.",
+                                        "enum": [
+                                          "small",
+                                          "medium",
+                                          "large"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "order"
+                                    ]
+                                  },
+                                  "type": "array"
+                                },
+                                "enhancements": {
+                                  "additionalProperties": {},
+                                  "type": "object"
+                                },
+                                "ignoreParentSettings": {
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "ignoreFilters": {
+                                      "default": false,
+                                      "description": "Ignore global filters in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreQuery": {
+                                      "default": false,
+                                      "description": "Ignore the global query bar in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreTimerange": {
+                                      "default": false,
+                                      "description": "Ignore the global time range in controls.",
+                                      "type": "boolean"
+                                    },
+                                    "ignoreValidations": {
+                                      "default": false,
+                                      "description": "Ignore validations in controls.",
+                                      "type": "boolean"
+                                    }
+                                  }
+                                },
+                                "labelPosition": {
+                                  "default": "oneLine",
+                                  "description": "Position of the labels for controls. For example, \"oneLine\", \"twoLine\".",
+                                  "enum": [
+                                    "oneLine",
+                                    "twoLine"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "ignoreParentSettings"
+                              ]
+                            },
+                            "description": {
+                              "default": "",
+                              "description": "A short description.",
+                              "type": "string"
+                            },
+                            "kibanaSavedObjectMeta": {
+                              "additionalProperties": false,
+                              "default": {},
+                              "description": "A container for various metadata",
+                              "type": "object",
+                              "properties": {
+                                "searchSource": {
+                                  "additionalProperties": true,
+                                  "type": "object",
+                                  "properties": {
+                                    "filter": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "A filter for the search source.",
+                                        "type": "object",
+                                        "properties": {
+                                          "$state": {
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "store": {
+                                                "description": "Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').",
+                                                "enum": [
+                                                  "appState",
+                                                  "globalState"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "store"
+                                            ]
+                                          },
+                                          "meta": {
+                                            "additionalProperties": true,
+                                            "type": "object",
+                                            "properties": {
+                                              "alias": {
+                                                "nullable": true,
+                                                "type": "string"
+                                              },
+                                              "controlledBy": {
+                                                "type": "string"
+                                              },
+                                              "disabled": {
+                                                "type": "boolean"
+                                              },
+                                              "field": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "index": {
+                                                "type": "string"
+                                              },
+                                              "isMultiIndex": {
+                                                "type": "boolean"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "negate": {
+                                                "type": "boolean"
+                                              },
+                                              "params": {},
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "params"
+                                            ]
+                                          },
+                                          "query": {
+                                            "additionalProperties": {},
+                                            "type": "object"
+                                          }
+                                        },
+                                        "required": [
+                                          "meta"
+                                        ]
+                                      },
+                                      "type": "array"
+                                    },
+                                    "query": {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "language": {
+                                          "description": "The query language such as KQL or Lucene.",
+                                          "type": "string"
+                                        },
+                                        "query": {
+                                          "anyOf": [
+                                            {
+                                              "description": "A text-based query such as Kibana Query Language (KQL) or Lucene query language.",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "additionalProperties": {},
+                                              "type": "object"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "query",
+                                        "language"
+                                      ]
+                                    },
+                                    "sort": {
+                                      "items": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "enum": [
+                                                "asc",
+                                                "desc"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "format": {
+                                                  "type": "string"
+                                                },
+                                                "order": {
+                                                  "enum": [
+                                                    "asc",
+                                                    "desc"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "order"
+                                              ]
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "numeric_type": {
+                                                  "enum": [
+                                                    "double",
+                                                    "long",
+                                                    "date",
+                                                    "date_nanos"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "order": {
+                                                  "enum": [
+                                                    "asc",
+                                                    "desc"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "order"
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "options": {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "hidePanelTitles": {
+                                  "default": false,
+                                  "description": "Hide the panel titles in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncColors": {
+                                  "default": true,
+                                  "description": "Synchronize colors between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncCursor": {
+                                  "default": true,
+                                  "description": "Synchronize cursor position between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "syncTooltips": {
+                                  "default": true,
+                                  "description": "Synchronize tooltips between related panels in the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "useMargins": {
+                                  "default": true,
+                                  "description": "Show margins between panels in the dashboard layout.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "panels": {
+                              "default": [],
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "h": {
+                                            "default": 15,
+                                            "description": "The height of the panel in grid units",
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "i": {
+                                            "type": "string"
+                                          },
+                                          "w": {
+                                            "default": 24,
+                                            "description": "The width of the panel in grid units",
+                                            "maximum": 48,
+                                            "minimum": 1,
+                                            "type": "number"
+                                          },
+                                          "x": {
+                                            "description": "The x coordinate of the panel in grid units",
+                                            "type": "number"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the panel in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "x",
+                                          "y",
+                                          "i"
+                                        ]
+                                      },
+                                      "id": {
+                                        "description": "The saved object id for by reference panels",
+                                        "type": "string"
+                                      },
+                                      "panelConfig": {
+                                        "additionalProperties": true,
+                                        "type": "object",
+                                        "properties": {}
+                                      },
+                                      "panelIndex": {
+                                        "type": "string"
+                                      },
+                                      "panelRefName": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "description": "The title of the panel",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "The embeddable type",
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "deprecated": true,
+                                        "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "panelConfig",
+                                      "type",
+                                      "gridData",
+                                      "panelIndex"
+                                    ]
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "collapsed": {
+                                        "description": "The collapsed state of the section.",
+                                        "type": "boolean"
+                                      },
+                                      "gridData": {
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "i": {
+                                            "type": "string"
+                                          },
+                                          "y": {
+                                            "description": "The y coordinate of the section in grid units",
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "y",
+                                          "i"
+                                        ]
+                                      },
+                                      "panels": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "gridData": {
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "h": {
+                                                  "default": 15,
+                                                  "description": "The height of the panel in grid units",
+                                                  "minimum": 1,
+                                                  "type": "number"
+                                                },
+                                                "i": {
+                                                  "type": "string"
+                                                },
+                                                "w": {
+                                                  "default": 24,
+                                                  "description": "The width of the panel in grid units",
+                                                  "maximum": 48,
+                                                  "minimum": 1,
+                                                  "type": "number"
+                                                },
+                                                "x": {
+                                                  "description": "The x coordinate of the panel in grid units",
+                                                  "type": "number"
+                                                },
+                                                "y": {
+                                                  "description": "The y coordinate of the panel in grid units",
+                                                  "type": "number"
+                                                }
+                                              },
+                                              "required": [
+                                                "x",
+                                                "y",
+                                                "i"
+                                              ]
+                                            },
+                                            "id": {
+                                              "description": "The saved object id for by reference panels",
+                                              "type": "string"
+                                            },
+                                            "panelConfig": {
+                                              "additionalProperties": true,
+                                              "type": "object",
+                                              "properties": {}
+                                            },
+                                            "panelIndex": {
+                                              "type": "string"
+                                            },
+                                            "panelRefName": {
+                                              "type": "string"
+                                            },
+                                            "title": {
+                                              "description": "The title of the panel",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "The embeddable type",
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "deprecated": true,
+                                              "description": "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "panelConfig",
+                                            "type",
+                                            "gridData",
+                                            "panelIndex"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "title": {
+                                        "description": "The title of the section.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "title",
+                                      "gridData",
+                                      "panels"
+                                    ]
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "refreshInterval": {
+                              "additionalProperties": false,
+                              "description": "A container for various refresh interval settings",
+                              "type": "object",
+                              "properties": {
+                                "display": {
+                                  "deprecated": true,
+                                  "description": "A human-readable string indicating the refresh frequency. No longer used.",
+                                  "type": "string"
+                                },
+                                "pause": {
+                                  "description": "Whether the refresh interval is set to be paused while viewing the dashboard.",
+                                  "type": "boolean"
+                                },
+                                "section": {
+                                  "deprecated": true,
+                                  "description": "No longer used.",
+                                  "type": "number"
+                                },
+                                "value": {
+                                  "description": "A numeric value indicating refresh frequency in milliseconds.",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "pause",
+                                "value"
+                              ]
+                            },
+                            "tags": {
+                              "items": {
+                                "description": "An array of tags applied to this dashboard",
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "timeFrom": {
+                              "description": "An ISO string indicating when to restore time from",
+                              "type": "string"
+                            },
+                            "timeRestore": {
+                              "default": false,
+                              "description": "Whether to restore time upon viewing this dashboard",
+                              "type": "boolean"
+                            },
+                            "timeTo": {
+                              "description": "An ISO string indicating when to restore time from",
+                              "type": "string"
+                            },
+                            "title": {
+                              "description": "A human-readable title for the dashboard",
+                              "type": "string"
+                            },
+                            "version": {
+                              "deprecated": true,
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "title",
+                            "options"
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "createdBy": {
+                          "type": "string"
+                        },
+                        "error": {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "metadata": {
+                              "additionalProperties": true,
+                              "type": "object",
+                              "properties": {}
+                            },
+                            "statusCode": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "error",
+                            "message",
+                            "statusCode"
+                          ]
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "managed": {
+                          "type": "boolean"
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "originId": {
+                          "type": "string"
+                        },
+                        "references": {
+                          "items": {
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "type",
+                              "id"
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        },
+                        "updatedBy": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes",
+                        "references"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "item"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Update an existing dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Unstable (Do not use)"
+      }
+    }
+  },
+  "components": {}
+}

--- a/src/platform/plugins/shared/dashboard/docs/openapi/bundled.yaml
+++ b/src/platform/plugins/shared/dashboard/docs/openapi/bundled.yaml
@@ -1,0 +1,2659 @@
+openapi: 3.0.3
+info:
+  title: Dashboards (unstable)
+  description: |
+    The Dashboards API allows you to manage and interact with Kibana dashboards.
+    You can create, update, delete, and retrieve dashboards programmatically.
+  version: '0.1'
+  contact:
+    name: Kibana Presentation Team
+  license:
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
+servers:
+  - url: https://{kibana_url}
+    variables:
+      kibana_url:
+        default: localhost:5601
+tags:
+  - name: dashboards
+    description: Dashboards APIs enable you to manage and interact with Kibana dashboards.
+paths:
+  /api/dashboards/dashboard:
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard
+      parameters:
+        - description: The page number to return. Default is "1".
+          in: query
+          name: page
+          required: false
+          schema:
+            default: 1
+            minimum: 1
+            type: number
+        - description: The number of dashboards to display on each page (max 1000). Default is "20".
+          in: query
+          name: perPage
+          required: false
+          schema:
+            maximum: 1000
+            minimum: 1
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  items:
+                    items:
+                      additionalProperties: true
+                      type: object
+                      properties:
+                        attributes:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            description:
+                              default: ''
+                              description: A short description.
+                              type: string
+                            tags:
+                              items:
+                                description: An array of tags applied to this dashboard
+                                type: string
+                              type: array
+                            timeRestore:
+                              default: false
+                              description: Whether to restore time upon viewing this dashboard
+                              type: boolean
+                            title:
+                              description: A human-readable title for the dashboard
+                              type: string
+                          required:
+                            - title
+                        createdAt:
+                          type: string
+                        createdBy:
+                          type: string
+                        error:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            error:
+                              type: string
+                            message:
+                              type: string
+                            metadata:
+                              additionalProperties: true
+                              type: object
+                              properties: {}
+                            statusCode:
+                              type: number
+                          required:
+                            - error
+                            - message
+                            - statusCode
+                        id:
+                          type: string
+                        managed:
+                          type: boolean
+                        namespaces:
+                          items:
+                            type: string
+                          type: array
+                        originId:
+                          type: string
+                        references:
+                          items:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - name
+                              - type
+                              - id
+                          type: array
+                        type:
+                          type: string
+                        updatedAt:
+                          type: string
+                        updatedBy:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                        - id
+                        - type
+                        - attributes
+                        - references
+                    type: array
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+      summary: Get a list of dashboards
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+  /api/dashboards/dashboard/{dashboardId}:
+    delete:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: delete-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses: {}
+      summary: Delete a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard-id
+      parameters:
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                  meta:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      aliasPurpose:
+                        enum:
+                          - savedObjectConversion
+                          - savedObjectImport
+                        type: string
+                      aliasTargetId:
+                        type: string
+                      outcome:
+                        enum:
+                          - exactMatch
+                          - aliasMatch
+                          - conflict
+                        type: string
+                    required:
+                      - outcome
+                required:
+                  - item
+                  - meta
+      summary: Get a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    post:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: post-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ''
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  'y':
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - 'y'
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  'y':
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - 'y'
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+                spaces:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - attributes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Create a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    put:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: put-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: 'true'
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ''
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  'y':
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - 'y'
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  'y':
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - 'y'
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+              required:
+                - attributes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ''
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        'y':
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - 'y'
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        'y':
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - 'y'
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              'y':
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - 'y'
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Update an existing dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+components: {}

--- a/src/platform/plugins/shared/dashboard/docs/openapi/entrypoint.yaml
+++ b/src/platform/plugins/shared/dashboard/docs/openapi/entrypoint.yaml
@@ -1,0 +1,2658 @@
+openapi: 3.0.3
+info:
+  title: Dashboards (unstable)
+  description: |
+    The Dashboards API allows you to manage and interact with Kibana dashboards.
+    You can create, update, delete, and retrieve dashboards programmatically.
+  version: "0.1"
+  contact:
+    name: Kibana Presentation Team
+  license:
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
+tags:
+  - name: dashboards
+    description: Dashboards APIs enable you to manage and interact with Kibana dashboards.
+servers:
+  - url: "https://{kibana_url}"
+    variables:
+      kibana_url:
+        default: localhost:5601
+paths:
+  "/api/dashboards/dashboard":
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard
+      parameters:
+        - description: The page number to return. Default is "1".
+          in: query
+          name: page
+          required: false
+          schema:
+            default: 1
+            minimum: 1
+            type: number
+        - description: The number of dashboards to display on each page (max 1000). Default is "20".
+          in: query
+          name: perPage
+          required: false
+          schema:
+            maximum: 1000
+            minimum: 1
+            type: number
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  items:
+                    items:
+                      additionalProperties: true
+                      type: object
+                      properties:
+                        attributes:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            description:
+                              default: ""
+                              description: A short description.
+                              type: string
+                            tags:
+                              items:
+                                description: An array of tags applied to this dashboard
+                                type: string
+                              type: array
+                            timeRestore:
+                              default: false
+                              description: Whether to restore time upon viewing this dashboard
+                              type: boolean
+                            title:
+                              description: A human-readable title for the dashboard
+                              type: string
+                          required:
+                            - title
+                        createdAt:
+                          type: string
+                        createdBy:
+                          type: string
+                        error:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            error:
+                              type: string
+                            message:
+                              type: string
+                            metadata:
+                              additionalProperties: true
+                              type: object
+                              properties: {}
+                            statusCode:
+                              type: number
+                          required:
+                            - error
+                            - message
+                            - statusCode
+                        id:
+                          type: string
+                        managed:
+                          type: boolean
+                        namespaces:
+                          items:
+                            type: string
+                          type: array
+                        originId:
+                          type: string
+                        references:
+                          items:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - name
+                              - type
+                              - id
+                          type: array
+                        type:
+                          type: string
+                        updatedAt:
+                          type: string
+                        updatedBy:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                        - id
+                        - type
+                        - attributes
+                        - references
+                    type: array
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+      summary: Get a list of dashboards
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+  "/api/dashboards/dashboard/{dashboardId}":
+    delete:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: delete-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: "true"
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses: {}
+      summary: Delete a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    get:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: get-dashboards-dashboard-id
+      parameters:
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ""
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        "y":
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - "y"
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        "y":
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - "y"
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              "y":
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - "y"
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                  meta:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      aliasPurpose:
+                        enum:
+                          - savedObjectConversion
+                          - savedObjectImport
+                        type: string
+                      aliasTargetId:
+                        type: string
+                      outcome:
+                        enum:
+                          - exactMatch
+                          - aliasMatch
+                          - conflict
+                        type: string
+                    required:
+                      - outcome
+                required:
+                  - item
+                  - meta
+      summary: Get a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    post:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: post-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: "true"
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ""
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  "y":
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - "y"
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  "y":
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - "y"
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        "y":
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - "y"
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+                spaces:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - attributes
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ""
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        "y":
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - "y"
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        "y":
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - "y"
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              "y":
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - "y"
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Create a dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)
+    put:
+      description: This functionality is unstable and will be changed or removed in a future release. Unstable features are not subject to the support SLA of official GA features.
+      operationId: put-dashboards-dashboard-id
+      parameters:
+        - description: A required header to protect against CSRF attacks
+          in: header
+          name: kbn-xsrf
+          required: true
+          schema:
+            example: "true"
+            type: string
+        - description: A unique identifier for the dashboard.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              type: object
+              properties:
+                attributes:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    controlGroupInput:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        autoApplySelections:
+                          default: true
+                          description: Show apply selections button in controls.
+                          type: boolean
+                        chainingSystem:
+                          default: HIERARCHICAL
+                          description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                          enum:
+                            - NONE
+                            - HIERARCHICAL
+                          type: string
+                        controls:
+                          default: []
+                          description: An array of control panels and their state in the control group.
+                          items:
+                            additionalProperties: true
+                            type: object
+                            properties:
+                              controlConfig:
+                                additionalProperties: {}
+                                type: object
+                              grow:
+                                default: false
+                                description: Expand width of the control panel to fit available space.
+                                type: boolean
+                              id:
+                                description: The unique ID of the control.
+                                type: string
+                              order:
+                                description: The order of the control panel in the control group.
+                                type: number
+                              type:
+                                description: The type of the control panel.
+                                type: string
+                              width:
+                                default: medium
+                                description: Minimum width of the control panel in the control group.
+                                enum:
+                                  - small
+                                  - medium
+                                  - large
+                                type: string
+                            required:
+                              - type
+                              - order
+                          type: array
+                        enhancements:
+                          additionalProperties: {}
+                          type: object
+                        ignoreParentSettings:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            ignoreFilters:
+                              default: false
+                              description: Ignore global filters in controls.
+                              type: boolean
+                            ignoreQuery:
+                              default: false
+                              description: Ignore the global query bar in controls.
+                              type: boolean
+                            ignoreTimerange:
+                              default: false
+                              description: Ignore the global time range in controls.
+                              type: boolean
+                            ignoreValidations:
+                              default: false
+                              description: Ignore validations in controls.
+                              type: boolean
+                        labelPosition:
+                          default: oneLine
+                          description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                          enum:
+                            - oneLine
+                            - twoLine
+                          type: string
+                      required:
+                        - ignoreParentSettings
+                    description:
+                      default: ""
+                      description: A short description.
+                      type: string
+                    kibanaSavedObjectMeta:
+                      additionalProperties: false
+                      default: {}
+                      description: A container for various metadata
+                      type: object
+                      properties:
+                        searchSource:
+                          additionalProperties: true
+                          type: object
+                          properties:
+                            filter:
+                              items:
+                                additionalProperties: false
+                                description: A filter for the search source.
+                                type: object
+                                properties:
+                                  $state:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      store:
+                                        description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                        enum:
+                                          - appState
+                                          - globalState
+                                        type: string
+                                    required:
+                                      - store
+                                  meta:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      alias:
+                                        nullable: true
+                                        type: string
+                                      controlledBy:
+                                        type: string
+                                      disabled:
+                                        type: boolean
+                                      field:
+                                        type: string
+                                      group:
+                                        type: string
+                                      index:
+                                        type: string
+                                      isMultiIndex:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      negate:
+                                        type: boolean
+                                      params: {}
+                                      type:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - params
+                                  query:
+                                    additionalProperties: {}
+                                    type: object
+                                required:
+                                  - meta
+                              type: array
+                            query:
+                              additionalProperties: false
+                              type: object
+                              properties:
+                                language:
+                                  description: The query language such as KQL or Lucene.
+                                  type: string
+                                query:
+                                  anyOf:
+                                    - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                      type: string
+                                    - additionalProperties: {}
+                                      type: object
+                              required:
+                                - query
+                                - language
+                            sort:
+                              items:
+                                additionalProperties:
+                                  anyOf:
+                                    - enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        format:
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                    - additionalProperties: false
+                                      type: object
+                                      properties:
+                                        numeric_type:
+                                          enum:
+                                            - double
+                                            - long
+                                            - date
+                                            - date_nanos
+                                          type: string
+                                        order:
+                                          enum:
+                                            - asc
+                                            - desc
+                                          type: string
+                                      required:
+                                        - order
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                    options:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        hidePanelTitles:
+                          default: false
+                          description: Hide the panel titles in the dashboard.
+                          type: boolean
+                        syncColors:
+                          default: true
+                          description: Synchronize colors between related panels in the dashboard.
+                          type: boolean
+                        syncCursor:
+                          default: true
+                          description: Synchronize cursor position between related panels in the dashboard.
+                          type: boolean
+                        syncTooltips:
+                          default: true
+                          description: Synchronize tooltips between related panels in the dashboard.
+                          type: boolean
+                        useMargins:
+                          default: true
+                          description: Show margins between panels in the dashboard layout.
+                          type: boolean
+                    panels:
+                      default: []
+                      items:
+                        anyOf:
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  h:
+                                    default: 15
+                                    description: The height of the panel in grid units
+                                    minimum: 1
+                                    type: number
+                                  i:
+                                    description: The unique identifier of the panel
+                                    type: string
+                                  w:
+                                    default: 24
+                                    description: The width of the panel in grid units
+                                    maximum: 48
+                                    minimum: 1
+                                    type: number
+                                  x:
+                                    description: The x coordinate of the panel in grid units
+                                    type: number
+                                  "y":
+                                    description: The y coordinate of the panel in grid units
+                                    type: number
+                                required:
+                                  - x
+                                  - "y"
+                              id:
+                                description: The saved object id for by reference panels
+                                type: string
+                              panelConfig:
+                                additionalProperties: true
+                                type: object
+                                properties: {}
+                              panelIndex:
+                                description: The unique ID of the panel.
+                                type: string
+                              panelRefName:
+                                type: string
+                              title:
+                                description: The title of the panel
+                                type: string
+                              type:
+                                description: The embeddable type
+                                type: string
+                              version:
+                                deprecated: true
+                                description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                type: string
+                            required:
+                              - panelConfig
+                              - type
+                              - gridData
+                          - additionalProperties: false
+                            type: object
+                            properties:
+                              collapsed:
+                                description: The collapsed state of the section.
+                                type: boolean
+                              gridData:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  i:
+                                    description: The unique identifier of the section
+                                    type: string
+                                  "y":
+                                    description: The y coordinate of the section in grid units
+                                    type: number
+                                required:
+                                  - "y"
+                              panels:
+                                default: []
+                                description: The panels that belong to the section.
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          description: The unique identifier of the panel
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        "y":
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - "y"
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      description: The unique ID of the panel.
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                type: array
+                              title:
+                                description: The title of the section.
+                                type: string
+                            required:
+                              - title
+                              - gridData
+                      type: array
+                    refreshInterval:
+                      additionalProperties: false
+                      description: A container for various refresh interval settings
+                      type: object
+                      properties:
+                        display:
+                          deprecated: true
+                          description: A human-readable string indicating the refresh frequency. No longer used.
+                          type: string
+                        pause:
+                          description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                          type: boolean
+                        section:
+                          deprecated: true
+                          description: No longer used.
+                          type: number
+                        value:
+                          description: A numeric value indicating refresh frequency in milliseconds.
+                          type: number
+                      required:
+                        - pause
+                        - value
+                    tags:
+                      items:
+                        description: An array of tags applied to this dashboard
+                        type: string
+                      type: array
+                    timeFrom:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    timeRestore:
+                      default: false
+                      description: Whether to restore time upon viewing this dashboard
+                      type: boolean
+                    timeTo:
+                      description: An ISO string indicating when to restore time from
+                      type: string
+                    title:
+                      description: A human-readable title for the dashboard
+                      type: string
+                    version:
+                      deprecated: true
+                      type: number
+                  required:
+                    - title
+                    - options
+                references:
+                  items:
+                    additionalProperties: false
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - name
+                      - type
+                      - id
+                  type: array
+              required:
+                - attributes
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+                properties:
+                  item:
+                    additionalProperties: true
+                    type: object
+                    properties:
+                      attributes:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          controlGroupInput:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              autoApplySelections:
+                                default: true
+                                description: Show apply selections button in controls.
+                                type: boolean
+                              chainingSystem:
+                                default: HIERARCHICAL
+                                description: The chaining strategy for multiple controls. For example, "HIERARCHICAL" or "NONE".
+                                enum:
+                                  - NONE
+                                  - HIERARCHICAL
+                                type: string
+                              controls:
+                                default: []
+                                description: An array of control panels and their state in the control group.
+                                items:
+                                  additionalProperties: true
+                                  type: object
+                                  properties:
+                                    controlConfig:
+                                      additionalProperties: {}
+                                      type: object
+                                    grow:
+                                      default: false
+                                      description: Expand width of the control panel to fit available space.
+                                      type: boolean
+                                    id:
+                                      description: The unique ID of the control.
+                                      type: string
+                                    order:
+                                      description: The order of the control panel in the control group.
+                                      type: number
+                                    type:
+                                      description: The type of the control panel.
+                                      type: string
+                                    width:
+                                      default: medium
+                                      description: Minimum width of the control panel in the control group.
+                                      enum:
+                                        - small
+                                        - medium
+                                        - large
+                                      type: string
+                                  required:
+                                    - type
+                                    - order
+                                type: array
+                              enhancements:
+                                additionalProperties: {}
+                                type: object
+                              ignoreParentSettings:
+                                additionalProperties: false
+                                type: object
+                                properties:
+                                  ignoreFilters:
+                                    default: false
+                                    description: Ignore global filters in controls.
+                                    type: boolean
+                                  ignoreQuery:
+                                    default: false
+                                    description: Ignore the global query bar in controls.
+                                    type: boolean
+                                  ignoreTimerange:
+                                    default: false
+                                    description: Ignore the global time range in controls.
+                                    type: boolean
+                                  ignoreValidations:
+                                    default: false
+                                    description: Ignore validations in controls.
+                                    type: boolean
+                              labelPosition:
+                                default: oneLine
+                                description: Position of the labels for controls. For example, "oneLine", "twoLine".
+                                enum:
+                                  - oneLine
+                                  - twoLine
+                                type: string
+                            required:
+                              - ignoreParentSettings
+                          description:
+                            default: ""
+                            description: A short description.
+                            type: string
+                          kibanaSavedObjectMeta:
+                            additionalProperties: false
+                            default: {}
+                            description: A container for various metadata
+                            type: object
+                            properties:
+                              searchSource:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  filter:
+                                    items:
+                                      additionalProperties: false
+                                      description: A filter for the search source.
+                                      type: object
+                                      properties:
+                                        $state:
+                                          additionalProperties: false
+                                          type: object
+                                          properties:
+                                            store:
+                                              description: Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').
+                                              enum:
+                                                - appState
+                                                - globalState
+                                              type: string
+                                          required:
+                                            - store
+                                        meta:
+                                          additionalProperties: true
+                                          type: object
+                                          properties:
+                                            alias:
+                                              nullable: true
+                                              type: string
+                                            controlledBy:
+                                              type: string
+                                            disabled:
+                                              type: boolean
+                                            field:
+                                              type: string
+                                            group:
+                                              type: string
+                                            index:
+                                              type: string
+                                            isMultiIndex:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            negate:
+                                              type: boolean
+                                            params: {}
+                                            type:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - params
+                                        query:
+                                          additionalProperties: {}
+                                          type: object
+                                      required:
+                                        - meta
+                                    type: array
+                                  query:
+                                    additionalProperties: false
+                                    type: object
+                                    properties:
+                                      language:
+                                        description: The query language such as KQL or Lucene.
+                                        type: string
+                                      query:
+                                        anyOf:
+                                          - description: A text-based query such as Kibana Query Language (KQL) or Lucene query language.
+                                            type: string
+                                          - additionalProperties: {}
+                                            type: object
+                                    required:
+                                      - query
+                                      - language
+                                  sort:
+                                    items:
+                                      additionalProperties:
+                                        anyOf:
+                                          - enum:
+                                              - asc
+                                              - desc
+                                            type: string
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              format:
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                          - additionalProperties: false
+                                            type: object
+                                            properties:
+                                              numeric_type:
+                                                enum:
+                                                  - double
+                                                  - long
+                                                  - date
+                                                  - date_nanos
+                                                type: string
+                                              order:
+                                                enum:
+                                                  - asc
+                                                  - desc
+                                                type: string
+                                            required:
+                                              - order
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                          options:
+                            additionalProperties: false
+                            type: object
+                            properties:
+                              hidePanelTitles:
+                                default: false
+                                description: Hide the panel titles in the dashboard.
+                                type: boolean
+                              syncColors:
+                                default: true
+                                description: Synchronize colors between related panels in the dashboard.
+                                type: boolean
+                              syncCursor:
+                                default: true
+                                description: Synchronize cursor position between related panels in the dashboard.
+                                type: boolean
+                              syncTooltips:
+                                default: true
+                                description: Synchronize tooltips between related panels in the dashboard.
+                                type: boolean
+                              useMargins:
+                                default: true
+                                description: Show margins between panels in the dashboard layout.
+                                type: boolean
+                          panels:
+                            default: []
+                            items:
+                              anyOf:
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        h:
+                                          default: 15
+                                          description: The height of the panel in grid units
+                                          minimum: 1
+                                          type: number
+                                        i:
+                                          type: string
+                                        w:
+                                          default: 24
+                                          description: The width of the panel in grid units
+                                          maximum: 48
+                                          minimum: 1
+                                          type: number
+                                        x:
+                                          description: The x coordinate of the panel in grid units
+                                          type: number
+                                        "y":
+                                          description: The y coordinate of the panel in grid units
+                                          type: number
+                                      required:
+                                        - x
+                                        - "y"
+                                        - i
+                                    id:
+                                      description: The saved object id for by reference panels
+                                      type: string
+                                    panelConfig:
+                                      additionalProperties: true
+                                      type: object
+                                      properties: {}
+                                    panelIndex:
+                                      type: string
+                                    panelRefName:
+                                      type: string
+                                    title:
+                                      description: The title of the panel
+                                      type: string
+                                    type:
+                                      description: The embeddable type
+                                      type: string
+                                    version:
+                                      deprecated: true
+                                      description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                      type: string
+                                  required:
+                                    - panelConfig
+                                    - type
+                                    - gridData
+                                    - panelIndex
+                                - additionalProperties: false
+                                  type: object
+                                  properties:
+                                    collapsed:
+                                      description: The collapsed state of the section.
+                                      type: boolean
+                                    gridData:
+                                      additionalProperties: false
+                                      type: object
+                                      properties:
+                                        i:
+                                          type: string
+                                        "y":
+                                          description: The y coordinate of the section in grid units
+                                          type: number
+                                      required:
+                                        - "y"
+                                        - i
+                                    panels:
+                                      items:
+                                        additionalProperties: false
+                                        type: object
+                                        properties:
+                                          gridData:
+                                            additionalProperties: false
+                                            type: object
+                                            properties:
+                                              h:
+                                                default: 15
+                                                description: The height of the panel in grid units
+                                                minimum: 1
+                                                type: number
+                                              i:
+                                                type: string
+                                              w:
+                                                default: 24
+                                                description: The width of the panel in grid units
+                                                maximum: 48
+                                                minimum: 1
+                                                type: number
+                                              x:
+                                                description: The x coordinate of the panel in grid units
+                                                type: number
+                                              "y":
+                                                description: The y coordinate of the panel in grid units
+                                                type: number
+                                            required:
+                                              - x
+                                              - "y"
+                                              - i
+                                          id:
+                                            description: The saved object id for by reference panels
+                                            type: string
+                                          panelConfig:
+                                            additionalProperties: true
+                                            type: object
+                                            properties: {}
+                                          panelIndex:
+                                            type: string
+                                          panelRefName:
+                                            type: string
+                                          title:
+                                            description: The title of the panel
+                                            type: string
+                                          type:
+                                            description: The embeddable type
+                                            type: string
+                                          version:
+                                            deprecated: true
+                                            description: The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).
+                                            type: string
+                                        required:
+                                          - panelConfig
+                                          - type
+                                          - gridData
+                                          - panelIndex
+                                      type: array
+                                    title:
+                                      description: The title of the section.
+                                      type: string
+                                  required:
+                                    - title
+                                    - gridData
+                                    - panels
+                            type: array
+                          refreshInterval:
+                            additionalProperties: false
+                            description: A container for various refresh interval settings
+                            type: object
+                            properties:
+                              display:
+                                deprecated: true
+                                description: A human-readable string indicating the refresh frequency. No longer used.
+                                type: string
+                              pause:
+                                description: Whether the refresh interval is set to be paused while viewing the dashboard.
+                                type: boolean
+                              section:
+                                deprecated: true
+                                description: No longer used.
+                                type: number
+                              value:
+                                description: A numeric value indicating refresh frequency in milliseconds.
+                                type: number
+                            required:
+                              - pause
+                              - value
+                          tags:
+                            items:
+                              description: An array of tags applied to this dashboard
+                              type: string
+                            type: array
+                          timeFrom:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          timeRestore:
+                            default: false
+                            description: Whether to restore time upon viewing this dashboard
+                            type: boolean
+                          timeTo:
+                            description: An ISO string indicating when to restore time from
+                            type: string
+                          title:
+                            description: A human-readable title for the dashboard
+                            type: string
+                          version:
+                            deprecated: true
+                            type: number
+                        required:
+                          - title
+                          - options
+                      createdAt:
+                        type: string
+                      createdBy:
+                        type: string
+                      error:
+                        additionalProperties: false
+                        type: object
+                        properties:
+                          error:
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties: true
+                            type: object
+                            properties: {}
+                          statusCode:
+                            type: number
+                        required:
+                          - error
+                          - message
+                          - statusCode
+                      id:
+                        type: string
+                      managed:
+                        type: boolean
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      originId:
+                        type: string
+                      references:
+                        items:
+                          additionalProperties: false
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - name
+                            - type
+                            - id
+                        type: array
+                      type:
+                        type: string
+                      updatedAt:
+                        type: string
+                      updatedBy:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - id
+                      - type
+                      - attributes
+                      - references
+                required:
+                  - item
+      summary: Update an existing dashboard
+      tags:
+        - Dashboards
+      x-state: Unstable (Do not use)


### PR DESCRIPTION
Publishes OpenAPI specs for unstable dashboards APIs.

## Steps for automatic OAS generation such as Dashboard APIs
1. Change [routes `access`](https://github.com/elastic/kibana/blob/42377e498dc7a563367cf1e259ea068e117c9ad0/src/platform/plugins/shared/dashboard/server/api/register_routes.ts#L35) to `public` if necessary.
2. Change the version on each route to a public version string, e.g. `2023-10-31`.
3. Add `server.oas.enabled: true` to your kibana.yml
4. Run `node scripts/capture_oas_snapshot.js` to generate the `oas_docs/bundle.json` and `bundle.serverless.json`.
5. Change to the `oas_docs` directory and run `make`.

These APIs are unstable and may be used for internal (Elastic) use only.

Reviewers can generate an ephemeral website for testing output with the following steps:
1. `cd oas_docs`
6. `make api-docs`
7. `make api-docs-preview`
8. Click the link(s) for the preview docs. Those links only last for a few hours.