### PR TITLE
[AI4DSOC] [Attack discovery] In AI4DSOC projects, don't prompt the user to update the `kibana.alert.workflow_status` of alerts

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
@@ -21,10 +21,11 @@ import {
 } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 
+import { useAssistantAvailability } from '../../../../assistant/use_assistant_availability';
 import { useAddToNewCase } from './use_add_to_case';
 import { useAddToExistingCase } from './use_add_to_existing_case';
 import { useViewInAiAssistant } from '../attack_discovery_panel/view_in_ai_assistant/use_view_in_ai_assistant';
-import { APP_ID, SECURITY_FEATURE_ID } from '../../../../../common';
+import { APP_ID } from '../../../../../common';
 import { useKibana } from '../../../../common/lib/kibana';
 import * as i18n from './translations';
 import { UpdateAlertsModal } from './update_alerts_modal';
@@ -55,12 +56,9 @@ const TakeActionComponent: React.FC<Props> = ({
   );
 
   const {
-    services: {
-      application: { capabilities },
-      cases,
-    },
+    services: { cases },
   } = useKibana();
-  const aiForSoc = capabilities[SECURITY_FEATURE_ID].configurations;
+  const { hasSearchAILakeConfigurations } = useAssistantAvailability();
 
   const { attackDiscoveryAlertsEnabled } = useKibanaFeatureFlags();
 
@@ -165,12 +163,12 @@ const TakeActionComponent: React.FC<Props> = ({
 
       setPendingAction(workflowStatus);
 
-      if (aiForSoc) {
+      if (hasSearchAILakeConfigurations) {
         // there's no modal for AI for SOC, so we call onConfirm directly
         onConfirm({ updateAlerts: false, workflowStatus });
       }
     },
-    [aiForSoc, closePopover, onConfirm]
+    [closePopover, hasSearchAILakeConfigurations, onConfirm]
   );
 
   const onClickAddToNewCase = useCallback(async () => {
@@ -343,7 +341,7 @@ const TakeActionComponent: React.FC<Props> = ({
         <EuiContextMenuPanel size="s" items={allItems} />
       </EuiPopover>
 
-      {pendingAction != null && !aiForSoc && (
+      {pendingAction != null && !hasSearchAILakeConfigurations && (
         <UpdateAlertsModal
           alertsCount={alertIds.length}
           attackDiscoveriesCount={attackDiscoveryIds.length}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/update_alerts_modal/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/update_alerts_modal/index.test.tsx
@@ -50,20 +50,26 @@ describe('UpdateAlertsModal', () => {
     expect(defaultProps.onCancel).toHaveBeenCalled();
   });
 
-  it('calls onConfirm(false) when markDiscoveriesOnly is clicked', () => {
+  it('calls onConfirm with updateAlerts: false when markDiscoveriesOnly is clicked', () => {
     render(<UpdateAlertsModal {...defaultProps} />);
 
     fireEvent.click(screen.getByTestId('markDiscoveriesOnly'));
 
-    expect(defaultProps.onConfirm).toHaveBeenCalledWith(false);
+    expect(defaultProps.onConfirm).toHaveBeenCalledWith({
+      updateAlerts: false,
+      workflowStatus: 'acknowledged',
+    });
   });
 
-  it('calls onConfirm(true) when markAlertsAndDiscoveries is clicked', () => {
+  it('calls onConfirm with updateAlerts: true when markAlertsAndDiscoveries is clicked', () => {
     render(<UpdateAlertsModal {...defaultProps} />);
 
     fireEvent.click(screen.getByTestId('markAlertsAndDiscoveries'));
 
-    expect(defaultProps.onConfirm).toHaveBeenCalledWith(true);
+    expect(defaultProps.onConfirm).toHaveBeenCalledWith({
+      updateAlerts: true,
+      workflowStatus: 'acknowledged',
+    });
   });
 
   it.each([

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/update_alerts_modal/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/update_alerts_modal/index.tsx
@@ -28,7 +28,13 @@ interface Props {
   attackDiscoveriesCount: number;
   onCancel: () => void;
   onClose: () => void;
-  onConfirm: (updateAlerts: boolean) => void;
+  onConfirm: ({
+    updateAlerts,
+    workflowStatus,
+  }: {
+    updateAlerts: boolean;
+    workflowStatus: 'open' | 'acknowledged' | 'closed';
+  }) => Promise<void>;
   workflowStatus: 'open' | 'acknowledged' | 'closed';
 }
 
@@ -45,12 +51,12 @@ const UpdateAlertsModalComponent: React.FC<Props> = ({
   const titleId = useGeneratedHtmlId();
 
   const markDiscoveriesOnly = useCallback(() => {
-    onConfirm(false);
-  }, [onConfirm]);
+    onConfirm({ updateAlerts: false, workflowStatus });
+  }, [onConfirm, workflowStatus]);
 
   const markAlertsAndDiscoveries = useCallback(() => {
-    onConfirm(true);
-  }, [onConfirm]);
+    onConfirm({ updateAlerts: true, workflowStatus });
+  }, [onConfirm, workflowStatus]);
 
   const confirmButtons = useMemo(
     () => (


### PR DESCRIPTION
## [AI4DSOC] [Attack discovery] In AI4DSOC projects, don't prompt the user to update the `kibana.alert.workflow_status` of alerts

This PR updates Attack discovery for AI4DSOC projects, such that it does NOT prompt the user with a modal to [optionally update the kibana.alert.workflow_status of alerts associated with Attack discoveries](https://github.com/elastic/kibana/pull/225029), as illustrated by the animated gif below:

![ai_for_soc_take_action](https://github.com/user-attachments/assets/1c58632f-f18d-4164-a31a-e8fbbd90bae2)

_Above: AI4DSOC: The modal is NOT displayed, and the associated alerts are NOT updated_

The animated gif above illustrates that in AI4DSOC projects:

- The modal prompting the user to update the `kibana.alert.workflow_status` of alerts is NOT displayed
- Only the workflow status of the Attack discovery is updated

### All other serverless projects

All other (non-AI4DSOC) serverless projects display the modal, and optionally update the workflow status of the alerts, as illustrated by the animated gif below:

![serverless](https://github.com/user-attachments/assets/d3dc067f-3fc3-461c-a7b5-a0640f82cc68)

_Above: All other serverless projects: The modal is displayed, and the associated alerts are updated_

The animated gif above illustrates that for all other serverless projects:

- The modal prompting the user to update the `kibana.alert.workflow_status` of alerts is displayed
- The workflow status of the Attack discovery is (optionally) updated

### Elastic Cloud and self manged

Elastic Cloud and self manged deployments display the modal, and optionally update the workflow status of the alerts, as illustrated by the animated gif below:

![self-managed](https://github.com/user-attachments/assets/0aeb7d4e-81a7-44ca-bdb5-86573d8ad3c9)

_Above: Self managed: The modal is displayed, and the associated alerts are updated_

The animated gif above illustrates that for Elastic cloud and self manged:

- The modal prompting the user to update the `kibana.alert.workflow_status` of alerts is displayed
- The workflow status of the Attack discovery is (optionally) updated

### Feature flags

Enable the required and recommended `assistantAttackDiscoverySchedulingEnabled` features flag in `config/kibana.dev.yml`:

```yaml
feature_flags.overrides:
  securitySolution.attackDiscoveryAlertsEnabled: true
  securitySolution.assistantAttackDiscoverySchedulingEnabled: true
```

### AI4DSOC

- To test with an AI4DSOC project, add the following setting to `config/serverless.security.dev.yaml`:

```yaml
xpack.securitySolutionServerless.productTypes:
[
  { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
]
```

### Desk testing

1) Navigate to Security > Attack discovery

2) Click `Generate` to generate attack discoveries

3) Click the `Take action` dropdown on an Attack discovery

4) Click `Mark as acknowledged`

**Expected result**

The modal is displayed, and alerts are (optionally) updated for the deployment, for the deployment-type in the table below:

| Deployment                    | Modal displayed | Alerts (optionally) updated |
|-------------------------------|-----------------|-----------------------------|
| AI4DSOC                       | ❌               | ❌                           |
| All other serverless projects | ✅               | ✅                           |
| Elastic Cloud and self manged | ✅               | ✅                           |

5) Select (at least) 2 discoveries via their checkboxes

6) Click the `Selected 2 Attack discoveries` popover menu

7) Click `Mark as closed` from the popover menu

**Expected result**

Once again, the modal is displayed, and alerts are (optionally) updated for the deployment, for the deployment-type in the table below:

| Deployment                    | Modal displayed | Alerts (optionally) updated |
|-------------------------------|-----------------|-----------------------------|
| AI4DSOC                       | ❌               | ❌                           |
| All other serverless projects | ✅               | ✅                           |
| Elastic Cloud and self manged | ✅               | ✅                           |


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->