### PR TITLE
chore(NA): mute additional sass-warnings

### DIFF
--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -224,7 +224,7 @@ export function getWebpackConfig(
                       includePaths: [Path.resolve(worker.repoRoot, 'node_modules')],
                       sourceMap: true,
                       quietDeps: true,
-                      silenceDeprecations: ['import', 'legacy-js-api'],
+                      silenceDeprecations: ['color-functions', 'import', 'global-builtin', 'legacy-js-api'],
                     },
                   },
                 },

--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -224,7 +224,12 @@ export function getWebpackConfig(
                       includePaths: [Path.resolve(worker.repoRoot, 'node_modules')],
                       sourceMap: true,
                       quietDeps: true,
-                      silenceDeprecations: ['color-functions', 'import', 'global-builtin', 'legacy-js-api'],
+                      silenceDeprecations: [
+                        'color-functions',
+                        'import',
+                        'global-builtin',
+                        'legacy-js-api',
+                      ],
                     },
                   },
                 },


### PR DESCRIPTION
Follow up of https://github.com/elastic/kibana/pull/225061

A new set of sass warnings start reporting. This PR mute those as well

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->