### PR TITLE
[AI Infra] Include error message when connector is not found

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.test.ts
@@ -51,9 +51,11 @@ describe('getConnectorById', () => {
       throw new Error('Something wrong');
     });
 
-    await expect(() =>
-      getConnectorById({ actionsClient, connectorId })
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"No connector found for id 'my-connector-id'"`);
+    await expect(() => getConnectorById({ actionsClient, connectorId })).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      "No connector found for id 'my-connector-id'
+      Something wrong"
+    `);
   });
 
   it('throws the connector type is not compatible', async () => {

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
@@ -29,7 +29,10 @@ export const getConnectorById = async ({
       throwIfSystemAction: true,
     });
   } catch (error) {
-    throw createInferenceRequestError(`No connector found for id '${connectorId}'`, 400);
+    throw createInferenceRequestError(
+      `No connector found for id '${connectorId}'\n${error.message}`,
+      400
+    );
   }
 
   return connectorToInference(connector);

--- a/x-pack/test/functional_gen_ai/inference/tests/chat_complete.ts
+++ b/x-pack/test/functional_gen_ai/inference/tests/chat_complete.ts
@@ -168,7 +168,8 @@ export const chatCompleteSuite = (
         expect(message).to.eql({
           type: 'error',
           code: 'requestError',
-          message: "No connector found for id 'do-not-exist'",
+          message:
+            "No connector found for id 'do-not-exist'\nSaved object [action/do-not-exist] not found",
         });
       });
 
@@ -335,7 +336,8 @@ export const chatCompleteSuite = (
             type: 'error',
             error: {
               code: 'requestError',
-              message: "No connector found for id 'do-not-exist'",
+              message:
+                "No connector found for id 'do-not-exist'\nSaved object [action/do-not-exist] not found",
               meta: {
                 status: 400,
               },


### PR DESCRIPTION
## Summary

Improves error logging when fetching connector to include the actual error message to better debug the ongoing issue outlined in https://github.com/elastic/kibana/issues/225711







<!--ONMERGE {"backportTargets":["8.18","8.19","9.1"]} ONMERGE-->