### PR TITLE
Fix "How's the navigation working for you?" shown with each session

### DIFF
--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/feedback_btn.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/feedback_btn.tsx
@@ -26,13 +26,15 @@ interface Props {
 
 export const FeedbackBtn: FC<Props> = ({ solutionId }) => {
   const { euiTheme } = useEuiTheme();
-  const [showCallOut, setShowCallOut] = useState(
-    sessionStorage.getItem(FEEDBACK_BTN_KEY) !== 'hidden'
-  );
+  const [showCallOut, setShowCallOut] = useState(() => {
+    const storedValue =
+      localStorage.getItem(FEEDBACK_BTN_KEY) || sessionStorage.getItem(FEEDBACK_BTN_KEY);
+    return storedValue !== 'hidden';
+  });
 
   const onDismiss = () => {
     setShowCallOut(false);
-    sessionStorage.setItem(FEEDBACK_BTN_KEY, 'hidden');
+    localStorage.setItem(FEEDBACK_BTN_KEY, 'hidden');
   };
 
   const onClick = () => {


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/227157




<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->