### PR TITLE
[Docs] Add known issue about Dashboard Copy link action getting stuck

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -4,6 +4,24 @@ navigation_title: "Known issues"
 
 # Kibana known issues
 
+::::{dropdown} Dashboard **Copy link** doesn't work when sharing from a space other than the default space
+
+Applies to: {{stack}} 9.0.3
+
+**Details**
+
+When attempting to share a dashboard from a space that isn't the default space, the **Copy link** action never completes.
+
+**Action**
+
+To avoid this error, don't upgrade {{kib}} to {{stack}} 9.0.3 or upgrade {{kib}} to {{stack}} 9.0.4 when available.
+
+**Resolved**
+
+This issue is resolved in {{stack}} 9.0.4.
+
+::::
+
 ::::{dropdown} Upgrading Kibana from 8.18.x to 9.0.2 fails due to a configuration conflict in the kibana.yml file
 
 Applies to: {{stack}} 9.0.2

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -4,7 +4,7 @@ navigation_title: "Known issues"
 
 # Kibana known issues
 
-::::{dropdown} Dashboard **Copy link** doesn't work when sharing from a space other than the default space
+::::{dropdown} Dashboard Copy link doesn't work when sharing from a space other than the default space
 
 Applies to: {{stack}} 9.0.3
 


### PR DESCRIPTION
This PR adds a known issue about the dashboard Copy link action getting stuck when triggered from a non-default space in version 9.0.3

There will be different PRs for adding this known issue to 8.x and 7.x affected versions.

Closes: https://github.com/elastic/docs-content/issues/2133