### PR TITLE
[8.19] [Security Assistant] Enable `InferenceChatModel` by default (#227856)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2814,10 +2814,3 @@ x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics
 # See https://github.com/elastic/kibana/pull/199404
 # Prevent backport assignments
 * @kibanamachine
-####
-## These rules are always last so they take ultimate priority over everything else
-####
-
-# See https://github.com/elastic/kibana/pull/199404
-# Prevent backport assignments
-* @kibanamachine

--- a/api_docs/kbn_elastic_assistant_common.devdocs.json
+++ b/api_docs/kbn_elastic_assistant_common.devdocs.json
@@ -2696,6 +2696,23 @@
         "signature": [
           "{ type: \"index\"; name: string; index: string; description: string; field: string; queryDescription: string; namespace?: string | undefined; users?: { id?: string | undefined; name?: string | undefined; }[] | undefined; inputSchema?: { description: string; fieldName: string; fieldType: string; }[] | undefined; outputFields?: string[] | undefined; }"
         ],
+        "path": "x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/knowledge_base/entries/common_attributes.gen.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/elastic-assistant-common",
+        "id": "def-common.INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG",
+        "type": "string",
+        "tags": [],
+        "label": "INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG",
+        "description": [
+          "\nThis feature flag disables the InferenceChatModel feature.\n\nIt may be overridden via the following setting in `kibana.yml` or `kibana.dev.yml`:\n```\nfeature_flags.overrides:\n  securitySolution.inferenceChatModelDisabled: true\n```"
+        ],
+        "signature": [
+          "\"securitySolution.inferenceChatModelDisabled\""
+        ],
         "path": "x-pack/packages/kbn-elastic-assistant-common/impl/schemas/knowledge_base/entries/common_attributes.gen.ts",
         "deprecated": false,
         "trackAdoption": false,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
@@ -128,16 +128,16 @@ export const ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX =
   '.alerts-security.attack.discovery.alerts' as const;
 
 /**
- * This feature flag enables the InferenceChatModel feature.
+ * This feature flag disables the InferenceChatModel feature.
  *
  * It may be overridden via the following setting in `kibana.yml` or `kibana.dev.yml`:
  * ```
  * feature_flags.overrides:
- *   securitySolution.inferenceChatModelEnabled: true
+ *   securitySolution.inferenceChatModelDisabled: true
  * ```
  */
-export const INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG =
-  'securitySolution.inferenceChatModelEnabled' as const;
+export const INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG =
+  'securitySolution.inferenceChatModelDisabled' as const;
 
 /**
  * The server timeout is set to 4 minutes to allow for long-running requests.

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
@@ -61,7 +61,7 @@ export interface AgentExecutorParams<T extends boolean> {
   llmType?: string;
   isOssModel?: boolean;
   inference: InferenceServerStart;
-  inferenceChatModelEnabled?: boolean;
+  inferenceChatModelDisabled?: boolean;
   logger: Logger;
   onNewReplacements?: (newReplacements: Replacements) => void;
   replacements: Replacements;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/agentRunnable.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/agentRunnable.ts
@@ -27,7 +27,7 @@ export const agentRunnableFactory = async ({
   llm,
   llmType,
   tools,
-  inferenceChatModelEnabled,
+  inferenceChatModelDisabled,
   isOpenAI,
   isStream,
   prompt,
@@ -37,7 +37,7 @@ export const agentRunnableFactory = async ({
     | ActionsClientChatVertexAI
     | ActionsClientChatOpenAI
     | InferenceChatModel;
-  inferenceChatModelEnabled: boolean;
+  inferenceChatModelDisabled: boolean;
   isOpenAI: boolean;
   llmType: string | undefined;
   tools: StructuredToolInterface[] | ToolDefinition[];
@@ -51,7 +51,7 @@ export const agentRunnableFactory = async ({
     prompt,
   } as const;
 
-  if (!inferenceChatModelEnabled && (isOpenAI || llmType === 'inference')) {
+  if (inferenceChatModelDisabled && (isOpenAI || llmType === 'inference')) {
     return createOpenAIToolsAgent(params);
   }
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
@@ -26,7 +26,7 @@ interface StreamGraphParams {
   apmTracer: APMTracer;
   assistantGraph: DefaultAssistantGraph;
   inputs: GraphInputs;
-  inferenceChatModelEnabled?: boolean;
+  inferenceChatModelDisabled?: boolean;
   isEnabledKnowledgeBase: boolean;
   logger: Logger;
   onLlmResponse?: OnLlmResponse;
@@ -54,7 +54,7 @@ export const streamGraph = async ({
   apmTracer,
   assistantGraph,
   inputs,
-  inferenceChatModelEnabled = false,
+  inferenceChatModelDisabled = false,
   isEnabledKnowledgeBase,
   logger,
   onLlmResponse,
@@ -108,7 +108,7 @@ export const streamGraph = async ({
 
   // Stream is from tool calling agent or structured chat agent
   if (
-    inferenceChatModelEnabled ||
+    !inferenceChatModelDisabled ||
     inputs.isOssModel ||
     inputs?.llmType === 'bedrock' ||
     inputs?.llmType === 'gemini'

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
@@ -67,6 +67,7 @@ describe('callAssistantGraph', () => {
     saved_objects: [],
   });
   const mockLogger = loggerMock.create();
+  const getChatModel = jest.fn();
   const defaultParams = {
     actionsClient: actionsClientMock.create(),
     alertsIndexPattern: 'test-pattern',
@@ -75,7 +76,10 @@ describe('callAssistantGraph', () => {
     conversationId: 'test-conversation',
     dataClients: mockDataClients,
     esClient: elasticsearchClientMock.createScopedClusterClient().asCurrentUser,
-    inference: {},
+    inference: {
+      getChatModel,
+    },
+    inferenceChatModelDisabled: true,
     langChainMessages: [{ content: 'test message' }],
     llmTasks: { retrieveDocumentationAvailable: jest.fn(), retrieveDocumentation: jest.fn() },
     llmType: 'openai',
@@ -121,217 +125,286 @@ describe('callAssistantGraph', () => {
     );
     getPromptMock.mockResolvedValue('prompt');
   });
+  describe('inferenceChatModelDisabled = true', () => {
+    it('calls invokeGraph with correct parameters for non-streaming', async () => {
+      const result = await callAssistantGraph(defaultParams);
 
-  it('calls invokeGraph with correct parameters for non-streaming', async () => {
-    const result = await callAssistantGraph(defaultParams);
-
-    expect(invokeGraph).toHaveBeenCalledWith(
-      expect.objectContaining({
-        inputs: expect.objectContaining({
-          input: 'test message',
-        }),
-      })
-    );
-    expect(result.body).toEqual({
-      connector_id: 'test-connector',
-      data: 'test-output',
-      trace_data: {},
-      replacements: [],
-      status: 'ok',
-      conversationId: 'new-conversation-id',
-    });
-  });
-
-  it('calls streamGraph with correct parameters for streaming', async () => {
-    const params = { ...defaultParams, isStream: true };
-    await callAssistantGraph(params);
-
-    expect(streamGraph).toHaveBeenCalledWith(
-      expect.objectContaining({
-        inputs: expect.objectContaining({
-          input: 'test message',
-        }),
-      })
-    );
-  });
-
-  it('calls getDefaultAssistantGraph without signal for openai', async () => {
-    await callAssistantGraph(defaultParams);
-    expect(getDefaultAssistantGraphMock.mock.calls[0][0]).not.toHaveProperty('signal');
-  });
-
-  it('calls getDefaultAssistantGraph with signal for bedrock', async () => {
-    await callAssistantGraph({ ...defaultParams, llmType: 'bedrock' });
-    expect(getDefaultAssistantGraphMock.mock.calls[0][0]).toHaveProperty('signal');
-  });
-
-  it('handles error when anonymizationFieldsDataClient.findDocuments fails', async () => {
-    (mockDataClients?.anonymizationFieldsDataClient?.findDocuments as jest.Mock).mockRejectedValue(
-      new Error('test error')
-    );
-
-    await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
-  });
-
-  it('handles error when kbDataClient.isInferenceEndpointExists fails', async () => {
-    (mockDataClients?.kbDataClient?.isInferenceEndpointExists as jest.Mock).mockRejectedValue(
-      new Error('test error')
-    );
-
-    await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
-  });
-
-  it('returns correct response when no conversationId is returned', async () => {
-    (invokeGraph as jest.Mock).mockResolvedValue({ output: 'test-output', traceData: {} });
-
-    const result = await callAssistantGraph(defaultParams);
-
-    expect(result.body).toEqual({
-      connector_id: 'test-connector',
-      data: 'test-output',
-      trace_data: {},
-      replacements: [],
-      status: 'ok',
-    });
-  });
-
-  it('calls getPrompt for each tool and the default system prompt', async () => {
-    const params = {
-      ...defaultParams,
-      assistantTools: [
-        { ...mockTool, name: 'test-tool' },
-        { ...mockTool, name: 'test-tool2' },
-      ],
-    };
-    await callAssistantGraph(params);
-
-    expect(getPromptMock).toHaveBeenCalledTimes(3);
-    expect(getPromptMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'test-model',
-        provider: 'openai',
-        promptId: 'test-tool',
-        promptGroupId: toolsGroupId,
-      })
-    );
-    expect(getPromptMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'test-model',
-        provider: 'openai',
-        promptId: 'test-tool2',
-        promptGroupId: toolsGroupId,
-      })
-    );
-    expect(getPromptMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'test-model',
-        provider: 'openai',
-        promptId: promptDictionary.systemPrompt,
-        promptGroupId: promptGroupId.aiAssistant,
-      })
-    );
-
-    expect(getTool).toHaveBeenCalledWith(
-      expect.objectContaining({
-        description: 'prompt',
-      })
-    );
-  });
-
-  it('Passes only Elastic tools, not custom, to Telemetry tracer', async () => {
-    await callAssistantGraph({
-      ...defaultParams,
-      assistantTools: [
-        { ...mockTool, name: 'test-tool', getTool: getTool.mockReturnValue({ name: 'test-tool' }) },
-        {
-          ...mockTool,
-          name: 'test-tool2',
-          getTool: getTool.mockReturnValue({ name: 'test-tool2' }),
-        },
-      ],
-    });
-    expect(telemetryTracerMock).toHaveBeenCalledWith(
-      {
-        elasticTools: ['test-tool2', 'test-tool2'],
-        telemetry: {},
-        telemetryParams: {},
-      },
-      {
-        ...mockLogger,
-        context: ['defaultAssistantGraph'],
-      }
-    );
-  });
-
-  describe('agentRunnable', () => {
-    it('creates OpenAIToolsAgent for openai llmType', async () => {
-      const params = { ...defaultParams, llmType: 'openai' };
-      await callAssistantGraph(params);
-
-      expect(createOpenAIToolsAgent).toHaveBeenCalled();
-      expect(createToolCallingAgent).not.toHaveBeenCalled();
-    });
-
-    it('creates OpenAIToolsAgent for inference llmType', async () => {
-      defaultParams.actionsClient.get = jest.fn().mockResolvedValue({
-        config: {
-          provider: 'elastic',
-          providerConfig: { model_id: 'rainbow-sprinkles' },
-        },
+      expect(invokeGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
+      expect(result.body).toEqual({
+        connector_id: 'test-connector',
+        data: 'test-output',
+        trace_data: {},
+        replacements: [],
+        status: 'ok',
+        conversationId: 'new-conversation-id',
       });
-      const params = { ...defaultParams, llmType: 'inference' };
-      await callAssistantGraph(params);
-
-      expect(createOpenAIToolsAgent).toHaveBeenCalled();
-      expect(createToolCallingAgent).not.toHaveBeenCalled();
     });
 
-    it('creates ToolCallingAgent for bedrock llmType', async () => {
-      const params = { ...defaultParams, llmType: 'bedrock' };
+    it('calls streamGraph with correct parameters for streaming', async () => {
+      const params = { ...defaultParams, isStream: true };
       await callAssistantGraph(params);
 
-      expect(createToolCallingAgent).toHaveBeenCalled();
-      expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      expect(streamGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
     });
 
-    it('creates ToolCallingAgent for gemini llmType', async () => {
+    it('calls getDefaultAssistantGraph without signal for openai', async () => {
+      await callAssistantGraph(defaultParams);
+      expect(getDefaultAssistantGraphMock.mock.calls[0][0]).not.toHaveProperty('signal');
+    });
+
+    it('calls getDefaultAssistantGraph with signal for bedrock', async () => {
+      await callAssistantGraph({ ...defaultParams, llmType: 'bedrock' });
+      expect(getDefaultAssistantGraphMock.mock.calls[0][0]).toHaveProperty('signal');
+    });
+
+    it('handles error when anonymizationFieldsDataClient.findDocuments fails', async () => {
+      (
+        mockDataClients?.anonymizationFieldsDataClient?.findDocuments as jest.Mock
+      ).mockRejectedValue(new Error('test error'));
+
+      await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
+    });
+
+    it('handles error when kbDataClient.isInferenceEndpointExists fails', async () => {
+      (mockDataClients?.kbDataClient?.isInferenceEndpointExists as jest.Mock).mockRejectedValue(
+        new Error('test error')
+      );
+
+      await expect(callAssistantGraph(defaultParams)).rejects.toThrow('test error');
+    });
+
+    it('returns correct response when no conversationId is returned', async () => {
+      (invokeGraph as jest.Mock).mockResolvedValue({ output: 'test-output', traceData: {} });
+
+      const result = await callAssistantGraph(defaultParams);
+
+      expect(result.body).toEqual({
+        connector_id: 'test-connector',
+        data: 'test-output',
+        trace_data: {},
+        replacements: [],
+        status: 'ok',
+      });
+    });
+
+    it('calls getPrompt for each tool and the default system prompt', async () => {
       const params = {
         ...defaultParams,
-        request: {
-          body: { model: 'gemini-1.5-flash' },
-        } as unknown as AgentExecutorParams<boolean>['request'],
-        llmType: 'gemini',
+        assistantTools: [
+          { ...mockTool, name: 'test-tool' },
+          { ...mockTool, name: 'test-tool2' },
+        ],
       };
       await callAssistantGraph(params);
 
-      expect(createToolCallingAgent).toHaveBeenCalled();
-      expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      expect(getPromptMock).toHaveBeenCalledTimes(3);
+      expect(getPromptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          provider: 'openai',
+          promptId: 'test-tool',
+          promptGroupId: toolsGroupId,
+        })
+      );
+      expect(getPromptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          provider: 'openai',
+          promptId: 'test-tool2',
+          promptGroupId: toolsGroupId,
+        })
+      );
+      expect(getPromptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          provider: 'openai',
+          promptId: promptDictionary.systemPrompt,
+          promptGroupId: promptGroupId.aiAssistant,
+        })
+      );
+
+      expect(getTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'prompt',
+        })
+      );
     });
 
-    it('creates ToolCallingAgent for oss model', async () => {
-      const params = { ...defaultParams, llmType: 'openai', isOssModel: true };
-      await callAssistantGraph(params);
-
-      expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
-      expect(createToolCallingAgent).toHaveBeenCalled();
+    it('Passes only Elastic tools, not custom, to Telemetry tracer', async () => {
+      await callAssistantGraph({
+        ...defaultParams,
+        assistantTools: [
+          {
+            ...mockTool,
+            name: 'test-tool',
+            getTool: getTool.mockReturnValue({ name: 'test-tool' }),
+          },
+          {
+            ...mockTool,
+            name: 'test-tool2',
+            getTool: getTool.mockReturnValue({ name: 'test-tool2' }),
+          },
+        ],
+      });
+      expect(telemetryTracerMock).toHaveBeenCalledWith(
+        {
+          elasticTools: ['test-tool2', 'test-tool2'],
+          telemetry: {},
+          telemetryParams: {},
+        },
+        {
+          ...mockLogger,
+          context: ['defaultAssistantGraph'],
+        }
+      );
     });
-    it('does not calls resolveProviderAndModel when llmType === openai', async () => {
-      const params = { ...defaultParams, llmType: 'openai' };
-      await callAssistantGraph(params);
 
-      expect(resolveProviderAndModelMock).not.toHaveBeenCalled();
+    describe('agentRunnable', () => {
+      it('creates OpenAIToolsAgent for openai llmType', async () => {
+        const params = { ...defaultParams, llmType: 'openai' };
+        await callAssistantGraph(params);
+
+        expect(createOpenAIToolsAgent).toHaveBeenCalled();
+        expect(createToolCallingAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates OpenAIToolsAgent for inference llmType', async () => {
+        defaultParams.actionsClient.get = jest.fn().mockResolvedValue({
+          config: {
+            provider: 'elastic',
+            providerConfig: { model_id: 'rainbow-sprinkles' },
+          },
+        });
+        const params = { ...defaultParams, llmType: 'inference' };
+        await callAssistantGraph(params);
+
+        expect(createOpenAIToolsAgent).toHaveBeenCalled();
+        expect(createToolCallingAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for bedrock llmType', async () => {
+        const params = { ...defaultParams, llmType: 'bedrock' };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for gemini llmType', async () => {
+        const params = {
+          ...defaultParams,
+          request: {
+            body: { model: 'gemini-1.5-flash' },
+          } as unknown as AgentExecutorParams<boolean>['request'],
+          llmType: 'gemini',
+        };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for oss model', async () => {
+        const params = { ...defaultParams, llmType: 'openai', isOssModel: true };
+        await callAssistantGraph(params);
+
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+        expect(createToolCallingAgent).toHaveBeenCalled();
+      });
+      it('does not calls resolveProviderAndModel when llmType === openai', async () => {
+        const params = { ...defaultParams, llmType: 'openai' };
+        await callAssistantGraph(params);
+
+        expect(resolveProviderAndModelMock).not.toHaveBeenCalled();
+      });
+      it('calls resolveProviderAndModel when llmType === inference', async () => {
+        const params = { ...defaultParams, llmType: 'inference' };
+        await callAssistantGraph(params);
+
+        expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      });
+      it('calls resolveProviderAndModel when llmType === undefined', async () => {
+        const params = { ...defaultParams, llmType: undefined };
+        await callAssistantGraph(params);
+
+        expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      });
     });
-    it('calls resolveProviderAndModel when llmType === inference', async () => {
-      const params = { ...defaultParams, llmType: 'inference' };
-      await callAssistantGraph(params);
+  });
+  describe('inferenceChatModelDisabled = false', () => {
+    const newDefaultParams = {
+      ...defaultParams,
+      inferenceChatModelDisabled: false,
+    };
+    it('calls invokeGraph with correct parameters for non-streaming', async () => {
+      const result = await callAssistantGraph(newDefaultParams);
 
-      expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      expect(invokeGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
+      expect(result.body).toEqual({
+        connector_id: 'test-connector',
+        data: 'test-output',
+        trace_data: {},
+        replacements: [],
+        status: 'ok',
+        conversationId: 'new-conversation-id',
+      });
+      expect(getChatModel).toHaveBeenCalled();
     });
-    it('calls resolveProviderAndModel when llmType === undefined', async () => {
-      const params = { ...defaultParams, llmType: undefined };
+
+    it('calls streamGraph with correct parameters for streaming', async () => {
+      const params = { ...newDefaultParams, isStream: true };
       await callAssistantGraph(params);
 
-      expect(resolveProviderAndModelMock).toHaveBeenCalled();
+      expect(streamGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputs: expect.objectContaining({
+            input: 'test message',
+          }),
+        })
+      );
+      expect(getChatModel).toHaveBeenCalled();
+    });
+
+    describe('agentRunnable', () => {
+      it('creates ToolCallingAgent for openai llmType', async () => {
+        const params = { ...newDefaultParams, llmType: 'openai' };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates ToolCallingAgent for inference llmType', async () => {
+        newDefaultParams.actionsClient.get = jest.fn().mockResolvedValue({
+          config: {
+            provider: 'elastic',
+            providerConfig: { model_id: 'rainbow-sprinkles' },
+          },
+        });
+        const params = { ...newDefaultParams, llmType: 'inference' };
+        await callAssistantGraph(params);
+
+        expect(createToolCallingAgent).toHaveBeenCalled();
+        expect(createOpenAIToolsAgent).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
@@ -42,7 +42,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
   dataClients,
   esClient,
   inference,
-  inferenceChatModelEnabled = false,
+  inferenceChatModelDisabled = false,
   langChainMessages,
   llmTasks,
   llmType,
@@ -76,7 +76,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
    * the state unintentionally. For this reason, only call createLlmInstance at runtime
    */
   const createLlmInstance = async () =>
-    inferenceChatModelEnabled
+    !inferenceChatModelDisabled
       ? inference.getChatModel({
           request,
           connectorId,
@@ -231,7 +231,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
     llm,
     llmType,
     tools,
-    inferenceChatModelEnabled,
+    inferenceChatModelDisabled,
     isOpenAI,
     isStream,
     prompt: chatPromptTemplate,
@@ -306,7 +306,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
       apmTracer,
       assistantGraph,
       inputs,
-      inferenceChatModelEnabled,
+      inferenceChatModelDisabled,
       isEnabledKnowledgeBase: telemetryParams?.isEnabledKnowledgeBase ?? false,
 
       logger,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
@@ -22,7 +22,7 @@ import {
   INTERNAL_API_ACCESS,
   PostEvaluateBody,
   PostEvaluateResponse,
-  INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+  INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
 } from '@kbn/elastic-assistant-common';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
 import { getDefaultArguments } from '@kbn/langchain/server';
@@ -176,8 +176,8 @@ export const postEvaluateRoute = (
             (await ctx.elasticAssistant.llmTasks.retrieveDocumentationAvailable()) ?? false;
 
           const { featureFlags } = await context.core;
-          const inferenceChatModelEnabled = await featureFlags.getBooleanValue(
-            INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+          const inferenceChatModelDisabled = await featureFlags.getBooleanValue(
+            INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
             false
           );
 
@@ -274,7 +274,7 @@ export const postEvaluateRoute = (
               const isOpenAI = llmType === 'openai' && !isOssModel;
               const llmClass = getLlmClass(llmType);
               const createLlmInstance = async () =>
-                inferenceChatModelEnabled
+                !inferenceChatModelDisabled
                   ? inference.getChatModel({
                       request,
                       connectorId: connector.id,
@@ -420,7 +420,7 @@ export const postEvaluateRoute = (
               const agentRunnable = await agentRunnableFactory({
                 llm: chatModel,
                 llmType,
-                inferenceChatModelEnabled,
+                inferenceChatModelDisabled,
                 isOpenAI,
                 tools,
                 isStream: false,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
@@ -235,7 +235,7 @@ export interface LangChainExecuteParams {
   contentReferencesStore: ContentReferencesStore;
   llmTasks?: LlmTasksPluginStart;
   inference: InferenceServerStart;
-  inferenceChatModelEnabled?: boolean;
+  inferenceChatModelDisabled?: boolean;
   isOssModel?: boolean;
   conversationId?: string;
   context: AwaitedProperties<
@@ -266,7 +266,7 @@ export const langChainExecute = async ({
   actionTypeId,
   connectorId,
   contentReferencesStore,
-  inferenceChatModelEnabled,
+  inferenceChatModelDisabled,
   isOssModel,
   context,
   actionsClient,
@@ -335,7 +335,7 @@ export const langChainExecute = async ({
     esClient,
     llmTasks,
     inference,
-    inferenceChatModelEnabled,
+    inferenceChatModelDisabled,
     isStream,
     llmType: getLlmType(actionTypeId),
     isOssModel,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -19,7 +19,7 @@ import {
   pruneContentReferences,
   ExecuteConnectorRequestQuery,
   POST_ACTIONS_CONNECTOR_EXECUTE,
-  INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+  INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
 } from '@kbn/elastic-assistant-common';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
 import { getPrompt } from '../lib/prompt';
@@ -82,9 +82,9 @@ export const postActionsConnectorExecuteRoute = (
         let onLlmResponse;
 
         const coreContext = await context.core;
-        const inferenceChatModelEnabled =
+        const inferenceChatModelDisabled =
           (await coreContext?.featureFlags?.getBooleanValue(
-            INFERENCE_CHAT_MODEL_ENABLED_FEATURE_FLAG,
+            INFERENCE_CHAT_MODEL_DISABLED_FEATURE_FLAG,
             false
           )) ?? false;
 
@@ -190,7 +190,7 @@ export const postActionsConnectorExecuteRoute = (
             connectorId,
             contentReferencesStore,
             isOssModel,
-            inferenceChatModelEnabled,
+            inferenceChatModelDisabled,
             conversationId,
             context: ctx,
             logger,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Assistant] Enable `InferenceChatModel` by default (#227856)](https://github.com/elastic/kibana/pull/227856)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Steph Milovic","email":"stephanie.milovic@elastic.co"},"sourceCommit":{"committedDate":"2025-07-15T23:11:15Z","message":"[Security Assistant] Enable `InferenceChatModel` by default (#227856)","sha":"63bde264707b4dcdbe06e4c06cb8136ee2cfea37","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","ci:cloud-deploy","Team:Security Generative AI","backport:version","v9.1.0","v8.19.0","ci:security-genai-run-evals","v9.2.0"],"title":"[Security Assistant] Enable `InferenceChatModel` by default","number":227856,"url":"https://github.com/elastic/kibana/pull/227856","mergeCommit":{"message":"[Security Assistant] Enable `InferenceChatModel` by default (#227856)","sha":"63bde264707b4dcdbe06e4c06cb8136ee2cfea37"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/228113","number":228113,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227856","number":227856,"mergeCommit":{"message":"[Security Assistant] Enable `InferenceChatModel` by default (#227856)","sha":"63bde264707b4dcdbe06e4c06cb8136ee2cfea37"}}]}] BACKPORT-->