### PR TITLE
[8.17] [Docs] Add known issue about Dashboard Copy link action getting stuck (#228024)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -98,9 +98,28 @@ include::upgrade-notes.asciidoc[]
 [[release-notes-8.17.8]]
 == {kib} 8.17.8
 
-The 8.17.8 release includes the following fixes.
+The 8.17.8 release includes the following fixes and known issues.
 
 IMPORTANT: The 8.17.8 release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory for more details].
+
+[float]
+[[known-issues-8.17.8]]
+=== Known issues
+
+// tag::known-issue-227976[]
+.Dashboard Copy link doesn't work when sharing from a space other than the default space
+[%collapsible]
+====
+**This issue is resolved in versions 8.19.0, 8.18.4, and 8.17.9** ({kibana-pull}227625[#227625]).
+
+*Details* +
+When attempting to share a dashboard from a space that isn't the default space, the **Copy link** action never completes.
+
+*Workaround* +
+To avoid this issue, don't upgrade {kib} to one of the affected versions, or upgrade to a higher version that includes a fix for it.
+
+====
+// end::known-issue-227976[]
 
 [float]
 [[fixes-v8.17.8]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.17`:
 - [[Docs] Add known issue about Dashboard Copy link action getting stuck (#228024)](https://github.com/elastic/kibana/pull/228024)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2025-07-15T15:00:37Z","message":"[Docs] Add known issue about Dashboard Copy link action getting stuck (#228024)\n\nThis PR adds a known issue about the dashboard Copy link action getting\nstuck when triggered from a non-default space in version 8.x\n\nequivalent of: https://github.com/elastic/kibana/pull/228005","sha":"cd3f44822a363371d5116f87a0de0deeb9023a13","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:version","v8.19.0","v8.18.4","v8.17.9"],"title":"[Docs] Add known issue about Dashboard Copy link action getting stuck","number":228024,"url":"https://github.com/elastic/kibana/pull/228024","mergeCommit":{"message":"[Docs] Add known issue about Dashboard Copy link action getting stuck (#228024)\n\nThis PR adds a known issue about the dashboard Copy link action getting\nstuck when triggered from a non-default space in version 8.x\n\nequivalent of: https://github.com/elastic/kibana/pull/228005","sha":"cd3f44822a363371d5116f87a0de0deeb9023a13"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228024","number":228024,"mergeCommit":{"message":"[Docs] Add known issue about Dashboard Copy link action getting stuck (#228024)\n\nThis PR adds a known issue about the dashboard Copy link action getting\nstuck when triggered from a non-default space in version 8.x\n\nequivalent of: https://github.com/elastic/kibana/pull/228005","sha":"cd3f44822a363371d5116f87a0de0deeb9023a13"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->