### PR TITLE
[Content Connectors] Fix race condition error for task registration of Agentless connectors infra service

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/plugin.ts
@@ -29,6 +29,7 @@ import { PLUGIN_ID } from '../common/constants';
 import { registerApiKeysRoutes } from './routes/api_keys';
 import { SearchConnectorsConfig } from './config';
 import { AgentlessConnectorDeploymentsSyncService } from './task';
+import { AgentlessConnectorsInfraServiceFactory } from './services/infra_service_factory';
 
 export class SearchConnectorsPlugin
   implements
@@ -43,6 +44,7 @@ export class SearchConnectorsPlugin
   private readonly logger: LoggerFactory;
   private readonly config: SearchConnectorsConfig;
   private agentlessConnectorDeploymentsSyncService: AgentlessConnectorDeploymentsSyncService;
+  private agentlessConnectorsInfraServiceFactory: AgentlessConnectorsInfraServiceFactory;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.connectors = [];
@@ -51,10 +53,11 @@ export class SearchConnectorsPlugin
     this.agentlessConnectorDeploymentsSyncService = new AgentlessConnectorDeploymentsSyncService(
       this.logger.get()
     );
+    this.agentlessConnectorsInfraServiceFactory = new AgentlessConnectorsInfraServiceFactory();
   }
 
   public setup(
-    coreSetup: CoreSetup<SearchConnectorsPluginStartDependencies, SearchConnectorsPluginStart>,
+    coreSetup: CoreSetup<SearchConnectorsPluginStartDependencies>,
     plugins: SearchConnectorsPluginSetupDependencies
   ) {
     const http = coreSetup.http;
@@ -74,23 +77,15 @@ export class SearchConnectorsPlugin
 
     this.connectors = getConnectorTypes(http.staticAssets);
 
-    const coreStartServices = coreSetup.getStartServices();
-
     // There seems to be no way to check for agentless here
     // So we register a task, but do not execute it in `start` method
     this.logger.get().debug('Registering agentless connectors infra sync task');
 
-    coreStartServices
-      .then(([coreStart, searchConnectorsPluginStartDependencies]) => {
-        this.agentlessConnectorDeploymentsSyncService.registerInfraSyncTask(
-          plugins,
-          coreStart,
-          searchConnectorsPluginStartDependencies
-        );
-      })
-      .catch((err) => {
-        this.logger.get().error(`Error registering agentless connectors infra sync task`, err);
-      });
+    this.agentlessConnectorDeploymentsSyncService.registerInfraSyncTask(
+      coreSetup,
+      plugins,
+      this.agentlessConnectorsInfraServiceFactory
+    );
     const router = http.createRouter();
 
     // Enterprise Search Routes
@@ -121,6 +116,11 @@ export class SearchConnectorsPlugin
         .info(
           'Agentless is supported, scheduling initial agentless connectors infrastructure watcher task'
         );
+      this.agentlessConnectorsInfraServiceFactory.initialize({
+        coreStart: core,
+        plugins,
+        logger: this.logger.get(),
+      });
       this.agentlessConnectorDeploymentsSyncService
         .scheduleInfraSyncTask(this.config, plugins.taskManager)
         .catch((err) => {

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/infra_service_factory.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/infra_service_factory.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import { CoreStart, SavedObjectsClient } from '@kbn/core/server';
+import { SearchConnectorsPluginStartDependencies } from '../types';
+import { AgentlessConnectorsInfraService } from '.';
+
+export interface AgentlessConnectorsInfraServiceContext {
+  logger: Logger;
+  coreStart: CoreStart;
+  plugins: SearchConnectorsPluginStartDependencies;
+}
+
+export class AgentlessConnectorsInfraServiceFactory {
+  private isInitialized = false;
+  private agentlessConnectorsInfraService?: AgentlessConnectorsInfraService;
+
+  public initialize({ coreStart, plugins, logger }: AgentlessConnectorsInfraServiceContext) {
+    if (this.isInitialized) {
+      throw new Error('AgentlessConnectorsInfraServiceFactory already initialized');
+    }
+    this.isInitialized = true;
+
+    const esClient = coreStart.elasticsearch.client.asInternalUser;
+    const savedObjects = coreStart.savedObjects;
+
+    const agentPolicyService = plugins.fleet.agentPolicyService;
+    const packagePolicyService = plugins.fleet.packagePolicyService;
+    const agentService = plugins.fleet.agentService;
+
+    const soClient = new SavedObjectsClient(savedObjects.createInternalRepository());
+
+    this.agentlessConnectorsInfraService = new AgentlessConnectorsInfraService(
+      soClient,
+      esClient,
+      packagePolicyService,
+      agentPolicyService,
+      agentService,
+      logger
+    );
+  }
+
+  public getAgentlessConnectorsInfraService() {
+    if (!this.isInitialized) {
+      throw new Error('AgentlessConnectorsInfraServiceFactory not initialized');
+    }
+
+    return this.agentlessConnectorsInfraService;
+  }
+}

--- a/x-pack/platform/plugins/shared/content_connectors/server/types.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/types.ts
@@ -51,8 +51,5 @@ export interface SearchConnectorsPluginSetupDependencies {
   log: Logger;
   ml?: MlPluginSetup;
   router: IRouter;
-  getStartServices: StartServicesAccessor<
-    SearchConnectorsPluginStartDependencies,
-    SearchConnectorsPluginStart
-  >;
+  getStartServices: StartServicesAccessor<SearchConnectorsPluginStartDependencies, unknown>;
 }

--- a/x-pack/platform/plugins/shared/content_connectors/tsconfig.json
+++ b/x-pack/platform/plugins/shared/content_connectors/tsconfig.json
@@ -57,6 +57,7 @@
     "@kbn/licensing-plugin",
     "@kbn/spaces-plugin",
     "@kbn/core-http-browser-mocks",
-    "@kbn/home-plugin"
+    "@kbn/home-plugin",
+    "@kbn/logging"
   ]
 }


### PR DESCRIPTION
This PR fixing Content connectors task failing to schedule with error: `Error scheduling search:agentless-connectors-manager-task...`

Replaced plugin setup logic dependent to the start services with the factory.

Serverless:

<img width="2148" height="962" alt="Screenshot 2025-07-11 at 1 04 05 PM" src="https://github.com/user-attachments/assets/c5b32502-623f-4590-b959-d62c1dde8933" />

ESS:

<img width="1694" height="978" alt="Screenshot 2025-07-11 at 1 06 31 PM" src="https://github.com/user-attachments/assets/86b0b596-2547-4156-9231-5f8109a5e6be" />


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->