### PR TITLE
[9.0] [Security Solution] Enable accidentally skipped prebuilt rules package integration tests (#226759)

### DIFF
--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -58,9 +58,10 @@ enabled:
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/ess_basic_license.config.ts
-  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/ess_air_gapped.config.ts
-  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/ess_air_gapped_large_package.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped_large_package.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_disabled/configs/ess_basic_license.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_trial_license.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/common_fields/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/type_specific_fields/configs/ess.config.ts

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped.config.ts
@@ -8,20 +8,21 @@
 import { FtrConfigProviderContext } from '@kbn/test';
 import path from 'path';
 
-export const BUNDLED_PACKAGE_DIR = path.join(
+const SECURITY_DETECTION_ENGINE_PACKAGES_PATH = path.join(
   path.dirname(__filename),
-  '../fixtures/packages/large'
+  '../../fixtures/packages'
 );
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../../../../../config/ess/config.base.basic')
   );
 
   return {
     ...functionalConfig.getAll(),
     testFiles: [
-      require.resolve('../prebuilt_rules_package/air_gapped/install_large_bundled_package'),
+      require.resolve('../../import_export/import_with_installing_package'),
+      require.resolve('../../prebuilt_rules_package/air_gapped'),
     ],
     kbnTestServer: {
       ...functionalConfig.get('kbnTestServer'),
@@ -30,12 +31,14 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         /*  Tests in this directory simulate an air-gapped environment in which the instance doesn't have access to EPR.
          *  To do that, we point the Fleet url to an invalid URL, and instruct Fleet to fetch bundled packages at the
          *  location defined in BUNDLED_PACKAGE_DIR.
-         *  Since we want to test the installation of a large package, we created a specific package `security_detection_engine-100.0.0`
-         *  which contains 15000 rules assets and 750 unique rules, and attempt to install it.
          */
         `--xpack.fleet.isAirGapped=true`,
-        `--xpack.fleet.developer.bundledPackageLocation=${BUNDLED_PACKAGE_DIR}`,
+        `--xpack.fleet.developer.bundledPackageLocation=${SECURITY_DETECTION_ENGINE_PACKAGES_PATH}`,
       ],
+    },
+    junit: {
+      reportName:
+        'Rules Management - Prebuilt Rules (Common) Integration Tests - ESS Basic License (Air Gapped)',
     },
   };
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped_large_package.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped_large_package.config.ts
@@ -8,21 +8,20 @@
 import { FtrConfigProviderContext } from '@kbn/test';
 import path from 'path';
 
-const SECURITY_DETECTION_ENGINE_PACKAGES_PATH = path.join(
+export const BUNDLED_PACKAGE_DIR = path.join(
   path.dirname(__filename),
-  '../fixtures/packages'
+  '../../fixtures/packages/large'
 );
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../../../../../config/ess/config.base.basic')
   );
 
   return {
     ...functionalConfig.getAll(),
     testFiles: [
-      require.resolve('../import_export/import_with_installing_package'),
-      require.resolve('../prebuilt_rules_package/air_gapped'),
+      require.resolve('../../prebuilt_rules_package/air_gapped/install_large_bundled_package'),
     ],
     kbnTestServer: {
       ...functionalConfig.get('kbnTestServer'),
@@ -31,10 +30,16 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         /*  Tests in this directory simulate an air-gapped environment in which the instance doesn't have access to EPR.
          *  To do that, we point the Fleet url to an invalid URL, and instruct Fleet to fetch bundled packages at the
          *  location defined in BUNDLED_PACKAGE_DIR.
+         *  Since we want to test the installation of a large package, we created a specific package `security_detection_engine-100.0.0`
+         *  which contains 15000 rules assets and 750 unique rules, and attempt to install it.
          */
         `--xpack.fleet.isAirGapped=true`,
-        `--xpack.fleet.developer.bundledPackageLocation=${SECURITY_DETECTION_ENGINE_PACKAGES_PATH}`,
+        `--xpack.fleet.developer.bundledPackageLocation=${BUNDLED_PACKAGE_DIR}`,
       ],
+    },
+    junit: {
+      reportName:
+        'Rules Management - Prebuilt Rules (Common) Integration Tests - ESS Basic License (Air Gapped, Large Package)',
     },
   };
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_trial_license.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_trial_license.config.ts
@@ -9,15 +9,15 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../../../../../config/ess/config.base.trial')
   );
 
   const testConfig = {
     ...functionalConfig.getAll(),
-    testFiles: [require.resolve('..')],
+    testFiles: [require.resolve('../../prebuilt_rules_package/install_package_from_epr')],
     junit: {
       reportName:
-        'Rules Management - Prebuilt Rules (Common) Integration Tests - ESS Basic License',
+        'Rules Management - Prebuilt Rules (Common) Integration Tests - ESS Trial License',
     },
   };
 

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/serverless_essentials_tier.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/serverless_essentials_tier.config.ts
@@ -11,6 +11,6 @@ export default createTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:
-      'Rules Management - Prebuilt Rules (Customization Disabled) Integration Tests - Serverless Env Essentials Tier',
+      'Rules Management - Prebuilt Rules (Common) Integration Tests - Serverless Env Essentials Tier',
   },
 });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/index.ts
@@ -12,6 +12,7 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     this.tags('skipFIPS');
     loadTestFile(require.resolve('./import_export'));
     loadTestFile(require.resolve('./install_prebuilt_rules'));
+    loadTestFile(require.resolve('./prebuilt_rules_package'));
     loadTestFile(require.resolve('./status'));
   });
 };

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/prebuilt_rules_package/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/prebuilt_rules_package/index.ts
@@ -10,7 +10,6 @@ import { FtrProviderContext } from '../../../../../../ftr_provider_context';
 export default ({ loadTestFile }: FtrProviderContext): void => {
   describe('Prebuilt rules package', function () {
     loadTestFile(require.resolve('./bootstrap_prebuilt_rules'));
-    loadTestFile(require.resolve('./install_package_from_epr'));
     loadTestFile(require.resolve('./update_package'));
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Enable accidentally skipped prebuilt rules package integration tests (#226759)](https://github.com/elastic/kibana/pull/226759)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-07-10T17:32:29Z","message":"[Security Solution] Enable accidentally skipped prebuilt rules package integration tests (#226759)\n\n## Summary\n\nThis PR enables accidentally skipped prebuilt rules package integration tests.\n\n## Details\n\nThe integration tests were accidentally skipped by missing `loadTestFile(require.resolve('./prebuilt_rules_package'));` line in https://github.com/elastic/kibana/pull/225495 as the result of merge conflicts.\n\nEnabling those integration tests revealed an issue with the installing all prebuilt rules integration tests. Since the prebuilt rules package contains ML rules all rules installation fails under the low-tier license as ML rules require high-tier license. So this single test was changed to run under high-tier license.\n\nJust for the record, ML related UI issues has been addressed in https://github.com/elastic/kibana/pull/224676. It means that users may observe this error under low-tier license only by using the API directly.","sha":"189cfb5bce4e490e73e1c16faf8bddbd203d8b2a","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v9.1.0","v8.19.0","v9.2.0","v8.18.4","v9.0.4"],"title":"[Security Solution] Enable accidentally skipped prebuilt rules package integration tests","number":226759,"url":"https://github.com/elastic/kibana/pull/226759","mergeCommit":{"message":"[Security Solution] Enable accidentally skipped prebuilt rules package integration tests (#226759)\n\n## Summary\n\nThis PR enables accidentally skipped prebuilt rules package integration tests.\n\n## Details\n\nThe integration tests were accidentally skipped by missing `loadTestFile(require.resolve('./prebuilt_rules_package'));` line in https://github.com/elastic/kibana/pull/225495 as the result of merge conflicts.\n\nEnabling those integration tests revealed an issue with the installing all prebuilt rules integration tests. Since the prebuilt rules package contains ML rules all rules installation fails under the low-tier license as ML rules require high-tier license. So this single test was changed to run under high-tier license.\n\nJust for the record, ML related UI issues has been addressed in https://github.com/elastic/kibana/pull/224676. It means that users may observe this error under low-tier license only by using the API directly.","sha":"189cfb5bce4e490e73e1c16faf8bddbd203d8b2a"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227506","number":227506,"state":"MERGED","mergeCommit":{"sha":"93f21228e7cf49d7f93ea857c2a815203083181d","message":"[9.1] [Security Solution] Enable accidentally skipped prebuilt rules package integration tests (#226759) (#227506)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Enable accidentally skipped prebuilt rules\npackage integration tests\n(#226759)](https://github.com/elastic/kibana/pull/226759)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227505","number":227505,"state":"MERGED","mergeCommit":{"sha":"4c9c5dfadc63a489fbdba79f18f94134cb08c80b","message":"[8.19] [Security Solution] Enable accidentally skipped prebuilt rules package integration tests (#226759) (#227505)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Enable accidentally skipped prebuilt rules\npackage integration tests\n(#226759)](https://github.com/elastic/kibana/pull/226759)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226759","number":226759,"mergeCommit":{"message":"[Security Solution] Enable accidentally skipped prebuilt rules package integration tests (#226759)\n\n## Summary\n\nThis PR enables accidentally skipped prebuilt rules package integration tests.\n\n## Details\n\nThe integration tests were accidentally skipped by missing `loadTestFile(require.resolve('./prebuilt_rules_package'));` line in https://github.com/elastic/kibana/pull/225495 as the result of merge conflicts.\n\nEnabling those integration tests revealed an issue with the installing all prebuilt rules integration tests. Since the prebuilt rules package contains ML rules all rules installation fails under the low-tier license as ML rules require high-tier license. So this single test was changed to run under high-tier license.\n\nJust for the record, ML related UI issues has been addressed in https://github.com/elastic/kibana/pull/224676. It means that users may observe this error under low-tier license only by using the API directly.","sha":"189cfb5bce4e490e73e1c16faf8bddbd203d8b2a"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->