### PR TITLE
Unskip Saved Objects Tagging Functional Tests

### DIFF
--- a/x-pack/platform/test/functional/page_objects/tag_management_page.ts
+++ b/x-pack/platform/test/functional/page_objects/tag_management_page.ts
@@ -469,12 +469,11 @@ export class TagManagementPageObject extends FtrService {
       await this.openActionMenu();
     }
 
-    const actionExists = await this.testSubjects.exists(`actionBar-button-${actionId}`);
-
     if (!menuWasOpened) {
       await this.toggleActionMenu();
     }
 
+    const actionExists = await this.testSubjects.exists(`actionBar-button-${actionId}`);
     return actionExists;
   }
 

--- a/x-pack/platform/test/saved_object_tagging/functional/tests/feature_control.ts
+++ b/x-pack/platform/test/saved_object_tagging/functional/tests/feature_control.ts
@@ -52,8 +52,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const addFeatureControlSuite = ({ user, description, privileges }: FeatureControlUserSuite) => {
     const testPrefix = (allowed: boolean) => (allowed ? `can` : `can't`);
 
-    // Failing: See https://github.com/elastic/kibana/issues/216512
-    describe.skip(description, () => {
+    describe(description, () => {
       before(async () => {
         await loginAs(user);
         await tagManagementPage.navigateTo();


### PR DESCRIPTION
## Summary

Closes #216512 
Closes #217274 

Addresses a race condition in functional test execution:

- **Before:** The code was checking if an action exists while the menu was open, then closing the menu afterward if it wasn't originally open.
- **After:** The code now ensures the menu is in the same state as it was at the beginning of the function before checking if the action exists

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
- ~~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- ~~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
- ~~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- ~~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- ~~[ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->