### PR TITLE
[Security Soluton][Endpoint] Fix `run_sentinelone_host` dev script to retry when checking S1 agent status on VM

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/sentinelone_host/common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/sentinelone_host/common.ts
@@ -211,7 +211,11 @@ export const installSentinelOneAgent = async ({
     await hostVm.exec(`sudo ${installPath} management token set ${siteToken}`);
     await hostVm.exec(`sudo ${installPath} control start`);
 
-    const status = (await hostVm.exec(`sudo ${installPath} control status`)).stdout;
+    const status = (
+      await pRetry(async () => {
+        return hostVm.exec(`sudo ${installPath} control status`);
+      })
+    ).stdout;
 
     try {
       // Generate an alert in SentinelOne


### PR DESCRIPTION
## Summary

- Add retry attempts when getting a status of the SentinelOne agent running on the host VM
    - It seems that it now takes the S1 a bit of time to start up, which was causing the command to get its run status to fail (see error below)


Error:

```
│ERROR Error: Command failed with exit code 1: multipass exec ptavares-sentinelone-support-3876 -- sudo /opt/sentinelone/bin/sentinelctl control status
   │      Agent must be running in order to execute this command

```



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->