### PR TITLE
[8.19] Skip Streams tests

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/index.ts
@@ -8,7 +8,7 @@
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('Streams Endpoints', () => {
+  describe.skip('Streams Endpoints', () => {
     loadTestFile(require.resolve('./basic'));
     loadTestFile(require.resolve('./enrichment'));
     loadTestFile(require.resolve('./classic'));


### PR DESCRIPTION
Streams code is being backported to 8.19 to avoid merge conflicts for other code but Streams itself isn't available in 8.19.
However, there is a Kibana test pipeline that tests Kibana's forward compatibility with Elasticsearch 9.0.

The `_data_stream/{NAME}/_settings` API that Streams uses is only available in Elasticsearch 8.19 and 9.1, so this pipeline fails.

Rather than figuring out how to skip tests only in this pipeline, we'll disable all Streams tests for 8.19.