### PR TITLE
[ES|QL] Fixes wrong validation on expressions between aggregations

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/stats/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/stats/utils.ts
@@ -181,10 +181,15 @@ export function checkFunctionContent(arg: ESQLFunction) {
   if (isAggregation(arg) || isFunctionOperatorParam(arg)) {
     return true;
   }
-  return (arg as ESQLFunction).args.every(
-    (subArg): boolean =>
+  return (arg as ESQLFunction).args.every((subArg): boolean => {
+    // Differentiate between array and non-array arguments
+    if (Array.isArray(subArg)) {
+      return subArg.every((item) => checkFunctionContent(item as ESQLFunction));
+    }
+    return (
       isLiteral(subArg) ||
       isAggregation(subArg) ||
       (isNotAnAggregation(subArg) ? checkFunctionContent(subArg) : false)
-  );
+    );
+  });
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/stats/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/stats/validate.test.ts
@@ -91,6 +91,11 @@ describe('STATS Validation', () => {
         statsExpectErrors('from a_index | STATS abs( doubleField + sum( doubleField )) ', [
           'Cannot combine aggregation and non-aggregation values in [STATS], found [abs(doubleField+sum(doubleField))]',
         ]);
+        // This is a valid expression as it is an operation on two aggregation functions
+        statsExpectErrors(
+          'from a_index | STATS sum(doubleField) / (min(doubleField) + max(doubleField))  ',
+          []
+        );
       });
 
       test('errors on each aggregation field, which does not contain at least one agg function', () => {


### PR DESCRIPTION
## Summary

Fixes wrong client side validation error in expressions between aggregations

Before
<img width="3196" height="542" alt="image" src="https://github.com/user-attachments/assets/512f0b2c-b64f-40c9-aa08-645f3f312bc6" />


After
<img width="1598" height="186" alt="image" src="https://github.com/user-attachments/assets/d47b1888-4ae9-4f9c-b474-383dede4b3d0" />


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->