### PR TITLE
[ResponseOps][Cases] Skip analytics sync task if health check times out

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.ts
@@ -137,7 +137,7 @@ export class BackfillTaskRunner implements CancellableTask {
     return esClient.cluster.health({
       index: this.destIndex,
       wait_for_status: 'green',
-      timeout: '300ms', // this is probably too much
+      timeout: '300ms',
       wait_for_active_shards: 'all',
     });
   }


### PR DESCRIPTION
## Summary

This PR skips the synchronization task for the cases analytics indexes if the cluster health is not green. Previously, an error was being thrown, and this led to lots of noise in the serverless environment



