### PR TITLE
[Security Assistant] Implements token tracking for Bedrock `converseStream` subaction

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.ts
@@ -10,7 +10,7 @@ import type { Logger } from '@kbn/logging';
 import type { Stream } from 'openai/streaming';
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 import { getTokensFromBedrockConverseStream } from './get_token_count_from_bedrock_converse_stream';
-import type { SmithyStream } from './get_token_count_from_bedrock_converse';
+import type { SmithyStream } from './get_token_count_from_bedrock_client_send';
 import { getTokensFromBedrockClientSend } from './get_token_count_from_bedrock_client_send';
 import type { InvokeAsyncIteratorBody } from './get_token_count_from_invoke_async_iterator';
 import { getTokenCountFromInvokeAsyncIterator } from './get_token_count_from_invoke_async_iterator';

--- a/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/gen_ai_token_tracking.ts
@@ -10,8 +10,10 @@ import type { Logger } from '@kbn/logging';
 import type { Stream } from 'openai/streaming';
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 import { getTokensFromBedrockConverseStream } from './get_token_count_from_bedrock_converse_stream';
-import type { SmithyStream } from './get_token_count_from_bedrock_client_send';
-import { getTokensFromBedrockClientSend } from './get_token_count_from_bedrock_client_send';
+import {
+  getTokensFromBedrockClientSend,
+  type SmithyStream,
+} from './get_token_count_from_bedrock_client_send';
 import type { InvokeAsyncIteratorBody } from './get_token_count_from_invoke_async_iterator';
 import { getTokenCountFromInvokeAsyncIterator } from './get_token_count_from_invoke_async_iterator';
 import { getTokenCountFromBedrockInvoke } from './get_token_count_from_bedrock_invoke';

--- a/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/get_token_count_from_bedrock_client_send.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/get_token_count_from_bedrock_client_send.ts
@@ -14,7 +14,7 @@ export type SmithyStream = SmithyMessageDecoderStream<{
   };
 }>;
 
-export const getTokensFromBedrockConverseStream = async function (
+export const getTokensFromBedrockClientSend = async function (
   responseStream: SmithyStream,
   logger: Logger
 ): Promise<{ total_tokens: number; prompt_tokens: number; completion_tokens: number } | null> {

--- a/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/get_token_count_from_bedrock_converse_stream.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/get_token_count_from_bedrock_converse_stream.ts
@@ -30,7 +30,10 @@ export const getTokensFromBedrockConverseStream = async function (
     try {
       await finished(responseStream);
     } catch (e) {
-      logger.error('An error occurred while calculating streaming response tokens');
+      logger.error(
+        'An error occurred while calculating streaming response tokens',
+        e.name ?? e.message ?? e.toString()
+      );
     }
     const usage = responseBuffer[responseBuffer.length - 1] as { metadata: { body: string } };
 
@@ -46,7 +49,10 @@ export const getTokensFromBedrockConverseStream = async function (
     }
     return null; // Return the final tokens once the generator finishes
   } catch (e) {
-    logger.error('Response from Bedrock converse API did not contain usage object');
+    logger.error(
+      'Response from Bedrock converse API did not contain usage object',
+      e.name ?? e.message ?? e.toString()
+    );
     return null;
   }
 };

--- a/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/get_token_count_from_bedrock_converse_stream.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/token_tracking/get_token_count_from_bedrock_converse_stream.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Readable } from 'stream';
+import { EventStreamMarshaller } from '@smithy/eventstream-serde-node';
+import { fromUtf8, toUtf8 } from '@smithy/util-utf8';
+import { identity } from 'lodash';
+import { finished } from 'stream/promises';
+
+export const getTokensFromBedrockConverseStream = async function (
+  responseStream: Readable,
+  logger: Logger
+): Promise<{ total_tokens: number; prompt_tokens: number; completion_tokens: number } | null> {
+  try {
+    const marshaller = new EventStreamMarshaller({
+      utf8Encoder: toUtf8,
+      utf8Decoder: fromUtf8,
+    });
+    const responseBuffer: unknown[] = [];
+    for await (const chunk of marshaller.deserialize(responseStream, identity)) {
+      if (chunk) {
+        responseBuffer.push(chunk);
+      }
+    }
+    try {
+      await finished(responseStream);
+    } catch (e) {
+      logger.error('An error occurred while calculating streaming response tokens');
+    }
+    const usage = responseBuffer[responseBuffer.length - 1] as { metadata: { body: string } };
+
+    if (usage) {
+      const parsedResponse = JSON.parse(toUtf8(usage.metadata.body)) as {
+        usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+      };
+      return {
+        total_tokens: parsedResponse.usage.totalTokens,
+        prompt_tokens: parsedResponse.usage.inputTokens,
+        completion_tokens: parsedResponse.usage.outputTokens,
+      };
+    }
+    return null; // Return the final tokens once the generator finishes
+  } catch (e) {
+    logger.error('Response from Bedrock converse API did not contain usage object');
+    return null;
+  }
+};

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.test.ts
@@ -25,7 +25,10 @@ describe('bedrockClaudeAdapter', () => {
       return {
         actionId: '',
         status: 'ok',
-        data: new PassThrough(),
+        data: {
+          stream: new PassThrough(),
+          tokenStream: new PassThrough(),
+        },
       };
     });
   });

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
@@ -76,7 +76,7 @@ export const bedrockClaudeAdapter: InferenceConnectorAdapter = {
         subActionParams,
       });
       const result = res.data as { stream: Readable };
-      return { ...res, data: result.stream };
+      return { ...res, data: result?.stream };
     }).pipe(
       handleConnectorResponse({ processStream: serdeEventstreamIntoObservable }),
       tap((eventData) => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
@@ -21,6 +21,7 @@ import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import type { ImageBlock } from '@aws-sdk/client-bedrock-runtime';
 import { isDefined } from '@kbn/ml-is-defined';
 import type { DocumentType as JsonMember } from '@smithy/types';
+import type { Readable } from 'stream';
 import { InferenceConnectorAdapter } from '../../types';
 import { handleConnectorResponse } from '../../utils';
 import type { BedRockImagePart, BedRockMessage, BedRockTextPart } from './types';
@@ -69,11 +70,13 @@ export const bedrockClaudeAdapter: InferenceConnectorAdapter = {
       signal: abortSignal,
     };
 
-    return defer(() => {
-      return executor.invoke({
+    return defer(async () => {
+      const res = await executor.invoke({
         subAction: 'converseStream',
         subActionParams,
       });
+      const result = res.data as { stream: Readable };
+      return { ...res, data: result.stream };
     }).pipe(
       handleConnectorResponse({ processStream: serdeEventstreamIntoObservable }),
       tap((eventData) => {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
@@ -1162,9 +1162,16 @@ describe('BedrockConnector', () => {
         );
       });
 
-      it('responds with a readable stream', async () => {
-        const response = await connector.converseStream(aiAssistantBody, connectorUsageCollector);
-        expect(response instanceof PassThrough).toEqual(true);
+      it('should handle and split streaming response', async () => {
+        const result = (await connector.converseStream(
+          aiAssistantBody,
+          connectorUsageCollector
+        )) as unknown as {
+          stream?: unknown;
+          tokenStream?: unknown;
+        };
+        expect(result.stream instanceof PassThrough).toEqual(true);
+        expect(result.tokenStream instanceof PassThrough).toEqual(true);
       });
 
       it('errors during API calls are properly handled', async () => {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -568,7 +568,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
     signal,
     timeout = DEFAULT_TIMEOUT_MS,
     connectorUsageCollector,
-  }: ConverseStreamParams) {
+  }: ConverseStreamParams): Promise<ConverseActionResponse> {
     const modelId = reqModel ?? this.model;
     const currentModel = encodeURIComponent(decodeURIComponent(modelId));
     const path = `/model/${currentModel}/converse-stream`;
@@ -619,7 +619,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
       };
     }
 
-    return { ...response.data };
+    return response;
   }
 
   /**
@@ -644,7 +644,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
     }: ConverseStreamParams,
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<ConverseActionResponse> {
-    const res = (await this._converseStream({
+    return await this._converseStream({
       messages,
       model: reqModel,
       stopSequences,
@@ -656,11 +656,6 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
       signal,
       timeout,
       connectorUsageCollector,
-    })) as unknown as {
-      stream: IncomingMessage;
-      tokenStream: IncomingMessage;
-    };
-
-    return res;
+    });
   }
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -14,7 +14,7 @@ import type { SmithyMessageDecoderStream } from '@smithy/eventstream-codec';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import type { AxiosError, Method } from 'axios';
 import type { IncomingMessage } from 'http';
-import { PassThrough } from 'stream';
+import { PassThrough, Readable } from 'stream';
 import { getCustomAgents } from '@kbn/actions-plugin/server/lib/get_custom_agents';
 import type { SubActionRequestParams } from '@kbn/actions-plugin/server/sub_action_framework/types';
 import type { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
@@ -608,7 +608,18 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
       connectorUsageCollector
     );
 
-    return response.data.pipe(new PassThrough()) as unknown as IncomingMessage;
+    if (response.data) {
+      const resultStream = response.data as SmithyMessageDecoderStream<unknown>;
+      // splits the stream in two, [stream = consumer, tokenStream = token tracking]
+      const [stream, tokenStream] = tee(resultStream);
+      return {
+        ...response.data,
+        stream: Readable.from(stream).pipe(new PassThrough()),
+        tokenStream: Readable.from(tokenStream).pipe(new PassThrough()),
+      };
+    }
+
+    return { ...response.data };
   }
 
   /**
@@ -632,7 +643,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
       timeout = DEFAULT_TIMEOUT_MS,
     }: ConverseStreamParams,
     connectorUsageCollector: ConnectorUsageCollector
-  ): Promise<IncomingMessage> {
+  ): Promise<ConverseActionResponse> {
     const res = (await this._converseStream({
       messages,
       model: reqModel,
@@ -646,6 +657,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
       timeout,
       connectorUsageCollector,
     })) as unknown as IncomingMessage;
+
     return res;
   }
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -656,7 +656,10 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
       signal,
       timeout,
       connectorUsageCollector,
-    })) as unknown as IncomingMessage;
+    })) as unknown as {
+      stream: IncomingMessage;
+      tokenStream: IncomingMessage;
+    };
 
     return res;
   }


### PR DESCRIPTION
## Summary

This PR refactors and extends the token tracking logic for Bedrock streaming responses in Kibana AI connectors. It improves clarity between different stream handling methods and adds support for token counting on `converseStream` sub-actions.

## Changes

- **Updated** Bedrock connector type:
  - Enhanced `_converseStream` to return both the main event stream (`stream`) and a duplicate stream (`tokenStream`) for token counting via `tee`.
  - Updated type annotations for `converseStream` to return `ConverseActionResponse` with both streams.
- **Renamed** `get_token_count_from_bedrock_converse.ts` to `get_token_count_from_bedrock_client_send.ts` for clearer differentiation from `converseStream` handlers.
- **Added** new `get_token_count_from_bedrock_converse_stream.ts` to deserialize Bedrock `converseStream` event streams and extract token usage metadata.
- **Updated** `getGenAiTokenTracking`:
  - Added a conditional branch for `.bedrock` `converseStream` actions to use the new `getTokensFromBedrockConverseStream` function.
  - Preserved existing behavior for other sub-actions.
- **Modified** `bedrock_claude_adapter.ts`:
  - Adjusted `executor.invoke` handling to extract the new `stream` property from the `converseStream` response structure.

## Why

`InferenceChatModel` uses a new Bedrock subAction called `converseStream`. The subaction includes streamed usage metadata in the final event. This change makes it possible to track prompt, completion, and total token counts for `converseStream` responses. The split streams ensure one can be consumed by the observable pipeline and one by the token tracking logic without interference.

## Notes

- The `EventStreamMarshaller` from `@smithy/eventstream-serde-node` is used to deserialize the `Readable` stream for token extraction.
- Stream termination is handled using `stream/promises.finished` to detect early closures.
- The implementation ensures error handling and telemetry logging for missing or malformed usage metadata.


## To test

1. Have a Bedrock connector
2. Enable the `InferenceChatModel` feature flag:
  ```
  feature_flags.overrides.securitySolution.inferenceChatModelEnabled: true
  ```
3. Send a message to Security AI Assistant with the Bedrock connector
4. Go to Discover
5. Query the `.kibana-event-log-*` index for `event.action: execute and kibana.action.type_id: .bedrock`
6. Pop open the event for your sent message, confirm that `action.execution.gen_ai.usage` has token tracking data. For example:
  ```
"action": {
    "name": "Claude 4 Sonnet (US-West-2)",
    "id": "my-bedrock-v4",
    "type_id": ".bedrock",
    "execution": {
      "uuid": "27ed2912-e9ae-428d-8fcf-bb8aae8f619c",
      "gen_ai": {
        "usage": {
          "total_tokens": 2115,
          "prompt_tokens": 2012,
          "completion_tokens": 103
        }
      },
      "usage": {
        "request_body_bytes": 7213
      }
    }
}
  ```




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->