### PR TITLE
[8.19] Fix auto commits codeowners (#228121)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2814,10 +2814,3 @@ x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics
 # See https://github.com/elastic/kibana/pull/199404
 # Prevent backport assignments
 * @kibanamachine
-####
-## These rules are always last so they take ultimate priority over everything else
-####
-
-# See https://github.com/elastic/kibana/pull/199404
-# Prevent backport assignments
-* @kibanamachine


### PR DESCRIPTION
# Backport

Related to #228110 / #228093

This will backport the following commits from `9.0` to `8.19`:
 - [Fix auto commits codeowners (#228121)](https://github.com/elastic/kibana/pull/228121)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-16T04:32:21Z","message":"Fix auto commits codeowners (#228121)\n\n## Summary\n\nRelated to #228109\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cc83a497b679b52d06b81a3e5d443b8c5ca63fec","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:version","v8.18.0","v8.19.0"],"title":"Fix auto commits codeowners","number":228121,"url":"https://github.com/elastic/kibana/pull/228121","mergeCommit":{"message":"Fix auto commits codeowners (#228121)\n\n## Summary\n\nRelated to #228109\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cc83a497b679b52d06b81a3e5d443b8c5ca63fec"}},"sourceBranch":"9.0","suggestedTargetBranches":["8.18","8.19"],"targetPullRequestStates":[{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->