### PR TITLE
[8.17] [APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884)

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/routing/apm_error_boundary.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/routing/apm_error_boundary.tsx
@@ -5,12 +5,12 @@
  * 2.0.
  */
 import { NotFoundRouteException } from '@kbn/typed-react-router-config';
-import { EuiErrorBoundary } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import React from 'react';
 import { NotFoundPrompt } from '@kbn/shared-ux-prompt-not-found';
 import { useLocation } from 'react-router-dom';
-import { ApmPluginStartDeps } from '../../plugin';
+import { KibanaErrorBoundary } from '@kbn/shared-ux-error-boundary';
+import type { ApmPluginStartDeps } from '../../plugin';
 
 export function ApmErrorBoundary({ children }: { children?: React.ReactNode }) {
   const location = useLocation();
@@ -65,9 +65,9 @@ function ErrorWithTemplate({ error }: { error: Error }) {
 
   return (
     <ObservabilityPageTemplate pageHeader={pageHeader}>
-      <EuiErrorBoundary>
+      <KibanaErrorBoundary>
         <DummyComponent error={error} />
-      </EuiErrorBoundary>
+      </KibanaErrorBoundary>
     </ObservabilityPageTemplate>
   );
 }

--- a/x-pack/plugins/observability_solution/apm/tsconfig.json
+++ b/x-pack/plugins/observability_solution/apm/tsconfig.json
@@ -128,6 +128,7 @@
     "@kbn/router-utils",
     "@kbn/react-hooks",
     "@kbn/alerting-comparators",
+    "@kbn/shared-ux-error-boundary",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884)](https://github.com/elastic/kibana/pull/226884)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-07-08T16:11:36Z","message":"[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884)\n\nPR 1 of 2\n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nAPM Error Template. Compared to the infra PRs done in\nhttps://github.com/elastic/kibana/issues/225972, here we can the change\nis on the routing level, so we can reproduce it on different pages.\n\n## Testing\n\n- Introduce an error in the apm page (maybe a typo, non-existent\ncomponent, or anything) - it can be in a service overview page, as in\nthe example, or any other page.\n\n<img width=\"1006\" alt=\"code error\"\nsrc=\"https://github.com/user-attachments/assets/5cb4e8b8-453a-450b-8a86-c3d7096d02a2\"\n/>\n\n- Open `localhost:5601/ftw/app/apm/services/ _your_service_name_\n/overview`\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n<img width=\"1718\" alt=\"apm page error\"\nsrc=\"https://github.com/user-attachments/assets/a84e6fb5-b8d0-4a0d-a172-70da9edac04d\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"873e4b4dd73c3d0a0e54ea530c0e3b2a877c0114","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.1.0","v8.19.0","v9.2.0","v8.18.4"],"title":"[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template","number":226884,"url":"https://github.com/elastic/kibana/pull/226884","mergeCommit":{"message":"[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884)\n\nPR 1 of 2\n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nAPM Error Template. Compared to the infra PRs done in\nhttps://github.com/elastic/kibana/issues/225972, here we can the change\nis on the routing level, so we can reproduce it on different pages.\n\n## Testing\n\n- Introduce an error in the apm page (maybe a typo, non-existent\ncomponent, or anything) - it can be in a service overview page, as in\nthe example, or any other page.\n\n<img width=\"1006\" alt=\"code error\"\nsrc=\"https://github.com/user-attachments/assets/5cb4e8b8-453a-450b-8a86-c3d7096d02a2\"\n/>\n\n- Open `localhost:5601/ftw/app/apm/services/ _your_service_name_\n/overview`\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n<img width=\"1718\" alt=\"apm page error\"\nsrc=\"https://github.com/user-attachments/assets/a84e6fb5-b8d0-4a0d-a172-70da9edac04d\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"873e4b4dd73c3d0a0e54ea530c0e3b2a877c0114"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227101","number":227101,"state":"MERGED","mergeCommit":{"sha":"af3b7a557a2f99cf7fd1ebc72240ad5171cfe20a","message":"[9.1] [APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884) (#227101)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM\nError Template (#226884)](https://github.com/elastic/kibana/pull/226884)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227100","number":227100,"state":"MERGED","mergeCommit":{"sha":"55d4f20777862cef2a6328b9eb409a1d7af88e75","message":"[8.19] [APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884) (#227100)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM\nError Template (#226884)](https://github.com/elastic/kibana/pull/226884)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226884","number":226884,"mergeCommit":{"message":"[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884)\n\nPR 1 of 2\n\n## Summary\n\nThis PR replaces `EuiErrorBoundary` with `KibanaErrorBoundary` on the\nAPM Error Template. Compared to the infra PRs done in\nhttps://github.com/elastic/kibana/issues/225972, here we can the change\nis on the routing level, so we can reproduce it on different pages.\n\n## Testing\n\n- Introduce an error in the apm page (maybe a typo, non-existent\ncomponent, or anything) - it can be in a service overview page, as in\nthe example, or any other page.\n\n<img width=\"1006\" alt=\"code error\"\nsrc=\"https://github.com/user-attachments/assets/5cb4e8b8-453a-450b-8a86-c3d7096d02a2\"\n/>\n\n- Open `localhost:5601/ftw/app/apm/services/ _your_service_name_\n/overview`\n- The error should be visible, and it should still work as before (but\nalso including telemetry)\n\n<img width=\"1718\" alt=\"apm page error\"\nsrc=\"https://github.com/user-attachments/assets/a84e6fb5-b8d0-4a0d-a172-70da9edac04d\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"873e4b4dd73c3d0a0e54ea530c0e3b2a877c0114"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227099","number":227099,"state":"MERGED","mergeCommit":{"sha":"4919a09289e48dca136f803f76ad1902d595c3a8","message":"[8.18] [APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM Error Template (#226884) (#227099)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[APM] Replace EuiErrorBoundary with KibanaErrorBoundary on the APM\nError Template (#226884)](https://github.com/elastic/kibana/pull/226884)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}}]}] BACKPORT-->