### PR TITLE
[Security Solution] Doclinks: Add '.html' extension to fix a broken doc link

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -531,7 +531,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
         ? `${SERVERLESS_DOCS}security-prebuilt-rules-management.html#update-prebuilt-rules`
         : `${SECURITY_SOLUTION_DOCS}prebuilt-rules-management.html#update-prebuilt-rules`,
       prebuiltRuleCustomizationPromoBlog: `${ELASTIC_WEBSITE_URL}blog/security-prebuilt-rules-editing`,
-      resolvePrebuiltRuleConflicts: `${SECURITY_SOLUTION_DOCS}prebuilt-rules-update-modified-unmodified#resolve-reduce-rule-conflicts`,
+      resolvePrebuiltRuleConflicts: `${SECURITY_SOLUTION_DOCS}prebuilt-rules-update-modified-unmodified.html#resolve-reduce-rule-conflicts`,
       createEsqlRuleType: `${SECURITY_SOLUTION_DOCS}rules-ui-create.html#create-esql-rule`,
       ruleUiAdvancedParams: `${SECURITY_SOLUTION_DOCS}rules-ui-create.html#rule-ui-advanced-params`,
       entityAnalytics: {


### PR DESCRIPTION
## Summary
Fixes a typo introduced while resolving conflicts in PR https://github.com/elastic/kibana/pull/228291

