### PR TITLE
[8.19] [Detection Engine] Display dataview pattern as tooltip during rule creation (#226909)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/data_view_selector_field.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/data_view_selector_field.tsx
@@ -25,11 +25,12 @@ export function DataViewSelectorField({ field }: DataViewSelectorProps): JSX.Ele
   const fieldAndError = field ? getFieldValidityAndErrorMessage(field) : undefined;
   const isInvalid = fieldAndError?.isInvalid;
   const errorMessage = fieldAndError?.errorMessage;
-  const comboBoxOptions = useMemo(
+  const comboBoxOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(
     () =>
       dataViews.map(({ id, title, name }) => ({
         id,
         label: name ?? title,
+        toolTipContent: title,
       })),
     [dataViews]
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Detection Engine] Display dataview pattern as tooltip during rule creation (#226909)](https://github.com/elastic/kibana/pull/226909)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryland Herrick","email":"ryalnd@gmail.com"},"sourceCommit":{"committedDate":"2025-07-11T01:40:55Z","message":"[Detection Engine] Display dataview pattern as tooltip during rule creation (#226909)\n\n## Summary\n\nThe story behind this feature is a little circuitous: the [original\nissue](https://github.com/elastic/kibana/issues/137823) was about the\nfull dataview index pattern being truncated, and the [first\nattempt](https://github.com/elastic/kibana/pull/214495) to fix this did\nso by instead displaying the data view _name_ instead of its index\npattern. However, this meant that users were less likely to see _any_\nindex pattern associated to the dataview, rather than the full pattern.\n\nThis PR finishes the story by, in addition to preferring the data view's\n_name_ as the dropdown option, adds its full index pattern as the\n_tooltip_ for the corresponding option.\n\n## What this PR does\n* Adds the index pattern for the dataview as a tooltip on the Data View\ndropdown during rule creation\n\n## Screenshots\n\n<kbd>Before: \n<img width=\"894\" alt=\"Screenshot 2025-07-07 at 5 13 34 PM\"\nsrc=\"https://github.com/user-attachments/assets/1079f8c0-148f-4b1f-9469-ab17fc408d64\"\n/>\n\n</kbd>\n\n<kbd>After:\n<img width=\"894\" alt=\"Screenshot 2025-07-07 at 5 14 26 PM\"\nsrc=\"https://github.com/user-attachments/assets/335e54f9-9c6b-4833-8d1d-a254329ab7c1\"\n/>\n\n</kbd>\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"7086158afef2d5dfa67efdd76ba9962df1e1af95","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Data Views","backport missing","Feature:Rule Creation","backport:all-open","Team:Detection Engine","v9.1.0","v9.2.0","v8.18.4","v9.0.4","v8.17.9"],"title":"[Detection Engine] Display dataview pattern as tooltip during rule creation","number":226909,"url":"https://github.com/elastic/kibana/pull/226909","mergeCommit":{"message":"[Detection Engine] Display dataview pattern as tooltip during rule creation (#226909)\n\n## Summary\n\nThe story behind this feature is a little circuitous: the [original\nissue](https://github.com/elastic/kibana/issues/137823) was about the\nfull dataview index pattern being truncated, and the [first\nattempt](https://github.com/elastic/kibana/pull/214495) to fix this did\nso by instead displaying the data view _name_ instead of its index\npattern. However, this meant that users were less likely to see _any_\nindex pattern associated to the dataview, rather than the full pattern.\n\nThis PR finishes the story by, in addition to preferring the data view's\n_name_ as the dropdown option, adds its full index pattern as the\n_tooltip_ for the corresponding option.\n\n## What this PR does\n* Adds the index pattern for the dataview as a tooltip on the Data View\ndropdown during rule creation\n\n## Screenshots\n\n<kbd>Before: \n<img width=\"894\" alt=\"Screenshot 2025-07-07 at 5 13 34 PM\"\nsrc=\"https://github.com/user-attachments/assets/1079f8c0-148f-4b1f-9469-ab17fc408d64\"\n/>\n\n</kbd>\n\n<kbd>After:\n<img width=\"894\" alt=\"Screenshot 2025-07-07 at 5 14 26 PM\"\nsrc=\"https://github.com/user-attachments/assets/335e54f9-9c6b-4833-8d1d-a254329ab7c1\"\n/>\n\n</kbd>\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"7086158afef2d5dfa67efdd76ba9962df1e1af95"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227557","number":227557,"state":"MERGED","mergeCommit":{"sha":"32bb66c13fa806ad808b9df92a19a3da43ee83c7","message":"[9.1] [Detection Engine] Display dataview pattern as tooltip during rule creation (#226909) (#227557)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Detection Engine] Display dataview pattern as tooltip during rule\ncreation (#226909)](https://github.com/elastic/kibana/pull/226909)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ryland Herrick <ryalnd@gmail.com>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226909","number":226909,"mergeCommit":{"message":"[Detection Engine] Display dataview pattern as tooltip during rule creation (#226909)\n\n## Summary\n\nThe story behind this feature is a little circuitous: the [original\nissue](https://github.com/elastic/kibana/issues/137823) was about the\nfull dataview index pattern being truncated, and the [first\nattempt](https://github.com/elastic/kibana/pull/214495) to fix this did\nso by instead displaying the data view _name_ instead of its index\npattern. However, this meant that users were less likely to see _any_\nindex pattern associated to the dataview, rather than the full pattern.\n\nThis PR finishes the story by, in addition to preferring the data view's\n_name_ as the dropdown option, adds its full index pattern as the\n_tooltip_ for the corresponding option.\n\n## What this PR does\n* Adds the index pattern for the dataview as a tooltip on the Data View\ndropdown during rule creation\n\n## Screenshots\n\n<kbd>Before: \n<img width=\"894\" alt=\"Screenshot 2025-07-07 at 5 13 34 PM\"\nsrc=\"https://github.com/user-attachments/assets/1079f8c0-148f-4b1f-9469-ab17fc408d64\"\n/>\n\n</kbd>\n\n<kbd>After:\n<img width=\"894\" alt=\"Screenshot 2025-07-07 at 5 14 26 PM\"\nsrc=\"https://github.com/user-attachments/assets/335e54f9-9c6b-4833-8d1d-a254329ab7c1\"\n/>\n\n</kbd>\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"7086158afef2d5dfa67efdd76ba9962df1e1af95"}},{"branch":"8.18","label":"v8.18.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227554","number":227554,"state":"MERGED","mergeCommit":{"sha":"132c0bf03c23b331f1c67bc930f5a373d71fdf30","message":"[8.18] [Detection Engine] Display dataview pattern as tooltip during rule creation (#226909) (#227554)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Detection Engine] Display dataview pattern as tooltip during rule\ncreation (#226909)](https://github.com/elastic/kibana/pull/226909)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ryland Herrick <ryalnd@gmail.com>"}},{"branch":"9.0","label":"v9.0.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227556","number":227556,"state":"MERGED","mergeCommit":{"sha":"fc55a8e48d58e3b5eb1a1014fc5009e2b00bdf0e","message":"[9.0] [Detection Engine] Display dataview pattern as tooltip during rule creation (#226909) (#227556)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Detection Engine] Display dataview pattern as tooltip during rule\ncreation (#226909)](https://github.com/elastic/kibana/pull/226909)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ryland Herrick <ryalnd@gmail.com>"}},{"branch":"8.17","label":"v8.17.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227553","number":227553,"state":"MERGED","mergeCommit":{"sha":"94f6ed7c634c9099b226014430ec6c0f16b91829","message":"[8.17] [Detection Engine] Display dataview pattern as tooltip during rule creation (#226909) (#227553)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[Detection Engine] Display dataview pattern as tooltip during rule\ncreation (#226909)](https://github.com/elastic/kibana/pull/226909)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ryland Herrick <ryalnd@gmail.com>"}},{"url":"https://github.com/elastic/kibana/pull/227555","number":227555,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->