### PR TITLE
[8.18] [Obs AI Assistant] Inject user prompt before tool call when query actions are clicked (#227462)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
@@ -292,24 +292,35 @@ export function ChatBody({
   }) => {
     setStickToBottom(true);
     switch (payload.type) {
-      case ChatActionClickType.executeEsqlQuery:
+      case ChatActionClickType.executeEsqlQuery: {
+        const now = new Date().toISOString();
         next(
-          messages.concat({
-            '@timestamp': new Date().toISOString(),
-            message: {
-              role: MessageRole.Assistant,
-              content: '',
-              function_call: {
-                name: 'execute_query',
-                arguments: JSON.stringify({
-                  query: payload.query,
-                }),
-                trigger: MessageRole.User,
+          messages.concat([
+            {
+              '@timestamp': now,
+              message: {
+                role: MessageRole.User,
+                content: `Display results for the following ES|QL query:\n\n\`\`\`esql\n${payload.query}\n\`\`\``,
               },
             },
-          })
+            {
+              '@timestamp': now,
+              message: {
+                role: MessageRole.Assistant,
+                content: '',
+                function_call: {
+                  name: 'execute_query',
+                  arguments: JSON.stringify({
+                    query: payload.query,
+                  }),
+                  trigger: MessageRole.User,
+                },
+              },
+            },
+          ])
         );
         break;
+      }
 
       case ChatActionClickType.updateVisualization:
         const visualizeQueryResponse = message;
@@ -331,25 +342,36 @@ export function ChatBody({
           })
         );
         break;
-      case ChatActionClickType.visualizeEsqlQuery:
+      case ChatActionClickType.visualizeEsqlQuery: {
+        const now = new Date().toISOString();
         next(
-          messages.concat({
-            '@timestamp': new Date().toISOString(),
-            message: {
-              role: MessageRole.Assistant,
-              content: '',
-              function_call: {
-                name: 'visualize_query',
-                arguments: JSON.stringify({
-                  query: payload.query,
-                  intention: VisualizeESQLUserIntention.visualizeAuto,
-                }),
-                trigger: MessageRole.User,
+          messages.concat([
+            {
+              '@timestamp': now,
+              message: {
+                role: MessageRole.User,
+                content: `Visualize the following ES|QL query:\n\n\`\`\`esql\n${payload.query}\n\`\`\``,
               },
             },
-          })
+            {
+              '@timestamp': now,
+              message: {
+                role: MessageRole.Assistant,
+                content: '',
+                function_call: {
+                  name: 'visualize_query',
+                  arguments: JSON.stringify({
+                    query: payload.query,
+                    intention: VisualizeESQLUserIntention.visualizeAuto,
+                  }),
+                  trigger: MessageRole.User,
+                },
+              },
+            },
+          ])
         );
         break;
+      }
     }
   };
 

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
@@ -340,33 +340,35 @@ export function ChatBody({
           );
           break;
         case ChatActionClickType.visualizeEsqlQuery: {
-        const now = new Date().toISOString();
-        next(
-          messages.concat([
-            {
-              '@timestamp': now,
-              message: {
-                role: MessageRole.User,
-                content: `Visualize the following ES|QL query:\n\n\`\`\`esql\n${payload.query}\n\`\`\``,
-              },
-            },
-            {
-              '@timestamp': now,
-              message: {
-                role: MessageRole.Assistant,
-                content: '',
-                function_call: {
-                  name: 'visualize_query',
-                  arguments: JSON.stringify({
-                    query: payload.query,
-                    intention: VisualizeESQLUserIntention.visualizeAuto,
-                  }),
-                  trigger: MessageRole.User,
+          const now = new Date().toISOString();
+          next(
+            messages.concat([
+              {
+                '@timestamp': now,
+                message: {
+                  role: MessageRole.User,
+                  content: `Visualize the following ES|QL query:\n\n\`\`\`esql\n${payload.query}\n\`\`\``,
                 },
               },
-            })
+              {
+                '@timestamp': now,
+                message: {
+                  role: MessageRole.Assistant,
+                  content: '',
+                  function_call: {
+                    name: 'visualize_query',
+                    arguments: JSON.stringify({
+                      query: payload.query,
+                      intention: VisualizeESQLUserIntention.visualizeAuto,
+                    }),
+                    trigger: MessageRole.User,
+                  },
+                },
+              },
+            ])
           );
           break;
+        }
       }
     },
     [messages, next]

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/visualize_esql.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/visualize_esql.ts
@@ -21,10 +21,20 @@ const getMessageForLLM = (
   if (hasErrors) {
     return 'The query has syntax errors';
   }
-  return intention === VisualizeESQLUserIntention.executeAndReturnResults ||
+
+  if (
+    intention === VisualizeESQLUserIntention.executeAndReturnResults ||
     intention === VisualizeESQLUserIntention.generateQueryOnly
-    ? 'These results are not visualized'
-    : 'Only following query is visualized: ```esql\n' + query + '\n```';
+  ) {
+    return 'These results are not visualized.';
+  }
+
+  // This message is added to avoid the model echoing the full ES|QL query back to the user.
+  // The UI already shows the chart.
+  return `Only the following query is visualized: \`\`\`esql\n' + ${query} + '\n\`\`\`\n
+  If the query is visualized once, don't attempt to visualize the same query again immediately.
+  After calling visualize_query you are done - **do NOT repeat the ES|QL query or add any further
+  explanation unless the user explicitly asks for it again.** Mention that the query is visualized.`;
 };
 
 export function registerVisualizeESQLFunction({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Obs AI Assistant] Inject user prompt before tool call when query actions are clicked (#227462)](https://github.com/elastic/kibana/pull/227462)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-07-11T12:25:04Z","message":"[Obs AI Assistant] Inject user prompt before tool call when query actions are clicked (#227462)\n\nCloses https://github.com/elastic/obs-ai-assistant-team/issues/309\n\n## Summary\n\nThis PR improves the `Display Results` and `visualize this query`\nactions by injecting a user prompt first and then the tool call to\nmaintain correct message ordering. This fixes the empty message that was\nobserved when visualize this query was clicked.\n\nHowever, in any case, if an empty message is received this should be\nhandled separately to avoid breaking the conversation flow.\n\n## Testing instructions:\n1. Generate some logs\n2. Pick the LLM (Needs to be tested with Elastic Managed LLM, Claude\n3.5, Claude 3.7, GPT-4, etc)\n3. Ask the assistant to generate a query\n4. Click on `Display results` -- the results should be shown and the\nuser should be able to continue the conversation\n5. Click on `Visualize this query` -- the visualization should be shown\nand the user should be able to continue the conversation\n\n## Traces with each model:\n\n- EIS (Visualize this query) -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/b1dcb77fb39ad7efbf82d9c4a1feb0e0?selectedSpanNodeId=U3BhbjoyOTk3ODQ%3D\n<img width=\"715\" height=\"868\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/75fd8efe-82df-4f7f-ad4f-f915e09d49da\"\n/>\n\n- EIS (Display results) -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/e7d8c42774491e6e2bcf328c34203c14?selectedSpanNodeId=U3BhbjozMDAxOTg%3D\n\n\nhttps://github.com/user-attachments/assets/6aa520db-2b40-4317-ace0-7be206ebb669\n\n- Bedrock+Claude 3.7 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/f1bc4f490fcc990db9dbddf0782cff7e?selectedSpanNodeId=U3BhbjoyOTk4MDA%3D\n<img width=\"709\" height=\"889\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86f77ff9-1783-42d3-8b31-8680fd7da227\"\n/>\n\n\n- Bedrock+Claude 3.5 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/457a7cc939ce3b18ae3a9e2b066c3a7f?selectedSpanNodeId=U3BhbjoyOTk4MTY%3D\n<img width=\"714\" height=\"942\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fe96b72e-24d0-4a85-9b42-a9862bdf4139\"\n/>\n\n\n- AzureOpenAI+GPT 4.1 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/de9fc09a6f0162b7b2d6f52fbb188469?selectedSpanNodeId=U3BhbjoyOTk4MzI%3D\n<img width=\"715\" height=\"877\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cca5326e-9350-426f-9f2e-a407d26e193d\"\n/>\n\n\n- Gemini 2.0 Flash -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/982da6b0ff4bae04f45af0271aa4cd84?selectedSpanNodeId=U3BhbjoyOTk4NTI%3D\n<img width=\"709\" height=\"880\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d29b99c7-e3f6-4318-a19b-0a92e7aa690b\"\n/>\n\n- Gemini 2.5 Flash -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/9f7115cc79bb2e929dbeb93670555e81?selectedSpanNodeId=U3BhbjoyOTk4NjU%3D\n<img width=\"708\" height=\"872\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4c6e48fd-ccaf-413c-b01d-21c0fc8df061\"\n/>\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"021b30816e86ddb2e1fa2a8c911ff85ab07e1d43","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.2.0","v8.18.4","v9.0.4"],"title":"[Obs AI Assistant] Inject user prompt before tool call when query actions are clicked","number":227462,"url":"https://github.com/elastic/kibana/pull/227462","mergeCommit":{"message":"[Obs AI Assistant] Inject user prompt before tool call when query actions are clicked (#227462)\n\nCloses https://github.com/elastic/obs-ai-assistant-team/issues/309\n\n## Summary\n\nThis PR improves the `Display Results` and `visualize this query`\nactions by injecting a user prompt first and then the tool call to\nmaintain correct message ordering. This fixes the empty message that was\nobserved when visualize this query was clicked.\n\nHowever, in any case, if an empty message is received this should be\nhandled separately to avoid breaking the conversation flow.\n\n## Testing instructions:\n1. Generate some logs\n2. Pick the LLM (Needs to be tested with Elastic Managed LLM, Claude\n3.5, Claude 3.7, GPT-4, etc)\n3. Ask the assistant to generate a query\n4. Click on `Display results` -- the results should be shown and the\nuser should be able to continue the conversation\n5. Click on `Visualize this query` -- the visualization should be shown\nand the user should be able to continue the conversation\n\n## Traces with each model:\n\n- EIS (Visualize this query) -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/b1dcb77fb39ad7efbf82d9c4a1feb0e0?selectedSpanNodeId=U3BhbjoyOTk3ODQ%3D\n<img width=\"715\" height=\"868\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/75fd8efe-82df-4f7f-ad4f-f915e09d49da\"\n/>\n\n- EIS (Display results) -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/e7d8c42774491e6e2bcf328c34203c14?selectedSpanNodeId=U3BhbjozMDAxOTg%3D\n\n\nhttps://github.com/user-attachments/assets/6aa520db-2b40-4317-ace0-7be206ebb669\n\n- Bedrock+Claude 3.7 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/f1bc4f490fcc990db9dbddf0782cff7e?selectedSpanNodeId=U3BhbjoyOTk4MDA%3D\n<img width=\"709\" height=\"889\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86f77ff9-1783-42d3-8b31-8680fd7da227\"\n/>\n\n\n- Bedrock+Claude 3.5 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/457a7cc939ce3b18ae3a9e2b066c3a7f?selectedSpanNodeId=U3BhbjoyOTk4MTY%3D\n<img width=\"714\" height=\"942\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fe96b72e-24d0-4a85-9b42-a9862bdf4139\"\n/>\n\n\n- AzureOpenAI+GPT 4.1 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/de9fc09a6f0162b7b2d6f52fbb188469?selectedSpanNodeId=U3BhbjoyOTk4MzI%3D\n<img width=\"715\" height=\"877\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cca5326e-9350-426f-9f2e-a407d26e193d\"\n/>\n\n\n- Gemini 2.0 Flash -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/982da6b0ff4bae04f45af0271aa4cd84?selectedSpanNodeId=U3BhbjoyOTk4NTI%3D\n<img width=\"709\" height=\"880\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d29b99c7-e3f6-4318-a19b-0a92e7aa690b\"\n/>\n\n- Gemini 2.5 Flash -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/9f7115cc79bb2e929dbeb93670555e81?selectedSpanNodeId=U3BhbjoyOTk4NjU%3D\n<img width=\"708\" height=\"872\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4c6e48fd-ccaf-413c-b01d-21c0fc8df061\"\n/>\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"021b30816e86ddb2e1fa2a8c911ff85ab07e1d43"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227643","number":227643,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227641","number":227641,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227462","number":227462,"mergeCommit":{"message":"[Obs AI Assistant] Inject user prompt before tool call when query actions are clicked (#227462)\n\nCloses https://github.com/elastic/obs-ai-assistant-team/issues/309\n\n## Summary\n\nThis PR improves the `Display Results` and `visualize this query`\nactions by injecting a user prompt first and then the tool call to\nmaintain correct message ordering. This fixes the empty message that was\nobserved when visualize this query was clicked.\n\nHowever, in any case, if an empty message is received this should be\nhandled separately to avoid breaking the conversation flow.\n\n## Testing instructions:\n1. Generate some logs\n2. Pick the LLM (Needs to be tested with Elastic Managed LLM, Claude\n3.5, Claude 3.7, GPT-4, etc)\n3. Ask the assistant to generate a query\n4. Click on `Display results` -- the results should be shown and the\nuser should be able to continue the conversation\n5. Click on `Visualize this query` -- the visualization should be shown\nand the user should be able to continue the conversation\n\n## Traces with each model:\n\n- EIS (Visualize this query) -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/b1dcb77fb39ad7efbf82d9c4a1feb0e0?selectedSpanNodeId=U3BhbjoyOTk3ODQ%3D\n<img width=\"715\" height=\"868\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/75fd8efe-82df-4f7f-ad4f-f915e09d49da\"\n/>\n\n- EIS (Display results) -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/e7d8c42774491e6e2bcf328c34203c14?selectedSpanNodeId=U3BhbjozMDAxOTg%3D\n\n\nhttps://github.com/user-attachments/assets/6aa520db-2b40-4317-ace0-7be206ebb669\n\n- Bedrock+Claude 3.7 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/f1bc4f490fcc990db9dbddf0782cff7e?selectedSpanNodeId=U3BhbjoyOTk4MDA%3D\n<img width=\"709\" height=\"889\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86f77ff9-1783-42d3-8b31-8680fd7da227\"\n/>\n\n\n- Bedrock+Claude 3.5 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/457a7cc939ce3b18ae3a9e2b066c3a7f?selectedSpanNodeId=U3BhbjoyOTk4MTY%3D\n<img width=\"714\" height=\"942\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fe96b72e-24d0-4a85-9b42-a9862bdf4139\"\n/>\n\n\n- AzureOpenAI+GPT 4.1 -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/de9fc09a6f0162b7b2d6f52fbb188469?selectedSpanNodeId=U3BhbjoyOTk4MzI%3D\n<img width=\"715\" height=\"877\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cca5326e-9350-426f-9f2e-a407d26e193d\"\n/>\n\n\n- Gemini 2.0 Flash -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/982da6b0ff4bae04f45af0271aa4cd84?selectedSpanNodeId=U3BhbjoyOTk4NTI%3D\n<img width=\"709\" height=\"880\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d29b99c7-e3f6-4318-a19b-0a92e7aa690b\"\n/>\n\n- Gemini 2.5 Flash -\nhttps://35-187-109-62.sslip.io/projects/UHJvamVjdDo5/traces/9f7115cc79bb2e929dbeb93670555e81?selectedSpanNodeId=U3BhbjoyOTk4NjU%3D\n<img width=\"708\" height=\"872\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4c6e48fd-ccaf-413c-b01d-21c0fc8df061\"\n/>\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"021b30816e86ddb2e1fa2a8c911ff85ab07e1d43"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227642","number":227642,"state":"OPEN"}]}] BACKPORT-->