### PR TITLE
[docs] Remove references to old lifecycles

### DIFF
--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -168,7 +168,7 @@ $$$action-config-email-domain-allowlist$$$
     Disabled action types will not appear as an option when creating new connectors, but existing connectors and actions of that type will remain in Kibana and will not function.
 
     ::::{important}
-    [Preconfigured connectors](/reference/connectors-kibana/pre-configured-connectors.md) are not affected by this setting. 
+    [Preconfigured connectors](/reference/connectors-kibana/pre-configured-connectors.md) are not affected by this setting.
     ::::
 
     Data type: `string`
@@ -492,7 +492,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
     * For an [{{bedrock}} connector](/reference/connectors-kibana/bedrock-action-type.md), current support is for the Anthropic Claude models.
        * In {{serverless-full}}, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`.
        * In {{stack}} 9.0, the default is `anthropic.claude-3-5-sonnet-20240620-v1:0`.
-       * In {{stack}} 9.1 and later, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`. {applies_to}`stack: planned 9.1`
+       * In {{stack}} 9.1 and later, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`. {applies_to}`stack: ga 9.1`
     * For a [{{gemini}} connector](/reference/connectors-kibana/gemini-action-type.md), current support is for the Gemini models. Defaults to `gemini-2.5-pro`.
     * For a [OpenAI connector](/reference/connectors-kibana/openai-action-type.md), it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`.
 

--- a/docs/reference/configuration-reference/security-settings.md
+++ b/docs/reference/configuration-reference/security-settings.md
@@ -120,8 +120,9 @@ xpack.security.authc.providers.saml.<provider-name>.useRelayStateDeepLink ![logo
 % TBD: Available only on Elastic Cloud?
 
 #### Discontinued SAML settings
+
 ```{applies_to}
-ess: discontinued 8.0
+ess: removed 8.0
 ```
 The following settings are available in {{ecloud}} for all supported versions before 8.0:
 

--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -281,8 +281,8 @@ groups:
             self: all
             ess: all
          # example: |
-      
-      - setting: xpack.actions.email.services.ses.host 
+
+      - setting: xpack.actions.email.services.ses.host
         id: action-config-email-services-ses-host
         description: |
           The SMTP endpoint for an Amazon Simple Email Service (SES) service provider that can be used by email connectors.
@@ -1139,7 +1139,7 @@ groups:
           * For an [{{bedrock}} connector](/kibana/docs/reference/connectors-kibana/bedrock-action-type.md), current support is for the Anthropic Claude models.
             * In {{serverless-full}}, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`.
             * In {{stack}} 9.0, the default is `anthropic.claude-3-5-sonnet-20240620-v1:0`.
-            * In {{stack}} 9.1 and later, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`. {applies_to}`stack: planned 9.1`
+            * In {{stack}} 9.1 and later, the default is `us.anthropic.claude-3-7-sonnet-20250219-v1:0`. {applies_to}`stack: ga 9.1`
           * For a [{{gemini}} connector](/kibana/docs/reference/connectors-kibana/gemini-action-type.md), current support is for the Gemini models. Defaults to `gemini-2.5-pro`.
           * For a [OpenAI connector](/kibana/docs/reference/connectors-kibana/openai-action-type.md), it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`.
         # state: deprecated/hidden/tech-preview


### PR DESCRIPTION
Related to https://github.com/elastic/docs-projects/issues/508 

Remove references to old lifecycles:

- [x] `discontinued`
- [x] `planned`

<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->