### PR TITLE
[9.1] [SecuritySolution] [Bug] Hide timeline for priv mon onboarding (#225442)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -39,6 +39,7 @@ import { usePrivilegedMonitoringEngineStatus } from '../api/hooks/use_privileged
 import { PrivilegedUserMonitoringManageDataSources } from '../components/privileged_user_monitoring_manage_data_sources';
 import { EmptyPrompt } from '../../common/components/empty_prompt';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
+import { useLinkInfo, useUpdateLinkConfig } from '../../common/links/links_hooks';
 import { PageLoader } from '../../common/components/page_loader';
 
 type PageState =
@@ -176,6 +177,25 @@ export const EntityAnalyticsPrivilegedUserMonitoringPage = () => {
     engineStatus.isError,
     engineStatus.isLoading,
   ]);
+
+  const linkInfo = useLinkInfo(SecurityPageName.entityAnalyticsPrivilegedUserMonitoring);
+  const updateLinkConfig = useUpdateLinkConfig();
+
+  // Update UrlParam to add hideTimeline to the URL when the onboarding is loaded and removes it when dashboard is loaded
+  useEffect(() => {
+    // do not change the link config when the engine status is being fetched
+    if (state.type === 'fetchingEngineStatus') {
+      return;
+    }
+
+    const hideTimeline = ['onboarding', 'initializingEngine'].includes(state.type);
+    // update the hideTimeline property in the link config. This call triggers expensive operations, use with love
+    const hideTimelineConfig = linkInfo?.hideTimeline ?? false;
+
+    if (hideTimeline !== hideTimelineConfig) {
+      updateLinkConfig(SecurityPageName.entityAnalyticsPrivilegedUserMonitoring, { hideTimeline });
+    }
+  }, [linkInfo?.hideTimeline, state.type, updateLinkConfig]);
 
   const fullHeightCSS = css`
     min-height: calc(100vh - 240px);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[SecuritySolution] [Bug] Hide timeline for priv mon onboarding (#225442)](https://github.com/elastic/kibana/pull/225442)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-07-15T07:13:36Z","message":"[SecuritySolution] [Bug] Hide timeline for priv mon onboarding (#225442)\n\n## Summary\n\nFix the bug that caused the timeline to overlap with the onboarding\ncomponents on the privileged user monitoring page.\nSince the timeline is not required on an onboarding page, we decided to\nhide it.\n\nFor now, I decided to implement the simplest change to fix the bug,\nwhich is adding a URL param (`hideTimeline`) exclusively for hiding the\ntimeline. I also considered updating the existing `timeline` URL\nparameter, but that seems too complicated for a bug fix, especially\nsince it would require updating the timeline Redux store, which already\nhas a `show` property used for other purposes. If this use case becomes\nwidely used, we can refactor it to be part of the timeline core\nimplementation.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: Sergi Massaneda <sergi.massaneda@elastic.co>","sha":"fbbef6723787cf73321ce4e8cb48e26d70867b7f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport missing","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v9.1.0","v9.2.0"],"title":"[SecuritySolution] [Bug] Hide timeline for priv mon onboarding","number":225442,"url":"https://github.com/elastic/kibana/pull/225442","mergeCommit":{"message":"[SecuritySolution] [Bug] Hide timeline for priv mon onboarding (#225442)\n\n## Summary\n\nFix the bug that caused the timeline to overlap with the onboarding\ncomponents on the privileged user monitoring page.\nSince the timeline is not required on an onboarding page, we decided to\nhide it.\n\nFor now, I decided to implement the simplest change to fix the bug,\nwhich is adding a URL param (`hideTimeline`) exclusively for hiding the\ntimeline. I also considered updating the existing `timeline` URL\nparameter, but that seems too complicated for a bug fix, especially\nsince it would require updating the timeline Redux store, which already\nhas a `show` property used for other purposes. If this use case becomes\nwidely used, we can refactor it to be part of the timeline core\nimplementation.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: Sergi Massaneda <sergi.massaneda@elastic.co>","sha":"fbbef6723787cf73321ce4e8cb48e26d70867b7f"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225442","number":225442,"mergeCommit":{"message":"[SecuritySolution] [Bug] Hide timeline for priv mon onboarding (#225442)\n\n## Summary\n\nFix the bug that caused the timeline to overlap with the onboarding\ncomponents on the privileged user monitoring page.\nSince the timeline is not required on an onboarding page, we decided to\nhide it.\n\nFor now, I decided to implement the simplest change to fix the bug,\nwhich is adding a URL param (`hideTimeline`) exclusively for hiding the\ntimeline. I also considered updating the existing `timeline` URL\nparameter, but that seems too complicated for a bug fix, especially\nsince it would require updating the timeline Redux store, which already\nhas a `show` property used for other purposes. If this use case becomes\nwidely used, we can refactor it to be part of the timeline core\nimplementation.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: Sergi Massaneda <sergi.massaneda@elastic.co>","sha":"fbbef6723787cf73321ce4e8cb48e26d70867b7f"}}]}] BACKPORT-->