### PR TITLE
[9.0] [Deployment Agnostic] Adding registryUrl configuration for DA tests (#221628)

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/serverless.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/serverless.config.base.ts
@@ -124,6 +124,9 @@ export function createServerlessTestConfig<T extends DeploymentAgnosticCommonSer
           '--xpack.uptime.service.username=localKibanaIntegrationTestsUser',
           '--xpack.uptime.service.devUrl=mockDevUrl',
           '--xpack.uptime.service.manifestUrl=mockDevUrl',
+          ...(dockerRegistryPort
+            ? [`--xpack.fleet.registryUrl=http://localhost:${dockerRegistryPort}`]
+            : []),
         ],
       },
       testFiles: options.testFiles,

--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
@@ -161,6 +161,9 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
           '--xpack.uptime.service.devUrl=mockDevUrl',
           '--xpack.uptime.service.manifestUrl=mockDevUrl',
           '--xpack.observabilityAIAssistant.disableKbSemanticTextMigration=true',
+          ...(dockerRegistryPort
+            ? [`--xpack.fleet.registryUrl=http://localhost:${dockerRegistryPort}`]
+            : []),
         ],
       },
     };


### PR DESCRIPTION
# Backport

Closes #205017

This will backport the following commits from `main` to `9.0`:
 - [[Deployment Agnostic] Adding registryUrl configuration for DA tests (#221628)](https://github.com/elastic/kibana/pull/221628)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2025-05-27T17:14:24Z","message":"[Deployment Agnostic] Adding registryUrl configuration for DA tests (#221628)\n\nWhen introducing package registry configuration in\nhttps://github.com/elastic/kibana/pull/193144 I missed the set up of\n`xpack.fleet.registryUrl` which has resulted in flaky tests whenever the\ntest uses fleet underneath.","sha":"1a5ba164838a212ded3760afb0a932f7d208cf11","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","v9.1.0","v8.19.0"],"title":"[Deployment Agnostic] Adding registryUrl configuration for DA tests","number":221628,"url":"https://github.com/elastic/kibana/pull/221628","mergeCommit":{"message":"[Deployment Agnostic] Adding registryUrl configuration for DA tests (#221628)\n\nWhen introducing package registry configuration in\nhttps://github.com/elastic/kibana/pull/193144 I missed the set up of\n`xpack.fleet.registryUrl` which has resulted in flaky tests whenever the\ntest uses fleet underneath.","sha":"1a5ba164838a212ded3760afb0a932f7d208cf11"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221628","number":221628,"mergeCommit":{"message":"[Deployment Agnostic] Adding registryUrl configuration for DA tests (#221628)\n\nWhen introducing package registry configuration in\nhttps://github.com/elastic/kibana/pull/193144 I missed the set up of\n`xpack.fleet.registryUrl` which has resulted in flaky tests whenever the\ntest uses fleet underneath.","sha":"1a5ba164838a212ded3760afb0a932f7d208cf11"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/222736","number":222736,"state":"MERGED","mergeCommit":{"sha":"739d2abeedf4604c2c37b14c04263a2b370455a5","message":"[8.19] [Deployment Agnostic] Adding registryUrl configuration for DA tests (#221628) (#222736)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Deployment Agnostic] Adding registryUrl configuration for DA tests\n(#221628)](https://github.com/elastic/kibana/pull/221628)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}}]}] BACKPORT-->