### PR TITLE
[8.18] [Profiling] Replace EuiErrorBoundary with KibanaErrorBoundary on the Profiling Routing (#227193)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/routing/router_error_boundary.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/routing/router_error_boundary.tsx
@@ -5,12 +5,12 @@
  * 2.0.
  */
 import { NotFoundRouteException } from '@kbn/typed-react-router-config';
-import { EuiErrorBoundary } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import React from 'react';
 import { NotFoundPrompt } from '@kbn/shared-ux-prompt-not-found';
 import { useLocation } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
+import { KibanaErrorBoundary } from '@kbn/shared-ux-error-boundary';
 import type { ProfilingPluginPublicStartDeps } from '../types';
 
 export function RouterErrorBoundary({ children }: { children?: React.ReactNode }) {
@@ -58,14 +58,13 @@ function ErrorWithTemplate({ error }: { error: Error }) {
 
   return (
     <ObservabilityPageTemplate pageHeader={pageHeader}>
-      <EuiErrorBoundary>
+      <KibanaErrorBoundary>
         <DummyComponent error={error} />
-      </EuiErrorBoundary>
+      </KibanaErrorBoundary>
     </ObservabilityPageTemplate>
   );
 }
 
-function DummyComponent({ error }: { error: Error }) {
+function DummyComponent({ error }: { error: Error }): any {
   throw error;
-  return <div />;
 }

--- a/x-pack/solutions/observability/plugins/profiling/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/profiling/tsconfig.json
@@ -55,7 +55,8 @@
     "@kbn/deeplinks-observability",
     "@kbn/react-kibana-context-render",
     "@kbn/apm-data-access-plugin",
-    "@kbn/security-plugin-types-server"
+    "@kbn/security-plugin-types-server",
+    "@kbn/shared-ux-error-boundary",
     // add references to other TypeScript projects the plugin depends on
 
     // requiredPlugins from ./kibana.json


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Profiling] Replace EuiErrorBoundary with KibanaErrorBoundary on the Profiling Routing (#227193)](https://github.com/elastic/kibana/pull/227193)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-07-09T15:03:34Z","message":"[Profiling] Replace EuiErrorBoundary with KibanaErrorBoundary on the Profiling Routing (#227193)\n\nCloses #227061 \n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nProfiling Routing\n\n## Testing\n\n- Introduce an error in the Profiling app (maybe a typo, non-existent\ncomponent, or anything) like in the other examples in the similar PRs -\nit should work on any Profiling page\n\n- Open Profiling\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n\n![image](https://github.com/user-attachments/assets/f2dd7c86-6f25-4673-85eb-67fc2ae90ed7)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e01ac53feca323d125b402c920b89032c72302e0","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:obs-ux-infra_services","v9.2.0"],"title":"[Profiling] Replace EuiErrorBoundary with KibanaErrorBoundary on the Profiling Routing","number":227193,"url":"https://github.com/elastic/kibana/pull/227193","mergeCommit":{"message":"[Profiling] Replace EuiErrorBoundary with KibanaErrorBoundary on the Profiling Routing (#227193)\n\nCloses #227061 \n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nProfiling Routing\n\n## Testing\n\n- Introduce an error in the Profiling app (maybe a typo, non-existent\ncomponent, or anything) like in the other examples in the similar PRs -\nit should work on any Profiling page\n\n- Open Profiling\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n\n![image](https://github.com/user-attachments/assets/f2dd7c86-6f25-4673-85eb-67fc2ae90ed7)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e01ac53feca323d125b402c920b89032c72302e0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227193","number":227193,"mergeCommit":{"message":"[Profiling] Replace EuiErrorBoundary with KibanaErrorBoundary on the Profiling Routing (#227193)\n\nCloses #227061 \n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nProfiling Routing\n\n## Testing\n\n- Introduce an error in the Profiling app (maybe a typo, non-existent\ncomponent, or anything) like in the other examples in the similar PRs -\nit should work on any Profiling page\n\n- Open Profiling\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n\n![image](https://github.com/user-attachments/assets/f2dd7c86-6f25-4673-85eb-67fc2ae90ed7)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e01ac53feca323d125b402c920b89032c72302e0"}},{"url":"https://github.com/elastic/kibana/pull/227275","number":227275,"branch":"9.0","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/227276","number":227276,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->