### PR TITLE
[ES|QL] Fixes license race condition for CCS indices

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -161,7 +161,6 @@ export const ESQLEditor = memo(function ESQLEditor({
   const [isCodeEditorExpandedFocused, setIsCodeEditorExpandedFocused] = useState(false);
   const [isQueryLoading, setIsQueryLoading] = useState(true);
   const [abortController, setAbortController] = useState(new AbortController());
-  const [license, setLicense] = useState<ILicense | undefined>(undefined);
 
   // contains both client side validation and server messages
   const [editorMessages, setEditorMessages] = useState<{
@@ -444,10 +443,18 @@ export const ESQLEditor = memo(function ESQLEditor({
   }, []);
 
   const { cache: dataSourcesCache, memoizedSources } = useMemo(() => {
-    const fn = memoize((...args: [DataViewsPublicPluginStart, CoreStart, boolean]) => ({
-      timestamp: Date.now(),
-      result: getESQLSources(...args),
-    }));
+    const fn = memoize(
+      (
+        ...args: [
+          DataViewsPublicPluginStart,
+          CoreStart,
+          (() => Promise<ILicense | undefined>) | undefined
+        ]
+      ) => ({
+        timestamp: Date.now(),
+        result: getESQLSources(...args),
+      })
+    );
 
     return { cache: fn.cache, memoizedSources: fn };
   }, []);
@@ -456,9 +463,8 @@ export const ESQLEditor = memo(function ESQLEditor({
     const callbacks: ESQLCallbacks = {
       getSources: async () => {
         clearCacheWhenOld(dataSourcesCache, fixedQuery);
-        const ccrFeature = license?.getFeature('ccr');
-        const areRemoteIndicesAvailable = ccrFeature?.isAvailable ?? false;
-        const sources = await memoizedSources(dataViews, core, areRemoteIndicesAvailable).result;
+        const getLicense = kibana.services?.esql?.getLicense;
+        const sources = await memoizedSources(dataViews, core, getLicense).result;
         return sources;
       },
       getColumnsFor: async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
@@ -540,7 +546,6 @@ export const ESQLEditor = memo(function ESQLEditor({
     kibana.services?.esql,
     dataSourcesCache,
     fixedQuery,
-    license,
     memoizedSources,
     dataViews,
     core,
@@ -614,20 +619,6 @@ export const ESQLEditor = memo(function ESQLEditor({
       setQueryToTheCache();
     }
   }, [isLoading, isQueryLoading, parseMessages, code]);
-
-  useEffect(() => {
-    async function fetchLicense() {
-      try {
-        const ls = await kibana.services?.esql?.getLicense();
-        if (!isEqual(license, ls)) {
-          setLicense(ls);
-        }
-      } catch (error) {
-        // failed to fetch
-      }
-    }
-    fetchLicense();
-  }, [kibana.services?.esql, license]);
 
   const queryValidation = useCallback(
     async ({ active }: { active: boolean }) => {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -13,6 +13,7 @@ import { UseEuiTheme, euiShadow } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { monaco } from '@kbn/monaco';
 import type { CoreStart } from '@kbn/core/public';
+import type { ILicense } from '@kbn/licensing-plugin/public';
 import { i18n } from '@kbn/i18n';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { MapCache } from 'lodash';
@@ -264,8 +265,11 @@ const getIntegrations = async (core: Pick<CoreStart, 'application' | 'http'>) =>
 export const getESQLSources = async (
   dataViews: DataViewsPublicPluginStart,
   core: Pick<CoreStart, 'application' | 'http'>,
-  areRemoteIndicesAvailable: boolean
+  getLicense: (() => Promise<ILicense | undefined>) | undefined
 ) => {
+  const ls = await getLicense?.();
+  const ccrFeature = ls?.getFeature('ccr');
+  const areRemoteIndicesAvailable = ccrFeature?.isAvailable ?? false;
   const [remoteIndices, localIndices, integrations] = await Promise.all([
     getRemoteIndicesList(dataViews, areRemoteIndicesAvailable),
     getIndicesList(dataViews),

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
@@ -14,8 +14,6 @@ import { CodeEditor } from '@kbn/code-editor';
 import { CONSOLE_LANG_ID, CONSOLE_THEME_ID, ConsoleLang, ESQLCallbacks, monaco } from '@kbn/monaco';
 import { i18n } from '@kbn/i18n';
 import { getESQLSources } from '@kbn/esql-editor/src/helpers';
-import { isEqual } from 'lodash';
-import { ILicense } from '@kbn/licensing-plugin/common/types';
 import { getESQLQueryColumns } from '@kbn/esql-utils';
 import { FieldType } from '@kbn/esql-ast/src/definitions/types';
 import { KBN_FIELD_TYPES } from '@kbn/field-types';
@@ -68,8 +66,6 @@ export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps
   const [editorInstance, setEditorInstace] = useState<
     monaco.editor.IStandaloneCodeEditor | undefined
   >();
-  const [license, setLicense] = useState<ILicense | undefined>(undefined);
-
   const divRef = useRef<HTMLDivElement | null>(null);
   const { setupResizeChecker, destroyResizeChecker } = useResizeCheckerUtils();
   const { registerKeyboardCommands, unregisterKeyboardCommands } = useKeyboardCommandsUtils();
@@ -114,20 +110,6 @@ export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps
   );
 
   useEffect(() => {
-    async function fetchLicense() {
-      try {
-        const ls = await licensing?.getLicense();
-        if (!isEqual(license, ls)) {
-          setLicense(ls);
-        }
-      } catch (error) {
-        // failed to fetch
-      }
-    }
-    fetchLicense();
-  }, [licensing, license]);
-
-  useEffect(() => {
     if (settings.isKeyboardShortcutsEnabled && editorInstance) {
       registerKeyboardCommands({
         editor: editorInstance,
@@ -159,9 +141,8 @@ export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps
   const esqlCallbacks: ESQLCallbacks = useMemo(() => {
     const callbacks: ESQLCallbacks = {
       getSources: async () => {
-        const ccrFeature = license?.getFeature('ccr');
-        const areRemoteIndicesAvailable = ccrFeature?.isAvailable ?? false;
-        return await getESQLSources(dataViews, { application, http }, areRemoteIndicesAvailable);
+        const getLicense = licensing?.getLicense;
+        return await getESQLSources(dataViews, { application, http }, getLicense);
       },
       getColumnsFor: async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
         if (queryToExecute) {
@@ -188,7 +169,7 @@ export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps
       },
     };
     return callbacks;
-  }, [license, dataViews, application, http, data.search.search]);
+  }, [licensing, dataViews, application, http, data.search.search]);
 
   const suggestionProvider = useMemo(
     () => ConsoleLang.getSuggestionProvider?.(esqlCallbacks, actionsProvider),


### PR DESCRIPTION
## Summary

Fixes a race condition on the retrieval of license to check if the editor should or not suggest remote indices.

The race condition can be seen only if you have CCS indices.

When you open Discover everything works fine


<img width="2146" height="780" alt="image (1)" src="https://github.com/user-attachments/assets/ff106bed-db26-42f8-83eb-7daea9c60e5d" />

But if you navigate to another app and come back to Discover the validation fails

<img width="1236" height="630" alt="image" src="https://github.com/user-attachments/assets/1c6557bd-ec59-4a92-9f5c-f402eef6afe4" />


The reason is that the license inside the memoized function gets undefined for a while (as it is an async call), the boolean flag gets false and the validation fails. This refactoring makes sure that the license check is inside the memoized function and will never report its status falsy





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->