### PR TITLE
[APM]Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Mobile

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/metric_item.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/metric_item.tsx
@@ -10,7 +10,7 @@ import { Chart, Metric, Settings } from '@elastic/charts';
 import { useElasticChartsTheme } from '@kbn/charts-theme';
 import { EuiSkeletonText, EuiPanel } from '@elastic/eui';
 import { isEmpty } from 'lodash';
-import { EuiErrorBoundary } from '@elastic/eui';
+import { KibanaErrorBoundary } from '@kbn/shared-ux-error-boundary';
 
 export function MetricItem({
   data,
@@ -40,12 +40,12 @@ export function MetricItem({
           <EuiSkeletonText lines={3} />
         </EuiPanel>
       ) : (
-        <EuiErrorBoundary>
+        <KibanaErrorBoundary>
           <Chart>
             <Settings baseTheme={chartBaseTheme} />
             <Metric id={`metric_${id}`} data={[data]} />
           </Chart>
-        </EuiErrorBoundary>
+        </KibanaErrorBoundary>
       )}
     </div>
   );

--- a/x-pack/solutions/observability/plugins/apm/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/apm/tsconfig.json
@@ -139,6 +139,7 @@
     "@kbn/presentation-containers",
     "@kbn/object-utils",
     "@kbn/cases-plugin",
+    "@kbn/shared-ux-error-boundary",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
PR 2 of 2

## Summary

This PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the APM Error Mobile Charts

## Testing

- Introduce an error in the APM mobile charts (maybe a typo, non-existent component, or anything) for example: 
<img width="976" alt="mobile code error" src="https://github.com/user-attachments/assets/3400d483-837c-464d-937f-de4916fad0e6" />


- Open the APM mobile service 
  - Can be created using synthtrace: `node scripts/synthtrace mobile --live --uniqueIds`
- The error should be visible, and it should still work as before (but also including telemetry)


<img width="1720" alt="mobile page error" src="https://github.com/user-attachments/assets/23e0d206-40bc-4f45-b39c-4e5967835473" />



<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.1"]} ONMERGE-->