### PR TITLE
fix Failing test: X-Pack API Integration Tests.x-pack/test/api_integration/apis/maps/search·ts

### DIFF
--- a/x-pack/platform/test/api_integration/apis/maps/search.ts
+++ b/x-pack/platform/test/api_integration/apis/maps/search.ts
@@ -14,7 +14,7 @@ import type { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
 
-  describe.only('search', () => {
+  describe('search', () => {
     describe('ES|QL', () => {
       it(`should return getColumns response in expected shape`, async () => {
         const resp = await supertest

--- a/x-pack/platform/test/api_integration/apis/maps/search.ts
+++ b/x-pack/platform/test/api_integration/apis/maps/search.ts
@@ -14,8 +14,7 @@ import type { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
 
-  // Failing: See https://github.com/elastic/kibana/issues/208138
-  describe.skip('search', () => {
+  describe.only('search', () => {
     describe('ES|QL', () => {
       it(`should return getColumns response in expected shape`, async () => {
         const resp = await supertest
@@ -37,8 +36,10 @@ export default function ({ getService }: FtrProviderContext) {
               type: 'geo_point',
             },
           ],
+          documents_found: 0,
           is_partial: false,
           values: [],
+          values_loaded: 0
         });
       });
 
@@ -78,8 +79,10 @@ export default function ({ getService }: FtrProviderContext) {
               type: 'date',
             },
           ],
+          documents_found: 3,
           is_partial: false,
           values: [['POINT (-120.9871642 38.68407028)', '2015-09-20T00:00:00.000Z']],
+          values_loaded: 6
         });
       });
     });

--- a/x-pack/platform/test/api_integration/apis/maps/search.ts
+++ b/x-pack/platform/test/api_integration/apis/maps/search.ts
@@ -39,7 +39,7 @@ export default function ({ getService }: FtrProviderContext) {
           documents_found: 0,
           is_partial: false,
           values: [],
-          values_loaded: 0
+          values_loaded: 0,
         });
       });
 
@@ -82,7 +82,7 @@ export default function ({ getService }: FtrProviderContext) {
           documents_found: 3,
           is_partial: false,
           values: [['POINT (-120.9871642 38.68407028)', '2015-09-20T00:00:00.000Z']],
-          values_loaded: 6
+          values_loaded: 6,
         });
       });
     });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/208138

ES|QL response added fields `documents_found` and `values_loaded`. PR updates expect clause to include these fields.