### PR TITLE
[AI4SOC] adding security_ai_prompts to fleet allowlist for installation

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/security_search_ai_lake.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/security_search_ai_lake.ts
@@ -26,6 +26,7 @@ export const SEARCH_AI_LAKE_ALLOWED_INSTALL_PACKAGES = [
   'elastic_agent',
   'elastic_connectors',
   'fleet_server',
+  'security_ai_prompts',
   'security_detection_engine',
   'system',
 ];


### PR DESCRIPTION
## Summary

Adding the integration for `security_ai_prompts` to the allowlist for the ai4soc project. 

Resolves https://github.com/elastic/kibana/issues/227419


