### PR TITLE
[Synthetics] Reject template strings in synthetics UI and server

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/translations/translations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/translations/translations.ts
@@ -21,7 +21,6 @@ export const STATUS_DOWN_LABEL = i18n.translate(
 export const NO_BACKTICKS_ERROR_MESSAGE = i18n.translate(
   'xpack.synthetics.monitorManagement.testNow.monitorInlineScriptBacktickError',
   {
-    defaultMessage:
-      'UI monitors do not support backtick (`) characters. Consider using Project Monitors instead.',
+    defaultMessage: 'Inline scripts may not contain backtick (`) characters.',
   }
 );

--- a/x-pack/solutions/observability/plugins/synthetics/common/translations/translations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/translations/translations.ts
@@ -17,3 +17,11 @@ export const STATUS_DOWN_LABEL = i18n.translate(
     defaultMessage: 'Down',
   }
 );
+
+export const NO_BACKTICKS_ERROR_MESSAGE = i18n.translate(
+  'xpack.synthetics.monitorManagement.testNow.monitorInlineScriptBacktickError',
+  {
+    defaultMessage:
+      'UI monitors do not support backtick (`) characters. Consider using Project Monitors instead.',
+  }
+);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/source_field.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/source_field.tsx
@@ -34,7 +34,7 @@ export interface SourceFieldProps {
 }
 
 export const SourceField = ({ onChange, onBlur, value, isEditFlow = false }: SourceFieldProps) => {
-  const { control, clearErrors } = useFormContext();
+  const { control } = useFormContext();
   const [sourceType, setSourceType] = useState<SourceType>(
     value.type === 'inline' ? SourceType.INLINE : SourceType.SCRIPT_RECORDER
   );
@@ -123,9 +123,6 @@ export const SourceField = ({ onChange, onBlur, value, isEditFlow = false }: Sou
                 onChange={(code) => {
                   field.onChange(code);
                   setConfig((prev) => ({ ...prev, script: code }));
-                  if (!code.includes('`')) {
-                    clearErrors(ConfigKey.SOURCE_INLINE);
-                  }
                   onBlur(ConfigKey.SOURCE_INLINE);
                 }}
               />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/hooks/use_run_once_errors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/hooks/use_run_once_errors.ts
@@ -8,6 +8,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { Locations, ServiceLocationErrors } from '../../monitor_add_edit/types';
+import { NO_BACKTICKS_ERROR_MESSAGE } from '../../../../../../common/translations/translations';
 
 export function useRunOnceErrors({
   testRunId,
@@ -61,6 +62,15 @@ export function useRunOnceErrors({
     (locationErrors?.length && locationErrors?.length === locations.length);
 
   const errorMessages = useMemo(() => {
+    if (runOnceServiceError?.message?.includes(NO_BACKTICKS_ERROR_MESSAGE)) {
+      return [
+        {
+          name: 'Error',
+          title: RunErrorLabel,
+          message: runOnceServiceError.message,
+        },
+      ];
+    }
     if (hasBlockingError) {
       return locationErrorReasons.length === 1
         ? [
@@ -84,7 +94,7 @@ export function useRunOnceErrors({
     }
 
     return [];
-  }, [locationsById, locationErrors, locationErrorReasons, hasBlockingError]);
+  }, [locationsById, locationErrors, locationErrorReasons, hasBlockingError, runOnceServiceError]);
 
   return {
     expectPings,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode_flyout_container.tsx
@@ -72,6 +72,9 @@ export function TestNowModeFlyoutContainer() {
         onDone={onDone}
         isPushing={flyoutOpenTestRun.status === 'loading'}
         errors={flyoutOpenTestRun.errors ?? []}
+        serviceError={
+          flyoutOpenTestRun.fetchError ? new Error(flyoutOpenTestRun.fetchError.message) : undefined
+        }
       />
     ) : null;
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/api.ts
@@ -10,7 +10,19 @@ import { TestNowResponse } from '../../../../../common/types';
 import { apiService } from '../../../../utils/api_service';
 import { SYNTHETICS_API_URLS } from '../../../../../common/constants';
 
-export const triggerTestNowMonitor = async ({
+async function performFetch<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    // this API service function throws errors that don't correspond to the expected Error type in the rest of the UI
+    if (isUnknownError(e)) {
+      throw new ManualTestRunError(e, e.body.message);
+    }
+    throw e;
+  }
+}
+
+export const triggerTestNowMonitor = ({
   configId,
   spaceId,
 }: {
@@ -18,17 +30,42 @@ export const triggerTestNowMonitor = async ({
   name: string;
   spaceId?: string;
 }): Promise<TestNowResponse | undefined> => {
-  return await apiService.post(
-    SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${configId}`,
-    undefined,
-    undefined,
-    {
+  return performFetch(() =>
+    apiService.post(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${configId}`, undefined, undefined, {
       spaceId,
-    }
+    })
   );
 };
 
-export const runOnceMonitor = async ({
+function isUnknownError(
+  error: unknown
+): error is { body: { message: string; error: string; statusCode: number } } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'body' in error &&
+    typeof error.body === 'object' &&
+    error.body !== null &&
+    'message' in error.body &&
+    'error' in error.body &&
+    'statusCode' in error.body
+  );
+}
+
+/**
+ * API Service sends errors that do not correspond to `Error`, which
+ * causes downstream issues. This class reformats the errors to correspond
+ * to the `Error` class utilized throughout the UI, while keeping any additional
+ * context.
+ */
+class ManualTestRunError extends Error {
+  constructor(public original: unknown, message: string) {
+    super(message);
+    Object.assign(this, original);
+  }
+}
+
+export const runOnceMonitor = ({
   monitor,
   id,
   spaceId,
@@ -37,12 +74,9 @@ export const runOnceMonitor = async ({
   id: string;
   spaceId?: string;
 }): Promise<{ errors: ServiceLocationErrors }> => {
-  return await apiService.post(
-    SYNTHETICS_API_URLS.RUN_ONCE_MONITOR + `/${id}`,
-    monitor,
-    undefined,
-    {
+  return performFetch(() =>
+    apiService.post(SYNTHETICS_API_URLS.RUN_ONCE_MONITOR + `/${id}`, monitor, undefined, {
       spaceId,
-    }
+    })
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -21,6 +21,8 @@ import { SyntheticsRestApiRouteFactory } from '../types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { normalizeAPIConfig, validateMonitor } from './monitor_validation';
 import { mapSavedObjectToMonitor } from './formatters/saved_object_to_monitor';
+import { ConfigKey } from '../../../common/runtime_types';
+import { NO_BACKTICKS_ERROR_MESSAGE } from '../../../common/translations/translations';
 
 export const addSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'POST',
@@ -74,6 +76,13 @@ export const addSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
             details: invalidOriginError(request.body.origin),
             payload: request.body,
           },
+        },
+      });
+    }
+    if (monitor[ConfigKey.SOURCE_INLINE] && monitor[ConfigKey.SOURCE_INLINE].includes('`')) {
+      return response.badRequest({
+        body: {
+          message: NO_BACKTICKS_ERROR_MESSAGE,
         },
       });
     }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { syncEditedMonitor } from './edit_monitor';
+import { syncEditedMonitor, uiMonitorContainsBacktickInInlineScript } from './edit_monitor';
 import { SavedObject } from '@kbn/core/server';
 import {
   EncryptedSyntheticsMonitorAttributes,
@@ -80,5 +80,40 @@ describe('syncEditedMonitor', () => {
         enabled: true,
       })
     );
+  });
+});
+
+describe('uiMonitorContainsBacktickInInlineScript', () => {
+  const baseBrowserMonitor = {
+    type: 'browser',
+    origin: 'ui',
+  } as any;
+
+  it('returns true when inline script contains a backtick', () => {
+    const monitor = {
+      ...baseBrowserMonitor,
+      'source.inline.script': 'step(`foo`, () => {})',
+    } as any;
+
+    expect(uiMonitorContainsBacktickInInlineScript(monitor)).toBe(true);
+  });
+
+  it('returns false when inline script does not contain a backtick', () => {
+    const monitor = {
+      ...baseBrowserMonitor,
+      'source.inline.script': 'step("foo", () => {})',
+    } as any;
+
+    expect(uiMonitorContainsBacktickInInlineScript(monitor)).toBe(false);
+  });
+
+  it('returns false for non-browser monitors', () => {
+    const monitor = {
+      type: 'http',
+      origin: 'ui',
+      urls: 'https://elastic.co',
+    } as any;
+
+    expect(uiMonitorContainsBacktickInInlineScript(monitor)).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -76,13 +76,7 @@ export const editSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => (
     if (monitor.origin && monitor.origin !== 'ui') {
       return response.badRequest(getInvalidOriginError(monitor));
     }
-    if (
-      monitor.type &&
-      monitor.type === 'browser' &&
-      monitor.origin === 'ui' &&
-      (monitor as BrowserFields)?.[ConfigKey.SOURCE_INLINE] &&
-      (monitor as BrowserFields)[ConfigKey.SOURCE_INLINE].includes('`')
-    ) {
+    if (uiMonitorContainsBacktickInInlineScript(monitor)) {
       return response.badRequest({
         body: {
           message: NO_BACKTICKS_ERROR_MESSAGE,
@@ -222,6 +216,15 @@ export const editSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => (
     }
   },
 });
+
+export const uiMonitorContainsBacktickInInlineScript = (monitor: SyntheticsMonitor): boolean => {
+  return !!(
+    monitor.origin === 'ui' &&
+    monitor.type === 'browser' &&
+    (monitor as BrowserFields)?.[ConfigKey.SOURCE_INLINE] &&
+    (monitor as BrowserFields)[ConfigKey.SOURCE_INLINE].includes('`')
+  );
+};
 
 const rollbackUpdate = async ({
   routeContext,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_validation.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_validation.ts
@@ -36,7 +36,6 @@ import {
   ALLOWED_SCHEDULES_IN_MINUTES,
   DEFAULT_FIELDS,
 } from '../../../common/constants/monitor_defaults';
-import { NO_BACKTICKS_ERROR_MESSAGE } from '../../../common/translations/translations';
 
 type MonitorCodecType =
   | typeof ICMPFieldsCodec
@@ -150,14 +149,6 @@ export function validateMonitor(monitorFields: MonitorFields, spaceId: string): 
   if (monitorType === MonitorTypeEnum.BROWSER) {
     const inlineScript = monitorFields[ConfigKey.SOURCE_INLINE];
     const projectContent = monitorFields[ConfigKey.SOURCE_PROJECT_CONTENT];
-    if (inlineScript?.includes('`')) {
-      return {
-        valid: false,
-        reason: 'Monitor is not a valid monitor of type browser',
-        details: NO_BACKTICKS_ERROR_MESSAGE,
-        payload: monitorFields,
-      };
-    }
     if (!inlineScript && !projectContent) {
       return {
         valid: false,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_validation.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_validation.ts
@@ -36,6 +36,7 @@ import {
   ALLOWED_SCHEDULES_IN_MINUTES,
   DEFAULT_FIELDS,
 } from '../../../common/constants/monitor_defaults';
+import { NO_BACKTICKS_ERROR_MESSAGE } from '../../../common/translations/translations';
 
 type MonitorCodecType =
   | typeof ICMPFieldsCodec
@@ -149,6 +150,14 @@ export function validateMonitor(monitorFields: MonitorFields, spaceId: string): 
   if (monitorType === MonitorTypeEnum.BROWSER) {
     const inlineScript = monitorFields[ConfigKey.SOURCE_INLINE];
     const projectContent = monitorFields[ConfigKey.SOURCE_PROJECT_CONTENT];
+    if (inlineScript?.includes('`')) {
+      return {
+        valid: false,
+        reason: 'Monitor is not a valid monitor of type browser',
+        details: NO_BACKTICKS_ERROR_MESSAGE,
+        payload: monitorFields,
+      };
+    }
     if (!inlineScript && !projectContent) {
       return {
         valid: false,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
@@ -12,6 +12,7 @@ import { SyntheticsRestApiRouteFactory } from '../types';
 import { ConfigKey, MonitorFields } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { validateMonitor } from '../monitor_cruds/monitor_validation';
+import { NO_BACKTICKS_ERROR_MESSAGE } from '../../../common/translations/translations';
 
 export const runOnceSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'POST',
@@ -33,6 +34,11 @@ export const runOnceSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () =
     const { monitorId } = request.params;
     if (isEmpty(monitor)) {
       return response.badRequest({ body: { message: 'Monitor data is empty.' } });
+    }
+    if (monitor[ConfigKey.SOURCE_INLINE] && monitor[ConfigKey.SOURCE_INLINE].includes('`')) {
+      return response.badRequest({
+        body: { message: NO_BACKTICKS_ERROR_MESSAGE },
+      });
     }
 
     const validationResult = validateMonitor(monitor, spaceId);

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -47,16 +47,11 @@ export const triggerTestNow = async (
   try {
     const { normalizedMonitor } = await monitorConfigRepository.getDecrypted(monitorId, spaceId);
 
-    // Narrow SyntheticsMonitor to the browser variant that contains an inline script
-    const hasInlineScript = (
-      m: SyntheticsMonitor
-    ): m is SyntheticsMonitor & {
-      [ConfigKey.SOURCE_INLINE]: string;
-    } => typeof (m as any)[ConfigKey.SOURCE_INLINE] === 'string';
-
     const monitorAttrs = normalizedMonitor.attributes as SyntheticsMonitor;
 
-    if (hasInlineScript(monitorAttrs) && monitorAttrs[ConfigKey.SOURCE_INLINE].includes('`')) {
+    const inlineScript = (monitorAttrs as any)[ConfigKey.SOURCE_INLINE] as string | undefined;
+
+    if (typeof inlineScript === 'string' && inlineScript.includes('`')) {
       return response.badRequest({
         body: {
           message: NO_BACKTICKS_ERROR_MESSAGE,


### PR DESCRIPTION
## Summary

Resolves #225498.

This PR hardens both the **UI** and **API** layers against unsupported backtick (`` ` ``) characters in browser monitor *inline scripts*, fully resolving **issue #225498**.

### Key changes

1. **Shared copy & i18n**  
   • Added `NO_BACKTICKS_ERROR_MESSAGE` in `common/translations/translations.ts`.

2. **UI – Monitor editor & Test-now fly-out**  
   • `source_field.tsx` – converted the inline-script editor to a **react-hook-form Controller** with a `validate` rule that blocks backticks and surfaces the new i18n error; removed redundant local state and manual error clearing.  
   • `use_run_once_errors.ts` & `test_now_mode_flyout_container.tsx` – propagate server-side backtick errors into the fly-out error list.

3. **UI – Manual test-run API wrapper**  
   Added `performFetch` + `ManualTestRunError` to normalise non-standard errors from `apiService`, ensuring consistent UX when a backtick violation is returned.

4. **Server routes**  
   Added early backtick validation to:
   * `add_monitor.ts`
   * `edit_monitor.ts` (helper `uiMonitorContainsBacktickInInlineScript`)
   * `run_once_monitor.ts`
   * `test_now_monitor.ts`

5. **Validation layer**  
   Removed duplicate backtick logic from `monitor_validation.ts` (now fully handled at route level).

6. **Tests**  
   • **Unit** – new tests for `uiMonitorContainsBacktickInInlineScript`.  
   • **API integration (deployment-agnostic)** – create & edit monitor tests ensure 400 responses when backticks are present.  
   All Jest suites remain green.

---

## Testing

### 1. UI

1. Navigate to *Uptime → Create monitor → Browser → Inline script*.
2. Paste a script containing a backtick, e.g.
   ```js
   step(`name`, async () => {});
   ```
   **Expect:** validation error `Inline scripts may not contain backtick ()1) characters.` and Save button disabled.
3. Replace the backtick with a quote, blur the field. **Expect:** error disappears, monitor can be saved.
4. Edit an existing browser monitor, add a backtick, click **Save**. **Expect:** toast with the same error; monitor not updated.

### 2. Test-now / Run-once

1. With a valid script, click **Test now** – run should start.
2. Add a backtick to the inline script, click **Test now** again. **Expect:** flyout shows the backtick error; no run queued.

### 3. API

Create monitor with curl:
```bash
curl -X POST $KIBANA_HOST/api/synthetics/monitors \
  -H 'kbn-xsrf: 1' -H 'Content-Type: application/json' \
  -d '{
        "type":"browser",
        "name":"bad monitor",
        "locations":["us_central"],
        "inline_script":"step(`bad`, async () => {})"
      }'
```
**Expect:** `400` with the backtick error message. Repeat for `PUT /monitors/{id}`, `POST /run_once`, `POST /test_now`.


---

These changes ensure a single, consistent error surface for invalid inline scripts across the entire Synthetics workflow, preventing broken run-once executions.