### PR TITLE
fix(llm): return "field.name (empty)"

### DIFF
--- a/x-pack/solutions/observability/packages/utils-common/llm/log_analysis/sort_and_truncate_analyzed_fields.ts
+++ b/x-pack/solutions/observability/packages/utils-common/llm/log_analysis/sort_and_truncate_analyzed_fields.ts
@@ -24,7 +24,7 @@ export function sortAndTruncateAnalyzedFields(
         let label = `${field.name}:${field.types.join(',')}`;
 
         if (field.empty) {
-          return `${name} (empty)`;
+          return `${label} (empty)`;
         }
 
         label += ` - ${field.cardinality} distinct values`;


### PR DESCRIPTION
This fixes a small bug when the field is empty in the sortAndTruncateAnalyzedFields function