### PR TITLE
[7.17] fix: incorrect value field type in set processor (#227568)

### DIFF
--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processor_form.container.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processor_form.container.tsx
@@ -79,7 +79,7 @@ export const ProcessorFormContainer: FunctionComponent<Props> = ({
         type: formState.type,
         fields: formState.customOptions
           ? {
-              ...formState.customOptions,
+              customOptions: formState.customOptions,
             }
           : {
               ...formState.fields,

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/serialize.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/serialize.ts
@@ -8,6 +8,7 @@
 import { Processor } from '../../../../common/types';
 
 import { ProcessorInternal } from './types';
+import { convertProccesorsToJson } from './utils';
 
 interface SerializeArgs {
   /**
@@ -35,7 +36,7 @@ const convertProcessorInternalToProcessor = (
   const { options, onFailure, type, id } = processor;
   const outProcessor = {
     [type]: {
-      ...options,
+      ...convertProccesorsToJson(options),
     },
   };
 

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.test.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getValue, setValue, hasTemplateSnippet } from './utils';
+import { getValue, setValue, hasTemplateSnippet, convertProccesorsToJson } from './utils';
 
 describe('get and set values', () => {
   const testObject = Object.freeze([{ onFailure: [{ onFailure: 1 }] }]);
@@ -49,5 +49,25 @@ describe('template snippets', () => {
     expect(hasTemplateSnippet('hello{{{world}}}')).toBe(true);
     expect(hasTemplateSnippet('{{{hello}}}world')).toBe(true);
     expect(hasTemplateSnippet('{{{hello.world}}}')).toBe(true);
+  });
+});
+
+describe('convert processors to json', () => {
+  it('returns converted processors', () => {
+    const obj = {
+      field1: 'mustNotChange',
+      field2: 123,
+      field3: '{1: "mustNotChange"}',
+      value: '{"1": """aaa"bbb"""}',
+      customOptions: '{"customProcessor": """aaa"bbb"""}',
+    };
+
+    expect(convertProccesorsToJson(obj)).toEqual({
+      field1: 'mustNotChange',
+      field2: 123,
+      field3: '{1: "mustNotChange"}',
+      value: { 1: 'aaa"bbb' },
+      customProcessor: 'aaa"bbb',
+    });
   });
 });

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/utils.ts
@@ -119,3 +119,41 @@ export const hasTemplateSnippet = (str: string = '') => {
   //  * And followed by }}}
   return /{{{.+}}}/.test(str);
 };
+
+const escapeLiteralStrings = (data: string): string[] => {
+  const splitData = data.split(`"""`);
+  for (let i = 1; i < splitData.length - 1; i += 2) {
+    splitData[i] = JSON.stringify(splitData[i]);
+  }
+  return splitData;
+};
+
+const convertProcessorValueToJson = (data: string): any => {
+  if (!data) {
+    return undefined;
+  }
+
+  try {
+    const escapedData = escapeLiteralStrings(data);
+    return JSON.parse(escapedData.join(''));
+  } catch (error) {
+    return data;
+  }
+};
+
+const fieldToConvertToJson = ['value'];
+
+export const convertProccesorsToJson = (obj: { [key: string]: any }): { [key: string]: any } => {
+  return Object.fromEntries(
+    Object.entries(obj).flatMap(([key, value]) => {
+      if (key === 'customOptions') {
+        const convertedValue = convertProcessorValueToJson(value);
+        return Object.entries(convertedValue);
+      } else if (fieldToConvertToJson.includes(key)) {
+        return [[key, convertProcessorValueToJson(value)]];
+      } else {
+        return [[key, value]];
+      }
+    })
+  );
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.17` to `7.17`:
 - [fix: incorrect value field type in set processor (#227568)](https://github.com/elastic/kibana/pull/227568)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-14T12:24:15Z","message":"fix: incorrect value field type in set processor (#227568)\n\nCloses #193512\n\n## Summary\n\nThis PR fixes and issue where `value` field was always interpreted as a\nstring even when user entered numerical value. Originally those changes\nwere introduced in #200692 and #204336.","sha":"71c0c90e31ec7896700620443abadf959384050b","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","Feature:Ingest Node Pipelines","backport:version","v7.17.30","v8.17.9"],"title":"fix: incorrect value field type in set processor","number":227568,"url":"https://github.com/elastic/kibana/pull/227568","mergeCommit":{"message":"fix: incorrect value field type in set processor (#227568)\n\nCloses #193512\n\n## Summary\n\nThis PR fixes and issue where `value` field was always interpreted as a\nstring even when user entered numerical value. Originally those changes\nwere introduced in #200692 and #204336.","sha":"71c0c90e31ec7896700620443abadf959384050b"}},"sourceBranch":"8.17","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"7.17","label":"v7.17.30","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227568","number":227568,"mergeCommit":{"message":"fix: incorrect value field type in set processor (#227568)\n\nCloses #193512\n\n## Summary\n\nThis PR fixes and issue where `value` field was always interpreted as a\nstring even when user entered numerical value. Originally those changes\nwere introduced in #200692 and #204336.","sha":"71c0c90e31ec7896700620443abadf959384050b"}}]}] BACKPORT-->