### PR TITLE
[9.0] [Gemini Connector] Throw tool validation error on MALFORMED_FUNCTION_CALL finish reason when processing Gemini Stream (#227110)

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/process_vertex_stream.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/process_vertex_stream.ts
@@ -13,11 +13,44 @@ import {
 } from '@kbn/inference-common';
 import { generateFakeToolCallId } from '../../../../common';
 import type { GenerateContentResponseChunk } from './types';
+import { createToolValidationError } from '../../errors';
 
 export function processVertexStream() {
   return (source: Observable<GenerateContentResponseChunk>) =>
     new Observable<ChatCompletionChunkEvent | ChatCompletionTokenCountEvent>((subscriber) => {
       function handleNext(value: GenerateContentResponseChunk) {
+        const finishReason = value.candidates?.[0].finishReason as string | undefined;
+
+        function emitTokenCountIfApplicable() {
+          // 'usageMetadata' can be present as an empty object on chunks
+          // only the last chunk will have its fields populated
+          if (value.usageMetadata?.totalTokenCount) {
+            subscriber.next({
+              type: ChatCompletionEventType.ChatCompletionTokenCount,
+              tokens: {
+                prompt: value.usageMetadata.promptTokenCount,
+                completion: value.usageMetadata.candidatesTokenCount,
+                total: value.usageMetadata.totalTokenCount,
+              },
+            });
+          }
+        }
+
+        if (finishReason === 'UNEXPECTED_TOOL_CALL' || finishReason === 'MALFORMED_FUNCTION_CALL') {
+          const finishMessage = value.candidates?.[0].finishMessage;
+          const validationErrorMessage = finishMessage
+            ? `${finishReason} - ${finishMessage}`
+            : finishReason;
+          emitTokenCountIfApplicable();
+          subscriber.error(
+            createToolValidationError(validationErrorMessage, {
+              errorsText: finishMessage,
+              toolCalls: [],
+            })
+          );
+          return;
+        }
+
         const contentPart = value.candidates?.[0].content.parts[0];
         const completion = contentPart?.text;
         const toolCall = contentPart?.functionCall;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Gemini Connector] Throw tool validation error on MALFORMED_FUNCTION_CALL finish reason when processing Gemini Stream (#227110)](https://github.com/elastic/kibana/pull/227110)
- **Important:** Additional changes are added in the diff as they weren't backported before (overall error handling and emitting token count if applicable)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Srdjan Lulic","email":"srdjan.lulic@elastic.co"},"sourceCommit":{"committedDate":"2025-07-09T13:58:15Z","message":"[Gemini Connector] Throw tool validation error on MALFORMED_FUNCTION_CALL finish reason when processing Gemini Stream (#227110)\n\nCloses: https://github.com/elastic/kibana/issues/227096\n## Summary\n\nThrow tool validation error on `MALFORMED_FUNCTION_CALL` finish reason\n- Update the error-throwing finish reasons when processing vertex stream\n- Enrich the error message with finish message so it's captured in the\ntrace for easier troubleshooting.\n\n### Testing\n- The bug was caught when the API was throwing the error below during\nthe Obs AI Assistant evaluation:\n```bash\nERROR ChatCompletionError: Cannot read properties of undefined (reading 'parts')\n          at Object.next (throw_serialized_chat_completion_errors.ts:29:17)\n          at \n```\n- Reproduced in the debug mode and found the root cause:\n<img width=\"1657\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/073469dc-fc48-4f09-9aaf-2b5cfd85edfb\"\n/>\n\n- Fixed and ensured this gets captured in a trace:\n- [trace example prior to this\nchange](https://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMQ==/traces/76ab1b0405dcf157f7ca5e74f5cbcca8?selected):\n<img width=\"1222\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/71be8d73-78a8-4bd6-86d4-f772600ade76\"\n/>\n\n- [new trace\nexample](https://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMQ==/traces/2dadbbfa9e132f4de71da255fe157f95?selected):\n  \n<img width=\"1222\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1d0738d8-4c6e-4d55-8dae-769f1ebcffac\"\n/>","sha":"92cce95c20cdf2c24f09a521b3649b35bbdcaef3","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.2.0","v8.18.4","v9.0.4"],"title":"[Gemini Connector] Throw tool validation error on MALFORMED_FUNCTION_CALL finish reason when processing Gemini Stream","number":227110,"url":"https://github.com/elastic/kibana/pull/227110","mergeCommit":{"message":"[Gemini Connector] Throw tool validation error on MALFORMED_FUNCTION_CALL finish reason when processing Gemini Stream (#227110)\n\nCloses: https://github.com/elastic/kibana/issues/227096\n## Summary\n\nThrow tool validation error on `MALFORMED_FUNCTION_CALL` finish reason\n- Update the error-throwing finish reasons when processing vertex stream\n- Enrich the error message with finish message so it's captured in the\ntrace for easier troubleshooting.\n\n### Testing\n- The bug was caught when the API was throwing the error below during\nthe Obs AI Assistant evaluation:\n```bash\nERROR ChatCompletionError: Cannot read properties of undefined (reading 'parts')\n          at Object.next (throw_serialized_chat_completion_errors.ts:29:17)\n          at \n```\n- Reproduced in the debug mode and found the root cause:\n<img width=\"1657\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/073469dc-fc48-4f09-9aaf-2b5cfd85edfb\"\n/>\n\n- Fixed and ensured this gets captured in a trace:\n- [trace example prior to this\nchange](https://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMQ==/traces/76ab1b0405dcf157f7ca5e74f5cbcca8?selected):\n<img width=\"1222\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/71be8d73-78a8-4bd6-86d4-f772600ade76\"\n/>\n\n- [new trace\nexample](https://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMQ==/traces/2dadbbfa9e132f4de71da255fe157f95?selected):\n  \n<img width=\"1222\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1d0738d8-4c6e-4d55-8dae-769f1ebcffac\"\n/>","sha":"92cce95c20cdf2c24f09a521b3649b35bbdcaef3"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227266","number":227266,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227265","number":227265,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227110","number":227110,"mergeCommit":{"message":"[Gemini Connector] Throw tool validation error on MALFORMED_FUNCTION_CALL finish reason when processing Gemini Stream (#227110)\n\nCloses: https://github.com/elastic/kibana/issues/227096\n## Summary\n\nThrow tool validation error on `MALFORMED_FUNCTION_CALL` finish reason\n- Update the error-throwing finish reasons when processing vertex stream\n- Enrich the error message with finish message so it's captured in the\ntrace for easier troubleshooting.\n\n### Testing\n- The bug was caught when the API was throwing the error below during\nthe Obs AI Assistant evaluation:\n```bash\nERROR ChatCompletionError: Cannot read properties of undefined (reading 'parts')\n          at Object.next (throw_serialized_chat_completion_errors.ts:29:17)\n          at \n```\n- Reproduced in the debug mode and found the root cause:\n<img width=\"1657\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/073469dc-fc48-4f09-9aaf-2b5cfd85edfb\"\n/>\n\n- Fixed and ensured this gets captured in a trace:\n- [trace example prior to this\nchange](https://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMQ==/traces/76ab1b0405dcf157f7ca5e74f5cbcca8?selected):\n<img width=\"1222\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/71be8d73-78a8-4bd6-86d4-f772600ade76\"\n/>\n\n- [new trace\nexample](https://35-187-109-62.sslip.io/projects/UHJvamVjdDoxMQ==/traces/2dadbbfa9e132f4de71da255fe157f95?selected):\n  \n<img width=\"1222\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1d0738d8-4c6e-4d55-8dae-769f1ebcffac\"\n/>","sha":"92cce95c20cdf2c24f09a521b3649b35bbdcaef3"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->