### PR TITLE
[Serverless] Moved pre configured LLM connector settings to Kibana tiers config yml files

### DIFF
--- a/config/serverless.chat.yml
+++ b/config/serverless.chat.yml
@@ -27,3 +27,16 @@ xpack.contentConnectors.enabled: false
 
 ## Disable Kibana Product Intercept
 xpack.product_intercept.enabled: false
+
+# Elastic Managed LLM
+xpack.actions.preconfigured:
+  Elastic-Managed-LLM:
+    name: Elastic Managed LLM
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".rainbow-sprinkles-elastic"
+      providerConfig:
+        model_id: "rainbow-sprinkles"

--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -124,3 +124,16 @@ xpack.searchQueryRules.enabled: true
 
 ## Search Connectors in stack management
 xpack.contentConnectors.ui.enabled: false
+
+# Elastic Managed LLM
+xpack.actions.preconfigured:
+  Elastic-Managed-LLM:
+    name: Elastic Managed LLM
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".rainbow-sprinkles-elastic"
+      providerConfig:
+        model_id: "rainbow-sprinkles"

--- a/config/serverless.oblt.complete.yml
+++ b/config/serverless.oblt.complete.yml
@@ -25,3 +25,16 @@ xpack.features.overrides:
   stackAlerts.hidden: true
   ### By default, this feature named as `Synthetics and Uptime`, but should be renamed to `Synthetics` since `Uptime` is not available.
   uptime.name: 'Synthetics'
+
+# Elastic Managed LLM
+xpack.actions.preconfigured:
+  Elastic-Managed-LLM:
+    name: Elastic Managed LLM
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".rainbow-sprinkles-elastic"
+      providerConfig:
+        model_id: "rainbow-sprinkles"

--- a/config/serverless.security.complete.yml
+++ b/config/serverless.security.complete.yml
@@ -2,3 +2,16 @@
 
 ## Cloud settings
 xpack.cloud.serverless.product_tier: complete
+
+# Elastic Managed LLM
+xpack.actions.preconfigured:
+  Elastic-Managed-LLM:
+    name: Elastic Managed LLM
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".rainbow-sprinkles-elastic"
+      providerConfig:
+        model_id: "rainbow-sprinkles"

--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -84,3 +84,16 @@ xpack.fleet.internal.registry.searchAiLakePackageAllowlistEnabled: true
 
 # Pin the prebuilt rules package version to the version that contains promotion rules
 xpack.securitySolution.prebuiltRulesPackageVersion: '9.0.5-beta.1'
+
+# Elastic Managed LLM
+xpack.actions.preconfigured:
+  Elastic-Managed-LLM:
+    name: Elastic Managed LLM
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".rainbow-sprinkles-elastic"
+      providerConfig:
+        model_id: "rainbow-sprinkles"


### PR DESCRIPTION
Resolves https://github.com/elastic/observability-dev/issues/4618
1. Instead of using [serverless-gitops](https://github.com/elastic/serverless-gitops/blob/main/services/kibana-controller/values/production/default.yaml) per environment configuration, moving it to Kibana yml. 
2. Excluded Elastic LLM configuration from Essential tiers for Security and Observability solutions by adding it only to the relevant tiers specific yml config files. 
3. Added Elastic LLM configuration to Search serverless config `serverless.es.yml` and OneChat config `serverless.chat.yml`