### PR TITLE
Fix top level field mappings issue, use `dynamic: 'false'` instead of `dynamic: false`

### DIFF
--- a/src/core/packages/saved-objects/base-server-internal/index.ts
+++ b/src/core/packages/saved-objects/base-server-internal/index.ts
@@ -15,6 +15,7 @@ export {
   getRootPropertiesObjects,
   getTypes,
   type IndexMapping,
+  type IndexMappingSafe,
   type IndexMappingMeta,
   type IndexTypesMap,
   type SavedObjectsTypeMappingDefinitions,

--- a/src/core/packages/saved-objects/base-server-internal/src/mappings/index.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/mappings/index.ts
@@ -14,6 +14,7 @@ export type {
   ZdtAlgoIndexMappingMeta,
   IndexMappingMeta,
   IndexMapping,
+  IndexMappingSafe,
   IndexTypesMap,
   IndexMappingMigrationStateMeta,
 } from './types';

--- a/src/core/packages/saved-objects/base-server-internal/src/mappings/types.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/mappings/types.ts
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { SavedObjectsTypeMappingDefinition } from '@kbn/core-saved-objects-server';
 import type {
-  SavedObjectsTypeMappingDefinition,
   SavedObjectsMappingProperties,
+  SavedObjectsMappingPropertiesSafe,
 } from '@kbn/core-saved-objects-server';
 import type { VirtualVersionMap } from '../model_version';
 
@@ -52,9 +53,16 @@ export interface SavedObjectsTypeMappingDefinitions {
 
 /** @internal */
 export interface IndexMapping {
-  dynamic?: boolean | 'strict';
+  dynamic?: false | 'false' | 'strict';
   properties: SavedObjectsMappingProperties;
   _meta?: IndexMappingMeta;
+}
+
+/** @internal */
+export interface IndexMappingSafe extends IndexMapping {
+  // we forbid the `dynamic: false` to make sure the definitions match what is stored by ES (dynamic: 'false')
+  dynamic?: 'false' | 'strict';
+  properties: SavedObjectsMappingPropertiesSafe;
 }
 
 /** @internal */

--- a/src/core/packages/saved-objects/migration-server-internal/src/core/build_active_mappings.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/core/build_active_mappings.ts
@@ -12,6 +12,7 @@ import type { SavedObjectsMappingProperties } from '@kbn/core-saved-objects-serv
 import type {
   IndexMapping,
   IndexMappingMeta,
+  IndexMappingSafe,
   SavedObjectsTypeMappingDefinitions,
 } from '@kbn/core-saved-objects-base-server-internal';
 
@@ -40,7 +41,7 @@ export function buildActiveMappings(
  *
  * @returns {IndexMapping}
  */
-export function getBaseMappings(): IndexMapping {
+export function getBaseMappings(): IndexMappingSafe {
   // Important: the ZDT algorithm won't trigger a reindex on documents
   // when changes on root field mappings are detected, meaning that adding
   // a non-indexed root field and then later switching it to indexed is

--- a/src/core/packages/saved-objects/server/index.ts
+++ b/src/core/packages/saved-objects/server/index.ts
@@ -40,6 +40,7 @@ export type {
   SavedObjectsTypeMappingDefinition,
   SavedObjectsFieldMapping,
   SavedObjectsMappingProperties,
+  SavedObjectsMappingPropertiesSafe,
 } from './src/mapping_definition';
 export type {
   SavedObjectMigration,

--- a/src/core/packages/saved-objects/server/src/mapping_definition.ts
+++ b/src/core/packages/saved-objects/server/src/mapping_definition.ts
@@ -44,9 +44,14 @@ export interface SavedObjectsTypeMappingDefinition {
   /** The dynamic property of the mapping, either `false` or `'strict'`. If
    * unspecified `dynamic: 'strict'` will be inherited from the top-level
    * index mappings. */
-  dynamic?: false | 'strict';
+  dynamic?: false | 'false' | 'strict';
   /** The underlying properties of the type mapping */
   properties: SavedObjectsMappingProperties;
+}
+
+/** @private */
+export interface SavedObjectsTypeMappingDefinitionSafe extends SavedObjectsTypeMappingDefinition {
+  dynamic: 'false' | 'strict';
 }
 
 /**
@@ -56,6 +61,10 @@ export interface SavedObjectsTypeMappingDefinition {
  */
 export interface SavedObjectsMappingProperties {
   [field: string]: SavedObjectsFieldMapping;
+}
+
+export interface SavedObjectsMappingPropertiesSafe {
+  [field: string]: SavedObjectsFieldMappingSafe;
 }
 
 /**
@@ -76,10 +85,14 @@ export type SavedObjectsFieldMapping = EsMappingProperty &
      * Note: To limit the number of mapping fields Saved Object types should
      * *never* use `dynamic: true`.
      */
-    dynamic?: false | 'strict';
+    dynamic?: false | 'false' | 'strict';
     /**
      * Some mapping types do not accept the `properties` attributes. Explicitly adding it as optional to our type
      * to avoid type failures on all code using accessing them via `SavedObjectsFieldMapping.properties`.
      */
     properties?: Record<EsPropertyName, EsMappingProperty>;
   };
+
+export type SavedObjectsFieldMappingSafe = SavedObjectsFieldMapping & {
+  dynamic?: 'false' | 'strict';
+};

--- a/src/core/packages/saved-objects/server/src/mapping_definition.ts
+++ b/src/core/packages/saved-objects/server/src/mapping_definition.ts
@@ -63,7 +63,7 @@ export interface SavedObjectsMappingProperties {
   [field: string]: SavedObjectsFieldMapping;
 }
 
-export interface SavedObjectsMappingPropertiesSafe {
+export interface SavedObjectsMappingPropertiesSafe extends SavedObjectsMappingProperties {
   [field: string]: SavedObjectsFieldMappingSafe;
 }
 

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -81,6 +81,7 @@ describe('migration actions', () => {
       aliases: ['existing_index_with_docs_alias'],
       esCapabilities,
       mappings: {
+        // @ts-expect-error allowed for test purposes only (dynamic mapping definition)
         dynamic: true,
         properties: {
           someProperty: {
@@ -986,7 +987,7 @@ describe('migration actions', () => {
         client,
         indexName: 'reindex_target_6',
         mappings: {
-          dynamic: false,
+          dynamic: 'false',
           properties: { title: { type: 'integer' } }, // integer is incompatible with string title
         },
         esCapabilities,
@@ -1471,7 +1472,7 @@ describe('migration actions', () => {
         client,
         indexName: 'existing_index_without_mappings',
         mappings: {
-          dynamic: false,
+          dynamic: 'false',
           properties: {},
         },
         esCapabilities,

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -90,6 +90,7 @@ export const runActionTestSuite = ({
       aliases: ['existing_index_with_docs_alias'],
       esCapabilities,
       mappings: {
+        // @ts-expect-error allowed for test purposes only (dynamic mapping definition)
         dynamic: true,
         properties: {
           someProperty: {
@@ -153,6 +154,7 @@ export const runActionTestSuite = ({
       aliases: ['existing_index_with_100k_docs_alias'],
       esCapabilities,
       mappings: {
+        // @ts-expect-error allowed for test purposes only (dynamic mapping definition)
         dynamic: true,
         properties: {},
       },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/1802

The PR aims at aligning the in-memory representation with the one coming from ES mappings, to prevent such discrepancies.