### PR TITLE
🌊 Streams: Fix processing preview table bugs

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
@@ -145,7 +145,7 @@ export function PreviewTable({
 
   const leadingControlColumns: EuiDataGridControlColumn[] = useMemo(
     () =>
-      selectableRow
+      selectableRow && visibleColumns.length > 0
         ? [
             {
               id: 'selection',
@@ -172,7 +172,7 @@ export function PreviewTable({
             },
           ]
         : [],
-    [onRowSelected, selectableRow, selectedRowIndex]
+    [onRowSelected, selectableRow, selectedRowIndex, visibleColumns.length]
   );
 
   return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/preview_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/preview_flyout.tsx
@@ -5,15 +5,13 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { UnifiedDocViewerFlyout } from '@kbn/unified-doc-viewer-plugin/public';
 import { DataTableRecord } from '@kbn/discover-utils';
 import useAsync from 'react-use/lib/useAsync';
 import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
 import { useKibana } from '../../../hooks/use_kibana';
 import { useSimulatorSelector } from './state_management/stream_enrichment_state_machine';
-import { docViewJson } from './doc_viewer_json';
-import { docViewDiff } from './doc_viewer_diff';
 
 export const FLYOUT_WIDTH_KEY = 'streamsEnrichment:flyoutWidth';
 
@@ -25,24 +23,16 @@ export const PreviewFlyout = ({
   currentDoc,
   hits,
   setExpandedDoc,
+  docViewsRegistry,
 }: {
   currentDoc?: DataTableRecordWithIndex;
   hits: DataTableRecordWithIndex[];
   setExpandedDoc: (doc?: DataTableRecordWithIndex) => void;
+  docViewsRegistry: DocViewsRegistry;
 }) => {
   const streamName = useSimulatorSelector((state) => state.context.streamName);
   const { core, dependencies } = useKibana();
-  const { data, unifiedDocViewer } = dependencies.start;
-
-  const docViewsRegistry = useMemo(() => {
-    const docViewers = unifiedDocViewer.registry.getAll();
-    const myRegistry = new DocViewsRegistry([
-      docViewers.find((docView) => docView.id === 'doc_view_table')!,
-      docViewDiff,
-      docViewJson,
-    ]);
-    return myRegistry;
-  }, [unifiedDocViewer.registry]);
+  const { data } = dependencies.start;
 
   const { value: streamDataView } = useAsync(() =>
     data.dataViews.create({

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
@@ -444,7 +444,12 @@ const OutcomePreviewTable = () => {
         }
       />
       <DocViewerContext.Provider value={docViewerContext}>
-        <PreviewFlyout currentDoc={currentDoc} hits={hits} setExpandedDoc={setExpandedDoc} />
+        <PreviewFlyout
+          currentDoc={currentDoc}
+          hits={hits}
+          setExpandedDoc={setExpandedDoc}
+          docViewsRegistry={docViewsRegistry}
+        />
       </DocViewerContext.Provider>
     </>
   );


### PR DESCRIPTION
Fixes two bugs with the processing preview table:

Hide leading action column if there are no columns visible because they are all hidden. Originally I looked into automatically showing all of them if they get all hidden, but I reverted back from that since the data grid controls allow to hide all colunms as well (there even is a "Hide all" button). This made it much easier to just support the case of no columns selected - it's not hard for the user to bring them back anyway.

The diff viewer was always shown. This happened because there were two doc view registries on two levels of the component hierarchy - I probably forgot one during refactoring. Cleaned that up.