### PR TITLE
Replace style with css in Fleet files owned by Cloud Sec

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -477,7 +477,7 @@ function SecretInputField({
     );
     return (
       <EuiFlexGroup direction="column" gutterSize="s" alignItems="flexStart">
-        <EuiFlexItem grow={false} style={{ width: '100%' }}>
+        <EuiFlexItem grow={false} css={{ width: '100%' }}>
           {inputComponent}
         </EuiFlexItem>
         <EuiFlexItem grow={false}>{cancelButton}</EuiFlexItem>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/add_first_integration_splash.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/add_first_integration_splash.tsx
@@ -59,7 +59,7 @@ const CenteredEuiStepNumber = styled(EuiStepNumber)`
 
 // step numbers are not centered in smaller layouts without this
 const CenteredEuiImage = (props: EuiImageProps) => (
-  <div style={{ margin: '0 auto' }}>
+  <div css={{ margin: '0 auto' }}>
     <EuiImage role="presentation" {...props} />
   </div>
 );
@@ -92,7 +92,7 @@ const AddIntegrationStepsIllustrations = () => {
             <CenteredEuiStepNumber status="incomplete" number={1} />
           </EuiFlexItem>
           <EuiFlexItem>
-            <div style={{ margin: '0 auto' }}>
+            <div css={{ margin: '0 auto' }}>
               <CenteredEuiImage alt="" src={assetsBasePath + '1_install_agent.svg'} />
             </div>
           </EuiFlexItem>


### PR DESCRIPTION
## Summary

Part of the resolution of this issue: 
- https://github.com/elastic/kibana/issues/149246

Removes the `style` prop in React components and elements to avoid using inline styles. Instead, it uses now the `emotion.css` prop to dynamically attach all styles to the native `class` attribute.

Files co-owned with the Fleet team, according to `CODEOWNERS` where I searched for instances of `style` prop:
- `x-pack/platform/plugins/shared/fleet/public/components/cloud_security_posture`
- `x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/components/cloud_security_posture`
- `x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.*`
- `x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/`

### Motivation

This is a performance and maintenance task. The way to properly style components is using the `css` prop. What happens under-the-hood is that all values are attached to a single native CSS class, and this class is attached to the DOM element. However, the `style` prop will simply pass all those values down to the native HTML style attribute.

So what is the difference i.e. if we have a list with 1000 elements?
- With the `style` prop, the styles we want to apply will be copied 1000 times and attached to each element
- With the `css` prop, the styles will only exist once in memory. The generated CSS class will be the one attached to each element

That's the reason why it's a best practice to use classes vs style attribute in bare HTML. And the reason why in Kibana, we must favor the `css` prop over `style`. However, in cases where those styles are dynamic values (width calculations, derived from other values, etc), we might generate multiple CSS classes. So in those cases, it's better to just rely on the `style` prop.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Minor risk of getting slightly worse performance if we replace `style` props with `css` and the values we propagate are dynamic and change frequently, because those will create multiple classNames. But both impact and probability are minor.



