### PR TITLE
chore(NA): auto codeowners update correctly updated for cases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -435,7 +435,7 @@ src/platform/packages/shared/kbn-babel-register @elastic/kibana-operations
 src/platform/packages/shared/kbn-cache-cli @elastic/kibana-operations
 src/platform/packages/shared/kbn-calculate-auto @elastic/obs-ux-management-team
 src/platform/packages/shared/kbn-calculate-width-from-char-count @elastic/kibana-visualizations
-src/platform/packages/shared/kbn-cases-components @elastic/response-ops
+src/platform/packages/shared/kbn-cases-components @elastic/kibana-cases
 src/platform/packages/shared/kbn-cbor @elastic/kibana-operations
 src/platform/packages/shared/kbn-cell-actions @elastic/security-threat-hunting-investigations
 src/platform/packages/shared/kbn-chart-icons @elastic/kibana-visualizations
@@ -944,7 +944,7 @@ x-pack/platform/plugins/shared/aiops @elastic/ml-ui
 x-pack/platform/plugins/shared/alerting @elastic/response-ops
 x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-ux-infra_services-team
 x-pack/platform/plugins/shared/automatic_import @elastic/security-scalability
-x-pack/platform/plugins/shared/cases @elastic/response-ops @elastic/kibana-cases
+x-pack/platform/plugins/shared/cases @elastic/kibana-cases
 x-pack/platform/plugins/shared/cloud @elastic/kibana-core
 x-pack/platform/plugins/shared/content_connectors @elastic/search-kibana
 x-pack/platform/plugins/shared/dashboard_enhanced @elastic/kibana-presentation
@@ -996,16 +996,16 @@ x-pack/platform/test/alerting_api_integration/common/plugins/alerts_restricted @
 x-pack/platform/test/alerting_api_integration/common/plugins/task_manager_fixture @elastic/response-ops
 x-pack/platform/test/alerting_api_integration/packages/helpers @elastic/response-ops
 x-pack/platform/test/api_integration/apis/entity_manager/fixture_plugin @elastic/obs-entities
-x-pack/platform/test/cases_api_integration/common/plugins/cases @elastic/response-ops
-x-pack/platform/test/cases_api_integration/common/plugins/observability @elastic/response-ops
-x-pack/platform/test/cases_api_integration/common/plugins/security_solution @elastic/response-ops
+x-pack/platform/test/cases_api_integration/common/plugins/cases @elastic/kibana-cases
+x-pack/platform/test/cases_api_integration/common/plugins/observability @elastic/kibana-cases
+x-pack/platform/test/cases_api_integration/common/plugins/security_solution @elastic/kibana-cases
 x-pack/platform/test/cloud_integration/plugins/saml_provider @elastic/kibana-core
 x-pack/platform/test/encrypted_saved_objects_api_integration/plugins/api_consumer_plugin @elastic/kibana-security
 x-pack/platform/test/functional_cors/plugins/kibana_cors_test @elastic/kibana-security
 x-pack/platform/test/functional_embedded/plugins/iframe_embedded @elastic/kibana-core
 x-pack/platform/test/functional_execution_context/plugins/alerts @elastic/kibana-core
 x-pack/platform/test/functional_with_es_ssl/plugins/alerts @elastic/response-ops
-x-pack/platform/test/functional_with_es_ssl/plugins/cases @elastic/response-ops
+x-pack/platform/test/functional_with_es_ssl/plugins/cases @elastic/kibana-cases
 x-pack/platform/test/licensing_plugin/plugins/test_feature_usage @elastic/kibana-security
 x-pack/platform/test/plugin_api_integration/plugins/elasticsearch_client @elastic/kibana-core
 x-pack/platform/test/plugin_api_integration/plugins/event_log @elastic/response-ops

--- a/src/platform/packages/shared/kbn-cases-components/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-cases-components/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/cases-components",
   "owner": [
-    "@elastic/response-ops"
+    "@elastic/kibana-cases"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/platform/plugins/shared/cases/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/cases/kibana.jsonc
@@ -2,7 +2,6 @@
   "type": "plugin",
   "id": "@kbn/cases-plugin",
   "owner": [
-    "@elastic/response-ops",
     "@elastic/kibana-cases"
   ],
   "group": "platform",

--- a/x-pack/platform/test/cases_api_integration/common/plugins/cases/kibana.jsonc
+++ b/x-pack/platform/test/cases_api_integration/common/plugins/cases/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/cases-api-integration-test-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": "@elastic/kibana-cases",
   "plugin": {
     "id": "casesApiIntegrationTestPlugin",
     "server": true,

--- a/x-pack/platform/test/cases_api_integration/common/plugins/observability/kibana.jsonc
+++ b/x-pack/platform/test/cases_api_integration/common/plugins/observability/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-fixtures-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": "@elastic/kibana-cases",
   "plugin": {
     "id": "observabilityFixtures",
     "server": true,

--- a/x-pack/platform/test/cases_api_integration/common/plugins/security_solution/kibana.jsonc
+++ b/x-pack/platform/test/cases_api_integration/common/plugins/security_solution/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/security-solution-fixtures-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": "@elastic/kibana-cases",
   "plugin": {
     "id": "securitySolutionFixtures",
     "server": true,

--- a/x-pack/platform/test/functional_with_es_ssl/plugins/cases/kibana.jsonc
+++ b/x-pack/platform/test/functional_with_es_ssl/plugins/cases/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/functional-with-es-ssl-cases-test-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": "@elastic/kibana-cases",
   "plugin": {
     "id": "functionalWithEsSslCasesTestPlugin",
     "server": true,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/pull/225216

Follow up and fix for https://github.com/elastic/kibana/pull/226891

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->