### PR TITLE
replace uptime logger name

### DIFF
--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.test.ts
@@ -43,7 +43,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'uptime' } } }
       );
       expect(result).toEqual({
         body: {},
@@ -71,7 +71,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'uptime' } } }
       );
     });
   });
@@ -86,7 +86,7 @@ describe('UptimeEsClient', () => {
 
       expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
         meta: true,
-        context: { loggingOptions: { loggerName: 'synthetics' } },
+        context: { loggingOptions: { loggerName: 'uptime' } },
       });
       expect(result).toEqual({
         indices: 'heartbeat-*',
@@ -112,7 +112,7 @@ describe('UptimeEsClient', () => {
       await expect(uptimeEsClient.count(mockCountParams)).rejects.toThrow(mockError);
       expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
         meta: true,
-        context: { loggingOptions: { loggerName: 'synthetics' } },
+        context: { loggingOptions: { loggerName: 'uptime' } },
       });
     });
   });
@@ -166,7 +166,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*,synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'uptime' } } }
       );
     });
     it('appends synthetics-* in index for legacy alerts when settings are never saved', async () => {
@@ -195,7 +195,7 @@ describe('UptimeEsClient', () => {
           index: 'heartbeat-*,synthetics-*',
           ...mockSearchParams,
         },
-        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'uptime' } } }
       );
     });
     it('does not append synthetics-* to index for stack version 8.10.0 or later', async () => {
@@ -222,7 +222,7 @@ describe('UptimeEsClient', () => {
             match_all: {},
           },
         },
-        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'uptime' } } }
       );
 
       uptimeEsClient = new UptimeEsClient(savedObjectsClient, esClient, {
@@ -242,7 +242,7 @@ describe('UptimeEsClient', () => {
             match_all: {},
           },
         },
-        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+        { meta: true, context: { loggingOptions: { loggerName: 'uptime' } } }
       );
     });
   });

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/lib.ts
@@ -237,6 +237,6 @@ export function createEsParams<T extends estypes.SearchRequest>(params: T): T {
 
 function getElasticsearchRequestLoggingOptions(): ElasticsearchRequestLoggingOptions {
   return {
-    loggerName: 'synthetics',
+    loggerName: 'uptime',
   };
 }

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_details.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_details.test.ts.snap
@@ -58,7 +58,7 @@ Array [
   Object {
     "context": Object {
       "loggingOptions": Object {
-        "loggerName": "synthetics",
+        "loggerName": "uptime",
       },
     },
     "meta": true,
@@ -112,7 +112,7 @@ Array [
   Object {
     "context": Object {
       "loggingOptions": Object {
-        "loggerName": "synthetics",
+        "loggerName": "uptime",
       },
     },
     "meta": true,

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_duration.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/__snapshots__/get_monitor_duration.test.ts.snap
@@ -72,7 +72,7 @@ Array [
   Object {
     "context": Object {
       "loggingOptions": Object {
-        "loggerName": "synthetics",
+        "loggerName": "uptime",
       },
     },
     "meta": true,

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_certs.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_certs.test.ts
@@ -256,7 +256,7 @@ describe('getCerts', () => {
           Object {
             "context": Object {
               "loggingOptions": Object {
-                "loggerName": "synthetics",
+                "loggerName": "uptime",
               },
             },
             "meta": true,

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_latest_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_latest_monitor.test.ts
@@ -107,7 +107,7 @@ describe('getLatestMonitor', () => {
     expect(result?.monitor?.id).toBe('testMonitor');
     expect(mockEsClient.search).toHaveBeenCalledWith(expectedGetLatestSearchParams, {
       meta: true,
-      context: { loggingOptions: { loggerName: 'synthetics' } },
+      context: { loggingOptions: { loggerName: 'uptime' } },
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.test.ts
@@ -859,7 +859,7 @@ describe('monitor availability', () => {
           Object {
             "context": Object {
               "loggingOptions": Object {
-                "loggerName": "synthetics",
+                "loggerName": "uptime",
               },
             },
             "meta": true,

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_network_events.test.ts
@@ -216,7 +216,7 @@ describe('getNetworkEvents', () => {
           Object {
             "context": Object {
               "loggingOptions": Object {
-                "loggerName": "synthetics",
+                "loggerName": "uptime",
               },
             },
             "meta": true,

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_pings.test.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_pings.test.ts
@@ -166,7 +166,7 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "loggerName": "synthetics",
+              "loggerName": "uptime",
             },
           },
           "meta": true,
@@ -231,7 +231,7 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "loggerName": "synthetics",
+              "loggerName": "uptime",
             },
           },
           "meta": true,
@@ -296,7 +296,7 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "loggerName": "synthetics",
+              "loggerName": "uptime",
             },
           },
           "meta": true,
@@ -366,7 +366,7 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "loggerName": "synthetics",
+              "loggerName": "uptime",
             },
           },
           "meta": true,
@@ -477,7 +477,7 @@ describe('getAll', () => {
         Object {
           "context": Object {
             "loggingOptions": Object {
-              "loggerName": "synthetics",
+              "loggerName": "uptime",
             },
           },
           "meta": true,


### PR DESCRIPTION
## Summary

Follow up PR to this [one](https://github.com/elastic/kibana/pull/225570/) where loggerName `synthetics` gets replaced with `uptime`

To test it enable Uptime through `Stack Management > Advanced Settings` and add following to your `kibana.dev.yml`

```
logging.loggers:
  - name: elasticsearch.query.myqueries
    level: debug
```

You should be able to see uptime logs:

```
[2025-07-08T12:24:03.702+03:00][DEBUG][elasticsearch.query.uptime] 200 - 159.0B
POST /heartbeat-*/_search
{"query":{"bool":{"filter":[{"range":{"@timestamp":{"gte":"now-15m","lte":"now"}}},{"exists":{"field":"summary"}},{"bool":{"must_not":{"exists":{"field":"run_once"}}}}]}},"size":0,"aggs":{"timeseries":{"date_histogram":{"field":"@timestamp","fixed_interval":"36000ms","missing":"0","time_zone":"Europe/Athens"},"aggs":{"down":{"sum":{"field":"summary.down"}},"up":{"sum":{"field":"summary.up"}}}}}}
```

cc @afharo 

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->