### PR TITLE
[AI4SOC] Remove unsupported gap columns from the rules table in AI4SOC

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/promotion_rules/promotion_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/promotion_rules/promotion_rules_table.tsx
@@ -31,9 +31,7 @@ import {
   LAST_EXECUTION_COLUMN,
   RULE_NAME_COLUMN,
   SEARCH_DURATION_COLUMN,
-  TOTAL_UNFILLED_DURATION_COLUMN,
   useEnabledColumn,
-  useGapDurationColumn,
   useRuleExecutionStatusColumn,
 } from '../../../detection_engine/rule_management_ui/components/rules_table/use_columns';
 import { useUserData } from '../../../detections/components/user_info';
@@ -194,7 +192,6 @@ const useRulesColumns = ({ currentTab }: ColumnsProps): Array<EuiBasicTableColum
     isLoadingJobs: false,
     mlJobs: [],
   });
-  const gapDurationColumn = useGapDurationColumn();
 
   return useMemo(() => {
     if (currentTab === PromotionRuleTabs.monitoring) {
@@ -202,12 +199,10 @@ const useRulesColumns = ({ currentTab }: ColumnsProps): Array<EuiBasicTableColum
         {
           ...RULE_NAME_COLUMN,
           render: (value: Rule['name']) => <EuiText size="s">{value}</EuiText>,
-          width: '30%',
+          width: '38%',
         } as EuiBasicTableColumn<Rule>,
         INDEXING_DURATION_COLUMN,
         SEARCH_DURATION_COLUMN,
-        gapDurationColumn,
-        TOTAL_UNFILLED_DURATION_COLUMN,
         LAST_EXECUTION_COLUMN,
         executionStatusColumn,
         enabledColumn,
@@ -224,5 +219,5 @@ const useRulesColumns = ({ currentTab }: ColumnsProps): Array<EuiBasicTableColum
       executionStatusColumn,
       enabledColumn,
     ];
-  }, [currentTab, enabledColumn, executionStatusColumn, gapDurationColumn]);
+  }, [currentTab, enabledColumn, executionStatusColumn]);
 };


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/227314**

## Summary

In the AI4SOC tier, the feature for Rule Gaps Monitoring and Mitigation is not available. However, the Rule Monitoring table under the Configurations → Rules section still displays the following gap-related columns:
- Last Gap (if any)
- Unfilled gaps duration

These columns have been removed in this PR.

**Before**

<img width="1635" height="271" alt="image" src="https://github.com/user-attachments/assets/6e45d435-c650-4335-8fc2-5651c49703d3" />

**After**

<img width="1631" height="255" alt="image" src="https://github.com/user-attachments/assets/48bce224-154a-4c13-877f-ab80301c3a8f" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->