### PR TITLE
[Unified search] Stop using relative labels in time picker

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/customize_panel_editor.tsx
@@ -272,6 +272,7 @@ export const CustomizePanelEditor = ({
               end={timeRange?.to ?? undefined}
               onTimeChange={({ start, end }) => setTimeRange({ from: start, to: end })}
               showUpdateButton={false}
+              canRoundRelativeUnits={false}
               dateFormat={dateFormat}
               commonlyUsedRanges={commonlyUsedRangesForDatePicker}
               data-test-subj="customizePanelTimeRangeDatePicker"

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -509,6 +509,7 @@ export const QueryBarTopRow = React.memo(
           onRefresh={onRefresh}
           onRefreshChange={props.onRefreshChange}
           showUpdateButton={false}
+          canRoundRelativeUnits={false}
           recentlyUsedRanges={recentlyUsedRanges}
           locale={i18n.getLocale()}
           commonlyUsedRanges={commonlyUsedRanges}


### PR DESCRIPTION
Fixes #143157 

## Summary

Updates the time picker in unified search and dashboard custom panel settings to not display or change labels to relative formats.

| Before | After |
|--|--| 
| <img width="1136" height="500" alt="image" src="https://github.com/user-attachments/assets/4a5f448a-192a-47a9-a3bd-09895e0f042e" /> | <img width="1146" height="520" alt="image" src="https://github.com/user-attachments/assets/2948766f-8c6c-42ab-b5e6-5d3d46b95504" /> |




