### PR TITLE
[OBX-UX-MGMT] Skip only the flaky test not the suite

### DIFF
--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
@@ -76,7 +76,6 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
     },
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/217739
   describe('Observability alerts >', function () {
     this.tags('includeFirefox');
     const testSubjects = getService('testSubjects');
@@ -157,6 +156,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
           await observability.alerts.common.submitQuery('');
         });
 
+        // FLAKY: https://github.com/elastic/kibana/issues/217739
         it.skip('Autocompletion works', async () => {
           await browser.refresh();
           await observability.alerts.common.typeInQueryBar('kibana.alert.s');

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
@@ -77,7 +77,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
   };
 
   // FLAKY: https://github.com/elastic/kibana/issues/217739
-  describe.skip('Observability alerts >', function () {
+  describe('Observability alerts >', function () {
     this.tags('includeFirefox');
     const testSubjects = getService('testSubjects');
     const retry = getService('retry');
@@ -157,7 +157,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
           await observability.alerts.common.submitQuery('');
         });
 
-        it('Autocompletion works', async () => {
+        it.skip('Autocompletion works', async () => {
           await browser.refresh();
           await observability.alerts.common.typeInQueryBar('kibana.alert.s');
           await observability.alerts.common.clickOnQueryBar();


### PR DESCRIPTION
## Summary

Related to #217739 
The flaky test is not flaking on the test runner, neither locally, also tried to use`yarn build --skip-os-packages`, but still unable to see the test failing, as shown in this [217739](https://github.com/elastic/kibana/pull/226408)

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->