### PR TITLE
[8.17] [CI] bump ci disk to 85gb (#227665)

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -10,6 +10,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+      diskSizeGb: 85
     retry:
       automatic:
         - exit_status: '*'
@@ -39,6 +40,7 @@ steps:
       provider: gcp
       machineType: n2-highcpu-8
       preemptible: true
+      diskSizeGb: 85
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -67,6 +69,7 @@ steps:
       provider: gcp
       machineType: n2-standard-16
       preemptible: true
+      diskSizeGb: 85
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -81,6 +84,7 @@ steps:
       provider: gcp
       machineType: n2-standard-32
       preemptible: true
+      diskSizeGb: 85
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -97,6 +101,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
+      diskSizeGb: 85
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -128,6 +133,7 @@ steps:
       provider: gcp
       machineType: n2-highmem-4
       preemptible: true
+      diskSizeGb: 85
     timeout_in_minutes: 80
     retry:
       automatic:
@@ -143,6 +149,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+      diskSizeGb: 85
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -159,6 +166,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+      diskSizeGb: 85
     timeout_in_minutes: 10
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
@@ -395,8 +403,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
-    artifact_paths:
-      "target/plugin_so_types_snapshot.json"
+    artifact_paths: 'target/plugin_so_types_snapshot.json'
     timeout_in_minutes: 30
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -4,6 +4,7 @@ steps:
     timeout_in_minutes: 10
     agents:
       machineType: n2-standard-2
+      diskSizeGb: 85
 
   - wait
 
@@ -26,6 +27,7 @@ steps:
     agents:
       machineType: n2-highcpu-8
       preemptible: true
+      diskSizeGb: 85
     key: quick_checks
     timeout_in_minutes: 60
     retry:
@@ -50,6 +52,7 @@ steps:
     agents:
       machineType: n2-standard-16
       preemptible: true
+      diskSizeGb: 85
     key: linting
     timeout_in_minutes: 60
     retry:
@@ -62,6 +65,7 @@ steps:
     agents:
       machineType: n2-standard-32
       preemptible: true
+      diskSizeGb: 85
     key: linting_with_types
     timeout_in_minutes: 60
     retry:
@@ -88,6 +92,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
+      diskSizeGb: 85
     key: check_types
     timeout_in_minutes: 60
     retry:
@@ -101,6 +106,7 @@ steps:
     label: Mark CI Stats as ready
     agents:
       machineType: n2-standard-2
+      diskSizeGb: 85
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -114,6 +120,7 @@ steps:
     label: 'Pick Test Group Run Order'
     agents:
       machineType: n2-standard-2
+      diskSizeGb: 85
     timeout_in_minutes: 10
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
@@ -129,6 +136,7 @@ steps:
     agents:
       machineType: n2-highmem-4
       preemptible: true
+      diskSizeGb: 85
     key: build_api_docs
     timeout_in_minutes: 90
     retry:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[CI] bump ci disk to 85gb (#227665)](https://github.com/elastic/kibana/pull/227665)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-11T14:24:37Z","message":"[CI] bump ci disk to 85gb (#227665)\n\n## Summary\nStill seeing some operations run out of disk at 80gb","sha":"3657d74b81579fcd4aa0afd4be826aa3ccf2d3ef","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","skip-ci","backport:prev-major","backport:current-major","v9.2.0"],"title":"[CI] bump ci disk to 85gb","number":227665,"url":"https://github.com/elastic/kibana/pull/227665","mergeCommit":{"message":"[CI] bump ci disk to 85gb (#227665)\n\n## Summary\nStill seeing some operations run out of disk at 80gb","sha":"3657d74b81579fcd4aa0afd4be826aa3ccf2d3ef"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227665","number":227665,"mergeCommit":{"message":"[CI] bump ci disk to 85gb (#227665)\n\n## Summary\nStill seeing some operations run out of disk at 80gb","sha":"3657d74b81579fcd4aa0afd4be826aa3ccf2d3ef"}},{"url":"https://github.com/elastic/kibana/pull/227667","number":227667,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/227668","number":227668,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/227669","number":227669,"branch":"9.0","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/227670","number":227670,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->