### PR TITLE
[9.0] [APM]Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Mobile (#226887)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/metric_item.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/metric_item.tsx
@@ -10,7 +10,7 @@ import { Chart, Metric, Settings } from '@elastic/charts';
 import { useElasticChartsTheme } from '@kbn/charts-theme';
 import { EuiSkeletonText, EuiPanel } from '@elastic/eui';
 import { isEmpty } from 'lodash';
-import { EuiErrorBoundary } from '@elastic/eui';
+import { KibanaErrorBoundary } from '@kbn/shared-ux-error-boundary';
 
 export function MetricItem({
   data,
@@ -40,12 +40,12 @@ export function MetricItem({
           <EuiSkeletonText lines={3} />
         </EuiPanel>
       ) : (
-        <EuiErrorBoundary>
+        <KibanaErrorBoundary>
           <Chart>
             <Settings baseTheme={chartBaseTheme} />
             <Metric id={`metric_${id}`} data={[data]} />
           </Chart>
-        </EuiErrorBoundary>
+        </KibanaErrorBoundary>
       )}
     </div>
   );

--- a/x-pack/solutions/observability/plugins/apm/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/apm/tsconfig.json
@@ -134,7 +134,8 @@
     "@kbn/entityManager-plugin",
     "@kbn/core-http-server-utils",
     "@kbn/key-value-metadata-table",
-    "@kbn/event-stacktrace"
+    "@kbn/event-stacktrace",
+    "@kbn/shared-ux-error-boundary",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[APM]Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Mobile (#226887)](https://github.com/elastic/kibana/pull/226887)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-07-08T14:01:28Z","message":"[APM]Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Mobile (#226887)\n\nPR 2 of 2\n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nAPM Error Mobile Charts\n\n## Testing\n\n- Introduce an error in the APM mobile charts (maybe a typo,\nnon-existent component, or anything) for example:\n<img width=\"976\" alt=\"mobile code error\"\nsrc=\"https://github.com/user-attachments/assets/3400d483-837c-464d-937f-de4916fad0e6\"\n/>\n\n\n- Open the APM mobile service \n- Can be created using synthtrace: `node scripts/synthtrace mobile\n--live --uniqueIds`\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n\n<img width=\"1720\" alt=\"mobile page error\"\nsrc=\"https://github.com/user-attachments/assets/23e0d206-40bc-4f45-b39c-4e5967835473\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f9b4e4249b6ae05e9f25579cea43c9be4e71cf74","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.2.0"],"title":"[APM]Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Mobile","number":226887,"url":"https://github.com/elastic/kibana/pull/226887","mergeCommit":{"message":"[APM]Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Mobile (#226887)\n\nPR 2 of 2\n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nAPM Error Mobile Charts\n\n## Testing\n\n- Introduce an error in the APM mobile charts (maybe a typo,\nnon-existent component, or anything) for example:\n<img width=\"976\" alt=\"mobile code error\"\nsrc=\"https://github.com/user-attachments/assets/3400d483-837c-464d-937f-de4916fad0e6\"\n/>\n\n\n- Open the APM mobile service \n- Can be created using synthtrace: `node scripts/synthtrace mobile\n--live --uniqueIds`\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n\n<img width=\"1720\" alt=\"mobile page error\"\nsrc=\"https://github.com/user-attachments/assets/23e0d206-40bc-4f45-b39c-4e5967835473\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f9b4e4249b6ae05e9f25579cea43c9be4e71cf74"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226887","number":226887,"mergeCommit":{"message":"[APM]Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Mobile (#226887)\n\nPR 2 of 2\n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nAPM Error Mobile Charts\n\n## Testing\n\n- Introduce an error in the APM mobile charts (maybe a typo,\nnon-existent component, or anything) for example:\n<img width=\"976\" alt=\"mobile code error\"\nsrc=\"https://github.com/user-attachments/assets/3400d483-837c-464d-937f-de4916fad0e6\"\n/>\n\n\n- Open the APM mobile service \n- Can be created using synthtrace: `node scripts/synthtrace mobile\n--live --uniqueIds`\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n\n<img width=\"1720\" alt=\"mobile page error\"\nsrc=\"https://github.com/user-attachments/assets/23e0d206-40bc-4f45-b39c-4e5967835473\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f9b4e4249b6ae05e9f25579cea43c9be4e71cf74"}}]}] BACKPORT-->