### PR TITLE
[Lens] Fix color mapping gradient picker UI

### DIFF
--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/color/color_handling.ts
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/color/color_handling.ts
@@ -192,7 +192,7 @@ export function getGradientColorScale(
           ),
         ]
       : colorMode.steps.map((d) => getColor(d, palettes));
-  steps.sort(() => (colorMode.sort === 'asc' ? -1 : 1));
+  if (colorMode.sort === 'asc') steps.reverse();
   const scale = chroma.scale(steps).mode('lab');
   return (value: number) => scale(value).hex();
 }

--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/color_picker/color_swatch.tsx
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/color_picker/color_swatch.tsx
@@ -76,6 +76,11 @@ export const ColorSwatch = ({
       repositionOnScroll={true}
       closePopover={() => dispatch(hideColorPickerVisibility())}
       anchorPosition="upLeft"
+      css={css`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      `}
       button={
         swatchShape === 'round' ? (
           <button

--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/palette_selector/gradient.tsx
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/palette_selector/gradient.tsx
@@ -96,7 +96,7 @@ export function Gradient({
         css={css`
           position: absolute;
           left: 0;
-          top: 6px;
+          top: 8px;
         `}
       >
         {startStepColor ? (


### PR DESCRIPTION
## Summary

Fixes reversed gradient on the Lens color mapping UI.

Fixes #227928

## Details

This was strange, for some reason on **Firefox** the `sort` call in the `getGradientColorScale` function does not mutate the array of `steps`. I'm not sure how this is isolated to this use case, maybe it's because the sort compare function has no params. In any case this is really a `reverse` operation not a `sort`.

Also fixed the misalignment of the `ColorSwatch` pickers, `EuiPopover` centering styles are not great here and use `vertical-alignment: middle` over more resident styles, see comments for details.

## Checklist

Check the PR satisfies following conditions. 

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->