### PR TITLE
Skip deployment agnostic streams permission test suite for MKI runs

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/permissions.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/permissions.ts
@@ -22,7 +22,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const config = getService('config');
   const isServerless = !!config.get('serverless');
 
-  describe('Fails on missing permissions', () => {
+  describe('Fails on missing permissions', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/227583
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       adminApiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
       editorApiClient = await createStreamsRepositoryEditorClient(roleScopedSupertest);


### PR DESCRIPTION
## Summary

This PR skips the Observability deployment agnostic streams permissions test suite for MKI runs.

More details in #227583.