### PR TITLE
[onechat] exclude rounds from conversation list endpoint

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
@@ -119,3 +119,5 @@ export interface Conversation {
   updated_at: string;
   rounds: ConversationRound[];
 }
+
+export type ConversationWithoutRounds = Omit<Conversation, 'rounds'>;

--- a/x-pack/platform/packages/shared/onechat/onechat-common/chat/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/chat/index.ts
@@ -11,6 +11,7 @@ export {
   type ToolCallWithResult,
   type ConversationRound,
   type Conversation,
+  type ConversationWithoutRounds,
   type ConversationRoundStepMixin,
   type ToolCallStep,
   type ConversationRoundStep,

--- a/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
@@ -65,6 +65,7 @@ export {
   type ToolCallWithResult,
   type ConversationRound,
   type Conversation,
+  type ConversationWithoutRounds,
   type ToolCallStep,
   type ConversationRoundStep,
   type ReasoningStepData,

--- a/x-pack/platform/plugins/shared/onechat/common/http_api/conversations.ts
+++ b/x-pack/platform/plugins/shared/onechat/common/http_api/conversations.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { Conversation } from '@kbn/onechat-common';
+import type { ConversationWithoutRounds } from '@kbn/onechat-common';
 
 export interface ListConversationsResponse {
-  results: Conversation[];
+  results: ConversationWithoutRounds[];
 }

--- a/x-pack/platform/plugins/shared/onechat/public/services/conversations/conversations_service.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/conversations/conversations_service.ts
@@ -6,7 +6,7 @@
  */
 
 import type { HttpSetup } from '@kbn/core-http-browser';
-import { Conversation } from '@kbn/onechat-common';
+import { Conversation, ConversationWithoutRounds } from '@kbn/onechat-common';
 import type { ListConversationsResponse } from '../../../common/http_api/conversations';
 import type {
   ConversationListOptions,
@@ -20,7 +20,7 @@ export class ConversationsService {
     this.http = http;
   }
 
-  async list({ agentId }: ConversationListOptions) {
+  async list({ agentId }: ConversationListOptions): Promise<ConversationWithoutRounds[]> {
     const response = await this.http.get<ListConversationsResponse>('/api/chat/conversations', {
       query: {
         agent_id: agentId,


### PR DESCRIPTION
## Summary

List conversation response should exclude `rounds` as this will make API calls heavy otherwise

See this comment: https://github.com/elastic/kibana/pull/227958/files#r2207443883

<img width="1460" height="720" alt="Screenshot 2025-07-15 at 16 52 41" src="https://github.com/user-attachments/assets/91b919f1-fb67-4fc2-8c07-1b3137494886" />
