### PR TITLE
[Workspace Chrome] fix timelines modal for new layout

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout/layouts/legacy-fixed/legacy_fixed_global_app_style.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout/layouts/legacy-fixed/legacy_fixed_global_app_style.tsx
@@ -69,6 +69,12 @@ const globalLayoutStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     --kbn-application--sticky-headers-offset: calc(
       var(--euiFixedHeadersOffset, 0px) + var(--kbn-application--top-bar-height, 0px)
     );
+
+    // for forward compatibility with grid layout,
+    --kbn-application--content-top: var(--kbnAppHeadersOffset, var(--euiFixedHeadersOffset, 0));
+    --kbn-application--content-left: 0px;
+    --kbn-application--content-bottom: 0px;
+    --kbn-application--content-right: 0px;
   }
 
   // Conditionally override :root CSS fixed header variable. Updating \`--euiFixedHeadersOffset\`

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
@@ -23,10 +23,10 @@ export const usePaneStyles = () => {
   return css`
     // euiOverlayMask styles
     position: fixed;
-    top: var(--euiFixedHeadersOffset, 0);
-    left: 0;
-    right: 0;
-    bottom: 0;
+    top: var(--kbn-application--content-top, 0px);
+    left: var(--kbn-application--content-left, 0px);
+    right: var(--kbn-application--content-right, 0px);
+    bottom: var(--kbn-application--content-bottom, 0px);
     // TODO EUI: add color with transparency
     background: ${transparentize(euiTheme.colors.ink, 0.5)};
     z-index: ${(euiTheme.levels.flyout as number) +
@@ -43,10 +43,10 @@ export const usePaneStyles = () => {
     .timeline-container {
       min-width: 150px;
       position: fixed;
-      top: var(--euiFixedHeadersOffset, 0);
-      right: 0;
-      bottom: 0;
-      left: 0;
+      top: var(--kbn-application--content-top, 0px);
+      left: var(--kbn-application--content-left, 0px);
+      right: var(--kbn-application--content-right, 0px);
+      bottom: var(--kbn-application--content-bottom, 0px);
       background: ${euiBackgroundColor(EuiTheme, 'plain')};
       ${euiCanAnimate} {
         animation: ${euiAnimSlideInUp(euiTheme.size.xxl)} ${euiTheme.animation.normal}


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/225263

We're preparing Kibana for new layout (available behind feature flag) and currently addressing obvious bugs that appear in new layout. 

to enable new layout: 
```
feature_flags.overrides:
  core.chrome.layoutType: 'grid'
```

Ideally needs to be tested in all: 
- [x] old layout + classic nav; 
- [x] old layout + solution nav; 
- [x] new layout + classic nav; 
- [x] new layout + solution nav

**new layout before the fix:**

![Screenshot 2025-07-08 at 13 49 44](https://github.com/user-attachments/assets/6a824ace-08c3-4bff-82e3-6be552a412d5)

The reason for the bug in the new layout `euiFixedHeadersOffset` is 0 because there are no longer fixed headers in the new layout. So we have to adjust for new layout variables usage


**after the fix:**

![Screenshot 2025-07-08 at 13 49 11](https://github.com/user-attachments/assets/943d402e-82f4-4bfa-89ed-40a88e852731)


