### PR TITLE
[ML] Optimize the `ingest_pipelines` endpoint

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/ml_inference/hooks/use_fetch_pipelines.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/ml_inference/hooks/use_fetch_pipelines.ts
@@ -23,8 +23,7 @@ export const useFetchPipelines = () => {
     async function fetchPipelines() {
       let names: string[] = [];
       try {
-        const results = await getAllIngestPipelines();
-        names = Object.keys(results);
+        names = await getAllIngestPipelines();
         setPipelineNames(names);
       } catch (e) {
         toasts.danger({

--- a/x-pack/platform/plugins/shared/ml/public/application/services/ml_api_service/trained_models.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/services/ml_api_service/trained_models.ts
@@ -177,8 +177,8 @@ export function trainedModelsApiProvider(httpService: HttpService) {
     /**
      * Fetches all ingest pipelines
      */
-    getAllIngestPipelines() {
-      return httpService.http<NodesOverviewResponse>({
+    getAllIngestPipelines(): Promise<string[]> {
+      return httpService.http<string[]>({
         path: `${ML_INTERNAL_BASE_PATH}/trained_models/ingest_pipelines`,
         method: 'GET',
         version: '1',

--- a/x-pack/platform/plugins/shared/ml/server/models/model_management/models_provider.ts
+++ b/x-pack/platform/plugins/shared/ml/server/models/model_management/models_provider.ts
@@ -493,20 +493,13 @@ export class ModelsProvider {
    * Retrieves existing pipelines.
    *
    */
-  async getPipelines() {
-    let result = {};
-    try {
-      result = await this._client.asCurrentUser.ingest.getPipeline();
-    } catch (error) {
-      if (error.statusCode === 404) {
-        // ES returns 404 when there are no pipelines
-        // Instead, we should return an empty response and a 200
-        return result;
-      }
-      throw error;
-    }
+  async getPipelines(): Promise<string[]> {
+    const result = await this._client.asCurrentUser.ingest.getPipeline(
+      { summary: true },
+      { ignore: [404] }
+    );
 
-    return result;
+    return Object.keys(result);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/ml/server/models/model_management/models_provider.ts
+++ b/x-pack/platform/plugins/shared/ml/server/models/model_management/models_provider.ts
@@ -479,14 +479,10 @@ export class ModelsProvider {
    *
    */
   async createInferencePipeline(pipelineConfig: IngestPipeline, pipelineName: string) {
-    let result = {};
-
-    result = await this._client.asCurrentUser.ingest.putPipeline({
+    return await this._client.asCurrentUser.ingest.putPipeline({
       id: pipelineName,
       ...pipelineConfig,
     });
-
-    return result;
   }
 
   /**

--- a/x-pack/platform/test/api_integration/apis/ml/trained_models/create_inference_pipeline.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/trained_models/create_inference_pipeline.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { USER } from '../../../services/ml/security_common';
+import { getCommonRequestHeader } from '../../../services/ml/common_api';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+
+  let testModelIds: string[] = [];
+
+  describe('POST trained_models/create_inference_pipeline', () => {
+    before(async () => {
+      await ml.testResources.setKibanaTimeZoneToUTC();
+      testModelIds = await ml.api.createTestTrainedModels('regression', 1, false);
+    });
+
+    after(async () => {
+      // delete all created ingest pipelines
+      await Promise.all(testModelIds.map((modelId) => ml.api.deleteIngestPipeline(modelId)));
+      await ml.api.cleanMlIndices();
+    });
+
+    it('creates a pipeline', async () => {
+      const { body: createPipelineResponseBody, status: createPipelineStatus } = await supertest
+        .post(`/internal/ml/trained_models/create_inference_pipeline`)
+        .send({
+          pipelineName: 'pipeline_dfa_regression_model_n_0',
+          pipeline: {
+            processors: [
+              {
+                inference: {
+                  model_id: 'dfa_regression_model_n_0',
+                },
+              },
+            ],
+          },
+        })
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(200, createPipelineStatus, createPipelineResponseBody);
+
+      expect(createPipelineResponseBody).to.eql({ acknowledged: true });
+
+      // assert that the pipeline was created
+      const { body, status } = await supertest
+        .get(`/internal/ml/trained_models/dfa_regression_model_n_0/pipelines`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(200, status, body);
+
+      expect(body.length).to.eql(1);
+      expect(body[0].model_id).to.eql('dfa_regression_model_n_0');
+      expect(Object.keys(body[0].pipelines).length).to.eql(1);
+    });
+
+    it('returns an error in case user does not have required permission', async () => {
+      const { body, status } = await supertest
+        .post(`/internal/ml/trained_models/create_inference_pipeline`)
+        .send({
+          pipelineName: 'pipeline_dfa_regression_model_n_0',
+          pipeline: {
+            processors: [
+              {
+                inference: {
+                  model_id: 'dfa_regression_model_n_0',
+                },
+              },
+            ],
+          },
+        })
+        .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(403, status, body);
+    });
+  });
+};

--- a/x-pack/platform/test/api_integration/apis/ml/trained_models/get_all_pipelines.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/trained_models/get_all_pipelines.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { USER } from '../../../services/ml/security_common';
+import { getCommonRequestHeader } from '../../../services/ml/common_api';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+  let testModelIds: string[] = [];
+
+  describe('GET trained_models/ingest_pipelines', () => {
+    before(async () => {
+      await ml.testResources.setKibanaTimeZoneToUTC();
+      testModelIds = await ml.api.createTestTrainedModels('regression', 2, true);
+    });
+
+    after(async () => {
+      // delete all created ingest pipelines
+      await Promise.all(testModelIds.map((modelId) => ml.api.deleteIngestPipeline(modelId)));
+      await ml.api.cleanMlIndices();
+    });
+
+    it('returns pipeline ids only', async () => {
+      const { body, status } = await supertest
+        .get(`/internal/ml/trained_models/ingest_pipelines`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(200, status, body);
+
+      expect(body).to.contain('pipeline_dfa_regression_model_n_0');
+      expect(body).to.contain('pipeline_dfa_regression_model_n_1');
+    });
+
+    it('returns an error in case user does not have required permission', async () => {
+      const { body, status } = await supertest
+        .get(`/internal/ml/trained_models/ingest_pipelines`)
+        .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(403, status, body);
+    });
+  });
+};

--- a/x-pack/platform/test/api_integration/apis/ml/trained_models/index.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/trained_models/index.ts
@@ -9,6 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('trained models', function () {
+    this.tags(['dima']);
     loadTestFile(require.resolve('./trained_models_list'));
     loadTestFile(require.resolve('./get_models'));
     loadTestFile(require.resolve('./get_model_stats'));
@@ -17,5 +18,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./put_model'));
     loadTestFile(require.resolve('./start_stop_deployment'));
     loadTestFile(require.resolve('./model_downloads'));
+    loadTestFile(require.resolve('./get_all_pipelines'));
   });
 }

--- a/x-pack/platform/test/api_integration/apis/ml/trained_models/index.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/trained_models/index.ts
@@ -9,7 +9,6 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('trained models', function () {
-    this.tags(['dima']);
     loadTestFile(require.resolve('./trained_models_list'));
     loadTestFile(require.resolve('./get_models'));
     loadTestFile(require.resolve('./get_model_stats'));
@@ -19,5 +18,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./start_stop_deployment'));
     loadTestFile(require.resolve('./model_downloads'));
     loadTestFile(require.resolve('./get_all_pipelines'));
+    loadTestFile(require.resolve('./create_inference_pipeline'));
   });
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/209513

- Optimizes the `/trained_models/ingest_pipelines` endpoint by only fetching pipeline names 
- Adds API integration tests for `/trained_models/ingest_pipelines` and `/trained_models/create_inference_pipeline` endpoints


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->