### PR TITLE
Unskip input_controls_vis test suite

### DIFF
--- a/src/platform/test/functional/apps/dashboard_elements/input_control_vis/input_control_options.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/input_control_vis/input_control_options.ts
@@ -82,6 +82,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should replace existing filter pill(s) when new item is selected', async () => {
         await comboBox.clear('listControlSelect0');
+        await common.sleep(500); // give time for filter to be removed and event handlers to fire
         await comboBox.set('listControlSelect0', 'osx');
         await visEditor.inputControlSubmit();
         await common.sleep(1000);

--- a/src/platform/test/functional/apps/dashboard_elements/input_control_vis/input_control_options.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/input_control_vis/input_control_options.ts
@@ -23,6 +23,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const inspector = getService('inspector');
   const find = getService('find');
   const comboBox = getService('comboBox');
+  const retry = getService('retry');
   const FIELD_NAME = 'machine.os.raw';
 
   describe('input control options', () => {
@@ -82,7 +83,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should replace existing filter pill(s) when new item is selected', async () => {
         await comboBox.clear('listControlSelect0');
-        await common.sleep(500); // give time for filter to be removed and event handlers to fire
+        await retry.waitFor('input control is clear', async () => {
+          return (await comboBox.doesComboBoxHaveSelectedOptions('listControlSelect0')) === false;
+        });
         await comboBox.set('listControlSelect0', 'osx');
         await visEditor.inputControlSubmit();
         await common.sleep(1000);

--- a/src/platform/test/functional/apps/dashboard_elements/input_control_vis/input_control_options.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/input_control_vis/input_control_options.ts
@@ -25,8 +25,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const comboBox = getService('comboBox');
   const FIELD_NAME = 'machine.os.raw';
 
-  // Failing: See https://github.com/elastic/kibana/issues/225165
-  describe.skip('input control options', () => {
+  describe('input control options', () => {
     before(async () => {
       await visualize.initTests();
       await timePicker.resetDefaultAbsoluteRangeViaUiSettings();


### PR DESCRIPTION
[Flaky test runner x 200](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8603)

Fixes #225165

## Summary

Unskip input_controls_vis test suite.

The failure did not re-occur in 200 flaky tests after only unskipping the test in 6f48e39. 

However, logs during failures are indicating that the `osx` option could not be found. Since we clear the previous selection right before setting the `osx` option, it might be possible that the events following the clear are not always completely resolved before we try to set a new option. So this adds a `waitFor` check to ensure the input control is actually clear before we set a new option.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->