### PR TITLE
fix: incorrect value field type in set processor

### DIFF
--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processor_form.container.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processor_form.container.tsx
@@ -79,7 +79,7 @@ export const ProcessorFormContainer: FunctionComponent<Props> = ({
         type: formState.type,
         fields: formState.customOptions
           ? {
-              ...formState.customOptions,
+              customOptions: formState.customOptions,
             }
           : {
               ...formState.fields,

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/serialize.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/serialize.ts
@@ -8,6 +8,7 @@
 import { Processor } from '../../../../common/types';
 
 import { ProcessorInternal } from './types';
+import { convertProccesorsToJson } from './utils';
 
 interface SerializeArgs {
   /**
@@ -35,7 +36,7 @@ const convertProcessorInternalToProcessor = (
   const { options, onFailure, type, id } = processor;
   const outProcessor = {
     [type]: {
-      ...options,
+      ...convertProccesorsToJson(options),
     },
   };
 

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.test.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getValue, setValue, hasTemplateSnippet } from './utils';
+import { getValue, setValue, hasTemplateSnippet, convertProccesorsToJson } from './utils';
 
 describe('get and set values', () => {
   const testObject = Object.freeze([{ onFailure: [{ onFailure: 1 }] }]);
@@ -49,5 +49,25 @@ describe('template snippets', () => {
     expect(hasTemplateSnippet('hello{{{world}}}')).toBe(true);
     expect(hasTemplateSnippet('{{{hello}}}world')).toBe(true);
     expect(hasTemplateSnippet('{{{hello.world}}}')).toBe(true);
+  });
+});
+
+describe('convert processors to json', () => {
+  it('returns converted processors', () => {
+    const obj = {
+      field1: 'mustNotChange',
+      field2: 123,
+      field3: '{1: "mustNotChange"}',
+      value: '{"1": """aaa"bbb"""}',
+      customOptions: '{"customProcessor": """aaa"bbb"""}',
+    };
+
+    expect(convertProccesorsToJson(obj)).toEqual({
+      field1: 'mustNotChange',
+      field2: 123,
+      field3: '{1: "mustNotChange"}',
+      value: { 1: 'aaa"bbb' },
+      customProcessor: 'aaa"bbb',
+    });
   });
 });

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.ts
@@ -119,3 +119,41 @@ export const hasTemplateSnippet = (str: string = '') => {
   //  * And followed by }}}
   return /{{{.+}}}/.test(str);
 };
+
+const escapeLiteralStrings = (data: string): string[] => {
+  const splitData = data.split(`"""`);
+  for (let i = 1; i < splitData.length - 1; i += 2) {
+    splitData[i] = JSON.stringify(splitData[i]);
+  }
+  return splitData;
+};
+
+const convertProcessorValueToJson = (data: string): any => {
+  if (!data) {
+    return undefined;
+  }
+
+  try {
+    const escapedData = escapeLiteralStrings(data);
+    return JSON.parse(escapedData.join(''));
+  } catch (error) {
+    return data;
+  }
+};
+
+const fieldToConvertToJson = ['value'];
+
+export const convertProccesorsToJson = (obj: { [key: string]: any }): { [key: string]: any } => {
+  return Object.fromEntries(
+    Object.entries(obj).flatMap(([key, value]) => {
+      if (key === 'customOptions') {
+        const convertedValue = convertProcessorValueToJson(value);
+        return Object.entries(convertedValue);
+      } else if (fieldToConvertToJson.includes(key)) {
+        return [[key, convertProcessorValueToJson(value)]];
+      } else {
+        return [[key, value]];
+      }
+    })
+  );
+};


### PR DESCRIPTION
Closes #193512

## Summary

This PR fixes and issue where `value` field was always interpreted as a string even when user entered numerical value. Originally those changes were introduced in #200692 and #204336.

| Before | After |
| -------- | ------- |
| <img width="1920" height="934" alt="FireShot Capture 029 - Ingest Pipelines - Elastic_ -  my-test-deployment2 kb us-central1 gcp qa cld elstc co" src="https://github.com/user-attachments/assets/3b446813-6d7c-4157-b6aa-efbb40cc84e3" /> | <img width="1920" height="934" alt="FireShot Capture 031 - Ingest Pipelines - Elastic -  localhost" src="https://github.com/user-attachments/assets/1bc958f8-4009-4934-93a0-61769fc43c60" /> |
| <img width="1920" height="934" alt="FireShot Capture 030 - Ingest Pipelines - Elastic_ -  my-test-deployment2 kb us-central1 gcp qa cld elstc co" src="https://github.com/user-attachments/assets/30d97816-a986-44bd-81e1-6a17ecdbea37" /> | <img width="1920" height="934" alt="FireShot Capture 032 - Ingest Pipelines - Elastic -  localhost" src="https://github.com/user-attachments/assets/5101a473-e1af-48db-a040-7d668ab70236" /> |