### PR TITLE
Replace `style` with `css` in CSP plugin

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/chart_panel.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/chart_panel.tsx
@@ -67,22 +67,22 @@ export const ChartPanel: FC<PropsWithChildren<ChartPanelProps>> = ({
 
   return (
     <EuiPanel hasBorder={hasBorder} hasShadow={false} style={styles} data-test-subj="chart-panel">
-      <EuiFlexGroup direction="column" gutterSize="m" style={{ height: '100%' }}>
+      <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup justifyContent={'spaceBetween'}>
-            <EuiFlexItem grow={false} style={{ justifyContent: 'center' }}>
+            <EuiFlexItem grow={false} css={{ justifyContent: 'center' }}>
               {title && (
                 <EuiTitle size="s">
-                  <h3 style={{ lineHeight: 'initial', paddingLeft: euiTheme.size.s }}>{title}</h3>
+                  <h3 css={{ lineHeight: 'initial', paddingLeft: euiTheme.size.s }}>{title}</h3>
                 </EuiTitle>
               )}
             </EuiFlexItem>
-            <EuiFlexItem grow={false} style={{ flexDirection: 'row', gap: euiTheme.size.s }}>
+            <EuiFlexItem grow={false} css={{ flexDirection: 'row', gap: euiTheme.size.s }}>
               {rightSideItems}
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem style={{ height: '100%' }}>{renderChart()}</EuiFlexItem>
+        <EuiFlexItem css={{ height: '100%' }}>{renderChart()}</EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>
   );

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/empty_states_illustration_container.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/empty_states_illustration_container.tsx
@@ -18,4 +18,4 @@ const SVG_WIDTH = 376;
  */
 export const EmptyStatesIllustrationContainer: React.FC<{ children: React.ReactNode }> = ({
   children,
-}) => <div style={{ height: SVG_HEIGHT, width: SVG_WIDTH }}>{children}</div>;
+}) => <div css={{ height: SVG_HEIGHT, width: SVG_WIDTH }}>{children}</div>;

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/no_findings_states/no_findings_states.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/no_findings_states/no_findings_states.tsx
@@ -190,7 +190,7 @@ const EmptySecurityFindingsPrompt = () => {
     <EuiFlexGroup>
       <EuiFlexItem>
         <EuiEmptyPrompt
-          style={{ padding: euiTheme.size.l }}
+          css={{ padding: euiTheme.size.l }}
           data-test-subj={PACKAGE_NOT_INSTALLED_TEST_SUBJECT}
           icon={
             <EmptyStatesIllustrationContainer>
@@ -266,7 +266,7 @@ const EmptySecurityFindingsPrompt = () => {
       {is3PSupportedPage && (
         <EuiFlexItem>
           <EuiEmptyPrompt
-            style={{ padding: euiTheme.size.l }}
+            css={{ padding: euiTheme.size.l }}
             data-test-subj={THIRD_PARTY_INTEGRATIONS_NO_MISCONFIGURATIONS_FINDINGS_PROMPT}
             icon={
               <EmptyStatesIllustrationContainer>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -83,7 +83,7 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
     <EuiFlexGroup>
       <EuiFlexItem>
         <EuiEmptyPrompt
-          style={{ padding: euiTheme.size.l }}
+          css={{ padding: euiTheme.size.l }}
           data-test-subj={NO_VULNERABILITIES_STATUS_TEST_SUBJ.NOT_INSTALLED}
           icon={
             <EmptyStatesIllustrationContainer>
@@ -146,7 +146,7 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
       {is3PSupportedPage && (
         <EuiFlexItem>
           <EuiEmptyPrompt
-            style={{ padding: euiTheme.size.l }}
+            css={{ padding: euiTheme.size.l }}
             data-test-subj={THIRD_PARTY_INTEGRATIONS_NO_VULNERABILITIES_FINDINGS_PROMPT}
             icon={
               <EmptyStatesIllustrationContainer>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -104,7 +104,7 @@ const TotalIntegrationsCount = ({
   pageCount,
   totalCount,
 }: Record<'pageCount' | 'totalCount', number>) => (
-  <EuiText size="xs" style={{ marginLeft: 8 }}>
+  <EuiText size="xs" css={{ marginLeft: 8 }}>
     <EuiTextColor color="subdued">
       <FormattedMessage
         id="xpack.csp.benchmarks.totalIntegrationsCountMessage"
@@ -125,7 +125,7 @@ const BenchmarkSearchField = ({
 
   return (
     <EuiFlexGroup>
-      <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
+      <EuiFlexItem grow={true} css={{ alignItems: 'flex-end' }}>
         <EuiFieldSearch
           fullWidth
           onSearch={setLocalValue}

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/compliance_score_chart.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/compliance_score_chart.tsx
@@ -67,7 +67,7 @@ const CounterButtonLink = ({
     <>
       <EuiText
         size="s"
-        style={{
+        css={{
           fontWeight: euiTheme.font.weight.bold,
           marginBottom: euiTheme.size.xs,
         }}
@@ -89,12 +89,14 @@ const CounterButtonLink = ({
         <EuiText
           color={color}
           css={css`
+            font-weight: ${euiTheme.font.weight.medium};
+            font-size: 18px;
+
             &:hover {
               border-bottom: 2px solid ${color};
               padding-bottom: 4px;
             }
           `}
-          style={{ fontWeight: euiTheme.font.weight.medium, fontSize: '18px' }}
           size="s"
         >
           <CompactFormattedNumber number={count} abbreviateAbove={999} />
@@ -154,7 +156,7 @@ const PercentageLabels = ({
 
   return (
     <EuiFlexGroup gutterSize="l" justifyContent="spaceBetween">
-      <EuiFlexItem grow={false} style={borderLeftStyles}>
+      <EuiFlexItem grow={false} css={borderLeftStyles}>
         <CounterButtonLink
           text="Passed Findings"
           count={stats.totalPassed}
@@ -163,7 +165,7 @@ const PercentageLabels = ({
           onClick={() => onEvalCounterClick(RULE_PASSED)}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false} style={borderLeftStyles}>
+      <EuiFlexItem grow={false} css={borderLeftStyles}>
         <CounterButtonLink
           text="Failed Findings"
           count={stats.totalFailed}
@@ -277,7 +279,7 @@ const CounterLink = ({
         onClick={onClick}
         css={{ display: 'flex' }}
       >
-        <EuiText color={color} style={{ fontWeight: euiTheme.font.weight.medium }} size="s">
+        <EuiText color={color} css={{ fontWeight: euiTheme.font.weight.medium }} size="s">
           <CompactFormattedNumber number={count} abbreviateAbove={999} />
           &nbsp;
         </EuiText>
@@ -299,7 +301,7 @@ export const ComplianceScoreChart = ({
     <EuiFlexGroup
       direction="column"
       justifyContent="spaceBetween"
-      style={{ height: '100%' }}
+      css={{ height: '100%' }}
       gutterSize="none"
     >
       <EuiFlexItem grow={2}>
@@ -312,7 +314,7 @@ export const ComplianceScoreChart = ({
               justifyContent="flexEnd"
               gutterSize="none"
               alignItems="flexStart"
-              style={{ paddingRight: euiTheme.size.xl }}
+              css={{ paddingRight: euiTheme.size.xl }}
             >
               {compact ? (
                 <CompactPercentageLabels

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
@@ -150,7 +150,7 @@ const IntegrationPostureDashboard = ({
     return (
       // height is calculated for the screen height minus the kibana header, page title, and tabs
       <div
-        style={{
+        css={{
           height: `calc(100vh - ${KIBANA_HEADERS_HEIGHT}px)`,
           display: 'flex',
           justifyContent: 'center',

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
@@ -191,7 +191,7 @@ export const BenchmarkDetailsBox = ({
           <EuiText size="xs">{benchmarkInfo.assetType}</EuiText>
         </EuiLink>
       </EuiFlexItem>
-      <EuiFlexItem grow={false} style={{ justifyContent: 'flex-end' }}>
+      <EuiFlexItem grow={false} css={{ justifyContent: 'flex-end' }}>
         <EuiFlexGroup gutterSize="m" alignItems="center">
           <CISBenchmarkIcon type={benchmarkId} name={`${benchmarkName}`} />
           <EuiToolTip content={cisTooltip}>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -205,7 +205,7 @@ export const BenchmarksSection = ({
           </EuiFlexItem>
           <EuiFlexItem grow={dashboardColumnsGrow.third}>
             <div
-              style={{
+              css={{
                 paddingRight: euiTheme.size.base,
               }}
             >

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/json_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/json_tab.tsx
@@ -13,7 +13,7 @@ import { EuiPanel } from '@elastic/eui';
 
 export const JsonTab = ({ data }: { data: CspFinding }) => (
   <EuiPanel>
-    <div style={{ height: '100vh' }}>
+    <div css={{ height: '100vh' }}>
       <CodeEditor
         isCopyable
         allowFullScreen

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/table_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/table_tab.tsx
@@ -66,7 +66,7 @@ const columns: EuiInMemoryTableProps<FlattenedItem>['columns'] = [
   {
     field: 'value',
     name: i18n.translate('xpack.csp.flyout.tableTab.fieldValueLabel', { defaultMessage: 'Value' }),
-    render: (value, record) => <div style={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
+    render: (value, record) => <div css={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
   },
 ];
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -31,7 +31,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
         bottomBorder
         pageTitle={
           <EuiFlexGroup direction="column" gutterSize="none">
-            <EuiFlexItem style={{ width: 'fit-content' }}>
+            <EuiFlexItem css={{ width: 'fit-content' }}>
               <Link to={generatePath(cloudPosturePages.benchmarks.path)}>
                 <EuiButtonEmpty iconType="arrowLeft" contentProps={{ style: { padding: 0 } }}>
                   <FormattedMessage
@@ -43,7 +43,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFlexGroup gutterSize="s">
-                <EuiFlexItem grow={false} style={{ marginBottom: 6 }}>
+                <EuiFlexItem grow={false} css={{ marginBottom: 6 }}>
                   <CISBenchmarkIcon type={params.benchmarkId} size={'l'} />
                 </EuiFlexItem>
                 <EuiFlexItem>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -211,7 +211,7 @@ const SearchField = ({
 
   return (
     <div>
-      <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
+      <EuiFlexItem grow={true} css={{ alignItems: 'flex-end' }}>
         <EuiFieldSearch
           data-test-subj={RULES_TABLE_HEADER_TEST_SUBJ.RULES_TABLE_HEADER_SEARCH_INPUT}
           isLoading={isSearching}
@@ -220,7 +220,7 @@ const SearchField = ({
           })}
           value={localValue}
           onChange={(e) => setLocalValue(e.target.value)}
-          style={{ minWidth: 150 }}
+          css={{ minWidth: 150 }}
           fullWidth
         />
       </EuiFlexItem>
@@ -312,7 +312,7 @@ const CurrentPageOfTotal = ({
           grow={false}
           data-test-subj={RULES_TABLE_HEADER_TEST_SUBJ.RULES_TABLE_HEADER_RULE_SHOWING_LABEL}
         >
-          <EuiText size="xs" textAlign="left" color="subdued" style={{ marginLeft: '8px' }}>
+          <EuiText size="xs" textAlign="left" color="subdued" css={{ marginLeft: '8px' }}>
             <FormattedMessage
               id="xpack.csp.rules.rulesTable.showingPageOfTotalLabel"
               defaultMessage="Showing {pageSize} of {total, plural, one {# rule} other {# rules}} {pipe} Selected {selectedRulesAmount, plural, one {# rule} other {# rules}}"
@@ -361,8 +361,8 @@ const CurrentPageOfTotal = ({
             anchorPosition="downLeft"
             panelPaddingSize="s"
           >
-            <EuiPopoverTitle style={{ minWidth: 240 }}>
-              <EuiText size="s" textAlign="left" color="subdued" style={{ marginLeft: '8px' }}>
+            <EuiPopoverTitle css={{ minWidth: 240 }}>
+              <EuiText size="s" textAlign="left" color="subdued" css={{ marginLeft: '8px' }}>
                 <b>
                   <FormattedMessage
                     id="xpack.csp.rules.rulesTable.bulkActionsOptionTitle"

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_json_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_json_tab.tsx
@@ -17,7 +17,7 @@ interface VulnerabilityJsonTabProps {
 export const VulnerabilityJsonTab = ({ vulnerabilityRecord }: VulnerabilityJsonTabProps) => {
   return (
     <EuiPanel data-test-subj={JSON_TAB_VULNERABILITY_FLYOUT}>
-      <div style={{ height: '100vh' }}>
+      <div css={{ height: '100vh' }}>
         <CodeEditor
           enableFindAction
           isCopyable

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_table_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_table_tab.tsx
@@ -70,7 +70,7 @@ const columns: EuiInMemoryTableProps<FlattenedItem>['columns'] = [
     name: i18n.translate('xpack.csp.vulnerabilities.flyoutTabs.fieldValueLabel', {
       defaultMessage: 'Value',
     }),
-    render: (value: unknown) => <div style={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
+    render: (value: unknown) => <div css={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
   },
 ];
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_table_panel_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_table_panel_section.tsx
@@ -121,7 +121,7 @@ export const VulnerabilityTablePanelSection = () => {
         field: 'vulnerabilityCount',
         name: (
           <span>
-            <EuiIcon type={'sortDown'} style={{ marginRight: euiTheme.size.xs }} />
+            <EuiIcon type={'sortDown'} css={{ marginRight: euiTheme.size.xs }} />
             {i18n.translate(
               'xpack.csp.cnvmDashboardTable.section.topVulnerableResources.column.vulnerabilities',
               {
@@ -202,7 +202,7 @@ export const VulnerabilityTablePanelSection = () => {
           field: 'vulnerabilityCount',
           name: (
             <span>
-              <EuiIcon type={'sortDown'} style={{ marginRight: euiTheme.size.xs }} />
+              <EuiIcon type={'sortDown'} css={{ marginRight: euiTheme.size.xs }} />
               {i18n.translate(
                 'xpack.csp.cnvmDashboardTable.section.topVulnerableResources.column.vulnerabilityCount',
                 {
@@ -330,7 +330,7 @@ export const VulnerabilityTablePanelSection = () => {
         field: 'vulnerabilityCount',
         name: (
           <span>
-            <EuiIcon type={'sortDown'} style={{ marginRight: euiTheme.size.xs }} />
+            <EuiIcon type={'sortDown'} css={{ marginRight: euiTheme.size.xs }} />
             {i18n.translate(
               'xpack.csp.cnvmDashboardTable.section.topVulnerability.column.vulnerabilities',
               {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_trend_graph.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_trend_graph.tsx
@@ -72,7 +72,7 @@ const AccountDropDown = ({
   options: Array<{ value: string; label: string }>;
 }) => (
   <EuiComboBox
-    style={{ width: 320 }}
+    css={{ width: 320 }}
     compressed
     prepend={i18n.translate(
       'xpack.csp.vulnerabilityDashboard.trendGraphChart.accountsDropDown.prepend.accountsTitle',
@@ -211,7 +211,7 @@ export const VulnerabilityTrendGraph = () => {
         <ViewAllButton key="vulnerability-trend-graph-view-all-button" />,
       ]}
     >
-      <div style={chartStyle}>
+      <div css={chartStyle}>
         <Chart>
           <Settings
             baseTheme={charts.theme.useChartsBaseTheme()}

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/plugin.tsx
@@ -138,7 +138,7 @@ export class CspPlugin
     const App = (props: CspRouterProps) => (
       <KibanaContextProvider services={{ ...core, ...plugins, storage }}>
         <RedirectAppLinks coreStart={core}>
-          <div style={{ width: '100%', height: '100%' }}>
+          <div css={{ width: '100%', height: '100%' }}>
             <SetupContext.Provider value={{ isCloudEnabled: this.isCloudEnabled }}>
               <CspRouter {...props} />
             </SetupContext.Provider>


### PR DESCRIPTION
## Summary

Part of the resolution of this issue: 
- https://github.com/elastic/kibana/issues/149246

Second attempt that re-takes the task after this PR was closed:
- https://github.com/elastic/kibana/pull/202487

Removes the `style` prop in React components and elements to avoid using inline styles. Instead, it uses now the `emotion.css` prop to dynamically attach all styles to the native `class` attribute.

### Motivation

This is a performance and maintenance task. The way to properly style components is using the `css` prop. What happens under-the-hood is that all values are attached to a single native CSS class, and this class is attached to the DOM element. However, the `style` prop will simply pass all those values down to the native HTML style attribute.

So what is the difference i.e. if we have a list with 1000 elements?
- With the `style` prop, the styles we want to apply will be copied 1000 times and attached to each element
- With the `css` prop, the styles will only exist once in memory. The generated CSS class will be the one attached to each element

That's the reason why it's a best practice to use classes vs style attribute in bare HTML. And the reason why in Kibana, we must favor the `css` prop over `style`. However, in cases where those styles are dynamic values (width calculations, derived from other values, etc), we might generate multiple CSS classes. So in those cases, it's better to just rely on the `style` prop.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Minor risk of getting slightly worse performance if we replace `style` props with `css` and the values we propagate are dynamic and change frequently, because those will create multiple classNames. But both impact and probability are minor.



