### PR TITLE
[Security Solution][Eslint] fix nested eslint workflow for webstorm

### DIFF
--- a/src/platform/packages/shared/kbn-securitysolution-ecs/.eslintrc.js
+++ b/src/platform/packages/shared/kbn-securitysolution-ecs/.eslintrc.js
@@ -70,19 +70,24 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -116,7 +121,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -127,7 +132,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/packages/connectors/.eslintrc.js
+++ b/x-pack/solutions/security/packages/connectors/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/.eslintrc.js
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/packages/features/.eslintrc.js
+++ b/x-pack/solutions/security/packages/features/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/packages/navigation/.eslintrc.js
+++ b/x-pack/solutions/security/packages/navigation/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/packages/side-nav/.eslintrc.js
+++ b/x-pack/solutions/security/packages/side-nav/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/packages/upselling/.eslintrc.js
+++ b/x-pack/solutions/security/packages/upselling/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/.eslintrc.js
@@ -68,19 +68,24 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +119,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +130,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/.eslintrc.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/.eslintrc.js
@@ -68,19 +68,25 @@
 
 // eslint-disable-next-line import/no-nodejs-modules
 const path = require('path');
+// eslint-disable-next-line import/no-nodejs-modules
+const { execSync } = require('child_process');
+
 const minimatch = require('minimatch');
 
 /** @type {Array.<RestrictedImportPath>} */
-const RESTRICTED_IMPORTS = [
+const RESTRICTED_IMPORTS_PATHS = [
   {
     name: 'enzyme',
     message: 'Please use @testing-library/react instead',
   },
 ];
 
-// root directory of the project dynamically calculated
-const ROOT_DIR = process.cwd();
-const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // e.g. ../../../../..
+const ROOT_DIR = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+  cwd: __dirname,
+}).trim();
+
+const ROOT_CLIMB_STRING = path.relative(__dirname, ROOT_DIR); // i.e. '../../..'
 
 /** @type {import('eslint').Linter.Config} */
 const rootConfig = require(`${ROOT_CLIMB_STRING}/.eslintrc`); // eslint-disable-line import/no-dynamic-require
@@ -114,7 +120,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     // Dynamic duplicates removal for all restricted imports
     const existingPaths = modernConfig.paths.filter(
       (existing) =>
-        !RESTRICTED_IMPORTS.some((restriction) =>
+        !RESTRICTED_IMPORTS_PATHS.some((restriction) =>
           typeof existing === 'string'
             ? existing === restriction.name
             : existing.name === restriction.name
@@ -125,7 +131,7 @@ for (const override of overridesWithNoRestrictedImportRule) {
     const newRuleConfig = [
       severity,
       {
-        paths: [...existingPaths, ...RESTRICTED_IMPORTS],
+        paths: [...existingPaths, ...RESTRICTED_IMPORTS_PATHS],
         patterns: modernConfig.patterns,
       },
     ];


### PR DESCRIPTION
By default automatic eslint configuration in webstorm settings

![image](https://github.com/user-attachments/assets/29351d6a-a452-4a7c-945d-177670ba9e9c)

[finds](https://www.jetbrains.com/help/webstorm/eslint.html#ws_js_eslint_manual_configuration:~:text=detects%20the%20working%20directory%20automatically.%20First%2C%20it%20looks%20for%20a%20directory%20closest%20to%20the%20linted%20file%20which%20contains%20a%20configuration%20file.) closest (to currently open file) eslint config and sets that directory as the current working directory for the entire eslint process

Some existing nested eslint config files do not account for that when searching for project root and assume that process.cwd() in eslint process would always be the kibana root. 

That's why they currently break in webstorm with `Error: Cannot find module '/.eslintrc'`

This PR fixes that regression.

But even after this fix is merged, webstorm users still need to use manual eslint config setting to detect the root of the project for eslint process to circumvent that faulty automatic cwd detection of webstorm and allow eslint cascade to work
to support nested .eslintrc.js in combination with root .eslintrc.js files.

![image](https://github.com/user-attachments/assets/48ddbbb9-954e-4e81-9b4d-2a626c9ef12a)

Unfortunately this is a known and current webstorm design limitation/bug per https://youtrack.jetbrains.com/issue/WEB-45381#focus=Comments-27-4342029.0-0

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->