### PR TITLE
[9.1] [Synthetics] Fixed edit private location with no monitors assigned (#227411)

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/edit_private_location.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/edit_private_location.ts
@@ -81,6 +81,21 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       rawExpect(apiResponse.body.locations).toEqual(rawExpect.arrayContaining(testResponse));
     });
 
+    it('successfully edits a private location label with no monitors assigned', async () => {
+      const privateLocation = privateLocations[0];
+
+      await supertestEditorWithApiKey
+        .put(`${SYNTHETICS_API_URLS.PRIVATE_LOCATIONS}/${privateLocation.id}`)
+        .send({ label: 'No monitors assigned' })
+        .expect(200);
+
+      // Set the label back, needed for the other tests
+      await supertestEditorWithApiKey
+        .put(`${SYNTHETICS_API_URLS.PRIVATE_LOCATIONS}/${privateLocation.id}`)
+        .send({ label: privateLocations[0].label })
+        .expect(200);
+    });
+
     it('adds a monitor in private location', async () => {
       newMonitor = {
         ...getFixtureJson('http_monitor'),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Synthetics] Fixed edit private location with no monitors assigned (#227411)](https://github.com/elastic/kibana/pull/227411)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-07-10T13:25:05Z","message":"[Synthetics] Fixed edit private location with no monitors assigned (#227411)\n\nThis PR fixes a bug that was found when editing the label of a private\nlocation with no monitors assigned.\n\nWhen checking the user privileges the following error was thrown:\n`[plugins.synthetics] Error: Can't check saved object privileges for 0\nnamespaces`","sha":"a946911347f8d80c1fc4116ea4592827031a196c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management","v9.2.0"],"title":"[Synthetics] Fixed edit private location with no monitors assigned","number":227411,"url":"https://github.com/elastic/kibana/pull/227411","mergeCommit":{"message":"[Synthetics] Fixed edit private location with no monitors assigned (#227411)\n\nThis PR fixes a bug that was found when editing the label of a private\nlocation with no monitors assigned.\n\nWhen checking the user privileges the following error was thrown:\n`[plugins.synthetics] Error: Can't check saved object privileges for 0\nnamespaces`","sha":"a946911347f8d80c1fc4116ea4592827031a196c"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227447","number":227447,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227411","number":227411,"mergeCommit":{"message":"[Synthetics] Fixed edit private location with no monitors assigned (#227411)\n\nThis PR fixes a bug that was found when editing the label of a private\nlocation with no monitors assigned.\n\nWhen checking the user privileges the following error was thrown:\n`[plugins.synthetics] Error: Can't check saved object privileges for 0\nnamespaces`","sha":"a946911347f8d80c1fc4116ea4592827031a196c"}}]}] BACKPORT-->