### PR TITLE
[FIX] Failing test: Chrome X-Pack Observability UI Functional Tests.x-pack/test/observability_functional/apps/observability/feature_controls/observability_security·ts - ObservabilityApp feature controls observability security feature controls observability cases all privileges "before all" hook for "shows observability/cases navlink"

### DIFF
--- a/x-pack/test/observability_functional/apps/observability/feature_controls/observability_security.ts
+++ b/x-pack/test/observability_functional/apps/observability/feature_controls/observability_security.ts
@@ -36,9 +36,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await kibanaServer.uiSettings.update(config.get('uiSettings.defaults'));
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/155090
-    // FLAKY: https://github.com/elastic/kibana/issues/155091
-    describe.skip('observability cases all privileges', () => {
+    describe('observability cases all privileges', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');
         await observability.users.setTestUserRole(


### PR DESCRIPTION
## Summary

It resumes/ fixes #155091
It resumes/ fixes #155090 
These tests were flaky in 2023, but now, according to FTR, they are working as expected.


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->