### PR TITLE
[Discover] Remove github project assignment for the deleted project

### DIFF
--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           issue-mappings: |
             [
-              {"label": "Team:DataDiscovery", "projectNumber": 44, "columnName": "Inbox"},
               {"label": "Feature:Canvas", "projectNumber": 38, "columnName": "Inbox"},
               {"label": "Feature:Dashboard", "projectNumber": 68, "columnName": "Inbox"},
               {"label": "Feature:Drilldowns", "projectNumber": 68, "columnName": "Inbox"},


### PR DESCRIPTION
That project was closed long time ago. The setting is only sending notifications about failed actions like https://github.com/elastic/kibana/actions/runs/16291146845

Suggestion: we might also want to remove `project-assigner` workflow completely since the new github projects provide other methods of automation in comparison with "classic" projects.
