### PR TITLE
Update ECS to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@elastic/charts": "70.1.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/ebt": "^1.2.1",
-    "@elastic/ecs": "^8.11.5",
+    "@elastic/ecs": "^9.0.0",
     "@elastic/elasticsearch": "9.0.3",
     "@elastic/ems-client": "8.6.3",
     "@elastic/eui": "104.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,6 +2128,8 @@
 
 "@elastic/ecs@^9.0.0":
   version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/ecs/-/ecs-9.0.0.tgz#5599c87f72a1b2137467f80c158777ff5c4fdd81"
+  integrity sha512-FVFOFGgo8D2XoYs/2M9gaC76VzKhMKkrVqnGkbuQAB0CKoAFy9k5I2K7IMmDs6l4R5OVFiJk6uwfLiTXyHyjDA==
 
 "@elastic/elasticsearch-types@npm:@elastic/elasticsearch@^8.2.1":
   version "8.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,10 +2126,8 @@
   dependencies:
     "@elastic/ecs-helpers" "^2.1.1"
 
-"@elastic/ecs@^8.11.5":
-  version "8.11.5"
-  resolved "https://registry.yarnpkg.com/@elastic/ecs/-/ecs-8.11.5.tgz#70b9fed9b5946e8930ddbbbf5a2c8202d59e26b9"
-  integrity sha512-S7qkIaRrKHyiU6ww0r5qt8mOh8wK8w3LpNdMb0qxuj6wxQmn6TVpZ9DxxICGVKwaPbQIYuNTmBPSUocl+VhINw==
+"@elastic/ecs@^9.0.0":
+  version "9.0.0"
 
 "@elastic/elasticsearch-types@npm:@elastic/elasticsearch@^8.2.1":
   version "8.6.0"


### PR DESCRIPTION
ECS in version 9.0.0 is released for a while (https://github.com/elastic/ecs), but we didn't update the typescript package. This PR makes sure it's up to date again.

This removes a couple deprecated fields and adds a couple new ones (see https://github.com/elastic/ecs/releases/tag/v9.0.0 for details)