### PR TITLE
[DataView] Fix flyout styles

### DIFF
--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -263,73 +263,71 @@ const IndexPatternEditorFlyoutContentComponent = ({
 
   return (
     <FlyoutPanels.Group flyoutClassName={'indexPatternEditorFlyout'} maxWidth={1180}>
-      <FlyoutPanels.Item
-        css={styles.flyoutPanel}
-        data-test-subj="indexPatternEditorFlyout"
-        border="right"
-      >
-        <EuiTitle data-test-subj="flyoutTitle">
-          <h2>{editData ? editorTitleEditMode : editorTitle}</h2>
-        </EuiTitle>
-        {showManagementLink && editData && editData.id && (
-          <EuiLink
-            href={application.getUrlForApp('management', {
-              path: `/kibana/dataViews/dataView/${editData.id}`,
-            })}
+      <FlyoutPanels.Item data-test-subj="indexPatternEditorFlyout" border="right">
+        <FlyoutPanels.Content>
+          <EuiTitle data-test-subj="flyoutTitle">
+            <h2>{editData ? editorTitleEditMode : editorTitle}</h2>
+          </EuiTitle>
+          {showManagementLink && editData && editData.id && (
+            <EuiLink
+              href={application.getUrlForApp('management', {
+                path: `/kibana/dataViews/dataView/${editData.id}`,
+              })}
+            >
+              {i18n.translate('indexPatternEditor.goToManagementPage', {
+                defaultMessage: 'Manage settings and view field details',
+              })}
+            </EuiLink>
+          )}
+          <Form
+            form={form}
+            css={styles.patternEditorForm}
+            error={form.getErrors()}
+            isInvalid={form.isSubmitted && !form.isValid && form.getErrors().length}
+            data-validation-error={form.getErrors().length ? '1' : '0'}
+            data-test-subj="indexPatternEditorForm"
           >
-            {i18n.translate('indexPatternEditor.goToManagementPage', {
-              defaultMessage: 'Manage settings and view field details',
-            })}
-          </EuiLink>
-        )}
-        <Form
-          form={form}
-          css={styles.patternEditorForm}
-          error={form.getErrors()}
-          isInvalid={form.isSubmitted && !form.isValid && form.getErrors().length}
-          data-validation-error={form.getErrors().length ? '1' : '0'}
-          data-test-subj="indexPatternEditorForm"
-        >
-          <UseField path="isAdHoc" />
-          {indexPatternTypeSelect}
-          <EuiSpacer size="l" />
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <NameField namesNotAllowed={existingDataViewNames || []} />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="l" />
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <TitleField
-                isRollup={form.getFields().type?.value === INDEX_PATTERN_TYPE.ROLLUP}
-                matchedIndices$={dataViewEditorService.matchedIndices$}
-                rollupIndicesCapabilities={rollupIndicesCapabilities}
-                indexPatternValidationProvider={
-                  dataViewEditorService.indexPatternValidationProvider
-                }
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="l" />
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <TimestampField
-                options$={dataViewEditorService.timestampFieldOptions$}
-                isLoadingOptions$={dataViewEditorService.loadingTimestampFields$}
-                matchedIndices$={dataViewEditorService.matchedIndices$}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <AdvancedParamsContent
-            disableAllowHidden={type === INDEX_PATTERN_TYPE.ROLLUP}
-            disableId={!!editData}
-            onAllowHiddenChange={() => {
-              form.getFields().title.validate();
-            }}
-            defaultVisible={editData?.getAllowHidden()}
-          />
-        </Form>
+            <UseField path="isAdHoc" />
+            {indexPatternTypeSelect}
+            <EuiSpacer size="l" />
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <NameField namesNotAllowed={existingDataViewNames || []} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="l" />
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <TitleField
+                  isRollup={form.getFields().type?.value === INDEX_PATTERN_TYPE.ROLLUP}
+                  matchedIndices$={dataViewEditorService.matchedIndices$}
+                  rollupIndicesCapabilities={rollupIndicesCapabilities}
+                  indexPatternValidationProvider={
+                    dataViewEditorService.indexPatternValidationProvider
+                  }
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="l" />
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <TimestampField
+                  options$={dataViewEditorService.timestampFieldOptions$}
+                  isLoadingOptions$={dataViewEditorService.loadingTimestampFields$}
+                  matchedIndices$={dataViewEditorService.matchedIndices$}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <AdvancedParamsContent
+              disableAllowHidden={type === INDEX_PATTERN_TYPE.ROLLUP}
+              disableId={!!editData}
+              onAllowHiddenChange={() => {
+                form.getFields().title.validate();
+              }}
+              defaultVisible={editData?.getAllowHidden()}
+            />
+          </Form>
+        </FlyoutPanels.Content>
         <Footer
           onCancel={onCancel}
           onSubmit={async (adhoc?: boolean) => {
@@ -376,10 +374,6 @@ const IndexPatternEditorFlyoutContentComponent = ({
 const componentStyles = {
   patternEditorForm: css({
     flexGrow: 1,
-  }),
-  flyoutPanel: css({
-    display: 'flex',
-    flexDirection: 'column',
   }),
   loadingWrapper: ({ euiTheme }: UseEuiTheme) =>
     css({

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -265,22 +265,20 @@ const IndexPatternEditorFlyoutContentComponent = ({
     <FlyoutPanels.Group flyoutClassName={'indexPatternEditorFlyout'} maxWidth={1180}>
       <FlyoutPanels.Item data-test-subj="indexPatternEditorFlyout" border="right">
         <FlyoutPanels.Content>
-          <FlyoutPanels.Header>
-            <EuiTitle data-test-subj="flyoutTitle">
-              <h2>{editData ? editorTitleEditMode : editorTitle}</h2>
-            </EuiTitle>
-            {showManagementLink && editData && editData.id && (
-              <EuiLink
-                href={application.getUrlForApp('management', {
-                  path: `/kibana/dataViews/dataView/${editData.id}`,
-                })}
-              >
-                {i18n.translate('indexPatternEditor.goToManagementPage', {
-                  defaultMessage: 'Manage settings and view field details',
-                })}
-              </EuiLink>
-            )}
-          </FlyoutPanels.Header>
+          <EuiTitle data-test-subj="flyoutTitle">
+            <h2>{editData ? editorTitleEditMode : editorTitle}</h2>
+          </EuiTitle>
+          {showManagementLink && editData && editData.id && (
+            <EuiLink
+              href={application.getUrlForApp('management', {
+                path: `/kibana/dataViews/dataView/${editData.id}`,
+              })}
+            >
+              {i18n.translate('indexPatternEditor.goToManagementPage', {
+                defaultMessage: 'Manage settings and view field details',
+              })}
+            </EuiLink>
+          )}
           <Form
             form={form}
             css={styles.patternEditorForm}

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -265,20 +265,22 @@ const IndexPatternEditorFlyoutContentComponent = ({
     <FlyoutPanels.Group flyoutClassName={'indexPatternEditorFlyout'} maxWidth={1180}>
       <FlyoutPanels.Item data-test-subj="indexPatternEditorFlyout" border="right">
         <FlyoutPanels.Content>
-          <EuiTitle data-test-subj="flyoutTitle">
-            <h2>{editData ? editorTitleEditMode : editorTitle}</h2>
-          </EuiTitle>
-          {showManagementLink && editData && editData.id && (
-            <EuiLink
-              href={application.getUrlForApp('management', {
-                path: `/kibana/dataViews/dataView/${editData.id}`,
-              })}
-            >
-              {i18n.translate('indexPatternEditor.goToManagementPage', {
-                defaultMessage: 'Manage settings and view field details',
-              })}
-            </EuiLink>
-          )}
+          <FlyoutPanels.Header>
+            <EuiTitle data-test-subj="flyoutTitle">
+              <h2>{editData ? editorTitleEditMode : editorTitle}</h2>
+            </EuiTitle>
+            {showManagementLink && editData && editData.id && (
+              <EuiLink
+                href={application.getUrlForApp('management', {
+                  path: `/kibana/dataViews/dataView/${editData.id}`,
+                })}
+              >
+                {i18n.translate('indexPatternEditor.goToManagementPage', {
+                  defaultMessage: 'Manage settings and view field details',
+                })}
+              </EuiLink>
+            )}
+          </FlyoutPanels.Header>
           <Form
             form={form}
             css={styles.patternEditorForm}

--- a/src/platform/plugins/shared/data_view_editor/public/components/footer/footer.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/footer/footer.tsx
@@ -9,7 +9,6 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 
 import {
   EuiFlyoutFooter,
@@ -17,9 +16,7 @@ import {
   EuiFlexItem,
   EuiButtonEmpty,
   EuiButton,
-  type UseEuiTheme,
 } from '@elastic/eui';
-import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 
 export enum SubmittingType {
   savingAsAdHoc = 'savingAsAdHoc',
@@ -70,7 +67,6 @@ export const Footer = ({
   isPersisted,
   canSave,
 }: FooterProps) => {
-  const styles = useMemoCss(componentStyles);
   const isEditingAdHoc = isEdit && !isPersisted;
   const submitPersisted = () => {
     onSubmit(false);
@@ -80,7 +76,7 @@ export const Footer = ({
   };
 
   return (
-    <EuiFlyoutFooter css={styles.footer}>
+    <EuiFlyoutFooter>
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty
@@ -138,12 +134,4 @@ export const Footer = ({
       </EuiFlexGroup>
     </EuiFlyoutFooter>
   );
-};
-
-const componentStyles = {
-  footer: ({ euiTheme }: UseEuiTheme) =>
-    css({
-      marginLeft: -euiTheme.size.l,
-      marginRight: -euiTheme.size.l,
-    }),
 };

--- a/src/platform/plugins/shared/data_view_editor/public/components/footer/footer.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/footer/footer.tsx
@@ -90,7 +90,7 @@ export const Footer = ({
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="s" alignItems="center">
+          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="s" alignItems="center" wrap>
             {allowAdHoc && (
               <EuiFlexItem grow={false}>
                 <EuiButton


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/227951

## Summary

Before:
<img width="1508" height="792" alt="Screenshot 2025-07-15 at 11 09 01" src="https://github.com/user-attachments/assets/4108c6af-0303-46df-8444-cf865c03714a" />

After:
<img width="1719" height="810" alt="Screenshot 2025-07-16 at 11 13 25" src="https://github.com/user-attachments/assets/7e4cfd2d-a37b-492b-ac62-ec8e95d1d746" />




### Checklist


- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->