### PR TITLE
[Fleet] Fix Fleet usage telemetry

### DIFF
--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -10189,6 +10189,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "securitySolution:enablePrivilegedUserMonitoring": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "securitySolution:defaultAnomalyScore": {
           "type": "long",
           "_meta": {
@@ -10208,12 +10214,6 @@
           }
         },
         "securitySolution:enableAssetCriticality": {
-          "type": "boolean",
-          "_meta": {
-            "description": "Non-default value of setting."
-          }
-        },
-        "securitySolution:enablePrivilegedUserMonitoring": {
           "type": "boolean",
           "_meta": {
             "description": "Non-default value of setting."

--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -4324,6 +4324,9 @@
               },
               "enabled": {
                 "type": "boolean"
+              },
+              "agent_based": {
+                "type": "boolean"
               }
             }
           }

--- a/x-pack/platform/plugins/shared/fleet/server/collectors/package_collectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/collectors/package_collectors.ts
@@ -18,6 +18,7 @@ export interface PackageUsage {
   name: string;
   version: string;
   enabled: boolean;
+  agent_based?: boolean;
 }
 
 export interface AgentlessUsage {

--- a/x-pack/platform/plugins/shared/fleet/server/collectors/register.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/collectors/register.ts
@@ -237,6 +237,7 @@ export function registerFleetUsageCollector(
           name: { type: 'keyword' },
           version: { type: 'keyword' },
           enabled: { type: 'boolean' },
+          agent_based: { type: 'boolean' },
         },
       },
       agentless_agents: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -250,6 +250,58 @@ export const fleetUsagesSchema: RootSchema<any> = {
       },
     },
   },
+  agentless_agents: {
+    properties: {
+      total_enrolled: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of enrolled agents, in any state',
+        },
+      },
+      healthy: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of enrolled agents in a healthy state',
+        },
+      },
+      unhealthy: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of enrolled agents in an unhealthy state',
+        },
+      },
+      updating: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of enrolled agents in an updating state',
+        },
+      },
+      offline: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of enrolled agents currently offline',
+        },
+      },
+      inactive: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of enrolled agents currently inactive',
+        },
+      },
+      unenrolled: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of unenrolled agents',
+        },
+      },
+      total_all_statuses: {
+        type: 'long',
+        _meta: {
+          description: 'The total number of agents in any state, both enrolled and inactive',
+        },
+      },
+    },
+  },
   fleet_server: {
     properties: {
       total_enrolled: {
@@ -316,6 +368,10 @@ export const fleetUsagesSchema: RootSchema<any> = {
         name: { type: 'keyword' },
         version: { type: 'keyword' },
         enabled: { type: 'boolean' },
+        agent_based: {
+          type: 'boolean',
+          _meta: { description: 'true if package is agent-based', optional: true },
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/226033

Two types were missing for agentless telemetry added in https://github.com/elastic/kibana/pull/213668, causing the task to fail. This PR adds the missing types.

### Testing

1. Edit the interval of the `FleetUsageSender` task [here](https://github.com/elastic/kibana/blob/74c5788a5d0f69582e633005f55a588f8f03a6bf/x-pack/platform/plugins/shared/fleet/server/services/telemetry/fleet_usage_sender.ts#L35) to something small, e.g. `1m`.
2. Run ES + kibana and check kibana logs: Fleet usage telemetry should work, for example:
```
[2025-07-17T09:49:07.082+02:00][DEBUG][plugins.fleet] Fleet usage telemetry: {"agents_enabled":true,"agents":{"total_enrolled":0,"healthy":0,"unhealthy":0,"offline":0,"inactive":0,"unenrolled":0,"total_all_statuses":0,"updating":0},"fleet_server":{"total_enrolled":0,"healthy":0,"unhealthy":0,"offline":0,"updating":0,"inactive":0,"unenrolled":0,"total_all_statuses":0,"num_host_urls":1},"packages":[{"name":"fleet_server","version":"1.6.0","enabled":true,"agent_based":true},{"name":"synthetics","version":"1.4.2","enabled":false}],"agent_checkin_status":{"error":0,"degraded":0},"agents_per_policy":[],"agents_per_os":[],"fleet_server_config":{"policies":[{"input_config":{}}]},"agent_policies":{"count":1,"output_types":["elasticsearch"],"count_with_non_default_space":0,"count_with_global_data_tags":0},"agent_logs_panics_last_hour":[],"agent_logs_top_errors":[],"fleet_server_logs_top_errors":[],"license_issued_to":"elasticsearch","agentless_agents":{"total_enrolled":0,"healthy":0,"unhealthy":0,"offline":0,"inactive":0,"unenrolled":0,"total_all_statuses":0,"updating":0}}
[2025-07-17T09:49:07.082+02:00][DEBUG][plugins.fleet] Agents per privileges telemetry: {"root":0,"unprivileged":0}
[2025-07-17T09:49:07.083+02:00][DEBUG][plugins.fleet] Agents per version telemetry: []
[2025-07-17T09:49:07.083+02:00][DEBUG][plugins.fleet] Agents per output type telemetry: []
[2025-07-17T09:49:07.083+02:00][DEBUG][plugins.fleet] Agents upgrade details telemetry: []
[2025-07-17T09:49:07.083+02:00][DEBUG][plugins.fleet] Integrations details telemetry: []
```

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->