### PR TITLE
Polish MultiSelectFilter appearance in Rules page

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/component/multi_select_filter.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/component/multi_select_filter.tsx
@@ -158,7 +158,7 @@ export const MultiSelectFilter = <T extends string, K extends string = string>({
             compressed: false,
             'data-test-subj': `${id}-search-input`,
             css: css`
-              border-radius: 0px !important;
+              box-shadow: none;
             `,
           }}
           emptyMessage={'empty'}


### PR DESCRIPTION
## Summary

Polish inner border in `<MultiSelectFilter>` component, rendered upon clicking on `<RulesTableHeader>` in the Rule page.

[Link to EuiSelectable docs](https://eui.elastic.co/docs/components/forms/selection/selectable/#the-basics).

### Screenshots

<details><summary>Before</summary>
<img width="525" height="375" alt="Screenshot 2025-07-11 at 16 44 06" src="https://github.com/user-attachments/assets/f100ce36-0450-476c-ba40-d7b4c34f5b50" />
<img width="502" height="363" alt="Screenshot 2025-07-11 at 16 44 17" src="https://github.com/user-attachments/assets/7760c929-bf9c-4986-81ec-06f9604de109" />
</details> 

<details><summary>After</summary>
<img width="515" height="338" alt="Screenshot 2025-07-11 at 16 43 25" src="https://github.com/user-attachments/assets/b8a2e524-57cf-4bb6-a0f5-a47bfd17fd8e" />
<img width="491" height="345" alt="Screenshot 2025-07-11 at 16 43 34" src="https://github.com/user-attachments/assets/26fc1bbf-f1a7-440c-a050-2f7f6ee59d01" />
</details> 

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Only risk is we're keeping style overrides in EUI components, which should happen as little as possible. But the override enhances the appearance when putting these components together, which is an edge case.

<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->