### PR TITLE
[SecuritySolution] Fix error handling on creating index

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/create_index_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/create_index_modal.test.tsx
@@ -105,6 +105,7 @@ describe('CreateIndexModal', () => {
     await waitFor(() => {
       expect(screen.getByText(`Error creating index: ${errorMsg}`)).toBeInTheDocument();
     });
+    expect(onCreateMock).not.toHaveBeenCalled();
   });
 
   it('changes index mode when select is changed', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/create_index_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/create_index_modal.tsx
@@ -23,7 +23,6 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
 
 enum IndexMode {
@@ -78,10 +77,13 @@ export const CreateIndexModal = ({
     setError(null);
     const trimmedName = indexName.trim();
 
-    await createPrivMonImportIndex({
-      name: trimmedName,
-      mode: indexMode,
-    }).catch((err: SecurityAppError) => {
+    try {
+      await createPrivMonImportIndex({
+        name: trimmedName,
+        mode: indexMode,
+      });
+      onCreate(trimmedName);
+    } catch (err) {
       setError(
         i18n.translate(
           'xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.createIndex.error',
@@ -91,8 +93,7 @@ export const CreateIndexModal = ({
           }
         )
       );
-    });
-    onCreate(trimmedName);
+    }
   }, [indexName, createPrivMonImportIndex, indexMode, onCreate]);
 
   return (


### PR DESCRIPTION
## Summary

Fix error handling on creating the index. Index of duplicating index validation logic to address this error I am calling the create API and letting it handle errors.


Before this change, the modal would close even when an error occurred, giving the impression that the index had been created.

After this change, the modal will display an error when the creation API fails.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->