### PR TITLE
[Security Solution][Entity Analytics][PrivMon]Checking privmon engine state before initialization

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
@@ -122,7 +122,14 @@ export class PrivilegeMonitoringDataClient {
       EngineComponentResourceEnum.privmon_engine,
       'Initializing privilege monitoring engine'
     );
-
+    const currentEngineStatus = await this.getEngineStatus();
+    if (currentEngineStatus.status === PRIVILEGE_MONITORING_ENGINE_STATUS.STARTED) {
+      this.log(
+        'debug',
+        'Privilege monitoring engine is already initialized, skipping initialization.'
+      );
+      return this.engineClient.get();
+    }
     const descriptor = await this.engineClient.init();
     this.log('debug', `Initialized privileged monitoring engine saved object`);
     // create default index source for privilege monitoring


### PR DESCRIPTION
## Summary

The `init` API was erroring out with an error after the engine is started again after initialisation.

Error:
```
[13:02:51.701] [INFO ] [plugins.securitySolution] .entity_analytics.monitoring.users-default already exist
[13:02:51.742] [ERROR] [plugins.securitySolution] Failed to PUT settings for index .entity_analytics.monitoring.users-default: illegal_argument_exception
	Root causes:
		illegal_argument_exception: Can't update non dynamic settings [[index.mode]] for open indices [[.entity_analytics.monitoring.users-default/XVUArIPmR_KDr3n4xxdscg]] unless the `reopen` query parameter is set to true. Alternatively, close the indices, apply the settings changes, and reopen the indices
```

The PR adds a check of current privmon engine state and does not move ahead if it is already started.

Logs after the change : 

```
[13:09:09.199] [DEBUG] [plugins.securitySolution] [Privileged Monitoring Engine][namespace: default] Privilege monitoring engine is already initialized, skipping initialization.
```

## Testing Steps
1. Pull down this PR
2. Initialise the PrivmonEngine using any way. One way could be a dev console with the command : `POST kbn:/api/entity_analytics/monitoring/engine/init`
3. Keep initliazing it multiple time, you should not see any error in the logs or the API response.
4. The API response should always be 
```
{
  "status": "started",
  "apiKey": ""
}
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



