### PR TITLE
[Asset Inventory] UI adjustments for generic Flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
@@ -109,6 +109,7 @@ export const EntityInsight = <T,>({
     <>
       {insightContent.length > 0 && (
         <>
+          <EuiHorizontalRule />
           <EuiAccordion
             initialIsOpen={true}
             id="entityInsight-accordion"

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
@@ -109,7 +109,6 @@ export const EntityInsight = <T,>({
     <>
       {insightContent.length > 0 && (
         <>
-          <EuiHorizontalRule />
           <EuiAccordion
             initialIsOpen={true}
             id="entityInsight-accordion"

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiHorizontalRule, EuiTitle, useEuiTheme } from '@elastic/eui';
+import { EuiTitle, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { getFlattenedObject } from '@kbn/std';
 import type { GenericEntityRecord } from '../../../asset_inventory/types/generic_entity_record';
@@ -128,8 +128,6 @@ export const GenericEntityFlyoutContent = ({
           />
         </ExpandablePanel>
       </ExpandableSection>
-
-      <EuiHorizontalRule />
 
       <EntityInsight
         field={insightsField}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/content.tsx
@@ -81,6 +81,13 @@ export const GenericEntityFlyoutContent = ({
 
   return (
     <FlyoutBody>
+      <EntityInsight
+        field={insightsField}
+        value={insightsValue}
+        isPreviewMode={false}
+        isLinkEnabled={true}
+        openDetailsPanel={openGenericEntityDetailsPanelByPath}
+      />
       <ExpandableSection
         title={
           <FormattedMessage
@@ -128,14 +135,6 @@ export const GenericEntityFlyoutContent = ({
           />
         </ExpandablePanel>
       </ExpandableSection>
-
-      <EntityInsight
-        field={insightsField}
-        value={insightsValue}
-        isPreviewMode={false}
-        isLinkEnabled={true}
-        openDetailsPanel={openGenericEntityDetailsPanelByPath}
-      />
     </FlyoutBody>
   );
 };


### PR DESCRIPTION
### Summary

It closes https://github.com/elastic/security-team/issues/13074

This PR fixes small UX inconsistencies in the Asset Inventory generic flyout:
- Removed extra separator line rendered at the bottom of the Generic Flyout after the highlighted fields section.
- Moved Insights to the top to stay consistent with user and host flyouts



### Screenshot

Before

<img width="702" alt="image" src="https://github.com/user-attachments/assets/29beaa1f-f784-47a0-bd3d-5f77ed3d2fa9" />

After
<img width="706" alt="image" src="https://github.com/user-attachments/assets/03dd9d37-636c-4ae2-ac77-791e57046ede" />



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->