### PR TITLE
[Fix] Hide chrome when printing 

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -11,6 +11,7 @@ import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { BehaviorSubject, combineLatest, merge, type Observable, of, ReplaySubject } from 'rxjs';
 import { mergeMap, map, takeUntil, filter } from 'rxjs';
+import { isPrinting$ } from './utils/printing_observable';
 import { parse } from 'url';
 import { setEuiDevProviderWarning } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
@@ -137,8 +138,8 @@ export class ChromeService {
         )
       )
     );
-    this.isVisible$ = combineLatest([appHidden$, this.isForceHidden$]).pipe(
-      map(([appHidden, forceHidden]) => !appHidden && !forceHidden),
+    this.isVisible$ = combineLatest([appHidden$, this.isForceHidden$, isPrinting$]).pipe(
+      map(([appHidden, forceHidden, isPrinting]) => !appHidden && !forceHidden && !isPrinting),
       takeUntil(this.stop$)
     );
   }

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -11,7 +11,6 @@ import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { BehaviorSubject, combineLatest, merge, type Observable, of, ReplaySubject } from 'rxjs';
 import { mergeMap, map, takeUntil, filter } from 'rxjs';
-import { isPrinting$ } from './utils/printing_observable';
 import { parse } from 'url';
 import { setEuiDevProviderWarning } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
@@ -51,6 +50,7 @@ import type {
 import { RecentlyAccessedService } from '@kbn/recently-accessed';
 
 import { Logger } from '@kbn/logging';
+import { isPrinting$ } from './utils/printing_observable';
 import { DocTitleService } from './doc_title';
 import { NavControlsService } from './nav_controls';
 import { NavLinksService } from './nav_links';

--- a/src/core/packages/chrome/browser-internal/src/utils/printing_observable.ts
+++ b/src/core/packages/chrome/browser-internal/src/utils/printing_observable.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { distinctUntilChanged, fromEvent, map, merge, shareReplay, startWith } from 'rxjs';
+
+/**
+ * Emits true during printing (window.beforeprint), false otherwise.
+ */
+export const isPrinting$ = merge(
+  fromEvent(window, 'beforeprint').pipe(map(() => true)),
+  fromEvent(window, 'afterprint').pipe(map(() => false))
+).pipe(startWith(false), distinctUntilChanged(), shareReplay(1));


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/226865

Proposed quick fix for https://github.com/elastic/kibana/issues/226865. The main reason the dashboard print looks broken is that the new navigation is expanded by default, pushing the content to the side. In this PR, we use existing, well-tested functionality—chrome visibility—to hide the chrome along with the navigation and allow printing to focus on the main content: the dashboard.

The printing is still not ideal, but at least usable

[example good export.pdf](https://github.com/user-attachments/files/21125283/example.good.export.pdf)


## Release Notes

Hide Kibana's header and side navigation when trying to print or use the dashboard export with print mode.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->