### PR TITLE
[8.19] [Attack discovery] Update Attack discovery call to action buttons and flyout (#228150)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { Actions } from '.';
+
+const defaultProps = {
+  isLoading: false,
+  onGenerate: jest.fn(),
+  openFlyout: jest.fn(),
+};
+
+describe('Actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering action buttons', () => {
+    beforeEach(() => {
+      render(<Actions {...defaultProps} />);
+    });
+
+    it('renders the Run button', () => {
+      expect(screen.getByTestId('run')).toBeInTheDocument();
+    });
+
+    it('renders the settings button', () => {
+      expect(screen.getByTestId('settings')).toBeInTheDocument();
+    });
+
+    it('renders the schedule button', () => {
+      expect(screen.getByTestId('schedule')).toBeInTheDocument();
+    });
+  });
+
+  describe('disables buttons when isLoading is true', () => {
+    beforeEach(() => {
+      render(<Actions {...defaultProps} isLoading={true} />);
+    });
+
+    it('disables the run button', () => {
+      expect(screen.getByTestId('run')).toBeDisabled();
+    });
+
+    it('disables the settings button', () => {
+      expect(screen.getByTestId('settings')).toBeDisabled();
+    });
+
+    it('disables the schedule button', () => {
+      expect(screen.getByTestId('schedule')).toBeDisabled();
+    });
+  });
+
+  it('calls onGenerate when the run button is clicked', () => {
+    render(<Actions {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('run'));
+
+    expect(defaultProps.onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls openFlyout with "settings" when settings button is clicked', () => {
+    render(<Actions {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('settings'));
+
+    expect(defaultProps.openFlyout).toHaveBeenCalledWith('settings');
+  });
+
+  it('calls openFlyout with "schedule" when schedule button is clicked', () => {
+    render(<Actions {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('schedule'));
+
+    expect(defaultProps.openFlyout).toHaveBeenCalledWith('schedule');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+
+import type { SettingsOverrideOptions } from '../../results/history/types';
+import { Run } from '../run';
+import { Schedule } from '../schedule';
+import { Settings } from '../settings';
+
+interface Props {
+  isDisabled?: boolean;
+  isLoading: boolean;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
+  openFlyout: (tabId: string) => void;
+}
+
+const ActionsComponent: React.FC<Props> = ({ isLoading, onGenerate, openFlyout, isDisabled }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const runSettingsGroup = css`
+    display: flex;
+    gap: 1px;
+  `;
+
+  const scheduleSettingsSpacing = css`
+    margin-left: ${euiTheme.size.s};
+  `;
+
+  return (
+    <EuiFlexGroup alignItems="center" data-test-subj="actions" gutterSize="xs" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <div css={runSettingsGroup}>
+          <Run isLoading={isLoading} isDisabled={isDisabled} onGenerate={onGenerate} />
+          <Settings isLoading={isLoading} openFlyout={openFlyout} />
+        </div>
+      </EuiFlexItem>
+
+      <EuiFlexItem css={scheduleSettingsSpacing} grow={false}>
+        <Schedule isLoading={isLoading} openFlyout={openFlyout} />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+ActionsComponent.displayName = 'Actions';
+
+export const Actions = React.memo(ActionsComponent);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/index.test.tsx
@@ -107,20 +107,48 @@ describe('Actions', () => {
     expect(connectorSelector).not.toBeInTheDocument();
   });
 
-  it('invokes onGenerate when the generate button is clicked', () => {
-    const onGenerate = jest.fn();
+  describe('generate/run button', () => {
+    it('invokes onGenerate when the legacy generate button is clicked (feature flag false)', () => {
+      const featureFlagValue = false;
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(featureFlagValue),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
 
-    render(
-      <TestProviders>
-        <Header {...defaultProps} onGenerate={onGenerate} />
-      </TestProviders>
-    );
+      const onGenerate = jest.fn();
+      render(
+        <TestProviders>
+          <Header {...defaultProps} onGenerate={onGenerate} />
+        </TestProviders>
+      );
+      const generate = screen.getByTestId('generate');
+      fireEvent.click(generate);
+      expect(onGenerate).toHaveBeenCalled();
+    });
 
-    const generate = screen.getByTestId('generate');
+    it('invokes onGenerate when the new run button is clicked (feature flag true)', () => {
+      const featureFlagValue = true;
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(featureFlagValue),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
 
-    fireEvent.click(generate);
-
-    expect(onGenerate).toHaveBeenCalled();
+      const onGenerate = jest.fn();
+      render(
+        <TestProviders>
+          <Header {...defaultProps} onGenerate={onGenerate} />
+        </TestProviders>
+      );
+      const runBtn = screen.getByTestId('run');
+      fireEvent.click(runBtn);
+      expect(onGenerate).toHaveBeenCalled();
+    });
   });
 
   it('displays the cancel button when loading and the feature flag is false', () => {
@@ -195,32 +223,87 @@ describe('Actions', () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
-  it('disables the generate button when connectorId is undefined', () => {
-    const connectorId = undefined;
+  describe('disabled state', () => {
+    it('disables the legacy generate button when connectorId is undefined (feature flag false)', () => {
+      const featureFlagValue = false;
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(featureFlagValue),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
 
-    render(
-      <TestProviders>
-        <Header {...defaultProps} connectorId={connectorId} />
-      </TestProviders>
-    );
+      render(
+        <TestProviders>
+          <Header {...defaultProps} connectorId={undefined} />
+        </TestProviders>
+      );
+      const generate = screen.getByTestId('generate');
+      expect(generate).toBeDisabled();
+    });
 
-    const generate = screen.getByTestId('generate');
+    it('disables the new run button when connectorId is undefined (feature flag true)', () => {
+      const featureFlagValue = true;
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(featureFlagValue),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
 
-    expect(generate).toBeDisabled();
+      render(
+        <TestProviders>
+          <Header {...defaultProps} connectorId={undefined} />
+        </TestProviders>
+      );
+      const runBtn = screen.getByTestId('run');
+      expect(runBtn).toBeDisabled();
+    });
   });
 
-  it('invokes openFlyout when the settings button is clicked', async () => {
-    const openFlyout = jest.fn();
+  describe('settings button', () => {
+    it('invokes openFlyout when the legacy settings button is clicked (feature flag false)', async () => {
+      const featureFlagValue = false;
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(featureFlagValue),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
 
-    render(
-      <TestProviders>
-        <Header {...defaultProps} openFlyout={openFlyout} />
-      </TestProviders>
-    );
+      const openFlyout = jest.fn();
+      render(
+        <TestProviders>
+          <Header {...defaultProps} openFlyout={openFlyout} />
+        </TestProviders>
+      );
+      const settings = screen.getByTestId('openAlertSelection');
+      fireEvent.click(settings);
+      await waitFor(() => expect(openFlyout).toHaveBeenCalled());
+    });
 
-    const settings = screen.getByTestId('openAlertSelection');
-    fireEvent.click(settings);
+    it('invokes openFlyout when the new settings button is clicked (feature flag true)', async () => {
+      const featureFlagValue = true;
+      mockUseKibana.mockReturnValue({
+        services: {
+          featureFlags: {
+            getBooleanValue: jest.fn().mockReturnValue(featureFlagValue),
+          },
+        },
+      } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
 
-    await waitFor(() => expect(openFlyout).toHaveBeenCalled());
+      const openFlyout = jest.fn();
+      render(
+        <TestProviders>
+          <Header {...defaultProps} openFlyout={openFlyout} />
+        </TestProviders>
+      );
+      const settingsBtn = screen.getByTestId('settings');
+      fireEvent.click(settingsBtn);
+      await waitFor(() => expect(openFlyout).toHaveBeenCalled());
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/index.tsx
@@ -23,23 +23,26 @@ import {
 import { type AttackDiscoveryStats } from '@kbn/elastic-assistant-common';
 import { noop } from 'lodash/fp';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-
 import { ElasticLLMCostAwarenessTour } from '@kbn/elastic-assistant/impl/tour/elastic_llm';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '@kbn/elastic-assistant/impl/tour/const';
+
+import { Actions } from './actions';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
+import type { SettingsOverrideOptions } from '../results/history/types';
+import { SETTINGS_TAB_ID } from '../settings_flyout/constants';
 import { StatusBell } from './status_bell';
 import * as i18n from './translations';
 import { useKibanaFeatureFlags } from '../use_kibana_feature_flags';
-import { useSpaceId } from '../../../common/hooks/use_space_id';
 
 interface Props {
   connectorId: string | undefined;
   connectorsAreConfigured: boolean;
   isLoading: boolean;
   isDisabledActions: boolean;
-  onGenerate: () => void;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onCancel: () => void;
   onConnectorIdSelected: (connectorId: string) => void;
-  openFlyout: () => void;
+  openFlyout: (tabId: string) => void;
   stats: AttackDiscoveryStats | null;
   showFlyout: boolean;
 }
@@ -57,7 +60,7 @@ const HeaderComponent: React.FC<Props> = ({
   showFlyout,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const disabled = connectorId == null;
+  const isDisabled = connectorId == null;
   const [didCancel, setDidCancel] = useState(false);
   const { inferenceEnabled } = useAssistantContext();
   const { attackDiscoveryAlertsEnabled } = useKibanaFeatureFlags();
@@ -115,11 +118,13 @@ const HeaderComponent: React.FC<Props> = ({
             color: 'primary' as EuiButtonProps['color'],
             dataTestSubj: 'generate',
             fill: attackDiscoveryAlertsEnabled,
-            onClick: onGenerate,
+            onClick: () => onGenerate(),
             text: i18n.GENERATE,
           },
     [attackDiscoveryAlertsEnabled, handleCancel, isLoading, onGenerate]
   );
+
+  const openLegacySettingsFlyout = useCallback(() => openFlyout(SETTINGS_TAB_ID), [openFlyout]);
 
   return (
     <EuiFlexGroup
@@ -177,7 +182,23 @@ const HeaderComponent: React.FC<Props> = ({
               </EuiFlexGroup>
             )}
           </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
 
+      {/* Conditional rendering: New Actions component vs Legacy buttons */}
+      {attackDiscoveryAlertsEnabled ? (
+        /* New Actions component when feature flag is enabled */
+        <EuiFlexItem grow={false}>
+          <Actions
+            isLoading={isLoading}
+            onGenerate={onGenerate}
+            openFlyout={openFlyout}
+            isDisabled={isDisabled}
+          />
+        </EuiFlexItem>
+      ) : (
+        /* Legacy settings and generate buttons when feature flag is disabled */
+        <>
           <EuiFlexItem
             css={css`
               margin-right: ${euiTheme.size.m};
@@ -190,30 +211,30 @@ const HeaderComponent: React.FC<Props> = ({
                 color="text"
                 data-test-subj="openAlertSelection"
                 iconType="gear"
-                onClick={openFlyout}
+                onClick={openLegacySettingsFlyout}
               />
             </EuiToolTip>
           </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiToolTip
-          content={connectorId == null ? i18n.SELECT_A_CONNECTOR : null}
-          data-test-subj="generateTooltip"
-        >
-          <EuiButton
-            color={buttonProps.color}
-            data-test-subj={buttonProps.dataTestSubj}
-            disabled={disabled || didCancel || isDisabledActions}
-            fill={buttonProps.fill}
-            onClick={buttonProps.onClick}
-            size={attackDiscoveryAlertsEnabled ? 'm' : 's'}
-          >
-            {buttonProps.text}
-          </EuiButton>
-        </EuiToolTip>
-      </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip
+              content={connectorId == null ? i18n.SELECT_A_CONNECTOR : null}
+              data-test-subj="generateTooltip"
+            >
+              <EuiButton
+                color={buttonProps.color}
+                data-test-subj={buttonProps.dataTestSubj}
+                disabled={isDisabled || didCancel || isDisabledActions}
+                fill={buttonProps.fill}
+                onClick={buttonProps.onClick}
+                size={attackDiscoveryAlertsEnabled ? 'm' : 's'}
+              >
+                {buttonProps.text}
+              </EuiButton>
+            </EuiToolTip>
+          </EuiFlexItem>
+        </>
+      )}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { RUN, RUN_TOOLTIP, DISABLED_TOOLTIP } from './translations';
+import { Run } from '.';
+
+const defaultProps = {
+  isLoading: false,
+  onGenerate: jest.fn(),
+};
+
+describe('Run', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the run button with the expected text', () => {
+    render(<Run {...defaultProps} />);
+
+    expect(screen.getByTestId('run')).toHaveTextContent(RUN);
+  });
+
+  it('renders the tooltip on hover with the expected text', async () => {
+    render(<Run {...defaultProps} />);
+
+    fireEvent.mouseOver(screen.getByTestId('run'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('runTooltip')).toHaveTextContent(RUN_TOOLTIP);
+    });
+  });
+
+  it('renders the tooltip on hover with the disabled text when isDisabled is true', async () => {
+    render(<Run {...defaultProps} isDisabled={true} />);
+
+    fireEvent.mouseOver(screen.getByTestId('run'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('runTooltip')).toHaveTextContent(DISABLED_TOOLTIP);
+    });
+  });
+
+  it('disables the button when isLoading is true', () => {
+    render(<Run {...defaultProps} isLoading={true} />);
+
+    expect(screen.getByTestId('run')).toBeDisabled();
+  });
+
+  it('calls onGenerate when the button is clicked', () => {
+    render(<Run {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('run'));
+
+    expect(defaultProps.onGenerate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton, EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+
+import type { SettingsOverrideOptions } from '../../results/history/types';
+import * as i18n from './translations';
+
+interface Props {
+  isLoading: boolean;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
+  isDisabled?: boolean;
+}
+
+const runButtonStyles = css`
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  min-width: 74px;
+  width: 74px;
+`;
+
+const RunComponent: React.FC<Props> = ({ isLoading, onGenerate, isDisabled }) => (
+  <EuiToolTip
+    content={isDisabled ? i18n.DISABLED_TOOLTIP : i18n.RUN_TOOLTIP}
+    data-test-subj="runTooltip"
+    position="bottom"
+  >
+    <EuiButton
+      color="primary"
+      css={runButtonStyles}
+      data-test-subj="run"
+      iconType="play"
+      isDisabled={isLoading || isDisabled}
+      onClick={() => onGenerate()}
+    >
+      {i18n.RUN}
+    </EuiButton>
+  </EuiToolTip>
+);
+
+RunComponent.displayName = 'Run';
+
+export const Run = React.memo(RunComponent);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/translations.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const RUN = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.run.runButton',
+  {
+    defaultMessage: 'Run',
+  }
+);
+
+export const RUN_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.run.runButtonTooltip',
+  {
+    defaultMessage: 'Run ad-hoc Attack discoveries using your current settings',
+  }
+);
+
+export const DISABLED_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.run.disabledButtonTooltip',
+  {
+    defaultMessage: 'To run ad-hoc Attack discoveries, select a connector in settings',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/index.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { Schedule } from '.';
+import { TestProviders } from '../../../../common/mock';
+import { SCHEDULE, SCHEDULE_TOOLTIP } from './translations';
+
+const defaultProps = {
+  isLoading: false,
+  openFlyout: jest.fn(),
+};
+
+describe('Schedule', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the button with the expected text', () => {
+    render(
+      <TestProviders>
+        <Schedule {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('schedule')).toHaveTextContent(SCHEDULE);
+  });
+
+  it('renders the tooltip on hover with the expected text', async () => {
+    render(
+      <TestProviders>
+        <Schedule {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.mouseOver(screen.getByTestId('schedule'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scheduleTooltip')).toHaveTextContent(SCHEDULE_TOOLTIP);
+    });
+  });
+
+  it('disables the button when isLoading is true', () => {
+    render(
+      <TestProviders>
+        <Schedule {...defaultProps} isLoading={true} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('schedule')).toBeDisabled();
+  });
+
+  it('calls openFlyout with schedule when clicked', () => {
+    render(
+      <TestProviders>
+        <Schedule {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('schedule'));
+
+    expect(defaultProps.openFlyout).toHaveBeenCalledWith('schedule');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/index.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton, EuiToolTip } from '@elastic/eui';
+import React, { useCallback } from 'react';
+
+import { SCHEDULE_TAB_ID } from '../../settings_flyout/constants';
+import * as i18n from './translations';
+
+interface Props {
+  isLoading: boolean;
+  openFlyout: (tabId: string) => void;
+}
+
+const ScheduleComponent: React.FC<Props> = ({ isLoading, openFlyout }) => {
+  const onClick = useCallback(
+    () => openFlyout(SCHEDULE_TAB_ID), // Open the schedule tab in the flyout
+    [openFlyout]
+  );
+
+  return (
+    <EuiToolTip content={i18n.SCHEDULE_TOOLTIP} data-test-subj="scheduleTooltip" position="bottom">
+      <EuiButton
+        color="primary"
+        data-test-subj="schedule"
+        fill
+        iconType="calendar"
+        isDisabled={isLoading}
+        onClick={onClick}
+      >
+        {i18n.SCHEDULE}
+      </EuiButton>
+    </EuiToolTip>
+  );
+};
+
+ScheduleComponent.displayName = 'Schedule';
+
+export const Schedule = React.memo(ScheduleComponent);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/translations.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const SCHEDULE = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.schedule.scheduleButton',
+  {
+    defaultMessage: 'Schedule',
+  }
+);
+
+export const SCHEDULE_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.schedule.scheduleTooltip',
+  {
+    defaultMessage: 'Customize settings for scheduled discoveries',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/settings/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/settings/index.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { SETTINGS, SETTINGS_TOOLTIP } from './translations';
+import { Settings } from '.';
+import { SETTINGS_TAB_ID } from '../../settings_flyout/constants';
+
+const defaultProps = {
+  isLoading: false,
+  openFlyout: jest.fn(),
+};
+
+describe('Settings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the settings button with the expected aria-label', () => {
+    render(<Settings {...defaultProps} />);
+
+    expect(screen.getByTestId('settings')).toHaveAttribute('aria-label', SETTINGS);
+  });
+
+  it('renders the tooltip on hover with the expected text', async () => {
+    render(<Settings {...defaultProps} />);
+
+    fireEvent.mouseOver(screen.getByTestId('settings'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('settingsTooltip')).toHaveTextContent(SETTINGS_TOOLTIP);
+    });
+  });
+
+  it('disables the button when isLoading is true', () => {
+    render(<Settings {...defaultProps} isLoading={true} />);
+
+    expect(screen.getByTestId('settings')).toBeDisabled();
+  });
+
+  it('calls openFlyout with SETTINGS_TAB_ID when the button is clicked', () => {
+    render(<Settings {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('settings'));
+
+    expect(defaultProps.openFlyout).toHaveBeenCalledWith(SETTINGS_TAB_ID);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/settings/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/settings/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton, EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useCallback } from 'react';
+
+import { SETTINGS_TAB_ID } from '../../settings_flyout/constants';
+import * as i18n from './translations';
+
+interface Props {
+  isLoading: boolean;
+  openFlyout: (tabId: string) => void;
+}
+
+const settingsButtonStyles = css`
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  min-width: 40px;
+  padding-inline: 0;
+  width: 40px;
+`;
+
+const SettingsComponent: React.FC<Props> = ({ isLoading, openFlyout }) => {
+  const onClick = useCallback(
+    () => openFlyout(SETTINGS_TAB_ID), // open the settings tab in the flyout
+    [openFlyout]
+  );
+
+  return (
+    <EuiToolTip data-test-subj="settingsTooltip" content={i18n.SETTINGS_TOOLTIP} position="bottom">
+      <EuiButton
+        aria-label={i18n.SETTINGS}
+        color="primary"
+        css={settingsButtonStyles}
+        data-test-subj="settings"
+        iconType="indexSettings"
+        isDisabled={isLoading}
+        onClick={onClick}
+      />
+    </EuiToolTip>
+  );
+};
+
+SettingsComponent.displayName = 'Settings';
+
+export const Settings = React.memo(SettingsComponent);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/settings/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/settings/translations.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const SETTINGS = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.settings.settingsButton',
+  {
+    defaultMessage: 'Settings',
+  }
+);
+
+export const SETTINGS_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.settings.settingsTooltip',
+  {
+    defaultMessage: 'Customize settings for ad hoc runs',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
@@ -38,7 +38,22 @@ const mockConnectors: unknown[] = [
   },
 ];
 
-jest.mock('react-use/lib/useLocalStorage', () => jest.fn().mockReturnValue(['test-id', jest.fn()]));
+jest.mock('react-use/lib/useLocalStorage', () =>
+  jest.fn().mockImplementation((key, defaultValue) => {
+    // Return different values based on the localStorage key
+    if (key.includes('START_LOCAL_STORAGE_KEY')) {
+      return ['now-24h', jest.fn()];
+    }
+    if (key.includes('END_LOCAL_STORAGE_KEY')) {
+      return ['now', jest.fn()];
+    }
+    if (key.includes('CONNECTOR_ID_LOCAL_STORAGE_KEY')) {
+      return ['test-id', jest.fn()];
+    }
+    // For other keys, return the default value or 'test-id'
+    return [defaultValue || 'test-id', jest.fn()];
+  })
+);
 jest.mock('react-use/lib/useSessionStorage', () =>
   jest.fn().mockReturnValue([undefined, jest.fn()])
 );
@@ -212,8 +227,6 @@ describe('AttackDiscovery', () => {
       isFetched: true,
       data: mockConnectors,
     });
-
-    (useLocalStorage as jest.Mock).mockReturnValue(['test-id', jest.fn()]);
   });
 
   describe('page layout', () => {
@@ -508,7 +521,27 @@ describe('AttackDiscovery', () => {
   });
 
   describe('Alerts filtering feature', () => {
+    let fetchAttackDiscoveriesMock: jest.Mock;
     beforeEach(() => {
+      fetchAttackDiscoveriesMock = jest.fn();
+      (useAttackDiscovery as jest.Mock).mockReturnValue({
+        ...getMockUseAttackDiscoveriesWithCachedAttackDiscoveries(fetchAttackDiscoveriesMock),
+      });
+
+      // Override the localStorage mock to return proper values for this test
+      (useLocalStorage as jest.Mock).mockImplementation((key: string) => {
+        if (key.includes('attackDiscovery.start')) {
+          return ['now-24h', jest.fn()];
+        }
+        if (key.includes('attackDiscovery.end')) {
+          return ['now', jest.fn()];
+        }
+        if (key.includes('attackDiscovery.connectorId')) {
+          return ['test-id', jest.fn()];
+        }
+        return [undefined, jest.fn()];
+      });
+
       render(
         <TestProviders>
           <Router history={historyMock}>
@@ -525,9 +558,17 @@ describe('AttackDiscovery', () => {
 
       fireEvent.click(generate[0]);
 
-      expect(
-        (useAttackDiscovery as jest.Mock)().fetchAttackDiscoveries as jest.Mock
-      ).toHaveBeenCalledWith({ end: 'test-id', filter: undefined, size: 20, start: 'test-id' });
+      expect(fetchAttackDiscoveriesMock).toHaveBeenCalledWith({
+        end: 'now',
+        filter: undefined,
+        overrideConnectorId: undefined,
+        overrideEnd: undefined,
+        overrideFilter: undefined,
+        overrideSize: undefined,
+        overrideStart: undefined,
+        size: 100,
+        start: 'now-24h',
+      });
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -33,6 +33,7 @@ import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_que
 import { useKibana } from '../../common/lib/kibana';
 import { convertToBuildEsQuery } from '../../common/lib/kuery';
 import { SpyRoute } from '../../common/utils/route/spy_routes';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { Header } from './header';
 import { CONNECTOR_ID_LOCAL_STORAGE_KEY, getDefaultQuery, getSize, showLoading } from './helpers';
 import { LoadingCallout } from './loading_callout';
@@ -40,7 +41,9 @@ import { deserializeQuery } from './local_storage/deserialize_query';
 import { deserializeFilters } from './local_storage/deserialize_filters';
 import { PageTitle } from './page_title';
 import { Results } from './results';
+import type { SettingsOverrideOptions } from './results/history/types';
 import { SettingsFlyout } from './settings_flyout';
+import { SETTINGS_TAB_ID } from './settings_flyout/constants';
 import { parseFilterQuery } from './settings_flyout/parse_filter_query';
 import { useSourcererDataView } from '../../sourcerer/containers';
 import { useAttackDiscovery } from './use_attack_discovery';
@@ -68,7 +71,11 @@ const AttackDiscoveryPageComponent: React.FC = () => {
 
   // showing / hiding the flyout:
   const [showFlyout, setShowFlyout] = useState<boolean>(false);
-  const openFlyout = useCallback(() => setShowFlyout(true), []);
+  const [defaultSelectedTabId, setDefaultSelectedTabId] = useState<string>(SETTINGS_TAB_ID);
+  const openFlyout = useCallback((tabId: string) => {
+    setDefaultSelectedTabId(tabId);
+    setShowFlyout(true);
+  }, []);
 
   // time selection:
   const [start, setStart] = useLocalStorage<string>(
@@ -218,29 +225,40 @@ const AttackDiscoveryPageComponent: React.FC = () => {
 
   const invalidateGetAttackDiscoveryGenerations = useInvalidateGetAttackDiscoveryGenerations();
 
-  const onGenerate = useCallback(async () => {
-    const size = alertsContextCount ?? DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS;
-    const filter = parseFilterQuery({ filterQuery, kqlError });
-
-    try {
-      return await fetchAttackDiscoveries({
-        end,
-        filter, // <-- combined search bar query and filters
-        size,
-        start,
+  const onGenerate = useCallback(
+    async (overrideOptions?: SettingsOverrideOptions) => {
+      const size = getSize({
+        defaultMaxAlerts: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
+        localStorageAttackDiscoveryMaxAlerts,
       });
-    } finally {
-      invalidateGetAttackDiscoveryGenerations();
-    }
-  }, [
-    alertsContextCount,
-    end,
-    fetchAttackDiscoveries,
-    filterQuery,
-    invalidateGetAttackDiscoveryGenerations,
-    kqlError,
-    start,
-  ]);
+      const filter = parseFilterQuery({ filterQuery, kqlError });
+
+      try {
+        return await fetchAttackDiscoveries({
+          end,
+          filter, // <-- combined search bar query and filters
+          size,
+          start,
+          overrideConnectorId: overrideOptions?.overrideConnectorId,
+          overrideEnd: overrideOptions?.overrideEnd,
+          overrideFilter: overrideOptions?.overrideFilter,
+          overrideSize: overrideOptions?.overrideSize,
+          overrideStart: overrideOptions?.overrideStart,
+        });
+      } finally {
+        invalidateGetAttackDiscoveryGenerations();
+      }
+    },
+    [
+      end,
+      fetchAttackDiscoveries,
+      filterQuery,
+      invalidateGetAttackDiscoveryGenerations,
+      kqlError,
+      localStorageAttackDiscoveryMaxAlerts,
+      start,
+    ]
+  );
 
   useEffect(() => {
     setSelectedConnectorReplacements(replacements);
@@ -344,10 +362,12 @@ const AttackDiscoveryPageComponent: React.FC = () => {
             {showFlyout && (
               <SettingsFlyout
                 connectorId={connectorId}
+                defaultSelectedTabId={defaultSelectedTabId}
                 end={end}
                 filters={filters}
                 onClose={onClose}
                 onConnectorIdSelected={onConnectorIdSelected}
+                onGenerate={onGenerate}
                 query={query}
                 setEnd={setEnd}
                 setFilters={setFilters}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -33,7 +33,6 @@ import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_que
 import { useKibana } from '../../common/lib/kibana';
 import { convertToBuildEsQuery } from '../../common/lib/kuery';
 import { SpyRoute } from '../../common/utils/route/spy_routes';
-import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { Header } from './header';
 import { CONNECTOR_ID_LOCAL_STORAGE_KEY, getDefaultQuery, getSize, showLoading } from './helpers';
 import { LoadingCallout } from './loading_callout';

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/current/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/current/index.tsx
@@ -21,6 +21,7 @@ import { AttackDiscoveryPanel } from '../attack_discovery_panel';
 import { EmptyStates } from '../empty_states';
 import { showEmptyStates } from '../empty_states/helpers/show_empty_states';
 import { getInitialIsOpen, showLoading, showSummary } from '../../helpers';
+import type { SettingsOverrideOptions } from '../history/types';
 import { LoadingCallout } from '../../loading_callout';
 import { Summary } from '../summary';
 
@@ -38,7 +39,7 @@ interface Props {
   isLoadingPost: boolean;
   loadingConnectorId: string | null;
   localStorageAttackDiscoveryMaxAlerts: string | undefined;
-  onGenerate: () => Promise<void>;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onToggleShowAnonymized: () => void;
   selectedConnectorAttackDiscoveries: AttackDiscovery[];
   selectedConnectorLastUpdated: Date | null;

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
@@ -17,11 +17,12 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { AssistantBeacon } from '@kbn/ai-assistant-icon';
 import React, { useMemo } from 'react';
 
-import { AssistantBeacon } from '@kbn/ai-assistant-icon';
 import { AnimatedCounter } from './animated_counter';
 import { Generate } from '../generate';
+import type { SettingsOverrideOptions } from '../../history/types';
 import * as i18n from './translations';
 import { useKibanaFeatureFlags } from '../../../use_kibana_feature_flags';
 
@@ -31,7 +32,7 @@ interface Props {
   attackDiscoveriesCount: number;
   isDisabled?: boolean;
   isLoading: boolean;
-  onGenerate: () => void;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
 }
 
 const EmptyPromptComponent: React.FC<Props> = ({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
@@ -9,11 +9,12 @@ import { EuiButton, EuiToolTip } from '@elastic/eui';
 import React from 'react';
 
 import * as i18n from '../empty_prompt/translations';
+import type { SettingsOverrideOptions } from '../../history/types';
 
 interface Props {
   isDisabled?: boolean;
   isLoading: boolean;
-  onGenerate: () => void;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
 }
 
 const GenerateComponent: React.FC<Props> = ({ isLoading, isDisabled = false, onGenerate }) => {
@@ -24,7 +25,12 @@ const GenerateComponent: React.FC<Props> = ({ isLoading, isDisabled = false, onG
       content={disabled ? i18n.SELECT_A_CONNECTOR : null}
       data-test-subj="generateTooltip"
     >
-      <EuiButton color="primary" data-test-subj="generate" disabled={disabled} onClick={onGenerate}>
+      <EuiButton
+        color="primary"
+        data-test-subj="generate"
+        disabled={disabled}
+        onClick={() => onGenerate()}
+      >
         {i18n.GENERATE}
       </EuiButton>
     </EuiToolTip>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/index.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { Failure } from './failure';
 import { EmptyPrompt } from './empty_prompt';
 import { showFailurePrompt, showNoAlertsPrompt, showWelcomePrompt } from '../../helpers';
+import type { SettingsOverrideOptions } from '../history/types';
 import { NoAlerts } from './no_alerts';
 import { Welcome } from './welcome';
 
@@ -20,7 +21,7 @@ interface Props {
   connectorId: string | undefined;
   failureReason: string | null;
   isLoading: boolean;
-  onGenerate: () => Promise<void>;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   upToAlertsCount: number;
 }
 
@@ -36,6 +37,11 @@ const EmptyStatesComponent: React.FC<Props> = ({
 }) => {
   const isDisabled = connectorId == null;
 
+  // Return null when loading or when attack discoveries are present
+  if (isLoading || attackDiscoveriesCount > 0) {
+    return null;
+  }
+
   if (showWelcomePrompt({ aiConnectorsCount, isLoading })) {
     return <Welcome />;
   }
@@ -49,14 +55,16 @@ const EmptyStatesComponent: React.FC<Props> = ({
   }
 
   return (
-    <EmptyPrompt
-      aiConnectorsCount={aiConnectorsCount}
-      alertsCount={upToAlertsCount}
-      attackDiscoveriesCount={attackDiscoveriesCount}
-      isDisabled={isDisabled}
-      isLoading={isLoading}
-      onGenerate={onGenerate}
-    />
+    <div data-test-subj="emptyStates">
+      <EmptyPrompt
+        aiConnectorsCount={aiConnectorsCount}
+        alertsCount={upToAlertsCount}
+        attackDiscoveriesCount={attackDiscoveriesCount}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        onGenerate={onGenerate}
+      />
+    </div>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/no_alerts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/no_alerts/index.tsx
@@ -13,16 +13,17 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { AssistantIcon } from '@kbn/ai-assistant-icon';
 import React, { useMemo } from 'react';
 
-import { AssistantIcon } from '@kbn/ai-assistant-icon';
-import * as i18n from './translations';
 import { Generate } from '../generate';
+import type { SettingsOverrideOptions } from '../../history/types';
+import * as i18n from './translations';
 
 interface Props {
   isDisabled: boolean;
   isLoading: boolean;
-  onGenerate: () => void;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
 }
 
 const NoAlertsComponent: React.FC<Props> = ({ isDisabled, isLoading, onGenerate }) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.tsx
@@ -29,6 +29,7 @@ import { SearchAndFilter } from './search_and_filter';
 import { ACKNOWLEDGED, CLOSED, OPEN } from './search_and_filter/translations';
 import { Summary } from '../summary';
 import * as i18n from './translations';
+import type { SettingsOverrideOptions } from './types';
 import { useDismissAttackDiscoveryGeneration } from '../../use_dismiss_attack_discovery_generations';
 import { useIdsFromUrl } from './use_ids_from_url';
 import { useFindAttackDiscoveries } from '../../use_find_attack_discoveries';
@@ -49,7 +50,7 @@ const EMPTY_QUERY = '';
 interface Props {
   aiConnectors: AIConnector[] | undefined;
   localStorageAttackDiscoveryMaxAlerts: string | undefined;
-  onGenerate: () => Promise<void>;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onToggleShowAnonymized: () => void;
   showAnonymized: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/types.ts
@@ -9,3 +9,11 @@ export interface ConnectorFilterOptionData {
   description?: string;
   deleted?: boolean;
 }
+
+export interface SettingsOverrideOptions {
+  overrideConnectorId?: string;
+  overrideEnd?: string;
+  overrideFilter?: Record<string, unknown>;
+  overrideSize?: number;
+  overrideStart?: string;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/index.test.tsx
@@ -143,28 +143,6 @@ describe('Results', () => {
     } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
   });
 
-  it('renders the EmptyStates when showEmptyStates returns true', () => {
-    render(
-      <TestProviders>
-        <Results {...defaultProps} aiConnectors={[]} />
-      </TestProviders>
-    );
-
-    expect(screen.getByTestId('welcome')).toBeInTheDocument();
-  });
-
-  it('calls onGenerate when the generate button is clicked', () => {
-    render(
-      <TestProviders>
-        <Results {...defaultProps} alertsContextCount={0} />
-      </TestProviders>
-    );
-
-    fireEvent.click(screen.getByTestId('generate'));
-
-    expect(defaultProps.onGenerate).toHaveBeenCalled();
-  });
-
   it('renders the Summary when showSummary returns true', () => {
     render(
       <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/index.tsx
@@ -20,6 +20,7 @@ import { Current } from './current';
 import { EmptyStates } from './empty_states';
 import { showEmptyStates } from './empty_states/helpers/show_empty_states';
 import { History } from './history';
+import type { SettingsOverrideOptions } from './history/types';
 import { useKibanaFeatureFlags } from '../use_kibana_feature_flags';
 
 interface Props {
@@ -36,7 +37,7 @@ interface Props {
   isLoadingPost: boolean;
   localStorageAttackDiscoveryMaxAlerts: string | undefined;
   loadingConnectorId: string | null;
-  onGenerate: () => Promise<void>;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onToggleShowAnonymized: () => void;
   selectedConnectorAttackDiscoveries: AttackDiscovery[];
   selectedConnectorLastUpdated: Date | null;

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/index.test.tsx
@@ -9,6 +9,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { Summary } from '.';
+import { TestProviders } from '../../../../common/mock';
+import { getMockAttackDiscoveryAlerts } from '../../mock/mock_attack_discovery_alerts';
 
 jest.mock('../../../../common/lib/kibana');
 
@@ -34,28 +36,89 @@ describe('Summary', () => {
     expect(summaryCount).toHaveTextContent('5 discoveries|20 alerts|Generated: a few seconds ago');
   });
 
-  it('renders the expected button icon when showAnonymized is false', () => {
-    render(<Summary {...defaultProps} />);
-
-    const toggleAnonymized = screen.getByTestId('toggleAnonymized').querySelector('span');
-
-    expect(toggleAnonymized).toHaveAttribute('data-euiicon-type', 'eyeClosed');
-  });
-
-  it('renders the expected button icon when showAnonymized is true', () => {
-    render(<Summary {...defaultProps} showAnonymized={true} />);
-
-    const toggleAnonymized = screen.getByTestId('toggleAnonymized').querySelector('span');
-
-    expect(toggleAnonymized).toHaveAttribute('data-euiicon-type', 'eye');
-  });
-
-  it('calls onToggleShowAnonymized when toggle button is clicked', () => {
+  it('calls onToggleShowAnonymized when the toggle button is clicked', () => {
     render(<Summary {...defaultProps} />);
 
     const toggleAnonymized = screen.getByTestId('toggleAnonymized');
     fireEvent.click(toggleAnonymized);
 
     expect(defaultProps.onToggleShowAnonymized).toHaveBeenCalled();
+  });
+
+  it('renders the loading spinner when isLoading is true', () => {
+    render(
+      <TestProviders>
+        <Summary {...defaultProps} isLoading={true} />
+      </TestProviders>
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders without lastUpdated', () => {
+    render(
+      <TestProviders>
+        <Summary {...defaultProps} lastUpdated={null} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('summaryCount')).not.toHaveTextContent('Generated:');
+  });
+
+  it('renders SelectedActions when selectedAttackDiscoveries is not empty', () => {
+    const selectedAttackDiscoveries = { '0b8cf9c7-5ba1-49ce-b53d-3cfb06918b60': true };
+    render(
+      <TestProviders>
+        <Summary
+          {...defaultProps}
+          selectedAttackDiscoveries={selectedAttackDiscoveries}
+          selectedConnectorAttackDiscoveries={getMockAttackDiscoveryAlerts()}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByText(/Selected 1 Attack discovery/)).toBeInTheDocument();
+  });
+
+  it('passes refetchFindAttackDiscoveries to SelectedActions', () => {
+    const refetchFindAttackDiscoveries = jest.fn();
+    const selectedAttackDiscoveries = { '0b8cf9c7-5ba1-49ce-b53d-3cfb06918b60': true };
+    render(
+      <TestProviders>
+        <Summary
+          {...defaultProps}
+          refetchFindAttackDiscoveries={refetchFindAttackDiscoveries}
+          selectedAttackDiscoveries={selectedAttackDiscoveries}
+          selectedConnectorAttackDiscoveries={getMockAttackDiscoveryAlerts()}
+        />
+      </TestProviders>
+    );
+
+    // The prop is passed, but we can't trigger it directly from here; just ensure no error
+    expect(screen.getByText(/Selected 1 Attack discovery/)).toBeInTheDocument();
+  });
+
+  it('renders the switch checked when showAnonymized is true', () => {
+    render(
+      <TestProviders>
+        <Summary {...defaultProps} showAnonymized={true} />
+      </TestProviders>
+    );
+
+    const toggleButton = screen.getByTestId('toggleAnonymized');
+
+    expect(toggleButton).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders the switch unchecked when showAnonymized is false', () => {
+    render(
+      <TestProviders>
+        <Summary {...defaultProps} showAnonymized={false} />
+      </TestProviders>
+    );
+
+    const toggleButton = screen.getByTestId('toggleAnonymized');
+
+    expect(toggleButton).toHaveAttribute('aria-checked', 'false');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/index.tsx
@@ -5,21 +5,14 @@
  * 2.0.
  */
 
-import {
-  EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLoadingSpinner,
-  EuiToolTip,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSwitch, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React from 'react';
 
 import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
 import { SelectedActions } from './selected_actions';
 import { SummaryCount } from './summary_count';
-import { SHOW_REAL_VALUES, SHOW_ANONYMIZED_LABEL } from '../../translations';
+import { SHOW_ANONYMIZED_LABEL } from '../../translations';
 
 interface Props {
   alertsCount: number;
@@ -89,20 +82,13 @@ const SummaryComponent: React.FC<Props> = ({
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>
-        <EuiToolTip
-          content={showAnonymized ? SHOW_REAL_VALUES : SHOW_ANONYMIZED_LABEL}
-          data-test-subj="toggleAnonymizedToolTip"
-        >
-          <EuiButtonIcon
-            aria-label={showAnonymized ? SHOW_REAL_VALUES : SHOW_ANONYMIZED_LABEL}
-            css={css`
-              border-radius: 50%;
-            `}
-            data-test-subj="toggleAnonymized"
-            iconType={showAnonymized ? 'eye' : 'eyeClosed'}
-            onClick={onToggleShowAnonymized}
-          />
-        </EuiToolTip>
+        <EuiSwitch
+          checked={showAnonymized}
+          compressed={true}
+          data-test-subj="toggleAnonymized"
+          label={SHOW_ANONYMIZED_LABEL}
+          onChange={onToggleShowAnonymized}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/index.tsx
@@ -94,8 +94,6 @@ const AlertSelectionComponent: React.FC<Props> = ({
     <EuiForm data-test-subj="alertSelection" fullWidth>
       {showConnectorSelector && spaceId && (
         <AssistantSpaceIdProvider spaceId={spaceId}>
-          <EuiSpacer size="s" />
-
           <EuiText data-test-subj="customizeAlerts" size="s">
             <p>{i18n.CUSTOMIZE_THE_CONNECTOR_AND_ALERTS}</p>
           </EuiText>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/translations.ts
@@ -40,7 +40,7 @@ export const CUSTOMIZE_THE_CONNECTOR_AND_ALERTS = i18n.translate(
   'xpack.securitySolution.attackDiscovery.settingsFlyout.alertSelection.customizeTheConnectorAndAlertsLabel',
   {
     defaultMessage:
-      'Customize the connector and alerts that will be analyzed when generating Attack discoveries on the fly. Scheduled Attack discoveries are set up independently.',
+      'Customize the connector and alerts that will be analyzed when generating Attack discoveries on the fly, which are private to you. Scheduled Attack discoveries are set up independently.',
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/constants.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/constants.tsx
@@ -6,3 +6,7 @@
  */
 
 export const MIN_FLYOUT_WIDTH = 448; // px
+
+export const SETTINGS_TAB_ID = 'settings';
+
+export const SCHEDULE_TAB_ID = 'schedule';

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/footer/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/footer/index.test.tsx
@@ -5,21 +5,50 @@
  * 2.0.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
 
 import { Footer } from '.';
+import { CLOSE } from './translations';
+
+const defaultProps = {
+  closeModal: jest.fn(),
+};
 
 describe('Footer', () => {
-  const closeModal = jest.fn();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-  beforeEach(() => jest.clearAllMocks());
+  it('renders the default close button text', () => {
+    render(<Footer {...defaultProps} />);
 
-  it('calls closeModal when the cancel button is clicked', () => {
-    render(<Footer closeModal={closeModal} />);
+    const closeButton = screen.getByTestId('close');
+
+    expect(closeButton).toHaveTextContent(CLOSE);
+  });
+
+  it('renders custom close button text', () => {
+    render(<Footer {...defaultProps} closeButtonText="Custom Close" />);
+
+    const closeButton = screen.getByTestId('close');
+
+    expect(closeButton).toHaveTextContent('Custom Close');
+  });
+
+  it('calls closeModal when the button is clicked', () => {
+    render(<Footer {...defaultProps} />);
 
     fireEvent.click(screen.getByTestId('close'));
 
-    expect(closeModal).toHaveBeenCalled();
+    expect(defaultProps.closeModal).toHaveBeenCalled();
+  });
+
+  it('renders actionButtons when provided', () => {
+    render(
+      <Footer {...defaultProps} actionButtons={<div data-test-subj="action">{'Action'}</div>} />
+    );
+
+    expect(screen.getByTestId('action')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/footer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/footer/index.tsx
@@ -11,11 +11,16 @@ import React from 'react';
 import * as i18n from './translations';
 
 interface Props {
-  closeModal: () => void;
   actionButtons?: React.ReactNode;
+  closeButtonText?: string;
+  closeModal: () => void;
 }
 
-const FooterComponent: React.FC<Props> = ({ closeModal, actionButtons }) => {
+const FooterComponent: React.FC<Props> = ({
+  actionButtons,
+  closeButtonText = i18n.CLOSE,
+  closeModal,
+}) => {
   return (
     <EuiFlexGroup
       alignItems="center"
@@ -26,7 +31,7 @@ const FooterComponent: React.FC<Props> = ({ closeModal, actionButtons }) => {
     >
       <EuiFlexItem grow={false}>
         <EuiButtonEmpty data-test-subj="close" onClick={closeModal} size="s">
-          {i18n.CLOSE}
+          {closeButtonText}
         </EuiButtonEmpty>
       </EuiFlexItem>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/translations.ts
@@ -14,6 +14,27 @@ export const SAVE = i18n.translate(
   }
 );
 
+export const SAVE_AND_RUN = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.settingsFlyout.saveAndRunButton',
+  {
+    defaultMessage: 'Save and run',
+  }
+);
+
+export const SELECT_A_CONNECTOR_TO_SAVE = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.settingsFlyout.selectAConnectorToSaveTooltip',
+  {
+    defaultMessage: 'Select a connector to save',
+  }
+);
+
+export const SELECT_A_CONNECTOR_TO_SAVE_AND_RUN = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.settingsFlyout.selectAConnectorToSaveAndRunTooltip',
+  {
+    defaultMessage: 'Select a connector to save and run',
+  }
+);
+
 export const RESET = i18n.translate(
   'xpack.securitySolution.attackDiscovery.settingsFlyout.resetLabel',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_schedule_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_schedule_view.tsx
@@ -74,7 +74,7 @@ export const useScheduleView = (): UseScheduleView => {
             data-test-subj="createNewSchedule"
             fill
             onClick={openFlyout}
-            size="s"
+            size="m"
             iconType="plusInCircle"
           >
             {i18n.CREATE_NEW_SCHEDULE}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.test.tsx
@@ -6,15 +6,60 @@
  */
 
 import { createFilterManagerMock } from '@kbn/data-plugin/public/query/filter_manager/filter_manager.mock';
-import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import React from 'react';
 
 import { useKibana } from '../../../../common/lib/kibana';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useSettingsView } from './use_settings_view';
+import type { UseSettingsView } from './use_settings_view';
 import { TestProviders } from '../../../../common/mock';
 
 const mockFilterManager = createFilterManagerMock();
+
+// Mock EuiSuperDatePicker to capture onTimeChange
+const mockOnTimeChange = jest.fn();
+jest.mock('@elastic/eui', () => ({
+  ...jest.requireActual('@elastic/eui'),
+  EuiSuperDatePicker: (props: { onTimeChange: jest.Mock }) => {
+    if (props.onTimeChange) {
+      mockOnTimeChange.mockImplementation(props.onTimeChange);
+    }
+    return <div data-test-subj="alertSelectionDatePicker" />;
+  },
+}));
+
+// Mock for discover-utils UI_SETTINGS in case META_FIELDS is imported from there
+jest.mock('@kbn/discover-utils', () => ({
+  UI_SETTINGS: {
+    META_FIELDS: 'metaFields',
+    SORT_DEFAULT_ORDER_SETTING: 'discover:sort:defaultOrder',
+    DOC_HIDE_TIME_COLUMN_SETTING: 'doc_table:hideTimeColumn',
+  },
+  buildDataTableRecord: jest.fn(),
+  getDefaultSort: jest.fn().mockReturnValue([]),
+  getSortArray: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('@kbn/data-plugin/common', () => ({
+  getEsQueryConfig: jest.fn().mockReturnValue({}),
+  createEscapeValue: jest.fn().mockReturnValue(() => ''),
+  getCalculateAutoTimeExpression: jest.fn().mockReturnValue(jest.fn()),
+  UI_SETTINGS: {
+    HISTOGRAM_BAR_TARGET: 'HISTOGRAM_BAR_TARGET',
+    HISTOGRAM_MAX_BARS: 'HISTOGRAM_MAX_BARS',
+    SEARCH_QUERY_LANGUAGE: 'SEARCH_QUERY_LANGUAGE',
+    QUERY_ALLOW_LEADING_WILDCARDS: 'QUERY_ALLOW_LEADING_WILDCARDS',
+    META_FIELDS: 'metaFields',
+    // Add more keys as needed for coverage
+  },
+  KBN_FIELD_TYPES: {
+    DATE: 'date',
+    DATE_RANGE: 'date_range',
+  },
+}));
+
+const mockOnQuerySubmit = jest.fn();
 
 jest.mock('react-router', () => ({
   matchPath: jest.fn(),
@@ -30,6 +75,40 @@ jest.mock('../../../../common/hooks/use_space_id', () => {
     useSpaceId: jest.fn().mockReturnValue('default'),
   };
 });
+jest.mock('../../../../data_view_manager/hooks/use_data_view', () => ({
+  useDataView: jest.fn().mockReturnValue({
+    dataView: {
+      id: 'security',
+      title: 'security',
+    },
+    status: 'ready',
+  }),
+}));
+jest.mock('../../use_kibana_feature_flags', () => ({
+  useKibanaFeatureFlags: jest.fn().mockReturnValue({
+    attackDiscoveryAlertsEnabled: true,
+  }),
+}));
+jest.mock('../../../../common/lib/kuery', () => ({
+  convertToBuildEsQuery: jest
+    .fn()
+    .mockReturnValue([
+      JSON.stringify({ bool: { must: [], filter: [], should: [], must_not: [] } }),
+      undefined,
+    ]),
+}));
+
+jest.mock('../parse_filter_query', () => ({
+  parseFilterQuery: jest
+    .fn()
+    .mockReturnValue({ bool: { must: [], filter: [], should: [], must_not: [] } }),
+}));
+
+// Mock for data-plugin/public
+jest.mock('@kbn/data-plugin/public', () => ({
+  ...jest.requireActual('@kbn/data-plugin/public'),
+  FilterManager: jest.fn().mockImplementation(() => mockFilterManager),
+}));
 
 const defaultProps = {
   connectorId: undefined,
@@ -37,6 +116,7 @@ const defaultProps = {
   onSettingsChanged: jest.fn(),
   onSettingsReset: jest.fn(),
   onSettingsSave: jest.fn(),
+  onGenerate: jest.fn(),
   settings: {
     end: 'now',
     filters: [],
@@ -74,7 +154,12 @@ describe('useSettingsView', () => {
         },
         unifiedSearch: {
           ui: {
-            SearchBar: () => <div data-test-subj="mockSearchBar" />,
+            SearchBar: (props: { onQuerySubmit: jest.Mock }) => {
+              if (props.onQuerySubmit) {
+                mockOnQuerySubmit.mockImplementation(props.onQuerySubmit);
+              }
+              return <div data-test-subj="alertSelectionSearchBar" />;
+            },
           },
         },
       },
@@ -86,8 +171,31 @@ describe('useSettingsView', () => {
     } as unknown as jest.Mocked<ReturnType<typeof useSourcererDataView>>);
   });
 
+  // DRY helper for simulating connector change and save
+  function simulateConnectorChangeAndSave(
+    result: {
+      current: UseSettingsView;
+    },
+    newConnectorId: string
+  ) {
+    let handleLocalConnectorIdChange: ((id: string) => void) | undefined;
+    if (React.isValidElement(result.current.settingsView)) {
+      handleLocalConnectorIdChange = (result.current.settingsView as React.ReactElement).props
+        .onConnectorIdSelected;
+    }
+    act(() => {
+      handleLocalConnectorIdChange?.(newConnectorId);
+    });
+
+    render(<TestProviders>{result.current.actionButtons}</TestProviders>);
+
+    fireEvent.click(screen.getByTestId('save'));
+  }
+
   it('should return the alert selection component with `AlertSelectionQuery` as settings view', () => {
-    const { result } = renderHook(() => useSettingsView(defaultProps));
+    const { result } = renderHook(() => useSettingsView(defaultProps), {
+      wrapper: TestProviders,
+    });
 
     render(<TestProviders>{result.current.settingsView}</TestProviders>);
 
@@ -95,7 +203,9 @@ describe('useSettingsView', () => {
   });
 
   it('should return the alert selection component with `AlertSelectionRange` as settings view', () => {
-    const { result } = renderHook(() => useSettingsView(defaultProps));
+    const { result } = renderHook(() => useSettingsView(defaultProps), {
+      wrapper: TestProviders,
+    });
 
     render(<TestProviders>{result.current.settingsView}</TestProviders>);
 
@@ -103,7 +213,9 @@ describe('useSettingsView', () => {
   });
 
   it('should return reset action button', () => {
-    const { result } = renderHook(() => useSettingsView(defaultProps));
+    const { result } = renderHook(() => useSettingsView(defaultProps), {
+      wrapper: TestProviders,
+    });
 
     render(<TestProviders>{result.current.actionButtons}</TestProviders>);
 
@@ -111,32 +223,191 @@ describe('useSettingsView', () => {
   });
 
   it('should return save action button', () => {
-    const { result } = renderHook(() => useSettingsView(defaultProps));
+    const { result } = renderHook(() => useSettingsView(defaultProps), {
+      wrapper: TestProviders,
+    });
 
     render(<TestProviders>{result.current.actionButtons}</TestProviders>);
 
     expect(screen.getByTestId('save')).toBeInTheDocument();
   });
 
-  it('when the save button is clicked - invokes onSettingsSave', () => {
-    const { result } = renderHook(() => useSettingsView(defaultProps));
+  it('disables the save button when localConnectorId is null', () => {
+    const props = { ...defaultProps, connectorId: undefined };
+    const { result } = renderHook(() => useSettingsView(props), {
+      wrapper: TestProviders,
+    });
 
     render(<TestProviders>{result.current.actionButtons}</TestProviders>);
 
-    const save = screen.getByTestId('save');
-    fireEvent.click(save);
-
-    expect(defaultProps.onSettingsSave).toHaveBeenCalled();
+    expect(screen.getByTestId('save')).toBeDisabled();
   });
 
-  it('when the reset button is clicked - invokes onSettingsReset', () => {
-    const { result } = renderHook(() => useSettingsView(defaultProps));
+  it('enables the save button when localConnectorId is set', () => {
+    const props = { ...defaultProps, connectorId: 'test-connector' };
+    const { result } = renderHook(() => useSettingsView(props), {
+      wrapper: TestProviders,
+    });
 
     render(<TestProviders>{result.current.actionButtons}</TestProviders>);
 
-    const reset = screen.getByTestId('reset');
-    fireEvent.click(reset);
+    expect(screen.getByTestId('save')).not.toBeDisabled();
+  });
 
-    expect(defaultProps.onSettingsReset).toHaveBeenCalled();
+  it('disables the save and run button when localConnectorId is null', () => {
+    const props = { ...defaultProps, connectorId: undefined };
+    const { result } = renderHook(() => useSettingsView(props), {
+      wrapper: TestProviders,
+    });
+
+    render(<TestProviders>{result.current.actionButtons}</TestProviders>);
+
+    expect(screen.getByTestId('saveAndRun')).toBeDisabled();
+  });
+
+  it('enables the save and run button when localConnectorId is set', () => {
+    const props = { ...defaultProps, connectorId: 'test-connector' };
+    const { result } = renderHook(() => useSettingsView(props), {
+      wrapper: TestProviders,
+    });
+
+    render(<TestProviders>{result.current.actionButtons}</TestProviders>);
+
+    expect(screen.getByTestId('saveAndRun')).not.toBeDisabled();
+  });
+
+  it('invokes onSettingsSave when the save button is clicked', () => {
+    const onSettingsSave = jest.fn();
+    const props = {
+      ...defaultProps,
+      connectorId: 'old-connector',
+      onSettingsSave,
+    };
+    const { result } = renderHook(() => useSettingsView(props), {
+      wrapper: TestProviders,
+    });
+
+    render(<TestProviders>{result.current.actionButtons}</TestProviders>);
+
+    fireEvent.click(screen.getByTestId('save'));
+
+    expect(onSettingsSave).toHaveBeenCalled();
+  });
+
+  it('invokes onConnectorIdSelected when the save button is clicked and the connector changed', () => {
+    const onSettingsSave = jest.fn();
+    const onConnectorIdSelected = jest.fn();
+    const props = {
+      ...defaultProps,
+      connectorId: 'old-connector',
+      onSettingsSave,
+      onConnectorIdSelected,
+    };
+    const { result } = renderHook(() => useSettingsView(props), {
+      wrapper: TestProviders,
+    });
+
+    simulateConnectorChangeAndSave(result as { current: UseSettingsView }, 'new-connector');
+
+    expect(onConnectorIdSelected).toHaveBeenCalledWith('new-connector');
+  });
+
+  describe('when save and run is clicked', () => {
+    interface SaveAndRunProps {
+      connectorId: string;
+      onSettingsSave: jest.Mock;
+      onGenerate: jest.Mock;
+      onConnectorIdSelected: (connectorId: string) => void;
+      onSettingsChanged?: typeof defaultProps.onSettingsChanged;
+      onSettingsReset?: typeof defaultProps.onSettingsReset;
+      settings: typeof defaultProps.settings;
+      showConnectorSelector: boolean;
+      stats: null;
+    }
+    let onSettingsSave: jest.Mock;
+    let onGenerate: jest.Mock;
+    let props: SaveAndRunProps;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      onSettingsSave = jest.fn();
+      onGenerate = jest.fn();
+      props = {
+        ...defaultProps,
+        connectorId: 'test-connector',
+        onSettingsSave,
+        onGenerate,
+        onConnectorIdSelected: jest.fn(), // always provide a function
+      };
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('invokes onSettingsSave when save and run is clicked', () => {
+      const { result } = renderHook(() => useSettingsView(props), {
+        wrapper: TestProviders,
+      });
+      render(<TestProviders>{result.current.actionButtons}</TestProviders>);
+
+      fireEvent.click(screen.getByTestId('saveAndRun'));
+
+      expect(onSettingsSave).toHaveBeenCalled();
+    });
+
+    it('invokes onGenerate when save and run is clicked', () => {
+      const { result } = renderHook(() => useSettingsView(props), {
+        wrapper: TestProviders,
+      });
+
+      render(<TestProviders>{result.current.actionButtons}</TestProviders>);
+
+      fireEvent.click(screen.getByTestId('saveAndRun'));
+      jest.runAllTimers();
+
+      expect(onGenerate).toHaveBeenCalled();
+    });
+  });
+
+  describe('when query is submitted', () => {
+    it('invokes onSettingsChanged with the new query', () => {
+      const onSettingsChanged = jest.fn();
+      const props = { ...defaultProps, onSettingsChanged };
+      const { result } = renderHook(() => useSettingsView(props), {
+        wrapper: TestProviders,
+      });
+      render(<TestProviders>{result.current.settingsView}</TestProviders>);
+
+      act(() => {
+        mockOnQuerySubmit({ query: { query: 'new query', language: 'kuery' } });
+      });
+
+      expect(onSettingsChanged).toHaveBeenCalledWith({
+        ...props.settings,
+        query: { query: 'new query', language: 'kuery' },
+      });
+    });
+  });
+
+  describe('when time is changed', () => {
+    it('invokes onSettingsChanged with the new time', () => {
+      const onSettingsChanged = jest.fn();
+      const props = { ...defaultProps, onSettingsChanged };
+      const { result } = renderHook(() => useSettingsView(props), {
+        wrapper: TestProviders,
+      });
+      render(<TestProviders>{result.current.settingsView}</TestProviders>);
+
+      act(() => {
+        mockOnTimeChange({ start: 'now-1h', end: 'now' });
+      });
+
+      expect(onSettingsChanged).toHaveBeenCalledWith({
+        ...props.settings,
+        start: 'now-1h',
+        end: 'now',
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_settings_view.tsx
@@ -6,22 +6,29 @@
  */
 
 import { FilterManager } from '@kbn/data-plugin/public';
+import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import {
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { AttackDiscoveryStats } from '@kbn/elastic-assistant-common';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { DEFAULT_STACK_BY_FIELD } from '..';
 import { AlertSelection } from '../alert_selection';
 import { AlertSelectionOld } from '../alert_selection/alert_selection_old';
 import { useKibana } from '../../../../common/lib/kibana';
+import { convertToBuildEsQuery } from '../../../../common/lib/kuery';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { parseFilterQuery } from '../parse_filter_query';
+import type { SettingsOverrideOptions } from '../../results/history/types';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
 import * as i18n from './translations';
 import type { AlertsSelectionSettings } from '../types';
 import { useKibanaFeatureFlags } from '../../use_kibana_feature_flags';
@@ -34,6 +41,7 @@ export interface UseSettingsView {
 interface Props {
   connectorId: string | undefined;
   onConnectorIdSelected: (connectorId: string) => void;
+  onGenerate?: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onSettingsChanged?: (settings: AlertsSelectionSettings) => void;
   onSettingsReset?: () => void;
   onSettingsSave?: () => void;
@@ -45,6 +53,7 @@ interface Props {
 export const useSettingsView = ({
   connectorId,
   onConnectorIdSelected,
+  onGenerate,
   onSettingsReset,
   onSettingsSave,
   onSettingsChanged,
@@ -56,10 +65,23 @@ export const useSettingsView = ({
   const { uiSettings } = useKibana().services;
   const filterManager = useRef<FilterManager>(new FilterManager(uiSettings));
   const { attackDiscoveryAlertsEnabled } = useKibanaFeatureFlags();
+  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView();
+  const { dataView: experimentalDataView } = useDataView();
 
   const [alertSummaryStackBy0, setAlertSummaryStackBy0] = useState<string>(DEFAULT_STACK_BY_FIELD);
+
   const [alertsPreviewStackBy0, setAlertsPreviewStackBy0] =
     useState<string>(DEFAULT_STACK_BY_FIELD);
+  const [localConnectorId, setLocalConnectorId] = useState<string | undefined>(connectorId);
+
+  // Sync local connector ID with prop changes
+  useEffect(() => {
+    setLocalConnectorId(connectorId);
+  }, [connectorId]);
+
+  const handleLocalConnectorIdChange = useCallback((newConnectorId: string) => {
+    setLocalConnectorId(newConnectorId);
+  }, []);
 
   const settingsView = useMemo(
     () =>
@@ -67,9 +89,9 @@ export const useSettingsView = ({
         <AlertSelection
           alertsPreviewStackBy0={alertsPreviewStackBy0}
           alertSummaryStackBy0={alertSummaryStackBy0}
-          connectorId={connectorId}
+          connectorId={localConnectorId}
           filterManager={filterManager.current}
-          onConnectorIdSelected={onConnectorIdSelected}
+          onConnectorIdSelected={handleLocalConnectorIdChange}
           onSettingsChanged={onSettingsChanged}
           setAlertsPreviewStackBy0={setAlertsPreviewStackBy0}
           setAlertSummaryStackBy0={setAlertSummaryStackBy0}
@@ -94,8 +116,8 @@ export const useSettingsView = ({
     [
       alertSummaryStackBy0,
       alertsPreviewStackBy0,
-      connectorId,
-      onConnectorIdSelected,
+      localConnectorId,
+      handleLocalConnectorIdChange,
       onSettingsChanged,
       attackDiscoveryAlertsEnabled,
       settings,
@@ -130,28 +152,122 @@ export const useSettingsView = ({
     };
   }, [onSettingsChanged, settings]);
 
+  const handleSave = useCallback(() => {
+    if (localConnectorId && localConnectorId !== connectorId) {
+      onConnectorIdSelected(localConnectorId);
+    }
+    onSettingsSave?.();
+  }, [connectorId, localConnectorId, onConnectorIdSelected, onSettingsSave]);
+
+  const onSaveAndRun = useCallback(() => {
+    handleSave();
+
+    // Convert settings to filter query for overrides
+    const [filterQuery, kqlError] = convertToBuildEsQuery({
+      config: getEsQueryConfig(uiSettings),
+      dataViewSpec: oldSourcererDataView,
+      dataView: experimentalDataView,
+      queries: [settings.query],
+      filters: settings.filters,
+    });
+
+    const overrideFilter = parseFilterQuery({ filterQuery, kqlError });
+
+    // Pass the localConnectorId and settings overrides to ensure we use the selected values
+    onGenerate?.({
+      overrideConnectorId: localConnectorId,
+      overrideEnd: settings.end,
+      overrideFilter,
+      overrideSize: settings.size,
+      overrideStart: settings.start,
+    });
+  }, [
+    experimentalDataView,
+    handleSave,
+    localConnectorId,
+    oldSourcererDataView,
+    onGenerate,
+    settings.end,
+    settings.filters,
+    settings.query,
+    settings.size,
+    settings.start,
+    uiSettings,
+  ]);
+
   const actionButtons = useMemo(() => {
     return (
-      <EuiFlexGroup alignItems="center" gutterSize="none">
+      <EuiFlexGroup
+        alignItems="center"
+        css={css`
+          gap: 16px;
+        `}
+        gutterSize="none"
+        responsive={false}
+      >
         <EuiFlexItem
           css={css`
             margin-right: ${euiTheme.size.s};
           `}
           grow={false}
         >
-          <EuiButtonEmpty data-test-subj="reset" flush="both" onClick={onSettingsReset} size="s">
+          <EuiButtonEmpty data-test-subj="reset" flush="both" onClick={onSettingsReset} size="m">
             {i18n.RESET}
           </EuiButtonEmpty>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          <EuiButton data-test-subj="save" fill onClick={onSettingsSave} size="s">
-            {i18n.SAVE}
-          </EuiButton>
+          <EuiToolTip
+            content={localConnectorId == null ? i18n.SELECT_A_CONNECTOR_TO_SAVE : undefined}
+            position="top"
+          >
+            <EuiButton
+              color="primary"
+              css={css`
+                min-inline-size: 80px;
+                width: 80px;
+              `}
+              data-test-subj="save"
+              isDisabled={localConnectorId == null}
+              onClick={handleSave}
+              size="m"
+            >
+              {i18n.SAVE}
+            </EuiButton>
+          </EuiToolTip>
         </EuiFlexItem>
+
+        {attackDiscoveryAlertsEnabled && (
+          <EuiFlexItem grow={false}>
+            <EuiToolTip
+              content={
+                localConnectorId == null ? i18n.SELECT_A_CONNECTOR_TO_SAVE_AND_RUN : undefined
+              }
+              position="top"
+            >
+              <EuiButton
+                data-test-subj="saveAndRun"
+                isDisabled={localConnectorId == null}
+                fill
+                iconType="play"
+                onClick={onSaveAndRun}
+                size="m"
+              >
+                {i18n.SAVE_AND_RUN}
+              </EuiButton>
+            </EuiToolTip>
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     );
-  }, [euiTheme.size.s, onSettingsReset, onSettingsSave]);
+  }, [
+    attackDiscoveryAlertsEnabled,
+    euiTheme.size.s,
+    handleSave,
+    localConnectorId,
+    onSaveAndRun,
+    onSettingsReset,
+  ]);
 
   return { settingsView, actionButtons };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_tabs_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/hooks/use_tabs_view.tsx
@@ -15,11 +15,31 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import type { AttackDiscoveryStats } from '@kbn/elastic-assistant-common';
+import { css } from '@emotion/react';
 
+import { SCHEDULE_TAB_ID, SETTINGS_TAB_ID } from '../constants';
+import type { SettingsOverrideOptions } from '../../results/history/types';
 import * as i18n from './translations';
-import { useSettingsView } from './use_settings_view';
 import type { AlertsSelectionSettings } from '../types';
+import { useSettingsView } from './use_settings_view';
 import { useScheduleView } from './use_schedule_view';
+
+const SETTINGS_TAB_CLASS = 'settingsTab';
+
+// We're hiding the tabs in the flyout to accommodate a late-breaking design change.
+// Per a team agreement, the tabs will be refactored out in a future PR.
+const hiddenTabsStyles = css`
+  &.${SETTINGS_TAB_CLASS} > .euiTabs {
+    display: none;
+  }
+  &.${SETTINGS_TAB_CLASS} .euiTabs .euiSpacer {
+    display: none;
+  }
+  /* Hide spacers that are direct children of tab panels to clean up the layout */
+  div[role='tabpanel'] > .euiSpacer {
+    display: none;
+  }
+`;
 
 /*
  * Fixes tabs to the top and allows the content to scroll.
@@ -27,7 +47,7 @@ import { useScheduleView } from './use_schedule_view';
 const ScrollableFlyoutTabbedContent = (props: EuiTabbedContentProps) => (
   <EuiFlexGroup direction="column" gutterSize="none">
     <EuiFlexItem grow={true}>
-      <EuiTabbedContent {...props} />
+      <EuiTabbedContent {...props} className={SETTINGS_TAB_CLASS} css={hiddenTabsStyles} />
     </EuiFlexItem>
   </EuiFlexGroup>
 );
@@ -39,7 +59,9 @@ export interface UseTabsView {
 
 interface Props {
   connectorId: string | undefined;
+  defaultSelectedTabId?: string;
   onConnectorIdSelected: (connectorId: string) => void;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onSettingsChanged?: (settings: AlertsSelectionSettings) => void;
   onSettingsReset?: () => void;
   onSettingsSave?: () => void;
@@ -49,7 +71,9 @@ interface Props {
 
 export const useTabsView = ({
   connectorId,
+  defaultSelectedTabId,
   onConnectorIdSelected,
+  onGenerate,
   onSettingsReset,
   onSettingsSave,
   onSettingsChanged,
@@ -59,6 +83,7 @@ export const useTabsView = ({
   const { settingsView, actionButtons: filterActionButtons } = useSettingsView({
     connectorId,
     onConnectorIdSelected,
+    onGenerate,
     onSettingsReset,
     onSettingsSave,
     onSettingsChanged,
@@ -70,7 +95,7 @@ export const useTabsView = ({
 
   const settingsTab: EuiTabbedContentTab = useMemo(
     () => ({
-      id: 'settings',
+      id: SETTINGS_TAB_ID,
       name: i18n.SETTINGS_TAB_LABEL,
       content: (
         <>
@@ -84,7 +109,7 @@ export const useTabsView = ({
 
   const scheduleTab: EuiTabbedContentTab = useMemo(
     () => ({
-      id: 'schedule',
+      id: SCHEDULE_TAB_ID,
       name: i18n.SCHEDULE_TAB_LABEL,
       content: (
         <>
@@ -100,7 +125,7 @@ export const useTabsView = ({
     return [settingsTab, scheduleTab];
   }, [scheduleTab, settingsTab]);
 
-  const [selectedTabId, setSelectedTabId] = useState<string>(tabs[0].id);
+  const [selectedTabId, setSelectedTabId] = useState<string>(defaultSelectedTabId ?? tabs[0].id);
   const selectedTab = tabs.find((tab) => tab.id === selectedTabId) ?? tabs[0];
 
   useEffect(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/index.tsx
@@ -15,7 +15,6 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
-
 import { DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS } from '@kbn/elastic-assistant';
 import {
   ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG,
@@ -31,20 +30,23 @@ import * as i18n from './translations';
 import { useSettingsView } from './hooks/use_settings_view';
 import { useTabsView } from './hooks/use_tabs_view';
 import type { AlertsSelectionSettings } from './types';
-import { MIN_FLYOUT_WIDTH } from './constants';
+import { MIN_FLYOUT_WIDTH, SCHEDULE_TAB_ID } from './constants';
 import { getMaxAlerts } from './alert_selection/helpers/get_max_alerts';
 import { getDefaultQuery } from '../helpers';
+import type { SettingsOverrideOptions } from '../results/history/types';
 import { useKibanaFeatureFlags } from '../use_kibana_feature_flags';
 
 export const DEFAULT_STACK_BY_FIELD = 'kibana.alert.rule.name';
 
 export interface Props {
   connectorId: string | undefined;
+  defaultSelectedTabId?: string;
   end: string | undefined;
   filters: Filter[] | undefined;
   localStorageAttackDiscoveryMaxAlerts: string | undefined;
   onClose: () => void;
   onConnectorIdSelected: (connectorId: string) => void;
+  onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   query: Query | undefined;
   setEnd: React.Dispatch<React.SetStateAction<string | undefined>>;
   setFilters: React.Dispatch<React.SetStateAction<Filter[] | undefined>>;
@@ -57,11 +59,13 @@ export interface Props {
 
 const SettingsFlyoutComponent: React.FC<Props> = ({
   connectorId,
+  defaultSelectedTabId,
   end,
   filters,
   localStorageAttackDiscoveryMaxAlerts,
   onClose,
   onConnectorIdSelected,
+  onGenerate,
   query,
   setEnd,
   setFilters,
@@ -128,6 +132,7 @@ const SettingsFlyoutComponent: React.FC<Props> = ({
   const { settingsView, actionButtons: settingsActionButtons } = useSettingsView({
     connectorId,
     onConnectorIdSelected,
+    onGenerate,
     onSettingsReset,
     onSettingsSave,
     onSettingsChanged: setSettings,
@@ -138,7 +143,9 @@ const SettingsFlyoutComponent: React.FC<Props> = ({
 
   const { tabsContainer, actionButtons: tabsActionButtons } = useTabsView({
     connectorId,
+    defaultSelectedTabId,
     onConnectorIdSelected,
+    onGenerate,
     onSettingsReset,
     onSettingsSave,
     onSettingsChanged: setSettings,
@@ -160,6 +167,13 @@ const SettingsFlyoutComponent: React.FC<Props> = ({
     return settingsActionButtons;
   }, [isAttackDiscoverySchedulingEnabled, settingsActionButtons, tabsActionButtons]);
 
+  const title =
+    defaultSelectedTabId === SCHEDULE_TAB_ID
+      ? i18n.ATTACK_DISCOVERY_SCHEDULE
+      : i18n.ATTACK_DISCOVERY_SETTINGS;
+
+  const closeButtonText = defaultSelectedTabId !== SCHEDULE_TAB_ID ? i18n.CANCEL : undefined;
+
   const hasBorder =
     isAttackDiscoverySchedulingEnabled || attackDiscoveryAlertsEnabled ? false : true;
 
@@ -176,11 +190,7 @@ const SettingsFlyoutComponent: React.FC<Props> = ({
     >
       <EuiFlyoutHeader hasBorder={hasBorder}>
         <EuiTitle data-test-subj="title" size="m">
-          <h2 id={flyoutTitleId}>
-            {attackDiscoveryAlertsEnabled
-              ? i18n.ATTACK_DISCOVERY_SETTINGS_AND_SCHEDULE
-              : i18n.ATTACK_DISCOVERY_SETTINGS}
-          </h2>
+          <h2 id={flyoutTitleId}>{title}</h2>
         </EuiTitle>
       </EuiFlyoutHeader>
 
@@ -190,7 +200,11 @@ const SettingsFlyoutComponent: React.FC<Props> = ({
       </EuiFlyoutBody>
 
       <EuiFlyoutFooter>
-        <Footer closeModal={onClose} actionButtons={actionButtons} />
+        <Footer
+          actionButtons={actionButtons}
+          closeButtonText={closeButtonText}
+          closeModal={onClose}
+        />
       </EuiFlyoutFooter>
     </EuiFlyoutResizable>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/index.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { ConfirmationModal } from '.';
+import {
+  ARE_YOU_SURE,
+  CANCEL,
+  DISCARD_CHANGES,
+  DISCARD_UNSAVED_CHANGES,
+  YOU_MADE_CHANGES,
+} from './translations';
+
+const defaultProps = {
+  onCancel: jest.fn(),
+  onDiscard: jest.fn(),
+};
+
+describe('ConfirmationModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a title with the expected text', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+
+    expect(screen.getByTestId('title')).toHaveTextContent(DISCARD_UNSAVED_CHANGES);
+  });
+
+  it('renders a body with the expected text', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+
+    const body = screen.getByTestId('body');
+
+    expect(body).toHaveTextContent(YOU_MADE_CHANGES);
+    expect(body).toHaveTextContent(ARE_YOU_SURE);
+  });
+
+  it('renders a cancel button with the expected text', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+
+    expect(screen.getByTestId('cancel')).toHaveTextContent(CANCEL);
+  });
+
+  it('calls onCancel when the cancel button is clicked', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('cancel'));
+
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a discard changes button with the expected text', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+
+    expect(screen.getByTestId('discardChanges')).toHaveTextContent(DISCARD_CHANGES);
+  });
+
+  it('calls onDiscard when the discard changes button is clicked', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('discardChanges'));
+
+    expect(defaultProps.onDiscard).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/index.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+
+import * as i18n from './translations';
+
+interface Props {
+  onCancel: () => void;
+  onDiscard: () => void;
+}
+
+const ConfirmationModalComponent: React.FC<Props> = ({ onCancel, onDiscard }) => (
+  <EuiModal
+    css={css`
+      max-width: 454px;
+    `}
+    data-test-subj="confirmationModal"
+    onClose={onCancel}
+  >
+    <EuiModalHeader>
+      <EuiModalHeaderTitle data-test-subj="title">
+        {i18n.DISCARD_UNSAVED_CHANGES}
+      </EuiModalHeaderTitle>
+    </EuiModalHeader>
+
+    <EuiModalBody data-test-subj="body">
+      {i18n.YOU_MADE_CHANGES}
+      <EuiSpacer size="m" />
+      {i18n.ARE_YOU_SURE}
+    </EuiModalBody>
+
+    <EuiModalFooter>
+      <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty data-test-subj="cancel" onClick={onCancel}>
+            {i18n.CANCEL}
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton color="danger" data-test-subj="discardChanges" fill onClick={onDiscard}>
+            {i18n.DISCARD_CHANGES}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiModalFooter>
+  </EuiModal>
+);
+
+ConfirmationModalComponent.displayName = 'ConfirmationModal';
+
+export const ConfirmationModal = React.memo(ConfirmationModalComponent);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/translations.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const ARE_YOU_SURE = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.schedule.confirmationModal.areYouSureModalBody',
+  {
+    defaultMessage: 'Are you sure you want to discard them?',
+  }
+);
+
+export const CANCEL = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.schedule.confirmationModal.cancelButton',
+  {
+    defaultMessage: 'Cancel',
+  }
+);
+
+export const DISCARD_CHANGES = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.schedule.confirmationModal.discardChangesButton',
+  {
+    defaultMessage: 'Discard changes',
+  }
+);
+
+export const DISCARD_UNSAVED_CHANGES = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.schedule.confirmationModal.discardUnsavedChangesTitle',
+  {
+    defaultMessage: 'Discard unsaved changes?',
+  }
+);
+export const YOU_MADE_CHANGES = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.schedule.youMadeChangesModalBody',
+  {
+    defaultMessage:
+      "You've made changes to your schedule that haven't been saved. If you leave now, those changes will be lost.",
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.test.tsx
@@ -14,7 +14,7 @@ import { CreateFlyout } from '.';
 import * as i18n from './translations';
 
 import { useKibana } from '../../../../../common/lib/kibana';
-import { TestProviders } from '../../../../../common/mock';
+import { TestProviders } from '../../../../../common/mock/test_providers';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { useCreateAttackDiscoverySchedule } from '../logic/use_create_schedule';
 
@@ -124,6 +124,78 @@ describe('CreateFlyout', () => {
     await waitFor(() => {
       expect(defaultProps.onClose).toHaveBeenCalled();
     });
+  });
+
+  describe('confirmation modal', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <CreateFlyout {...defaultProps} />
+        </TestProviders>
+      );
+
+      // Simulate unsaved changes:
+      const input = screen.getByTestId('alertsRange');
+      fireEvent.change(input, { target: { value: 'changed' } });
+
+      // Click the close button to trigger the confirmation modal
+      fireEvent.click(screen.getByTestId('euiFlyoutCloseButton'));
+    });
+
+    it('renders the confirmation modal when there are unsaved changes and close is clicked', () => {
+      expect(screen.getByTestId('confirmationModal')).toBeInTheDocument();
+    });
+
+    it('calls onClose when discard is clicked in confirmation modal', () => {
+      fireEvent.click(screen.getByTestId('discardChanges'));
+
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    it('closes the confirmation modal when cancel is clicked', () => {
+      fireEvent.click(screen.getByTestId('cancel'));
+
+      expect(screen.queryByTestId('confirmationModal')).not.toBeInTheDocument();
+    });
+
+    it('renders the confirmation modal when there are unsaved changes and escape key is pressed', () => {
+      // First, close the modal that was opened in beforeEach
+      fireEvent.click(screen.getByTestId('cancel'));
+
+      // Verify modal is closed
+      expect(screen.queryByTestId('confirmationModal')).not.toBeInTheDocument();
+
+      // Now press escape key on the flyout
+      const flyout = screen.getByTestId('scheduleCreateFlyout');
+      fireEvent.keyDown(flyout, { key: 'Escape' });
+
+      // Verify the confirmation modal is shown
+      expect(screen.getByTestId('confirmationModal')).toBeInTheDocument();
+    });
+  });
+
+  it('does not call createAttackDiscoverySchedule if a connector is not found', async () => {
+    (useLoadConnectors as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: [],
+    });
+    const mutateAsync = jest.fn();
+    (useCreateAttackDiscoverySchedule as jest.Mock).mockReturnValue({
+      isLoading: false,
+      mutateAsync,
+    });
+    await act(async () => {
+      render(
+        <TestProviders>
+          <CreateFlyout {...defaultProps} />
+        </TestProviders>
+      );
+    });
+
+    // Simulate save
+    fireEvent.click(screen.getByTestId('save'));
+
+    expect(mutateAsync).not.toHaveBeenCalled();
   });
 
   describe('schedule form', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
 import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -13,13 +12,17 @@ import {
   EuiFlyoutResizable,
   EuiSpacer,
   EuiTitle,
+  isDOMNode,
+  keys,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useAssistantContext, useLoadConnectors } from '@kbn/elastic-assistant';
+import React, { useCallback, useState } from 'react';
 
 import { DataViewManagerScopeName } from '../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { ConfirmationModal } from '../confirmation_modal';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { Footer } from '../../footer';
 import { MIN_FLYOUT_WIDTH } from '../../constants';
@@ -34,6 +37,19 @@ interface Props {
 }
 
 export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const onFormMutated = useCallback(() => setHasUnsavedChanges(true), []);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+
+  const onCancel = useCallback(() => {
+    setShowConfirmModal(false); // just close the modal
+  }, []);
+
+  const onDiscard = useCallback(() => {
+    setShowConfirmModal(false);
+    onClose();
+  }, [onClose]);
+
   const flyoutTitleId = useGeneratedHtmlId({
     prefix: 'attackDiscoveryScheduleCreateFlyoutTitle',
   });
@@ -88,36 +104,62 @@ export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
 
   const { editForm, actionButtons } = useEditForm({
     isLoading: isLoadingConnectors || isLoadingQuery,
+    onFormMutated,
     onSave: onCreateSchedule,
     saveButtonTitle: i18n.SCHEDULE_CREATE_BUTTON_TITLE,
   });
 
+  const handleCloseButtonClick = useCallback(() => {
+    if (hasUnsavedChanges) {
+      setShowConfirmModal(true);
+    } else {
+      onClose();
+    }
+  }, [hasUnsavedChanges, onClose]);
+
+  const onKeyDown = useCallback(
+    (ev: React.KeyboardEvent) => {
+      if (isDOMNode(ev.target) && ev.currentTarget.contains(ev.target) && ev.key === keys.ESCAPE) {
+        ev.preventDefault();
+        ev.stopPropagation();
+
+        handleCloseButtonClick();
+      }
+    },
+    [handleCloseButtonClick]
+  );
+
   return (
-    <EuiFlyoutResizable
-      aria-labelledby={flyoutTitleId}
-      data-test-subj="scheduleCreateFlyout"
-      minWidth={MIN_FLYOUT_WIDTH}
-      onClose={onClose}
-      paddingSize="m"
-      side="right"
-      size="m"
-      type="overlay"
-    >
-      <EuiFlyoutHeader hasBorder>
-        <EuiTitle data-test-subj="title" size="m">
-          <h2 id={flyoutTitleId}>{i18n.SCHEDULE_CREATE_TITLE}</h2>
-        </EuiTitle>
-      </EuiFlyoutHeader>
+    <>
+      <EuiFlyoutResizable
+        aria-labelledby={flyoutTitleId}
+        data-test-subj="scheduleCreateFlyout"
+        minWidth={MIN_FLYOUT_WIDTH}
+        onClose={handleCloseButtonClick}
+        onKeyDown={onKeyDown}
+        paddingSize="m"
+        side="right"
+        size="m"
+        type="overlay"
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle data-test-subj="title" size="m">
+            <h2 id={flyoutTitleId}>{i18n.SCHEDULE_CREATE_TITLE}</h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
 
-      <EuiFlyoutBody>
-        <EuiSpacer size="s" />
-        {editForm}
-      </EuiFlyoutBody>
+        <EuiFlyoutBody>
+          <EuiSpacer size="s" />
+          {editForm}
+        </EuiFlyoutBody>
 
-      <EuiFlyoutFooter>
-        <Footer closeModal={onClose} actionButtons={actionButtons} />
-      </EuiFlyoutFooter>
-    </EuiFlyoutResizable>
+        <EuiFlyoutFooter>
+          <Footer closeModal={handleCloseButtonClick} actionButtons={actionButtons} />
+        </EuiFlyoutFooter>
+      </EuiFlyoutResizable>
+
+      {showConfirmModal && <ConfirmationModal onCancel={onCancel} onDiscard={onDiscard} />}
+    </>
   );
 });
 CreateFlyout.displayName = 'CreateFlyout';

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.test.tsx
@@ -174,4 +174,50 @@ describe('DetailsFlyout', () => {
       expect(screen.getByTestId('save')).toBeInTheDocument();
     });
   });
+
+  describe('confirmation modal', () => {
+    beforeEach(async () => {
+      await renderComponent();
+
+      // Enter edit mode
+      const editButton = screen.getByTestId('edit');
+      fireEvent.click(editButton);
+      // Simulate unsaved changes
+      const input = screen.getByTestId('alertsRange');
+      fireEvent.change(input, { target: { value: 'changed' } });
+      // Click the close button to trigger the confirmation modal
+      fireEvent.click(screen.getByTestId('euiFlyoutCloseButton'));
+    });
+
+    it('renders the confirmation modal when there are unsaved changes and close is clicked', () => {
+      expect(screen.getByTestId('confirmationModal')).toBeInTheDocument();
+    });
+
+    it('calls onClose when discard is clicked in confirmation modal', () => {
+      fireEvent.click(screen.getByTestId('discardChanges'));
+
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    it('closes the confirmation modal when cancel is clicked', () => {
+      fireEvent.click(screen.getByTestId('cancel'));
+
+      expect(screen.queryByTestId('confirmationModal')).not.toBeInTheDocument();
+    });
+
+    it('renders the confirmation modal when there are unsaved changes and escape key is pressed', () => {
+      // First, close the modal that was opened in beforeEach
+      fireEvent.click(screen.getByTestId('cancel'));
+
+      // Verify modal is closed
+      expect(screen.queryByTestId('confirmationModal')).not.toBeInTheDocument();
+
+      // Now press escape key on the flyout
+      const flyout = screen.getByTestId('scheduleDetailsFlyout');
+      fireEvent.keyDown(flyout, { key: 'Escape' });
+
+      // Verify the confirmation modal is shown
+      expect(screen.getByTestId('confirmationModal')).toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { triggersActionsUiMock } from '@kbn/triggers-actions-ui-plugin/public/mocks';
 import { useLoadConnectors } from '@kbn/elastic-assistant/impl/connectorland/use_load_connectors';
 
@@ -193,5 +193,20 @@ describe('EditForm', () => {
         },
       })
     );
+  });
+
+  it('calls onFormMutated when settings change', async () => {
+    const onFormMutatedMock = jest.fn();
+
+    render(
+      <TestProviders>
+        <EditForm {...defaultProps} onFormMutated={onFormMutatedMock} />
+      </TestProviders>
+    );
+
+    const input = screen.getByTestId('alertsRange');
+    fireEvent.change(input, { target: { value: 'changed' } });
+
+    expect(onFormMutatedMock).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.tsx
@@ -41,10 +41,11 @@ export interface FormState {
 export interface FormProps {
   initialValue: AttackDiscoveryScheduleSchema;
   onChange: (state: FormState) => void;
+  onFormMutated?: () => void;
 }
 
 export const EditForm: React.FC<FormProps> = React.memo((props) => {
-  const { initialValue, onChange } = props;
+  const { initialValue, onChange, onFormMutated } = props;
   const {
     triggersActionsUi: { actionTypeRegistry },
   } = useKibana().services;
@@ -74,8 +75,9 @@ export const EditForm: React.FC<FormProps> = React.memo((props) => {
     (newSettings: AlertsSelectionSettings) => {
       setSettings(newSettings);
       setFieldValue('alertsSelectionSettings', newSettings);
+      onFormMutated?.();
     },
-    [setFieldValue]
+    [onFormMutated, setFieldValue]
   );
 
   const [connectorId, setConnectorId] = React.useState<string | undefined>(
@@ -86,8 +88,9 @@ export const EditForm: React.FC<FormProps> = React.memo((props) => {
     (selectedConnectorId: string) => {
       setConnectorId(selectedConnectorId);
       setFieldValue('connectorId', selectedConnectorId);
+      onFormMutated?.();
     },
-    [setFieldValue]
+    [onFormMutated, setFieldValue]
   );
 
   const { settingsView } = useSettingsView({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/use_edit_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/use_edit_form.tsx
@@ -47,12 +47,19 @@ export interface UseEditForm {
 export interface UseEditFormProps {
   isLoading: boolean;
   initialValue?: AttackDiscoveryScheduleSchema;
+  onFormMutated?: () => void;
   onSave?: (scheduleData: AttackDiscoveryScheduleSchema) => void;
   saveButtonTitle?: string;
 }
 
 export const useEditForm = (props: UseEditFormProps): UseEditForm => {
-  const { isLoading, initialValue = defaultInitialValue, onSave, saveButtonTitle } = props;
+  const {
+    initialValue = defaultInitialValue,
+    isLoading,
+    onFormMutated,
+    onSave,
+    saveButtonTitle,
+  } = props;
   const { euiTheme } = useEuiTheme();
 
   const [formState, setFormState] = useState<FormState>({
@@ -84,8 +91,10 @@ export const useEditForm = (props: UseEditFormProps): UseEditForm => {
         />
       );
     }
-    return <EditForm initialValue={initialValue} onChange={setFormState} />;
-  }, [initialValue, isLoading]);
+    return (
+      <EditForm initialValue={initialValue} onChange={setFormState} onFormMutated={onFormMutated} />
+    );
+  }, [initialValue, isLoading, onFormMutated]);
 
   const actionButtons = useMemo(() => {
     return (
@@ -97,7 +106,7 @@ export const useEditForm = (props: UseEditFormProps): UseEditForm => {
           grow={false}
         >
           <EuiFlexItem grow={false}>
-            <EuiButton data-test-subj="save" fill size="s" onClick={onCreate} disabled={isLoading}>
+            <EuiButton data-test-subj="save" size="m" onClick={onCreate} disabled={isLoading}>
               {saveButtonTitle ?? i18n.SCHEDULE_SAVE_BUTTON_TITLE}
             </EuiButton>
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/translations.ts
@@ -14,9 +14,16 @@ export const ATTACK_DISCOVERY_SETTINGS = i18n.translate(
   }
 );
 
-export const ATTACK_DISCOVERY_SETTINGS_AND_SCHEDULE = i18n.translate(
-  'xpack.securitySolution.attackDiscovery.settingsFlyout.attackDiscoverySettingsAndScheduleTitle',
+export const ATTACK_DISCOVERY_SCHEDULE = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.settingsFlyout.attackDiscoveryScheduleTitle',
   {
-    defaultMessage: 'Attack discovery settings & schedule',
+    defaultMessage: 'Attack discovery schedule',
+  }
+);
+
+export const CANCEL = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.settingsFlyout.cancelButtonLabel',
+  {
+    defaultMessage: 'Cancel',
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/translations.ts
@@ -31,7 +31,7 @@ export const ERROR_GENERATING_ATTACK_DISCOVERIES = i18n.translate(
 export const SHOW_ANONYMIZED_LABEL = i18n.translate(
   'xpack.securitySolution.attackDiscovery.showAnonymizedLabel',
   {
-    defaultMessage: 'Show anonymized',
+    defaultMessage: 'Show anonymized values',
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.test.tsx
@@ -177,7 +177,7 @@ describe('useAttackDiscovery', () => {
     expect(mockedUseKibana.services.http.post).toHaveBeenCalledWith(
       '/internal/elastic_assistant/attack_discovery',
       {
-        body: `{"alertsIndexPattern":"alerts-index-pattern","anonymizationFields":[],"replacements":{},"size":${SIZE},"subAction":"invokeAI","apiConfig":{"connectorId":"test-id","actionTypeId":".gen-ai"}}`,
+        body: `{"alertsIndexPattern":"alerts-index-pattern","anonymizationFields":[],"replacements":{},"size":${SIZE},"subAction":"invokeAI","apiConfig":{"connectorId":"test-id","actionTypeId":".gen-ai"},"connectorName":"OpenAI connector"}`,
         version: '1',
       }
     );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Attack discovery] Update Attack discovery call to action buttons and flyout (#228150)](https://github.com/elastic/kibana/pull/228150)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andrew Macri","email":"andrew.macri@elastic.co"},"sourceCommit":{"committedDate":"2025-07-16T20:06:35Z","message":"[Attack discovery] Update Attack discovery call to action buttons and flyout (#228150)\n\n## [Attack discovery] Update Attack discovery call to action buttons and flyout\n\nThis PR updates the Attack discovery call to action buttons and flyout, as illustrated by the animated gif below:\n\n![03_cta_tooltips](https://github.com/user-attachments/assets/f43b39dc-a184-43db-a812-16e97798186f)\n\n Highlights include:\n\n- `Schedule` is the new primary call to action\n- The `Generate` button is renamed to `Run`\n- The settings gear is restyled as a split button, associated with the `Run` button\n- `Save and run` is a new default action available the settings flyout\n- It's no longer possible to tab between Settings and Schedules in the flyout\n- The Show anonymized values toggle button is restyled as a switch\n- A confirmation dialog is displayed when users attempt to close an unsaved schedule**\n\n![17_discard_unsaved_changes](https://github.com/user-attachments/assets/0c288036-7599-4051-bd17-0ceccf6c273c)\n\nSee the screenshots in the _Details_ section below for additional style and text updates.\n\n** Users will only be prompted when the `Connector`, `Custom query`, `Date range`, or `Set number of alerts to analyze` schedule properties are modified\n\n### Details\n\nThe following before and after screenshots detail the changes in this PR:\n\n**Header**\n\n| Before | After |\n|--------|-------|\n| ![01_header_before](https://github.com/user-attachments/assets/424e7c97-6cd6-4dd8-8d1b-936ce4bd7aa1)       | ![02_header_after](https://github.com/user-attachments/assets/b3ace302-d641-4fde-9848-a00603d7c46c)      |\n\nThe tooltips for the call to action buttons in the header are illustrated by the following animated gif:\n\n![03_cta_tooltips](https://github.com/user-attachments/assets/f43b39dc-a184-43db-a812-16e97798186f)\n\n**Settings**\n\n| Before | After |\n|--------|-------|\n| ![04_settings_before](https://github.com/user-attachments/assets/dc6a6783-08b3-420f-96fd-69de62e2939b)       | ![05_settings_after](https://github.com/user-attachments/assets/13d55965-3b36-4e5a-8cc7-7b3a283d01ed)      |\n\n**Schedule list**\n\n| Before | After |\n|--------|-------|\n| ![06_schedule_list_before](https://github.com/user-attachments/assets/de6df104-3cd0-43da-8b86-51b4257a5549)       | ![07_schedule_list_after](https://github.com/user-attachments/assets/37fe980a-88f9-4e2f-96c0-1a00f06a6693)      |\n\n**Schedule preview**\n\n| Before | After |\n|--------|-------|\n| ![08_schedule_preview_before](https://github.com/user-attachments/assets/7e8d7814-b84f-4d88-93d3-776662ea7d6a)       | ![09_schedule_preview_after](https://github.com/user-attachments/assets/190e93c3-a9eb-4f81-a463-24a21dacad21)      |\n\n**Edit schedule**\n\n| Before | After |\n|--------|-------|\n| ![10_edit_before](https://github.com/user-attachments/assets/aa3dedd1-6b93-4d89-960f-d436aff0eaab)       | ![11_edit_after](https://github.com/user-attachments/assets/38294d80-e27b-419e-a56c-567ead0995c3)      |\n\n**Schedule empty state**\n\n| Before | After |\n|--------|-------|\n| ![12_schedule_empty_state_before](https://github.com/user-attachments/assets/32ae309a-61e6-45bd-bb38-766477878b05)       | ![13_schedule_empty_state_after](https://github.com/user-attachments/assets/3b72a289-5749-45b6-b5f4-fe5117047351)      |\n\n**Create new schedule**\n\n| Before | After |\n|--------|-------|\n| ![14_create_new_schedule_before](https://github.com/user-attachments/assets/6ca666b6-c013-484c-98d3-bc9a44b8c237)       | ![15_create_new_schedule_after](https://github.com/user-attachments/assets/f5c86749-0e1f-4caa-976e-61355381af66)      |\n\n**Discard unsaved changes**\n\n![16_discard_unsaved_changes](https://github.com/user-attachments/assets/79400951-7186-464b-b86b-ff8e85c29dce)\n\n![17_discard_unsaved_changes](https://github.com/user-attachments/assets/0c288036-7599-4051-bd17-0ceccf6c273c)\n\n### Feature flags\n\nThe following feature flags must be enabled in `config/kibana.dev.yml` to view the changes in this PR.\n\n```yaml\nfeature_flags.overrides:\n  securitySolution.attackDiscoveryAlertsEnabled: true\n  securitySolution.assistantAttackDiscoverySchedulingEnabled: true\n```","sha":"18bf4de80ce1da4a5fcb996490535a9d3df9f10e","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Team:Security Generative AI","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Attack discovery] Update Attack discovery call to action buttons and flyout","number":228150,"url":"https://github.com/elastic/kibana/pull/228150","mergeCommit":{"message":"[Attack discovery] Update Attack discovery call to action buttons and flyout (#228150)\n\n## [Attack discovery] Update Attack discovery call to action buttons and flyout\n\nThis PR updates the Attack discovery call to action buttons and flyout, as illustrated by the animated gif below:\n\n![03_cta_tooltips](https://github.com/user-attachments/assets/f43b39dc-a184-43db-a812-16e97798186f)\n\n Highlights include:\n\n- `Schedule` is the new primary call to action\n- The `Generate` button is renamed to `Run`\n- The settings gear is restyled as a split button, associated with the `Run` button\n- `Save and run` is a new default action available the settings flyout\n- It's no longer possible to tab between Settings and Schedules in the flyout\n- The Show anonymized values toggle button is restyled as a switch\n- A confirmation dialog is displayed when users attempt to close an unsaved schedule**\n\n![17_discard_unsaved_changes](https://github.com/user-attachments/assets/0c288036-7599-4051-bd17-0ceccf6c273c)\n\nSee the screenshots in the _Details_ section below for additional style and text updates.\n\n** Users will only be prompted when the `Connector`, `Custom query`, `Date range`, or `Set number of alerts to analyze` schedule properties are modified\n\n### Details\n\nThe following before and after screenshots detail the changes in this PR:\n\n**Header**\n\n| Before | After |\n|--------|-------|\n| ![01_header_before](https://github.com/user-attachments/assets/424e7c97-6cd6-4dd8-8d1b-936ce4bd7aa1)       | ![02_header_after](https://github.com/user-attachments/assets/b3ace302-d641-4fde-9848-a00603d7c46c)      |\n\nThe tooltips for the call to action buttons in the header are illustrated by the following animated gif:\n\n![03_cta_tooltips](https://github.com/user-attachments/assets/f43b39dc-a184-43db-a812-16e97798186f)\n\n**Settings**\n\n| Before | After |\n|--------|-------|\n| ![04_settings_before](https://github.com/user-attachments/assets/dc6a6783-08b3-420f-96fd-69de62e2939b)       | ![05_settings_after](https://github.com/user-attachments/assets/13d55965-3b36-4e5a-8cc7-7b3a283d01ed)      |\n\n**Schedule list**\n\n| Before | After |\n|--------|-------|\n| ![06_schedule_list_before](https://github.com/user-attachments/assets/de6df104-3cd0-43da-8b86-51b4257a5549)       | ![07_schedule_list_after](https://github.com/user-attachments/assets/37fe980a-88f9-4e2f-96c0-1a00f06a6693)      |\n\n**Schedule preview**\n\n| Before | After |\n|--------|-------|\n| ![08_schedule_preview_before](https://github.com/user-attachments/assets/7e8d7814-b84f-4d88-93d3-776662ea7d6a)       | ![09_schedule_preview_after](https://github.com/user-attachments/assets/190e93c3-a9eb-4f81-a463-24a21dacad21)      |\n\n**Edit schedule**\n\n| Before | After |\n|--------|-------|\n| ![10_edit_before](https://github.com/user-attachments/assets/aa3dedd1-6b93-4d89-960f-d436aff0eaab)       | ![11_edit_after](https://github.com/user-attachments/assets/38294d80-e27b-419e-a56c-567ead0995c3)      |\n\n**Schedule empty state**\n\n| Before | After |\n|--------|-------|\n| ![12_schedule_empty_state_before](https://github.com/user-attachments/assets/32ae309a-61e6-45bd-bb38-766477878b05)       | ![13_schedule_empty_state_after](https://github.com/user-attachments/assets/3b72a289-5749-45b6-b5f4-fe5117047351)      |\n\n**Create new schedule**\n\n| Before | After |\n|--------|-------|\n| ![14_create_new_schedule_before](https://github.com/user-attachments/assets/6ca666b6-c013-484c-98d3-bc9a44b8c237)       | ![15_create_new_schedule_after](https://github.com/user-attachments/assets/f5c86749-0e1f-4caa-976e-61355381af66)      |\n\n**Discard unsaved changes**\n\n![16_discard_unsaved_changes](https://github.com/user-attachments/assets/79400951-7186-464b-b86b-ff8e85c29dce)\n\n![17_discard_unsaved_changes](https://github.com/user-attachments/assets/0c288036-7599-4051-bd17-0ceccf6c273c)\n\n### Feature flags\n\nThe following feature flags must be enabled in `config/kibana.dev.yml` to view the changes in this PR.\n\n```yaml\nfeature_flags.overrides:\n  securitySolution.attackDiscoveryAlertsEnabled: true\n  securitySolution.assistantAttackDiscoverySchedulingEnabled: true\n```","sha":"18bf4de80ce1da4a5fcb996490535a9d3df9f10e"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228150","number":228150,"mergeCommit":{"message":"[Attack discovery] Update Attack discovery call to action buttons and flyout (#228150)\n\n## [Attack discovery] Update Attack discovery call to action buttons and flyout\n\nThis PR updates the Attack discovery call to action buttons and flyout, as illustrated by the animated gif below:\n\n![03_cta_tooltips](https://github.com/user-attachments/assets/f43b39dc-a184-43db-a812-16e97798186f)\n\n Highlights include:\n\n- `Schedule` is the new primary call to action\n- The `Generate` button is renamed to `Run`\n- The settings gear is restyled as a split button, associated with the `Run` button\n- `Save and run` is a new default action available the settings flyout\n- It's no longer possible to tab between Settings and Schedules in the flyout\n- The Show anonymized values toggle button is restyled as a switch\n- A confirmation dialog is displayed when users attempt to close an unsaved schedule**\n\n![17_discard_unsaved_changes](https://github.com/user-attachments/assets/0c288036-7599-4051-bd17-0ceccf6c273c)\n\nSee the screenshots in the _Details_ section below for additional style and text updates.\n\n** Users will only be prompted when the `Connector`, `Custom query`, `Date range`, or `Set number of alerts to analyze` schedule properties are modified\n\n### Details\n\nThe following before and after screenshots detail the changes in this PR:\n\n**Header**\n\n| Before | After |\n|--------|-------|\n| ![01_header_before](https://github.com/user-attachments/assets/424e7c97-6cd6-4dd8-8d1b-936ce4bd7aa1)       | ![02_header_after](https://github.com/user-attachments/assets/b3ace302-d641-4fde-9848-a00603d7c46c)      |\n\nThe tooltips for the call to action buttons in the header are illustrated by the following animated gif:\n\n![03_cta_tooltips](https://github.com/user-attachments/assets/f43b39dc-a184-43db-a812-16e97798186f)\n\n**Settings**\n\n| Before | After |\n|--------|-------|\n| ![04_settings_before](https://github.com/user-attachments/assets/dc6a6783-08b3-420f-96fd-69de62e2939b)       | ![05_settings_after](https://github.com/user-attachments/assets/13d55965-3b36-4e5a-8cc7-7b3a283d01ed)      |\n\n**Schedule list**\n\n| Before | After |\n|--------|-------|\n| ![06_schedule_list_before](https://github.com/user-attachments/assets/de6df104-3cd0-43da-8b86-51b4257a5549)       | ![07_schedule_list_after](https://github.com/user-attachments/assets/37fe980a-88f9-4e2f-96c0-1a00f06a6693)      |\n\n**Schedule preview**\n\n| Before | After |\n|--------|-------|\n| ![08_schedule_preview_before](https://github.com/user-attachments/assets/7e8d7814-b84f-4d88-93d3-776662ea7d6a)       | ![09_schedule_preview_after](https://github.com/user-attachments/assets/190e93c3-a9eb-4f81-a463-24a21dacad21)      |\n\n**Edit schedule**\n\n| Before | After |\n|--------|-------|\n| ![10_edit_before](https://github.com/user-attachments/assets/aa3dedd1-6b93-4d89-960f-d436aff0eaab)       | ![11_edit_after](https://github.com/user-attachments/assets/38294d80-e27b-419e-a56c-567ead0995c3)      |\n\n**Schedule empty state**\n\n| Before | After |\n|--------|-------|\n| ![12_schedule_empty_state_before](https://github.com/user-attachments/assets/32ae309a-61e6-45bd-bb38-766477878b05)       | ![13_schedule_empty_state_after](https://github.com/user-attachments/assets/3b72a289-5749-45b6-b5f4-fe5117047351)      |\n\n**Create new schedule**\n\n| Before | After |\n|--------|-------|\n| ![14_create_new_schedule_before](https://github.com/user-attachments/assets/6ca666b6-c013-484c-98d3-bc9a44b8c237)       | ![15_create_new_schedule_after](https://github.com/user-attachments/assets/f5c86749-0e1f-4caa-976e-61355381af66)      |\n\n**Discard unsaved changes**\n\n![16_discard_unsaved_changes](https://github.com/user-attachments/assets/79400951-7186-464b-b86b-ff8e85c29dce)\n\n![17_discard_unsaved_changes](https://github.com/user-attachments/assets/0c288036-7599-4051-bd17-0ceccf6c273c)\n\n### Feature flags\n\nThe following feature flags must be enabled in `config/kibana.dev.yml` to view the changes in this PR.\n\n```yaml\nfeature_flags.overrides:\n  securitySolution.attackDiscoveryAlertsEnabled: true\n  securitySolution.assistantAttackDiscoverySchedulingEnabled: true\n```","sha":"18bf4de80ce1da4a5fcb996490535a9d3df9f10e"}}]}] BACKPORT-->