### PR TITLE
Add fleet server host fallback for agentless

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -405,6 +405,7 @@ describe('Agent policy', () => {
         updated_by: 'system',
         schema_version: '1.1.1',
         is_protected: false,
+        fleet_server_host_id: 'default-fleet-server',
       });
     });
 
@@ -441,6 +442,46 @@ describe('Agent policy', () => {
         updated_by: 'system',
         schema_version: '1.1.1',
         is_protected: false,
+        fleet_server_host_id: 'fleet-default-fleet-server-host',
+      });
+    });
+
+    it('should create an agentless policy with a fallback fleet_server_host_id if not provided', async () => {
+      jest
+        .spyOn(appContextService, 'getConfig')
+        .mockReturnValue({ agentless: { enabled: true } } as any);
+      jest
+        .spyOn(appContextService, 'getCloud')
+        .mockReturnValue({ isServerlessEnabled: true } as any);
+
+      const soClient = getAgentPolicyCreateMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.find.mockResolvedValueOnce({
+        total: 0,
+        saved_objects: [],
+        per_page: 0,
+        page: 1,
+      });
+
+      const res = await agentPolicyService.create(soClient, esClient, {
+        name: 'test',
+        namespace: 'default',
+        supports_agentless: true,
+      });
+      expect(res).toEqual({
+        id: 'mocked',
+        name: 'test',
+        namespace: 'default',
+        supports_agentless: true,
+        status: 'active',
+        is_managed: false,
+        revision: 1,
+        updated_at: expect.anything(),
+        updated_by: 'system',
+        schema_version: '1.1.1',
+        is_protected: false,
+        fleet_server_host_id: 'default-fleet-server',
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -448,6 +448,11 @@ class AgentPolicyService {
 
     this.checkAgentless(agentPolicy);
 
+    if (agentPolicy.supports_agentless && !agentPolicy.fleet_server_host_id) {
+      const { fleetServerId } = agentlessAgentService.getDefaultSettings();
+      agentPolicy.fleet_server_host_id = fleetServerId;
+    }
+
     await this.requireUniqueName(soClient, agentPolicy);
     await validatePolicyNamespaceForSpace({
       spaceId: soClient.getCurrentNamespace(),

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.test.ts
@@ -27,6 +27,15 @@ jest.mock('.', () => ({
   },
 }));
 
+jest.mock('./agents/agentless_agent', () => ({
+  agentlessAgentService: {
+    getDefaultSettings: jest.fn().mockReturnValue({
+      outputId: 'es-default-output',
+      fleetServerId: 'default-fleet-server',
+    }),
+  },
+}));
+
 jest.mock('./agent_policy', () => ({
   agentPolicyService: {
     find: jest.fn(),

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.ts
@@ -9,37 +9,21 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 
 import pMap from 'p-map';
 
-import {
-  MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS,
-  SO_SEARCH_LIMIT,
-  DEFAULT_OUTPUT_ID,
-  SERVERLESS_DEFAULT_OUTPUT_ID,
-  DEFAULT_FLEET_SERVER_HOST_ID,
-  SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID,
-} from '../constants';
+import { MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS, SO_SEARCH_LIMIT } from '../constants';
 
 import type { AgentPolicySOAttributes } from '../types';
 
 import { getAgentPolicySavedObjectType, agentPolicyService } from './agent_policy';
+import { agentlessAgentService } from './agents/agentless_agent';
 import { fleetServerHostService } from './fleet_server_host';
 import { outputService } from './output';
 
 import { appContextService } from '.';
 
 export async function ensureCorrectAgentlessSettingsIds(esClient: ElasticsearchClient) {
-  const cloudSetup = appContextService.getCloud();
-  const isCloud = cloudSetup?.isCloudEnabled;
-  const isServerless = cloudSetup?.isServerlessEnabled;
-  const correctOutputId = isServerless
-    ? SERVERLESS_DEFAULT_OUTPUT_ID
-    : isCloud
-    ? DEFAULT_OUTPUT_ID
-    : undefined;
-  const correctFleetServerId = isServerless
-    ? SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID
-    : isCloud
-    ? DEFAULT_FLEET_SERVER_HOST_ID
-    : undefined;
+  const { outputId: correctOutputId, fleetServerId: correctFleetServerId } =
+    agentlessAgentService.getDefaultSettings();
+
   let fixOutput = false;
   let fixFleetServer = false;
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
@@ -634,81 +634,6 @@ describe('Agentless Agent service', () => {
     );
   });
 
-  it('should create agentless agent when fleet_server_host_id is not provided', async () => {
-    (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce(
-      mockAgentlessDeploymentResponse
-    );
-    const soClient = getAgentPolicyCreateMock();
-    // ignore unrelated unique name constraint
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-    jest.spyOn(appContextService, 'getConfig').mockReturnValue({
-      agentless: {
-        enabled: true,
-        api: {
-          url: 'http://api.agentless.com',
-          tls: {
-            certificate: '/path/to/cert',
-            key: '/path/to/key',
-            ca: '/path/to/ca',
-          },
-        },
-        deploymentSecrets: {
-          fleetAppToken: 'fleet-app-token',
-          elasticsearchAppToken: 'es-app-token',
-        },
-      },
-    } as any);
-    jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: true } as any);
-    jest
-      .spyOn(appContextService, 'getKibanaVersion')
-      .mockReturnValue('mocked-kibana-version-infinite');
-    mockedFleetServerHostService.get.mockResolvedValue({
-      id: 'mocked-fleet-server-id',
-      host: 'http://fleetserver:8220',
-      active: true,
-      is_default: true,
-      host_urls: ['http://fleetserver:8220'],
-    } as any);
-    mockedListEnrollmentApiKeys.mockResolvedValue({
-      items: [
-        {
-          id: 'mocked-fleet-enrollment-token-id',
-          policy_id: 'mocked-fleet-enrollment-policy-id',
-          api_key: 'mocked-fleet-enrollment-api-key',
-        },
-      ],
-    } as any);
-
-    const createAgentlessAgentReturnValue = await agentlessAgentService.createAgentlessAgent(
-      esClient,
-      soClient,
-      {
-        id: 'mocked-agentless-agent-policy-id',
-        name: 'agentless agent policy',
-        namespace: 'default',
-        data_output_id: 'mock-fleet-default-output',
-        supports_agentless: true,
-      } as AgentPolicy
-    );
-
-    expect(axios).toHaveBeenCalledTimes(1);
-    expect(createAgentlessAgentReturnValue).toEqual(mockAgentlessDeploymentResponse);
-    expect(axios).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          fleet_token: 'mocked-fleet-enrollment-api-key',
-          fleet_url: 'http://fleetserver:8220',
-          policy_id: 'mocked-agentless-agent-policy-id',
-          stack_version: 'mocked-kibana-version-infinite',
-        }),
-        headers: expect.anything(),
-        httpsAgent: expect.anything(),
-        method: 'POST',
-        url: 'http://api.agentless.com/api/v1/ess/deployments',
-      })
-    );
-  });
-
   it('should delete agentless agent for ESS', async () => {
     const returnValue = {
       id: 'mocked',
@@ -1265,6 +1190,48 @@ describe('Agentless Agent service', () => {
           supports_agentless: true,
         } as AgentPolicy)
       ).rejects.toThrowError(new AgentlessAgentConfigError('missing Fleet enrollment token'));
+    });
+
+    it('should throw AgentlessAgentConfigError if agent policy is missing fleet_server_host_id', async () => {
+      const soClient = getAgentPolicyCreateMock();
+      // ignore unrelated unique name constraint
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      jest.spyOn(appContextService, 'getConfig').mockReturnValue({
+        agentless: {
+          enabled: true,
+          api: {
+            url: 'http://api.agentless.com/api/v1/ess',
+            tls: {
+              certificate: '/path/to/cert',
+              key: '/path/to/key',
+            },
+          },
+          deploymentSecrets: {
+            fleetAppToken: 'fleet-app-token',
+            elasticsearchAppToken: 'es-app-token',
+          },
+        },
+      } as any);
+      jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: true } as any);
+      mockedListEnrollmentApiKeys.mockResolvedValue({
+        items: [
+          {
+            id: 'mocked',
+            policy_id: 'mocked',
+            api_key: 'mocked',
+          },
+        ],
+      } as any);
+
+      await expect(
+        agentlessAgentService.createAgentlessAgent(esClient, soClient, {
+          id: 'mocked',
+          name: 'agentless agent policy',
+          namespace: 'default',
+          data_output_id: 'mock-fleet-default-output',
+          supports_agentless: true,
+        } as AgentPolicy)
+      ).rejects.toThrowError(new AgentlessAgentConfigError('missing fleet_server_host_id'));
     });
 
     it('should throw an error and log and error when the Agentless API returns a status not handled and not in the 2xx series', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
@@ -30,6 +30,10 @@ import {
   AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION,
   AGENTLESS_GLOBAL_TAG_NAME_DIVISION,
   AGENTLESS_GLOBAL_TAG_NAME_TEAM,
+  DEFAULT_OUTPUT_ID,
+  SERVERLESS_DEFAULT_OUTPUT_ID,
+  DEFAULT_FLEET_SERVER_HOST_ID,
+  SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID,
 } from '../../constants';
 
 import { appContextService } from '../app_context';
@@ -56,6 +60,27 @@ interface AgentlessAgentErrorHandlingMessages {
 }
 
 class AgentlessAgentService {
+  public getDefaultSettings() {
+    const cloudSetup = appContextService.getCloud();
+    const isCloud = cloudSetup?.isCloudEnabled;
+    const isServerless = cloudSetup?.isServerlessEnabled;
+    const outputId = isServerless
+      ? SERVERLESS_DEFAULT_OUTPUT_ID
+      : isCloud
+      ? DEFAULT_OUTPUT_ID
+      : undefined;
+    const fleetServerId = isServerless
+      ? SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID
+      : isCloud
+      ? DEFAULT_FLEET_SERVER_HOST_ID
+      : undefined;
+
+    return {
+      outputId,
+      fleetServerId,
+    };
+  }
+
   public async createAgentlessAgent(
     esClient: ElasticsearchClient,
     soClient: SavedObjectsClientContract,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
@@ -407,17 +407,14 @@ class AgentlessAgentService {
       throw new AgentlessAgentConfigError('missing Fleet enrollment token');
     }
 
-    const { fleetServerId: defaultFleetServerId } = this.getDefaultSettings();
-    const fleetServerHostId = policy.fleet_server_host_id ?? defaultFleetServerId;
-
-    if (!fleetServerHostId) {
+    if (!policy.fleet_server_host_id) {
       throw new AgentlessAgentConfigError('missing fleet_server_host_id');
     }
 
     let defaultFleetHost: FleetServerHost;
 
     try {
-      defaultFleetHost = await fleetServerHostService.get(soClient, fleetServerHostId);
+      defaultFleetHost = await fleetServerHostService.get(soClient, policy.fleet_server_host_id);
     } catch (e) {
       throw new AgentlessAgentConfigError('missing default Fleet server host');
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
@@ -407,14 +407,17 @@ class AgentlessAgentService {
       throw new AgentlessAgentConfigError('missing Fleet enrollment token');
     }
 
-    if (!policy.fleet_server_host_id) {
+    const { fleetServerId: defaultFleetServerId } = this.getDefaultSettings();
+    const fleetServerHostId = policy.fleet_server_host_id ?? defaultFleetServerId;
+
+    if (!fleetServerHostId) {
       throw new AgentlessAgentConfigError('missing fleet_server_host_id');
     }
 
     let defaultFleetHost: FleetServerHost;
 
     try {
-      defaultFleetHost = await fleetServerHostService.get(soClient, policy.fleet_server_host_id);
+      defaultFleetHost = await fleetServerHostService.get(soClient, fleetServerHostId);
     } catch (e) {
       throw new AgentlessAgentConfigError('missing default Fleet server host');
     }


### PR DESCRIPTION
## Summary

Resolves: https://github.com/elastic/kibana/issues/226898

Checking locally:

You'll need to comment out the call to create an agentless deployment and fake the successful response
x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts:174

```
    const response = { data: { code: 'SUCCESS', error: null } };

    // const response = await axios<AgentlessApiDeploymentResponse>(requestConfig).catch(
    //   (error: Error | AxiosError) => {
    //     this.catchAgentlessApiError(
    //       'create',
    //       error,
    //       logger,
    //       agentlessAgentPolicy.id,
    //       requestConfig,
    //       requestConfigDebugStatus,
    //       errorMetadata,
    //       traceId
    //     );
    //   }
    // );
```
You should not see the error 
```
Error creating an agentless deployment for connector <CONNECTOR_ID>: Error validating Agentless API configuration in Fleet, missing fleet_server_host_id
```
in Kibana logs and see in the network that it was configured.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->