### PR TITLE
[onechat] Update create ES|QL tool sample in README

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/README.md
+++ b/x-pack/platform/plugins/shared/onechat/README.md
@@ -286,20 +286,21 @@ Configure Claude Desktop by adding this to its configuration:
 The ES|QL Tool API enables users to build custom ES|QL-powered tools that the LLM can execute against any index. Here's how to create your first ES|QL tool using a POST request in Kibana DevTools:
 
 ```json
-POST kbn://api/chat/tools/esql
+POST kbn://api/chat/tools
 {
   "id": "case_by_id",
   "description": "Find a custom case by id.",
-  "query": "FROM my_cases | WHERE case_id == ?case_id | KEEP title, description | LIMIT 1",
-  "params": {
-    "case_id": {
-      "type": "keyword",
-      "description": "The id of the case to retrieve"
+  "configuration": {
+    "query": "FROM my_cases | WHERE case_id == ?case_id | KEEP title, description | LIMIT 1",
+    "params": {
+      "case_id": {
+        "type": "keyword",
+        "description": "The id of the case to retrieve"
+      }
     }
   },
-  "meta": {
-    "tags": ["salesforce"]
-  }
+  "type": "esql",
+  "tags": ["salesforce"]
 }
 ```
 


### PR DESCRIPTION
## Summary

Updating the OneChat README to incorporate the latest API changes in #227452 for the example of creating an ES|QL tool. It now reads:

```json
POST kbn://api/chat/tools
{
  "id": "case_by_id",
  "description": "Find a custom case by id.",
  "configuration": {
    "query": "FROM my_cases | WHERE case_id == ?case_id | KEEP title, description | LIMIT 1",
    "params": {
      "case_id": {
        "type": "keyword",
        "description": "The id of the case to retrieve"
      }
    }
  },
  "type": "esql",
  "tags": ["salesforce"]
}


