### PR TITLE
🌊 Streams: Fix preview table always showing expand buttons

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
@@ -144,31 +144,34 @@ export function PreviewTable({
   }, [canonicalColumnOrder, setSorting, setVisibleColumns, visibleColumns.length]);
 
   const leadingControlColumns: EuiDataGridControlColumn[] = useMemo(
-    () => [
-      {
-        id: 'selection',
-        width: 36,
-        headerCellRender: () => null,
-        rowCellRender: ({ rowIndex }) => (
-          <EuiButtonIcon
-            onClick={() => {
-              if (selectableRow && onRowSelected) {
-                onRowSelected(rowIndex);
-              }
-            }}
-            aria-label={i18n.translate(
-              'xpack.streams.resultPanel.euiDataGrid.preview.selectRowAriaLabel',
-              {
-                defaultMessage: 'Select row {rowIndex}',
-                values: { rowIndex: rowIndex + 1 },
-              }
-            )}
-            iconType={selectedRowIndex === rowIndex && selectableRow ? 'minimize' : 'expand'}
-            color={selectedRowIndex === rowIndex && selectableRow ? 'primary' : 'text'}
-          />
-        ),
-      },
-    ],
+    () =>
+      selectableRow
+        ? [
+            {
+              id: 'selection',
+              width: 36,
+              headerCellRender: () => null,
+              rowCellRender: ({ rowIndex }) => (
+                <EuiButtonIcon
+                  onClick={() => {
+                    if (selectableRow && onRowSelected) {
+                      onRowSelected(rowIndex);
+                    }
+                  }}
+                  aria-label={i18n.translate(
+                    'xpack.streams.resultPanel.euiDataGrid.preview.selectRowAriaLabel',
+                    {
+                      defaultMessage: 'Select row {rowIndex}',
+                      values: { rowIndex: rowIndex + 1 },
+                    }
+                  )}
+                  iconType={selectedRowIndex === rowIndex && selectableRow ? 'minimize' : 'expand'}
+                  color={selectedRowIndex === rowIndex && selectableRow ? 'primary' : 'text'}
+                />
+              ),
+            },
+          ]
+        : [],
     [onRowSelected, selectableRow, selectedRowIndex]
   );
 


### PR DESCRIPTION
Expand buttons are only relevant for the processing view, but it's always shown. This PR fixes that.