### PR TITLE
[ESQL] Add completion command to inline docs

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
@@ -233,6 +233,85 @@ ROW key=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]
       ),
     },
     {
+      label: i18n.translate('languageDocumentation.documentationESQL.completionCommand', {
+        defaultMessage: 'COMPLETION',
+      }),
+      preview: true,
+      description: (
+        <Markdown
+          openLinksInNewTab={true}
+          markdownContent={i18n.translate(
+            'languageDocumentation.documentationESQL.completionCommand.markdown',
+            {
+              defaultMessage: `### COMPLETION
+
+The \`COMPLETION\` processing command uses a machine learning model to generate text completions based on the provided prompt. The command works with any LLM deployed to the [Elasticsearch inference API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) and can be chained with other ES|QL commands for further processing.
+
+**Syntax**
+
+\`\`\` esql
+COMPLETION [column =] prompt WITH inference_id
+\`\`\` 
+
+**Parameters**
+
+* \`column\`: (Optional) The name of the output column that will contain the completion results. If not specified, the results will be stored in a column named \`completion\`. If the specified column already exists, it will be overwritten with the new completion results.
+* \`prompt\`: The input text or expression that will be used as the prompt for the completion. This can be a string literal or a reference to a column containing text.
+* \`inference_id\`: The ID of the inference endpoint to use for text completion. The inference endpoint must be configured with the \`completion\` task type.
+
+**Examples**
+
+The following is basic example with an inline prompt:
+
+\`\`\` esql
+ROW question = "What is Elasticsearch?"
+| COMPLETION answer = question WITH test_completion_model
+| KEEP question, answer
+\`\`\` 
+
+| question:keyword | answer:keyword |
+|------------------|----------------|
+| What is Elasticsearch? | A distributed search and analytics engine |
+
+This example uses a prompt constructed from multiple columns to generate a summary:
+
+\`\`\` esql
+FROM movies
+| SORT rating DESC
+| LIMIT 10
+| EVAL prompt = CONCAT(
+   "Summarize this movie using the following information: \\n",
+   "Title: ", title, "\\n",
+   "Synopsis: ", synopsis, "\\n",
+   "Actors: ", MV_CONCAT(actors, ", "), "\\n",
+  )
+| COMPLETION summary = prompt WITH test_completion_model
+| KEEP title, summary, rating
+\`\`\` 
+
+| title:keyword | summary:keyword | rating:double |
+|---------------|-----------------|---------------|
+| The Shawshank Redemption | A tale of hope and redemption in prison. | 9.3 |
+| The Godfather | A mafia family's rise and fall. | 9.2 |
+| The Dark Knight | Batman battles the Joker in Gotham. | 9.0 |
+| Pulp Fiction | Interconnected crime stories with dark humor. | 8.9 |
+| Fight Club | A man starts an underground fight club. | 8.8 |
+| Inception | A thief steals secrets through dreams. | 8.8 |
+| The Matrix | A hacker discovers reality is a simulation. | 8.7 |
+| Parasite | Class conflict between two families. | 8.6 |
+| Interstellar | A team explores space to save humanity. | 8.6 |
+| The Prestige | Rival magicians engage in dangerous competition. | 8.5 |
+
+`,
+              ignoreTag: true,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like COMPLETION, prompt, inference_id',
+            }
+          )}
+        />
+      ),
+    },
+    {
       label: i18n.translate('languageDocumentation.documentationESQL.dissect', {
         defaultMessage: 'DISSECT',
       }),

--- a/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
@@ -261,7 +261,7 @@ COMPLETION [column =] prompt WITH inference_id
 
 **Examples**
 
-The following is basic example with an inline prompt:
+The following is a basic example with an inline prompt:
 
 \`\`\` esql
 ROW question = "What is Elasticsearch?"


### PR DESCRIPTION
Closes https://github.com/elastic/docs-content/issues/2152


<img width="270" height="433" alt="Screenshot 2025-07-16 at 17 27 13" src="https://github.com/user-attachments/assets/afe97953-449a-4914-b739-a9b0c2414b0c" />

---

<img width="269" height="657" alt="Screenshot 2025-07-16 at 17 27 27" src="https://github.com/user-attachments/assets/60f916cd-336a-485c-a0b0-068b0e70586c" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->