### PR TITLE
[9.1][Fleet] fix backfill agentless logic for all packages (#225767)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
@@ -90,6 +90,9 @@ async function createPackagePolicy(
   newPackagePolicy.policy_id = agentPolicy.id;
   newPackagePolicy.policy_ids = [agentPolicy.id];
   newPackagePolicy.name = await incrementPackageName(soClient, packageToInstall);
+  if (agentPolicy.supports_agentless) {
+    newPackagePolicy.supports_agentless = agentPolicy.supports_agentless;
+  }
 
   await packagePolicyService.create(soClient, esClient, newPackagePolicy, {
     spaceId: options.spaceId,

--- a/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.test.ts
@@ -8,9 +8,38 @@
 import { backfillPackagePolicySupportsAgentless } from './backfill_agentless';
 import { packagePolicyService } from './package_policy';
 
-jest.mock('./audit_logging', () => ({
-  auditLoggingService: {
-    writeCustomSoAuditLog: jest.fn(),
+jest.mock('.', () => ({
+  appContextService: {
+    getLogger: () => ({
+      debug: jest.fn(),
+    }),
+    getInternalUserSOClientForSpaceId: jest.fn(),
+    getInternalUserSOClientWithoutSpaceExtension: () => ({
+      find: jest.fn().mockImplementation((options) => {
+        if (options.type === 'ingest-agent-policies') {
+          return {
+            saved_objects: [{ id: 'agent_policy_1' }, { id: 'agent_policy_2' }],
+          };
+        } else {
+          return {
+            saved_objects: [
+              {
+                id: 'package_policy_1',
+                attributes: {
+                  inputs: [],
+                  policy_ids: ['agent_policy_1'],
+                  supports_agentless: false,
+                  package: {
+                    name: 'cloud_asset_inventory',
+                    version: '0.19.0',
+                  },
+                },
+              },
+            ],
+          };
+        }
+      }),
+    }),
   },
 }));
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.ts
@@ -53,7 +53,7 @@ export async function backfillPackagePolicySupportsAgentless(esClient: Elasticse
           'inputs',
           'package',
         ],
-        filter: `${savedObjectType}.attributes.package.name:cloud_security_posture AND (NOT ${savedObjectType}.attributes.supports_agentless:true) AND ${savedObjectType}.attributes.policy_ids:(${agentPolicyIds.join(
+        filter: `(NOT ${savedObjectType}.attributes.supports_agentless:true) AND ${savedObjectType}.attributes.policy_ids:(${agentPolicyIds.join(
           ' OR '
         )})`,
         perPage: SO_SEARCH_LIMIT,
@@ -65,7 +65,7 @@ export async function backfillPackagePolicySupportsAgentless(esClient: Elasticse
     .getLogger()
     .debug(
       `Backfilling supports_agentless on package policies: ${packagePoliciesToUpdate.map(
-        (policy) => policy.id
+        (policy: PackagePolicy) => policy.id
       )}`
     );
 
@@ -80,7 +80,7 @@ export async function backfillPackagePolicySupportsAgentless(esClient: Elasticse
 
     await pMap(
       packagePoliciesToUpdate,
-      (packagePolicy) => {
+      (packagePolicy: PackagePolicy) => {
         const soClient = appContextService.getInternalUserSOClientForSpaceId(
           packagePolicy.spaceIds?.[0]
         );


### PR DESCRIPTION
Backport https://github.com/elastic/kibana/pull/225767