### PR TITLE
[9.1] [ES|QL] Fixes wrong validation on expressions between aggregations (#227989)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands_helpers.ts
@@ -50,10 +50,17 @@ export function checkFunctionContent(arg: ESQLFunction) {
     return true;
   }
   return (arg as ESQLFunction).args.every(
-    (subArg): boolean =>
-      isLiteralItem(subArg) ||
-      isAggregation(subArg) ||
-      (isNotAnAggregation(subArg) ? checkFunctionContent(subArg) : false)
+    (subArg): boolean => {
+       // Differentiate between array and non-array arguments
+      if (Array.isArray(subArg)) {
+        return subArg.every((item) => checkFunctionContent(item as ESQLFunction));
+      }
+      return (
+        isLiteralItem(subArg) ||
+        isAggregation(subArg) ||
+        (isNotAnAggregation(subArg) ? checkFunctionContent(subArg) : false)
+      );
+    }
   );
 }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands_helpers.ts
@@ -49,19 +49,17 @@ export function checkFunctionContent(arg: ESQLFunction) {
   if (isAggregation(arg) || isFunctionOperatorParam(arg)) {
     return true;
   }
-  return (arg as ESQLFunction).args.every(
-    (subArg): boolean => {
-       // Differentiate between array and non-array arguments
-      if (Array.isArray(subArg)) {
-        return subArg.every((item) => checkFunctionContent(item as ESQLFunction));
-      }
-      return (
-        isLiteralItem(subArg) ||
-        isAggregation(subArg) ||
-        (isNotAnAggregation(subArg) ? checkFunctionContent(subArg) : false)
-      );
+  return (arg as ESQLFunction).args.every((subArg): boolean => {
+    // Differentiate between array and non-array arguments
+    if (Array.isArray(subArg)) {
+      return subArg.every((item) => checkFunctionContent(item as ESQLFunction));
     }
-  );
+    return (
+      isLiteralItem(subArg) ||
+      isAggregation(subArg) ||
+      (isNotAnAggregation(subArg) ? checkFunctionContent(subArg) : false)
+    );
+  });
 }
 
 export function checkAggExistence(arg: ESQLFunction): boolean {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.stats.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.stats.ts
@@ -83,7 +83,7 @@ export const validationStatsCommandTestSuite = (setup: helpers.Setup) => {
             await expectErrors(
               'from a_index | STATS sum(doubleField) / (min(doubleField) + max(doubleField))  ',
               []
-        );
+            );
           });
 
           test('errors on each aggregation field, which does not contain at least one agg function', async () => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.stats.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.stats.ts
@@ -79,6 +79,11 @@ export const validationStatsCommandTestSuite = (setup: helpers.Setup) => {
             await expectErrors('from a_index | STATS abs( doubleField + sum( doubleField )) ', [
               'Cannot combine aggregation and non-aggregation values in [STATS], found [abs(doubleField+sum(doubleField))]',
             ]);
+            // This is a valid expression as it is an operation on two aggregation functions
+            await expectErrors(
+              'from a_index | STATS sum(doubleField) / (min(doubleField) + max(doubleField))  ',
+              []
+        );
           });
 
           test('errors on each aggregation field, which does not contain at least one agg function', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ES|QL] Fixes wrong validation on expressions between aggregations (#227989)](https://github.com/elastic/kibana/pull/227989)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-07-16T04:50:55Z","message":"[ES|QL] Fixes wrong validation on expressions between aggregations (#227989)\n\n## Summary\n\nFixes wrong client side validation error in expressions between\naggregations\n\nBefore\n<img width=\"3196\" height=\"542\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/512f0b2c-b64f-40c9-aa08-645f3f312bc6\"\n/>\n\n\nAfter\n<img width=\"1598\" height=\"186\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d47b1888-4ae9-4f9c-b474-383dede4b3d0\"\n/>\n\n\n### Checklist\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c027ebd64fb5819c224d6735e8edc11783211a1","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[ES|QL] Fixes wrong validation on expressions between aggregations","number":227989,"url":"https://github.com/elastic/kibana/pull/227989","mergeCommit":{"message":"[ES|QL] Fixes wrong validation on expressions between aggregations (#227989)\n\n## Summary\n\nFixes wrong client side validation error in expressions between\naggregations\n\nBefore\n<img width=\"3196\" height=\"542\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/512f0b2c-b64f-40c9-aa08-645f3f312bc6\"\n/>\n\n\nAfter\n<img width=\"1598\" height=\"186\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d47b1888-4ae9-4f9c-b474-383dede4b3d0\"\n/>\n\n\n### Checklist\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c027ebd64fb5819c224d6735e8edc11783211a1"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227989","number":227989,"mergeCommit":{"message":"[ES|QL] Fixes wrong validation on expressions between aggregations (#227989)\n\n## Summary\n\nFixes wrong client side validation error in expressions between\naggregations\n\nBefore\n<img width=\"3196\" height=\"542\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/512f0b2c-b64f-40c9-aa08-645f3f312bc6\"\n/>\n\n\nAfter\n<img width=\"1598\" height=\"186\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d47b1888-4ae9-4f9c-b474-383dede4b3d0\"\n/>\n\n\n### Checklist\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c027ebd64fb5819c224d6735e8edc11783211a1"}}]}] BACKPORT-->