### PR TITLE
[8.17] [Security Solution][Alerts] Refactor to disable "more options" button (#223412)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { mount, type ComponentType as EnzymeComponentType } from 'enzyme';
+import { render, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { AlertContextMenu } from './alert_context_menu';
 import { TestProviders } from '../../../../common/mock';
 import React from 'react';
@@ -103,72 +104,89 @@ jest.mock('../../../containers/detection_engine/alerts/use_alerts_privileges', (
   useAlertsPrivileges: jest.fn().mockReturnValue({ hasIndexWrite: true, hasKibanaCRUD: true }),
 }));
 
-const actionMenuButton = '[data-test-subj="timeline-context-menu-button"] button';
-const addToExistingCaseButton = '[data-test-subj="add-to-existing-case-action"]';
-const addToNewCaseButton = '[data-test-subj="add-to-new-case-action"]';
-const markAsOpenButton = '[data-test-subj="open-alert-status"]';
-const markAsAcknowledgedButton = '[data-test-subj="acknowledged-alert-status"]';
-const markAsClosedButton = '[data-test-subj="close-alert-status"]';
-const addEndpointEventFilterButton = '[data-test-subj="add-event-filter-menu-item"]';
-const applyAlertTagsButton = '[data-test-subj="alert-tags-context-menu-item"]';
-const applyAlertAssigneesButton = '[data-test-subj="alert-assignees-context-menu-item"]';
+const actionMenuButton = 'timeline-context-menu-button';
+const addToExistingCaseButton = 'add-to-existing-case-action';
+const addToNewCaseButton = 'add-to-new-case-action';
+const markAsOpenButton = 'open-alert-status';
+const markAsAcknowledgedButton = 'acknowledged-alert-status';
+const markAsClosedButton = 'close-alert-status';
+const addEndpointEventFilterButton = 'add-event-filter-menu-item';
+const applyAlertTagsButton = 'alert-tags-context-menu-item';
+const applyAlertAssigneesButton = 'alert-assignees-context-menu-item';
 
 describe('Alert table context menu', () => {
   describe('Case actions', () => {
-    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', () => {
-      const wrapper = mount(<AlertContextMenu {...props} scopeId={TableId.alertsOnAlertsPage} />, {
-        wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-      });
-
-      wrapper.find(actionMenuButton).simulate('click');
-      expect(wrapper.find(addToExistingCaseButton).first().exists()).toEqual(true);
-      expect(wrapper.find(addToNewCaseButton).first().exists()).toEqual(true);
-    });
-
-    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsRulesDetailsPage', () => {
-      const wrapper = mount(
-        <AlertContextMenu {...props} scopeId={TableId.alertsOnRuleDetailsPage} />,
-        {
-          wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-        }
+    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', async () => {
+      const wrapper = render(
+        <TestProviders>
+          <AlertContextMenu {...props} scopeId={TableId.alertsOnAlertsPage} />
+        </TestProviders>
       );
 
-      wrapper.find(actionMenuButton).simulate('click');
-      expect(wrapper.find(addToExistingCaseButton).first().exists()).toEqual(true);
-      expect(wrapper.find(addToNewCaseButton).first().exists()).toEqual(true);
+      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+      await waitFor(() => {
+        expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
+        expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
+      });
     });
 
-    test('it render AddToCase context menu item if timelineId === TimelineId.active', () => {
-      const wrapper = mount(<AlertContextMenu {...props} scopeId={TimelineId.active} />, {
-        wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-      });
+    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsRulesDetailsPage', async () => {
+      const wrapper = render(
+        <TestProviders>
+          <AlertContextMenu {...props} scopeId={TableId.alertsOnRuleDetailsPage} />
+        </TestProviders>
+      );
 
-      wrapper.find(actionMenuButton).simulate('click');
-      expect(wrapper.find(addToExistingCaseButton).first().exists()).toEqual(true);
-      expect(wrapper.find(addToNewCaseButton).first().exists()).toEqual(true);
+      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+      await waitFor(() => {
+        expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
+        expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
+      });
     });
 
-    test('it does NOT render AddToCase context menu item when timelineId is not in the allowed list', () => {
-      const wrapper = mount(<AlertContextMenu {...props} scopeId="timeline-test" />, {
-        wrappingComponent: TestProviders as EnzymeComponentType<{}>,
+    test('it render AddToCase context menu item if timelineId === TimelineId.active', async () => {
+      const wrapper = render(
+        <TestProviders>
+          <AlertContextMenu {...props} scopeId={TimelineId.active} />
+        </TestProviders>
+      );
+
+      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+      await waitFor(() => {
+        expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
+        expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
       });
-      wrapper.find(actionMenuButton).simulate('click');
-      expect(wrapper.find(addToExistingCaseButton).first().exists()).toEqual(false);
-      expect(wrapper.find(addToNewCaseButton).first().exists()).toEqual(false);
+    });
+
+    test('it does NOT render AddToCase context menu item when timelineId is not in the allowed list', async () => {
+      const wrapper = render(
+        <TestProviders>
+          <AlertContextMenu {...props} scopeId="timeline-test" />
+        </TestProviders>
+      );
+      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+      expect(wrapper.queryByTestId(addToExistingCaseButton)).toBeNull();
+      expect(wrapper.queryByTestId(addToNewCaseButton)).toBeNull();
     });
   });
 
   describe('Alert status actions', () => {
-    test('it renders the correct status action buttons', () => {
-      const wrapper = mount(<AlertContextMenu {...props} scopeId={TimelineId.active} />, {
-        wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-      });
+    test('it renders the correct status action buttons', async () => {
+      const wrapper = render(
+        <TestProviders>
+          <AlertContextMenu {...props} scopeId={TimelineId.active} />
+        </TestProviders>
+      );
 
-      wrapper.find(actionMenuButton).simulate('click');
+      await userEvent.click(wrapper.getByTestId(actionMenuButton));
 
-      expect(wrapper.find(markAsOpenButton).first().exists()).toEqual(false);
-      expect(wrapper.find(markAsAcknowledgedButton).first().exists()).toEqual(true);
-      expect(wrapper.find(markAsClosedButton).first().exists()).toEqual(true);
+      expect(wrapper.queryByTestId(markAsOpenButton)).toBeNull();
+      expect(wrapper.getByTestId(markAsAcknowledgedButton)).toBeInTheDocument();
+      expect(wrapper.getByTestId(markAsClosedButton)).toBeInTheDocument();
     });
   });
 
@@ -187,81 +205,87 @@ describe('Alert table context menu', () => {
           });
         });
 
-        test('it disables AddEndpointEventFilter when timeline id is not host events page', () => {
-          const wrapper = mount(
-            <AlertContextMenu {...endpointEventProps} scopeId={TimelineId.active} />,
-            {
-              wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-            }
+        test('it disables AddEndpointEventFilter when timeline id is not host events page', async () => {
+          const wrapper = render(
+            <TestProviders>
+              <AlertContextMenu {...endpointEventProps} scopeId={TimelineId.active} />
+            </TestProviders>
           );
 
-          wrapper.find(actionMenuButton).simulate('click');
-          expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
-          expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(true);
+          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+          const button = wrapper.getByTestId(addEndpointEventFilterButton);
+
+          expect(button).toBeInTheDocument();
+          expect(button).toBeDisabled();
         });
 
-        test('it enables AddEndpointEventFilter when timeline id is host events page', () => {
-          const wrapper = mount(
-            <AlertContextMenu {...endpointEventProps} scopeId={TableId.hostsPageEvents} />,
-            {
-              wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-            }
+        test('it enables AddEndpointEventFilter when timeline id is host events page', async () => {
+          const wrapper = render(
+            <TestProviders>
+              <AlertContextMenu {...endpointEventProps} scopeId={TableId.hostsPageEvents} />
+            </TestProviders>
           );
 
-          wrapper.find(actionMenuButton).simulate('click');
-          expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
-          expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(
-            false
-          );
+          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+          const button = wrapper.getByTestId(addEndpointEventFilterButton);
+
+          expect(button).toBeInTheDocument();
+          expect(button).not.toBeDisabled();
         });
 
-        test('it disables AddEndpointEventFilter when timeline id is host events page but is not from endpoint', () => {
+        test('it disables AddEndpointEventFilter when timeline id is host events page but is not from endpoint', async () => {
           const customProps = {
             ...props,
             ecsRowData: { ...ecsRowData, agent: { type: ['other'] }, event: { kind: ['event'] } },
           };
-          const wrapper = mount(
-            <AlertContextMenu {...customProps} scopeId={TableId.hostsPageEvents} />,
-            {
-              wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-            }
+          const wrapper = render(
+            <TestProviders>
+              <AlertContextMenu {...customProps} scopeId={TableId.hostsPageEvents} />
+            </TestProviders>
           );
 
-          wrapper.find(actionMenuButton).simulate('click');
-          expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
-          expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(true);
+          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+          const button = wrapper.getByTestId(addEndpointEventFilterButton);
+
+          expect(button).toBeInTheDocument();
+          expect(button).toBeDisabled();
         });
 
-        test('it enables AddEndpointEventFilter when timeline id is user events page', () => {
-          const wrapper = mount(
-            <AlertContextMenu {...endpointEventProps} scopeId={TableId.usersPageEvents} />,
-            {
-              wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-            }
+        test('it enables AddEndpointEventFilter when timeline id is user events page', async () => {
+          const wrapper = render(
+            <TestProviders>
+              <AlertContextMenu {...endpointEventProps} scopeId={TableId.usersPageEvents} />
+            </TestProviders>
           );
 
-          wrapper.find(actionMenuButton).simulate('click');
-          expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
-          expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(
-            false
-          );
+          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+          const button = wrapper.getByTestId(addEndpointEventFilterButton);
+
+          expect(button).toBeInTheDocument();
+          expect(button).not.toBeDisabled();
         });
 
-        test('it disables AddEndpointEventFilter when timeline id is user events page but is not from endpoint', () => {
+        test('it disables AddEndpointEventFilter when timeline id is user events page but is not from endpoint', async () => {
           const customProps = {
             ...props,
             ecsRowData: { ...ecsRowData, agent: { type: ['other'] }, event: { kind: ['event'] } },
           };
-          const wrapper = mount(
-            <AlertContextMenu {...customProps} scopeId={TableId.usersPageEvents} />,
-            {
-              wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-            }
+          const wrapper = render(
+            <TestProviders>
+              <AlertContextMenu {...customProps} scopeId={TableId.usersPageEvents} />
+            </TestProviders>
           );
 
-          wrapper.find(actionMenuButton).simulate('click');
-          expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
-          expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(true);
+          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+          const button = wrapper.getByTestId(addEndpointEventFilterButton);
+
+          expect(button).toBeInTheDocument();
+          expect(button).toBeDisabled();
         });
       });
 
@@ -273,54 +297,60 @@ describe('Alert table context menu', () => {
           });
         });
 
-        test('it removes AddEndpointEventFilter option when timeline id is host events page but does not has write event filters privilege', () => {
-          const wrapper = mount(
-            <AlertContextMenu {...endpointEventProps} scopeId={TableId.hostsPageEvents} />,
-            {
-              wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-            }
+        test('it disables actionMenuButton when timeline id is host events page but does not has write event filters privilege', () => {
+          const wrapper = render(
+            <TestProviders>
+              <AlertContextMenu {...endpointEventProps} scopeId={TableId.hostsPageEvents} />
+            </TestProviders>
           );
 
-          // Entire actionMenuButton is removed as there is no option available
-          expect(wrapper.find(actionMenuButton).first().exists()).toEqual(false);
+          // <TestProviders>Entire actionMenuButton is disabled as there is no option available
+          expect(wrapper.getByTestId(actionMenuButton)).toBeDisabled();
         });
 
-        test('it removes AddEndpointEventFilter option when timeline id is user events page but does not has write event filters privilege', () => {
-          const wrapper = mount(
-            <AlertContextMenu {...endpointEventProps} scopeId={TableId.usersPageEvents} />,
-            {
-              wrappingComponent: TestProviders as EnzymeComponentType<{}>,
-            }
+        test('it disables actionMenuButton when timeline id is user events page but does not has write event filters privilege', () => {
+          const wrapper = render(
+            <TestProviders>
+              <AlertContextMenu {...endpointEventProps} scopeId={TableId.usersPageEvents} />
+            </TestProviders>
           );
 
-          // Entire actionMenuButton is removed as there is no option available
-          expect(wrapper.find(actionMenuButton).first().exists()).toEqual(false);
+          // <TestProviders>Entire actionMenuButton is disabled as there is no option available
+          expect(wrapper.getByTestId(actionMenuButton)).toBeDisabled();
         });
       });
     });
-  });
 
-  describe('Apply alert tags action', () => {
-    test('it renders the apply alert tags action button', () => {
-      const wrapper = mount(<AlertContextMenu {...props} scopeId={TimelineId.active} />, {
-        wrappingComponent: TestProviders as EnzymeComponentType<{}>,
+    describe('Apply alert tags action', () => {
+      test('it renders the apply alert tags action button', async () => {
+        const wrapper = render(
+          <TestProviders>
+            <AlertContextMenu {...props} scopeId={TimelineId.active} />
+          </TestProviders>
+        );
+
+        await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+        await waitFor(() => {
+          expect(wrapper.getByTestId(applyAlertTagsButton)).toBeTruthy();
+        });
       });
-
-      wrapper.find(actionMenuButton).simulate('click');
-
-      expect(wrapper.find(applyAlertTagsButton).first().exists()).toEqual(true);
     });
-  });
 
-  describe('Assign alert action', () => {
-    test('it renders the assign alert action button', () => {
-      const wrapper = mount(<AlertContextMenu {...props} scopeId={TimelineId.active} />, {
-        wrappingComponent: TestProviders as EnzymeComponentType<{}>,
+    describe('Assign alert action', () => {
+      test('it renders the assign alert action button', async () => {
+        const wrapper = render(
+          <TestProviders>
+            <AlertContextMenu {...props} scopeId={TimelineId.active} />
+          </TestProviders>
+        );
+
+        await userEvent.click(wrapper.getByTestId(actionMenuButton));
+
+        await waitFor(() => {
+          expect(wrapper.getByTestId(applyAlertAssigneesButton)).toBeTruthy();
+        });
       });
-
-      wrapper.find(actionMenuButton).simulate('click');
-
-      expect(wrapper.find(applyAlertAssigneesButton).first().exists()).toEqual(true);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -127,28 +127,12 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
   );
 
   const onButtonClick = useCallback(() => {
-    setPopover(!isPopoverOpen);
-  }, [isPopoverOpen]);
+    setPopover((current) => !current);
+  }, []);
 
   const closePopover = useCallback((): void => {
     setPopover(false);
   }, []);
-
-  const button = useMemo(() => {
-    return (
-      <EuiToolTip position="top" content={i18n.MORE_ACTIONS}>
-        <EuiButtonIcon
-          aria-label={ariaLabel}
-          data-test-subj="timeline-context-menu-button"
-          size="s"
-          iconType="boxesHorizontal"
-          data-popover-open={isPopoverOpen}
-          onClick={onButtonClick}
-          isDisabled={disabled}
-        />
-      </EuiToolTip>
-    );
-  }, [disabled, onButtonClick, ariaLabel, isPopoverOpen]);
 
   const refetchAll = useCallback(() => {
     const refetchQuery = (newQueries: inputsModel.GlobalQuery[]) => {
@@ -280,6 +264,26 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
     [alertTagsPanels, alertAssigneesPanels, items]
   );
 
+  const button = useMemo(() => {
+    const hasItems = !!items.length;
+    const tooltipContent = hasItems ? i18n.MORE_ACTIONS : i18n.INSUFFICIENT_PRIVILEGES;
+
+    return (
+      <EuiToolTip position="top" content={tooltipContent}>
+        <EuiButtonIcon
+          aria-label={ariaLabel}
+          data-test-subj="timeline-context-menu-button"
+          size="s"
+          iconType="boxesHorizontal"
+          data-popover-open={isPopoverOpen}
+          onClick={onButtonClick}
+          isDisabled={disabled || !hasItems}
+          color={isPopoverOpen ? 'primary' : 'text'}
+        />
+      </EuiToolTip>
+    );
+  }, [ariaLabel, isPopoverOpen, onButtonClick, disabled, items.length]);
+
   const osqueryFlyout = useMemo(() => {
     return (
       <OsqueryFlyout
@@ -293,28 +297,26 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
 
   return (
     <>
-      {items.length > 0 && (
-        <div key="actions-context-menu">
-          <EventsTdContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH}>
-            <EuiPopover
-              id="singlePanel"
-              button={button}
-              isOpen={isPopoverOpen}
-              closePopover={closePopover}
-              panelPaddingSize="none"
-              anchorPosition="downLeft"
-              repositionOnScroll
-            >
-              <EuiContextMenu
-                size="s"
-                initialPanelId={0}
-                panels={panels}
-                data-test-subj="actions-context-menu"
-              />
-            </EuiPopover>
-          </EventsTdContent>
-        </div>
-      )}
+      <div key="actions-context-menu">
+        <EventsTdContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH}>
+          <EuiPopover
+            id="singlePanel"
+            button={button}
+            isOpen={isPopoverOpen}
+            closePopover={closePopover}
+            panelPaddingSize="none"
+            anchorPosition="downLeft"
+            repositionOnScroll
+          >
+            <EuiContextMenu
+              size="s"
+              initialPanelId={0}
+              panels={panels}
+              data-test-subj="actions-context-menu"
+            />
+          </EuiPopover>
+        </EventsTdContent>
+      </div>
       {openAddExceptionFlyout &&
         ruleId &&
         ruleRuleId &&

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
@@ -397,3 +397,10 @@ export const EVENT_RENDERED_VIEW_COLUMNS = {
     defaultMessage: 'Event Summary',
   }),
 };
+
+export const INSUFFICIENT_PRIVILEGES = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.insufficientPrivileges',
+  {
+    defaultMessage: 'Insufficient privileges',
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/cases/attach_alert_to_case.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/cases/attach_alert_to_case.cy.ts
@@ -43,12 +43,12 @@ describe.skip('Alerts timeline', { tags: ['@ess'] }, () => {
 
     it('should not allow user with read only privileges to attach alerts to existing cases', () => {
       // Disabled actions for read only users are hidden, so the ... icon is not even shown
-      cy.get(TIMELINE_CONTEXT_MENU_BTN).should('not.exist');
+      cy.get(TIMELINE_CONTEXT_MENU_BTN).should('be.disabled');
     });
 
     it('should not allow user with read only privileges to attach alerts to a new case', () => {
       // Disabled actions for read only users are hidden, so the ... icon is not even shown
-      cy.get(TIMELINE_CONTEXT_MENU_BTN).should('not.exist');
+      cy.get(TIMELINE_CONTEXT_MENU_BTN).should('be.disabled');
     });
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alert_assignments.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alert_assignments.ts
@@ -91,7 +91,7 @@ export const checkEmptyAssigneesStateInAlertDetailsFlyout = () => {
 };
 
 export const alertsTableMoreActionsAreNotAvailable = () => {
-  cy.get(TIMELINE_CONTEXT_MENU_BTN).should('not.exist');
+  cy.get(TIMELINE_CONTEXT_MENU_BTN).should('be.disabled');
 };
 
 export const asigneesMenuItemsAreNotAvailable = () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Security Solution][Alerts] Refactor to disable "more options" button (#223412)](https://github.com/elastic/kibana/pull/223412)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicholas Peretti","email":"nicholas.peretti@elastic.co"},"sourceCommit":{"committedDate":"2025-07-08T14:07:43Z","message":"[Security Solution][Alerts] Refactor to disable \"more options\" button (#223412)\n\n## Summary\n\nFixes #210995\n\nWhen users have read-only profiles for security, they won't see the\n\"more options\" button in the alerts table:\n\n<img width=\"334\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fb6393ae-05d8-4108-98d8-681a1cdeffd2\"\n/>\n\nUnfortunately, this impacts the width of the \"Actions\" column, making it\nlarger than it should be.\n\n## Solution\n\nAs described in #210995 , it would be best to just disable the button\nrather than hide it.\n\n<img width=\"351\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a3c5d284-9716-4ae7-8f7d-b7d8dfd11db7\"\n/>\n\n\n\n### Checklist\n\n<details>\n<summary>Expand</summary>\n\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n\n</details>\n\n---------\n\nCo-authored-by: natasha-moore-elastic <137783811+natasha-moore-elastic@users.noreply.github.com>","sha":"414216bc9836eb97949b795218f47e93f31e9243","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting","Team: SecuritySolution","backport:version","v9.1.0","v8.19.0","v9.2.0","v8.18.4","v8.17.9"],"title":"Refactor to disable \"more options\" button","number":223412,"url":"https://github.com/elastic/kibana/pull/223412","mergeCommit":{"message":"[Security Solution][Alerts] Refactor to disable \"more options\" button (#223412)\n\n## Summary\n\nFixes #210995\n\nWhen users have read-only profiles for security, they won't see the\n\"more options\" button in the alerts table:\n\n<img width=\"334\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fb6393ae-05d8-4108-98d8-681a1cdeffd2\"\n/>\n\nUnfortunately, this impacts the width of the \"Actions\" column, making it\nlarger than it should be.\n\n## Solution\n\nAs described in #210995 , it would be best to just disable the button\nrather than hide it.\n\n<img width=\"351\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a3c5d284-9716-4ae7-8f7d-b7d8dfd11db7\"\n/>\n\n\n\n### Checklist\n\n<details>\n<summary>Expand</summary>\n\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n\n</details>\n\n---------\n\nCo-authored-by: natasha-moore-elastic <137783811+natasha-moore-elastic@users.noreply.github.com>","sha":"414216bc9836eb97949b795218f47e93f31e9243"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","8.18","8.17"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227049","number":227049,"state":"MERGED","mergeCommit":{"sha":"fba78577a82421473787b3eb11d16c0a1d95e1e5","message":"[9.1] [Security Solution][Alerts] Refactor to disable \"more options\" button (#223412) (#227049)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution][Alerts] Refactor to disable \"more options\" button\n(#223412)](https://github.com/elastic/kibana/pull/223412)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nicholas Peretti <nicholas.peretti@elastic.co>\nCo-authored-by: natasha-moore-elastic <137783811+natasha-moore-elastic@users.noreply.github.com>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223412","number":223412,"mergeCommit":{"message":"[Security Solution][Alerts] Refactor to disable \"more options\" button (#223412)\n\n## Summary\n\nFixes #210995\n\nWhen users have read-only profiles for security, they won't see the\n\"more options\" button in the alerts table:\n\n<img width=\"334\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fb6393ae-05d8-4108-98d8-681a1cdeffd2\"\n/>\n\nUnfortunately, this impacts the width of the \"Actions\" column, making it\nlarger than it should be.\n\n## Solution\n\nAs described in #210995 , it would be best to just disable the button\nrather than hide it.\n\n<img width=\"351\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a3c5d284-9716-4ae7-8f7d-b7d8dfd11db7\"\n/>\n\n\n\n### Checklist\n\n<details>\n<summary>Expand</summary>\n\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n\n</details>\n\n---------\n\nCo-authored-by: natasha-moore-elastic <137783811+natasha-moore-elastic@users.noreply.github.com>","sha":"414216bc9836eb97949b795218f47e93f31e9243"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->