### PR TITLE
[Synthetics] Fixed EnableDefaultAlerting test

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/enable_default_alerting.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/enable_default_alerting.ts
@@ -18,8 +18,7 @@ import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
 import { PrivateLocationTestService } from '../../services/synthetics_private_location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
-  // FLAKY: https://github.com/elastic/kibana/issues/225448
-  describe.skip('EnableDefaultAlerting', function () {
+  describe('EnableDefaultAlerting', function () {
     const supertest = getService('supertestWithoutAuth');
     const kibanaServer = getService('kibanaServer');
     const retry = getService('retry');
@@ -47,7 +46,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     beforeEach(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await kibanaServer.savedObjects.clean({
+        types: ['synthetics-monitor-multi-space'],
+      });
       privateLocation = await privateLocationTestService.addTestPrivateLocation();
       httpMonitorJson = {
         ..._httpMonitorJson,


### PR DESCRIPTION
This PR closes #225448 .

`EnableDefaultAlerting` creates a new Fleet agent-policy for every test case.
Immediately after each case our `beforeEach` calls `kibanaServer.savedObjects.cleanStandardList()`, which deletes all saved-objects, including `ingest-agent-policies/<id>`.

Fleet’s `packagePolicyService.bulkCreate()` is invoked from the Synthetics server when the monitor is saved.
Because we call it with `asyncDeploy: true`, Fleet queues the package-policy creation and returns. A few seconds later the background task tries to attach the new synthetics package-policy to the agent-policy ID it received. If we have wiped that saved-object in the meantime the lookup fails.

Instead of wiping everything we now remove only the objects that matter for the test in the `beforeEach`.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->