### PR TITLE
[9.1] [Entity Analytics] Control privileged user monitoring with advanced setting (#226591)

### DIFF
--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -102,6 +102,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'keyword',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'securitySolution:enablePrivilegedUserMonitoring': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'securitySolution:defaultAnomalyScore': {
     type: 'long',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -72,6 +72,7 @@ export interface UsageStats {
   'securitySolution:enableVisualizationsInFlyout': boolean;
   'securitySolution:enableGraphVisualization': boolean;
   'securitySolution:enableAssetInventory': boolean;
+  'securitySolution:enablePrivilegedUserMonitoring': boolean;
   'securitySolution:enableCloudConnector': boolean;
   'search:includeFrozen': boolean;
   'courier:maxConcurrentShardRequests': number;

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -10737,6 +10737,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "securitySolution:enablePrivilegedUserMonitoring": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "securitySolution:excludeColdAndFrozenTiersInAnalyzer": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -222,6 +222,10 @@ export const ENABLE_ASSET_INVENTORY_SETTING = 'securitySolution:enableAssetInven
 
 /** This Kibana Advanced Setting allows users to enable/disable the Cloud Connector Feature */
 export const ENABLE_CLOUD_CONNECTOR_SETTING = 'securitySolution:enableCloudConnector' as const;
+
+/** This Kibana Advanced Setting allows users to enable/disable the privilged user monitoring feature */
+export const ENABLE_PRIVILEGED_USER_MONITORING_SETTING =
+  'securitySolution:enablePrivilegedUserMonitoring' as const;
 /**
  * Id for the notifications alerting type
  * @deprecated Once we are confident all rules relying on side-car actions SO's have been migrated to SO references we should remove this function

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/links.ts
@@ -12,6 +12,7 @@ import {
   ENTITY_ANALYTICS_LANDING_PATH,
   ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH,
   ENTITY_ANALYTICS_OVERVIEW_PATH,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
 } from '../../common/constants';
 import type { LinkItem } from '../common/links/types';
 import { ENTITY_ANALYTICS, ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING } from '../app/translations';
@@ -42,6 +43,7 @@ const privMonLinks: LinkItem = {
     }),
   ],
   hideWhenExperimentalKey: 'privilegedUserMonitoringDisabled',
+  uiSettingRequired: ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
   hideTimeline: false,
   skipUrlState: false,
   capabilities: [`${SECURITY_FEATURE_ID}.entity-analytics`],
@@ -87,6 +89,7 @@ export const entityAnalyticsLinks: LinkItem = {
   hideTimeline: true,
   skipUrlState: true,
   hideWhenExperimentalKey: 'privilegedUserMonitoringDisabled',
+  uiSettingRequired: ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
   capabilities: [`${SECURITY_FEATURE_ID}.entity-analytics`],
   licenseType: 'platinum',
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/create_index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/create_index.ts
@@ -10,8 +10,13 @@ import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
 import { CreatePrivilegesImportIndexRequestBody } from '../../../../../common/api/entity_analytics/monitoring/create_index.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 
 export const createPrivilegeMonitoringIndicesRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -42,6 +47,11 @@ export const createPrivilegeMonitoringIndicesRoute = (
         const siemResponse = buildSiemResponse(response);
         const indexName = request.body.name;
         const indexMode = request.body.mode;
+
+        await assertAdvancedSettingsEnabled(
+          await context.core,
+          ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+        );
 
         try {
           await secSol

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/health.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/health.ts
@@ -10,8 +10,13 @@ import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 
 import type { PrivMonHealthResponse } from '../../../../../common/api/entity_analytics/privilege_monitoring/health.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 
 export const healthCheckPrivilegeMonitoringRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -37,6 +42,11 @@ export const healthCheckPrivilegeMonitoringRoute = (
       async (context, request, response): Promise<IKibanaResponse<PrivMonHealthResponse>> => {
         const siemResponse = buildSiemResponse(response);
         const secSol = await context.securitySolution;
+
+        await assertAdvancedSettingsEnabled(
+          await context.core,
+          ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+        );
 
         try {
           const body = await secSol.getPrivilegeMonitoringDataClient().getEngineStatus();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/init.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/init.ts
@@ -10,8 +10,13 @@ import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 
 import type { InitMonitoringEngineResponse } from '../../../../../common/api/entity_analytics/privilege_monitoring/engine/init.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 
 export const initPrivilegeMonitoringEngineRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -41,6 +46,11 @@ export const initPrivilegeMonitoringEngineRoute = (
       ): Promise<IKibanaResponse<InitMonitoringEngineResponse>> => {
         const siemResponse = buildSiemResponse(response);
         const secSol = await context.securitySolution;
+
+        await assertAdvancedSettingsEnabled(
+          await context.core,
+          ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+        );
 
         try {
           const body = await secSol.getPrivilegeMonitoringDataClient().init();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/monitoring_entity_source/list.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/monitoring_entity_source/list.ts
@@ -9,12 +9,17 @@ import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type { IKibanaResponse, Logger } from '@kbn/core/server';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
 import {
   ListEntitySourcesRequestQuery,
   type ListEntitySourcesResponse,
 } from '../../../../../../common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const listMonitoringEntitySourceRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -44,6 +49,11 @@ export const listMonitoringEntitySourceRoute = (
         const siemResponse = buildSiemResponse(response);
 
         try {
+          await assertAdvancedSettingsEnabled(
+            await context.core,
+            ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+          );
+
           const secSol = await context.securitySolution;
           const client = secSol.getMonitoringEntitySourceDataClient();
           const body = await client.list(request.query);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/monitoring_entity_source/monitoring_entity_source.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/monitoring_entity_source/monitoring_entity_source.ts
@@ -10,7 +10,11 @@
 import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type { IKibanaResponse, Logger } from '@kbn/core/server';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
 import type {
   GetEntitySourceResponse,
@@ -23,6 +27,7 @@ import {
   GetEntitySourceRequestParams,
   UpdateEntitySourceRequestParams,
 } from '../../../../../../common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const monitoringEntitySourceRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -52,6 +57,11 @@ export const monitoringEntitySourceRoute = (
         const siemResponse = buildSiemResponse(response);
 
         try {
+          await assertAdvancedSettingsEnabled(
+            await context.core,
+            ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+          );
+
           const secSol = await context.securitySolution;
           const client = secSol.getMonitoringEntitySourceDataClient();
           const body = await client.init(request.body);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/privileged_access_detection/pad_install.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/privileged_access_detection/pad_install.ts
@@ -10,9 +10,14 @@ import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 
 import type { InstallPrivilegedAccessDetectionPackageResponse } from '../../../../../../common/api/entity_analytics/privilege_monitoring/privileged_access_detection/install.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const padInstallRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -42,6 +47,11 @@ export const padInstallRoute = (
       ): Promise<IKibanaResponse<InstallPrivilegedAccessDetectionPackageResponse>> => {
         const siemResponse = buildSiemResponse(response);
         const secSol = await context.securitySolution;
+
+        await assertAdvancedSettingsEnabled(
+          await context.core,
+          ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+        );
 
         try {
           const clientResponse = await secSol

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/search_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/search_indices.ts
@@ -10,9 +10,14 @@ import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { take } from 'lodash/fp';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
-import { API_VERSIONS, APP_ID } from '../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
 import { SearchPrivilegesIndicesRequestQuery } from '../../../../../common/api/entity_analytics/monitoring';
+import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 
 // Return a subset of all indices that contain the user.name field
 const LIMIT = 20;
@@ -45,6 +50,11 @@ export const searchPrivilegeMonitoringIndicesRoute = (
         const secSol = await context.securitySolution;
         const siemResponse = buildSiemResponse(response);
         const query = request.query.searchQuery;
+
+        await assertAdvancedSettingsEnabled(
+          await context.core,
+          ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+        );
 
         try {
           const indices = await secSol

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/create.ts
@@ -11,8 +11,13 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { CreatePrivMonUserRequestBody } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/create.gen';
 import type { CreatePrivMonUserResponse } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/create.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const createUserRoute = (router: EntityAnalyticsRoutesDeps['router'], logger: Logger) => {
   router.versioned
@@ -38,6 +43,10 @@ export const createUserRoute = (router: EntityAnalyticsRoutesDeps['router'], log
         const siemResponse = buildSiemResponse(response);
 
         try {
+          await assertAdvancedSettingsEnabled(
+            await context.core,
+            ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+          );
           const secSol = await context.securitySolution;
           const body = await secSol
             .getPrivilegeMonitoringDataClient()

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/delete.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/delete.ts
@@ -11,8 +11,13 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { DeletePrivMonUserRequestParams } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/delete.gen';
 import type { DeletePrivMonUserResponse } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/delete.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const deleteUserRoute = (router: EntityAnalyticsRoutesDeps['router'], logger: Logger) => {
   router.versioned
@@ -38,6 +43,10 @@ export const deleteUserRoute = (router: EntityAnalyticsRoutesDeps['router'], log
         const siemResponse = buildSiemResponse(response);
 
         try {
+          await assertAdvancedSettingsEnabled(
+            await context.core,
+            ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+          );
           const secSol = await context.securitySolution;
           await secSol.getPrivilegeMonitoringDataClient().deleteUser(request.params.id);
           return response.ok({ body: { aknowledged: true } });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/list.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/list.ts
@@ -11,8 +11,13 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { ListPrivMonUsersRequestQuery } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/list.gen';
 import type { ListPrivMonUsersResponse } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/list.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const listUsersRoute = (router: EntityAnalyticsRoutesDeps['router'], logger: Logger) => {
   router.versioned
@@ -36,8 +41,12 @@ export const listUsersRoute = (router: EntityAnalyticsRoutesDeps['router'], logg
       },
       async (context, request, response): Promise<IKibanaResponse<ListPrivMonUsersResponse>> => {
         const siemResponse = buildSiemResponse(response);
-
         try {
+          await assertAdvancedSettingsEnabled(
+            await context.core,
+            ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+          );
+
           const secSol = await context.securitySolution;
           const body = await secSol.getPrivilegeMonitoringDataClient().listUsers(request.query.kql);
           return response.ok({ body });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/update.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/update.ts
@@ -13,8 +13,13 @@ import {
   UpdatePrivMonUserRequestParams,
   UpdatePrivMonUserRequestBody,
 } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/update.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const updateUserRoute = (router: EntityAnalyticsRoutesDeps['router'], logger: Logger) => {
   router.versioned
@@ -41,6 +46,10 @@ export const updateUserRoute = (router: EntityAnalyticsRoutesDeps['router'], log
         const siemResponse = buildSiemResponse(response);
 
         try {
+          await assertAdvancedSettingsEnabled(
+            await context.core,
+            ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+          );
           const secSol = await context.securitySolution;
           const body = await secSol
             .getPrivilegeMonitoringDataClient()

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/upload_csv.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/routes/users/upload_csv.ts
@@ -14,9 +14,14 @@ import { PRIVMON_USERS_CSV_MAX_SIZE_BYTES_WITH_TOLERANCE } from '../../../../../
 import type { HapiReadableStream } from '../../../../../types';
 import type { ConfigType } from '../../../../../config';
 import type { PrivmonBulkUploadUsersCSVResponse } from '../../../../../../common/api/entity_analytics/privilege_monitoring/users/upload_csv.gen';
-import { API_VERSIONS, APP_ID } from '../../../../../../common/constants';
+import {
+  API_VERSIONS,
+  APP_ID,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
+} from '../../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../../types';
 import { checkAndInitPrivilegedMonitoringResources } from '../../check_and_init_privileged_monitoring_resources';
+import { assertAdvancedSettingsEnabled } from '../../../utils/assert_advanced_setting_enabled';
 
 export const uploadUsersCSVRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -62,6 +67,11 @@ export const uploadUsersCSVRoute = (
         const siemResponse = buildSiemResponse(response);
 
         try {
+          await assertAdvancedSettingsEnabled(
+            await context.core,
+            ENABLE_PRIVILEGED_USER_MONITORING_SETTING
+          );
+
           await checkAndInitPrivilegedMonitoringResources(context, logger);
 
           const secSol = await context.securitySolution;

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -43,6 +43,7 @@ import {
   NEWS_FEED_URL_SETTING,
   NEWS_FEED_URL_SETTING_DEFAULT,
   SHOW_RELATED_INTEGRATIONS_SETTING,
+  ENABLE_PRIVILEGED_USER_MONITORING_SETTING,
 } from '../common/constants';
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import { LogLevelSetting } from '../common/api/detection_engine/rule_monitoring';
@@ -399,6 +400,32 @@ export const initUiSettings = (
       requiresPageReload: false,
       solution: 'security',
     },
+    ...(experimentalFeatures.privilegedUserMonitoringDisabled
+      ? {}
+      : {
+          [ENABLE_PRIVILEGED_USER_MONITORING_SETTING]: {
+            name: i18n.translate(
+              'xpack.securitySolution.uiSettings.enablePrivilegedUserMonitoringLabel',
+              {
+                defaultMessage: 'Privileged user monitoring',
+              }
+            ),
+            value: false,
+            description: i18n.translate(
+              'xpack.securitySolution.uiSettings.enablePrivilegedUserMonitoringDescription',
+              {
+                defaultMessage:
+                  '<p>Enables the privileged user monitoring dashboard and onboarding experience which are in technical preview.</p>',
+                values: { p: (chunks) => `<p>${chunks}</p>` },
+              }
+            ),
+            type: 'boolean',
+            category: [APP_ID],
+            requiresPageReload: true,
+            schema: schema.boolean(),
+            solution: 'security',
+          },
+        }),
     ...(experimentalFeatures.extendedRuleExecutionLoggingEnabled
       ? {
           [EXTENDED_RULE_EXECUTION_LOGGING_ENABLED_SETTING]: {

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine.ts
@@ -8,6 +8,7 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 import { dataViewRouteHelpersFactory } from '../../utils/data_view';
+import { enablePrivmonSetting } from '../../utils';
 
 export default ({ getService }: FtrProviderContext) => {
   const api = getService('securitySolutionApi');
@@ -16,8 +17,10 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring APIs', () => {
     const dataView = dataViewRouteHelpersFactory(supertest);
+    const kibanaServer = getService('kibanaServer');
     before(async () => {
       await dataView.create('security-solution');
+      await enablePrivmonSetting(kibanaServer);
     });
 
     after(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_access_detection/pad_installation.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_access_detection/pad_installation.ts
@@ -8,6 +8,7 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
 import { dataViewRouteHelpersFactory } from '../../../utils/data_view';
+import { enablePrivmonSetting } from '../../../utils';
 
 export default ({ getService }: FtrProviderContext) => {
   const api = getService('securitySolutionApi');
@@ -95,6 +96,7 @@ export default ({ getService }: FtrProviderContext) => {
       await dataView.create('security-solution');
       await uninstallPackage();
       await deleteMLJobs();
+      await enablePrivmonSetting(kibanaServer);
     });
 
     after(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/search_indices.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/search_indices.ts
@@ -9,11 +9,13 @@ import expect from '@kbn/expect';
 
 import { PRIVILEGED_MONITOR_IMPORT_USERS_INDEX_MAPPING } from '@kbn/security-solution-plugin/server/lib/entity_analytics/privilege_monitoring/elasticsearch/indices';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
+import { enablePrivmonSetting } from '../../utils';
 
 export default ({ getService }: FtrProviderContext) => {
   const api = getService('securitySolutionApi');
   const es = getService('es');
   const log = getService('log');
+  const kibanaServer = getService('kibanaServer');
 
   const logWhenNot200 = (res: any) => {
     if (res.status !== 200) {
@@ -30,6 +32,8 @@ export default ({ getService }: FtrProviderContext) => {
         index: indexName,
         mappings: { properties: PRIVILEGED_MONITOR_IMPORT_USERS_INDEX_MAPPING },
       });
+
+      await enablePrivmonSetting(kibanaServer);
     });
 
     after(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/utils/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/utils/index.ts
@@ -11,3 +11,4 @@ export * from './asset_criticality';
 export * from './entity_store';
 export * from './elastic_asset_checker';
 export * from './entity_analytics';
+export * from './privmon_advanced_settings';

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/utils/privmon_advanced_settings.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/utils/privmon_advanced_settings.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ENABLE_PRIVILEGED_USER_MONITORING_SETTING } from '@kbn/security-solution-plugin/common/constants';
+import { KbnClient } from '@kbn/test';
+
+export const enablePrivmonSetting = async (kibanaServer: KbnClient) => {
+  await kibanaServer.uiSettings.update({
+    [ENABLE_PRIVILEGED_USER_MONITORING_SETTING]: true,
+  });
+};
+
+export const disablePrivmonSetting = async (kibanaServer: KbnClient) => {
+  await kibanaServer.uiSettings.update({
+    [ENABLE_PRIVILEGED_USER_MONITORING_SETTING]: false,
+  });
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Entity Analytics] Control privileged user monitoring with advanced setting (#226591)](https://github.com/elastic/kibana/pull/226591)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mark Hopkin","email":"mark.hopkin@elastic.co"},"sourceCommit":{"committedDate":"2025-07-16T20:38:17Z","message":"[Entity Analytics] Control privileged user monitoring with advanced setting (#226591)\n\n## Summary\n\nAdd an advanced setting to control access to the privileged user\nmonitoring PoC. This also controls the new entity analytics landing page\nas they are tied together.\n\n- the advanced setting only appears if the\n`privilegedUserMonitoringDisabled` feature flag is not enabled (this\nmeans it won't appear in serverless)\n- The APIs cannot be called unless the advanced setting is enabled, a\n403 is returned\n\n<img width=\"1166\" alt=\"Screenshot 2025-07-04 at 15 10 03\"\nsrc=\"https://github.com/user-attachments/assets/02ff4cbf-c08d-4d45-af32-bbefe50fed4b\"\n/>\n\n\ntest steps:\n\nServerless case\n- on a fresh kibana with `privilegedUserMonitoringDisabled` experimental\nfeature flag enabled\n- the privileged user monitoring dashboard link should not exist\n- the APIs should not be callable\n- the advanced setting should not be visible\n\nnon-serverless case \n- on a fresh kibana with no experimental features enabled \n- the privileged user monitoring dashboard link should not exist\n- the APIs should not be callable\n- Now go and enable the advanced setting\n- the privileged user monitoring nav should appear and the feature\nshould work as normal","sha":"a25f8e7658485985cb5dca26ef0d3b2eedab3ca8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Entity Analytics","backport:version","v9.1.0","v9.2.0"],"title":"[Entity Analytics] Control privileged user monitoring with advanced setting","number":226591,"url":"https://github.com/elastic/kibana/pull/226591","mergeCommit":{"message":"[Entity Analytics] Control privileged user monitoring with advanced setting (#226591)\n\n## Summary\n\nAdd an advanced setting to control access to the privileged user\nmonitoring PoC. This also controls the new entity analytics landing page\nas they are tied together.\n\n- the advanced setting only appears if the\n`privilegedUserMonitoringDisabled` feature flag is not enabled (this\nmeans it won't appear in serverless)\n- The APIs cannot be called unless the advanced setting is enabled, a\n403 is returned\n\n<img width=\"1166\" alt=\"Screenshot 2025-07-04 at 15 10 03\"\nsrc=\"https://github.com/user-attachments/assets/02ff4cbf-c08d-4d45-af32-bbefe50fed4b\"\n/>\n\n\ntest steps:\n\nServerless case\n- on a fresh kibana with `privilegedUserMonitoringDisabled` experimental\nfeature flag enabled\n- the privileged user monitoring dashboard link should not exist\n- the APIs should not be callable\n- the advanced setting should not be visible\n\nnon-serverless case \n- on a fresh kibana with no experimental features enabled \n- the privileged user monitoring dashboard link should not exist\n- the APIs should not be callable\n- Now go and enable the advanced setting\n- the privileged user monitoring nav should appear and the feature\nshould work as normal","sha":"a25f8e7658485985cb5dca26ef0d3b2eedab3ca8"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226591","number":226591,"mergeCommit":{"message":"[Entity Analytics] Control privileged user monitoring with advanced setting (#226591)\n\n## Summary\n\nAdd an advanced setting to control access to the privileged user\nmonitoring PoC. This also controls the new entity analytics landing page\nas they are tied together.\n\n- the advanced setting only appears if the\n`privilegedUserMonitoringDisabled` feature flag is not enabled (this\nmeans it won't appear in serverless)\n- The APIs cannot be called unless the advanced setting is enabled, a\n403 is returned\n\n<img width=\"1166\" alt=\"Screenshot 2025-07-04 at 15 10 03\"\nsrc=\"https://github.com/user-attachments/assets/02ff4cbf-c08d-4d45-af32-bbefe50fed4b\"\n/>\n\n\ntest steps:\n\nServerless case\n- on a fresh kibana with `privilegedUserMonitoringDisabled` experimental\nfeature flag enabled\n- the privileged user monitoring dashboard link should not exist\n- the APIs should not be callable\n- the advanced setting should not be visible\n\nnon-serverless case \n- on a fresh kibana with no experimental features enabled \n- the privileged user monitoring dashboard link should not exist\n- the APIs should not be callable\n- Now go and enable the advanced setting\n- the privileged user monitoring nav should appear and the feature\nshould work as normal","sha":"a25f8e7658485985cb5dca26ef0d3b2eedab3ca8"}}]}] BACKPORT-->