### PR TITLE
[Search sessions] Add singulars/plurals to expiration badges

### DIFF
--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/get_expiration_status.test.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/get_expiration_status.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import moment from 'moment';
+import { getExpirationStatus } from './get_expiration_status';
+
+const CURRENT_MOCK_DATE = '2025-01-01T00:00:00.000Z';
+
+beforeEach(() => {
+  jest.useFakeTimers().setSystemTime(new Date(CURRENT_MOCK_DATE));
+});
+
+const setup = ({
+  expiresSoonWarning = moment.duration(7, 'days'),
+  expires,
+}: {
+  expiresSoonWarning?: moment.Duration;
+  expires: string;
+}) => {
+  return getExpirationStatus(
+    {
+      enabled: true,
+      notTouchedTimeout: moment.duration(0),
+      maxUpdateRetries: 0,
+      defaultExpiration: moment.duration(0),
+      management: {
+        expiresSoonWarning,
+        refreshInterval: moment.duration(0),
+        refreshTimeout: moment.duration(0),
+        maxSessions: 0,
+      },
+    },
+    expires || CURRENT_MOCK_DATE
+  );
+};
+
+describe('getExpirationStatus', () => {
+  describe('when it expires in more than the configured expiresSoonWarning', () => {
+    it('returns undefined', () => {
+      const status = setup({
+        expiresSoonWarning: moment.duration(7, 'days'),
+        expires: moment.utc(CURRENT_MOCK_DATE).add(8, 'days').toISOString(),
+      });
+      expect(status).toBeUndefined();
+    });
+  });
+
+  describe('when it expires in less than the configured expiresSoonWarning', () => {
+    describe('when it expires in 1 day', () => {
+      it('should return the correct stastus', () => {
+        const status = setup({
+          expiresSoonWarning: moment.duration(7, 'days'),
+          expires: moment.utc(CURRENT_MOCK_DATE).add(1, 'day').toISOString(),
+        });
+        expect(status).toEqual({
+          toolTipContent: 'Expires in 1 day',
+          statusContent: '1 day',
+        });
+      });
+    });
+
+    describe('when it expires in 2 days', () => {
+      it('should return the correct status', () => {
+        const status = setup({
+          expiresSoonWarning: moment.duration(7, 'days'),
+          expires: moment.utc(CURRENT_MOCK_DATE).add(2, 'days').toISOString(),
+        });
+        expect(status).toEqual({
+          toolTipContent: 'Expires in 2 days',
+          statusContent: '2 days',
+        });
+      });
+    });
+
+    describe('when it expires in less than 1 day', () => {
+      describe('when it expires in 1 hour', () => {
+        it('should return the correct status', () => {
+          const status = setup({
+            expiresSoonWarning: moment.duration(7, 'days'),
+            expires: moment.utc(CURRENT_MOCK_DATE).add(1, 'hour').toISOString(),
+          });
+          expect(status).toEqual({
+            toolTipContent: 'This session expires in 1 hour',
+            statusContent: '1 hour',
+          });
+        });
+      });
+
+      describe('when it expires in 2 hours', () => {
+        it('should return the correct status', () => {
+          const status = setup({
+            expiresSoonWarning: moment.duration(7, 'days'),
+            expires: moment.utc(CURRENT_MOCK_DATE).add(2, 'hours').toISOString(),
+          });
+          expect(status).toEqual({
+            toolTipContent: 'This session expires in 2 hours',
+            statusContent: '2 hours',
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/get_expiration_status.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/lib/get_expiration_status.ts
@@ -22,11 +22,11 @@ export const getExpirationStatus = (config: SearchSessionsConfigSchema, expires:
   const sufficientDays = Math.ceil(moment.duration(config.management.expiresSoonWarning).asDays());
 
   let toolTipContent = i18n.translate('data.mgmt.searchSessions.status.expiresSoonInDays', {
-    defaultMessage: 'Expires in {numDays} days',
+    defaultMessage: 'Expires in {numDays, plural, one {# day} other {# days}}',
     values: { numDays: expiresInDays },
   });
   let statusContent = i18n.translate('data.mgmt.searchSessions.status.expiresSoonInDaysTooltip', {
-    defaultMessage: '{numDays} days',
+    defaultMessage: '{numDays, plural, one {# day} other {# days}}',
     values: { numDays: expiresInDays },
   });
 
@@ -35,11 +35,11 @@ export const getExpirationStatus = (config: SearchSessionsConfigSchema, expires:
     const expiresInHours = Math.floor(durationToExpire.asHours());
 
     toolTipContent = i18n.translate('data.mgmt.searchSessions.status.expiresSoonInHours', {
-      defaultMessage: 'This session expires in {numHours} hours',
+      defaultMessage: 'This session expires in {numHours, plural, one {# hour} other {# hours}}',
       values: { numHours: expiresInHours },
     });
     statusContent = i18n.translate('data.mgmt.searchSessions.status.expiresSoonInHoursTooltip', {
-      defaultMessage: '{numHours} hours',
+      defaultMessage: '{numHours, plural, one {# hour} other {# hours}}',
       values: { numHours: expiresInHours },
     });
   }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/122931

Adds singulars and plurals to the search sessions expiration badges.

| Scenario | Screenshot |
|----------|-------------|
| More than 1 day | ![image](https://github.com/user-attachments/assets/1935820f-80be-4748-864b-6bf4a9aa62ee) |
| 1 day | ![image](https://github.com/user-attachments/assets/37ca52b5-8712-444f-bf04-ff2f43013583) |
| More than 1 hour | ![image](https://github.com/user-attachments/assets/b000789f-2396-430d-a1a8-a398f183815c) |
| 1 hour | ![image](https://github.com/user-attachments/assets/5af02abc-0a8c-492c-9e9f-2a0f16e6c8f2) |
| 0 hours🙈 | ![image](https://github.com/user-attachments/assets/0b8cea3d-ab70-4059-a758-828df5f67a35) |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->