### PR TITLE
[onechat] fix recursion limit errors

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/chat/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/chat/run_chat_agent.ts
@@ -78,7 +78,7 @@ export const runChatAgent: RunChatAgentFn = async (
         agentId,
         runId,
       },
-      recursionLimit: 10,
+      recursionLimit: 25,
       callbacks: [],
     }
   );

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/reasoning/run_reasoning_agent.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/reasoning/run_reasoning_agent.ts
@@ -78,7 +78,7 @@ export const runReasoningAgent: RunChatAgentFn = async (
         agentId,
         runId,
       },
-      recursionLimit: 25,
+      recursionLimit: 40,
       callbacks: [],
     }
   );


### PR DESCRIPTION
## Summary

Increase the `recursionLimit` for the normal and reasoning modes, as the current numbers are a bit too conservative and causing issues with complex requests.

- Closes: https://github.com/elastic/search-team/issues/10365