### PR TITLE
[Cloud Security] fix data not fetched by vulnerability expandable flyout in preview mode

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
@@ -165,10 +165,10 @@ export interface FindingVulnerabilityFullFlyoutContentProps {
 
 interface BaseVulnerabilityFlyoutProps {
   vulnerabilityId: string | string[];
-  resourceId: string;
+  resourceId?: string;
   packageName: string | string[];
   packageVersion: string | string[];
-  eventId: string;
+  eventId?: string;
 }
 
 export type FindingsVulnerabilityPanelExpandableFlyoutPropsNonPreview = FlyoutPanelProps & {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_flyout.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_flyout.tsx
@@ -19,10 +19,10 @@ const VulnerabilityFindingFlyout = ({
   children,
 }: {
   vulnerabilityId: string | string[];
-  resourceId: string;
+  resourceId?: string;
   packageName: string | string[];
   packageVersion: string | string[];
-  eventId: string;
+  eventId?: string;
   children: any;
 }) => {
   const { data } = useVulnerabilityFinding({

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/vulnerabilities_findings_details_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/vulnerabilities_findings_details_table.tsx
@@ -234,10 +234,10 @@ export const VulnerabilitiesFindingsDetailsTable = memo(
                 id: VulnerabilityFindingsPreviewPanelKey,
                 params: {
                   vulnerabilityId: vulnerability?.id,
-                  resourceId: finding?.resource?.id || '',
+                  resourceId: finding?.resource?.id,
                   packageName: vulnerability?.package?.name,
                   packageVersion: vulnerability?.package?.version,
-                  eventId: finding?.event?.id || '',
+                  eventId: finding?.event?.id,
                   scopeId,
                   isPreviewMode: true,
                   banner: {


### PR DESCRIPTION
## Summary

The following PR closes the following [issue](https://github.com/elastic/kibana/issues/227245).


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->