### PR TITLE
[ci] increase memory limits to 10g

### DIFF
--- a/packages/kbn-ts-type-check-cli/run_type_check_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_cli.ts
@@ -128,7 +128,7 @@ run(
           ...(flagsReader.boolean('verbose') ? ['--verbose'] : []),
         ],
         env: {
-          NODE_OPTIONS: '--max-old-space-size=8192',
+          NODE_OPTIONS: '--max-old-space-size=10240',
         },
         cwd: REPO_ROOT,
         wait: true,


### PR DESCRIPTION
## Summary
On 8.19 typechecks on PRs started to run out of memory consistently. The memory limit is bumped to 10g on main already, this PR adds it to 9.0 to prevent eventual failures from the same issue.