### PR TITLE
[Synthetics] Fixed edit private location with no monitors assigned

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_private_location.ts
@@ -86,6 +86,21 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       rawExpect(apiResponse.body.locations).toEqual(rawExpect.arrayContaining(testResponse));
     });
 
+    it('successfully edits a private location label with no monitors assigned', async () => {
+      const privateLocation = privateLocations[0];
+
+      await supertestEditorWithApiKey
+        .put(`${SYNTHETICS_API_URLS.PRIVATE_LOCATIONS}/${privateLocation.id}`)
+        .send({ label: 'No monitors assigned' })
+        .expect(200);
+
+      // Set the label back, needed for the other tests
+      await supertestEditorWithApiKey
+        .put(`${SYNTHETICS_API_URLS.PRIVATE_LOCATIONS}/${privateLocation.id}`)
+        .send({ label: privateLocations[0].label })
+        .expect(200);
+    });
+
     it('adds a monitor in private location', async () => {
       newMonitor = {
         ...getFixtureJson('http_monitor'),


### PR DESCRIPTION
This PR fixes a bug that was found when editing the label of a private location with no monitors assigned.

When checking the user privileges the following error was thrown:
`[plugins.synthetics] Error: Can't check saved object privileges for 0 namespaces`

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->