### PR TITLE
[Onechat] Support navigation in Elastic Cloud Hosted

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/onechat/kibana.jsonc
@@ -8,18 +8,9 @@
     "id": "onechat",
     "server": true,
     "browser": true,
-    "configPath": [
-      "xpack",
-      "onechat"
-    ],
-    "requiredPlugins": [
-      "actions",
-      "inference",
-      "features"
-    ],
-    "requiredBundles": [
-      "kibanaReact"
-    ],
+    "configPath": ["xpack", "onechat"],
+    "requiredPlugins": ["actions", "inference", "features"],
+    "requiredBundles": ["kibanaReact"],
     "optionalPlugins": [],
     "extraPublicDirs": []
   }

--- a/x-pack/platform/plugins/shared/onechat/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/onechat/kibana.jsonc
@@ -8,9 +8,18 @@
     "id": "onechat",
     "server": true,
     "browser": true,
-    "configPath": ["xpack", "onechat"],
-    "requiredPlugins": ["actions", "inference", "features"],
-    "requiredBundles": ["kibanaReact"],
+    "configPath": [
+      "xpack",
+      "onechat"
+    ],
+    "requiredPlugins": [
+      "actions",
+      "inference",
+      "features"
+    ],
+    "requiredBundles": [
+      "kibanaReact"
+    ],
     "optionalPlugins": [],
     "extraPublicDirs": []
   }

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_breadcrumbs.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_breadcrumbs.ts
@@ -36,7 +36,7 @@ export const useBreadcrumb = (breadcrumbs: OnechatBreadcrumb[]) => {
     return [
       {
         text: i18n.translate('xpack.onechat.breadcrumb.onechat', {
-          defaultMessage: 'OneChat',
+          defaultMessage: 'Chat',
         }),
         href: appUrl,
       },

--- a/x-pack/platform/plugins/shared/onechat/public/application/pages/agent_create.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/pages/agent_create.tsx
@@ -14,10 +14,6 @@ import { CreateAgent } from '../components/agents/edit/create_agent';
 export const OnechatAgentsCreate = () => {
   useBreadcrumb([
     {
-      text: labels.chat.title,
-      path: appPaths.root,
-    },
-    {
       text: labels.agents.title,
       path: appPaths.agents.list,
     },

--- a/x-pack/platform/plugins/shared/onechat/public/application/pages/agent_edit.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/pages/agent_edit.tsx
@@ -16,10 +16,6 @@ export const OnechatAgentsEdit = () => {
   const { agentId } = useParams<{ agentId: string }>();
   useBreadcrumb([
     {
-      text: labels.chat.title,
-      path: appPaths.root,
-    },
-    {
       text: labels.agents.title,
       path: appPaths.agents.list,
     },

--- a/x-pack/platform/plugins/shared/onechat/public/application/pages/agents.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/pages/agents.tsx
@@ -14,10 +14,6 @@ import { labels } from '../utils/i18n';
 export const OnechatAgentsPage = () => {
   useBreadcrumb([
     {
-      text: labels.chat.title,
-      path: appPaths.root,
-    },
-    {
       text: labels.agents.title,
       path: appPaths.agents.list,
     },

--- a/x-pack/platform/plugins/shared/onechat/public/application/pages/conversations.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/pages/conversations.tsx
@@ -6,8 +6,17 @@
  */
 
 import React from 'react';
+import { useBreadcrumb } from '../hooks/use_breadcrumbs';
+import { appPaths } from '../utils/app_paths';
 import { OnechatConversationsView } from '../components/conversations/conversations_view';
+import { labels } from '../utils/i18n';
 
 export const OnechatConversationsPage: React.FC = () => {
+  useBreadcrumb([
+    {
+      text: labels.conversations.title,
+      path: appPaths.chat.new,
+    },
+  ]);
   return <OnechatConversationsView />;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/pages/tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/pages/tools.tsx
@@ -5,15 +5,13 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { OnechatTools } from '../components/tools/tools';
 import { useBreadcrumb } from '../hooks/use_breadcrumbs';
+import { labels } from '../utils/i18n';
+import { appPaths } from '../utils/app_paths';
 
 export const OnechatToolsPage = () => {
-  useBreadcrumb([
-    { text: i18n.translate('xpack.onechat.chat.title', { defaultMessage: 'Chat' }) },
-    { text: i18n.translate('xpack.onechat.tools.title', { defaultMessage: 'Tools' }) },
-  ]);
+  useBreadcrumb([{ text: labels.tools.title, path: appPaths.tools.list }]);
   return <OnechatTools />;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/app_paths.ts
@@ -22,4 +22,7 @@ export const appPaths = {
       return `/conversations/${conversationId}`;
     },
   },
+  tools: {
+    list: '/tools',
+  },
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/i18n.ts
@@ -8,7 +8,12 @@
 import { i18n } from '@kbn/i18n';
 
 export const labels = {
-  chat: { title: i18n.translate('xpack.onechat.root.title', { defaultMessage: 'Chat' }) },
+  conversations: {
+    title: i18n.translate('xpack.onechat.conversations.title', { defaultMessage: 'Conversations' }),
+  },
+  tools: {
+    title: i18n.translate('xpack.onechat.tools.title', { defaultMessage: 'Tools' }),
+  },
   agents: {
     title: i18n.translate('xpack.onechat.agents.list.title', { defaultMessage: 'Agents' }),
     newAgent: i18n.translate('xpack.onechat.agents.new.title', { defaultMessage: 'New Agent' }),

--- a/x-pack/platform/plugins/shared/onechat/public/register.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/register.ts
@@ -23,7 +23,7 @@ export const registerApp = ({
   core.application.register({
     id: ONECHAT_APP_ID,
     appRoute: ONECHAT_PATH,
-    category: DEFAULT_APP_CATEGORIES.chat,
+    category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
     title: ONECHAT_TITLE,
     euiIconType: 'logoElasticsearch',
     visibleIn: ['sideNav', 'globalSearch'],

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -106,6 +106,18 @@ export const getNavigationTreeDefinition = ({
                 },
                 {
                   children: [
+                    { link: 'onechat:conversations' },
+                    { link: 'onechat:tools' },
+                    { link: 'onechat:agents' },
+                  ],
+                  id: 'chat',
+                  title: i18n.translate('xpack.enterpriseSearch.searchNav.chat', {
+                    defaultMessage: 'Chat',
+                  }),
+                  renderAs: 'accordion',
+                },
+                {
+                  children: [
                     {
                       getIsActive: ({ pathNameSerialized, prepend }) => {
                         return (


### PR DESCRIPTION
## Summary

- Add chat to new solution navigation. 
- Make chat appear in global collapsible navigation
- Update breadcrumbs to be consistent 

- The UX in old navigation is poor atm

Testing:
- chat appears in search results and navigation only if feature flag is enabled

### Screenshots 
<img width="1134" height="796" alt="Screenshot 2025-07-16 at 17 40 45" src="https://github.com/user-attachments/assets/4d618021-4df0-4409-9687-1ab04aa526ff" />
<img width="1728" height="689" alt="Screenshot 2025-07-17 at 10 16 45" src="https://github.com/user-attachments/assets/5bbfc088-1440-4b3c-9aae-54a4f9fdea74" />

