### PR TITLE
Make sure rrule freq is number

### DIFF
--- a/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.ts
+++ b/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.ts
@@ -50,7 +50,7 @@ export const convertToRRule = ({
   }
 
   const frequency = form.customFrequency ?? (form.frequency as Frequency);
-  rRule.freq = frequency;
+  rRule.freq = Number(frequency);
 
   rRule.interval = form.interval;
 


### PR DESCRIPTION
> [!IMPORTANT]
> This is a fix for an issue that manifests **only** in the 8.19 track

## 📄 Summary

Adds a `Number()` runtime type cast to make sure that the recurring schedule frequency is correctly passed as a number to the report schedule API.

<details>
<summary>

## 🧪 Verification steps

</summary>

- Create a Dashboard
- Open the Export (⬇️) menu in the toolbar
- Click `Schedule export`
- From the Schedule dropdown select `Weekly on ...`
- Submit the form
- The report should be correctly scheduled

</details>

## 🔗 References

Fixes #226582
