### PR TITLE
[9.0] [Infra] Replace EuiErrorBoundary with KibanaErrorBoundary on the Infra Metrics (#226805)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/index.tsx
@@ -10,19 +10,14 @@ import { i18n } from '@kbn/i18n';
 import React, { useContext } from 'react';
 import { Routes, Route } from '@kbn/shared-ux-router';
 
-import {
-  EuiErrorBoundary,
-  EuiHeaderLinks,
-  EuiHeaderLink,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
+import { EuiHeaderLinks, EuiHeaderLink, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { HeaderMenuPortal, useLinkProps } from '@kbn/observability-shared-plugin/public';
 import type { SharePublicStart } from '@kbn/share-plugin/public/plugin';
 import type { ObservabilityOnboardingLocatorParams } from '@kbn/deeplinks-observability';
 import { OBSERVABILITY_ONBOARDING_LOCATOR } from '@kbn/deeplinks-observability';
 import { dynamic } from '@kbn/shared-ux-utility';
+import { KibanaErrorBoundary } from '@kbn/shared-ux-error-boundary';
 import { HelpCenterContent } from '../../components/help_center_content';
 import { useReadOnlyBadge } from '../../hooks/use_readonly_badge';
 import { MetricsSettingsPage } from './settings';
@@ -72,7 +67,7 @@ export const InfrastructurePage = () => {
   });
 
   return (
-    <EuiErrorBoundary>
+    <KibanaErrorBoundary>
       <ReactQueryProvider>
         <AlertPrefillProvider>
           <ReloadRequestTimeProvider>
@@ -145,7 +140,7 @@ export const InfrastructurePage = () => {
           </ReloadRequestTimeProvider>
         </AlertPrefillProvider>
       </ReactQueryProvider>
-    </EuiErrorBoundary>
+    </KibanaErrorBoundary>
   );
 };
 

--- a/x-pack/solutions/observability/plugins/infra/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/infra/tsconfig.json
@@ -116,7 +116,8 @@
     "@kbn/observability-utils-common",
     "@kbn/charts-theme",
     "@kbn/response-ops-rule-params",
-    "@kbn/core-test-helpers-model-versions"
+    "@kbn/core-test-helpers-model-versions",
+    "@kbn/shared-ux-error-boundary"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Infra] Replace EuiErrorBoundary with KibanaErrorBoundary on the Infra Metrics (#226805)](https://github.com/elastic/kibana/pull/226805)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-07-08T13:54:20Z","message":"[Infra] Replace EuiErrorBoundary with KibanaErrorBoundary on the Infra Metrics (#226805)\n\nPart of #225972 \n 3 of 5\n\n## Summary\n\nThis PR replaces EuiErrorBoundary with KibanaErrorBoundary on the Infra\nMetrics.\n\n## Testing\n\n- Introduce an error in the metrics page (maybe a typo, non-existent\ncomponent, or anything)\n- Open http://localhost:5601/ftw/app/metrics/\n- The error should be visible and it should still work as before (but\nalso including telemetry)\n-\n![image](https://github.com/user-attachments/assets/0fe1d2e0-ca98-40b5-862f-60b567b1e8a6)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c6e758cfc5afe395396409cf8b16baa024dc821b","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.2.0"],"title":"[Infra] Replace EuiErrorBoundary with KibanaErrorBoundary on the Infra Metrics","number":226805,"url":"https://github.com/elastic/kibana/pull/226805","mergeCommit":{"message":"[Infra] Replace EuiErrorBoundary with KibanaErrorBoundary on the Infra Metrics (#226805)\n\nPart of #225972 \n 3 of 5\n\n## Summary\n\nThis PR replaces EuiErrorBoundary with KibanaErrorBoundary on the Infra\nMetrics.\n\n## Testing\n\n- Introduce an error in the metrics page (maybe a typo, non-existent\ncomponent, or anything)\n- Open http://localhost:5601/ftw/app/metrics/\n- The error should be visible and it should still work as before (but\nalso including telemetry)\n-\n![image](https://github.com/user-attachments/assets/0fe1d2e0-ca98-40b5-862f-60b567b1e8a6)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c6e758cfc5afe395396409cf8b16baa024dc821b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226805","number":226805,"mergeCommit":{"message":"[Infra] Replace EuiErrorBoundary with KibanaErrorBoundary on the Infra Metrics (#226805)\n\nPart of #225972 \n 3 of 5\n\n## Summary\n\nThis PR replaces EuiErrorBoundary with KibanaErrorBoundary on the Infra\nMetrics.\n\n## Testing\n\n- Introduce an error in the metrics page (maybe a typo, non-existent\ncomponent, or anything)\n- Open http://localhost:5601/ftw/app/metrics/\n- The error should be visible and it should still work as before (but\nalso including telemetry)\n-\n![image](https://github.com/user-attachments/assets/0fe1d2e0-ca98-40b5-862f-60b567b1e8a6)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c6e758cfc5afe395396409cf8b16baa024dc821b"}}]}] BACKPORT-->