### PR TITLE
[9.1] [SecuritySolution] [Bug] Fix Manage data sources page index import  (#226099)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen.ts
@@ -15,9 +15,10 @@
  */
 
 import { z } from '@kbn/zod';
+import { BooleanFromString } from '@kbn/zod-helpers';
 
-export type MonitoringEntitySourceDescriptor = z.infer<typeof MonitoringEntitySourceDescriptor>;
-export const MonitoringEntitySourceDescriptor = z.object({
+export type CreateMonitoringEntitySource = z.infer<typeof CreateMonitoringEntitySource>;
+export const CreateMonitoringEntitySource = z.object({
   type: z.string(),
   name: z.string(),
   managed: z.boolean().optional(),
@@ -33,14 +34,42 @@ export const MonitoringEntitySourceDescriptor = z.object({
       })
     )
     .optional(),
-  filter: z.object({}).optional(),
+  filter: z
+    .object({
+      kuery: z.union([z.string(), z.object({})]).optional(),
+    })
+    .optional(),
 });
 
-export type MonitoringEntitySourceResponse = z.infer<typeof MonitoringEntitySourceResponse>;
-export const MonitoringEntitySourceResponse = z.object({
-  id: z.string().optional(),
-  name: z.string().optional(),
+export type UpdatedMonitoringEntitySource = z.infer<typeof UpdatedMonitoringEntitySource>;
+export const UpdatedMonitoringEntitySource = z.object({
   type: z.string().optional(),
+  name: z.string().optional(),
+  managed: z.boolean().optional(),
+  indexPattern: z.string().optional(),
+  enabled: z.boolean().optional(),
+  error: z.string().optional(),
+  integrationName: z.string().optional(),
+  matchers: z
+    .array(
+      z.object({
+        fields: z.array(z.string()),
+        values: z.array(z.string()),
+      })
+    )
+    .optional(),
+  filter: z
+    .object({
+      kuery: z.union([z.string(), z.object({})]).optional(),
+    })
+    .optional(),
+});
+
+export type MonitoringEntitySource = z.infer<typeof MonitoringEntitySource>;
+export const MonitoringEntitySource = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
   indexPattern: z.string().optional(),
   integrationName: z.string().optional(),
   enabled: z.boolean().optional(),
@@ -52,4 +81,54 @@ export const MonitoringEntitySourceResponse = z.object({
       })
     )
     .optional(),
+  filter: z
+    .object({
+      kuery: z.union([z.string(), z.object({})]).optional(),
+    })
+    .optional(),
 });
+
+export type CreateEntitySourceRequestBody = z.infer<typeof CreateEntitySourceRequestBody>;
+export const CreateEntitySourceRequestBody = CreateMonitoringEntitySource;
+export type CreateEntitySourceRequestBodyInput = z.input<typeof CreateEntitySourceRequestBody>;
+
+export type CreateEntitySourceResponse = z.infer<typeof CreateEntitySourceResponse>;
+export const CreateEntitySourceResponse = UpdatedMonitoringEntitySource;
+
+export type DeleteEntitySourceRequestParams = z.infer<typeof DeleteEntitySourceRequestParams>;
+export const DeleteEntitySourceRequestParams = z.object({
+  id: z.string(),
+});
+export type DeleteEntitySourceRequestParamsInput = z.input<typeof DeleteEntitySourceRequestParams>;
+
+export type GetEntitySourceRequestParams = z.infer<typeof GetEntitySourceRequestParams>;
+export const GetEntitySourceRequestParams = z.object({
+  id: z.string(),
+});
+export type GetEntitySourceRequestParamsInput = z.input<typeof GetEntitySourceRequestParams>;
+
+export type GetEntitySourceResponse = z.infer<typeof GetEntitySourceResponse>;
+export const GetEntitySourceResponse = MonitoringEntitySource;
+export type ListEntitySourcesRequestQuery = z.infer<typeof ListEntitySourcesRequestQuery>;
+export const ListEntitySourcesRequestQuery = z.object({
+  type: z.string().optional(),
+  managed: BooleanFromString.optional(),
+  name: z.string().optional(),
+});
+export type ListEntitySourcesRequestQueryInput = z.input<typeof ListEntitySourcesRequestQuery>;
+
+export type ListEntitySourcesResponse = z.infer<typeof ListEntitySourcesResponse>;
+export const ListEntitySourcesResponse = z.array(MonitoringEntitySource);
+
+export type UpdateEntitySourceRequestParams = z.infer<typeof UpdateEntitySourceRequestParams>;
+export const UpdateEntitySourceRequestParams = z.object({
+  id: z.string(),
+});
+export type UpdateEntitySourceRequestParamsInput = z.input<typeof UpdateEntitySourceRequestParams>;
+
+export type UpdateEntitySourceRequestBody = z.infer<typeof UpdateEntitySourceRequestBody>;
+export const UpdateEntitySourceRequestBody = MonitoringEntitySource;
+export type UpdateEntitySourceRequestBodyInput = z.input<typeof UpdateEntitySourceRequestBody>;
+
+export type UpdateEntitySourceResponse = z.infer<typeof UpdateEntitySourceResponse>;
+export const UpdateEntitySourceResponse = UpdatedMonitoringEntitySource;

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.schema.yaml
@@ -7,25 +7,27 @@ info:
 paths:
   /api/entity_analytics/monitoring/entity_source:
     post:
-      operationId: createEntitySource
+      operationId: CreateEntitySource
+      x-codegen-enabled: true
       summary: Create a new entity source configuration
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MonitoringEntitySourceDescriptor"
+              $ref: "#/components/schemas/CreateMonitoringEntitySource"
       responses:
         "200":
           description: Entity source created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MonitoringEntitySourceResponse"
+                $ref: "#/components/schemas/UpdatedMonitoringEntitySource"
 
   /api/entity_analytics/monitoring/entity_source/{id}:
     get:
-      operationId: getEntitySource
+      operationId: GetEntitySource
+      x-codegen-enabled: true
       summary: Get an entity source configuration by ID
       parameters:
         - name: id
@@ -39,10 +41,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MonitoringEntitySourceResponse"
+                $ref: "#/components/schemas/MonitoringEntitySource"
 
     put:
-      operationId: updateEntitySource
+      operationId: UpdateEntitySource
+      x-codegen-enabled: true
       summary: Update an entity source configuration
       parameters:
         - name: id
@@ -55,13 +58,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MonitoringEntitySourceDescriptor"
+              $ref: "#/components/schemas/MonitoringEntitySource"
       responses:
         "200":
           description: Entity source updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdatedMonitoringEntitySource"          
 
     delete:
-      operationId: deleteEntitySource
+      operationId: DeleteEntitySource
+      x-codegen-enabled: true
       summary: Delete an entity source configuration
       parameters:
         - name: id
@@ -75,8 +83,23 @@ paths:
 
   /api/entity_analytics/monitoring/entity_source/list:
     get:
-      operationId: listEntitySources
+      operationId: ListEntitySources
+      x-codegen-enabled: true
       summary: List all entity source configurations
+      parameters:
+        - name: type
+          in: query
+          schema:
+            type: string
+        - name: managed
+          in: query
+          schema:
+            type: boolean
+        - name: name
+          in: query
+          schema:
+            type: string
+
       responses:
         "200":
           description: List of entity sources retrieved
@@ -85,10 +108,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/MonitoringEntitySourceDescriptor"
+                  $ref: "#/components/schemas/MonitoringEntitySource"
 components:
   schemas:
-    MonitoringEntitySourceDescriptor:
+    CreateMonitoringEntitySource:
       type: object
       required: [type, name]
       properties:
@@ -124,9 +147,56 @@ components:
                   type: string                
         filter:
           type: object
+          properties:
+            kuery:
+              oneOf:
+                - type: string
+                - type: object
 
-    MonitoringEntitySourceResponse:
+    UpdatedMonitoringEntitySource:
       type: object
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        managed:
+          type: boolean
+        indexPattern:
+          type: string
+        enabled:
+          type: boolean
+        error:
+          type: string
+        integrationName:
+          type: string
+        matchers:
+          type: array
+          items:
+            type: object
+            required:
+            - fields
+            - values
+            properties:
+              fields:
+                type: array
+                items:
+                  type: string                  
+              values:
+                type: array
+                items:
+                  type: string                
+        filter:
+          type: object
+          properties:
+            kuery:
+              oneOf:
+                - type: string
+                - type: object
+
+    MonitoringEntitySource:
+      type: object
+      required: [type, name, id, managed]
       properties:
         id:
           type: string
@@ -155,4 +225,11 @@ components:
               values:
                 type: array
                 items:
-                  type: string
+                  type: string        
+        filter:
+          type: object
+          properties:
+            kuery:
+              oneOf:
+                - type: string
+                - type: object

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -269,6 +269,18 @@ import type {
 } from './entity_analytics/monitoring/search_indices.gen';
 import type { InitMonitoringEngineResponse } from './entity_analytics/privilege_monitoring/engine/init.gen';
 import type { PrivMonHealthResponse } from './entity_analytics/privilege_monitoring/health.gen';
+import type {
+  CreateEntitySourceRequestBodyInput,
+  CreateEntitySourceResponse,
+  DeleteEntitySourceRequestParamsInput,
+  GetEntitySourceRequestParamsInput,
+  GetEntitySourceResponse,
+  ListEntitySourcesRequestQueryInput,
+  ListEntitySourcesResponse,
+  UpdateEntitySourceRequestParamsInput,
+  UpdateEntitySourceRequestBodyInput,
+  UpdateEntitySourceResponse,
+} from './entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import type { InstallPrivilegedAccessDetectionPackageResponse } from './entity_analytics/privilege_monitoring/privileged_access_detection/install.gen';
 import type { GetPrivilegedAccessDetectionPackageStatusResponse } from './entity_analytics/privilege_monitoring/privileged_access_detection/status.gen';
 import type {
@@ -627,6 +639,19 @@ If a record already exists for the specified entity, that record is overwritten 
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  async createEntitySource(props: CreateEntitySourceProps) {
+    this.log.info(`${new Date().toISOString()} Calling API CreateEntitySource`);
+    return this.kbnClient
+      .request<CreateEntitySourceResponse>({
+        path: '/api/entity_analytics/monitoring/entity_source',
+        headers: {
+          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+        },
+        method: 'POST',
+        body: props.body,
+      })
+      .catch(catchAxiosErrorFormatAndThrow);
+  }
   async createPrivilegesImportIndex(props: CreatePrivilegesImportIndexProps) {
     this.log.info(`${new Date().toISOString()} Calling API CreatePrivilegesImportIndex`);
     return this.kbnClient
@@ -827,6 +852,18 @@ For detailed information on Kibana actions and alerting, and additional API call
         method: 'DELETE',
 
         query: props.query,
+      })
+      .catch(catchAxiosErrorFormatAndThrow);
+  }
+  async deleteEntitySource(props: DeleteEntitySourceProps) {
+    this.log.info(`${new Date().toISOString()} Calling API DeleteEntitySource`);
+    return this.kbnClient
+      .request({
+        path: replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
+        headers: {
+          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+        },
+        method: 'DELETE',
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
@@ -1403,6 +1440,18 @@ finalize it.
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  async getEntitySource(props: GetEntitySourceProps) {
+    this.log.info(`${new Date().toISOString()} Calling API GetEntitySource`);
+    return this.kbnClient
+      .request<GetEntitySourceResponse>({
+        path: replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
+        headers: {
+          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+        },
+        method: 'GET',
+      })
+      .catch(catchAxiosErrorFormatAndThrow);
+  }
   async getEntityStoreStatus(props: GetEntityStoreStatusProps) {
     this.log.info(`${new Date().toISOString()} Calling API GetEntityStoreStatus`);
     return this.kbnClient
@@ -1956,6 +2005,20 @@ providing you with the most current and effective threat detection capabilities.
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  async listEntitySources(props: ListEntitySourcesProps) {
+    this.log.info(`${new Date().toISOString()} Calling API ListEntitySources`);
+    return this.kbnClient
+      .request<ListEntitySourcesResponse>({
+        path: '/api/entity_analytics/monitoring/entity_source/list',
+        headers: {
+          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+        },
+        method: 'GET',
+
+        query: props.query,
+      })
+      .catch(catchAxiosErrorFormatAndThrow);
+  }
   async listPrivMonUsers(props: ListPrivMonUsersProps) {
     this.log.info(`${new Date().toISOString()} Calling API ListPrivMonUsers`);
     return this.kbnClient
@@ -2496,6 +2559,19 @@ The difference between the `id` and `rule_id` is that the `id` is a unique rule 
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  async updateEntitySource(props: UpdateEntitySourceProps) {
+    this.log.info(`${new Date().toISOString()} Calling API UpdateEntitySource`);
+    return this.kbnClient
+      .request<UpdateEntitySourceResponse>({
+        path: replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
+        headers: {
+          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+        },
+        method: 'PUT',
+        body: props.body,
+      })
+      .catch(catchAxiosErrorFormatAndThrow);
+  }
   async updatePrivMonUser(props: UpdatePrivMonUserProps) {
     this.log.info(`${new Date().toISOString()} Calling API UpdatePrivMonUser`);
     return this.kbnClient
@@ -2632,6 +2708,9 @@ export interface CreateAlertsMigrationProps {
 export interface CreateAssetCriticalityRecordProps {
   body: CreateAssetCriticalityRecordRequestBodyInput;
 }
+export interface CreateEntitySourceProps {
+  body: CreateEntitySourceRequestBodyInput;
+}
 export interface CreatePrivilegesImportIndexProps {
   body: CreatePrivilegesImportIndexRequestBodyInput;
 }
@@ -2661,6 +2740,9 @@ export interface DeleteAssetCriticalityRecordProps {
 export interface DeleteEntityEngineProps {
   query: DeleteEntityEngineRequestQueryInput;
   params: DeleteEntityEngineRequestParamsInput;
+}
+export interface DeleteEntitySourceProps {
+  params: DeleteEntitySourceRequestParamsInput;
 }
 export interface DeleteNoteProps {
   body: DeleteNoteRequestBodyInput;
@@ -2755,6 +2837,9 @@ export interface GetEndpointSuggestionsProps {
 export interface GetEntityEngineProps {
   params: GetEntityEngineRequestParamsInput;
 }
+export interface GetEntitySourceProps {
+  params: GetEntitySourceRequestParamsInput;
+}
 export interface GetEntityStoreStatusProps {
   query: GetEntityStoreStatusRequestQueryInput;
 }
@@ -2834,6 +2919,9 @@ export interface InternalUploadAssetCriticalityRecordsProps {
 export interface ListEntitiesProps {
   query: ListEntitiesRequestQueryInput;
 }
+export interface ListEntitySourcesProps {
+  query: ListEntitySourcesRequestQueryInput;
+}
 export interface ListPrivMonUsersProps {
   query: ListPrivMonUsersRequestQueryInput;
 }
@@ -2911,6 +2999,10 @@ export interface SuggestUserProfilesProps {
 }
 export interface TriggerRiskScoreCalculationProps {
   body: TriggerRiskScoreCalculationRequestBodyInput;
+}
+export interface UpdateEntitySourceProps {
+  params: UpdateEntitySourceRequestParamsInput;
+  body: UpdateEntitySourceRequestBodyInput;
 }
 export interface UpdatePrivMonUserProps {
   params: UpdatePrivMonUserRequestParamsInput;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
@@ -6,6 +6,11 @@
  */
 
 import { useMemo } from 'react';
+import type {
+  CreateEntitySourceResponse,
+  ListEntitySourcesResponse,
+  UpdateEntitySourceResponse,
+} from '../../../common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import type { CreatePrivilegesImportIndexResponse } from '../../../common/api/entity_analytics/monitoring/create_index.gen';
 import type { PrivMonHealthResponse } from '../../../common/api/entity_analytics/privilege_monitoring/health.gen';
 import type { InitMonitoringEngineResponse } from '../../../common/api/entity_analytics/privilege_monitoring/engine/init.gen';
@@ -65,6 +70,13 @@ import { type ListEntitiesRequestQuery } from '../../../common/api/entity_analyt
 export interface DeleteAssetCriticalityResponse {
   deleted: true;
 }
+
+/**
+ * This hardcoded name was temporarily introduced for 9.1.0.
+ * It is used to identify the only entity source that can be edited by the UI.
+ */
+const ENTITY_SOURCE_NAME = 'User Monitored Indices';
+
 export const useEntityAnalyticsRoutes = () => {
   const http = useKibana().services.http;
 
@@ -237,19 +249,31 @@ export const useEntityAnalyticsRoutes = () => {
      * Register a data source for privilege monitoring engine
      */
     const registerPrivMonMonitoredIndices = async (indexPattern: string | undefined) =>
-      http.fetch<SearchPrivilegesIndicesResponse>(
-        '/api/entity_analytics/monitoring/entity_source',
-        {
-          version: API_VERSIONS.public.v1,
-          method: 'POST',
+      http.fetch<CreateEntitySourceResponse>('/api/entity_analytics/monitoring/entity_source', {
+        version: API_VERSIONS.public.v1,
+        method: 'POST',
 
-          body: JSON.stringify({
-            type: 'index',
-            name: 'User Monitored Indices',
-            indexPattern,
-          }),
-        }
-      );
+        body: JSON.stringify({
+          type: 'index',
+          name: ENTITY_SOURCE_NAME,
+          indexPattern,
+        }),
+      });
+
+    /**
+     * Update a data source for privilege monitoring engine
+     */
+    const updatePrivMonMonitoredIndices = async (id: string, indexPattern: string | undefined) =>
+      http.fetch<UpdateEntitySourceResponse>('/api/entity_analytics/monitoring/entity_source', {
+        version: API_VERSIONS.public.v1,
+        method: 'PUT',
+        body: JSON.stringify({
+          id,
+          type: 'index',
+          name: ENTITY_SOURCE_NAME,
+          indexPattern,
+        }),
+      });
 
     /**
      * Create asset criticality
@@ -345,6 +369,21 @@ export const useEntityAnalyticsRoutes = () => {
       );
     };
 
+    /**
+     * List all data source for privilege monitoring engine
+     */
+    const listPrivMonMonitoredIndices = async ({ signal }: { signal?: AbortSignal }) =>
+      http.fetch<ListEntitySourcesResponse>('/api/entity_analytics/monitoring/entity_source/list', {
+        version: API_VERSIONS.public.v1,
+        method: 'GET',
+        signal,
+        query: {
+          type: 'index',
+          managed: false,
+          name: ENTITY_SOURCE_NAME,
+        },
+      });
+
     const uploadPrivilegedUserMonitoringFile = async (
       fileContent: string,
       fileName: string
@@ -424,12 +463,14 @@ export const useEntityAnalyticsRoutes = () => {
       uploadPrivilegedUserMonitoringFile,
       initPrivilegedMonitoringEngine,
       registerPrivMonMonitoredIndices,
+      updatePrivMonMonitoredIndices,
       fetchPrivilegeMonitoringEngineStatus,
       fetchRiskEngineSettings,
       calculateEntityRiskScore,
       cleanUpRiskEngine,
       fetchEntitiesList,
       updateSavedObjectConfiguration,
+      listPrivMonMonitoredIndices,
     };
   }, [http]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/csv_upload_manage_data_source.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/csv_upload_manage_data_source.tsx
@@ -36,9 +36,9 @@ export const CsvUploadManageDataSource = ({
 
   return (
     <>
-      <EuiFlexGroup alignItems={'flexStart'} direction={'column'}>
-        <EuiFlexGroup gutterSize={'s'} alignItems={'center'}>
-          <EuiIcon size={'l'} type={'importAction'} />
+      <EuiFlexGroup alignItems="flexStart" direction="column">
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiIcon size="l" type="importAction" />
           <EuiText>
             <h1>
               <FormattedMessage
@@ -63,7 +63,7 @@ export const CsvUploadManageDataSource = ({
                   defaultMessage="There was an error retrieving previous CSV uploads."
                 />
               }
-              color={'danger'}
+              color="danger"
             />
           )}
           {isLoading && <EuiLoadingSpinner size="l" />}
@@ -89,7 +89,7 @@ export const CsvUploadManageDataSource = ({
           disabled={isError || isLoading}
           onClick={showImportFileModal}
           fullWidth={false}
-          iconType={'plusInCircle'}
+          iconType="plusInCircle"
         >
           <FormattedMessage
             id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.text"

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index.tsx
@@ -5,26 +5,14 @@
  * 2.0.
  */
 
-import {
-  EuiButton,
-  EuiCallOut,
-  EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiIcon,
-  EuiSpacer,
-  EuiText,
-  EuiLoadingSpinner,
-} from '@elastic/eui';
+import { EuiCallOut, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState } from 'react';
-import { useBoolean } from '@kbn/react-hooks';
 import { CsvUploadManageDataSource } from './csv_upload_manage_data_source';
 import { HeaderPage } from '../../../common/components/header_page';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
-import { IndexSelectorModal } from '../privileged_user_monitoring_onboarding/components/select_index_modal';
-import { useFetchPrivilegedUserIndices } from '../privileged_user_monitoring_onboarding/hooks/use_fetch_privileged_user_indices';
+import { IndexImportManageDataSource } from './index_import_manage_data_source';
 
 export interface AddDataSourceResult {
   successful: boolean;
@@ -33,28 +21,23 @@ export interface AddDataSourceResult {
 
 export const PrivilegedUserMonitoringManageDataSources = ({
   onBackToDashboardClicked,
-  onDone,
 }: {
   onBackToDashboardClicked: () => void;
-  onDone: (userCount: number) => void;
 }) => {
   const spaceId = useSpaceId();
   const [addDataSourceResult, setAddDataSourceResult] = useState<AddDataSourceResult | undefined>();
-  const [isIndexModalOpen, { on: showIndexModal, off: hideIndexModal }] = useBoolean(false);
-
-  const { data: indices = [], isFetching } = useFetchPrivilegedUserIndices(undefined);
 
   return (
     <>
       <EuiButtonEmpty
-        flush={'left'}
-        iconType={'arrowLeft'}
-        iconSide={'left'}
+        flush="left"
+        iconType="arrowLeft"
+        iconSide="left"
         onClick={onBackToDashboardClicked}
       >
         <FormattedMessage
           id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.back"
-          defaultMessage={'Back to privileged user monitoring'}
+          defaultMessage="Back to privileged user monitoring"
         />
       </EuiButtonEmpty>
       <HeaderPage
@@ -62,79 +45,45 @@ export const PrivilegedUserMonitoringManageDataSources = ({
         title={
           <FormattedMessage
             id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.title"
-            defaultMessage={'Manage data sources'}
+            defaultMessage="Manage data sources"
           />
         }
       />
       {addDataSourceResult?.successful && (
         <>
           <EuiCallOut
-            title={i18n.translate(
-              'xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.successMessage',
-              {
-                defaultMessage:
-                  'New data source of privileged users successfully set up: {userCount} users added',
-                values: { userCount: addDataSourceResult.userCount },
-              }
-            )}
+            title={
+              addDataSourceResult.userCount > 0
+                ? i18n.translate(
+                    'xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.successMessage',
+                    {
+                      defaultMessage:
+                        'New data source of privileged users successfully set up: {userCount} users added',
+                      values: { userCount: addDataSourceResult.userCount },
+                    }
+                  )
+                : i18n.translate(
+                    'xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.successMessageWithoutUserCount',
+                    {
+                      defaultMessage: 'New data source of privileged users successfully set up',
+                    }
+                  )
+            }
             color="success"
-            iconType={'check'}
+            iconType="check"
           />
-          <EuiSpacer size={'l'} />
+          <EuiSpacer size="l" />
         </>
       )}
-      <EuiFlexGroup alignItems={'flexStart'} direction={'column'}>
-        <EuiFlexGroup gutterSize={'s'} alignItems={'center'}>
-          <EuiIcon size={'l'} type={'indexOpen'} />
-          <EuiText>
-            <h1>
-              <FormattedMessage
-                id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices"
-                defaultMessage="Indices"
-              />
-            </h1>
-          </EuiText>
-        </EuiFlexGroup>
-        <EuiText>
-          <p>
-            <FormattedMessage
-              id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.infoText"
-              defaultMessage="One or more indices containing the user.name field. All user names in the indices, specified in the user.name field, will be defined as privileged users."
-            />
-          </p>
 
-          <h4>
-            {isFetching && <EuiLoadingSpinner size="m" data-test-subj="loading-indices-spinner" />}
-            {indices.length === 0 && (
-              <FormattedMessage
-                id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.noIndicesAdded"
-                defaultMessage="No indices added"
-              />
-            )}
-            {indices.length > 0 && (
-              <FormattedMessage
-                id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.numIndicesAdded"
-                defaultMessage="{indexCount, plural, one {# index} other {# indices}} added"
-                values={{ indexCount: indices.length }}
-              />
-            )}
-          </h4>
-        </EuiText>
-        <EuiButton fullWidth={false} iconType={'plusInCircle'} onClick={showIndexModal}>
-          <FormattedMessage
-            id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.btnText"
-            defaultMessage="Select index"
-          />
-        </EuiButton>
-      </EuiFlexGroup>
-      <EuiSpacer size={'xxl'} />
+      <IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />
+      <EuiSpacer size="xxl" />
       {spaceId && (
         <CsvUploadManageDataSource
           setAddDataSourceResult={setAddDataSourceResult}
           namespace={spaceId}
         />
       )}
-      {isIndexModalOpen && <IndexSelectorModal onClose={hideIndexModal} onImport={onDone} />}
     </>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index_import_manage_data_source.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index_import_manage_data_source.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { IndexImportManageDataSource } from './index_import_manage_data_source';
+import { TestProviders } from '../../../common/mock';
+
+const mockUseFetchMonitoredIndices = jest.fn().mockImplementation(() => ({
+  data: [],
+  isFetching: false,
+  refetch: jest.fn(),
+}));
+
+jest.mock('../privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices', () => ({
+  useFetchMonitoredIndices: () => mockUseFetchMonitoredIndices(),
+}));
+
+jest.mock('../../api/api', () => ({
+  useEntityAnalyticsRoutes: () => ({
+    updatePrivMonMonitoredIndices: jest.fn(),
+    registerPrivMonMonitoredIndices: jest.fn(),
+  }),
+}));
+
+describe('IndexImportManageDataSource', () => {
+  const setAddDataSourceResult = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders indices header and info text', () => {
+    render(<IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />, {
+      wrapper: TestProviders,
+    });
+
+    expect(
+      screen.getByText(/One or more indices containing the user\.name field/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows "No indices added" when there are no indices', () => {
+    render(<IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />, {
+      wrapper: TestProviders,
+    });
+    expect(screen.getByText(/No indices added/i)).toBeInTheDocument();
+  });
+
+  it('shows loading spinner when isFetching is true', () => {
+    mockUseFetchMonitoredIndices.mockImplementation(() => ({
+      data: [],
+      isFetching: true,
+      refetch: jest.fn(),
+    }));
+
+    render(<IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />, {
+      wrapper: TestProviders,
+    });
+    expect(screen.getByTestId('loading-indices-spinner')).toBeInTheDocument();
+  });
+
+  it('shows number of indices when indices exist', () => {
+    mockUseFetchMonitoredIndices.mockImplementation(() => ({
+      data: [{ indexPattern: 'foo,bar,baz' }],
+      isFetching: false,
+      refetch: jest.fn(),
+    }));
+
+    render(<IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />, {
+      wrapper: TestProviders,
+    });
+    expect(screen.getByText(/3 indices added/i)).toBeInTheDocument();
+  });
+
+  it('opens and closes the index selector modal', () => {
+    render(<IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />, {
+      wrapper: TestProviders,
+    });
+    fireEvent.click(screen.getByText(/Select index/i));
+    expect(screen.getByTestId('index-selector-modal')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByTestId('index-selector-modal')).not.toBeInTheDocument();
+  });
+
+  it('calls setAddDataSourceResult and refetch on import', async () => {
+    const refetch = jest.fn();
+
+    mockUseFetchMonitoredIndices.mockImplementation(() => ({
+      data: [{ indexPattern: 'foo,bar,baz' }],
+      isFetching: false,
+      refetch,
+    }));
+
+    render(<IndexImportManageDataSource setAddDataSourceResult={setAddDataSourceResult} />, {
+      wrapper: TestProviders,
+    });
+    fireEvent.click(screen.getByText(/Select index/i));
+    fireEvent.click(screen.getByText('Add privileged users'));
+    await waitFor(() => {
+      expect(setAddDataSourceResult).toHaveBeenCalledWith({ successful: true, userCount: 0 });
+      expect(refetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index_import_manage_data_source.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_manage_data_sources/index_import_manage_data_source.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButton, EuiLoadingSpinner, EuiFlexGroup, EuiIcon, EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useBoolean } from '@kbn/react-hooks';
+import { IndexSelectorModal } from '../privileged_user_monitoring_onboarding/components/select_index_modal';
+import { useFetchMonitoredIndices } from '../privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices';
+import type { AddDataSourceResult } from '.';
+
+export const IndexImportManageDataSource = ({
+  setAddDataSourceResult,
+}: {
+  setAddDataSourceResult: (result: AddDataSourceResult) => void;
+}) => {
+  const [isIndexModalOpen, { on: showIndexModal, off: hideIndexModal }] = useBoolean(false);
+  const { data: datasources = [], isFetching, refetch } = useFetchMonitoredIndices();
+  const monitoredDataSource = datasources[0];
+  const monitoredIndices = monitoredDataSource?.indexPattern
+    ? monitoredDataSource.indexPattern.split(',')
+    : [];
+
+  const onImport = async () => {
+    hideIndexModal();
+    setAddDataSourceResult({ successful: true, userCount: 0 });
+    await refetch();
+  };
+
+  return (
+    <>
+      <EuiFlexGroup alignItems="flexStart" direction="column">
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiIcon size="l" type="indexOpen" />
+          <EuiText>
+            <h1>
+              <FormattedMessage
+                id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices"
+                defaultMessage="Indices"
+              />
+            </h1>
+          </EuiText>
+        </EuiFlexGroup>
+        <EuiText>
+          <p>
+            <FormattedMessage
+              id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.infoText"
+              defaultMessage="One or more indices containing the user.name field. All user names in the indices, specified in the user.name field, will be defined as privileged users."
+            />
+          </p>
+
+          <h4>
+            {isFetching && <EuiLoadingSpinner size="m" data-test-subj="loading-indices-spinner" />}
+            {monitoredIndices.length === 0 && (
+              <FormattedMessage
+                id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.noIndicesAdded"
+                defaultMessage="No indices added"
+              />
+            )}
+            {monitoredIndices.length > 0 && (
+              <FormattedMessage
+                id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.numIndicesAdded"
+                defaultMessage="{indexCount, plural, one {# index} other {# indices}} added"
+                values={{ indexCount: monitoredIndices.length }}
+              />
+            )}
+          </h4>
+        </EuiText>
+        <EuiButton fullWidth={false} iconType="plusInCircle" onClick={showIndexModal}>
+          <FormattedMessage
+            id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.manageDataSources.indices.btnText"
+            defaultMessage="Select index"
+          />
+        </EuiButton>
+      </EuiFlexGroup>
+
+      {isIndexModalOpen && (
+        <IndexSelectorModal
+          onClose={hideIndexModal}
+          onImport={onImport}
+          editDataSource={monitoredDataSource}
+        />
+      )}
+    </>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/select_index_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/select_index_modal.tsx
@@ -48,18 +48,27 @@ export const DEBOUNCE_OPTIONS = { wait: 300 };
 export const IndexSelectorModal = ({
   onClose,
   onImport,
+  editDataSource,
 }: {
   onClose: () => void;
   onImport: (userCount: number) => void;
+  editDataSource?: {
+    id: string;
+    indexPattern?: string;
+  };
 }) => {
+  const [selectedOptions, setSelected] = useState<Array<EuiComboBoxOptionOption<string>>>(
+    editDataSource?.indexPattern?.split(',').map((index) => ({ label: index })) ?? []
+  );
+
   const [isCreateIndexModalOpen, { on: showCreateIndexModal, off: hideCreateIndexModal }] =
     useBoolean(false);
   const { addError } = useAppToasts();
   const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
   const { data: indices, isFetching, error, refetch } = useFetchPrivilegedUserIndices(searchQuery);
-  const [selectedOptions, setSelected] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
   const debouncedSetSearchQuery = useDebounceFn(setSearchQuery, DEBOUNCE_OPTIONS);
-  const { registerPrivMonMonitoredIndices } = useEntityAnalyticsRoutes();
+  const { registerPrivMonMonitoredIndices, updatePrivMonMonitoredIndices } =
+    useEntityAnalyticsRoutes();
   const options = useMemo(
     () =>
       indices?.map((index) => ({
@@ -76,11 +85,24 @@ export const IndexSelectorModal = ({
 
   const addPrivilegedUsers = useCallback(async () => {
     if (selectedOptions.length > 0) {
-      await registerPrivMonMonitoredIndices(selectedOptions.map(({ label }) => label).join(','));
+      if (editDataSource?.id) {
+        await updatePrivMonMonitoredIndices(
+          editDataSource.id,
+          selectedOptions.map(({ label }) => label).join(',')
+        );
+      } else {
+        await registerPrivMonMonitoredIndices(selectedOptions.map(({ label }) => label).join(','));
+      }
 
       onImport(0); // The API does not return the user count because it is not available at this point.
     }
-  }, [onImport, registerPrivMonMonitoredIndices, selectedOptions]);
+  }, [
+    editDataSource?.id,
+    onImport,
+    registerPrivMonMonitoredIndices,
+    selectedOptions,
+    updatePrivMonMonitoredIndices,
+  ]);
 
   const onCreateIndex = useCallback(
     (indexName: string) => {
@@ -88,13 +110,13 @@ export const IndexSelectorModal = ({
       setSelected(selectedOptions.concat({ label: indexName }));
       refetch();
     },
-    [hideCreateIndexModal, refetch, selectedOptions]
+    [hideCreateIndexModal, refetch, selectedOptions, setSelected]
   );
 
   return isCreateIndexModalOpen ? (
     <CreateIndexModal onClose={hideCreateIndexModal} onCreate={onCreateIndex} />
   ) : (
-    <EuiModal onClose={onClose} maxWidth="624px">
+    <EuiModal onClose={onClose} maxWidth="624px" data-test-subj="index-selector-modal">
       <EuiModalHeader>
         <EuiModalHeaderTitle>
           <FormattedMessage

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/hooks/use_fetch_monitored_indices.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useEntityAnalyticsRoutes } from '../../../api/api';
+
+export const useFetchMonitoredIndices = () => {
+  const { listPrivMonMonitoredIndices } = useEntityAnalyticsRoutes();
+  return useQuery(
+    ['POST', 'LIST_PRIVILEGED_USER_MONITORED_INDICES'],
+    ({ signal }) => listPrivMonMonitoredIndices({ signal }),
+    {
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
+    }
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -318,7 +318,6 @@ export const EntityAnalyticsPrivilegedUserMonitoringPage = () => {
         {state.type === 'manageDataSources' && (
           <PrivilegedUserMonitoringManageDataSources
             onBackToDashboardClicked={onBackToDashboardClicked}
-            onDone={initEngineCallBack}
           />
         )}
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/monitoring_entity_source_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/monitoring_entity_source_data_client.test.ts
@@ -12,7 +12,11 @@ import {
   loggingSystemMock,
 } from '@kbn/core/server/mocks';
 import { monitoringEntitySourceTypeName } from './saved_objects';
-import type { SavedObject, SavedObjectsFindResponse } from '@kbn/core/server';
+import type {
+  SavedObject,
+  SavedObjectsClientContract,
+  SavedObjectsFindResponse,
+} from '@kbn/core/server';
 
 describe('MonitoringEntitySourceDataClient', () => {
   const mockSavedObjectClient = savedObjectsClientMock.create();
@@ -33,6 +37,7 @@ describe('MonitoringEntitySourceDataClient', () => {
     type: 'test-type',
     name: 'Test Source',
     indexPattern: 'test-index-pattern',
+    managed: false,
     matchers: [
       {
         fields: ['user.role'],
@@ -56,10 +61,12 @@ describe('MonitoringEntitySourceDataClient', () => {
         (err as Error & { output?: { statusCode: number } }).output = { statusCode: 404 };
         throw err;
       });
-      defaultOpts.soClient.find.mockResolvedValue({
-        total: 0,
-        saved_objects: [],
-      } as unknown as SavedObjectsFindResponse<unknown, unknown>);
+      defaultOpts.soClient.asScopedToNamespace.mockReturnValue({
+        find: jest.fn().mockResolvedValue({
+          total: 0,
+          saved_objects: [],
+        }),
+      } as unknown as SavedObjectsClientContract);
 
       defaultOpts.soClient.create.mockResolvedValue({
         id: 'temp-id', // TODO: update to use dynamic ID
@@ -69,16 +76,84 @@ describe('MonitoringEntitySourceDataClient', () => {
       });
 
       const result = await dataClient.init(testDescriptor);
+      const id = `entity-analytics-monitoring-entity-source-${namespace}-${testDescriptor.type}-${testDescriptor.indexPattern}`;
 
       expect(defaultOpts.soClient.create).toHaveBeenCalledWith(
         monitoringEntitySourceTypeName,
         testDescriptor,
         {
-          id: `entity-analytics-monitoring-entity-source-${namespace}-${testDescriptor.type}-${testDescriptor.indexPattern}`,
+          id,
         }
       );
 
-      expect(result).toEqual(testDescriptor);
+      expect(result).toEqual({ ...testDescriptor, managed: false, id });
+    });
+
+    it('should update Monitoring Entity Source Sync Config Successfully when calling init when the SO already exists', async () => {
+      const existingDescriptor = {
+        total: 1,
+        saved_objects: [
+          {
+            attributes: testDescriptor,
+            id: 'entity-analytics-monitoring-entity-source-test-namespace-test-type-test-index-pattern',
+          },
+        ],
+      } as unknown as SavedObjectsFindResponse<unknown, unknown>;
+
+      const testSourceObject = {
+        filter: {},
+        indexPattern: 'test-index-pattern',
+        matchers: [
+          {
+            fields: ['user.role'],
+            values: ['admin'],
+          },
+        ],
+        name: 'Test Source',
+        type: 'test-type',
+        managed: false,
+      };
+
+      defaultOpts.soClient.asScopedToNamespace.mockReturnValue({
+        find: jest.fn().mockResolvedValue(existingDescriptor),
+      } as unknown as SavedObjectsClientContract);
+
+      defaultOpts.soClient.update.mockResolvedValue({
+        id: 'entity-analytics-monitoring-entity-source-test-namespace-test-type-test-index-pattern',
+        type: monitoringEntitySourceTypeName,
+        attributes: { ...testDescriptor, name: 'Updated Source' },
+        references: [],
+      });
+
+      const updatedDescriptor = { ...testDescriptor, name: 'Updated Source' };
+      const result = await dataClient.init(testDescriptor);
+
+      expect(defaultOpts.soClient.update).toHaveBeenCalledWith(
+        monitoringEntitySourceTypeName,
+        `entity-analytics-monitoring-entity-source-${namespace}-${testDescriptor.type}-${testDescriptor.indexPattern}`,
+        testSourceObject,
+        { refresh: 'wait_for' }
+      );
+
+      expect(result).toEqual(updatedDescriptor);
+    });
+
+    it('should not create Monitoring Entity Source Sync Config when a SO already exist with the same name', async () => {
+      const existingSavedObject = {
+        id: 'unique-id',
+        attributes: testDescriptor,
+      } as unknown as SavedObject<unknown>;
+
+      defaultOpts.soClient.asScopedToNamespace.mockReturnValue({
+        find: jest.fn().mockResolvedValue({
+          total: 1,
+          saved_objects: [existingSavedObject],
+        }),
+      } as unknown as SavedObjectsClientContract);
+
+      await expect(dataClient.init(testDescriptor)).rejects.toThrow(
+        `A monitoring entity source with the name "${testDescriptor.name}" already exists.`
+      );
     });
   });
 
@@ -101,46 +176,37 @@ describe('MonitoringEntitySourceDataClient', () => {
 
   describe('update', () => {
     it('should update Monitoring Entity Source Sync Config Successfully', async () => {
-      const existingDescriptor = {
-        total: 1,
-        saved_objects: [{ attributes: testDescriptor }],
-      } as unknown as SavedObjectsFindResponse<unknown, unknown>;
-
-      const testSourceObject = {
-        filter: {},
-        indexPattern: 'test-index-pattern',
-        matchers: [
-          {
-            fields: ['user.role'],
-            values: ['admin'],
-          },
-        ],
-        name: 'Test Source',
-        type: 'test-type',
+      const id = 'temp-id'; // TODO: https://github.com/elastic/security-team/issues/12851
+      const updateDescriptor = {
+        ...testDescriptor,
+        managed: false,
+        name: 'Updated Source',
+        id, // it preserves the id when updating
       };
 
-      defaultOpts.soClient.find.mockResolvedValue(
-        existingDescriptor as unknown as SavedObjectsFindResponse<unknown, unknown>
-      );
+      defaultOpts.soClient.asScopedToNamespace.mockReturnValue({
+        find: jest.fn().mockResolvedValue({
+          total: 0,
+          saved_objects: [],
+        }),
+      } as unknown as SavedObjectsClientContract);
 
       defaultOpts.soClient.update.mockResolvedValue({
-        id: `temp-id`, // TODO: https://github.com/elastic/security-team/issues/12851
+        id,
         type: monitoringEntitySourceTypeName,
-        attributes: { ...testDescriptor, name: 'Updated Source' },
+        attributes: updateDescriptor,
         references: [],
       });
 
-      const updatedDescriptor = { ...testDescriptor, name: 'Updated Source' };
-      const result = await dataClient.init(testDescriptor);
-
+      const result = await dataClient.update(updateDescriptor);
       expect(defaultOpts.soClient.update).toHaveBeenCalledWith(
         monitoringEntitySourceTypeName,
-        `entity-analytics-monitoring-entity-source-${namespace}-${testDescriptor.type}-${testDescriptor.indexPattern}`,
-        testSourceObject,
+        id,
+        updateDescriptor,
+
         { refresh: 'wait_for' }
       );
-
-      expect(result).toEqual(updatedDescriptor);
+      expect(result).toEqual(updateDescriptor);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/monitoring_entity_source_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/monitoring_entity_source_data_client.ts
@@ -7,8 +7,9 @@
 
 import type { IScopedClusterClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type {
-  MonitoringEntitySourceDescriptor,
-  MonitoringEntitySourceResponse,
+  CreateMonitoringEntitySource,
+  ListEntitySourcesRequestQuery,
+  MonitoringEntitySource,
 } from '../../../../common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import { MonitoringEntitySourceDescriptorClient } from './saved_objects';
 
@@ -28,9 +29,7 @@ export class MonitoringEntitySourceDataClient {
     });
   }
 
-  public async init(
-    input: MonitoringEntitySourceDescriptor
-  ): Promise<MonitoringEntitySourceResponse> {
+  public async init(input: CreateMonitoringEntitySource) {
     const descriptor = await this.monitoringEntitySourceClient.create({
       ...input,
     });
@@ -38,12 +37,12 @@ export class MonitoringEntitySourceDataClient {
     return descriptor;
   }
 
-  public async get(): Promise<MonitoringEntitySourceResponse> {
+  public async get(): Promise<MonitoringEntitySource> {
     this.log('debug', 'Getting Monitoring Entity Source Sync saved object');
     return this.monitoringEntitySourceClient.get();
   }
 
-  public async update(update: Partial<MonitoringEntitySourceResponse>) {
+  public async update(update: Partial<MonitoringEntitySource> & { id: string }) {
     this.log('debug', 'Updating Monitoring Entity Source Sync saved object');
 
     const sanitizedUpdate = {
@@ -62,9 +61,9 @@ export class MonitoringEntitySourceDataClient {
     return this.monitoringEntitySourceClient.delete();
   }
 
-  public async list(): Promise<MonitoringEntitySourceResponse[]> {
+  public async list(query: ListEntitySourcesRequestQuery): Promise<MonitoringEntitySource[]> {
     this.log('debug', 'Finding all Monitoring Entity Source Sync saved objects');
-    return this.monitoringEntitySourceClient.findAll();
+    return this.monitoringEntitySourceClient.findAll(query);
   }
 
   private log(level: Exclude<keyof Logger, 'get' | 'log' | 'isLevelEnabled'>, msg: string) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
@@ -69,7 +69,6 @@ import { privilegedUserParserTransform } from './users/privileged_user_parse_tra
 import type { Accumulator } from './users/bulk/utils';
 import { accumulateUpsertResults } from './users/bulk/utils';
 import type { PrivMonBulkUser, PrivMonUserSource } from './types';
-import type { MonitoringEntitySourceDescriptor } from './saved_objects';
 import {
   PrivilegeMonitoringEngineDescriptorClient,
   MonitoringEntitySourceDescriptorClient,
@@ -435,8 +434,7 @@ export class PrivilegeMonitoringDataClient {
    */
   public async plainIndexSync() {
     // get all monitoring index source saved objects of type 'index'
-    const indexSources: MonitoringEntitySourceDescriptor[] =
-      await this.monitoringIndexSourceClient.findByIndex();
+    const indexSources = await this.monitoringIndexSourceClient.findByIndex();
     if (indexSources.length === 0) {
       this.log('debug', 'No monitoring index sources found. Skipping sync.');
       return;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/monitoring_entity_source/list.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/monitoring_entity_source/list.ts
@@ -8,9 +8,13 @@
 import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type { IKibanaResponse, Logger } from '@kbn/core/server';
-import type { MonitoringEntitySourceResponse } from '../../../../../../common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
+import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
 import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
+import {
+  ListEntitySourcesRequestQuery,
+  type ListEntitySourcesResponse,
+} from '../../../../../../common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 
 export const listMonitoringEntitySourceRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -30,19 +34,19 @@ export const listMonitoringEntitySourceRoute = (
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: {},
+        validate: {
+          request: {
+            query: buildRouteValidationWithZod(ListEntitySourcesRequestQuery),
+          },
+        },
       },
-      async (
-        context,
-        request,
-        response
-      ): Promise<IKibanaResponse<MonitoringEntitySourceResponse[]>> => {
+      async (context, request, response): Promise<IKibanaResponse<ListEntitySourcesResponse>> => {
         const siemResponse = buildSiemResponse(response);
 
         try {
           const secSol = await context.securitySolution;
           const client = secSol.getMonitoringEntitySourceDataClient();
-          const body = await client.list();
+          const body = await client.list(request.query);
 
           return response.ok({ body });
         } catch (e) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/monitoring_entity_source.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/monitoring_entity_source.ts
@@ -5,6 +5,11 @@
  * 2.0.
  */
 import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type {
+  CreateMonitoringEntitySource,
+  ListEntitySourcesRequestQuery,
+  MonitoringEntitySource,
+} from '../../../../../common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import { monitoringEntitySourceTypeName } from './monitoring_entity_source_type';
 
 export interface MonitoringEntitySourceDependencies {
@@ -12,25 +17,10 @@ export interface MonitoringEntitySourceDependencies {
   namespace: string;
 }
 
-export interface MonitoringEntitySourceDescriptor {
-  type: string;
-  name: string;
-  managed?: boolean;
-  indexPattern?: string;
-  enabled?: boolean;
-  error?: string;
-  integrationName?: string;
-  matchers?: Array<{
-    fields: string[];
-    values: string[];
-  }>;
-  filter?: Record<string, unknown>;
-}
-
 export class MonitoringEntitySourceDescriptorClient {
   constructor(private readonly dependencies: MonitoringEntitySourceDependencies) {}
 
-  getDynamicSavedObjectId(attributes: MonitoringEntitySourceDescriptor) {
+  getDynamicSavedObjectId(attributes: CreateMonitoringEntitySource) {
     const { type, indexPattern, integrationName } = this.assertValidIdFields(attributes);
     const sourceName = indexPattern || integrationName;
     return `entity-analytics-monitoring-entity-source-${this.dependencies.namespace}-${type}${
@@ -38,13 +28,14 @@ export class MonitoringEntitySourceDescriptorClient {
     }`;
   }
 
-  async create(attributes: MonitoringEntitySourceDescriptor) {
+  async create(attributes: CreateMonitoringEntitySource) {
     const savedObjectId = this.getDynamicSavedObjectId(attributes);
+    await this.assertNameUniqueness({ ...attributes, id: savedObjectId });
 
     try {
       // If exists, update it.
       const { attributes: updated } =
-        await this.dependencies.soClient.update<MonitoringEntitySourceDescriptor>(
+        await this.dependencies.soClient.update<MonitoringEntitySource>(
           monitoringEntitySourceTypeName,
           savedObjectId,
           attributes,
@@ -56,37 +47,44 @@ export class MonitoringEntitySourceDescriptorClient {
 
       // Does not exist, create it.
       const { attributes: created } =
-        await this.dependencies.soClient.create<MonitoringEntitySourceDescriptor>(
+        await this.dependencies.soClient.create<CreateMonitoringEntitySource>(
           monitoringEntitySourceTypeName,
-          attributes,
+          { ...attributes, managed: attributes.managed ?? false }, // Ensure managed is set to true on creation
           { id: savedObjectId }
         );
-      return created;
+      return { ...created, id: savedObjectId };
     }
   }
 
-  async update(monitoringEntitySource: Partial<MonitoringEntitySourceDescriptor>) {
-    const id = this.getDynamicSavedObjectId(
-      monitoringEntitySource as MonitoringEntitySourceDescriptor
+  async update(monitoringEntitySource: Partial<MonitoringEntitySource> & { id: string }) {
+    await this.assertNameUniqueness(monitoringEntitySource);
+
+    const { attributes } = await this.dependencies.soClient.update<MonitoringEntitySource>(
+      monitoringEntitySourceTypeName,
+      monitoringEntitySource.id,
+      monitoringEntitySource,
+      { refresh: 'wait_for' }
     );
-    const { attributes } =
-      await this.dependencies.soClient.update<MonitoringEntitySourceDescriptor>(
-        monitoringEntitySourceTypeName,
-        id,
-        monitoringEntitySource,
-        { refresh: 'wait_for' }
-      );
+
     return attributes;
   }
 
-  async find() {
+  async find(query?: ListEntitySourcesRequestQuery) {
     const scopedSoClient = this.dependencies.soClient.asScopedToNamespace(
       this.dependencies.namespace
     );
-    return scopedSoClient.find<MonitoringEntitySourceDescriptor>({
+
+    return scopedSoClient.find<MonitoringEntitySource>({
       type: monitoringEntitySourceTypeName,
+      filter: this.getQueryFilters(query),
     });
   }
+
+  private getQueryFilters = (query?: ListEntitySourcesRequestQuery) => {
+    return Object.entries(query ?? {})
+      .map(([key, value]) => `${monitoringEntitySourceTypeName}.attributes.${key}: ${value}`)
+      .join(' and ');
+  };
 
   /**
    * Need to update to understand the id based on the
@@ -96,7 +94,7 @@ export class MonitoringEntitySourceDescriptorClient {
    * or use a dynamic ID based on the type and indexPattern/integrationName.
    */
   async get() {
-    const { attributes } = await this.dependencies.soClient.get<MonitoringEntitySourceDescriptor>(
+    const { attributes } = await this.dependencies.soClient.get<MonitoringEntitySource>(
       monitoringEntitySourceTypeName,
       'temp-id' // TODO: https://github.com/elastic/security-team/issues/12851
     );
@@ -114,26 +112,43 @@ export class MonitoringEntitySourceDescriptorClient {
     await this.dependencies.soClient.delete(monitoringEntitySourceTypeName, 'temp-id'); // TODO: https://github.com/elastic/security-team/issues/12851
   }
 
-  public async findByIndex(): Promise<MonitoringEntitySourceDescriptor[]> {
+  public async findByIndex(): Promise<MonitoringEntitySource[]> {
     const result = await this.find();
     return result.saved_objects
       .filter((so) => so.attributes.type === 'index')
-      .map((so) => so.attributes);
+      .map((so) => ({ ...so.attributes, id: so.id }));
   }
 
-  public async findAll(): Promise<MonitoringEntitySourceDescriptor[]> {
-    const result = await this.find();
+  public async findAll(query: ListEntitySourcesRequestQuery): Promise<MonitoringEntitySource[]> {
+    const result = await this.find(query);
     return result.saved_objects
       .filter((so) => so.attributes.type !== 'csv') // from the spec we are not using CSV on monitoring
-      .map((so) => so.attributes);
+      .map((so) => ({ ...so.attributes, id: so.id }));
   }
 
-  public assertValidIdFields(
-    source: Partial<MonitoringEntitySourceDescriptor>
-  ): MonitoringEntitySourceDescriptor {
+  private assertValidIdFields(source: Partial<MonitoringEntitySource>): MonitoringEntitySource {
     if (!source.type || (!source.indexPattern && !source.integrationName)) {
       throw new Error('Missing required fields for ID generation');
     }
-    return source as MonitoringEntitySourceDescriptor;
+    return source as MonitoringEntitySource;
+  }
+
+  private async assertNameUniqueness(attributes: Partial<MonitoringEntitySource>): Promise<void> {
+    if (attributes.name) {
+      const { saved_objects: savedObjects } = await this.find({
+        name: attributes.name,
+      });
+
+      // Exclude the current entity source if updating
+      const filteredSavedObjects = attributes.id
+        ? savedObjects.filter((so) => so.id !== attributes.id)
+        : savedObjects;
+
+      if (filteredSavedObjects.length > 0) {
+        throw new Error(
+          `A monitoring entity source with the name "${attributes.name}" already exists.`
+        );
+      }
+    }
   }
 }

--- a/x-pack/test/api_integration/services/security_solution_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_api.gen.ts
@@ -27,6 +27,7 @@ import { ConfigureRiskEngineSavedObjectRequestBodyInput } from '@kbn/security-so
 import { CopyTimelineRequestBodyInput } from '@kbn/security-solution-plugin/common/api/timeline/copy_timeline/copy_timeline_route.gen';
 import { CreateAlertsMigrationRequestBodyInput } from '@kbn/security-solution-plugin/common/api/detection_engine/signals_migration/create_signals_migration/create_signals_migration.gen';
 import { CreateAssetCriticalityRecordRequestBodyInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/asset_criticality/create_asset_criticality.gen';
+import { CreateEntitySourceRequestBodyInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import { CreatePrivilegesImportIndexRequestBodyInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/monitoring/create_index.gen';
 import { CreatePrivMonUserRequestBodyInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/users/create.gen';
 import { CreateRuleRequestBodyInput } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management/crud/create_rule/create_rule_route.gen';
@@ -45,6 +46,7 @@ import {
   DeleteEntityEngineRequestQueryInput,
   DeleteEntityEngineRequestParamsInput,
 } from '@kbn/security-solution-plugin/common/api/entity_analytics/entity_store/engine/delete.gen';
+import { DeleteEntitySourceRequestParamsInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import { DeleteNoteRequestBodyInput } from '@kbn/security-solution-plugin/common/api/timeline/delete_note/delete_note_route.gen';
 import { DeletePrivMonUserRequestParamsInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/users/delete.gen';
 import { DeleteRuleRequestQueryInput } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management/crud/delete_rule/delete_rule_route.gen';
@@ -83,6 +85,7 @@ import {
   GetEndpointSuggestionsRequestBodyInput,
 } from '@kbn/security-solution-plugin/common/api/endpoint/suggestions/get_suggestions.gen';
 import { GetEntityEngineRequestParamsInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/entity_store/engine/get.gen';
+import { GetEntitySourceRequestParamsInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import { GetEntityStoreStatusRequestQueryInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/entity_store/status.gen';
 import { GetNotesRequestQueryInput } from '@kbn/security-solution-plugin/common/api/timeline/get_notes/get_notes_route.gen';
 import { GetPolicyResponseRequestQueryInput } from '@kbn/security-solution-plugin/common/api/endpoint/policy/policy_response.gen';
@@ -124,6 +127,7 @@ import {
 } from '@kbn/security-solution-plugin/common/siem_migrations/model/api/rules/rule_migration.gen';
 import { InstallPrepackedTimelinesRequestBodyInput } from '@kbn/security-solution-plugin/common/api/timeline/install_prepackaged_timelines/install_prepackaged_timelines_route.gen';
 import { ListEntitiesRequestQueryInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/entity_store/entities/list_entities.gen';
+import { ListEntitySourcesRequestQueryInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import { ListPrivMonUsersRequestQueryInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/users/list.gen';
 import { PatchRuleRequestBodyInput } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management/crud/patch_rule/patch_rule_route.gen';
 import { PatchTimelineRequestBodyInput } from '@kbn/security-solution-plugin/common/api/timeline/patch_timelines/patch_timeline_route.gen';
@@ -157,6 +161,10 @@ import { StopEntityEngineRequestParamsInput } from '@kbn/security-solution-plugi
 import { StopRuleMigrationRequestParamsInput } from '@kbn/security-solution-plugin/common/siem_migrations/model/api/rules/rule_migration.gen';
 import { SuggestUserProfilesRequestQueryInput } from '@kbn/security-solution-plugin/common/api/detection_engine/users/suggest_user_profiles_route.gen';
 import { TriggerRiskScoreCalculationRequestBodyInput } from '@kbn/security-solution-plugin/common/api/entity_analytics/risk_engine/entity_calculation_route.gen';
+import {
+  UpdateEntitySourceRequestParamsInput,
+  UpdateEntitySourceRequestBodyInput,
+} from '@kbn/security-solution-plugin/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
 import {
   UpdatePrivMonUserRequestParamsInput,
   UpdatePrivMonUserRequestBodyInput,
@@ -330,6 +338,14 @@ If a record already exists for the specified entity, that record is overwritten 
         .post(routeWithNamespace('/api/asset_criticality', kibanaSpace))
         .set('kbn-xsrf', 'true')
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .send(props.body as object);
+    },
+    createEntitySource(props: CreateEntitySourceProps, kibanaSpace: string = 'default') {
+      return supertest
+        .post(routeWithNamespace('/api/entity_analytics/monitoring/entity_source', kibanaSpace))
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
@@ -510,6 +526,18 @@ For detailed information on Kibana actions and alerting, and additional API call
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
+    },
+    deleteEntitySource(props: DeleteEntitySourceProps, kibanaSpace: string = 'default') {
+      return supertest
+        .delete(
+          routeWithNamespace(
+            replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
+            kibanaSpace
+          )
+        )
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
     /**
      * Delete a note from a Timeline using the note ID.
@@ -949,6 +977,18 @@ finalize it.
         )
         .set('kbn-xsrf', 'true')
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
+    },
+    getEntitySource(props: GetEntitySourceProps, kibanaSpace: string = 'default') {
+      return supertest
+        .get(
+          routeWithNamespace(
+            replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
+            kibanaSpace
+          )
+        )
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
     getEntityStoreStatus(props: GetEntityStoreStatusProps, kibanaSpace: string = 'default') {
@@ -1402,6 +1442,14 @@ providing you with the most current and effective threat detection capabilities.
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
+    listEntitySources(props: ListEntitySourcesProps, kibanaSpace: string = 'default') {
+      return supertest
+        .get(routeWithNamespace('/api/entity_analytics/monitoring/entity_source/list', kibanaSpace))
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .query(props.query);
+    },
     listPrivMonUsers(props: ListPrivMonUsersProps, kibanaSpace: string = 'default') {
       return supertest
         .get(routeWithNamespace('/api/entity_analytics/monitoring/users/list', kibanaSpace))
@@ -1791,6 +1839,19 @@ The difference between the `id` and `rule_id` is that the `id` is a unique rule 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
+    updateEntitySource(props: UpdateEntitySourceProps, kibanaSpace: string = 'default') {
+      return supertest
+        .put(
+          routeWithNamespace(
+            replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
+            kibanaSpace
+          )
+        )
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .send(props.body as object);
+    },
     updatePrivMonUser(props: UpdatePrivMonUserProps, kibanaSpace: string = 'default') {
       return supertest
         .put(
@@ -1920,6 +1981,9 @@ export interface CreateAlertsMigrationProps {
 export interface CreateAssetCriticalityRecordProps {
   body: CreateAssetCriticalityRecordRequestBodyInput;
 }
+export interface CreateEntitySourceProps {
+  body: CreateEntitySourceRequestBodyInput;
+}
 export interface CreatePrivilegesImportIndexProps {
   body: CreatePrivilegesImportIndexRequestBodyInput;
 }
@@ -1949,6 +2013,9 @@ export interface DeleteAssetCriticalityRecordProps {
 export interface DeleteEntityEngineProps {
   query: DeleteEntityEngineRequestQueryInput;
   params: DeleteEntityEngineRequestParamsInput;
+}
+export interface DeleteEntitySourceProps {
+  params: DeleteEntitySourceRequestParamsInput;
 }
 export interface DeleteNoteProps {
   body: DeleteNoteRequestBodyInput;
@@ -2040,6 +2107,9 @@ export interface GetEndpointSuggestionsProps {
 export interface GetEntityEngineProps {
   params: GetEntityEngineRequestParamsInput;
 }
+export interface GetEntitySourceProps {
+  params: GetEntitySourceRequestParamsInput;
+}
 export interface GetEntityStoreStatusProps {
   query: GetEntityStoreStatusRequestQueryInput;
 }
@@ -2115,6 +2185,9 @@ export interface InstallPrepackedTimelinesProps {
 export interface ListEntitiesProps {
   query: ListEntitiesRequestQueryInput;
 }
+export interface ListEntitySourcesProps {
+  query: ListEntitySourcesRequestQueryInput;
+}
 export interface ListPrivMonUsersProps {
   query: ListPrivMonUsersRequestQueryInput;
 }
@@ -2189,6 +2262,10 @@ export interface SuggestUserProfilesProps {
 }
 export interface TriggerRiskScoreCalculationProps {
   body: TriggerRiskScoreCalculationRequestBodyInput;
+}
+export interface UpdateEntitySourceProps {
+  params: UpdateEntitySourceRequestParamsInput;
+  body: UpdateEntitySourceRequestBodyInput;
 }
 export interface UpdatePrivMonUserProps {
   params: UpdatePrivMonUserRequestParamsInput;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[SecuritySolution] [Bug] Fix Manage data sources page index import  (#226099)](https://github.com/elastic/kibana/pull/226099)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-07-07T12:39:14Z","message":"[SecuritySolution] [Bug] Fix Manage data sources page index import  (#226099)\n\nFix the Manage Data Sources page index import by implementing the\ncreation, updating, deletion, and retrieval of entity source\nconfigurations. It includes updates to the TypeScript definitions, API\nschema, and client-side API methods to support these operations.\n\nAfter this change, the user will be able to create only one data source\nusing the UI.\n\n### API and types changes \n* Added new types (`CreateMonitoringEntitySource`,\n`UpdatedMonitoringEntitySource`, `MonitoringEntitySource`) with expanded\nfields for entity source configurations, such as `indexPattern`,\n`enabled`, `error`, and `matchers`.\n[[1]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72R18-R21)\n[[2]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72L39-R64)\n[[3]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72R76-R122)\n\n* Updated the API schema (`monitoring_entity_source.schema.yaml`) to\nreflect new entity source operations, including `CreateEntitySource`,\n`UpdateEntitySource`, `DeleteEntitySource`, `GetEntitySource`, and\n`ListEntitySources`. Added support for query parameters and refined\nresponse schema definitions.\n[[1]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L10-R30)\n[[2]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L42-R48)\n[[3]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L58-R72)\n[[4]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L78-R102)\n[[5]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L88-R114)\n[[6]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L128-R189)\n[[7]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1R219-R220)\n\n* Add a uniqueness assertion for the data source name.\n\n* Create the data source 'PUT' API that allows updates\n\n* Force the `managed` to be consistently defined by default\n\n* Update list data sources API to support filter params\n\n### UI changes\n* Extract `IndexImportManageDataSource` component to its file.\n* Stop calling the `init` API on updates\n* Implement the edit mode instead of creating a new data source on every\nsave\n  * Load the already added indices when editing\n* Fix the displayed added indices message to show the right value\n\n### Video\n\nhttps://github.com/user-attachments/assets/9d1c1ad1-09b9-49f0-8cea-1b640a26e954\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"8453edc55264144db5af97ab7ea13d727322c92d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v9.1.0","v9.2.0"],"title":"[SecuritySolution] [Bug] Fix Manage data sources page index import ","number":226099,"url":"https://github.com/elastic/kibana/pull/226099","mergeCommit":{"message":"[SecuritySolution] [Bug] Fix Manage data sources page index import  (#226099)\n\nFix the Manage Data Sources page index import by implementing the\ncreation, updating, deletion, and retrieval of entity source\nconfigurations. It includes updates to the TypeScript definitions, API\nschema, and client-side API methods to support these operations.\n\nAfter this change, the user will be able to create only one data source\nusing the UI.\n\n### API and types changes \n* Added new types (`CreateMonitoringEntitySource`,\n`UpdatedMonitoringEntitySource`, `MonitoringEntitySource`) with expanded\nfields for entity source configurations, such as `indexPattern`,\n`enabled`, `error`, and `matchers`.\n[[1]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72R18-R21)\n[[2]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72L39-R64)\n[[3]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72R76-R122)\n\n* Updated the API schema (`monitoring_entity_source.schema.yaml`) to\nreflect new entity source operations, including `CreateEntitySource`,\n`UpdateEntitySource`, `DeleteEntitySource`, `GetEntitySource`, and\n`ListEntitySources`. Added support for query parameters and refined\nresponse schema definitions.\n[[1]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L10-R30)\n[[2]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L42-R48)\n[[3]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L58-R72)\n[[4]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L78-R102)\n[[5]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L88-R114)\n[[6]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L128-R189)\n[[7]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1R219-R220)\n\n* Add a uniqueness assertion for the data source name.\n\n* Create the data source 'PUT' API that allows updates\n\n* Force the `managed` to be consistently defined by default\n\n* Update list data sources API to support filter params\n\n### UI changes\n* Extract `IndexImportManageDataSource` component to its file.\n* Stop calling the `init` API on updates\n* Implement the edit mode instead of creating a new data source on every\nsave\n  * Load the already added indices when editing\n* Fix the displayed added indices message to show the right value\n\n### Video\n\nhttps://github.com/user-attachments/assets/9d1c1ad1-09b9-49f0-8cea-1b640a26e954\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"8453edc55264144db5af97ab7ea13d727322c92d"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226099","number":226099,"mergeCommit":{"message":"[SecuritySolution] [Bug] Fix Manage data sources page index import  (#226099)\n\nFix the Manage Data Sources page index import by implementing the\ncreation, updating, deletion, and retrieval of entity source\nconfigurations. It includes updates to the TypeScript definitions, API\nschema, and client-side API methods to support these operations.\n\nAfter this change, the user will be able to create only one data source\nusing the UI.\n\n### API and types changes \n* Added new types (`CreateMonitoringEntitySource`,\n`UpdatedMonitoringEntitySource`, `MonitoringEntitySource`) with expanded\nfields for entity source configurations, such as `indexPattern`,\n`enabled`, `error`, and `matchers`.\n[[1]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72R18-R21)\n[[2]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72L39-R64)\n[[3]](diffhunk://#diff-b8c44f34825a1f7fa2c3f70fdda00f38b07e19ef8600e1a2e937660346d95c72R76-R122)\n\n* Updated the API schema (`monitoring_entity_source.schema.yaml`) to\nreflect new entity source operations, including `CreateEntitySource`,\n`UpdateEntitySource`, `DeleteEntitySource`, `GetEntitySource`, and\n`ListEntitySources`. Added support for query parameters and refined\nresponse schema definitions.\n[[1]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L10-R30)\n[[2]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L42-R48)\n[[3]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L58-R72)\n[[4]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L78-R102)\n[[5]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L88-R114)\n[[6]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1L128-R189)\n[[7]](diffhunk://#diff-e7f2de573ae15c6a3c3781b2a97b9875299c0674f81dd673d2bf9b3a6cf397f1R219-R220)\n\n* Add a uniqueness assertion for the data source name.\n\n* Create the data source 'PUT' API that allows updates\n\n* Force the `managed` to be consistently defined by default\n\n* Update list data sources API to support filter params\n\n### UI changes\n* Extract `IndexImportManageDataSource` component to its file.\n* Stop calling the `init` API on updates\n* Implement the edit mode instead of creating a new data source on every\nsave\n  * Load the already added indices when editing\n* Fix the displayed added indices message to show the right value\n\n### Video\n\nhttps://github.com/user-attachments/assets/9d1c1ad1-09b9-49f0-8cea-1b640a26e954\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"8453edc55264144db5af97ab7ea13d727322c92d"}}]}] BACKPORT-->