### PR TITLE
[9.1] [Entity Store] Remove non ECS complaint identity fields mapping (#226741)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/entity_index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/entity_index.ts
@@ -65,17 +65,13 @@ export const getEntityIndexStatus = async ({
 export type MappingProperties = NonNullable<MappingTypeMapping['properties']>;
 
 export const generateIndexMappings = (
-  description: Pick<EntityEngineInstallationDescriptor, 'fields' | 'identityField'>
+  description: Pick<
+    EntityEngineInstallationDescriptor,
+    'fields' | 'identityField' | 'identityFieldMapping'
+  >
 ): MappingTypeMapping => {
   const identityFieldMappings: MappingProperties = {
-    [description.identityField]: {
-      type: 'keyword',
-      fields: {
-        text: {
-          type: 'match_only_text',
-        },
-      },
-    },
+    [description.identityField]: description.identityFieldMapping,
   };
 
   const otherFieldMappings = description.fields
@@ -99,11 +95,6 @@ export const BASE_ENTITY_INDEX_MAPPING: MappingProperties = {
   },
   'entity.name': {
     type: 'keyword',
-    fields: {
-      text: {
-        type: 'match_only_text',
-      },
-    },
   },
   'entity.source': {
     type: 'keyword',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/generic.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/generic.ts
@@ -15,6 +15,7 @@ export const genericEntityEngineDescription: EntityDescription = {
   entityType: 'generic',
   version: GENERIC_DEFINITION_VERSION,
   identityField: GENERIC_IDENTITY_FIELD,
+  identityFieldMapping: { type: 'keyword' },
   settings: {
     timestampField: '@timestamp',
   },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/host.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/host.ts
@@ -15,6 +15,7 @@ export const hostEntityEngineDescription: EntityDescription = {
   entityType: 'host',
   version: HOST_DEFINITION_VERSION,
   identityField: HOST_IDENTITY_FIELD,
+  identityFieldMapping: { type: 'keyword' },
   settings: {
     timestampField: '@timestamp',
   },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/service.ts
@@ -16,6 +16,7 @@ export const serviceEntityEngineDescription: EntityDescription = {
   entityType: 'service',
   version: SERVICE_DEFINITION_VERSION,
   identityField: SERVICE_IDENTITY_FIELD,
+  identityFieldMapping: { type: 'keyword' },
   settings: {
     timestampField: '@timestamp',
   },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/user.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/entity_descriptions/user.ts
@@ -14,6 +14,14 @@ export const userEntityEngineDescription: EntityDescription = {
   entityType: 'user',
   version: USER_DEFINITION_VERSION,
   identityField: USER_IDENTITY_FIELD,
+  identityFieldMapping: {
+    type: 'keyword',
+    fields: {
+      text: {
+        type: 'match_only_text',
+      },
+    },
+  },
   settings: {
     timestampField: '@timestamp',
   },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_definitions/types.ts
@@ -23,6 +23,7 @@ export type EntityDescription = PickPartial<
   | 'indexMappings'
   | 'settings'
   | 'pipeline'
-  | 'dynamic',
+  | 'dynamic'
+  | 'identityFieldMapping',
   'indexPatterns' | 'indexMappings' | 'settings' | 'dynamic'
 >;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.test.ts
@@ -38,6 +38,7 @@ const definition: EntityDefinition = convertToEntityManagerDefinition(
     version: '0.0.1',
     fields: [],
     identityField: 'host.name',
+    identityFieldMapping: { type: 'keyword' },
     indexMappings: {},
     indexPatterns: [],
     settings: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/__snapshots__/engine_description.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/__snapshots__/engine_description.test.ts.snap
@@ -697,11 +697,6 @@ Object {
       "type": "keyword",
     },
     "entity.id": Object {
-      "fields": Object {
-        "text": Object {
-          "type": "match_only_text",
-        },
-      },
       "type": "keyword",
     },
     "entity.name": Object {
@@ -1028,11 +1023,6 @@ Object {
       "type": "keyword",
     },
     "entity.name": Object {
-      "fields": Object {
-        "text": Object {
-          "type": "match_only_text",
-        },
-      },
       "type": "keyword",
     },
     "entity.source": Object {
@@ -1057,11 +1047,6 @@ Object {
       "type": "keyword",
     },
     "host.name": Object {
-      "fields": Object {
-        "text": Object {
-          "type": "match_only_text",
-        },
-      },
       "type": "keyword",
     },
     "host.os.name": Object {
@@ -1269,11 +1254,6 @@ Object {
       "type": "keyword",
     },
     "entity.name": Object {
-      "fields": Object {
-        "text": Object {
-          "type": "match_only_text",
-        },
-      },
       "type": "keyword",
     },
     "entity.source": Object {
@@ -1292,11 +1272,6 @@ Object {
       "type": "keyword",
     },
     "service.name": Object {
-      "fields": Object {
-        "text": Object {
-          "type": "match_only_text",
-        },
-      },
       "type": "keyword",
     },
     "service.node.name": Object {
@@ -1472,11 +1447,6 @@ Object {
       "type": "keyword",
     },
     "entity.name": Object {
-      "fields": Object {
-        "text": Object {
-          "type": "match_only_text",
-        },
-      },
       "type": "keyword",
     },
     "entity.source": Object {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/engine_description.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/engine_description.test.ts
@@ -62,7 +62,6 @@ describe('getUnitedEntityDefinition', () => {
       expect(entityManagerDefinition).toMatchSnapshot();
     });
   });
-
   describe('service', () => {
     const description = createEngineDescription({
       entityType: 'service',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/types.ts
@@ -21,6 +21,7 @@ export interface EntityEngineInstallationDescriptor {
   version: string;
   entityType: EntityType;
   identityField: string;
+  identityFieldMapping: MappingProperty;
 
   /**
    * Default static index patterns to use as the source of entity data.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Entity Store] Remove non ECS complaint identity fields mapping (#226741)](https://github.com/elastic/kibana/pull/226741)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rômulo Farias","email":"romulo.farias@elastic.co"},"sourceCommit":{"committedDate":"2025-07-07T17:24:16Z","message":"[Entity Store] Remove non ECS complaint identity fields mapping (#226741)\n\n## Summary\n\nIdentity fields (`user.name`, `host.name`, `entity.name` and\n`service.name`) were always defaulting to a mapping with `keyword` and\n`.text` `text` field, while that's not ECS complaint.\n\nThis PR removes `text` field from `host.name`, `entity.name` and\n`service.name` (keeps `user.name`)\n\n- Related to https://github.com/elastic/kibana/issues/226475\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nNo risk.","sha":"d839f7f2a764202a90c43002c74b7d37a35c52d9","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Entity Store] Remove non ECS complaint identity fields mapping","number":226741,"url":"https://github.com/elastic/kibana/pull/226741","mergeCommit":{"message":"[Entity Store] Remove non ECS complaint identity fields mapping (#226741)\n\n## Summary\n\nIdentity fields (`user.name`, `host.name`, `entity.name` and\n`service.name`) were always defaulting to a mapping with `keyword` and\n`.text` `text` field, while that's not ECS complaint.\n\nThis PR removes `text` field from `host.name`, `entity.name` and\n`service.name` (keeps `user.name`)\n\n- Related to https://github.com/elastic/kibana/issues/226475\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nNo risk.","sha":"d839f7f2a764202a90c43002c74b7d37a35c52d9"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226741","number":226741,"mergeCommit":{"message":"[Entity Store] Remove non ECS complaint identity fields mapping (#226741)\n\n## Summary\n\nIdentity fields (`user.name`, `host.name`, `entity.name` and\n`service.name`) were always defaulting to a mapping with `keyword` and\n`.text` `text` field, while that's not ECS complaint.\n\nThis PR removes `text` field from `host.name`, `entity.name` and\n`service.name` (keeps `user.name`)\n\n- Related to https://github.com/elastic/kibana/issues/226475\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nNo risk.","sha":"d839f7f2a764202a90c43002c74b7d37a35c52d9"}}]}] BACKPORT-->