### PR TITLE
[9.1] [SecuritySolution] Fix account switch visualisation and remove filter for multiple fields (#227574)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/columns.tsx
@@ -42,7 +42,7 @@ const timestampColumn: EuiBasicTableColumn<TableItemType> = {
   },
 };
 
-const getPrivilegedUserColumn = (fieldName: string) => ({
+const getPrivilegedUserColumn = () => ({
   field: 'privileged_user',
   name: (
     <FormattedMessage
@@ -52,21 +52,16 @@ const getPrivilegedUserColumn = (fieldName: string) => ({
   ),
   width: COLUMN_WIDTHS.privileged_user,
   render: (user: string[] | string) =>
-    user != null
-      ? getRowItemsWithActions({
-          values: isArray(user) ? user : [user],
-          // TODO We need a way to filter by several field with an OR expression
-          // because the ESQL queries several source indices that have different field names
-          // Issue to extend SecurityCellActions to support this: https://github.com/elastic/security-team/issues/12712
-          fieldName,
-          idPrefix: 'privileged-user-monitoring-privileged-user',
-          render: (item) => <UserName userName={item} scopeId={SCOPE_ID} />,
-          displayCount: 1,
-        })
-      : getEmptyTagValue(),
+    getRowItemsWithActions({
+      values: isArray(user) ? user : [user],
+      fieldName: 'user.name',
+      idPrefix: 'privileged-user-monitoring-privileged-user',
+      render: (item) => <UserName userName={item} scopeId={SCOPE_ID} />,
+      displayCount: 1,
+    }),
 });
 
-const getTargetUserColumn = (fieldName: string) => ({
+const getTargetUserColumn = () => ({
   field: 'target_user',
   name: (
     <FormattedMessage
@@ -74,16 +69,8 @@ const getTargetUserColumn = (fieldName: string) => ({
       defaultMessage="Target user"
     />
   ),
-  render: (user: string[] | string) =>
-    user != null
-      ? getRowItemsWithActions({
-          values: isArray(user) ? user : [user],
-          fieldName,
-          idPrefix: 'privileged-user-monitoring-target-user',
-          render: (item) => <UserName userName={item} scopeId={SCOPE_ID} />,
-          displayCount: 1,
-        })
-      : getEmptyTagValue(),
+  render: (user: string) =>
+    user != null ? <UserName userName={user} scopeId={SCOPE_ID} /> : getEmptyTagValue(),
 });
 
 const getIpColumn = (fieldName = 'source.ip') => ({
@@ -95,15 +82,13 @@ const getIpColumn = (fieldName = 'source.ip') => ({
     />
   ),
   render: (ips: string[] | string) =>
-    ips != null
-      ? getRowItemsWithActions({
-          values: isArray(ips) ? ips : [ips],
-          fieldName,
-          idPrefix: 'privileged-user-monitoring-ip',
-          render: (item) => <NetworkDetails ip={item} />,
-          displayCount: 1,
-        })
-      : getEmptyTagValue(),
+    getRowItemsWithActions({
+      values: isArray(ips) ? ips : [ips],
+      fieldName: '', // Dirty hack to disable CellActions, remove this when CellActions support multiple fields
+      idPrefix: 'privileged-user-monitoring-ip',
+      render: (item) => <NetworkDetails ip={item} />,
+      displayCount: 1,
+    }),
 });
 
 const getActionsColumn = (openRightPanel: (props: FlyoutPanelProps) => void) => ({
@@ -148,8 +133,8 @@ export const buildGrantedRightsColumns = (
 ): Array<EuiBasicTableColumn<TableItemType>> => [
   getActionsColumn(openRightPanel),
   timestampColumn,
-  getPrivilegedUserColumn('user.name'),
-  getTargetUserColumn('user.target.name'),
+  getPrivilegedUserColumn(),
+  getTargetUserColumn(),
   {
     field: 'group_name',
     name: (
@@ -167,9 +152,9 @@ export const buildAccountSwitchesColumns = (
 ): Array<EuiBasicTableColumn<TableItemType>> => [
   getActionsColumn(openRightPanel),
   timestampColumn,
-  getPrivilegedUserColumn('process.real_user.name'),
+  getPrivilegedUserColumn(),
   {
-    ...getTargetUserColumn('process.group_leader.user.name'),
+    ...getTargetUserColumn(),
     name: (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.privilegedUserMonitoring.userActivity.columns.targetAccount"
@@ -203,7 +188,7 @@ export const buildAuthenticationsColumns = (
 ): Array<EuiBasicTableColumn<TableItemType>> => [
   getActionsColumn(openRightPanel),
   timestampColumn,
-  getPrivilegedUserColumn('client.user.name'),
+  getPrivilegedUserColumn(),
   {
     field: 'source',
     name: (

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.test.tsx
@@ -28,6 +28,14 @@ jest.mock('../../../../../common/hooks/use_space_id', () => ({
   useSpaceId: jest.fn().mockReturnValue('default'),
 }));
 
+jest.mock('../../queries/helpers', () => {
+  const originalModule = jest.requireActual('../../queries/helpers');
+  return {
+    ...originalModule,
+    removeInvalidForkBranchesFromESQL: jest.fn((fields, esql) => esql),
+  };
+});
+
 const mockedSourcererDataView = {
   title: 'test-*',
   fields: {},
@@ -65,8 +73,6 @@ describe('UserActivityPrivilegedUsersPanel', () => {
     render(<UserActivityPrivilegedUsersPanel sourcererDataView={mockedSourcererDataView} />, {
       wrapper: TestProviders,
     });
-    // select a visualization that doesn't require dataview fields
-    fireEvent.click(screen.getByTestId('account_switches'));
 
     expect(screen.getByTestId('esql-dashboard-panel')).toBeInTheDocument();
   });
@@ -84,8 +90,7 @@ describe('UserActivityPrivilegedUsersPanel', () => {
     render(<UserActivityPrivilegedUsersPanel sourcererDataView={mockedSourcererDataView} />, {
       wrapper: TestProviders,
     });
-    // select a visualization that doesn't require dataview fields
-    fireEvent.click(screen.getByTestId('account_switches'));
+
     expect(screen.getByText('View all events')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/columns.tsx
@@ -52,7 +52,7 @@ import { SCOPE_ID } from '../../constants';
 
 const COLUMN_WIDTHS = { actions: '5%', '@timestamp': '20%', privileged_user: '15%' };
 
-const getPrivilegedUserColumn = (fieldName: string) => ({
+const getPrivilegedUserColumn = () => ({
   field: 'user.name',
   name: (
     <FormattedMessage
@@ -65,7 +65,7 @@ const getPrivilegedUserColumn = (fieldName: string) => ({
     user != null
       ? getRowItemsWithActions({
           values: isArray(user) ? user : [user],
-          fieldName,
+          fieldName: 'user.name',
           idPrefix: 'privileged-user-monitoring-privileged-user',
           render: (item) => <UserName userName={item} scopeId={SCOPE_ID} />,
           displayCount: 1,
@@ -321,7 +321,7 @@ export const buildPrivilegedUsersTableColumns = (
   euiTheme: EuiThemeComputed
 ): Array<EuiBasicTableColumn<TableItemType>> => [
   getActionsColumn(openUserFlyout),
-  getPrivilegedUserColumn('user.name'),
+  getPrivilegedUserColumn(),
   getRiskScoreColumn(euiTheme),
   getAssetCriticalityColumn(),
   getDataSourceColumn(),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/account_switches_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/account_switches_esql_query.ts
@@ -6,16 +6,28 @@
  */
 
 import type { DataViewFieldMap } from '@kbn/data-views-plugin/common';
-import { getPrivilegedMonitorUsersJoin } from './helpers';
+import { getPrivilegedMonitorUsersJoin, removeInvalidForkBranchesFromESQL } from './helpers';
 
 export const getAccountSwitchesEsqlSource = (
   namespace: string,
   indexPattern: string,
   fields: DataViewFieldMap
-) => {
-  return `FROM ${indexPattern} METADATA _id, _index
+) =>
+  removeInvalidForkBranchesFromESQL(
+    fields,
+    `FROM ${indexPattern} METADATA _id, _index
     ${getPrivilegedMonitorUsersJoin(namespace)}
-    | WHERE to_lower(process.command_line) RLIKE "(su|sudo su|sudo -i|sudo -s|ssh [^@]+@[^\s]+)"
-    | RENAME process.command_line AS command_process, process.group_leader.user.name AS target_user, process.parent.real_group.name AS group_name, process.real_user.name as privileged_user, host.ip AS host_ip
-    | KEEP @timestamp, privileged_user, host_ip, target_user, group_name, command_process, _id, _index`;
-};
+  | WHERE to_lower(process.command_line) RLIKE "(su .*|su|sudo su|sudo -i|sudo -s|ssh [^@]+@[^\s]+)"
+  | FORK
+    (
+         WHERE event.dataset != "endpoint.events.process" AND event.action =="logged-on"
+      |  EVAL target_user = REPLACE(user.effective.name, "\\\\(.*\\\\)", "")
+      |  EVAL group_name = COALESCE(user.group.name, user.group.id)
+      |  RENAME process.command_line AS command_process, user.name as privileged_user, host.ip AS host_ip
+    )
+    (
+         WHERE event.dataset == "endpoint.events.process"
+      |  RENAME process.command_line AS command_process, process.group_leader.user.name AS target_user, process.parent.real_group.name AS group_name, process.real_user.name as privileged_user, host.ip AS host_ip
+    )
+    | KEEP @timestamp, privileged_user, host_ip, target_user, group_name, command_process, _id, _index`
+  );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -1,4 +1,4 @@
-/*
+op/*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
@@ -40,6 +40,7 @@ import { PrivilegedUserMonitoringManageDataSources } from '../components/privile
 import { EmptyPrompt } from '../../common/components/empty_prompt';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { PageLoader } from '../../common/components/page_loader';
+import { DataViewManagerScopeName } from '../../data_view_manager/constants';
 
 type PageState =
   | { type: 'fetchingEngineStatus' }
@@ -109,8 +110,8 @@ export const EntityAnalyticsPrivilegedUserMonitoringPage = () => {
     sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView, status } = useDataView();
-  const { dataViewSpec } = useDataViewSpec();
+  const { dataView, status } = useDataView(DataViewManagerScopeName.explore);
+  const { dataViewSpec } = useDataViewSpec(DataViewManagerScopeName.explore); // TODO: newDataViewPicker - this could be left, as the fieldMap spec is actually being used
 
   const isSourcererLoading = useMemo(
     () => (newDataViewPickerEnabled ? status !== 'ready' : oldIsSourcererLoading),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -1,9 +1,11 @@
-op/*
+/*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+op;
 import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import {
   EuiButtonEmpty,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-op;
 import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import {
   EuiButtonEmpty,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[SecuritySolution] Fix account switch visualisation and remove filter for multiple fields (#227574)](https://github.com/elastic/kibana/pull/227574)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-07-16T12:52:39Z","message":"[SecuritySolution] Fix account switch visualisation and remove filter for multiple fields (#227574)\n\n## Summary\n\n* Update the account switch query to return data from non-endpoint logs\n  * It adds a FORK\n* Add `su .*` to the query filter for match commands like `su admin` \n* Remove filter from the UI for columns represented by multiple fields\n* This filter is removed to avoid bugs, since we can't filter by\nmultiple fields\n* Update the new dataview to use the Explorer sourcerer\n\n*** To test the new data view, you have to enable\n`newDataViewPickerEnabled`\n\n\n[ECS docs](https://www.elastic.co/docs/reference/ecs/ecs-user) ⬇️ \nLocation | Field Set | Description\n-- | -- | --\nuser.effective.* | user | User whose privileges were assumed","sha":"7e191f90e8bcd2c08915045f518c4678f19708eb","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v9.1.0","v9.2.0"],"title":"[SecuritySolution] Fix account switch visualisation and remove filter for multiple fields","number":227574,"url":"https://github.com/elastic/kibana/pull/227574","mergeCommit":{"message":"[SecuritySolution] Fix account switch visualisation and remove filter for multiple fields (#227574)\n\n## Summary\n\n* Update the account switch query to return data from non-endpoint logs\n  * It adds a FORK\n* Add `su .*` to the query filter for match commands like `su admin` \n* Remove filter from the UI for columns represented by multiple fields\n* This filter is removed to avoid bugs, since we can't filter by\nmultiple fields\n* Update the new dataview to use the Explorer sourcerer\n\n*** To test the new data view, you have to enable\n`newDataViewPickerEnabled`\n\n\n[ECS docs](https://www.elastic.co/docs/reference/ecs/ecs-user) ⬇️ \nLocation | Field Set | Description\n-- | -- | --\nuser.effective.* | user | User whose privileges were assumed","sha":"7e191f90e8bcd2c08915045f518c4678f19708eb"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227574","number":227574,"mergeCommit":{"message":"[SecuritySolution] Fix account switch visualisation and remove filter for multiple fields (#227574)\n\n## Summary\n\n* Update the account switch query to return data from non-endpoint logs\n  * It adds a FORK\n* Add `su .*` to the query filter for match commands like `su admin` \n* Remove filter from the UI for columns represented by multiple fields\n* This filter is removed to avoid bugs, since we can't filter by\nmultiple fields\n* Update the new dataview to use the Explorer sourcerer\n\n*** To test the new data view, you have to enable\n`newDataViewPickerEnabled`\n\n\n[ECS docs](https://www.elastic.co/docs/reference/ecs/ecs-user) ⬇️ \nLocation | Field Set | Description\n-- | -- | --\nuser.effective.* | user | User whose privileges were assumed","sha":"7e191f90e8bcd2c08915045f518c4678f19708eb"}}]}] BACKPORT-->