### PR TITLE
[Dashboard] Save button is disabled in case of save error

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -209,6 +209,7 @@ export function getDashboardApi({
         lastSavedId: savedObjectId$.value,
       });
 
+      if (saveResult?.error) return;
       unsavedChangesManager.internalApi.onSave(dashboardState, searchSourceReferences);
       references$.next(saveResult.references);
 


### PR DESCRIPTION
Closes #221579

Added an early return to ensure the `hasUnsavedChanges` flag remains true when `saveDashboardState` returns an error.

The video below shows the behavior after the fix.


https://github.com/user-attachments/assets/c6a1d914-6030-44a3-bcd5-2b801d78b97a



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->