### PR TITLE
[Alerts table] Unskipped pagination test

### DIFF
--- a/x-pack/solutions/observability/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/solutions/observability/test/functional/services/observability/alerts/common.ts
@@ -306,14 +306,16 @@ export function ObservabilityAlertsCommonProvider({
     await testSubjects.click(buttonSubject);
   };
 
-  const alertDataIsBeingLoaded = async () => {
-    return testSubjects.existOrFail('events-container-loading-true');
+  const selectAlertStatusFilter = async (alertStatus: AlertStatus) => {
+    await testSubjects.click('optionsList-control-0');
+    await testSubjects.click(`optionsList-control-selection-${alertStatus}`);
+    await testSubjects.click('optionsList-control-0');
   };
 
   const alertDataHasLoaded = async () => {
     await retry.waitFor(
       'Alert Table is loaded',
-      async () => await testSubjects.exists('events-container-loading-false', { timeout: 2500 })
+      async () => await testSubjects.exists('alertsTableIsLoaded', { timeout: 2500 })
     );
   };
 
@@ -439,7 +441,6 @@ export function ObservabilityAlertsCommonProvider({
     setWorkflowStatusFilter,
     getWorkflowStatusFilterValue,
     setAlertStatusFilter,
-    alertDataIsBeingLoaded,
     alertDataHasLoaded,
     submitQuery,
     typeInQueryBar,
@@ -457,5 +458,6 @@ export function ObservabilityAlertsCommonProvider({
     navigateToAlertDetails,
     createDataView,
     deleteDataView,
+    selectAlertStatusFilter,
   };
 }

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/pagination.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/pagination.ts
@@ -88,11 +88,13 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/120440
-      describe.skip('Pagination controls', () => {
+      describe('Pagination controls', () => {
         before(async () => {
-          await (await observability.alerts.pagination.getPageSizeSelector()).click();
-          await (await observability.alerts.pagination.getTenRowsPageSelector()).click();
+          await observability.alerts.common.selectAlertStatusFilter('recovered');
+          await retry.try(async () => {
+            await (await observability.alerts.pagination.getPageSizeSelector()).click();
+            await (await observability.alerts.pagination.getTenRowsPageSelector()).click();
+          });
           await observability.alerts.pagination.goToFirstPage();
         });
 
@@ -129,7 +131,6 @@ export default ({ getService }: FtrProviderContext) => {
 
         it('Goes to previous page', async () => {
           await observability.alerts.pagination.goToPrevPage();
-          await observability.alerts.common.alertDataIsBeingLoaded();
           await observability.alerts.common.alertDataHasLoaded();
           const tableRows = await observability.alerts.common.getTableCellsInRows();
           expect(tableRows.length).to.be(10);

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/pagination.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/pagination.ts
@@ -115,7 +115,6 @@ export default ({ getService }: FtrProviderContext) => {
 
         it('Goes to nth page', async () => {
           await observability.alerts.pagination.goToNthPage(3);
-          await observability.alerts.common.alertDataIsBeingLoaded();
           await observability.alerts.common.alertDataHasLoaded();
           const tableRows = await observability.alerts.common.getTableCellsInRows();
           expect(tableRows.length).to.be(10);
@@ -123,7 +122,6 @@ export default ({ getService }: FtrProviderContext) => {
 
         it('Goes to next page', async () => {
           await observability.alerts.pagination.goToNextPage();
-          await observability.alerts.common.alertDataIsBeingLoaded();
           await observability.alerts.common.alertDataHasLoaded();
           const tableRows = await observability.alerts.common.getTableCellsInRows();
           expect(tableRows.length).to.be(10);

--- a/x-pack/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/test/functional/services/observability/alerts/common.ts
@@ -306,14 +306,20 @@ export function ObservabilityAlertsCommonProvider({
     await testSubjects.click(buttonSubject);
   };
 
+  const selectAlertStatusFilter = async (alertStatus: AlertStatus) => {
+    await testSubjects.click('optionsList-control-0');
+    await testSubjects.click(`optionsList-control-selection-${alertStatus}`);
+    await testSubjects.click('optionsList-control-0');
+  };
+
   const alertDataIsBeingLoaded = async () => {
-    return testSubjects.existOrFail('events-container-loading-true');
+    return testSubjects.existOrFail('internalAlertsPageLoading');
   };
 
   const alertDataHasLoaded = async () => {
     await retry.waitFor(
       'Alert Table is loaded',
-      async () => await testSubjects.exists('events-container-loading-false', { timeout: 2500 })
+      async () => await testSubjects.exists('alertsTableIsLoaded', { timeout: 2500 })
     );
   };
 
@@ -457,5 +463,6 @@ export function ObservabilityAlertsCommonProvider({
     navigateToAlertDetails,
     createDataView,
     deleteDataView,
+    selectAlertStatusFilter,
   };
 }

--- a/x-pack/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/test/functional/services/observability/alerts/common.ts
@@ -312,10 +312,6 @@ export function ObservabilityAlertsCommonProvider({
     await testSubjects.click('optionsList-control-0');
   };
 
-  const alertDataIsBeingLoaded = async () => {
-    return testSubjects.existOrFail('internalAlertsPageLoading');
-  };
-
   const alertDataHasLoaded = async () => {
     await retry.waitFor(
       'Alert Table is loaded',
@@ -445,7 +441,6 @@ export function ObservabilityAlertsCommonProvider({
     setWorkflowStatusFilter,
     getWorkflowStatusFilterValue,
     setAlertStatusFilter,
-    alertDataIsBeingLoaded,
     alertDataHasLoaded,
     submitQuery,
     typeInQueryBar,

--- a/x-pack/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/test/functional/services/observability/alerts/common.ts
@@ -306,16 +306,14 @@ export function ObservabilityAlertsCommonProvider({
     await testSubjects.click(buttonSubject);
   };
 
-  const selectAlertStatusFilter = async (alertStatus: AlertStatus) => {
-    await testSubjects.click('optionsList-control-0');
-    await testSubjects.click(`optionsList-control-selection-${alertStatus}`);
-    await testSubjects.click('optionsList-control-0');
+  const alertDataIsBeingLoaded = async () => {
+    return testSubjects.existOrFail('events-container-loading-true');
   };
 
   const alertDataHasLoaded = async () => {
     await retry.waitFor(
       'Alert Table is loaded',
-      async () => await testSubjects.exists('alertsTableIsLoaded', { timeout: 2500 })
+      async () => await testSubjects.exists('events-container-loading-false', { timeout: 2500 })
     );
   };
 
@@ -441,6 +439,7 @@ export function ObservabilityAlertsCommonProvider({
     setWorkflowStatusFilter,
     getWorkflowStatusFilterValue,
     setAlertStatusFilter,
+    alertDataIsBeingLoaded,
     alertDataHasLoaded,
     submitQuery,
     typeInQueryBar,
@@ -458,6 +457,5 @@ export function ObservabilityAlertsCommonProvider({
     navigateToAlertDetails,
     createDataView,
     deleteDataView,
-    selectAlertStatusFilter,
   };
 }


### PR DESCRIPTION
This PR closes #120440 .

This test was skipped a long time ago and several things changed since then.
The main thing is that the container that shows the alerts changed, now it's a component that shows a `data-test-subj` equal to `internalAlertsPageLoading` when loading and `alertsTableIsLoaded` when the alerts have been loaded.

The component shown when alerts are being loaded is not always shown, probably for some caching, so I removed the `alertDataIsBeingLodaded` check.

I also had to add a function to include the `recovered` alerts because the `active` alerts in the test data are only 10 and the pagination cannot work with just 10 alerts.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->