### PR TITLE
[Attack Discovery][Scheduling][Bug] Use "Assistant" as an author for the LLM comment that we add in Cases (#12985)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v1.test.ts
@@ -60,7 +60,7 @@ describe('Attachments', () => {
 
       expect(query).toStrictEqual({
         _tag: 'Right',
-        right: defaultRequest,
+        right: { ...defaultRequest, is_assistant: undefined },
       });
     });
 
@@ -69,9 +69,24 @@ describe('Attachments', () => {
 
       expect(query).toStrictEqual({
         _tag: 'Right',
-        right: defaultRequest,
+        right: { ...defaultRequest, is_assistant: undefined },
       });
     });
+
+    test.each([undefined, null, true, false])(
+      'has expected attributes in request when `is_assistant` is %s',
+      (isAssistant) => {
+        const query = AttachmentRequestRt.decode({
+          ...defaultRequest,
+          is_assistant: isAssistant,
+        });
+
+        expect(query).toStrictEqual({
+          _tag: 'Right',
+          right: { ...defaultRequest, is_assistant: isAssistant },
+        });
+      }
+    );
 
     describe('errors', () => {
       describe('commentType: user', () => {
@@ -185,6 +200,7 @@ describe('Attachments', () => {
           pushed_by: null,
           updated_at: null,
           updated_by: null,
+          is_assistant: null,
           id: 'basic-comment-id',
           version: 'WzQ3LDFc',
         },
@@ -256,6 +272,7 @@ describe('Attachments', () => {
         comment: 'Solve this fast!',
         type: AttachmentType.user,
         owner: 'cases',
+        is_assistant: undefined,
       },
     ];
 
@@ -278,6 +295,26 @@ describe('Attachments', () => {
         right: defaultRequest,
       });
     });
+
+    test.each([undefined, null, true, false])(
+      'has expected attributes in request when `is_assistant` is %s',
+      (isAssistant) => {
+        const defaultBulkRequest = [
+          {
+            comment: 'Solve this fast!',
+            type: AttachmentType.user,
+            owner: 'cases',
+            is_assistant: isAssistant,
+          },
+        ];
+        const query = BulkCreateAttachmentsRequestRt.decode(defaultBulkRequest);
+
+        expect(query).toStrictEqual({
+          _tag: 'Right',
+          right: defaultBulkRequest,
+        });
+      }
+    );
 
     describe('errors', () => {
       it(`throws error when attachments are more than ${MAX_BULK_CREATE_ATTACHMENTS}`, () => {
@@ -340,6 +377,7 @@ describe('Attachments', () => {
           pushed_by: null,
           updated_at: null,
           updated_by: null,
+          is_assistant: null,
         },
       ],
       errors: [

--- a/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v1.ts
@@ -79,6 +79,7 @@ export const AttachmentRequestRt = rt.union([
     comment: limitedStringSchema({ fieldName: 'comment', min: 1, max: MAX_COMMENT_LENGTH }),
     type: rt.literal(AttachmentType.user),
     owner: rt.string,
+    is_assistant: rt.union([rt.boolean, rt.undefined, rt.null]),
   }),
   AlertAttachmentPayloadRt,
   rt.strict({

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v1.test.ts
@@ -142,7 +142,7 @@ describe('Attachments', () => {
 
       expect(query).toStrictEqual({
         _tag: 'Right',
-        right: defaultRequest,
+        right: { ...defaultRequest, is_assistant: undefined },
       });
     });
 
@@ -151,9 +151,24 @@ describe('Attachments', () => {
 
       expect(query).toStrictEqual({
         _tag: 'Right',
-        right: defaultRequest,
+        right: { ...defaultRequest, is_assistant: undefined },
       });
     });
+
+    test.each([undefined, null, true, false])(
+      'has expected attributes in request when `is_assistant` is %s',
+      (isAssistant) => {
+        const query = UserCommentAttachmentPayloadRt.decode({
+          ...defaultRequest,
+          is_assistant: isAssistant,
+        });
+
+        expect(query).toStrictEqual({
+          _tag: 'Right',
+          right: { ...defaultRequest, is_assistant: isAssistant },
+        });
+      }
+    );
   });
 
   describe('AlertAttachmentPayloadRt', () => {
@@ -399,6 +414,7 @@ describe('Attachments', () => {
       pushed_by: null,
       updated_at: null,
       updated_by: null,
+      is_assistant: null,
     };
     it('has expected attributes in request', () => {
       const query = AttachmentRt.decode(defaultRequest);
@@ -436,6 +452,7 @@ describe('Attachments', () => {
       pushed_by: null,
       updated_at: null,
       updated_by: null,
+      is_assistant: null,
     };
     it('has expected attributes in request', () => {
       const query = UserCommentAttachmentRt.decode(defaultRequest);

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v1.ts
@@ -58,6 +58,7 @@ export const UserCommentAttachmentPayloadRt = rt.strict({
   comment: rt.string,
   type: rt.literal(AttachmentType.user),
   owner: rt.string,
+  is_assistant: rt.union([rt.boolean, rt.undefined, rt.null]),
 });
 
 const UserCommentAttachmentAttributesRt = rt.intersection([

--- a/x-pack/platform/plugins/shared/cases/public/components/user_profiles/hoverable_assistant_resolver.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_profiles/hoverable_assistant_resolver.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { HoverableAssistantResolver } from './hoverable_assistant_resolver';
+
+describe('HoverableAssistantResolver', () => {
+  it('renders assistant title', async () => {
+    render(<HoverableAssistantResolver />);
+
+    expect(screen.getByText('Assistant')).toBeInTheDocument();
+  });
+
+  it('renders assistant title bolded by default', async () => {
+    render(<HoverableAssistantResolver />);
+
+    expect(screen.getByTestId('assistant-bolded')).toBeInTheDocument();
+  });
+
+  it('renders the tooltip when hovering', async () => {
+    render(<HoverableAssistantResolver />);
+
+    fireEvent.mouseOver(screen.getByText('Assistant'));
+
+    const assistantTooltip = within(await screen.findByTestId('assistant-tooltip'));
+
+    expect(assistantTooltip.getByText('Assistant')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/user_profiles/hoverable_assistant_resolver.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_profiles/hoverable_assistant_resolver.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiText, EuiToolTip } from '@elastic/eui';
+
+import * as i18n from './translations';
+
+const HoverableAssistantResolverComponent: React.FC = () => {
+  return (
+    <EuiToolTip
+      display="inlineBlock"
+      position="top"
+      content={i18n.ASSISTANT}
+      data-test-subj="assistant-tooltip"
+    >
+      <EuiText size="s" className="eui-textBreakWord" data-test-subj="assistant-title">
+        <strong data-test-subj={'assistant-bolded'}>{i18n.ASSISTANT}</strong>
+      </EuiText>
+    </EuiToolTip>
+  );
+};
+HoverableAssistantResolverComponent.displayName = 'HoverableAssistantResolver';
+
+export const HoverableAssistantResolver = React.memo(HoverableAssistantResolverComponent);

--- a/x-pack/platform/plugins/shared/cases/public/components/user_profiles/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_profiles/translations.ts
@@ -72,3 +72,7 @@ export const MAX_SELECTED_ASSIGNEES = (limit: number) =>
       "You've selected the maximum number of {count, plural, one {# assignee} other {# assignees}}",
     values: { count: limit },
   });
+
+export const ASSISTANT = i18n.translate('xpack.cases.assistant.title', {
+  defaultMessage: 'Assistant',
+});

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/attack_discovery/group_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/attack_discovery/group_alerts.test.ts
@@ -37,8 +37,9 @@ describe('groupAttackDiscoveryAlerts', () => {
       attack_discovery: '012479c7-bcb6-4945-a6cf-65e40931a156',
     });
     expect(
-      groups[0].comments?.[0].startsWith('## Coordinated credential access across hosts')
+      groups[0].comments?.[0].comment.startsWith('## Coordinated credential access across hosts')
     ).toBeTruthy();
+    expect(groups[0].comments?.[0].isAssistant).toBeTruthy();
     expect(groups[0].title).toEqual('Coordinated credential access across hosts');
   });
 
@@ -80,8 +81,9 @@ describe('groupAttackDiscoveryAlerts', () => {
       attack_discovery: '012479c7-bcb6-4945-a6cf-65e40931a156',
     });
     expect(
-      groups[0].comments?.[0].startsWith('## Coordinated credential access across hosts')
+      groups[0].comments?.[0].comment.startsWith('## Coordinated credential access across hosts')
     ).toBeTruthy();
+    expect(groups[0].comments?.[0].isAssistant).toBeTruthy();
     expect(groups[0].title).toEqual('Coordinated credential access across hosts');
 
     expect(groups[1].alerts).toEqual([
@@ -89,7 +91,8 @@ describe('groupAttackDiscoveryAlerts', () => {
       { _id: 'id2', _index: '.alerts-security.alerts-default' },
     ]);
     expect(groups[1].grouping).toEqual({ attack_discovery: 'another-id' });
-    expect(groups[1].comments?.[0].startsWith('## Another attack')).toBeTruthy();
+    expect(groups[1].comments?.[0].comment.startsWith('## Another attack')).toBeTruthy();
+    expect(groups[0].comments?.[0].isAssistant).toBeTruthy();
     expect(groups[1].title).toEqual('Another attack');
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/attack_discovery/group_alerts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/attack_discovery/group_alerts.ts
@@ -40,21 +40,24 @@ export const groupAttackDiscoveryAlerts = (alerts: CaseAlert[]): CasesGroupedAle
 
     const caseTitle = attackDiscovery.title.slice(0, MAX_TITLE_LENGTH);
     const caseComments = [
-      getAttackDiscoveryMarkdown({
-        attackDiscovery: {
-          id: attackDiscoveryId,
-          alertIds,
-          detailsMarkdown: attackDiscovery.details_markdown,
-          entitySummaryMarkdown: attackDiscovery.entity_summary_markdown,
-          mitreAttackTactics: attackDiscovery.mitre_attack_tactics,
-          summaryMarkdown: attackDiscovery.summary_markdown,
-          title: caseTitle,
-        },
-        replacements: attackDiscovery.replacements?.reduce((acc: Record<string, string>, r) => {
-          acc[r.uuid] = r.value;
-          return acc;
-        }, {}),
-      }),
+      {
+        isAssistant: true,
+        comment: getAttackDiscoveryMarkdown({
+          attackDiscovery: {
+            id: attackDiscoveryId,
+            alertIds,
+            detailsMarkdown: attackDiscovery.details_markdown,
+            entitySummaryMarkdown: attackDiscovery.entity_summary_markdown,
+            mitreAttackTactics: attackDiscovery.mitre_attack_tactics,
+            summaryMarkdown: attackDiscovery.summary_markdown,
+            title: caseTitle,
+          },
+          replacements: attackDiscovery.replacements?.reduce((acc: Record<string, string>, r) => {
+            acc[r.uuid] = r.value;
+            return acc;
+          }, {}),
+        }),
+      },
     ].slice(0, MAX_DOCS_PER_PAGE / 2);
 
     /**

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
@@ -3507,6 +3507,7 @@ describe('CasesConnectorExecutor', () => {
             attachments: [
               {
                 comment: 'comment-1',
+                is_assistant: false,
                 owner: 'securitySolution',
                 type: 'user',
               },

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
@@ -1144,10 +1144,11 @@ export class CasesConnectorExecutor {
     const bulkCreateAlertsRequest: BulkCreateAlertsReq[] = casesUnderAlertLimit.map(
       ({ theCase, alerts, comments }) => {
         const extraComments: UserCommentAttachmentPayload[] =
-          comments?.map((comment) => ({
+          comments?.map(({ comment, isAssistant }) => ({
             type: AttachmentType.user,
             comment,
             owner: theCase.owner,
+            is_assistant: isAssistant,
           })) ?? [];
         return {
           caseId: theCase.id,

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.mock.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.mock.ts
@@ -93,7 +93,7 @@ export const groupedAlerts = [
       { _id: 'alert-id-1', _index: 'alert-index-1' },
       { _id: 'alert-id-2', _index: 'alert-index-1' },
     ],
-    comments: ['comment-1'],
+    comments: [{ comment: 'comment-1', isAssistant: false }],
     grouping: { field_name_1: 'field_value_1' },
     title: 'custom-title',
   },
@@ -102,7 +102,10 @@ export const groupedAlerts = [
       { _id: 'alert-id-3', _index: 'alert-index-2' },
       { _id: 'alert-id-4', _index: 'alert-index-2' },
     ],
-    comments: ['comment-2', 'comment-3'],
+    comments: [
+      { comment: 'comment-2', isAssistant: false },
+      { comment: 'comment-3', isAssistant: true },
+    ],
     grouping: { field_name_2: 'field_value_2' },
   },
   {

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/schema.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/schema.ts
@@ -35,6 +35,11 @@ const RuleSchema = schema.object({
   ruleUrl: schema.nullable(schema.string()),
 });
 
+const CommentSchema = schema.object({
+  comment: schema.string(),
+  isAssistant: schema.boolean(),
+});
+
 const ReopenClosedCasesSchema = schema.boolean({ defaultValue: false });
 const TimeWindowSchema = schema.string({
   defaultValue: '7d',
@@ -72,7 +77,7 @@ const TimeWindowSchema = schema.string({
 
 export const CasesGroupedAlertsSchema = schema.object({
   alerts: schema.arrayOf(AlertSchema, { maxSize: MAX_ALERTS_PER_CASE }),
-  comments: schema.maybe(schema.arrayOf(schema.string(), { maxSize: MAX_DOCS_PER_PAGE / 2 })),
+  comments: schema.maybe(schema.arrayOf(CommentSchema, { maxSize: MAX_DOCS_PER_PAGE / 2 })),
   grouping: schema.recordOf(schema.string(), schema.any()),
   title: schema.maybe(schema.string({ maxLength: MAX_TITLE_LENGTH })),
 });

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/test_helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/test_helpers.ts
@@ -123,7 +123,7 @@ export const expectCasesToHaveTheCorrectAlertsAttachedWithPredefinedGrouping = (
   expect(casesClientMock.attachments.bulkCreate).nthCalledWith(1, {
     caseId: 'mock-id-1',
     attachments: [
-      { comment: 'comment-1', owner: 'securitySolution', type: 'user' },
+      { comment: 'comment-1', is_assistant: false, owner: 'securitySolution', type: 'user' },
       {
         alertId: ['alert-id-1', 'alert-id-2'],
         index: ['alert-index-1', 'alert-index-1'],
@@ -137,8 +137,8 @@ export const expectCasesToHaveTheCorrectAlertsAttachedWithPredefinedGrouping = (
   expect(casesClientMock.attachments.bulkCreate).nthCalledWith(2, {
     caseId: 'mock-id-2',
     attachments: [
-      { comment: 'comment-2', owner: 'securitySolution', type: 'user' },
-      { comment: 'comment-3', owner: 'securitySolution', type: 'user' },
+      { comment: 'comment-2', is_assistant: false, owner: 'securitySolution', type: 'user' },
+      { comment: 'comment-3', is_assistant: true, owner: 'securitySolution', type: 'user' },
       {
         alertId: ['alert-id-3', 'alert-id-4'],
         index: ['alert-index-2', 'alert-index-2'],

--- a/x-pack/platform/plugins/shared/cases/tsconfig.json
+++ b/x-pack/platform/plugins/shared/cases/tsconfig.json
@@ -93,7 +93,8 @@
     "@kbn/elastic-assistant-common",
     "@kbn/test",
     "@kbn/dev-utils",
-    "@kbn/tooling-log"
+    "@kbn/tooling-log",
+    "@kbn/ai-assistant-icon"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

BUG: https://github.com/elastic/security-team/issues/12985

This fixes the issue where we wrongly mention a user that last updated an attack discovery schedule as a author of the LLM generated comment added to the newly created Case via actions.

Instead we should show `"Assistant"` as an author of the comment.

### To test

1. Create Attack Discovery Schedule
2. Add Cases action to it
3. Enable and run the schedule

**Current behaviour**:

Create cases as a result of triggered actions has LLM generated comment under the user's name that last updated the schedule.

<img width="1704" alt="Screenshot 2025-07-08 at 19 05 03" src="https://github.com/user-attachments/assets/5138445b-ed9d-43a7-8819-677180dbd207" />

**Expected**:

We should show AI assistant as an author of the comment.

<img width="1707" alt="Screenshot 2025-07-08 at 19 09 30" src="https://github.com/user-attachments/assets/99e32897-4d44-4b16-b4c4-8a6181c3c45c" />

## NOTES

The feature is hidden behind the feature flag (in `kibana.dev.yml`):

```
feature_flags.overrides:
  securitySolution.attackDiscoveryAlertsEnabled: true
  securitySolution.assistantAttackDiscoverySchedulingEnabled: true
```
