### PR TITLE
[Bug] [Query Rules] Update snippet to match retriever spec

### DIFF
--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_run_query_ruleset.test.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_run_query_ruleset.test.tsx
@@ -154,7 +154,7 @@ describe('UseRunQueryRuleset', () => {
             criteria: [
               {
                 metadata: 'user_query',
-                values: 'search term',
+                values: ['search term'],
                 type: 'exact',
               },
               {
@@ -174,7 +174,7 @@ describe('UseRunQueryRuleset', () => {
 
     const buttonProps = (TryInConsoleButton as jest.Mock).mock.calls[0][0];
     expect(buttonProps.request).toContain('"user_query": "search term"');
-    expect(buttonProps.request).toMatch(/"user_location":\s*\[\s*"US",\s*"UK"\s*\]/);
+    expect(buttonProps.request).toMatch(/"user_location":\s*"US"/);
   });
 
   it('handles complex nested criteria values', () => {
@@ -185,7 +185,7 @@ describe('UseRunQueryRuleset', () => {
             criteria: [
               {
                 values: {
-                  nested_field: 'nested value',
+                  nested_field: ['nested value'],
                   another_field: ['array', 'of', 'values'],
                 },
                 type: 'exact',
@@ -202,6 +202,6 @@ describe('UseRunQueryRuleset', () => {
 
     const buttonProps = (TryInConsoleButton as jest.Mock).mock.calls[0][0];
     expect(buttonProps.request).toContain('"nested_field": "nested value"');
-    expect(buttonProps.request).toMatch(/"another_field":\s*\[\s*"array",\s*"of",\s*"values"\s*\]/);
+    expect(buttonProps.request).toMatch(/"another_field":\s*"array"s*/);
   });
 });

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_run_query_ruleset.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_run_query_ruleset.tsx
@@ -69,7 +69,7 @@ export const UseRunQueryRuleset = ({
 
     const reducedCriteria = criteriaData.reduce<Record<string, any>>(
       (acc, { metadata, values }) => {
-        if (metadata && values !== undefined) acc[metadata] = values;
+        if (metadata && values !== undefined) acc[metadata] = values ? values[0] : '';
         return acc;
       },
       {}
@@ -95,6 +95,7 @@ export const UseRunQueryRuleset = ({
     {
       "retriever": {
         "rule": {
+          // Update your criteria to test different results
           "match_criteria": ${matchCriteria},
           "ruleset_ids": [
             "${rulesetId}" // An array of one or more unique query ruleset IDs


### PR DESCRIPTION
## Summary

Update test snippet to match the retriever spec.

Instead of passing values array directly, it will get the first element from the array.
<img width="605" alt="Screenshot 2025-07-08 at 14 39 42" src="https://github.com/user-attachments/assets/94279cc6-14b9-4f5a-a787-919f709a94af" />

Tests are updated also, the mocked api call never returns the string for the values but turns them into an array for easier handling in UI.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->