### PR TITLE
[AI4DSOC] Change rule to integration matching logic to use rule_id field instead of id

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.tsx
@@ -32,7 +32,7 @@ const INTEGRATIONS_BUTTON = i18n.translate(
   }
 );
 
-export const FILTER_KEY = 'signal.rule.id';
+export const FILTER_KEY = 'signal.rule.rule_id';
 
 export interface IntegrationFilterButtonProps {
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_aggregations.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_aggregations.test.tsx
@@ -8,8 +8,8 @@
 import { groupStatsAggregations } from './group_stats_aggregations';
 
 describe('groupStatsAggregations', () => {
-  it('should return values depending for signal.rule.id input field', () => {
-    const aggregations = groupStatsAggregations('signal.rule.id');
+  it('should return values depending for signal.rule.rule_id input field', () => {
+    const aggregations = groupStatsAggregations('signal.rule.rule_id');
     expect(aggregations).toEqual([
       {
         unitsCount: {
@@ -48,7 +48,7 @@ describe('groupStatsAggregations', () => {
       {
         signalRuleIdSubAggregation: {
           terms: {
-            field: 'signal.rule.id',
+            field: 'signal.rule.rule_id',
           },
         },
       },
@@ -75,7 +75,7 @@ describe('groupStatsAggregations', () => {
       {
         signalRuleIdSubAggregation: {
           terms: {
-            field: 'signal.rule.id',
+            field: 'signal.rule.rule_id',
           },
         },
       },
@@ -102,7 +102,7 @@ describe('groupStatsAggregations', () => {
       {
         signalRuleIdSubAggregation: {
           terms: {
-            field: 'signal.rule.id',
+            field: 'signal.rule.rule_id',
           },
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_aggregations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_aggregations.ts
@@ -15,7 +15,7 @@ import {
 const RULE_SIGNAL_ID_SUB_AGGREGATION = {
   signalRuleIdSubAggregation: {
     terms: {
-      field: 'signal.rule.id',
+      field: 'signal.rule.rule_id',
     },
   },
 };
@@ -23,7 +23,7 @@ const RULE_SIGNAL_ID_SUB_AGGREGATION = {
 /**
  * Returns aggregations to be used to calculate the statistics to be used in the`extraAction` property of the EuiAccordion component.
  * It handles custom renders for the following fields:
- * - signal.rule.id
+ * - signal.rule.rule_id
  * - kibana.alert.severity
  * - kibana.alert.rule.name
  * And returns a default set of aggregation for all the other fields.
@@ -34,7 +34,7 @@ export const groupStatsAggregations = (field: string): NamedAggregation[] => {
   const aggMetrics: NamedAggregation[] = DEFAULT_GROUP_STATS_AGGREGATION('');
 
   switch (field) {
-    case 'signal.rule.id':
+    case 'signal.rule.rule_id':
       aggMetrics.push(SEVERITY_SUB_AGGREGATION, RULE_COUNT_AGGREGATION);
       break;
     case 'kibana.alert.severity':

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_renderers.test.tsx
@@ -137,8 +137,8 @@ describe('groupStatsRenderer', () => {
     jest.clearAllMocks();
   });
 
-  it('should return array of badges for signal.rule.id field', () => {
-    const badges = groupStatsRenderer('signal.rule.id', {
+  it('should return array of badges for signal.rule.rule_id field', () => {
+    const badges = groupStatsRenderer('signal.rule.rule_id', {
       key: '',
       severitiesSubAggregation: { buckets: [{ key: 'medium', doc_count: 10 }] },
       rulesCountAggregation: { value: 3 },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_stats_renderers.tsx
@@ -89,7 +89,7 @@ export const getIntegrationComponent = (
 /**
  * Returns stats to be used in the`extraAction` property of the EuiAccordion component used within the kbn-grouping package.
  * It handles custom renders for the following fields:
- * - signal.rule.id
+ * - signal.rule.rule_id
  * - kibana.alert.severity
  * - kibana.alert.rule.name
  * And returns a default view for all the other fields.
@@ -106,7 +106,7 @@ export const groupStatsRenderer = (
   const rulesBadge: GroupStatsItem = getRulesBadge(bucket);
 
   switch (selectedGroup) {
-    case 'signal.rule.id':
+    case 'signal.rule.rule_id':
       return [...severityComponent, rulesBadge, ...defaultBadges];
     case 'kibana.alert.severity':
       return [...integrationComponent, rulesBadge, ...defaultBadges];

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_title_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_title_renderers.test.tsx
@@ -42,7 +42,7 @@ describe('groupTitleRenderers', () => {
     (usePackageIconType as jest.Mock).mockReturnValue('iconType');
   });
 
-  it('should render correctly for signal.rule.id field', () => {
+  it('should render correctly for signal.rule.rule_id field', () => {
     (useTableSectionContext as jest.Mock).mockReturnValue({
       packages: [],
       ruleResponse: { isLoading: false },
@@ -51,7 +51,7 @@ describe('groupTitleRenderers', () => {
 
     const { getByTestId } = render(
       groupTitleRenderers(
-        'signal.rule.id',
+        'signal.rule.rule_id',
         {
           key: ['rule_id'],
           doc_count: 10,
@@ -183,7 +183,7 @@ describe('IntegrationNameGroupContent', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should render loading for signal.rule.id field when rule and packages are loading', () => {
+  it('should render loading for signal.rule.rule_id field when rule and packages are loading', () => {
     (useTableSectionContext as jest.Mock).mockReturnValue({
       packages: [],
       ruleResponse: { isLoading: true },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_title_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/group_title_renderers.tsx
@@ -19,7 +19,7 @@ import { firstNonNullValue } from '../../../../../common/endpoint/models/ecs_saf
 /**
  * Returns renderers to be used in the `buttonContent` property of the EuiAccordion component used within the kbn-grouping package.
  * It handles custom renders for the following fields:
- * - signal.rule.id
+ * - signal.rule.rule_id
  * - kibana.alert.rule.name
  * - host.name
  * - user.name
@@ -34,7 +34,7 @@ export const groupTitleRenderers: GroupPanelRenderer<AlertsGroupingAggregation> 
   nullGroupMessage
 ) => {
   switch (selectedGroup) {
-    case 'signal.rule.id':
+    case 'signal.rule.rule_id':
       return <IntegrationNameGroupContent title={bucket.key} />;
     case 'kibana.alert.rule.name':
       return isArray(bucket.key) ? (

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/grouping_options.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/grouping_options.tsx
@@ -26,7 +26,7 @@ const RULE_NAME = i18n.translate('xpack.securitySolution.alertsTable.groups.rule
 /**
  * Returns a list of fields for the default grouping options. These are displayed in the `Group alerts by` dropdown button.
  * The default values are:
- * - signal.rule.id
+ * - signal.rule.rule_id
  * - kibana.alert.severity
  * - kibana.alert.rule.name
  *
@@ -35,7 +35,7 @@ const RULE_NAME = i18n.translate('xpack.securitySolution.alertsTable.groups.rule
 export const groupingOptions: GroupOption[] = [
   {
     label: INTEGRATION_NAME,
-    key: 'signal.rule.id',
+    key: 'signal.rule.rule_id',
   },
   {
     label: SEVERITY,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/kibana_alert_related_integrations_cell_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/kibana_alert_related_integrations_cell_renderer.test.tsx
@@ -12,7 +12,6 @@ import {
   KibanaAlertRelatedIntegrationsCellRenderer,
   TABLE_RELATED_INTEGRATION_CELL_RENDERER_TEST_ID,
 } from './kibana_alert_related_integrations_cell_renderer';
-import { ALERT_RULE_PARAMETERS } from '@kbn/rule-data-utils';
 import {
   INTEGRATION_ICON_TEST_ID,
   INTEGRATION_LOADING_SKELETON_TEST_ID,
@@ -20,67 +19,43 @@ import {
 import { installationStatuses } from '@kbn/fleet-plugin/common/constants';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import { usePackageIconType } from '@kbn/fleet-plugin/public/hooks';
+import type { RuleResponse } from '../../../../../common/api/detection_engine';
+import { useGetIntegrationFromRuleId } from '../../../hooks/alert_summary/use_get_integration_from_rule_id';
 
 jest.mock('@kbn/fleet-plugin/public/hooks');
+jest.mock('../../../hooks/alert_summary/use_get_integration_from_rule_id');
 
 const LOADING_SKELETON_TEST_ID = `${TABLE_RELATED_INTEGRATION_CELL_RENDERER_TEST_ID}-${INTEGRATION_LOADING_SKELETON_TEST_ID}`;
 const ICON_TEST_ID = `${TABLE_RELATED_INTEGRATION_CELL_RENDERER_TEST_ID}-${INTEGRATION_ICON_TEST_ID}`;
+
+const alert: Alert = {
+  _id: '_id',
+  _index: '_index',
+};
+const packages: PackageListItem[] = [];
+const rules: RuleResponse[] = [];
 
 describe('KibanaAlertRelatedIntegrationsCellRenderer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should handle missing field', () => {
-    const alert: Alert = {
-      _id: '_id',
-      _index: '_index',
-    };
-    const packages: PackageListItem[] = [];
+  it('should not render integration icon', () => {
+    (useGetIntegrationFromRuleId as jest.Mock).mockReturnValue({
+      integration: undefined,
+    });
 
     const { queryByTestId } = render(
-      <KibanaAlertRelatedIntegrationsCellRenderer alert={alert} packages={packages} />
+      <KibanaAlertRelatedIntegrationsCellRenderer alert={alert} packages={packages} rules={rules} />
     );
 
     expect(queryByTestId(LOADING_SKELETON_TEST_ID)).not.toBeInTheDocument();
     expect(queryByTestId(ICON_TEST_ID)).not.toBeInTheDocument();
   });
 
-  it('should handle not finding matching integration', () => {
-    const alert: Alert = {
-      _id: '_id',
-      _index: '_index',
-      [ALERT_RULE_PARAMETERS]: [{ related_integrations: { package: ['splunk'] } }],
-    };
-    const packages: PackageListItem[] = [
-      {
-        id: 'other',
-        icons: [{ src: 'icon.svg', path: 'mypath/icon.svg', type: 'image/svg+xml' }],
-        name: 'other',
-        status: installationStatuses.NotInstalled,
-        title: 'Other',
-        version: '0.1.0',
-      },
-    ];
-
-    const { queryByTestId } = render(
-      <KibanaAlertRelatedIntegrationsCellRenderer alert={alert} packages={packages} />
-    );
-
-    expect(queryByTestId(LOADING_SKELETON_TEST_ID)).not.toBeInTheDocument();
-    expect(queryByTestId(ICON_TEST_ID)).not.toBeInTheDocument();
-  });
-
-  it('should show integration icon', () => {
-    (usePackageIconType as jest.Mock).mockReturnValue('iconType');
-
-    const alert: Alert = {
-      _id: '_id',
-      _index: '_index',
-      [ALERT_RULE_PARAMETERS]: [{ related_integrations: { package: ['splunk'] } }],
-    };
-    const packages: PackageListItem[] = [
-      {
+  it('should render integration icon', () => {
+    (useGetIntegrationFromRuleId as jest.Mock).mockReturnValue({
+      integration: {
         id: 'splunk',
         icons: [{ src: 'icon.svg', path: 'mypath/icon.svg', type: 'image/svg+xml' }],
         name: 'splunk',
@@ -88,10 +63,11 @@ describe('KibanaAlertRelatedIntegrationsCellRenderer', () => {
         title: 'Splunk',
         version: '0.1.0',
       },
-    ];
+    });
+    (usePackageIconType as jest.Mock).mockReturnValue('iconType');
 
     const { getByTestId, queryByTestId } = render(
-      <KibanaAlertRelatedIntegrationsCellRenderer alert={alert} packages={packages} />
+      <KibanaAlertRelatedIntegrationsCellRenderer alert={alert} packages={packages} rules={rules} />
     );
 
     expect(queryByTestId(LOADING_SKELETON_TEST_ID)).not.toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/kibana_alert_related_integrations_cell_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/kibana_alert_related_integrations_cell_renderer.tsx
@@ -6,18 +6,15 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import type { JsonValue } from '@kbn/utility-types';
 import type { Alert } from '@kbn/alerting-types';
-import { ALERT_RULE_PARAMETERS } from '@kbn/rule-data-utils';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
+import type { RuleResponse } from '../../../../../common/api/detection_engine';
+import { useGetIntegrationFromRuleId } from '../../../hooks/alert_summary/use_get_integration_from_rule_id';
 import { IntegrationIcon } from '../common/integration_icon';
-import { getAlertFieldValueAsStringOrNull, isJsonObjectValue } from '../../../utils/type_utils';
+import { getAlertFieldValueAsStringOrNull } from '../../../utils/type_utils';
 
 export const TABLE_RELATED_INTEGRATION_CELL_RENDERER_TEST_ID =
   'alert-summary-table-related-integrations-cell-renderer';
-
-const RELATED_INTEGRATIONS_FIELD = 'related_integrations';
-const PACKAGE_FIELD = 'package';
 
 export interface KibanaAlertRelatedIntegrationsCellRendererProps {
   /**
@@ -29,35 +26,27 @@ export interface KibanaAlertRelatedIntegrationsCellRendererProps {
    * This comes from the additionalContext property on the table.
    */
   packages: PackageListItem[];
+  /**
+   * List of rules for the AI for SOC.
+   * This comes from the additionalContext property on the table.
+   */
+  rules: RuleResponse[];
 }
 
 /**
- * Renders an integration/package icon. Retrieves the package name from the kibana.alert.rule.parameters field in the alert,
- * fetches all integrations/packages and use the icon from the one that matches by name.
- * Used in AI for SOC alert summary table.
+ * Renders an integration/package icon within the AI for SOC alert summary table Integration column.
  */
 export const KibanaAlertRelatedIntegrationsCellRenderer = memo(
-  ({ alert, packages }: KibanaAlertRelatedIntegrationsCellRendererProps) => {
-    const packageName: string | null = useMemo(() => {
-      const values: JsonValue[] | undefined = alert[ALERT_RULE_PARAMETERS];
-
-      if (Array.isArray(values) && values.length === 1) {
-        const value: JsonValue = values[0];
-        if (!isJsonObjectValue(value)) return null;
-
-        const relatedIntegration = value[RELATED_INTEGRATIONS_FIELD];
-        if (!isJsonObjectValue(relatedIntegration)) return null;
-
-        return getAlertFieldValueAsStringOrNull(relatedIntegration as Alert, PACKAGE_FIELD);
-      }
-
-      return null;
-    }, [alert]);
-
-    const integration = useMemo(
-      () => packages.find((p) => p.name === packageName),
-      [packages, packageName]
+  ({ alert, packages, rules }: KibanaAlertRelatedIntegrationsCellRendererProps) => {
+    const ruleRuleId: string = useMemo(
+      () => getAlertFieldValueAsStringOrNull(alert, 'signal.rule.rule_id') || '',
+      [alert]
     );
+    const { integration } = useGetIntegrationFromRuleId({
+      packages,
+      ruleId: ruleRuleId,
+      rules,
+    });
 
     return (
       <IntegrationIcon

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/render_cell.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/render_cell.test.tsx
@@ -11,12 +11,13 @@ import type { Alert } from '@kbn/alerting-types';
 import { CellValue } from './render_cell';
 import { TestProviders } from '../../../../common/mock';
 import { getEmptyValue } from '../../../../common/components/empty_value';
-import { ALERT_RULE_PARAMETERS, ALERT_SEVERITY, TIMESTAMP } from '@kbn/rule-data-utils';
+import { ALERT_SEVERITY, TIMESTAMP } from '@kbn/rule-data-utils';
 import { BADGE_TEST_ID } from './kibana_alert_severity_cell_renderer';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import { installationStatuses } from '@kbn/fleet-plugin/common/constants';
 import { TABLE_RELATED_INTEGRATION_CELL_RENDERER_TEST_ID } from './kibana_alert_related_integrations_cell_renderer';
 import { INTEGRATION_ICON_TEST_ID } from '../common/integration_icon';
+import type { RuleResponse } from '../../../../../common/api/detection_engine';
 
 const packages: PackageListItem[] = [
   {
@@ -28,6 +29,20 @@ const packages: PackageListItem[] = [
     version: '0.1.0',
   },
 ];
+const ruleResponse = {
+  rules: [
+    {
+      name: 'splunk',
+      related_integrations: [
+        {
+          package: 'splunk',
+        },
+      ],
+      rule_id: 'rule_rule_id',
+    } as RuleResponse,
+  ],
+  isLoading: false,
+};
 
 describe('CellValue', () => {
   beforeEach(() => {
@@ -45,7 +60,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -63,7 +84,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -81,7 +108,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -99,7 +132,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -117,7 +156,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -135,7 +180,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -153,7 +204,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -164,14 +221,20 @@ describe('CellValue', () => {
     const alert: Alert = {
       _id: '_id',
       _index: '_index',
-      [ALERT_RULE_PARAMETERS]: [{ related_integrations: { package: ['splunk'] } }],
+      'signal.rule.rule_id': 'rule_rule_id',
     };
-    const columnId = ALERT_RULE_PARAMETERS;
+    const columnId = 'signal.rule.rule_id';
     const schema = 'unknown';
 
     const { getByTestId } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -191,7 +254,13 @@ describe('CellValue', () => {
 
     const { getByTestId } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 
@@ -209,7 +278,13 @@ describe('CellValue', () => {
 
     const { getByText } = render(
       <TestProviders>
-        <CellValue alert={alert} columnId={columnId} packages={packages} schema={schema} />
+        <CellValue
+          alert={alert}
+          columnId={columnId}
+          packages={packages}
+          ruleResponse={ruleResponse}
+          schema={schema}
+        />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/render_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/render_cell.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { type ComponentProps, memo } from 'react';
-import { ALERT_RULE_PARAMETERS, ALERT_SEVERITY } from '@kbn/rule-data-utils';
+import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import type { GetTableProp } from './types';
 import { DatetimeSchemaCellRenderer } from './datetime_schema_cell_renderer';
 import { BasicCellRenderer } from './basic_cell_renderer';
@@ -31,6 +31,11 @@ export type CellValueProps = Pick<
    */
   | 'packages'
   /**
+   * Result from the useQuery to fetch all rules.
+   * This comes from the additionalContext property on the table.
+   */
+  | 'ruleResponse'
+  /**
    * Type of field used to drive how we render the value in the BasicCellRenderer.
    * This comes from EuiDataGrid.
    */
@@ -46,20 +51,28 @@ export type CellValueProps = Pick<
  *  - datetime
  * Finally it renders the rest as basic strings.
  */
-export const CellValue = memo(({ alert, columnId, packages, schema }: CellValueProps) => {
-  let component;
+export const CellValue = memo(
+  ({ alert, columnId, packages, ruleResponse, schema }: CellValueProps) => {
+    let component;
 
-  if (columnId === ALERT_RULE_PARAMETERS) {
-    component = <KibanaAlertRelatedIntegrationsCellRenderer alert={alert} packages={packages} />;
-  } else if (columnId === ALERT_SEVERITY) {
-    component = <KibanaAlertSeverityCellRenderer alert={alert} />;
-  } else if (schema === DATETIME_SCHEMA) {
-    component = <DatetimeSchemaCellRenderer alert={alert} field={columnId} />;
-  } else {
-    component = <BasicCellRenderer alert={alert} field={columnId} />;
+    if (columnId === 'signal.rule.rule_id') {
+      component = (
+        <KibanaAlertRelatedIntegrationsCellRenderer
+          alert={alert}
+          packages={packages}
+          rules={ruleResponse.rules}
+        />
+      );
+    } else if (columnId === ALERT_SEVERITY) {
+      component = <KibanaAlertSeverityCellRenderer alert={alert} />;
+    } else if (schema === DATETIME_SCHEMA) {
+      component = <DatetimeSchemaCellRenderer alert={alert} field={columnId} />;
+    } else {
+      component = <BasicCellRenderer alert={alert} field={columnId} />;
+    }
+
+    return <>{component}</>;
   }
-
-  return <>{component}</>;
-});
+);
 
 CellValue.displayName = 'CellValue';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
@@ -16,13 +16,7 @@ import type {
   AlertsTableImperativeApi,
   AlertsTableProps,
 } from '@kbn/response-ops-alerts-table/types';
-import {
-  ALERT_RULE_NAME,
-  ALERT_RULE_PARAMETERS,
-  ALERT_SEVERITY,
-  AlertConsumers,
-  TIMESTAMP,
-} from '@kbn/rule-data-utils';
+import { ALERT_RULE_NAME, ALERT_SEVERITY, AlertConsumers, TIMESTAMP } from '@kbn/rule-data-utils';
 import { ESQL_RULE_TYPE_ID, QUERY_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
 import type {
   EuiDataGridProps,
@@ -50,7 +44,7 @@ export const TIMESTAMP_COLUMN = i18n.translate(
   'xpack.securitySolution.alertSummary.table.column.timeStamp',
   { defaultMessage: 'Timestamp' }
 );
-export const RELATION_INTEGRATION_COLUMN = i18n.translate(
+export const RELATED_INTEGRATION_COLUMN = i18n.translate(
   'xpack.securitySolution.alertSummary.table.column.relatedIntegrationName',
   { defaultMessage: 'Integration' }
 );
@@ -69,8 +63,8 @@ export const columns: EuiDataGridProps['columns'] = [
     displayAsText: TIMESTAMP_COLUMN,
   },
   {
-    id: ALERT_RULE_PARAMETERS,
-    displayAsText: RELATION_INTEGRATION_COLUMN,
+    id: 'signal.rule.rule_id',
+    displayAsText: RELATED_INTEGRATION_COLUMN,
   },
   {
     id: ALERT_SEVERITY,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.test.ts
@@ -17,16 +17,6 @@ describe('useGetIntegrationFromRuleId', () => {
   });
 
   it('should return undefined integration when no matching rule is found', () => {
-    const packages: PackageListItem[] = [];
-    const ruleId = '';
-    const rules: RuleResponse[] = [];
-
-    const { result } = renderHook(() => useGetIntegrationFromRuleId({ packages, ruleId, rules }));
-
-    expect(result.current.integration).toBe(undefined);
-  });
-
-  it('should return undefined integration when the rule does not have the expected related_integrations', () => {
     const packages: PackageListItem[] = [
       {
         id: 'splunk',
@@ -37,11 +27,11 @@ describe('useGetIntegrationFromRuleId', () => {
         version: '0.1.0',
       },
     ];
-    const ruleId = 'rule_id';
+    const ruleId = 'wrong_rule_id';
     const rules: RuleResponse[] = [
       {
-        id: 'rule_id',
-        related_integrations: [{ package: 'wrong_integrations' }],
+        name: 'Rule name',
+        rule_id: 'rule_id',
       } as RuleResponse,
     ];
 
@@ -50,7 +40,7 @@ describe('useGetIntegrationFromRuleId', () => {
     expect(result.current.integration).toBe(undefined);
   });
 
-  it('should render a matching integration', () => {
+  it('should return undefined integration when no package name match the rule name', () => {
     const packages: PackageListItem[] = [
       {
         id: 'splunk',
@@ -64,8 +54,32 @@ describe('useGetIntegrationFromRuleId', () => {
     const ruleId = 'rule_id';
     const rules: RuleResponse[] = [
       {
-        id: 'rule_id',
+        related_integrations: [{ package: 'wrong_integrations' }],
+        rule_id: 'rule_id',
+      } as RuleResponse,
+    ];
+
+    const { result } = renderHook(() => useGetIntegrationFromRuleId({ packages, ruleId, rules }));
+
+    expect(result.current.integration).toBe(undefined);
+  });
+
+  it('should return a matching integration', () => {
+    const packages: PackageListItem[] = [
+      {
+        id: 'splunk',
+        icons: [{ src: 'icon.svg', path: 'mypath/icon.svg', type: 'image/svg+xml' }],
+        name: 'splunk',
+        status: installationStatuses.NotInstalled,
+        title: 'Splunk',
+        version: '0.1.0',
+      },
+    ];
+    const ruleId = 'splunk_rule_id';
+    const rules: RuleResponse[] = [
+      {
         related_integrations: [{ package: 'splunk' }],
+        rule_id: 'splunk_rule_id',
       } as RuleResponse,
     ];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.ts
@@ -17,7 +17,7 @@ export interface UseGetIntegrationFromRuleIdParams {
    */
   packages: PackageListItem[];
   /**
-   * Id of the rule. This should be the value from the signal.rule.id field
+   * Id of the rule. This should be the value from the signal.rule.rule_id field
    */
   ruleId: string | string[];
   /**
@@ -34,19 +34,20 @@ export interface UseGetIntegrationFromRuleIdResult {
 }
 
 /**
- * Hook that returns a package (integration) from a ruleId (value for the signal.rule.id field), a list of rules and packages.
- * This hook is used in the GroupedAlertTable's accordion when grouping by signal.rule.id, to render the title as well as statistics.
+ * Hook that returns a package (integration) from a ruleId (value for the signal.rule.rule_id field), a list of rules and packages.
+ * This hook is used in the GroupedAlertTable's accordion when grouping by signal.rule.rule_id (to render the title and statistics)
+ * as well as the Integration column cell renderer.
  */
 export const useGetIntegrationFromRuleId = ({
   packages,
   ruleId,
   rules = EMPTY_ARRAY,
 }: UseGetIntegrationFromRuleIdParams): UseGetIntegrationFromRuleIdResult => {
-  // From the ruleId (which should be a value for a signal.rule.id field) we find the rule
+  // From the ruleId (which should be a value for a signal.rule.rule_id field) we find the rule
   // of the same id, which we then use its name to match a package's name.
   const integration: PackageListItem | undefined = useMemo(() => {
     const signalRuleId = Array.isArray(ruleId) ? ruleId[0] : ruleId;
-    const rule = rules.find((r: RuleResponse) => r.id === signalRuleId);
+    const rule = rules.find((r: RuleResponse) => r.rule_id === signalRuleId);
     if (!rule) {
       return undefined;
     }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integrations.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integrations.test.ts
@@ -46,7 +46,7 @@ describe('useIntegrations', () => {
       rules: [
         {
           related_integrations: [{ package: 'splunk' }],
-          id: 'SplunkRuleId',
+          rule_id: 'SplunkRuleId',
         } as RuleResponse,
       ],
       isLoading: false,
@@ -105,7 +105,7 @@ describe('useIntegrations', () => {
       rules: [
         {
           related_integrations: [{ package: 'splunk' }],
-          id: 'SplunkRuleId',
+          rule_id: 'SplunkRuleId',
         } as RuleResponse,
       ],
       isLoading: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integrations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integrations.ts
@@ -80,14 +80,14 @@ export const useIntegrations = ({
         const currentFilter = filterExistsInFiltersArray(
           currentFilters,
           FILTER_KEY,
-          matchingRule.id
+          matchingRule.rule_id
         );
 
         // A EuiSelectableOption is checked only if there is no matching filter for that rule
         const integration = {
           'data-test-subj': `${INTEGRATION_OPTION_TEST_ID}${p.title}`,
           ...(!currentFilter && { checked: 'on' as EuiSelectableOptionCheckedType }),
-          key: matchingRule?.id, // we save the rule id that we will match again the signal.rule.id field on the alerts
+          key: matchingRule?.rule_id, // we save the rule id that we will match again the signal.rule.rule_id field on the alerts
           label: p.title,
         };
         result.push(integration);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components/header_title.tsx
@@ -29,7 +29,9 @@ export const HEADER_INTEGRATION_TITLE_TEST_ID = 'ai-for-soc-alert-flyout-header-
  */
 export const HeaderTitle = memo(() => {
   const { dataFormattedForFieldBrowser, getFieldsData } = useAIForSOCDetailsContext();
-  const { ruleId, ruleName, timestamp } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
+  const { ruleRuleId, ruleName, timestamp } = useBasicDataFromDetailsData(
+    dataFormattedForFieldBrowser
+  );
   const title = useMemo(() => getAlertTitle({ ruleName }), [ruleName]);
 
   const date = useMemo(() => new Date(timestamp), [timestamp]);
@@ -83,7 +85,7 @@ export const HeaderTitle = memo(() => {
                 />
               }
             >
-              <IntegrationIcon ruleId={ruleId} />
+              <IntegrationIcon ruleId={ruleRuleId} />
             </AlertHeaderBlock>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_basic_data_from_details_data.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_basic_data_from_details_data.test.tsx
@@ -23,6 +23,7 @@ describe('useBasicDataFromDetailsData', () => {
     expect(hookResult.result.current.ruleDescription).toEqual('');
     expect(hookResult.result.current.ruleId).toEqual('');
     expect(hookResult.result.current.ruleName).toEqual('');
+    expect(hookResult.result.current.ruleRuleId).toEqual('');
     expect(hookResult.result.current.timestamp).toEqual('');
     expect(hookResult.result.current.userName).toEqual('');
   });
@@ -42,6 +43,7 @@ describe('useBasicDataFromDetailsData', () => {
     expect(hookResult.result.current.ruleDescription).toEqual('rule-description');
     expect(hookResult.result.current.ruleId).toEqual('rule-uuid');
     expect(hookResult.result.current.ruleName).toEqual('rule-name');
+    expect(hookResult.result.current.ruleRuleId).toEqual('');
     expect(hookResult.result.current.timestamp).toEqual('2023-01-01T01:01:01.000Z');
     expect(hookResult.result.current.userName).toEqual('user-name');
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_basic_data_from_details_data.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_basic_data_from_details_data.tsx
@@ -21,6 +21,7 @@ export interface UseBasicDataFromDetailsDataResult {
   ruleDescription: string;
   ruleId: string;
   ruleName: string;
+  ruleRuleId: string;
   timestamp: string;
   userName: string;
 }
@@ -77,6 +78,11 @@ export const useBasicDataFromDetailsData = (
     [data]
   );
 
+  const ruleRuleId = useMemo(
+    () => getAlertDetailsFieldValue({ category: 'signal', field: 'signal.rule.rule_id' }, data),
+    [data]
+  );
+
   const timestamp = useMemo(
     () => getAlertDetailsFieldValue({ category: 'base', field: '@timestamp' }, data),
     [data]
@@ -99,6 +105,7 @@ export const useBasicDataFromDetailsData = (
       ruleDescription,
       ruleId,
       ruleName,
+      ruleRuleId,
       timestamp,
       userName,
     }),
@@ -113,6 +120,7 @@ export const useBasicDataFromDetailsData = (
       ruleDescription,
       ruleId,
       ruleName,
+      ruleRuleId,
       timestamp,
       userName,
     ]


### PR DESCRIPTION
## Summary

This PR changes the logic used in the AI4DSOC alert summary page to render the integration icon and title in multiple places:
- in the table group title when grouped by integration
- in the table integration column
- in the flyout header

The most important change introduced in this PR is the fact that we're now using the alert's `signal.rule.rule_id` field instead of `signal.rule.id` field, to match with the rule's `rule_id` field, instead of the `id` field. According to the rule's API, `The difference between the id and rule_id is that the id is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas rule_id is a stable rule identifier that can be assigned during rule creation`. So while the rule's` id` field might change every time we uninstall/reinstall an integration, the rule's `rule_id` field should not.
This change will prevent the issue mentioned in [this ticket](https://github.com/elastic/kibana/issues/227513) and [that one](https://github.com/elastic/kibana/issues/227529), where old rules are not mapped with their respective integrations.

I also took this opportunity to slightly change the logic in the integration cell renderer. Instead of relying on the `related_integration` value, I'm not reusing the same hook to find a matching rule and integration from the rule id.

Finally, now that the `related_integration` is less important (still used in a couple of places to match an integration with a rule), I decided to change the Integration column in the table from using the `alert.rule.parameters` field to use the `signal.rule.rule_id` field which is more consistent with the rest of the code base.

**_The UI should remain mostly unchanged._**

https://github.com/user-attachments/assets/6d01169f-7675-4a98-8889-b4a14712bd86

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

https://github.com/elastic/kibana/issues/227513
https://github.com/elastic/kibana/issues/227529

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->