### PR TITLE
Remove error state on title field

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_manual_entry_flyout.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_manual_entry_flyout.tsx
@@ -140,7 +140,6 @@ export function KnowledgeBaseEditManualEntryFlyout({
             fullWidth
             value={newEntryTitle}
             onChange={(e) => setNewEntryTitle(e.target.value)}
-            isInvalid={isEntryTitleInvalid}
           />
         </EuiFormRow>
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/224820

Remove error state for name field when creating a new knowledge base entry.

I consulted with @isaclfreire offline about this change and we agreed to remove the error state completely, as error states are not necessary in cases where all fields in a form are mandatory in order to continue.

### Before

https://github.com/user-attachments/assets/32aab4ad-e558-4e9c-b9c1-b54e9e20b362

### After

https://github.com/user-attachments/assets/4b873397-66fc-4b9c-be0c-dc118e54bfc9

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->