### PR TITLE
[Rules] Fixed serverless rules test

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/observability/rules/custom_threshold_consumer.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/rules/custom_threshold_consumer.ts
@@ -24,8 +24,11 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
   function createCustomThresholdRule({ ruleName }: { ruleName: string }) {
     it('navigates to the rules page', async () => {
-      await svlCommonNavigation.sidenav.clickLink({ text: 'Alerts' });
-      await testSubjects.click('manageRulesPageButton');
+      await retry.try(async () => {
+        await svlCommonNavigation.sidenav.clickLink({ text: 'Alerts' });
+        expect(await testSubjects.exists('manageRulesPageButton')).toBeTruthy();
+        await testSubjects.click('manageRulesPageButton');
+      });
     });
 
     it('should open the rule creation flyout', async () => {
@@ -58,9 +61,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     });
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/225800
-  // Failing: See https://github.com/elastic/kibana/issues/224460
-  describe.skip('Custom threshold rule - consumers', function () {
+  describe('Custom threshold rule - consumers', function () {
     // custom roles are not yet supported in MKI
     this.tags(['skipMKI']);
     const ruleIdList: string[] = [];

--- a/x-pack/test_serverless/functional/test_suites/observability/rules/es_query_consumer.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/rules/es_query_consumer.ts
@@ -24,8 +24,11 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
   function createESQueryRule({ ruleName }: { ruleName: string }) {
     it('navigates to the rules page', async () => {
-      await svlCommonNavigation.sidenav.clickLink({ text: 'Alerts' });
-      await testSubjects.click('manageRulesPageButton');
+      await retry.try(async () => {
+        await svlCommonNavigation.sidenav.clickLink({ text: 'Alerts' });
+        expect(await testSubjects.exists('manageRulesPageButton')).toBeTruthy();
+        await testSubjects.click('manageRulesPageButton');
+      });
     });
 
     it('should open the rule creation flyout', async () => {
@@ -57,8 +60,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     });
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/225813
-  describe.skip('ES Query rule - consumers', function () {
+  describe('ES Query rule - consumers', function () {
     // custom roles are not yet supported in MKI
     this.tags(['skipMKI']);
     const ruleIdList: string[] = [];


### PR DESCRIPTION
It closes #225813.
It closes #225800.
It closes #224460.

When clicking on the `Alerts` side nav button for some reason the navigation was sometimes not happening and the test was stuck in looking for the `manageRulesPageButton` but without trying clicking the `Alerts` button again.

Also worth mentioning that I was able to reproduce this only starting the server pointing to a Kibana build I previously created, I couldn't reproduce the issue running the server with the local Kibana.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->