### PR TITLE
[9.1] [Alerts table] Unskipped pagination test (#227486)

### DIFF
--- a/x-pack/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/test/functional/services/observability/alerts/common.ts
@@ -306,14 +306,16 @@ export function ObservabilityAlertsCommonProvider({
     await testSubjects.click(buttonSubject);
   };
 
-  const alertDataIsBeingLoaded = async () => {
-    return testSubjects.existOrFail('events-container-loading-true');
+  const selectAlertStatusFilter = async (alertStatus: AlertStatus) => {
+    await testSubjects.click('optionsList-control-0');
+    await testSubjects.click(`optionsList-control-selection-${alertStatus}`);
+    await testSubjects.click('optionsList-control-0');
   };
 
   const alertDataHasLoaded = async () => {
     await retry.waitFor(
       'Alert Table is loaded',
-      async () => await testSubjects.exists('events-container-loading-false', { timeout: 2500 })
+      async () => await testSubjects.exists('alertsTableIsLoaded', { timeout: 2500 })
     );
   };
 
@@ -439,7 +441,6 @@ export function ObservabilityAlertsCommonProvider({
     setWorkflowStatusFilter,
     getWorkflowStatusFilterValue,
     setAlertStatusFilter,
-    alertDataIsBeingLoaded,
     alertDataHasLoaded,
     submitQuery,
     typeInQueryBar,
@@ -457,5 +458,6 @@ export function ObservabilityAlertsCommonProvider({
     navigateToAlertDetails,
     createDataView,
     deleteDataView,
+    selectAlertStatusFilter,
   };
 }

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/pagination.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/pagination.ts
@@ -88,11 +88,13 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/120440
-      describe.skip('Pagination controls', () => {
+      describe('Pagination controls', () => {
         before(async () => {
-          await (await observability.alerts.pagination.getPageSizeSelector()).click();
-          await (await observability.alerts.pagination.getTenRowsPageSelector()).click();
+          await observability.alerts.common.selectAlertStatusFilter('recovered');
+          await retry.try(async () => {
+            await (await observability.alerts.pagination.getPageSizeSelector()).click();
+            await (await observability.alerts.pagination.getTenRowsPageSelector()).click();
+          });
           await observability.alerts.pagination.goToFirstPage();
         });
 
@@ -113,7 +115,6 @@ export default ({ getService }: FtrProviderContext) => {
 
         it('Goes to nth page', async () => {
           await observability.alerts.pagination.goToNthPage(3);
-          await observability.alerts.common.alertDataIsBeingLoaded();
           await observability.alerts.common.alertDataHasLoaded();
           const tableRows = await observability.alerts.common.getTableCellsInRows();
           expect(tableRows.length).to.be(10);
@@ -121,7 +122,6 @@ export default ({ getService }: FtrProviderContext) => {
 
         it('Goes to next page', async () => {
           await observability.alerts.pagination.goToNextPage();
-          await observability.alerts.common.alertDataIsBeingLoaded();
           await observability.alerts.common.alertDataHasLoaded();
           const tableRows = await observability.alerts.common.getTableCellsInRows();
           expect(tableRows.length).to.be(10);
@@ -129,7 +129,6 @@ export default ({ getService }: FtrProviderContext) => {
 
         it('Goes to previous page', async () => {
           await observability.alerts.pagination.goToPrevPage();
-          await observability.alerts.common.alertDataIsBeingLoaded();
           await observability.alerts.common.alertDataHasLoaded();
           const tableRows = await observability.alerts.common.getTableCellsInRows();
           expect(tableRows.length).to.be(10);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Alerts table] Unskipped pagination test (#227486)](https://github.com/elastic/kibana/pull/227486)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-07-15T05:45:30Z","message":"[Alerts table] Unskipped pagination test (#227486)\n\nThis PR closes #120440 .\n\nThis test was skipped a long time ago and several things changed since\nthen.\nThe main thing is that the container that shows the alerts changed, now\nit's a component that shows a `data-test-subj` equal to\n`internalAlertsPageLoading` when loading and `alertsTableIsLoaded` when\nthe alerts have been loaded.\n\nThe component shown when alerts are being loaded is not always shown,\nprobably for some caching, so I removed the `alertDataIsBeingLodaded`\ncheck.\n\nI also had to add a function to include the `recovered` alerts because\nthe `active` alerts in the test data are only 10 and the pagination\ncannot work with just 10 alerts.","sha":"ca9a70b7040399cb6a2433ff77b6e3d5fffc13cf","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","author:obs-ux-management","v9.2.0"],"title":"[Alerts table] Unskipped pagination test","number":227486,"url":"https://github.com/elastic/kibana/pull/227486","mergeCommit":{"message":"[Alerts table] Unskipped pagination test (#227486)\n\nThis PR closes #120440 .\n\nThis test was skipped a long time ago and several things changed since\nthen.\nThe main thing is that the container that shows the alerts changed, now\nit's a component that shows a `data-test-subj` equal to\n`internalAlertsPageLoading` when loading and `alertsTableIsLoaded` when\nthe alerts have been loaded.\n\nThe component shown when alerts are being loaded is not always shown,\nprobably for some caching, so I removed the `alertDataIsBeingLodaded`\ncheck.\n\nI also had to add a function to include the `recovered` alerts because\nthe `active` alerts in the test data are only 10 and the pagination\ncannot work with just 10 alerts.","sha":"ca9a70b7040399cb6a2433ff77b6e3d5fffc13cf"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227486","number":227486,"mergeCommit":{"message":"[Alerts table] Unskipped pagination test (#227486)\n\nThis PR closes #120440 .\n\nThis test was skipped a long time ago and several things changed since\nthen.\nThe main thing is that the container that shows the alerts changed, now\nit's a component that shows a `data-test-subj` equal to\n`internalAlertsPageLoading` when loading and `alertsTableIsLoaded` when\nthe alerts have been loaded.\n\nThe component shown when alerts are being loaded is not always shown,\nprobably for some caching, so I removed the `alertDataIsBeingLodaded`\ncheck.\n\nI also had to add a function to include the `recovered` alerts because\nthe `active` alerts in the test data are only 10 and the pagination\ncannot work with just 10 alerts.","sha":"ca9a70b7040399cb6a2433ff77b6e3d5fffc13cf"}}]}] BACKPORT-->