### PR TITLE
[9.0] [Security Solution] Fix prebuilt rules bulk edit flaky tests (#227051)

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/customization/customize_via_bulk_editing.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/customization/customize_via_bulk_editing.ts
@@ -10,9 +10,16 @@ import {
   BulkActionTypeEnum,
   BulkActionEditTypeEnum,
   BulkActionEditPayload,
+  BulkEditActionResponse,
 } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management';
+import { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import { deleteAllRules } from '../../../../../../../common/utils/security_solution';
-import { deleteAllPrebuiltRuleAssets, installMockPrebuiltRules } from '../../../../utils';
+import {
+  createPrebuiltRuleAssetSavedObjects,
+  createRuleAssetSavedObject,
+  deleteAllPrebuiltRuleAssets,
+  installPrebuiltRules,
+} from '../../../../utils';
 import { FtrProviderContext } from '../../../../../../ftr_provider_context';
 
 export default ({ getService }: FtrProviderContext): void => {
@@ -22,85 +29,349 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
 
   describe('@ess @serverless @skipInServerless Customize via bulk editing', () => {
-    before(async () => {
+    beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await deleteAllPrebuiltRuleAssets(es, log);
     });
 
-    const bulkEditingCases = [
-      {
-        type: BulkActionEditTypeEnum.add_tags,
-        value: ['new-tag'],
-      },
-      {
-        type: BulkActionEditTypeEnum.set_tags,
-        value: ['new-tag'],
-      },
-      {
-        type: BulkActionEditTypeEnum.delete_tags,
-        value: ['test-tag'],
-      },
-      {
-        type: BulkActionEditTypeEnum.delete_index_patterns,
-        // Testing index pattern removal requires as minimum of two index patterns
-        // to have a valid rule after the edit.
-        value: ['index-1'],
-      },
-      {
-        type: BulkActionEditTypeEnum.add_index_patterns,
-        value: ['test-*'],
-      },
-      {
-        type: BulkActionEditTypeEnum.set_index_patterns,
-        value: ['test-*'],
-      },
-      {
-        type: BulkActionEditTypeEnum.set_timeline,
-        value: { timeline_id: 'mock-id', timeline_title: 'mock-title' },
-      },
-      {
-        type: BulkActionEditTypeEnum.set_schedule,
-        value: { interval: '1m', lookback: '1m' },
-      },
+    const QUERY_PREBUILT_RULE_ID = 'test-query-prebuilt-rule';
+    const QUERY_PREBUILT_RULE_ASSET = createRuleAssetSavedObject({
+      rule_id: QUERY_PREBUILT_RULE_ID,
+      type: 'query',
+      query: '*:*',
+      language: 'kuery',
+      name: 'Query prebuilt rule',
+      index: ['existing-index-pattern-1', 'existing-index-pattern-2'],
+      tags: ['existing-tag-1', 'existing-tag-2'],
+      timeline_id: 'some-timeline-id',
+      timeline_title: 'some-timeline-title',
+      interval: '5m',
+      from: 'now-10m',
+      to: 'now',
+      version: 2,
+    });
+    const SAVED_QUERY_PREBUILT_RULE_ID = 'test-saved-query-prebuilt-rule';
+    const SAVED_QUERY_PREBUILT_RULE_ASSET = createRuleAssetSavedObject({
+      rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+      type: 'saved_query',
+      saved_id: 'test-saved-query',
+      name: 'Saved query prebuilt rule',
+      index: ['existing-index-pattern-1', 'existing-index-pattern-2'],
+      tags: ['existing-tag-1', 'existing-tag-2'],
+      timeline_id: 'some-timeline-id',
+      timeline_title: 'some-timeline-title',
+      interval: '5m',
+      from: 'now-10m',
+      to: 'now',
+      version: 3,
+    });
+    const EQL_PREBUILT_RULE_ID = 'test-eql-prebuilt-rule';
+    const EQL_PREBUILT_RULE_ASSET = createRuleAssetSavedObject({
+      rule_id: EQL_PREBUILT_RULE_ID,
+      type: 'eql',
+      name: 'EQL prebuilt rule',
+      query: 'any where true',
+      language: 'eql',
+      index: ['existing-index-pattern-1', 'existing-index-pattern-2'],
+      tags: ['existing-tag-1', 'existing-tag-2'],
+      timeline_id: 'some-timeline-id',
+      timeline_title: 'some-timeline-title',
+      interval: '5m',
+      from: 'now-10m',
+      to: 'now',
+      version: 4,
+    });
+    const PREBUILT_RULE_ASSETS = [
+      QUERY_PREBUILT_RULE_ASSET,
+      SAVED_QUERY_PREBUILT_RULE_ASSET,
+      EQL_PREBUILT_RULE_ASSET,
     ];
 
-    bulkEditingCases.forEach(({ type, value }) => {
-      it(`applies "${type}" bulk edit action to prebuilt rules`, async () => {
-        await installMockPrebuiltRules(supertest, es);
-
-        const {
-          body: {
-            data: [prebuiltRule],
-          },
-        } = await securitySolutionApi.findRules({
-          query: {
-            filter: 'alert.attributes.params.immutable: true',
-            per_page: 1,
-          },
-        });
-
-        const { body } = await securitySolutionApi
-          .performRulesBulkAction({
-            query: {},
-            body: {
-              ids: [prebuiltRule.id],
-              action: BulkActionTypeEnum.edit,
-              [BulkActionTypeEnum.edit]: [
-                {
-                  type,
-                  value,
-                } as BulkActionEditPayload,
-              ],
-            },
-          })
-          .expect(200);
-
-        expect(body).toMatchObject({
-          success: true,
-          rules_count: 1,
-        });
-        expect(body.attributes.summary).toMatchObject({ succeeded: 1, total: 1 });
+    const performBulkEditOnPrebuiltRules = async (
+      bulkEditPayload: BulkActionEditPayload
+    ): Promise<BulkEditActionResponse> => {
+      const {
+        body: { data: prebuiltRules },
+      } = await securitySolutionApi.findRules({
+        query: {
+          filter: 'alert.attributes.params.immutable: true',
+          per_page: PREBUILT_RULE_ASSETS.length,
+        },
       });
+
+      const { body: bulkEditResponse } = await securitySolutionApi
+        .performRulesBulkAction({
+          query: {},
+          body: {
+            ids: prebuiltRules.map((rule: RuleResponse) => rule.id),
+            action: BulkActionTypeEnum.edit,
+            [BulkActionTypeEnum.edit]: [bulkEditPayload],
+          },
+        })
+        .expect(200);
+
+      expect(bulkEditResponse).toMatchObject({
+        success: true,
+        rules_count: PREBUILT_RULE_ASSETS.length,
+      });
+      expect(bulkEditResponse.attributes.summary).toMatchObject({
+        succeeded: PREBUILT_RULE_ASSETS.length,
+        total: PREBUILT_RULE_ASSETS.length,
+      });
+
+      return bulkEditResponse;
+    };
+
+    it(`applies "${BulkActionEditTypeEnum.add_tags}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.add_tags,
+        value: ['new-tag'],
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            tags: ['existing-tag-1', 'existing-tag-2', 'new-tag'],
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            tags: ['existing-tag-1', 'existing-tag-2', 'new-tag'],
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            tags: ['existing-tag-1', 'existing-tag-2', 'new-tag'],
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.set_tags}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.set_tags,
+        value: ['new-tag'],
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            tags: ['new-tag'],
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            tags: ['new-tag'],
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            tags: ['new-tag'],
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.delete_tags}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.delete_tags,
+        value: ['existing-tag-1'],
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            tags: ['existing-tag-2'],
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            tags: ['existing-tag-2'],
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            tags: ['existing-tag-2'],
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.delete_index_patterns}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.delete_index_patterns,
+        value: ['existing-index-pattern-1'],
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-2'],
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-2'],
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-2'],
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.add_index_patterns}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.add_index_patterns,
+        value: ['test-*'],
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-1', 'existing-index-pattern-2', 'test-*'],
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-1', 'existing-index-pattern-2', 'test-*'],
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-1', 'existing-index-pattern-2', 'test-*'],
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.add_index_patterns}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.add_index_patterns,
+        value: ['test-*'],
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-1', 'existing-index-pattern-2', 'test-*'],
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-1', 'existing-index-pattern-2', 'test-*'],
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            index: ['existing-index-pattern-1', 'existing-index-pattern-2', 'test-*'],
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.set_index_patterns}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.set_index_patterns,
+        value: ['test-*'],
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            index: ['test-*'],
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            index: ['test-*'],
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            index: ['test-*'],
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.set_timeline}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.set_timeline,
+        value: { timeline_id: 'mock-id', timeline_title: 'mock-title' },
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            timeline_id: 'mock-id',
+            timeline_title: 'mock-title',
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            timeline_id: 'mock-id',
+            timeline_title: 'mock-title',
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            timeline_id: 'mock-id',
+            timeline_title: 'mock-title',
+          }),
+        ])
+      );
+    });
+
+    it(`applies "${BulkActionEditTypeEnum.set_schedule}" bulk edit action to prebuilt rules`, async () => {
+      await createPrebuiltRuleAssetSavedObjects(es, PREBUILT_RULE_ASSETS);
+      await installPrebuiltRules(es, supertest);
+
+      const bulkResponse = await performBulkEditOnPrebuiltRules({
+        type: BulkActionEditTypeEnum.set_schedule,
+        value: { interval: '1m', lookback: '1m' },
+      });
+
+      expect(bulkResponse.attributes.results.updated).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule_id: QUERY_PREBUILT_RULE_ID,
+            interval: '1m',
+            from: 'now-120s',
+            to: 'now',
+          }),
+          expect.objectContaining({
+            rule_id: SAVED_QUERY_PREBUILT_RULE_ID,
+            interval: '1m',
+            from: 'now-120s',
+            to: 'now',
+          }),
+          expect.objectContaining({
+            rule_id: EQL_PREBUILT_RULE_ID,
+            interval: '1m',
+            from: 'now-120s',
+            to: 'now',
+          }),
+        ])
+      );
     });
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Fix prebuilt rules bulk edit flaky tests (#227051)](https://github.com/elastic/kibana/pull/227051)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-07-10T18:09:49Z","message":"[Security Solution] Fix prebuilt rules bulk edit flaky tests (#227051)\n\n**Resolves: https://github.com/elastic/kibana/issues/222257**\n\n## Summary\n\nThis PR fixes prebuilt rules bulk edit integration tests flakiness and unskips the tests.\n\n## Details\n\nThe main reason of the flakiness was using `before()` instead of `beforeEach()` to clean up existing rules and prebuilt rule assets. The failure has been observed at `delete_tags` bulk edit. Since periodically it picked up a prebuilt rule with already deleted tags the test expectedly failed.\n\nThe fix switches to `beforeEach()` to clean up existing rules and prebuilt rule assets.\n\nOn top of that this PR refactors the tests to add explicit assertion on field values after bulk edits to make sure bulk edits actually have been applied successfully\n\n## Flaky test runner\n\n- ✅  [200 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8557)","sha":"e5ea2b4661840e5cf56e11d39d689990ab00949e","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","impact:high","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.2.0"],"title":"[Security Solution] Fix prebuilt rules bulk edit flaky tests","number":227051,"url":"https://github.com/elastic/kibana/pull/227051","mergeCommit":{"message":"[Security Solution] Fix prebuilt rules bulk edit flaky tests (#227051)\n\n**Resolves: https://github.com/elastic/kibana/issues/222257**\n\n## Summary\n\nThis PR fixes prebuilt rules bulk edit integration tests flakiness and unskips the tests.\n\n## Details\n\nThe main reason of the flakiness was using `before()` instead of `beforeEach()` to clean up existing rules and prebuilt rule assets. The failure has been observed at `delete_tags` bulk edit. Since periodically it picked up a prebuilt rule with already deleted tags the test expectedly failed.\n\nThe fix switches to `beforeEach()` to clean up existing rules and prebuilt rule assets.\n\nOn top of that this PR refactors the tests to add explicit assertion on field values after bulk edits to make sure bulk edits actually have been applied successfully\n\n## Flaky test runner\n\n- ✅  [200 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8557)","sha":"e5ea2b4661840e5cf56e11d39d689990ab00949e"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227522","number":227522,"state":"MERGED","mergeCommit":{"sha":"ae7ea4acee130669f76cfd7978ff99a10d9ba336","message":"[9.1] [Security Solution] Fix prebuilt rules bulk edit flaky tests (#227051) (#227522)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Fix prebuilt rules bulk edit flaky tests\n(#227051)](https://github.com/elastic/kibana/pull/227051)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227521","number":227521,"state":"MERGED","mergeCommit":{"sha":"84f97012bc8bb870781750a45fa2aad6338354b4","message":"[8.19] [Security Solution] Fix prebuilt rules bulk edit flaky tests (#227051) (#227521)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Fix prebuilt rules bulk edit flaky tests\n(#227051)](https://github.com/elastic/kibana/pull/227051)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227051","number":227051,"mergeCommit":{"message":"[Security Solution] Fix prebuilt rules bulk edit flaky tests (#227051)\n\n**Resolves: https://github.com/elastic/kibana/issues/222257**\n\n## Summary\n\nThis PR fixes prebuilt rules bulk edit integration tests flakiness and unskips the tests.\n\n## Details\n\nThe main reason of the flakiness was using `before()` instead of `beforeEach()` to clean up existing rules and prebuilt rule assets. The failure has been observed at `delete_tags` bulk edit. Since periodically it picked up a prebuilt rule with already deleted tags the test expectedly failed.\n\nThe fix switches to `beforeEach()` to clean up existing rules and prebuilt rule assets.\n\nOn top of that this PR refactors the tests to add explicit assertion on field values after bulk edits to make sure bulk edits actually have been applied successfully\n\n## Flaky test runner\n\n- ✅  [200 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8557)","sha":"e5ea2b4661840e5cf56e11d39d689990ab00949e"}}]}] BACKPORT-->