### PR TITLE
fix(sigevents): check manage permission

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
@@ -5,21 +5,20 @@
  * 2.0.
  */
 
-import { badRequest } from '@hapi/boom';
 import {
   SignificantEventsGetResponse,
   SignificantEventsPreviewResponse,
 } from '@kbn/streams-schema';
 import { z } from '@kbn/zod';
-import { SecurityError } from '../../../lib/streams/errors/security_error';
 import {
   STREAMS_API_PRIVILEGES,
   STREAMS_TIERED_SIGNIFICANT_EVENT_FEATURE,
 } from '../../../../common/constants';
+import { SecurityError } from '../../../lib/streams/errors/security_error';
 import { createServerRoute } from '../../create_server_route';
+import { assertEnterpriseLicense } from '../../utils/assert_enterprise_license';
 import { previewSignificantEvents } from './preview_significant_events';
 import { readSignificantEventsFromAlertsIndices } from './read_significant_events_from_alerts_indices';
-import { assertEnterpriseLicense } from '../../utils/assert_enterprise_license';
 
 // Make sure strings are expected for input, but still converted to a
 // Date, without breaking the OpenAPI generator
@@ -67,11 +66,6 @@ const previewSignificantEventsRoute = createServerRoute({
     const { streamsClient, scopedClusterClient } = await getScopedClients({
       request,
     });
-
-    const isStreamEnabled = await streamsClient.isStreamsEnabled();
-    if (!isStreamEnabled) {
-      throw badRequest('Streams is not enabled');
-    }
 
     const {
       body: { query },
@@ -133,15 +127,10 @@ const readSignificantEventsRoute = createServerRoute({
       throw new SecurityError(`Cannot access API on the current pricing tier`);
     }
 
-    const { streamsClient, assetClient, scopedClusterClient, licensing } = await getScopedClients({
+    const { assetClient, scopedClusterClient, licensing } = await getScopedClients({
       request,
     });
     await assertEnterpriseLicense(licensing);
-
-    const isStreamEnabled = await streamsClient.isStreamsEnabled();
-    if (!isStreamEnabled) {
-      throw badRequest('Streams are not enabled');
-    }
 
     const { name } = params.path;
     const { from, to, bucketSize } = params.query;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/significant_events_table.stories.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/significant_events_table.stories.tsx
@@ -57,6 +57,7 @@ export const Empty: StoryFn<{}> = () => {
         error: undefined,
       }}
       xFormatter={xFormatter}
+      canManage={true}
     />
   );
 };
@@ -97,6 +98,7 @@ export const SomeThings: StoryFn<{}> = () => {
         error: undefined,
       }}
       xFormatter={xFormatter}
+      canManage={true}
     />
   );
 };


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/streams-program/issues/356

Removes the checks on streams enable that causes issues when accessing the API with a readonly role, and adds checks for the manage privilege on the UI for the sig events actions (edit, add, delete)

Desc | Screenshots
-- | --
Before | <img width="369" height="467" alt="image" src="https://github.com/user-attachments/assets/20b5b9ec-e0c0-4f57-b9bd-0526e23ebc92" /> |
After | <img width="1752" height="625" alt="Screenshot 2025-07-14 at 3 45 41 PM" src="https://github.com/user-attachments/assets/af9f884c-8755-4406-8357-c5b4e64c1960" /> |
After | <img width="1634" height="534" alt="Screenshot 2025-07-14 at 3 45 37 PM" src="https://github.com/user-attachments/assets/4c359379-1e23-4b04-b8b0-6b8a49a644d0" /> |



### testing

- Enable streams from API and sig events in advanced settings
- Create some sig events with an admin
- Create a role with Streams Read privilege and index `*` -> `read, view_index_metadata`
- Go to the significant events page, asserts the actions are disabled
