### PR TITLE
[Security Assistant] Lift starter prompt feature flag

### DIFF
--- a/api_docs/kbn_elastic_assistant.devdocs.json
+++ b/api_docs/kbn_elastic_assistant.devdocs.json
@@ -1445,17 +1445,6 @@
             "path": "x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx",
             "deprecated": false,
             "trackAdoption": false
-          },
-          {
-            "parentPluginId": "@kbn/elastic-assistant",
-            "id": "def-public.AssistantAvailability.isStarterPromptsEnabled",
-            "type": "boolean",
-            "tags": [],
-            "label": "isStarterPromptsEnabled",
-            "description": [],
-            "path": "x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx",
-            "deprecated": false,
-            "trackAdoption": false
           }
         ],
         "initialIsOpen": false
@@ -2810,17 +2799,6 @@
             "type": "boolean",
             "tags": [],
             "label": "hasManageGlobalKnowledgeBase",
-            "description": [],
-            "path": "x-pack/platform/packages/shared/kbn-elastic-assistant/index.ts",
-            "deprecated": false,
-            "trackAdoption": false
-          },
-          {
-            "parentPluginId": "@kbn/elastic-assistant",
-            "id": "def-public.UseAssistantAvailability.isStarterPromptsEnabled",
-            "type": "boolean",
-            "tags": [],
-            "label": "isStarterPromptsEnabled",
             "description": [],
             "path": "x-pack/platform/packages/shared/kbn-elastic-assistant/index.ts",
             "deprecated": false,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/security_ai_prompts/use_find_prompts.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/security_ai_prompts/use_find_prompts.ts
@@ -39,7 +39,7 @@ export const useFindPrompts = (payload: UseFindPromptsParams) => {
   const { isAssistantEnabled, httpFetch, toasts } = payload.context;
 
   const QUERY = {
-    connector_id: payload.params.connector_id,
+    ...(payload.params.connector_id ? { connector_id: payload.params.connector_id } : {}),
     prompt_ids: payload.params.prompt_ids,
     prompt_group_id: payload.params.prompt_group_id,
   };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/empty_convo.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/empty_convo.tsx
@@ -89,15 +89,13 @@ export const EmptyConvo: React.FC<Props> = ({
           </EuiFlexGroup>
         </EuiPanel>
       </EuiFlexItem>
-      {assistantAvailability.isStarterPromptsEnabled && (
-        <EuiFlexItem grow={false} css={starterPromptWrapperClassName}>
-          <StarterPrompts
-            compressed={compressed}
-            connectorId={connectorId}
-            setUserPrompt={setUserPrompt}
-          />
-        </EuiFlexItem>
-      )}
+      <EuiFlexItem grow={false} css={starterPromptWrapperClassName}>
+        <StarterPrompts
+          compressed={compressed}
+          connectorId={connectorId}
+          setUserPrompt={setUserPrompt}
+        />
+      </EuiFlexItem>
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/empty_convo.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_body/empty_convo.tsx
@@ -11,7 +11,6 @@ import { css } from '@emotion/react';
 import { PromptResponse } from '@kbn/elastic-assistant-common';
 import { AssistantBeacon } from '@kbn/ai-assistant-icon';
 import { useVerticalBreakpoint } from './use_vertical_breakpoint';
-import { useAssistantContext } from '../../..';
 import { StarterPrompts } from './starter_prompts';
 import { SystemPrompt } from '../prompt_editor/system_prompt';
 import { SetupKnowledgeBaseButton } from '../../knowledge_base/setup_knowledge_base_button';
@@ -39,7 +38,6 @@ export const EmptyConvo: React.FC<Props> = ({
   setIsSettingsModalVisible,
   setUserPrompt,
 }) => {
-  const { assistantAvailability } = useAssistantContext();
   const breakpoint = useVerticalBreakpoint();
   const compressed = useMemo(() => breakpoint !== 'tall', [breakpoint]);
   return (

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx
@@ -78,7 +78,6 @@ export interface AssistantAvailability {
   hasUpdateAIAssistantAnonymization: boolean;
   // When true, user has `Edit` privilege for `Global Knowledge Base`
   hasManageGlobalKnowledgeBase: boolean;
-  isStarterPromptsEnabled: boolean;
 }
 
 export type GetAssistantMessages = (commentArgs: {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
@@ -42,7 +42,6 @@ export const mockAssistantAvailability: AssistantAvailability = {
   hasUpdateAIAssistantAnonymization: true,
   hasManageGlobalKnowledgeBase: true,
   isAssistantEnabled: true,
-  isStarterPromptsEnabled: true,
   isAssistantVisible: true,
 };
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/index.ts
@@ -203,6 +203,4 @@ export interface UseAssistantAvailability {
   hasUpdateAIAssistantAnonymization: boolean;
   // When true, user has `Edit` privilege for `Global Knowledge Base`
   hasManageGlobalKnowledgeBase: boolean;
-  // remove once product has signed off on prompt text
-  isStarterPromptsEnabled: boolean;
 }

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
@@ -59,7 +59,6 @@ const TestExternalProvidersComponent: React.FC<TestExternalProvidersProps> = ({ 
     hasUpdateAIAssistantAnonymization: true,
     hasManageGlobalKnowledgeBase: true,
     isAssistantEnabled: true,
-    isStarterPromptsEnabled: true,
     isAssistantVisible: true,
   };
   const queryClient = new QueryClient({

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/context/assistant_context/assistant_provider.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/context/assistant_context/assistant_provider.test.tsx
@@ -66,7 +66,6 @@ describe('AssistantProvider', () => {
           hasSearchAILakeConfigurations: expect.any(Boolean),
           hasUpdateAIAssistantAnonymization: expect.any(Boolean),
           isAssistantEnabled: expect.any(Boolean),
-          isStarterPromptsEnabled: expect.any(Boolean),
           isAssistantVisible: expect.any(Boolean),
         }),
         assistantFeatures: expect.objectContaining({

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/assistant_availability/use_assistant_availability.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/assistant_availability/use_assistant_availability.test.ts
@@ -75,7 +75,6 @@ describe('useAssistantAvailability', () => {
       hasConnectorsReadPrivilege: true,
       isAssistantEnabled: true,
       isAssistantVisible: true,
-      isStarterPromptsEnabled: true,
       hasUpdateAIAssistantAnonymization: true,
       hasManageGlobalKnowledgeBase: true,
     });
@@ -128,7 +127,6 @@ describe('useAssistantAvailability', () => {
       hasConnectorsReadPrivilege: true,
       isAssistantEnabled: true,
       isAssistantVisible: false,
-      isStarterPromptsEnabled: true,
       hasUpdateAIAssistantAnonymization: true,
       hasManageGlobalKnowledgeBase: true,
     });
@@ -174,7 +172,6 @@ describe('useAssistantAvailability', () => {
       hasConnectorsReadPrivilege: false,
       isAssistantEnabled: false,
       isAssistantVisible: false,
-      isStarterPromptsEnabled: false,
       hasUpdateAIAssistantAnonymization: false,
       hasManageGlobalKnowledgeBase: false,
     });
@@ -220,7 +217,6 @@ describe('useAssistantAvailability', () => {
       hasConnectorsReadPrivilege: true,
       isAssistantEnabled: true,
       isAssistantVisible: true,
-      isStarterPromptsEnabled: true,
       hasUpdateAIAssistantAnonymization: false,
       hasManageGlobalKnowledgeBase: false,
     });
@@ -251,7 +247,6 @@ describe('useAssistantAvailability', () => {
       hasConnectorsReadPrivilege: false,
       isAssistantEnabled: true,
       isAssistantVisible: true,
-      isStarterPromptsEnabled: true,
       hasUpdateAIAssistantAnonymization: false,
       hasManageGlobalKnowledgeBase: false,
     });

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/assistant_availability/use_assistant_availability.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/assistant_availability/use_assistant_availability.ts
@@ -13,13 +13,11 @@ import { useKibana } from '../../context/typed_kibana_context/typed_kibana_conte
 import { useLicense } from '../licence/use_licence';
 import { useIsNavControlVisible } from '../is_nav_control_visible/use_is_nav_control_visible';
 
-export const STARTER_PROMPTS_FEATURE_FLAG = 'elasticAssistant.starterPromptsEnabled' as const;
 export const useAssistantAvailability = (): UseAssistantAvailability => {
   const { isVisible } = useIsNavControlVisible();
   const isEnterprise = useLicense().isEnterprise();
   const {
     application: { capabilities },
-    featureFlags,
   } = useKibana().services;
 
   const hasAssistantPrivilege = capabilities[ASSISTANT_FEATURE_ID]?.['ai-assistant'] === true;
@@ -39,14 +37,11 @@ export const useAssistantAvailability = (): UseAssistantAvailability => {
     capabilities.actions?.delete === true &&
     capabilities.actions?.save === true;
 
-  const isStarterPromptsEnabled = featureFlags.getBooleanValue(STARTER_PROMPTS_FEATURE_FLAG, false);
-
   return {
     hasSearchAILakeConfigurations,
     hasAssistantPrivilege,
     hasConnectorsAllPrivilege,
     hasConnectorsReadPrivilege,
-    isStarterPromptsEnabled,
     isAssistantEnabled: isEnterprise,
     isAssistantVisible: isEnterprise && isVisible,
     hasUpdateAIAssistantAnonymization,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
@@ -41,7 +41,6 @@ export const MockAssistantProviderComponent: React.FC<Props> = ({
     hasManageGlobalKnowledgeBase: true,
     isAssistantEnabled: true,
     isAssistantVisible: true,
-    isStarterPromptsEnabled: true,
   };
   const chrome = chromeServiceMock.createStartContract();
   chrome.getChromeStyle$.mockReturnValue(of('classic'));


### PR DESCRIPTION
## Summary

As the "final" prompts were [added to the integration yesterday](https://github.com/elastic/integrations/pull/14536), we are ready to remove the feature flag for Starter Prompts 🎉 

## To test

1. Ensure you do not have the feature flag in your dev.yml (`feature_flags.overrides.elasticAssistant.starterPromptsEnabled: true`)
2. Run Kibana and open the Security Assistant
3. Ensure the starter prompts appear:
<img width="521" height="759" alt="Screenshot 2025-07-15 at 8 48 52 AM" src="https://github.com/user-attachments/assets/fc334d6a-30c3-4812-ad4d-97bccfe31d45" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->