### PR TITLE
[Security Assistant] Enable `InferenceChatModel` by default

### DIFF
--- a/api_docs/kbn_elastic_assistant_common.devdocs.json
+++ b/api_docs/kbn_elastic_assistant_common.devdocs.json
@@ -6182,15 +6182,15 @@
       },
       {
         "parentPluginId": "@kbn/elastic-assistant-common",
-        "id": "def-common.INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG",
+        "id": "def-common.INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG",
         "type": "string",
         "tags": [],
-        "label": "INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG",
+        "label": "INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG",
         "description": [
-          "\nThis feature flag enables the InferenceChatModel feature.\n\nIt may be overridden via the following setting in `kibana.yml` or `kibana.dev.yml`:\n```\nfeature_flags.overrides:\n  securitySolution.inferenceChatModelEnabled: true\n```"
+          "\nThis feature flag disables the InferenceChatModel feature.\n\nIt may be overridden via the following setting in `kibana.yml` or `kibana.dev.yml`:\n```\nfeature_flags.overrides:\n  securitySolution.inferenceChatModelDisabled: true\n```"
         ],
         "signature": [
-          "\"securitySolution.inferenceChatModelEnabled\""
+          "\"securitySolution.inferenceChatModelDisabled\""
         ],
         "path": "x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts",
         "deprecated": false,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
@@ -128,13 +128,13 @@ export const ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX =
   '.alerts-security.attack.discovery.alerts' as const;
 
 /**
- * This feature flag enables the InferenceChatModel feature.
+ * This feature flag disables the InferenceChatModel feature.
  *
  * It may be overridden via the following setting in `kibana.yml` or `kibana.dev.yml`:
  * ```
  * feature_flags.overrides:
- *   securitySolution.inferenceChatModelEnabled: true
+ *   securitySolution.inferenceChatModelDisabled: true
  * ```
  */
-export const INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG =
-  'securitySolution.inferenceChatModelEnabled' as const;
+export const INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG =
+  'securitySolution.inferenceChatModelDisabled' as const;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
@@ -61,7 +61,7 @@ export interface AgentExecutorParams<T extends boolean> {
   llmType?: string;
   isOssModel?: boolean;
   inference: InferenceServerStart;
-  inferenceChatModelEnabled?: boolean;
+  inferenceChatModelDisabled?: boolean;
   logger: Logger;
   onNewReplacements?: (newReplacements: Replacements) => void;
   replacements: Replacements;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/agentRunnable.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/agentRunnable.ts
@@ -27,7 +27,7 @@ export const agentRunnableFactory = async ({
   llm,
   llmType,
   tools,
-  inferenceChatModelEnabled,
+  inferenceChatModelDisabled,
   isOpenAI,
   isStream,
   prompt,
@@ -37,7 +37,7 @@ export const agentRunnableFactory = async ({
     | ActionsClientChatVertexAI
     | ActionsClientChatOpenAI
     | InferenceChatModel;
-  inferenceChatModelEnabled: boolean;
+  inferenceChatModelDisabled: boolean;
   isOpenAI: boolean;
   llmType: string | undefined;
   tools: StructuredToolInterface[] | ToolDefinition[];
@@ -51,7 +51,7 @@ export const agentRunnableFactory = async ({
     prompt,
   } as const;
 
-  if (!inferenceChatModelEnabled && (isOpenAI || llmType === 'inference')) {
+  if (inferenceChatModelDisabled && (isOpenAI || llmType === 'inference')) {
     return createOpenAIToolsAgent(params);
   }
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
@@ -26,7 +26,7 @@ interface StreamGraphParams {
   apmTracer: APMTracer;
   assistantGraph: DefaultAssistantGraph;
   inputs: GraphInputs;
-  inferenceChatModelEnabled?: boolean;
+  inferenceChatModelDisabled?: boolean;
   isEnabledKnowledgeBase: boolean;
   logger: Logger;
   onLlmResponse?: OnLlmResponse;
@@ -54,7 +54,7 @@ export const streamGraph = async ({
   apmTracer,
   assistantGraph,
   inputs,
-  inferenceChatModelEnabled = false,
+  inferenceChatModelDisabled = false,
   isEnabledKnowledgeBase,
   logger,
   onLlmResponse,
@@ -108,7 +108,7 @@ export const streamGraph = async ({
 
   // Stream is from tool calling agent or structured chat agent
   if (
-    inferenceChatModelEnabled ||
+    !inferenceChatModelDisabled ||
     inputs.isOssModel ||
     inputs?.llmType === 'bedrock' ||
     inputs?.llmType === 'gemini'

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
@@ -67,6 +67,7 @@ describe('callAssistantGraph', () => {
     saved_objects: [],
   });
   const mockLogger = loggerMock.create();
+  const getChatModel = jest.fn();
   const defaultParams = {
     actionsClient: actionsClientMock.create(),
     alertsIndexPattern: 'test-pattern',
@@ -75,7 +76,10 @@ describe('callAssistantGraph', () => {
     conversationId: 'test-conversation',
     dataClients: mockDataClients,
     esClient: elasticsearchClientMock.createScopedClusterClient().asCurrentUser,
-    inference: {},
+    inference: {
+      getChatModel,
+    },
+    inferenceChatModelDisabled: true,
     langChainMessages: [{ content: 'test message' }],
     llmTasks: { retrieveDocumentationAvailable: jest.fn(), retrieveDocumentation: jest.fn() },
     llmType: 'openai',
@@ -121,217 +125,286 @@ describe('callAssistantGraph', () => {
     );
     getPromptMock.mockResolvedValue('prompt');
   });
+  describe('inferenceChatModelDisabled = true', () => {
+    it('calls invokeGraph with correct parameters for non-streaming', async () => {
+      const result = await callAssistantGraph(defaultParams);
 
-  it('calls invokeGraph with correct parameters for non-streaming', async () => {
-    const result = await callAssistantGraph(defaultParams);
-
-    expect(invokeGraph).toHaveBeenCalledWith(
-      expect.objectContaining({
-        inputs: expect.objectContaining({
-          input: 'test message',
-        }),
-      })
-    );
-    expect(result.body).toEqual({
-      connector_id: 'test-connector',
-      data: 'test-output',
-      trace_data: {},
-      replacements: [],
-      status: 'ok',
-      conversationId: 'new-conversation-id',
-    });
-  });
-
-  it('calls streamGraph with correct parameters for streaming', async () => {
-    const params = { ...defaultParams, isStream: true };
-    await callAssistantGraph(params);
-
-    expect(streamGraph).toHaveBeenCalledWith(
-      expect.objectContaining({
-        inputs: expect.objectContaining({
-          input: 'test message',
-        }),
-      })
-    );
-  });
-
-  it('calls getDefaultAssistantGraph without signal for openai', async () => {
-    await callAssistantGraph(defaultParams);
-    expect(getDefaultAssistantGraphMock.mock.calls[0][0]).not.toHaveProperty('signal');
-  });
-
-  it('calls getDefaultAssistantGraph with signal for bedrock', async () => {
-    await callAssistantGraph({ ...defaultParams, llmType: 'bedrock' });
-    expect(getDefaultAssistantGraphMock.mock.calls[0][0]).toHaveProperty('signal');
-  });
-
-  it('handles error when anonymizationFieldsDataClient.findDocuments fails', async () => {
-    (mockDataClients?.anonymizationFieldsDataClient?.findDocuments as jest.Mock).mockRejectedValue(
-      new Error('test error')
-    );
-
-    await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
-  });
-
-  it('handles error when kbDataClient.isInferenceEndpointExists fails', async () => {
-    (mockDataClients?.kbDataClient?.isInferenceEndpointExists as jest.Mock).mockRejectedValue(
-      new Error('test error')
-    );
-
-    await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
-  });
-
-  it('returns correct response when no conversationId is returned', async () => {
-    (invokeGraph as jest.Mock).mockResolvedValue({ output: 'test-output', traceData: {} });
-
-    const result = await callAssistantGraph(defaultParams);
-
-    expect(result.body).toEqual({
-      connector_id: 'test-connector',
-      data: 'test-output',
-      trace_data: {},
-      replacements: [],
-      status: 'ok',
-    });
-  });
-
-  it('calls getPrompt for each tool and the default system prompt', async () => {
-    const params = {
-      ...defaultParams,
-      assistantTools: [
-        { ...mockTool, name: 'test-tool' },
-        { ...mockTool, name: 'test-tool2' },
-      ],
-    };
-    await callAssistantGraph(params);
-
-    expect(getPromptMock).toHaveBeenCalledTimes(3);
-    expect(getPromptMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'test-model',
-        provider: 'openai',
-        promptId: 'test-tool',
-        promptGroupId: toolsGroupId,
-      })
-    );
-    expect(getPromptMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'test-model',
-        provider: 'openai',
-        promptId: 'test-tool2',
-        promptGroupId: toolsGroupId,
-      })
-    );
-    expect(getPromptMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'test-model',
-        provider: 'openai',
-        promptId: promptDictionary.systemPrompt,
-        promptGroupId: promptGroupId.aiAssistant,
-      })
-    );
-
-    expect(getTool).toHaveBeenCalledWith(
-      expect.objectContaining({
-        description: 'prompt',
-      })
-    );
-  });
-
-  it('Passes only Elastic tools, not custom, to Telemetry tracer', async () => {
-    await callAssistantGraph({
-      ...defaultParams,
-      assistantTools: [
-        { ...mockTool, name: 'test-tool', getTool: getTool.mockReturnValue({ name: 'test-tool' }) },
-        {
-          ...mockTool,
-          name: 'test-tool2',
-          getTool: getTool.mockReturnValue({ name: 'test-tool2' }),
-        },
-      ],
-    });
-    expect(telemetryTracerMock).toHaveBeenCalledWith(
-      {
-        elasticTools: ['test-tool2', 'test-tool2'],
-        telemetry: {},
-        telemetryParams: {},
-      },
-      {
-        ...mockLogger,
-        context: ['defaultAssistantGraph'],
-      }
-    );
-  });
-
-  describe('agentRunnable', () => {
-    it('creates OpenAIToolsAgent for openai llmType', async () => {
-      const params = { ...defaultParams, llmType: 'openai' };
-      await callAssistantGraph(params);
-
-      expect(createOpenAIToolsAgent).toHaveBeenCalled();
-      expect(createToolCallingAgent).not.toHaveBeenCalled();
-    });
-
-    it('creates OpenAIToolsAgent for inference llmType', async () => {
-      defaultParams.actionsClient.get = jest.fn().mockResolvedValue({
-        config: {
-          provider: 'elastic',
-          providerConfig: { model_id: 'rainbow-sprinkles' },
-        },
+      expect(invokeGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
+      expect(result.body).toEqual({
+        connector_id: 'test-connector',
+        data: 'test-output',
+        trace_data: {},
+        replacements: [],
+        status: 'ok',
+        conversationId: 'new-conversation-id',
       });
-      const params = { ...defaultParams, llmType: 'inference' };
-      await callAssistantGraph(params);
-
-      expect(createOpenAIToolsAgent).toHaveBeenCalled();
-      expect(createToolCallingAgent).not.toHaveBeenCalled();
     });
 
-    it('creates ToolCallingAgent for bedrock llmType', async () => {
-      const params = { ...defaultParams, llmType: 'bedrock' };
+    it('calls streamGraph with correct parameters for streaming', async () => {
+      const params = { ...defaultParams, isStream: true };
       await callAssistantGraph(params);
 
-      expect(createToolCallingAgent).toHaveBeenCalled();
-      expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      expect(streamGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
     });
 
-    it('creates ToolCallingAgent for gemini llmType', async () => {
+    it('calls getDefaultAssistantGraph without signal for openai', async () => {
+      await callAssistantGraph(defaultParams);
+      expect(getDefaultAssistantGraphMock.mock.calls[0][0]).not.toHaveProperty('signal');
+    });
+
+    it('calls getDefaultAssistantGraph with signal for bedrock', async () => {
+      await callAssistantGraph({ ...defaultParams, llmType: 'bedrock' });
+      expect(getDefaultAssistantGraphMock.mock.calls[0][0]).toHaveProperty('signal');
+    });
+
+    it('handles error when anonymizationFieldsDataClient.findDocuments fails', async () => {
+      (
+        mockDataClients?.anonymizationFieldsDataClient?.findDocuments as jest.Mock
+      ).mockRejectedValue(new Error('test error'));
+
+      await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
+    });
+
+    it('handles error when kbDataClient.isInferenceEndpointExists fails', async () => {
+      (mockDataClients?.kbDataClient?.isInferenceEndpointExists as jest.Mock).mockRejectedValue(
+        new Error('test error')
+      );
+
+      await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
+    });
+
+    it('returns correct response when no conversationId is returned', async () => {
+      (invokeGraph as jest.Mock).mockResolvedValue({ output: 'test-output', traceData: {} });
+
+      const result = await callAssistantGraph(defaultParams);
+
+      expect(result.body).toEqual({
+        connector_id: 'test-connector',
+        data: 'test-output',
+        trace_data: {},
+        replacements: [],
+        status: 'ok',
+      });
+    });
+
+    it('calls getPrompt for each tool and the default system prompt', async () => {
       const params = {
         ...defaultParams,
-        request: {
-          body: { model: 'gemini-1.5-flash' },
-        } as unknown as AgentExecutorParams<boolean>['request'],
-        llmType: 'gemini',
+        assistantTools: [
+          { ...mockTool, name: 'test-tool' },
+          { ...mockTool, name: 'test-tool2' },
+        ],
       };
       await callAssistantGraph(params);
 
-      expect(createToolCallingAgent).toHaveBeenCalled();
-      expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      expect(getPromptMock).toHaveBeenCalledTimes(3);
+      expect(getPromptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          provider: 'openai',
+          promptId: 'test-tool',
+          promptGroupId: toolsGroupId,
+        })
+      );
+      expect(getPromptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          provider: 'openai',
+          promptId: 'test-tool2',
+          promptGroupId: toolsGroupId,
+        })
+      );
+      expect(getPromptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          provider: 'openai',
+          promptId: promptDictionary.systemPrompt,
+          promptGroupId: promptGroupId.aiAssistant,
+        })
+      );
+
+      expect(getTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'prompt',
+        })
+      );
     });
 
-    it('creates ToolCallingAgent for oss model', async () => {
-      const params = { ...defaultParams, llmType: 'openai', isOssModel: true };
-      await callAssistantGraph(params);
-
-      expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
-      expect(createToolCallingAgent).toHaveBeenCalled();
+    it('Passes only Elastic tools, not custom, to Telemetry tracer', async () => {
+      await callAssistantGraph({
+        ...defaultParams,
+        assistantTools: [
+          {
+            ...mockTool,
+            name: 'test-tool',
+            getTool: getTool.mockReturnValue({ name: 'test-tool' }),
+          },
+          {
+            ...mockTool,
+            name: 'test-tool2',
+            getTool: getTool.mockReturnValue({ name: 'test-tool2' }),
+          },
+        ],
+      });
+      expect(telemetryTracerMock).toHaveBeenCalledWith(
+        {
+          elasticTools: ['test-tool2', 'test-tool2'],
+          telemetry: {},
+          telemetryParams: {},
+        },
+        {
+          ...mockLogger,
+          context: ['defaultAssistantGraph'],
+        }
+      );
     });
-    it('does not calls resolveProviderAndModel when llmType === openai', async () => {
-      const params = { ...defaultParams, llmType: 'openai' };
-      await callAssistantGraph(params);
 
-      expect(resolveProviderAndModelMock).not.toHaveBeenCalled();
+    describe('agentRunnable', () => {
+      it('creates OpenAIToolsAgent for openai llmType', async () => {
+        const params = { ...defaultParams, llmType: 'openai' };
+        await callAssistantGraph(params);
+
+        expect(createOpenAIToolsAgent).toHaveBeenCalled();
+        expect(createToolCallingAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates OpenAIToolsAgent for inference llmType', async () => {
+        defaultParams.actionsClient.get = jest.fn().mockResolvedValue({
+          config: {
+            provider: 'elastic',
+            providerConfig: { model_id: 'rainbow-sprinkles' },
+          },
+        });
+        const params = { ...defaultParams, llmType: 'inference' };
+        await callAssistantGraph(params);
+
+        expect(createOpenAIToolsAgent).toHaveBeenCalled();
+        expect(createToolCallingAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for bedrock llmType', async () => {
+        const params = { ...defaultParams, llmType: 'bedrock' };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for gemini llmType', async () => {
+        const params = {
+          ...defaultParams,
+          request: {
+            body: { model: 'gemini-1.5-flash' },
+          } as unknown as AgentExecutorParams<boolean>['request'],
+          llmType: 'gemini',
+        };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for oss model', async () => {
+        const params = { ...defaultParams, llmType: 'openai', isOssModel: true };
+        await callAssistantGraph(params);
+
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+        expect(createToolCallingAgent).toHaveBeenCalled();
+      });
+      it('does not calls resolveProviderAndModel when llmType === openai', async () => {
+        const params = { ...defaultParams, llmType: 'openai' };
+        await callAssistantGraph(params);
+
+        expect(resolveProviderAndModelMock).not.toHaveBeenCalled();
+      });
+      it('calls resolveProviderAndModel when llmType === inference', async () => {
+        const params = { ...defaultParams, llmType: 'inference' };
+        await callAssistantGraph(params);
+
+        expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      });
+      it('calls resolveProviderAndModel when llmType === undefined', async () => {
+        const params = { ...defaultParams, llmType: undefined };
+        await callAssistantGraph(params);
+
+        expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      });
     });
-    it('calls resolveProviderAndModel when llmType === inference', async () => {
-      const params = { ...defaultParams, llmType: 'inference' };
-      await callAssistantGraph(params);
+  });
+  describe('inferenceChatModelDisabled = false', () => {
+    const newDefaultParams = {
+      ...defaultParams,
+      inferenceChatModelDisabled: false,
+    };
+    it('calls invokeGraph with correct parameters for non-streaming', async () => {
+      const result = await callAssistantGraph(newDefaultParams);
 
-      expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      expect(invokeGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
+      expect(result.body).toEqual({
+        connector_id: 'test-connector',
+        data: 'test-output',
+        trace_data: {},
+        replacements: [],
+        status: 'ok',
+        conversationId: 'new-conversation-id',
+      });
+      expect(getChatModel).toHaveBeenCalled();
     });
-    it('calls resolveProviderAndModel when llmType === undefined', async () => {
-      const params = { ...defaultParams, llmType: undefined };
+
+    it('calls streamGraph with correct parameters for streaming', async () => {
+      const params = { ...newDefaultParams, isStream: true };
       await callAssistantGraph(params);
 
-      expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      expect(streamGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
+      expect(getChatModel).toHaveBeenCalled();
+    });
+
+    describe('agentRunnable', () => {
+      it('creates ToolCallingAgent for openai llmType', async () => {
+        const params = { ...newDefaultParams, llmType: 'openai' };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for inference llmType', async () => {
+        newDefaultParams.actionsClient.get = jest.fn().mockResolvedValue({
+          config: {
+            provider: 'elastic',
+            providerConfig: { model_id: 'rainbow-sprinkles' },
+          },
+        });
+        const params = { ...newDefaultParams, llmType: 'inference' };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
@@ -42,7 +42,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
   dataClients,
   esClient,
   inference,
-  inferenceChatModelEnabled = false,
+  inferenceChatModelDisabled = false,
   langChainMessages,
   llmTasks,
   llmType,
@@ -76,7 +76,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
    * the state unintentionally. For this reason, only call createLlmInstance at runtime
    */
   const createLlmInstance = async () =>
-    inferenceChatModelEnabled
+    !inferenceChatModelDisabled
       ? inference.getChatModel({
           request,
           connectorId,
@@ -231,7 +231,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
     llm,
     llmType,
     tools,
-    inferenceChatModelEnabled,
+    inferenceChatModelDisabled,
     isOpenAI,
     isStream,
     prompt: chatPromptTemplate,
@@ -306,7 +306,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
       apmTracer,
       assistantGraph,
       inputs,
-      inferenceChatModelEnabled,
+      inferenceChatModelDisabled,
       isEnabledKnowledgeBase: telemetryParams?.isEnabledKnowledgeBase ?? false,
 
       logger,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
@@ -23,7 +23,7 @@ import {
   PostEvaluateBody,
   PostEvaluateResponse,
   DefendInsightType,
-  INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+  INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
 } from '@kbn/elastic-assistant-common';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
 import { getDefaultArguments } from '@kbn/langchain/server';
@@ -179,8 +179,8 @@ export const postEvaluateRoute = (
             (await ctx.elasticAssistant.llmTasks.retrieveDocumentationAvailable()) ?? false;
 
           const { featureFlags } = await context.core;
-          const inferenceChatModelEnabled = await featureFlags.getBooleanValue(
-            INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+          const inferenceChatModelDisabled = await featureFlags.getBooleanValue(
+            INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
             false
           );
 
@@ -321,7 +321,7 @@ export const postEvaluateRoute = (
               const isOpenAI = llmType === 'openai' && !isOssModel;
               const llmClass = getLlmClass(llmType);
               const createLlmInstance = async () =>
-                inferenceChatModelEnabled
+                !inferenceChatModelDisabled
                   ? inference.getChatModel({
                       request,
                       connectorId: connector.id,
@@ -467,7 +467,7 @@ export const postEvaluateRoute = (
               const agentRunnable = await agentRunnableFactory({
                 llm: chatModel,
                 llmType,
-                inferenceChatModelEnabled,
+                inferenceChatModelDisabled,
                 isOpenAI,
                 tools,
                 isStream: false,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
@@ -235,7 +235,7 @@ export interface LangChainExecuteParams {
   contentReferencesStore: ContentReferencesStore;
   llmTasks?: LlmTasksPluginStart;
   inference: InferenceServerStart;
-  inferenceChatModelEnabled?: boolean;
+  inferenceChatModelDisabled?: boolean;
   isOssModel?: boolean;
   conversationId?: string;
   context: AwaitedProperties<
@@ -266,7 +266,7 @@ export const langChainExecute = async ({
   actionTypeId,
   connectorId,
   contentReferencesStore,
-  inferenceChatModelEnabled,
+  inferenceChatModelDisabled,
   isOssModel,
   context,
   actionsClient,
@@ -335,7 +335,7 @@ export const langChainExecute = async ({
     esClient,
     llmTasks,
     inference,
-    inferenceChatModelEnabled,
+    inferenceChatModelDisabled,
     isStream,
     llmType: getLlmType(actionTypeId),
     isOssModel,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -19,7 +19,7 @@ import {
   pruneContentReferences,
   ExecuteConnectorRequestQuery,
   POST_ACTIONS_CONNECTOR_EXECUTE,
-  INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+  INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
 } from '@kbn/elastic-assistant-common';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
 import { getPrompt } from '../lib/prompt';
@@ -82,9 +82,9 @@ export const postActionsConnectorExecuteRoute = (
         let onLlmResponse;
 
         const coreContext = await context.core;
-        const inferenceChatModelEnabled =
+        const inferenceChatModelDisabled =
           (await coreContext?.featureFlags?.getBooleanValue(
-            INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+            INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
             false
           )) ?? false;
 
@@ -200,7 +200,7 @@ export const postActionsConnectorExecuteRoute = (
               connectorId,
               contentReferencesStore,
               isOssModel,
-              inferenceChatModelEnabled,
+              inferenceChatModelDisabled,
               conversationId,
               context: ctx,
               logger,


### PR DESCRIPTION
## Summary

Updates the feature flag to _disable_ rather than enable `InferenceChatModel`. This means `InferenceChatModel` is the default chat model, and the feature flag will disable and revert us back to the former chat models (`ActionsClientChatBedrockConverse`, `ActionsClientChatOpenAI`, `ActionsClientChatVertexAI`). The feature flag look like this:

```
# Disable InferenceChatModel
feature_flags.overrides.securitySolution.inferenceChatModelDisabled: true
```

### Testing

1. Send messages in the Security Assistant with Gemini, Bedrock, and OpenAI
2. Open LangSmith to ensure that these messages were sent with `InferenceChatModel`
3. Add the feature flag and send messages with the three providers
4. Open LangSmith to ensure that these messages were sent with the former chat models


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->