### PR TITLE
[Security Assistant] `KnowledgeBaseRetrievalTool` and `AskAboutESQLTool` prompt updates

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/tool_prompts.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/tool_prompts.ts
@@ -70,8 +70,46 @@ Never use this tool when they user wants to generate a ES|QL for their data.`,
     promptId: 'KnowledgeBaseRetrievalTool',
     promptGroupId,
     prompt: {
-      default:
-        "Call this for fetching details from the user's knowledge base. The knowledge base contains useful information the user wants to store between conversation contexts. Call this function when the user asks for information about themself, like 'what is my favorite...' or 'using my saved....'. Input must always be the free-text query on a single line, with no other text. You are welcome to re-write the query to be a summary of items/things to search for in the knowledge base, as a vector search will be performed to return similar results when requested. If the results returned do not look relevant, disregard and tell the user you were unable to find the information they were looking for. All requests include a `knowledge history` section which includes some existing knowledge of the user. DO NOT CALL THIS FUNCTION if the `knowledge history` sections appears to be able to answer the user's query.",
+      default: `Call this tool to fetch information from the user's knowledge base. The knowledge base contains useful details the user has saved between conversation contexts.
+
+Use this tool **only in the following cases**:
+
+1. When the user asks a question about their personal, organizational, saved, or previously provided information/knowledge, such as:
+- "What was the detection rule I saved for unusual AWS API calls?"
+- "Using my saved investigation notes, what did I find about the incident last Thursday?"
+- "What are my preferred index patterns?"
+- "What did I say about isolating hosts?"
+- "What is my favorite coffee spot near the office?" *(non-security example)*
+
+2. Always call this tool when the user's query includes phrases like:**
+- "my favorite"
+- "what did I say about"
+- "my saved"
+- "my notes"
+- "my preferences"
+- "using my"
+- "what do I know about"
+- "based on my saved knowledge"
+
+3. When you need to retrieve saved information the user has stored in their knowledge base, whether it's security-related or not.
+
+**Do NOT call this tool if**:
+- The \`knowledge history\` section already answers the user's question.
+- The user's query is about general knowledge not specific to their saved information.
+
+**When calling this tool**:
+- Provide only the user's free-text query as the input, rephrased if helpful to clarify the search intent.
+- Format the input as a single, clean line of text.
+
+Example:
+- User query: "What did I note about isolating endpoints last week?"
+- Tool input: "User notes about isolating endpoints."
+
+If no relevant information is found, inform the user you could not locate the requested information.
+
+**Important**:
+- Always check the \`knowledge history\` section first for an answer.
+- Only call this tool if the user's query is explicitly about their own saved data or preferences.`,
     },
   },
   {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/tool_prompts.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/tool_prompts.ts
@@ -43,10 +43,10 @@ ALWAYS use this tool to generate ES|QL queries and never generate ES|QL any othe
     },
   },
   {
-    promptId: 'AskAboutEsqlTool',
+    promptId: 'AskAboutESQLTool',
     promptGroupId,
     prompt: {
-      default: `You MUST use the "AskAboutEsqlTool" function when the user:
+      default: `You MUST use the "AskAboutESQLTool" function when the user:
 - asks for help with ES|QL
 - asks about ES|QL syntax
 - asks for ES|QL examples

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.ts
@@ -20,8 +20,46 @@ const toolDetails = {
   // note: this description is overwritten when `getTool` is called
   // local definitions exist ../elastic_assistant/server/lib/prompt/tool_prompts.ts
   // local definitions can be overwritten by security-ai-prompt integration definitions
-  description:
-    "Call this for fetching details from the user's knowledge base. The knowledge base contains useful information the user wants to store between conversation contexts. Call this function when the user asks for information about themself, like 'what is my favorite...' or 'using my saved....'. Input must always be the free-text query on a single line, with no other text. You are welcome to re-write the query to be a summary of items/things to search for in the knowledge base, as a vector search will be performed to return similar results when requested. If the results returned do not look relevant, disregard and tell the user you were unable to find the information they were looking for. All requests include a `knowledge history` section which includes some existing knowledge of the user. DO NOT CALL THIS FUNCTION if the `knowledge history` sections appears to be able to answer the user's query.",
+  description: `Call this tool to fetch information from the user's knowledge base. The knowledge base contains useful details the user has saved between conversation contexts.
+
+Use this tool **only in the following cases**:
+
+1. When the user asks a question about their personal, organizational, saved, or previously provided information/knowledge, such as:
+- "What was the detection rule I saved for unusual AWS API calls?"
+- "Using my saved investigation notes, what did I find about the incident last Thursday?"
+- "What are my preferred index patterns?"
+- "What did I say about isolating hosts?"
+- "What is my favorite coffee spot near the office?" *(non-security example)*
+
+2. Always call this tool when the user's query includes phrases like:**
+- "my favorite"
+- "what did I say about"
+- "my saved"
+- "my notes"
+- "my preferences"
+- "using my"
+- "what do I know about"
+- "based on my saved knowledge"
+
+3. When you need to retrieve saved information the user has stored in their knowledge base, whether it's security-related or not.
+
+**Do NOT call this tool if**:
+- The \`knowledge history\` section already answers the user's question.
+- The user's query is about general knowledge not specific to their saved information.
+
+**When calling this tool**:
+- Provide only the user's free-text query as the input, rephrased if helpful to clarify the search intent.
+- Format the input as a single, clean line of text.
+
+Example:
+- User query: "What did I note about isolating endpoints last week?"
+- Tool input: "User notes about isolating endpoints."
+
+If no relevant information is found, inform the user you could not locate the requested information.
+
+**Important**:
+- Always check the \`knowledge history\` section first for an answer.
+- Only call this tool if the user's query is explicitly about their own saved data or preferences.`,
   id: 'knowledge-base-retrieval-tool',
   name: 'KnowledgeBaseRetrievalTool',
 };


### PR DESCRIPTION
## Summary

@spong and I iterated on the `KnowledgeBaseRetrievalTool` prompt as we noticed poor evals, especially for GPT-4.1. This prompt brings us to 100% correctness rate

Additionally, I noticed the following error:
```
[ERROR][plugins.elasticAssistant.defaultAssistantGraph] Failed to get prompt for tool: AskAboutESQLTool
```

At first I thought the prompt was missing, but it turns out it was a capitalization mismatch (`AskAboutEsqlTool` vs `AskAboutESQLTool`). The capitalization is corrected in this PR, and here in the integrations repo: https://github.com/elastic/integrations/pull/14555

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->