### PR TITLE
[ResponseOps][Reporting] Add recurring schedule to rrule converstion test

### DIFF
--- a/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.test.ts
+++ b/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.test.ts
@@ -16,7 +16,7 @@ describe('convertToRRule', () => {
   const today = '2023-03-22';
   const startDate = moment(today);
 
-  test('should convert a maintenance window that is not recurring', () => {
+  test('should convert a recurring schedule that is not recurring', () => {
     const rRule = convertToRRule({ startDate, timezone });
 
     expect(rRule).toEqual({
@@ -27,7 +27,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a daily schedule', () => {
+  test('should convert a recurring schedule that is recurring on a daily schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -47,7 +47,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a daily schedule until', () => {
+  test('should convert a recurring schedule that is recurring on a daily schedule until', () => {
     const until = moment(today).add(1, 'month').toISOString();
     const rRule = convertToRRule({
       startDate,
@@ -70,7 +70,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a daily schedule after x', () => {
+  test('should convert a recurring schedule that is recurring on a daily schedule after x', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -92,7 +92,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a weekly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a weekly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -111,7 +111,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a monthly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a monthly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -130,7 +130,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a yearly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a yearly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -150,7 +150,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom daily schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom daily schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -170,7 +170,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom weekly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom weekly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -192,7 +192,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom monthly by day schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom monthly by day schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -214,7 +214,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom monthly by weekday schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom monthly by weekday schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -236,7 +236,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom yearly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom yearly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -257,4 +257,21 @@ describe('convertToRRule', () => {
       bymonthday: [22],
     });
   });
+
+  test.each(['frequency', 'customFrequency'])(
+    'should parse %s as string to number',
+    (frequencyKey) => {
+      const rRule = convertToRRule({
+        startDate,
+        timezone,
+        // @ts-expect-error Testing string to number parsing
+        recurringSchedule: {
+          [frequencyKey]: '1',
+          ends: 'never',
+        },
+      });
+      expect(typeof rRule.freq).toBe('number');
+      expect(rRule.freq).toBe(1);
+    }
+  );
 });


### PR DESCRIPTION
## 📄 Summary

Adds a test to check that the recurring schedule to rrule conversion correctly parses the schedule to handle cases where the frequencies are passed as strings (i.e. form hook lib).

> [!IMPORTANT]
> This works on main, but will fail in 8.19 where the parsing step was accidentally not added with the original backport. The main purpose of this PR is to use the related backport PR to add it and fix the issue on the 8.19 track.

<details>
<summary>

## 🧪 Verification steps

</summary>

- Create a Dashboard
- Open the Export (⬇️) menu in the toolbar
- Click `Schedule export`
- From the Schedule dropdown select `Weekly on ...`
- Submit the form
- The report should be correctly scheduled

</details>

## 🔗 References

Fixes #226582


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->