### PR TITLE
[Security Solution] Unskip real prebuilt rules package installation Cypress test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/install_via_fleet.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/install_via_fleet.cy.ts
@@ -5,124 +5,71 @@
  * 2.0.
  */
 
-import type { BulkInstallPackageInfo } from '@kbn/fleet-plugin/common';
-import type { Rule } from '@kbn/security-solution-plugin/public/detection_engine/rule_management/logic/types';
-
+import { BOOTSTRAP_PREBUILT_RULES_URL } from '@kbn/security-solution-plugin/common/api/detection_engine';
+import { installSinglePrebuiltRule } from '../../../../tasks/prebuilt_rules/install_prebuilt_rules';
 import { resetRulesTableState } from '../../../../tasks/common';
-import { INSTALL_ALL_RULES_BUTTON, TOASTER } from '../../../../screens/alerts_detection_rules';
-import { getRuleAssets } from '../../../../tasks/api_calls/prebuilt_rules';
+import { RULE_NAME } from '../../../../screens/alerts_detection_rules';
+import { deletePrebuiltRulesFleetPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../tasks/login';
-import { clickAddElasticRulesButton } from '../../../../tasks/prebuilt_rules';
-import { visitRulesManagementTable } from '../../../../tasks/rules_management';
+import { visitAddRulesPage, visitRulesManagementTable } from '../../../../tasks/rules_management';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
+import { expectManagementTableRules } from '../../../../tasks/alerts_detection_rules';
 
-// Failing: See https://github.com/elastic/kibana/issues/182439
-// Failing: See https://github.com/elastic/kibana/issues/182440
-describe.skip(
+const PREBUILT_RULES_PACKAGE_INSTALLATION_TIMEOUT_MS = 120000; // 2 minutes
+
+describe(
   'Detection rules, Prebuilt Rules Installation and Update workflow',
   { tags: ['@ess', '@serverless'] },
   () => {
     describe('Installation of prebuilt rules package via Fleet', () => {
       beforeEach(() => {
-        login();
+        deletePrebuiltRulesFleetPackage();
         resetRulesTableState();
         deleteAlertsAndRules();
-        cy.intercept('POST', '/api/fleet/epm/packages/_bulk*').as('installPackageBulk');
-        cy.intercept('POST', '/api/fleet/epm/packages/security_detection_engine/*').as(
-          'installPackage'
-        );
-        cy.intercept('POST', '/internal/detection_engine/prebuilt_rules/installation/_perform').as(
-          'installPrebuiltRules'
-        );
-        visitRulesManagementTable();
+
+        cy.intercept('POST', BOOTSTRAP_PREBUILT_RULES_URL).as('bootstrapPrebuiltRules');
+
+        login();
       });
 
-      it('should install package from Fleet in the background', () => {
-        /* Assert that the package in installed from Fleet */
-        cy.wait('@installPackageBulk', {
-          timeout: 60000,
-        }).then(({ response: bulkResponse }) => {
-          cy.wrap(bulkResponse?.statusCode).should('eql', 200);
+      it('should install prebuilt rules from the Fleet package', () => {
+        visitAddRulesPage();
 
-          const packages = bulkResponse?.body.items.map(
-            ({ name, result }: BulkInstallPackageInfo) => ({
-              name,
-            })
+        // Expect the package to be installed
+        cy.wait('@bootstrapPrebuiltRules', {
+          timeout: PREBUILT_RULES_PACKAGE_INSTALLATION_TIMEOUT_MS,
+        }).then(({ response }) => {
+          cy.wrap(response?.statusCode).should('eql', 200);
+
+          const securityDetectionEnginePackage = response?.body.packages.find(
+            (pkg: { name: string }) => pkg.name === 'security_detection_engine'
           );
 
-          const packagesBulkInstalled = packages.map(({ name }: { name: string }) => name);
-
-          // Under normal flow the package is installed via the Fleet bulk install API.
-          // However, for testing purposes the package can be installed via the Fleet individual install API,
-          // so we need to intercept and wait for that request as well.
-          if (!packagesBulkInstalled.includes('security_detection_engine')) {
-            // Should happen only during testing when the `xpack.securitySolution.prebuiltRulesPackageVersion` flag is set
-            cy.wait('@installPackage').then(({ response }) => {
-              cy.wrap(response?.statusCode).should('eql', 200);
-              cy.wrap(response?.body)
-                .should('have.property', 'items')
-                .should('have.length.greaterThan', 0);
-            });
-          } else {
-            // Normal flow, install via the Fleet bulk install API
-            expect(packages.length).to.have.greaterThan(0);
-            // At least one of the packages installed should be the security_detection_engine package
-            expect(packages).to.satisfy((pckgs: BulkInstallPackageInfo[]) =>
-              pckgs.some((pkg) => pkg.name === 'security_detection_engine')
-            );
-          }
-        });
-      });
-
-      it('should install rules from the Fleet package when user clicks on CTA', () => {
-        interface Response {
-          body: {
-            hits: {
-              hits: Array<{ _source: { ['security-rule']: Rule } }>;
-            };
-          };
-        }
-        const getRulesAndAssertNumberInstalled = () => {
-          getRuleAssets().then((response) => {
-            const ruleIds = (response as Response).body.hits.hits.map(
-              (hit) => hit._source['security-rule'].rule_id
-            );
-
-            const numberOfRulesToInstall = new Set(ruleIds).size;
-            clickAddElasticRulesButton();
-
-            cy.get(INSTALL_ALL_RULES_BUTTON).should('be.enabled').click();
-            cy.wait('@installPrebuiltRules', {
-              timeout: 60000,
-            }).then(() => {
-              cy.get(TOASTER)
-                .should('be.visible')
-                .should(
-                  'have.text',
-                  // i18n uses en-US format for numbers, which uses a comma as a thousands separator
-                  `${numberOfRulesToInstall.toLocaleString('en-US')} rules installed successfully.`
-                );
-            });
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(
+            securityDetectionEnginePackage,
+            'Bootstrap endpoint must return "security_detection_engine" package info.'
+          ).to.exist;
+          expect(
+            securityDetectionEnginePackage,
+            '"security_detection_engine" package must be just installed'
+          ).includes({
+            name: 'security_detection_engine',
+            status: 'installed',
           });
-        };
-        /* Retrieve how many rules were installed from the Fleet package */
-        /* See comments in test above for more details */
-        cy.wait('@installPackageBulk', {
-          timeout: 60000,
-        }).then(({ response: bulkResponse }) => {
-          cy.wrap(bulkResponse?.statusCode).should('eql', 200);
 
-          const packagesBulkInstalled = bulkResponse?.body.items.map(
-            ({ name }: { name: string }) => name
-          );
+          // Install some prebuilt rules
+          cy.get<JQuery<HTMLElement>>(RULE_NAME).then(($ruleNames) => {
+            const ruleNames = $ruleNames.get().map((x) => x.innerText);
 
-          if (!packagesBulkInstalled.includes('security_detection_engine')) {
-            cy.wait('@installPackage').then(() => {
-              getRulesAndAssertNumberInstalled();
-            });
-          } else {
-            getRulesAndAssertNumberInstalled();
-          }
+            installSinglePrebuiltRule(ruleNames[0]);
+            installSinglePrebuiltRule(ruleNames[1]);
+            installSinglePrebuiltRule(ruleNames[2]);
+
+            visitRulesManagementTable();
+
+            expectManagementTableRules([ruleNames[0], ruleNames[1], ruleNames[2]]);
+          });
         });
       });
     });

--- a/x-pack/test/security_solution_cypress/cypress/screens/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/alerts_detection_rules.ts
@@ -156,7 +156,8 @@ export const TOASTER = '[data-test-subj="euiToastHeader"]';
 
 export const TOASTER_MESSAGE = '[data-test-subj="errorToastMessage"]';
 
-export const SUCCESS_TOASTER = '[class*="euiToast-success"] [data-test-subj="euiToastHeader"]';
+export const SUCCESS_TOASTER_HEADER =
+  '[class*="euiToast-success"] [data-test-subj="euiToastHeader"]';
 
 export const TOASTER_BODY = '[data-test-subj="globalToastList"] [data-test-subj="euiToastBody"]';
 

--- a/x-pack/test/security_solution_cypress/cypress/screens/install_prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/install_prebuilt_rules.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const RULE_NAME = `[data-test-subj="ruleName"]`;
+export const INSTALL_SINGLE_RULE_BUTTON = `[data-test-subj*="installSinglePrebuiltRuleButton"]`;
+export const INSTALL_SINGLE_RULE_SPINNER = `[data-test-subj*="installSinglePrebuiltRuleButton-loadingSpinner"]`;

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
+import { epmRouteService } from '@kbn/fleet-plugin/common';
 import {
   PerformRuleInstallationResponseBody,
   PERFORM_RULE_INSTALLATION_URL,
   BOOTSTRAP_PREBUILT_RULES_URL,
 } from '@kbn/security-solution-plugin/common/api/detection_engine';
-import { ELASTIC_SECURITY_RULE_ID } from '@kbn/security-solution-plugin/common/detection_engine/constants';
+import {
+  ELASTIC_SECURITY_RULE_ID,
+  PREBUILT_RULES_PACKAGE_NAME,
+} from '@kbn/security-solution-plugin/common/detection_engine/constants';
 import type { PrePackagedRulesStatusResponse } from '@kbn/security-solution-plugin/public/detection_engine/rule_management/logic/types';
 import { getPrebuiltRuleWithExceptionsMock } from '@kbn/security-solution-plugin/server/lib/detection_engine/prebuilt_rules/mocks';
 import { createRuleAssetSavedObject } from '../../helpers/rules';
@@ -248,3 +252,48 @@ export const createAndInstallMockedPrebuiltRules = (
   // Install rules into Kibana as `alerts` SOs
   return installSpecificPrebuiltRulesRequest(ruleAssets);
 };
+
+const MAX_DELETE_FLEET_PACKAGE_RETRIES = 2;
+const DELETE_FLEET_PACKAGE_DELAY_MS = 5000;
+
+const deleteFleetPackage = (
+  packageName: string,
+  retries = MAX_DELETE_FLEET_PACKAGE_RETRIES,
+  delayMs = DELETE_FLEET_PACKAGE_DELAY_MS
+): Cypress.Chainable<Cypress.Response<unknown>> => {
+  const deleteWithRetries = (tried = 0): Cypress.Chainable<Cypress.Response<unknown>> => {
+    if (tried > retries) {
+      throw new Error(`Error deleting ${packageName} package`);
+    }
+
+    return rootRequest({
+      method: 'DELETE',
+      url: epmRouteService.getRemovePath(packageName),
+      body: JSON.stringify({ force: true }),
+      failOnStatusCode: false,
+    }).then((response) => {
+      if (response.status === 200) {
+        cy.log(`Deleted ${packageName} package (was installed)`);
+        return;
+      } else if (
+        response.status === 400 &&
+        (response.body as { message?: string }).message === `${packageName} is not installed`
+      ) {
+        cy.log(`Deleted ${packageName} package (was not installed)`, response.body);
+        return;
+      } else {
+        cy.log(`Error deleting ${packageName} package`, response.body);
+        cy.wait(delayMs).then(() => deleteWithRetries(tried + 1));
+      }
+
+      if (!Cypress.env(IS_SERVERLESS)) {
+        refreshSavedObjectIndices();
+      }
+    });
+  };
+
+  return deleteWithRetries();
+};
+
+export const deletePrebuiltRulesFleetPackage = (): Cypress.Chainable<Cypress.Response<unknown>> =>
+  deleteFleetPackage(PREBUILT_RULES_PACKAGE_NAME);

--- a/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules.ts
@@ -15,7 +15,7 @@ import {
   RULES_UPDATES_TAB,
   RULES_UPDATES_TABLE,
   TOASTER,
-  SUCCESS_TOASTER,
+  SUCCESS_TOASTER_HEADER,
 } from '../screens/alerts_detection_rules';
 import type { SAMPLE_PREBUILT_RULE } from './api_calls/prebuilt_rules';
 import {
@@ -184,7 +184,7 @@ export const assertRuleInstallationSuccessToastShown = (
   rules: Array<typeof SAMPLE_PREBUILT_RULE>
 ) => {
   const rulesString = rules.length > 1 ? 'rules' : 'rule';
-  cy.get(SUCCESS_TOASTER)
+  cy.get(SUCCESS_TOASTER_HEADER)
     .should('be.visible')
     .should('have.text', `${rules.length} ${rulesString} installed successfully`);
 };
@@ -200,7 +200,7 @@ export const assertRuleInstallationFailureToastShown = (
 
 export const assertRuleUpgradeSuccessToastShown = (rules: Array<typeof SAMPLE_PREBUILT_RULE>) => {
   const rulesString = rules.length > 1 ? 'rules' : 'rule';
-  cy.get(SUCCESS_TOASTER)
+  cy.get(SUCCESS_TOASTER_HEADER)
     .should('be.visible')
     .should('contain', `${rules.length} ${rulesString} updated successfully`);
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules/install_prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules/install_prebuilt_rules.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SUCCESS_TOASTER_HEADER } from '../../screens/alerts_detection_rules';
+import { INSTALL_SINGLE_RULE_BUTTON } from '../../screens/install_prebuilt_rules';
+import { getRuleRow } from '../alerts_detection_rules';
+
+/**
+ * Installs a single prebuilt rule by clicking the install button
+ * in the rule's table row on Add Rules page
+ */
+export const installSinglePrebuiltRule = (ruleName: string) => {
+  getRuleRow(ruleName).find(INSTALL_SINGLE_RULE_BUTTON).click();
+
+  cy.get(SUCCESS_TOASTER_HEADER).should('have.text', '1 rule installed successfully');
+
+  // Wait for the success toaster to disappear
+  cy.get(SUCCESS_TOASTER_HEADER).should('not.exist');
+};

--- a/x-pack/test/security_solution_cypress/cypress/tasks/rules_management.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/rules_management.ts
@@ -6,7 +6,7 @@
  */
 
 import { LAST_BREADCRUMB, RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../screens/breadcrumbs';
-import { RULES_MANAGEMENT_URL } from '../urls/rules_management';
+import { INSTALL_PREBUILT_RULES_URL, RULES_MANAGEMENT_URL } from '../urls/rules_management';
 import { resetRulesTableState } from './common';
 import { visit } from './navigation';
 
@@ -19,4 +19,8 @@ export function openRuleManagementPageViaBreadcrumbs(): void {
   cy.log('Navigate back to rules table via breadcrumbs');
   cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).not(LAST_BREADCRUMB).click();
   cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).filter(LAST_BREADCRUMB).should('exist');
+}
+
+export function visitAddRulesPage(): void {
+  visit(INSTALL_PREBUILT_RULES_URL);
 }

--- a/x-pack/test/security_solution_cypress/cypress/urls/rules_management.ts
+++ b/x-pack/test/security_solution_cypress/cypress/urls/rules_management.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+export const INSTALL_PREBUILT_RULES_URL = '/app/security/rules/add_rules';
 export const RULES_MANAGEMENT_URL = '/app/security/rules/management';
 export const RULES_MONITORING_URL = '/app/security/rules/monitoring';
 export const RULES_COVERAGE_OVERVIEW_URL = '/app/security/rules_coverage_overview';


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/182439**
**Resolves: https://github.com/elastic/kibana/issues/182440**

## Summary

This PR fixes and unskips real Prebuilt Rules real package installation Cypress test.

## Details

It's been a while since the test was skipped. Meantime we've changes the way the Prebuilt Rules package gets installed.

It required completely reworking the tests and merging them together to be able to unskip the test suite.

## Flaky test runner

- ✅ [ECH 200 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8580#_)
- ✅ [Serverless 200 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8581)




<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->