### PR TITLE
[ES|QL] Hides lookup index hidden indices from autocomplete

### DIFF
--- a/src/platform/plugins/shared/esql/server/services/esql_service.ts
+++ b/src/platform/plugins/shared/esql/server/services/esql_service.ts
@@ -51,16 +51,17 @@ export class EsqlService {
   ): Promise<IndicesAutocompleteResult> {
     const { client } = this.options;
 
-    // Execute: GET /_all/_settings/index.mode,aliases?flat_settings=true
+    // Execute: GET /_all/_settings/index.mode,index.hidden,aliases?flat_settings=true
     interface IndexModeResponse {
       [indexName: string]: {
         settings: {
           'index.mode': string;
+          'index.hidden': boolean;
         };
       };
     }
     const queryByIndexModeResponse = (await client.indices.getSettings({
-      name: 'index.mode',
+      name: ['index.hidden', 'index.mode'],
       flat_settings: true,
     })) as IndexModeResponse;
 
@@ -68,7 +69,7 @@ export class EsqlService {
     const indexNames: string[] = [];
 
     for (const [name, { settings }] of Object.entries(queryByIndexModeResponse)) {
-      if (settings['index.mode'] === mode) {
+      if (settings['index.mode'] === mode && !settings['index.hidden']) {
         indexNames.push(name);
         indices.push({ name, mode, aliases: [] });
       }

--- a/src/platform/plugins/shared/esql/server/services/integration_tests/testbed.ts
+++ b/src/platform/plugins/shared/esql/server/services/integration_tests/testbed.ts
@@ -74,6 +74,20 @@ export class EsqlServiceTestbed {
         },
       },
     });
+
+    // Lookup index hidden
+    await client.indices.create({
+      index: 'lookup_index3',
+      settings: {
+        'index.mode': 'lookup',
+        'index.hidden': true,
+      },
+      mappings: {
+        properties: {
+          field2: { type: 'keyword' },
+        },
+      },
+    });
   }
 
   public async setupTimeseriesIndices() {


### PR DESCRIPTION
## Summary

Doesn't suggest lookup_mode indices which are marked as hidden

<img width="493" height="99" alt="image" src="https://github.com/user-attachments/assets/e7cb08b7-aebf-4a47-8f0e-515cd2f5b203" />


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->