### PR TITLE
[Feature Flags] Extend dynamic-config docs

### DIFF
--- a/src/core/packages/feature-flags/README.mdx
+++ b/src/core/packages/feature-flags/README.mdx
@@ -163,3 +163,11 @@ PUT /internal/core/_settings
   }
 }
 ```
+
+> [!NOTE]
+> The `PUT /internal/core/_settings` endpoint is only available in the test environments. To enable it, add the following
+> to your `kibana.yml`:
+>
+> ```yaml
+> coreApp.allowDynamicConfigOverrides: true
+> ```


### PR DESCRIPTION
## Summary

Adds a callout about how to enable the dynamic config endpoint.


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




