### PR TITLE
[8.19] [ResponseOps][Reporting] Add recurring schedule to rrule converstion test (#227310)

### DIFF
--- a/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.test.ts
+++ b/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.test.ts
@@ -16,7 +16,7 @@ describe('convertToRRule', () => {
   const today = '2023-03-22';
   const startDate = moment(today);
 
-  test('should convert a maintenance window that is not recurring', () => {
+  test('should convert a recurring schedule that is not recurring', () => {
     const rRule = convertToRRule({ startDate, timezone });
 
     expect(rRule).toEqual({
@@ -27,7 +27,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a daily schedule', () => {
+  test('should convert a recurring schedule that is recurring on a daily schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -47,7 +47,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a daily schedule until', () => {
+  test('should convert a recurring schedule that is recurring on a daily schedule until', () => {
     const until = moment(today).add(1, 'month').toISOString();
     const rRule = convertToRRule({
       startDate,
@@ -70,7 +70,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a daily schedule after x', () => {
+  test('should convert a recurring schedule that is recurring on a daily schedule after x', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -92,7 +92,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a weekly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a weekly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -111,7 +111,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a monthly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a monthly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -130,7 +130,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a yearly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a yearly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -150,7 +150,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom daily schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom daily schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -170,7 +170,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom weekly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom weekly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -192,7 +192,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom monthly by day schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom monthly by day schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -214,7 +214,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom monthly by weekday schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom monthly by weekday schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -236,7 +236,7 @@ describe('convertToRRule', () => {
     });
   });
 
-  test('should convert a maintenance window that is recurring on a custom yearly schedule', () => {
+  test('should convert a recurring schedule that is recurring on a custom yearly schedule', () => {
     const rRule = convertToRRule({
       startDate,
       timezone,
@@ -257,4 +257,21 @@ describe('convertToRRule', () => {
       bymonthday: [22],
     });
   });
+
+  test.each(['frequency', 'customFrequency'])(
+    'should parse %s as string to number',
+    (frequencyKey) => {
+      const rRule = convertToRRule({
+        startDate,
+        timezone,
+        // @ts-expect-error Testing string to number parsing
+        recurringSchedule: {
+          [frequencyKey]: '1',
+          ends: 'never',
+        },
+      });
+      expect(typeof rRule.freq).toBe('number');
+      expect(rRule.freq).toBe(1);
+    }
+  );
 });

--- a/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.ts
+++ b/src/platform/packages/shared/response-ops/recurring-schedule-form/utils/convert_to_rrule.ts
@@ -11,8 +11,9 @@ import type { Moment } from 'moment';
 import { Frequency } from '@kbn/rrule';
 import { ISO_WEEKDAYS_TO_RRULE } from '../constants';
 import { getPresets } from './get_presets';
-import type { RRuleParams, RecurringSchedule } from '../types';
+import { parseSchedule } from './parse_schedule';
 import { getNthByWeekday } from './get_nth_by_weekday';
+import type { RRuleParams, RecurringSchedule } from '../types';
 
 export const convertToRRule = ({
   startDate,
@@ -27,6 +28,8 @@ export const convertToRRule = ({
 }): RRuleParams => {
   const presets = getPresets(startDate);
 
+  const parsedSchedule = parseSchedule(recurringSchedule);
+
   const rRule: RRuleParams = {
     dtstart: startDate.toISOString(),
     tzid: timezone,
@@ -35,7 +38,7 @@ export const convertToRRule = ({
       : {}),
   };
 
-  if (!recurringSchedule)
+  if (!parsedSchedule)
     return {
       ...rRule,
       // default to yearly and a count of 1
@@ -44,9 +47,9 @@ export const convertToRRule = ({
       count: 1,
     };
 
-  let form = recurringSchedule;
-  if (recurringSchedule.frequency !== 'CUSTOM') {
-    form = { ...recurringSchedule, ...presets[recurringSchedule.frequency] };
+  let form = parsedSchedule;
+  if (parsedSchedule.frequency !== 'CUSTOM') {
+    form = { ...parsedSchedule, ...presets[parsedSchedule.frequency] };
   }
 
   const frequency = form.customFrequency ?? (form.frequency as Frequency);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Reporting] Add recurring schedule to rrule converstion test (#227310)](https://github.com/elastic/kibana/pull/227310)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Umberto Pepato","email":"umbopepato@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-10T07:05:03Z","message":"[ResponseOps][Reporting] Add recurring schedule to rrule converstion test (#227310)\n\n## 📄 Summary\n\nAdds a test to check that the recurring schedule to rrule conversion\ncorrectly parses the schedule to handle cases where the frequencies are\npassed as strings (i.e. form hook lib).\n\n> [!IMPORTANT]\n> This works on main, but will fail in 8.19 where the parsing step was\naccidentally not added with the original backport. The main purpose of\nthis PR is to use the related backport PR to add it and fix the issue on\nthe 8.19 track.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n- Create a Dashboard\n- Open the Export (⬇️) menu in the toolbar\n- Click `Schedule export`\n- From the Schedule dropdown select `Weekly on ...`\n- Submit the form\n- The report should be correctly scheduled\n\n</details>\n\n## 🔗 References\n\nFixes #226582","sha":"a78c35701d629d78c4da456303987e67df3523bc","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[ResponseOps][Reporting] Add recurring schedule to rrule converstion test","number":227310,"url":"https://github.com/elastic/kibana/pull/227310","mergeCommit":{"message":"[ResponseOps][Reporting] Add recurring schedule to rrule converstion test (#227310)\n\n## 📄 Summary\n\nAdds a test to check that the recurring schedule to rrule conversion\ncorrectly parses the schedule to handle cases where the frequencies are\npassed as strings (i.e. form hook lib).\n\n> [!IMPORTANT]\n> This works on main, but will fail in 8.19 where the parsing step was\naccidentally not added with the original backport. The main purpose of\nthis PR is to use the related backport PR to add it and fix the issue on\nthe 8.19 track.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n- Create a Dashboard\n- Open the Export (⬇️) menu in the toolbar\n- Click `Schedule export`\n- From the Schedule dropdown select `Weekly on ...`\n- Submit the form\n- The report should be correctly scheduled\n\n</details>\n\n## 🔗 References\n\nFixes #226582","sha":"a78c35701d629d78c4da456303987e67df3523bc"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227358","number":227358,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227310","number":227310,"mergeCommit":{"message":"[ResponseOps][Reporting] Add recurring schedule to rrule converstion test (#227310)\n\n## 📄 Summary\n\nAdds a test to check that the recurring schedule to rrule conversion\ncorrectly parses the schedule to handle cases where the frequencies are\npassed as strings (i.e. form hook lib).\n\n> [!IMPORTANT]\n> This works on main, but will fail in 8.19 where the parsing step was\naccidentally not added with the original backport. The main purpose of\nthis PR is to use the related backport PR to add it and fix the issue on\nthe 8.19 track.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n- Create a Dashboard\n- Open the Export (⬇️) menu in the toolbar\n- Click `Schedule export`\n- From the Schedule dropdown select `Weekly on ...`\n- Submit the form\n- The report should be correctly scheduled\n\n</details>\n\n## 🔗 References\n\nFixes #226582","sha":"a78c35701d629d78c4da456303987e67df3523bc"}}]}] BACKPORT-->