### PR TITLE
[8.19] [follow up] small ui refactoring (#225234)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
@@ -391,10 +391,17 @@ export const BULK_FILL_RULE_GAPS_CONFIRMATION_CONFIRM = i18n.translate(
   }
 );
 
-export const BULK_MANUAL_RULE_RUN_LIMIT_ERROR_TITLE = i18n.translate(
-  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkManualRuleRunLimitErrorMessage',
+export const BULK_ACTION_LIMIT_ERROR_MODAL_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkActionErrorModalMessage',
   {
     defaultMessage: 'Cannot execute the bulk action',
+  }
+);
+
+export const BULK_ACTION_ERROR_MODAL_CLOSE_BUTTON = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkActionErrorModalCloseButton',
+  {
+    defaultMessage: 'Close',
   }
 );
 
@@ -404,23 +411,9 @@ export const BULK_MANUAL_RULE_RUN_LIMIT_ERROR_MESSAGE = (rulesCount: number) =>
     {
       values: { rulesCount },
       defaultMessage:
-        'Manual rule run cannot be scheduled for more than {rulesCount, plural, =1 {# rule} other {# rules}}',
+        'Manual rule run cannot be scheduled for more than {rulesCount, plural, =1 {# rule} other {# rules}}.',
     }
   );
-
-export const BULK_MANUAL_RULE_RUN_LIMIT_ERROR_CLOSE_BUTTON = i18n.translate(
-  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkManualRuleRunLimitErrorCloseButton',
-  {
-    defaultMessage: 'Close',
-  }
-);
-
-export const BULK_FILL_RULE_GAPS_LIMIT_ERROR_TITLE = i18n.translate(
-  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkFillRuleGapsRuleLimitErrorMessage',
-  {
-    defaultMessage: 'Cannot execute the bulk action',
-  }
-);
 
 export const BULK_FILL_RULE_GAPS_LIMIT_ERROR_MESSAGE = (rulesCount: number) =>
   i18n.translate(
@@ -431,13 +424,6 @@ export const BULK_FILL_RULE_GAPS_LIMIT_ERROR_MESSAGE = (rulesCount: number) =>
         'Cannot schedule gap fills for more than {rulesCount, plural, =1 {# rule} other {# rules}}.',
     }
   );
-
-export const BULK_FILL_RULE_GAPS_LIMIT_ERROR_CLOSE_BUTTON = i18n.translate(
-  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.bulkFillRuleGapsRuleLimitErrorCloseButton',
-  {
-    defaultMessage: 'Close',
-  }
-);
 
 export const BULK_EDIT_FLYOUT_FORM_SAVE = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.saveButtonLabel',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_limit_error_modal.tsx
@@ -14,29 +14,26 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
 } from '@elastic/eui';
+import * as i18n from '../../../../common/translations';
 
 interface BulkManualRuleRunRulesLimitErrorModalProps {
   onClose: () => void;
-  text: {
-    title: string;
-    message: string;
-    closeButton: string;
-  };
+  message: string;
 }
 
 const BulkActionRuleLimitErrorModalComponent = ({
   onClose,
-  text,
+  message,
 }: BulkManualRuleRunRulesLimitErrorModalProps) => {
   return (
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle>{text.title}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>{i18n.BULK_ACTION_LIMIT_ERROR_MODAL_TITLE}</EuiModalHeaderTitle>
       </EuiModalHeader>
-      <EuiModalBody>{text.message}</EuiModalBody>
+      <EuiModalBody>{message}</EuiModalBody>
       <EuiModalFooter>
         <EuiButton onClick={onClose} fill>
-          {text.closeButton}
+          {i18n.BULK_ACTION_ERROR_MODAL_CLOSE_BUTTON}
         </EuiButton>
       </EuiModalFooter>
     </EuiModal>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_manual_rule_run_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_manual_rule_run_limit_error_modal.tsx
@@ -14,16 +14,12 @@ interface BulkManualRuleRunRulesLimitErrorModalProps {
   onClose: () => void;
 }
 
-const text = {
-  title: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_TITLE,
-  message: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_MESSAGE(MAX_MANUAL_RULE_RUN_BULK_SIZE),
-  closeButton: i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_CLOSE_BUTTON,
-};
+const message = i18n.BULK_MANUAL_RULE_RUN_LIMIT_ERROR_MESSAGE(MAX_MANUAL_RULE_RUN_BULK_SIZE);
 
 const BulkManualRuleRunLimitErrorModalComponent = ({
   onClose,
 }: BulkManualRuleRunRulesLimitErrorModalProps) => {
-  return <BulkActionRuleLimitErrorModal onClose={onClose} text={text} />;
+  return <BulkActionRuleLimitErrorModal onClose={onClose} message={message} />;
 };
 
 export const BulkManualRuleRunLimitErrorModal = React.memo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_schedule_gap_fills_rule_limit_error_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_schedule_gap_fills_rule_limit_error_modal.tsx
@@ -14,16 +14,12 @@ interface BulkManualRuleRunRulesLimitErrorModalProps {
   onClose: () => void;
 }
 
-const text = {
-  title: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_TITLE,
-  message: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_MESSAGE(MAX_BULK_FILL_RULE_GAPS_BULK_SIZE),
-  closeButton: i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_CLOSE_BUTTON,
-};
+const message = i18n.BULK_FILL_RULE_GAPS_LIMIT_ERROR_MESSAGE(MAX_BULK_FILL_RULE_GAPS_BULK_SIZE);
 
 const BulkFillRuleGapsRuleLimitErrorModalComponent = ({
   onClose,
 }: BulkManualRuleRunRulesLimitErrorModalProps) => {
-  return <BulkActionRuleLimitErrorModal onClose={onClose} text={text} />;
+  return <BulkActionRuleLimitErrorModal onClose={onClose} message={message} />;
 };
 
 export const BulkFillRuleGapsRuleLimitErrorModal = React.memo(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[follow up] small ui refactoring (#225234)](https://github.com/elastic/kibana/pull/225234)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Edgar Santos","email":"edgar.santos@elastic.co"},"sourceCommit":{"committedDate":"2025-06-25T12:41:26Z","message":"[follow up] small ui refactoring (#225234)\n\n## Summary\nThis PR is a follow up of https://github.com/elastic/kibana/pull/225070,\naddressing the remaining comments regarding the UI.\n- moved some common text to their own translation variables\n- added missing period to the end of a sentence for consistency\n\n![image](https://github.com/user-attachments/assets/292fd417-2d50-4d32-98d2-df029db06b15)","sha":"3b0c225c38dcd4995b534f31343aa0db8cd25766","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Detection Engine","backport:version","v9.1.0","v8.19.0"],"title":"[follow up] small ui refactoring","number":225234,"url":"https://github.com/elastic/kibana/pull/225234","mergeCommit":{"message":"[follow up] small ui refactoring (#225234)\n\n## Summary\nThis PR is a follow up of https://github.com/elastic/kibana/pull/225070,\naddressing the remaining comments regarding the UI.\n- moved some common text to their own translation variables\n- added missing period to the end of a sentence for consistency\n\n![image](https://github.com/user-attachments/assets/292fd417-2d50-4d32-98d2-df029db06b15)","sha":"3b0c225c38dcd4995b534f31343aa0db8cd25766"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/225234","number":225234,"mergeCommit":{"message":"[follow up] small ui refactoring (#225234)\n\n## Summary\nThis PR is a follow up of https://github.com/elastic/kibana/pull/225070,\naddressing the remaining comments regarding the UI.\n- moved some common text to their own translation variables\n- added missing period to the end of a sentence for consistency\n\n![image](https://github.com/user-attachments/assets/292fd417-2d50-4d32-98d2-df029db06b15)","sha":"3b0c225c38dcd4995b534f31343aa0db8cd25766"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->