### PR TITLE
Fixing FIPS tests skips for ML Disabled

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/index.ts
@@ -9,17 +9,11 @@ import { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default ({ loadTestFile }: FtrProviderContext): void => {
   describe('Rules Management - Prebuilt Rules (ML Disabled)', function () {
-    /* Note: some tests below include skips when running in FIPS mode.
-     * "ML Disabled" currently assumes a basic license, which does not apply to
-     * FIPS, though any passing tests have been preserved.
-     * FIPS skips are placed at the lowest possible level to refrain from un-
-     * intentional skips, and to retain flexibility, granularity, and coverage.
-     * New additions to this index should consider this.
-     */
     loadTestFile(require.resolve('./review_installation'));
     loadTestFile(require.resolve('./perform_installation'));
+    loadTestFile(require.resolve('./status'));
+
     loadTestFile(require.resolve('./review_upgrade'));
     loadTestFile(require.resolve('./perform_upgrade'));
-    loadTestFile(require.resolve('./status'));
   });
 };

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/perform_installation/perform_installation.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/perform_installation/perform_installation.ts
@@ -19,13 +19,9 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
   const supertest = getService('supertest');
   const log = getService('log');
-  const config = getService('config');
-  const basic = config.get('esTestCluster.license') === 'basic';
 
   describe('@ess @serverless @skipInServerlessMKI Prebuilt rules installation perform', function () {
-    if (basic) {
-      this.tags('skipFIPS');
-    }
+    this.tags('skipFIPS');
 
     beforeEach(async () => {
       await deleteAllRules(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/perform_upgrade/perform_upgrade.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/perform_upgrade/perform_upgrade.ts
@@ -22,8 +22,6 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
   const supertest = getService('supertest');
   const log = getService('log');
-  const config = getService('config');
-  const basic = config.get('esTestCluster.license') === 'basic';
   const deps = {
     es,
     supertest,

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/perform_upgrade/perform_upgrade.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/perform_upgrade/perform_upgrade.ts
@@ -39,9 +39,7 @@ export default ({ getService }: FtrProviderContext): void => {
     const ruleId = 'ml-rule';
 
     describe('ALL_RULES mode', function () {
-      if (basic) {
-        this.tags('skipFIPS');
-      }
+      this.tags('skipFIPS');
 
       it('silently skips ML rules in ALL_RULES mode', async () => {
         await setUpRuleUpgrade({
@@ -76,9 +74,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('SPECIFIC_RULES mode', function () {
       describe(`doesn't upgrade`, function () {
-        if (basic) {
-          this.tags('skipFIPS');
-        }
+        this.tags('skipFIPS');
 
         it(`if target is an ML rule`, async () => {
           await createMlRuleThroughAlertingEndpoint(supertest, {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/review_installation/review_installation.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/review_installation/review_installation.ts
@@ -19,13 +19,9 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
   const supertest = getService('supertest');
   const log = getService('log');
-  const config = getService('config');
-  const basic = config.get('esTestCluster.license') === 'basic';
 
   describe('@ess @serverless @skipInServerlessMKI Prebuilt rules installation review', function () {
-    if (basic) {
-      this.tags('skipFIPS');
-    }
+    this.tags('skipFIPS');
 
     beforeEach(async () => {
       await deleteAllRules(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/review_upgrade/review_upgrade.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/review_upgrade/review_upgrade.ts
@@ -21,8 +21,6 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
   const supertest = getService('supertest');
   const log = getService('log');
-  const config = getService('config');
-  const basic = config.get('esTestCluster.license') === 'basic';
   const deps = {
     es,
     supertest,
@@ -38,9 +36,7 @@ export default ({ getService }: FtrProviderContext): void => {
     const ruleId = 'ml-rule';
 
     describe(`rule is excluded from response`, function () {
-      if (basic) {
-        this.tags('skipFIPS');
-      }
+      this.tags('skipFIPS');
 
       it('if target is an ML rule', async () => {
         await createMlRuleThroughAlertingEndpoint(supertest, {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/status/status.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/status/status.ts
@@ -20,13 +20,9 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
   const supertest = getService('supertest');
   const log = getService('log');
-  const config = getService('config');
-  const basic = config.get('esTestCluster.license') === 'basic';
 
   describe('@ess @serverless @skipInServerlessMKI Prebuilt rules status', function () {
-    if (basic) {
-      this.tags('skipFIPS');
-    }
+    this.tags('skipFIPS');
 
     beforeEach(async () => {
       await deleteAllRules(supertest, log);


### PR DESCRIPTION
## Summary

The license cannot be checked in FIPS mode as it will always be `trial`. The overrides are added in such a way that this check will not work.

Fixing the conditional skips to make them always skip
