### PR TITLE
[ML] AI Connector creation endpoint: test for error message handler

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/routes/connector/error_handler.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/connector/error_handler.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TransportResult } from '@elastic/elasticsearch';
+import { errors } from '@elastic/elasticsearch';
+import { kibanaResponseFactory, type KibanaResponseFactory } from '@kbn/core/server';
+import { errorHandler } from './error_handler';
+
+const createApiResponseError = ({
+  statusCode = 200,
+  headers = {},
+  body = {},
+}: {
+  statusCode?: number;
+  headers?: Record<string, string>;
+  body?: Record<string, any>;
+} = {}): TransportResult => {
+  return {
+    body,
+    statusCode,
+    headers,
+    warnings: [],
+    meta: {} as any,
+  };
+};
+
+describe('errorHandler', () => {
+  let response: KibanaResponseFactory;
+
+  beforeEach(() => {
+    response = kibanaResponseFactory;
+  });
+
+  describe('incoming error is KibanaServerError', () => {
+    it('should return bad request response if it is bad request error', () => {
+      const res = errorHandler(
+        response,
+        new errors.ResponseError(createApiResponseError({ statusCode: 400 }))
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('should return the cause for a bad request if available for bad request error', () => {
+      const res = errorHandler(
+        response,
+        new errors.ResponseError(
+          createApiResponseError({
+            body: {
+              message: 'Response Error',
+              error: {
+                root_cause: [
+                  {
+                    type: 'illegal_argument_exception',
+                    reason: 'root cause',
+                  },
+                  {
+                    type: 'illegal_argument_exception',
+                    reason: 'deep root cause',
+                  },
+                ],
+                caused_by: {
+                  type: 'illegal_argument_exception',
+                  reason: 'first caused by',
+                  caused_by: {
+                    type: 'illegal_argument_exception',
+                    reason: 'second caused by',
+                  },
+                },
+              },
+            },
+            statusCode: 400,
+          })
+        )
+      );
+      expect(res.status).toBe(400);
+      expect(res.payload.message).toBe('deep root cause');
+    });
+
+    it('should return a forbidden response if it is unauthorized error', () => {
+      const res = errorHandler(
+        response,
+        new errors.ResponseError(createApiResponseError({ statusCode: 401 }))
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('should return a not found response if it is not found error', () => {
+      const res = errorHandler(
+        response,
+        new errors.ResponseError(createApiResponseError({ statusCode: 404 }))
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('should return a custom error if it is custom error', () => {
+      const res = errorHandler(
+        response,
+        new errors.ResponseError(
+          createApiResponseError({ statusCode: 500, body: { message: 'Custom error' } })
+        )
+      );
+      expect(res.status).toBe(500);
+      expect(res.payload.includes('Custom error')).toBe(true);
+    });
+  });
+
+  describe('incoming error is not a KibanaServerError', () => {
+    it('throws original error if it is not KibanaServerError', () => {
+      try {
+        errorHandler(response, new Error('This is not a KibanaServerError'));
+      } catch (e) {
+        expect(e.message).toBe('This is not a KibanaServerError');
+      }
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/actions/server/routes/connector/error_handler.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/connector/error_handler.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { TransportResult } from '@elastic/elasticsearch';
+import type { TransportResult, DiagnosticResult } from '@elastic/elasticsearch';
 import { errors } from '@elastic/elasticsearch';
 import { kibanaResponseFactory, type KibanaResponseFactory } from '@kbn/core/server';
 import { errorHandler } from './error_handler';
@@ -17,14 +17,14 @@ const createApiResponseError = ({
 }: {
   statusCode?: number;
   headers?: Record<string, string>;
-  body?: Record<string, any>;
+  body?: DiagnosticResult['body'];
 } = {}): TransportResult => {
   return {
     body,
     statusCode,
     headers,
     warnings: [],
-    meta: {} as any,
+    meta: {} as DiagnosticResult['meta'],
   };
 };
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/223920

This PR adds a test file covering the error handler added in https://github.com/elastic/kibana/pull/221859 and covers:
a) an ES bad request
b) an unauthorized error
c) a 404 error
d) a custom error
e) when the error is not a Kibana server error


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->