### PR TITLE
chore: update @elastic/eslint-plugin-eui to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1427,7 +1427,7 @@
     "@cypress/debugging-proxy": "2.0.1",
     "@cypress/grep": "^4.0.1",
     "@cypress/webpack-preprocessor": "^6.0.2",
-    "@elastic/eslint-plugin-eui": "2.0.0",
+    "@elastic/eslint-plugin-eui": "2.1.0",
     "@elastic/makelogs": "^6.1.1",
     "@elastic/synthetics": "^1.18.2",
     "@emotion/babel-preset-css-prop": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,10 +2162,10 @@
     semver "^7.6.3"
     topojson-client "^3.1.0"
 
-"@elastic/eslint-plugin-eui@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-2.0.0.tgz#dba9f302c3a611440c88d7c34371a86e6f2285ae"
-  integrity sha512-AIhCyMfRNz80CdKZEllVW4VgqfXQgv3wE875lt228MAmwd3tAwNh0mROp8++kWb0WJoLAYW4vypw873AMWqyEw==
+"@elastic/eslint-plugin-eui@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-2.1.0.tgz#20296c12b3f79623217699a42d500e336b7e470f"
+  integrity sha512-xDTSJTkI7i9+PreDaaMU/I607aoVkWmVSJsXNj29iHhuNDhT+a2nZoE7FFVt51XaJe/LhbGM2xUaLBJeGEg92A==
 
 "@elastic/eui-amsterdam@npm:@elastic/eui@105.0.0-amsterdam.0":
   version "105.0.0-amsterdam.0"


### PR DESCRIPTION
`@elastic/eslint-plugin-eui`: `2.0.0` ⏩ `2.1.0`

[Questions? Please see our Kibana upgrade FAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)

## Changes

This PR updates the `@elastic/eslint-plugin-eui` version to latest: [`v2.1.0`](https://www.npmjs.com/package/@elastic/eslint-plugin-eui/v/2.1.0)

### `@elastic/eui/require-aria-label-for-modals` (fixed with GenAI: https://github.com/elastic/kibana/pull/227623)

Ensures that EUI modal components (`EuiModal`, `EuiFlyout`, `EuiConfirmModal`) have either an `aria-label` or `aria-labelledby` prop for accessibility. This helps screen reader users understand the purpose and content of modal dialogs.

### `@elastic/eui/consistent-is-invalid-props` (auto-fix available)

Ensures that form control components within `EuiFormRow` components have matching `isInvalid` prop values. This maintains consistent validation state between parent form rows and their child form controls, leading to a more predictable and accessible user experience.

### `@elastic/eui/sr_output_disabled_tooltip` (auto-fix available)

Ensures `disableScreenReaderOutput` is set when `EuiToolTip` content matches `EuiButtonIcon`'s `aria-label`.

> [!NOTE]
> `@elastic/eui/sr_output_disabled_tooltip` will be renamed to `@elastic/eui/sr-output-disabled-tooltip` for consistent rule naming.

## Package updates

### `@elastic/eslint-plugin-eui`

- Added new `sr_output_disabled_tooltip` rule. ([#8848](https://github.com/elastic/eui/pull/8848))
- Added new `consistent-is-invalid-props` rule. ([#8843](https://github.com/elastic/eui/pull/8843))
- Added new `require-aria-label-for-modals` rule. ([#8811](https://github.com/elastic/eui/pull/8811))
