### PR TITLE
[9.1][Assistant] Migrate Anonymization in-memory table to EuiBasicTable for better selection control (#222825)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -42265,11 +42265,37 @@ paths:
             default: 20
             minimum: 0
             type: integer
+        - description: If true, additionally fetch all anonymization fields, otherwise fetch only the provided page
+          in: query
+          name: all_data
+          required: false
+          schema:
+            type: boolean
       responses:
         '200':
           content:
             application/json:
               example:
+                aggregations:
+                  anonymized:
+                    buckets:
+                      allowed:
+                        doc_count: 1
+                      anonymized:
+                        doc_count: 1
+                      denied:
+                        doc_count: 1
+                all:
+                  - allowed: true
+                    anonymized: true
+                    createdAt: '2023-10-31T12:00:00Z'
+                    createdBy: user1
+                    field: user.name
+                    id: '1'
+                    namespace: default
+                    timestamp: '2023-10-31T12:00:00Z'
+                    updatedAt: '2023-10-31T12:00:00Z'
+                    updatedBy: user1
                 data:
                   - allowed: true
                     anonymized: true
@@ -42287,6 +42313,37 @@ paths:
               schema:
                 type: object
                 properties:
+                  aggregations:
+                    type: object
+                    properties:
+                      field_status:
+                        type: object
+                        properties:
+                          buckets:
+                            type: object
+                            properties:
+                              allowed:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              anonymized:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              denied:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                  all:
+                    items:
+                      $ref: '#/components/schemas/Security_AI_Assistant_API_AnonymizationFieldResponse'
+                    type: array
                   data:
                     items:
                       $ref: '#/components/schemas/Security_AI_Assistant_API_AnonymizationFieldResponse'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -45235,11 +45235,37 @@ paths:
             default: 20
             minimum: 0
             type: integer
+        - description: If true, additionally fetch all anonymization fields, otherwise fetch only the provided page
+          in: query
+          name: all_data
+          required: false
+          schema:
+            type: boolean
       responses:
         '200':
           content:
             application/json:
               example:
+                aggregations:
+                  anonymized:
+                    buckets:
+                      allowed:
+                        doc_count: 1
+                      anonymized:
+                        doc_count: 1
+                      denied:
+                        doc_count: 1
+                all:
+                  - allowed: true
+                    anonymized: true
+                    createdAt: '2023-10-31T12:00:00Z'
+                    createdBy: user1
+                    field: user.name
+                    id: '1'
+                    namespace: default
+                    timestamp: '2023-10-31T12:00:00Z'
+                    updatedAt: '2023-10-31T12:00:00Z'
+                    updatedBy: user1
                 data:
                   - allowed: true
                     anonymized: true
@@ -45257,6 +45283,37 @@ paths:
               schema:
                 type: object
                 properties:
+                  aggregations:
+                    type: object
+                    properties:
+                      field_status:
+                        type: object
+                        properties:
+                          buckets:
+                            type: object
+                            properties:
+                              allowed:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              anonymized:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              denied:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                  all:
+                    items:
+                      $ref: '#/components/schemas/Security_AI_Assistant_API_AnonymizationFieldResponse'
+                    type: array
                   data:
                     items:
                       $ref: '#/components/schemas/Security_AI_Assistant_API_AnonymizationFieldResponse'

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -39,7 +39,7 @@ pageLoadAssetSize:
   discover: 25000
   discoverEnhanced: 42730
   discoverShared: 17111
-  elasticAssistant: 279115
+  elasticAssistant: 294308
   elasticAssistantSharedState: 19295
   embeddable: 24000
   embeddableAlertsTable: 19615

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -201,11 +201,39 @@ paths:
             default: 20
             minimum: 0
             type: integer
+        - description: >-
+            If true, additionally fetch all anonymization fields, otherwise
+            fetch only the provided page
+          in: query
+          name: all_data
+          required: false
+          schema:
+            type: boolean
       responses:
         '200':
           content:
             application/json:
               example:
+                aggregations:
+                  anonymized:
+                    buckets:
+                      allowed:
+                        doc_count: 1
+                      anonymized:
+                        doc_count: 1
+                      denied:
+                        doc_count: 1
+                all:
+                  - allowed: true
+                    anonymized: true
+                    createdAt: '2023-10-31T12:00:00Z'
+                    createdBy: user1
+                    field: user.name
+                    id: '1'
+                    namespace: default
+                    timestamp: '2023-10-31T12:00:00Z'
+                    updatedAt: '2023-10-31T12:00:00Z'
+                    updatedBy: user1
                 data:
                   - allowed: true
                     anonymized: true
@@ -223,6 +251,37 @@ paths:
               schema:
                 type: object
                 properties:
+                  aggregations:
+                    type: object
+                    properties:
+                      field_status:
+                        type: object
+                        properties:
+                          buckets:
+                            type: object
+                            properties:
+                              allowed:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              anonymized:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              denied:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                  all:
+                    items:
+                      $ref: '#/components/schemas/AnonymizationFieldResponse'
+                    type: array
                   data:
                     items:
                       $ref: '#/components/schemas/AnonymizationFieldResponse'

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -201,11 +201,39 @@ paths:
             default: 20
             minimum: 0
             type: integer
+        - description: >-
+            If true, additionally fetch all anonymization fields, otherwise
+            fetch only the provided page
+          in: query
+          name: all_data
+          required: false
+          schema:
+            type: boolean
       responses:
         '200':
           content:
             application/json:
               example:
+                aggregations:
+                  anonymized:
+                    buckets:
+                      allowed:
+                        doc_count: 1
+                      anonymized:
+                        doc_count: 1
+                      denied:
+                        doc_count: 1
+                all:
+                  - allowed: true
+                    anonymized: true
+                    createdAt: '2023-10-31T12:00:00Z'
+                    createdBy: user1
+                    field: user.name
+                    id: '1'
+                    namespace: default
+                    timestamp: '2023-10-31T12:00:00Z'
+                    updatedAt: '2023-10-31T12:00:00Z'
+                    updatedBy: user1
                 data:
                   - allowed: true
                     anonymized: true
@@ -223,6 +251,37 @@ paths:
               schema:
                 type: object
                 properties:
+                  aggregations:
+                    type: object
+                    properties:
+                      field_status:
+                        type: object
+                        properties:
+                          buckets:
+                            type: object
+                            properties:
+                              allowed:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              anonymized:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                              denied:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    default: 0
+                                    type: integer
+                  all:
+                    items:
+                      $ref: '#/components/schemas/AnonymizationFieldResponse'
+                    type: array
                   data:
                     items:
                       $ref: '#/components/schemas/AnonymizationFieldResponse'

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/anonymization_fields/find_anonymization_fields_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/anonymization_fields/find_anonymization_fields_route.gen.ts
@@ -15,7 +15,7 @@
  */
 
 import { z } from '@kbn/zod';
-import { ArrayFromString } from '@kbn/zod-helpers';
+import { ArrayFromString, BooleanFromString } from '@kbn/zod-helpers';
 
 import { SortOrder } from '../common_attributes.gen';
 import { AnonymizationFieldResponse } from './bulk_crud_anonymization_fields_route.gen';
@@ -59,6 +59,10 @@ export const FindAnonymizationFieldsRequestQuery = z.object({
    * AnonymizationFields per page
    */
   per_page: z.coerce.number().int().min(0).optional().default(20),
+  /**
+   * If true, additionally fetch all anonymization fields, otherwise fetch only the provided page
+   */
+  all_data: BooleanFromString.optional(),
 });
 export type FindAnonymizationFieldsRequestQueryInput = z.input<
   typeof FindAnonymizationFieldsRequestQuery
@@ -70,4 +74,32 @@ export const FindAnonymizationFieldsResponse = z.object({
   perPage: z.number().int(),
   total: z.number().int(),
   data: z.array(AnonymizationFieldResponse),
+  all: z.array(AnonymizationFieldResponse).optional(),
+  aggregations: z
+    .object({
+      field_status: z
+        .object({
+          buckets: z
+            .object({
+              anonymized: z
+                .object({
+                  doc_count: z.number().int().optional().default(0),
+                })
+                .optional(),
+              allowed: z
+                .object({
+                  doc_count: z.number().int().optional().default(0),
+                })
+                .optional(),
+              denied: z
+                .object({
+                  doc_count: z.number().int().optional().default(0),
+                })
+                .optional(),
+            })
+            .optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/anonymization_fields/find_anonymization_fields_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/anonymization_fields/find_anonymization_fields_route.schema.yaml
@@ -65,6 +65,12 @@ paths:
             minimum: 0
             default: 20
           example: 20
+        - name: 'all_data'
+          in: query
+          description: If true, additionally fetch all anonymization fields, otherwise fetch only the provided page
+          required: false
+          schema:
+            type: boolean
 
       responses:
         200:
@@ -84,6 +90,37 @@ paths:
                     type: array
                     items:
                       $ref: './bulk_crud_anonymization_fields_route.schema.yaml#/components/schemas/AnonymizationFieldResponse'
+                  all:
+                    type: array
+                    items:
+                      $ref: './bulk_crud_anonymization_fields_route.schema.yaml#/components/schemas/AnonymizationFieldResponse'
+                  aggregations:
+                    type: object
+                    properties:
+                      field_status:
+                        type: object
+                        properties:
+                          buckets:
+                            type: object
+                            properties:
+                              anonymized:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    type: integer
+                                    default: 0
+                              allowed:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    type: integer
+                                    default: 0
+                              denied:
+                                type: object
+                                properties:
+                                  doc_count:
+                                    type: integer
+                                    default: 0
                 required:
                   - page
                   - perPage
@@ -104,6 +141,26 @@ paths:
                     createdBy: 'user1'
                     updatedBy: 'user1'
                     namespace: 'default'
+                all:
+                  - id: '1'
+                    field: 'user.name'
+                    anonymized: true
+                    allowed: true
+                    timestamp: '2023-10-31T12:00:00Z'
+                    createdAt: '2023-10-31T12:00:00Z'
+                    updatedAt: '2023-10-31T12:00:00Z'
+                    createdBy: 'user1'
+                    updatedBy: 'user1'
+                    namespace: 'default'
+                aggregations:
+                  anonymized:
+                    buckets:
+                      allowed:
+                        doc_count: 1
+                      anonymized:
+                        doc_count: 1
+                      denied:
+                        doc_count: 1
         400:
           description: Generic Error
           content:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/bulk_update_anonymization_fields.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/bulk_update_anonymization_fields.ts
@@ -49,7 +49,7 @@ export const bulkUpdateAnonymizationFields = async (
         'xpack.elasticAssistant.anonymizationFields.bulkActionsAnonymizationFieldsError',
         {
           defaultMessage: 'Error updating anonymization fields {error}',
-          values: { error },
+          values: { error: error.body?.message || JSON.stringify(error) },
         }
       ),
     });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields.ts
@@ -5,17 +5,62 @@
  * 2.0.
  */
 
-import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common/impl/schemas';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
 import {
-  API_VERSIONS,
   ELASTIC_AI_ASSISTANT_ANONYMIZATION_FIELDS_URL_FIND,
+  API_VERSIONS,
+  FindAnonymizationFieldsResponse,
 } from '@kbn/elastic-assistant-common';
 import { useAssistantContext } from '../../../assistant_context';
 
 export interface UseFetchAnonymizationFieldsParams {
-  signal?: AbortSignal | undefined;
+  page?: number; // API uses 1-based index
+  perPage?: number;
+  sortField?: string;
+  sortOrder?: 'asc' | 'desc';
+  signal?: AbortSignal;
+  filter?: string;
+  all?: boolean; // If true, additionally fetch all anonymization fields, otherwise fetch only the provided page
 }
+
+export interface FetchAnonymizationFields {
+  refetch: () => void;
+  data: FindAnonymizationFieldsResponse;
+  isFetched: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  isLoading: boolean;
+}
+
+export const QUERY_ALL = {
+  page: 0,
+  perPage: 1000,
+};
+
+export const DEFAULTS = {
+  ...QUERY_ALL,
+  sortField: 'field',
+  sortOrder: 'asc',
+};
+
+const getFilter = (f: string): string | null => {
+  if (!f || f.length === 0) {
+    return null;
+  }
+  return f
+    .split(' ')
+    .map((word) => {
+      if (word === 'is:allowed') {
+        return 'allowed: true';
+      } else if (word === 'is:anonymized') {
+        return 'anonymized: true';
+      } else {
+        return `field: ${word}*`;
+      }
+    })
+    .join(' AND ');
+};
 
 /**
  * API call for fetching anonymization fields for current spaceId
@@ -24,51 +69,115 @@ export interface UseFetchAnonymizationFieldsParams {
  * @param {HttpSetup} options.http - HttpSetup
  * @param {AbortSignal} [options.signal] - AbortSignal
  *
- * @returns {useQuery} hook for getting the status of the anonymization fields
+ * @returns {useInfiniteQuery} hook for getting the status of the anonymization fields
  */
 
-const QUERY = {
-  page: 1,
-  per_page: 1000, // Continue use in-memory paging till the new design will be ready
-};
-
-export const CACHING_KEYS = [
-  ELASTIC_AI_ASSISTANT_ANONYMIZATION_FIELDS_URL_FIND,
-  QUERY.page,
-  QUERY.per_page,
-  API_VERSIONS.public.v1,
-];
-
-export const useFetchAnonymizationFields = (payload?: UseFetchAnonymizationFieldsParams) => {
+export const useFetchAnonymizationFields = (
+  params?: UseFetchAnonymizationFieldsParams
+): FetchAnonymizationFields => {
   const {
-    assistantAvailability: { isAssistantEnabled },
+    all,
+    page = DEFAULTS.page,
+    perPage = DEFAULTS.perPage,
+    sortField = DEFAULTS.sortField,
+    sortOrder = DEFAULTS.sortOrder,
+    signal,
+    filter,
+  } = params || {};
+
+  const {
     http,
+    assistantAvailability: { isAssistantEnabled },
   } = useAssistantContext();
 
-  return useQuery<FindAnonymizationFieldsResponse, unknown, FindAnonymizationFieldsResponse>(
-    CACHING_KEYS,
-    async () =>
-      http.fetch(ELASTIC_AI_ASSISTANT_ANONYMIZATION_FIELDS_URL_FIND, {
-        method: 'GET',
-        version: API_VERSIONS.public.v1,
-        query: QUERY,
-        signal: payload?.signal,
-      }),
-    {
-      initialData: {
-        data: [],
-        page: 1,
-        perPage: 5,
-        total: 0,
-      },
-      placeholderData: {
-        data: [],
-        page: 1,
-        perPage: 5,
-        total: 0,
-      },
-      keepPreviousData: true,
-      enabled: isAssistantEnabled,
-    }
+  const fetchPage = useCallback(
+    async ({ pageParam = { page, perPage, sortField, sortOrder, filter, all } }) => {
+      const {
+        page: p = page,
+        perPage: pp = perPage,
+        sortField: sf = sortField,
+        sortOrder: so = sortOrder,
+        filter: f = '',
+        all: isAll,
+      } = pageParam;
+      const queryFilter = getFilter(f);
+
+      return http.fetch<FindAnonymizationFieldsResponse>(
+        ELASTIC_AI_ASSISTANT_ANONYMIZATION_FIELDS_URL_FIND,
+        {
+          method: 'GET',
+          version: API_VERSIONS.public.v1,
+          query: {
+            page: p + 1, // EUI uses 0-based index, while API uses 1-based index
+            per_page: pp,
+            sort_field: sf,
+            sort_order: so,
+            ...(queryFilter ? { filter: queryFilter } : {}),
+            all_data: isAll,
+          },
+          signal,
+        }
+      );
+    },
+    [page, perPage, sortField, sortOrder, filter, all, http, signal]
   );
+
+  // Next page param: include current sorting in next request
+  const getNextPageParam = useCallback(
+    (lastPage: FindAnonymizationFieldsResponse) => {
+      const totalPages = Math.ceil(lastPage.total / lastPage.perPage);
+      if (lastPage.page < totalPages) {
+        return {
+          page: lastPage.page + 1,
+          sortField,
+          sortOrder,
+        };
+      }
+      return undefined;
+    },
+    [sortField, sortOrder]
+  );
+
+  const CACHING_KEYS = [
+    sortField,
+    sortOrder,
+    perPage,
+    API_VERSIONS.public.v1,
+    ELASTIC_AI_ASSISTANT_ANONYMIZATION_FIELDS_URL_FIND,
+    page,
+    filter,
+    all,
+  ];
+
+  const { refetch, data, isFetched, isFetching, isError, isLoading } = useInfiniteQuery<
+    FindAnonymizationFieldsResponse,
+    unknown,
+    FindAnonymizationFieldsResponse
+  >(CACHING_KEYS, fetchPage, {
+    getNextPageParam,
+    enabled: isAssistantEnabled,
+    refetchOnWindowFocus: true,
+  });
+
+  const currentPageItems: FindAnonymizationFieldsResponse = useMemo(() => {
+    return (
+      data?.pages.at(-1) ?? {
+        page,
+        perPage,
+        total: 0,
+        data: [],
+        aggregations: {},
+        ...(all ? { all: [] } : {}),
+      }
+    );
+  }, [data, page, perPage, all]);
+
+  return {
+    refetch,
+    data: currentPageItems,
+    isFetched,
+    isFetching,
+    isError,
+    isLoading,
+  };
 };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/common/components/assistant_settings_management/pagination/use_session_pagination.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/common/components/assistant_settings_management/pagination/use_session_pagination.ts
@@ -30,7 +30,7 @@ interface InMemoryPagination {
   pageIndex: number;
 }
 
-interface ServerSidePagination {
+export interface ServerSidePagination {
   totalItemCount: number;
   pageSize: number;
   pageSizeOptions: number[];

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.test.tsx
@@ -23,6 +23,10 @@ import { FetchCurrentUserConversations, useFetchCurrentUserConversations } from 
 import * as all from './chat_send/use_chat_send';
 import { useConversation } from './use_conversation';
 import { AIConnector } from '../connectorland/connector_selector';
+import {
+  FetchAnonymizationFields,
+  useFetchAnonymizationFields,
+} from './api/anonymization_fields/use_fetch_anonymization_fields';
 
 jest.mock('../connectorland/use_load_connectors');
 jest.mock('../connectorland/connector_setup');
@@ -31,6 +35,7 @@ jest.mock('react-use/lib/useSessionStorage');
 
 jest.mock('./quick_prompts/quick_prompts', () => ({ QuickPrompts: jest.fn() }));
 jest.mock('./api/conversations/use_fetch_current_user_conversations');
+jest.mock('./api/anonymization_fields/use_fetch_anonymization_fields');
 
 jest.mock('./use_conversation');
 const apiConfig = { connectorId: '123' };
@@ -99,6 +104,15 @@ const mockUseConversation = {
   setApiConfig: jest.fn().mockResolvedValue({}),
 };
 
+const mockAnonymizationFields: FetchAnonymizationFields = {
+  refetch: jest.fn(),
+  data: { page: 1, perPage: 20, total: 0, data: [] },
+  isFetching: false,
+  isError: false,
+  isLoading: false,
+  isFetched: true,
+};
+
 const refetchResults = jest.fn();
 const defaultFetchUserConversations = {
   data: mockData,
@@ -147,6 +161,7 @@ describe('Assistant', () => {
     jest
       .mocked(useFetchCurrentUserConversations)
       .mockReturnValue(defaultFetchUserConversations as unknown as FetchCurrentUserConversations);
+    jest.mocked(useFetchAnonymizationFields).mockReturnValue(mockAnonymizationFields);
     jest
       .mocked(useLocalStorage)
       .mockReturnValue([mockData.welcome_id, persistToLocalStorage] as unknown as ReturnType<

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_anonymization_updater.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_anonymization_updater.test.ts
@@ -56,6 +56,7 @@ describe('useAnonymizationUpdater', () => {
   it('should initialize with default values', () => {
     const { result } = renderHook(() =>
       useAnonymizationUpdater({
+        anonymizationAllFields: mockAnonymizationFields,
         anonymizationFields: mockAnonymizationFields,
         http: mockHttp,
         toasts: mockToasts,
@@ -69,6 +70,7 @@ describe('useAnonymizationUpdater', () => {
   it('should update hasPendingChanges and updatedAnonymizationData on onListUpdated', async () => {
     const { result } = renderHook(() =>
       useAnonymizationUpdater({
+        anonymizationAllFields: mockAnonymizationFields,
         anonymizationFields: mockAnonymizationFields,
         http: mockHttp,
         toasts: mockToasts,
@@ -99,6 +101,7 @@ describe('useAnonymizationUpdater', () => {
 
     const { result } = renderHook(() =>
       useAnonymizationUpdater({
+        anonymizationAllFields: mockAnonymizationFields,
         anonymizationFields: mockAnonymizationFields,
         http: mockHttp,
         toasts: mockToasts,
@@ -129,7 +132,7 @@ describe('useAnonymizationUpdater', () => {
     expect(result.current.hasPendingChanges).toBe(true);
     expect(result.current.updatedAnonymizationData).toEqual({
       ...mockAnonymizationFields,
-      data: [mockField2, { ...mockField, anonymized: true }],
+      data: [{ ...mockField, anonymized: true }, mockField2],
     });
     await act(async () => {
       await result.current.onListUpdated(update2);
@@ -158,6 +161,7 @@ describe('useAnonymizationUpdater', () => {
 
     const { result } = renderHook(() =>
       useAnonymizationUpdater({
+        anonymizationAllFields: mockAnonymizationFields,
         anonymizationFields: mockAnonymizationFields,
         http: mockHttp,
         toasts: mockToasts,
@@ -203,6 +207,7 @@ describe('useAnonymizationUpdater', () => {
 
     const { result } = renderHook(() =>
       useAnonymizationUpdater({
+        anonymizationAllFields: mockAnonymizationFields,
         anonymizationFields: mockAnonymizationFields,
         http: mockHttp,
         toasts: mockToasts,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/constants.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/constants.tsx
@@ -30,6 +30,8 @@ export const CONVERSATION_TABLE_SESSION_STORAGE_KEY = 'conversationTable';
 export const QUICK_PROMPT_TABLE_SESSION_STORAGE_KEY = 'quickPromptTable';
 export const SYSTEM_PROMPT_TABLE_SESSION_STORAGE_KEY = 'systemPromptTable';
 export const ANONYMIZATION_TABLE_SESSION_STORAGE_KEY = 'anonymizationTable';
+export const ANONYMIZATION_PROMPT_CONTEXT_TABLE_SESSION_STORAGE_KEY =
+  'anonymizationPromptContextTable';
 
 /** The default `n` latest alerts, ordered by risk score, sent as context to the assistant */
 export const DEFAULT_LATEST_ALERTS = 100;

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization/settings/anonymization_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization/settings/anonymization_settings_management/index.tsx
@@ -25,7 +25,7 @@ import { useAnonymizationUpdater } from '../../../assistant/settings/use_setting
 import { Stats } from '../../../data_anonymization_editor/stats';
 import { ContextEditor } from '../../../data_anonymization_editor/context_editor';
 import * as i18n from '../anonymization_settings/translations';
-import { useFetchAnonymizationFields } from '../../../assistant/api/anonymization_fields/use_fetch_anonymization_fields';
+
 import { AssistantSettingsBottomBar } from '../../../assistant/settings/assistant_settings_bottom_bar';
 import { useAssistantContext } from '../../../assistant_context';
 import {
@@ -33,6 +33,9 @@ import {
   SAVE,
   SETTINGS_UPDATED_TOAST_TITLE,
 } from '../../../assistant/settings/translations';
+
+import { SEARCH, useTable } from './use_table';
+import { useSelection } from '../../../data_anonymization_editor/context_editor/selection/use_selection';
 
 export interface Props {
   modalMode?: boolean;
@@ -44,34 +47,61 @@ const AnonymizationSettingsManagementComponent: React.FC<Props> = ({
   onClose,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const { http, toasts } = useAssistantContext();
-  const { data: anonymizationFields, refetch } = useFetchAnonymizationFields();
+  const { http, toasts, nameSpace } = useAssistantContext();
 
   const {
+    anonymizationFields,
+    anonymizationAllFields,
+    anonymizationFieldsStatus,
+    onTableChange,
+    pagination,
+    sorting,
+    handleSearch,
+    refetch,
+  } = useTable(nameSpace);
+
+  const {
+    handlePageReset,
+    handleRowReset,
     hasPendingChanges,
     onListUpdated,
     resetAnonymizationSettings,
     saveAnonymizationSettings,
-    updatedAnonymizationData,
+    updatedAnonymizationData: updatedAnonymizationPageData,
   } = useAnonymizationUpdater({
+    anonymizationAllFields,
     anonymizationFields,
     http,
     toasts,
   });
 
+  const { selectionActions, selectionState } = useSelection({
+    anonymizationAllFields,
+    anonymizationPageFields: anonymizationFields,
+  });
+
+  const handleTableReset = useCallback(() => {
+    resetAnonymizationSettings();
+    selectionActions?.handleUnselectAll();
+  }, [resetAnonymizationSettings, selectionActions]);
+
   const onCancelClick = useCallback(() => {
     onClose?.();
-    resetAnonymizationSettings();
-  }, [onClose, resetAnonymizationSettings]);
+    handleTableReset();
+  }, [onClose, handleTableReset]);
 
   const handleSave = useCallback(async () => {
-    await saveAnonymizationSettings();
-    toasts?.addSuccess({
-      iconType: 'check',
-      title: SETTINGS_UPDATED_TOAST_TITLE,
-    });
+    const updateSuccess = await saveAnonymizationSettings();
+    if (updateSuccess) {
+      toasts?.addSuccess({
+        iconType: 'check',
+        title: SETTINGS_UPDATED_TOAST_TITLE,
+      });
+    }
+
     await refetch();
-  }, [refetch, saveAnonymizationSettings, toasts]);
+    selectionActions?.handleUnselectAll();
+  }, [refetch, saveAnonymizationSettings, selectionActions, toasts]);
 
   const onSaveButtonClicked = useCallback(() => {
     handleSave();
@@ -91,8 +121,9 @@ const AnonymizationSettingsManagementComponent: React.FC<Props> = ({
 
           <EuiFlexGroup alignItems="center" data-test-subj="summary" gutterSize="none">
             <Stats
+              anonymizationFieldsStatus={anonymizationFieldsStatus}
               isDataAnonymizable={true}
-              anonymizationFields={updatedAnonymizationData.data}
+              anonymizationFields={anonymizationFields.data}
               titleSize="m"
               gap={euiTheme.size.s}
             />
@@ -101,10 +132,21 @@ const AnonymizationSettingsManagementComponent: React.FC<Props> = ({
           <EuiSpacer size="m" />
 
           <ContextEditor
-            anonymizationFields={updatedAnonymizationData}
+            anonymizationAllFields={anonymizationAllFields}
+            anonymizationPageFields={updatedAnonymizationPageData}
             compressed={false}
             onListUpdated={onListUpdated}
             rawData={null}
+            onTableChange={onTableChange}
+            pagination={pagination}
+            sorting={sorting}
+            search={SEARCH}
+            handleSearch={handleSearch}
+            handleTableReset={handleTableReset}
+            handleRowReset={handleRowReset}
+            handlePageReset={handlePageReset}
+            selectionState={selectionState}
+            selectionActions={selectionActions}
           />
         </EuiModalBody>
         <EuiModalFooter>
@@ -126,8 +168,9 @@ const AnonymizationSettingsManagementComponent: React.FC<Props> = ({
 
         <EuiFlexGroup alignItems="center" data-test-subj="summary" gutterSize="none">
           <Stats
+            anonymizationFieldsStatus={anonymizationFieldsStatus}
             isDataAnonymizable={true}
-            anonymizationFields={updatedAnonymizationData.data}
+            anonymizationFields={anonymizationAllFields.data}
             titleSize="m"
             gap={euiTheme.size.s}
           />
@@ -136,10 +179,21 @@ const AnonymizationSettingsManagementComponent: React.FC<Props> = ({
         <EuiSpacer size="m" />
 
         <ContextEditor
-          anonymizationFields={updatedAnonymizationData}
+          anonymizationAllFields={anonymizationAllFields}
+          anonymizationPageFields={updatedAnonymizationPageData}
           compressed={false}
           onListUpdated={onListUpdated}
           rawData={null}
+          onTableChange={onTableChange}
+          pagination={pagination}
+          sorting={sorting}
+          search={SEARCH}
+          handleSearch={handleSearch}
+          handleRowReset={handleRowReset}
+          handlePageReset={handlePageReset}
+          handleTableReset={handleTableReset}
+          selectionState={selectionState}
+          selectionActions={selectionActions}
         />
       </EuiPanel>
       <AssistantSettingsBottomBar

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization/settings/anonymization_settings_management/use_table.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization/settings/anonymization_settings_management/use_table.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { EuiSearchBarOnChangeArgs, EuiSearchBarProps } from '@elastic/eui';
+import {
+  getDefaultTableOptions,
+  useSessionPagination,
+} from '../../../assistant/common/components/assistant_settings_management/pagination/use_session_pagination';
+import { ContextEditorRow, FIELDS } from '../../../data_anonymization_editor/context_editor/types';
+import { ANONYMIZATION_TABLE_SESSION_STORAGE_KEY } from '../../../assistant_context/constants';
+import { useFetchAnonymizationFields } from '../../../assistant/api/anonymization_fields/use_fetch_anonymization_fields';
+import {
+  ALLOWED,
+  ANONYMIZED,
+} from '../../../data_anonymization_editor/context_editor/translations';
+
+export const SEARCH: EuiSearchBarProps = {
+  box: {
+    incremental: true,
+  },
+  filters: [
+    {
+      field: FIELDS.ALLOWED,
+      type: 'is',
+      name: ALLOWED,
+    },
+    {
+      field: FIELDS.ANONYMIZED,
+      type: 'is',
+      name: ANONYMIZED,
+    },
+  ],
+};
+
+export const useTable = (nameSpace: string) => {
+  const defaultTableOptions = useMemo(() => {
+    return getDefaultTableOptions<ContextEditorRow>({
+      pageSize: 10,
+      sortDirection: 'asc',
+      sortField: 'field',
+    });
+  }, []);
+
+  const { onTableChange, pagination, sorting } = useSessionPagination<ContextEditorRow, false>({
+    defaultTableOptions,
+    nameSpace,
+    storageKey: ANONYMIZATION_TABLE_SESSION_STORAGE_KEY,
+    inMemory: false,
+  });
+
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const handleSearch = useCallback(
+    (query: EuiSearchBarOnChangeArgs) => {
+      setSearchQuery(query.queryText || '');
+    },
+    [setSearchQuery]
+  );
+
+  const { data: anonymizationFields, refetch } = useFetchAnonymizationFields({
+    page: pagination.pageIndex, // EUI uses 0-based index, while API uses 1-based index
+    perPage: pagination.pageSize, // Continue use in-memory paging till the new design will be ready
+    sortField: sorting.sort?.field,
+    sortOrder: sorting.sort?.direction,
+    filter: searchQuery,
+    all: true, // Fetch all anonymization fields in addition to the current page
+  });
+  const meta = useMemo(
+    () => ({
+      page: anonymizationFields?.page ?? 0,
+      perPage: anonymizationFields?.perPage ?? 0,
+      total: anonymizationFields?.total ?? 0,
+    }),
+    [anonymizationFields]
+  );
+  return {
+    anonymizationFieldsStatus: anonymizationFields?.aggregations?.field_status?.buckets,
+    anonymizationAllFields: useMemo(
+      () => ({
+        ...meta,
+        data: anonymizationFields.all || [],
+      }),
+      [anonymizationFields.all, meta]
+    ),
+    anonymizationFields: useMemo(
+      () => ({
+        ...meta,
+        data: anonymizationFields.data || [],
+      }),
+      [anonymizationFields.data, meta]
+    ),
+    onTableChange,
+    pagination,
+    sorting,
+    searchQuery,
+    handleSearch,
+    refetch,
+  };
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/bulk_actions/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/bulk_actions/index.test.tsx
@@ -13,6 +13,7 @@ import { BulkActions } from '.';
 
 const selected = [
   {
+    id: '1',
     allowed: true,
     anonymized: false,
     denied: false,
@@ -20,6 +21,7 @@ const selected = [
     rawValues: ['abc', 'def'],
   },
   {
+    id: '2',
     allowed: false,
     anonymized: true,
     denied: true,
@@ -33,7 +35,8 @@ const defaultProps = {
   disabled: false,
   onListUpdated: jest.fn(),
   onlyDefaults: false,
-  selected,
+  selectedFields: selected.map((item) => item.field),
+  handleRowChecked: jest.fn(),
 };
 
 describe('BulkActions', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/bulk_actions/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/bulk_actions/index.tsx
@@ -17,7 +17,8 @@ import {
 import React, { useCallback, useMemo, useState } from 'react';
 import { getContextMenuPanels, PRIMARY_PANEL_ID } from '../get_context_menu_panels';
 import * as i18n from '../translations';
-import { BatchUpdateListItem, ContextEditorRow } from '../types';
+import type { OnListUpdated } from '../../../assistant/settings/use_settings_updater/use_anonymization_updater';
+import type { HandleRowChecked } from '../selection/types';
 
 export interface Props {
   appliesTo: 'multipleRows' | 'singleRow';
@@ -26,8 +27,10 @@ export interface Props {
   disableAnonymize?: boolean;
   disableDeny?: boolean;
   disableUnanonymize?: boolean;
-  onListUpdated: (updates: BatchUpdateListItem[]) => void;
-  selected: ContextEditorRow[];
+  onListUpdated: OnListUpdated;
+  selectedField?: string; // Selected field for a single row, undefined if applies to multiple rows
+  selectedFields: string[]; // Selected fields for the entire table
+  handleRowChecked: HandleRowChecked;
 }
 
 const BulkActionsComponent: React.FC<Props> = ({
@@ -38,7 +41,9 @@ const BulkActionsComponent: React.FC<Props> = ({
   disableDeny = false,
   disableUnanonymize = false,
   onListUpdated,
-  selected,
+  selectedField,
+  selectedFields,
+  handleRowChecked,
 }) => {
   const [isPopoverOpen, setPopover] = useState(false);
 
@@ -48,7 +53,9 @@ const BulkActionsComponent: React.FC<Props> = ({
 
   const closePopover = useCallback(() => setPopover(false), []);
 
-  const onButtonClick = useCallback(() => setPopover((isOpen) => !isOpen), []);
+  const onButtonClick = useCallback(() => {
+    setPopover((isOpen) => !isOpen);
+  }, []);
 
   const button = useMemo(
     () => (
@@ -77,7 +84,9 @@ const BulkActionsComponent: React.FC<Props> = ({
         disableUnanonymize,
         closePopover,
         onListUpdated,
-        selected,
+        selectedField,
+        selectedFields,
+        handleRowChecked,
       }),
     [
       closePopover,
@@ -85,8 +94,10 @@ const BulkActionsComponent: React.FC<Props> = ({
       disableAnonymize,
       disableDeny,
       disableUnanonymize,
+      handleRowChecked,
       onListUpdated,
-      selected,
+      selectedField,
+      selectedFields,
     ]
   );
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_columns/get_selection_columns.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_columns/get_selection_columns.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiBasicTableColumn } from '@elastic/eui';
+import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common';
+import { ContextEditorRow } from '../types';
+import { InputCheckbox, PageSelectionCheckbox } from '../selection/table_selection_checkbox';
+import {
+  HandlePageChecked,
+  HandlePageUnchecked,
+  HandleRowChecked,
+  HandleRowUnChecked,
+} from '../selection/types';
+import type {
+  HandlePageReset,
+  HandleRowReset,
+} from '../../../assistant/settings/use_settings_updater/use_anonymization_updater';
+
+export const getSelectionColumns = ({
+  anonymizationPageFields,
+  handlePageChecked,
+  handlePageReset,
+  handlePageUnchecked,
+  handleRowChecked,
+  handleRowReset,
+  handleRowUnChecked,
+  hasUpdateAIAssistantAnonymization,
+  selectedFields,
+  totalItemCount,
+}: {
+  anonymizationPageFields: FindAnonymizationFieldsResponse['data'];
+  handlePageChecked: HandlePageChecked;
+  handlePageReset: HandlePageReset;
+  handlePageUnchecked: HandlePageUnchecked;
+  handleRowChecked: HandleRowChecked;
+  handleRowReset: HandleRowReset;
+  handleRowUnChecked: HandleRowUnChecked;
+  hasUpdateAIAssistantAnonymization: boolean;
+  selectedFields: string[];
+  totalItemCount: number;
+}): Array<EuiBasicTableColumn<ContextEditorRow>> => {
+  const selectionColumn: EuiBasicTableColumn<ContextEditorRow> = {
+    field: '',
+    name: (
+      <PageSelectionCheckbox
+        handlePageChecked={handlePageChecked}
+        handlePageUnchecked={handlePageUnchecked}
+        anonymizationPageFields={anonymizationPageFields}
+        selectedFields={selectedFields}
+        totalItemCount={totalItemCount}
+        handlePageReset={handlePageReset}
+      />
+    ),
+    render: (row: ContextEditorRow) => (
+      <InputCheckbox
+        row={row}
+        selectedFields={selectedFields}
+        handleRowChecked={handleRowChecked}
+        handleRowUnChecked={handleRowUnChecked}
+        handleRowReset={handleRowReset}
+      />
+    ),
+    width: '70px',
+    sortable: false,
+  };
+
+  return hasUpdateAIAssistantAnonymization ? [selectionColumn] : [];
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_columns/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_columns/index.test.tsx
@@ -56,11 +56,54 @@ describe('getColumns', () => {
     rawValues: ['authentication'],
   };
 
+  const mockField = {
+    timestamp: '2025-02-04T16:47:17.791Z',
+    createdAt: '2025-02-04T16:47:17.791Z',
+    field: 'user.name',
+    allowed: true,
+    anonymized: false,
+    updatedAt: '2025-02-20T16:56:58.086Z',
+    namespace: 'default',
+    id: 'blnb0ZQBQBIRhhJM6eMi',
+  };
+  const mockField2 = {
+    timestamp: '2025-02-04T16:47:17.791Z',
+    createdAt: '2025-02-04T16:47:17.791Z',
+    field: 'host.name',
+    allowed: true,
+    anonymized: false,
+    updatedAt: '2025-02-14T16:56:58.086Z',
+    namespace: 'default',
+    id: 'blnb0ZQBQBIRhhJM6egi',
+  };
+
+  const mockAnonymizationFields = {
+    perPage: 1000,
+    page: 1,
+    total: 2,
+    data: [mockField, mockField2],
+  };
+
+  const getColumnsParams = {
+    compressed: true,
+    hasUpdateAIAssistantAnonymization,
+    onListUpdated,
+    rawData,
+    anonymizationPageFields: mockAnonymizationFields.data,
+    selectedFields: [],
+    handlePageChecked: jest.fn(),
+    handlePageUnchecked: jest.fn(),
+    handleRowChecked: jest.fn(),
+    handleRowUnChecked: jest.fn(),
+    totalItemCount: 0,
+    anonymizationAllFields: mockAnonymizationFields.data,
+    handleRowReset: jest.fn(),
+    handlePageReset: jest.fn(),
+  };
+
   it('includes the values column when rawData is NOT null', () => {
     const columns: Array<EuiBasicTableColumn<ContextEditorRow> & { field?: string }> = getColumns({
-      onListUpdated,
-      rawData,
-      hasUpdateAIAssistantAnonymization,
+      ...getColumnsParams,
     });
 
     expect(columns.some(({ field }) => field === 'rawValues')).toBe(true);
@@ -68,9 +111,8 @@ describe('getColumns', () => {
 
   it('does NOT include the values column when rawData is null', () => {
     const columns: Array<EuiBasicTableColumn<ContextEditorRow> & { field?: string }> = getColumns({
-      onListUpdated,
+      ...getColumnsParams,
       rawData: null,
-      hasUpdateAIAssistantAnonymization,
     });
 
     expect(columns.some(({ field }) => field === 'rawValues')).toBe(false);
@@ -78,7 +120,7 @@ describe('getColumns', () => {
 
   describe('allowed column render()', () => {
     it('calls onListUpdated with a `remove` operation when the toggle is clicked on field that is allowed', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[0] as ColumnWithRender;
       const allowedRow = {
         ...row,
@@ -99,7 +141,7 @@ describe('getColumns', () => {
     });
 
     it('calls onListUpdated with an `add` operation when the toggle is clicked on a field that is NOT allowed', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[0] as ColumnWithRender;
       const notAllowedRow = {
         ...row,
@@ -121,9 +163,8 @@ describe('getColumns', () => {
 
     it('calls onListUpdated with a `remove` operation to update the `defaultAllowReplacement` list when the toggle is clicked on a default field that is allowed', () => {
       const columns = getColumns({
-        onListUpdated,
+        ...getColumnsParams,
         rawData: null,
-        hasUpdateAIAssistantAnonymization,
       }); // null raw data means the field is a default field
       const anonymizedColumn: ColumnWithRender = columns[0] as ColumnWithRender;
       const allowedRow = {
@@ -147,7 +188,7 @@ describe('getColumns', () => {
 
   describe('anonymized column render()', () => {
     it('disables the button when the field is not allowed', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const { getByTestId } = render(
@@ -160,7 +201,7 @@ describe('getColumns', () => {
     });
 
     it('enables the button when the field is allowed', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const { getByTestId } = render(
@@ -173,7 +214,7 @@ describe('getColumns', () => {
     });
 
     it('calls onListUpdated with an `add` operation when an unanonymized field is toggled', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const { getByTestId } = render(
@@ -190,7 +231,7 @@ describe('getColumns', () => {
     });
 
     it('calls onListUpdated with a `remove` operation when an anonymized field is toggled', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const anonymizedRow = {
@@ -213,9 +254,8 @@ describe('getColumns', () => {
 
     it('calls onListUpdated with an update to the `defaultAllowReplacement` list when rawData is null, because the field is a default', () => {
       const columns = getColumns({
-        onListUpdated,
+        ...getColumnsParams,
         rawData: null,
-        hasUpdateAIAssistantAnonymization,
       }); // null raw data means the field is a default field
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
@@ -233,7 +273,7 @@ describe('getColumns', () => {
     });
 
     it('displays a closed eye icon when the field is anonymized', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const { container } = render(
@@ -247,7 +287,7 @@ describe('getColumns', () => {
     });
 
     it('displays a open eye icon when the field is NOT anonymized', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const { container } = render(
@@ -261,7 +301,7 @@ describe('getColumns', () => {
     });
 
     it('displays Yes when the field is anonymized', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const { getByTestId } = render(
@@ -274,7 +314,7 @@ describe('getColumns', () => {
     });
 
     it('displays No when the field is NOT anonymized', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const anonymizedColumn: ColumnWithRender = columns[1] as ColumnWithRender;
 
       const { getByTestId } = render(
@@ -289,7 +329,7 @@ describe('getColumns', () => {
 
   describe('values column render()', () => {
     it('joins values with a comma', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const valuesColumn: ColumnWithRender = columns[3] as ColumnWithRender;
 
       const rowWithMultipleValues = {
@@ -310,7 +350,7 @@ describe('getColumns', () => {
 
   describe('actions column render()', () => {
     it('renders the bulk actions', () => {
-      const columns = getColumns({ onListUpdated, rawData, hasUpdateAIAssistantAnonymization });
+      const columns = getColumns({ ...getColumnsParams });
       const actionsColumn: ColumnWithRender = columns[4] as ColumnWithRender;
 
       render(

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_columns/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_columns/index.tsx
@@ -12,7 +12,9 @@ import styled from 'styled-components';
 
 import { BulkActions } from '../bulk_actions';
 import * as i18n from '../translations';
-import { BatchUpdateListItem, ContextEditorRow, FIELDS } from '../types';
+import { ContextEditorRow, FIELDS } from '../types';
+import { HandleRowChecked } from '../selection/types';
+import type { OnListUpdated } from '../../../assistant/settings/use_settings_updater/use_anonymization_updater';
 
 const AnonymizedButton = styled(EuiButtonEmpty)`
   max-height: 24px;
@@ -20,14 +22,18 @@ const AnonymizedButton = styled(EuiButtonEmpty)`
 
 export const getColumns = ({
   compressed = true,
+  handleRowChecked,
   hasUpdateAIAssistantAnonymization,
   onListUpdated,
   rawData,
+  selectedFields,
 }: {
   compressed?: boolean;
+  handleRowChecked: HandleRowChecked;
   hasUpdateAIAssistantAnonymization: boolean;
-  onListUpdated: (updates: BatchUpdateListItem[]) => void;
+  onListUpdated: OnListUpdated;
   rawData: Record<string, string[]> | null;
+  selectedFields: string[];
 }): Array<EuiBasicTableColumn<ContextEditorRow>> => {
   const actionsColumn: EuiBasicTableColumn<ContextEditorRow> = {
     field: FIELDS.ACTIONS,
@@ -42,7 +48,9 @@ export const getColumns = ({
           disableAnonymize={!row.allowed || (row.allowed && row.anonymized)}
           disableUnanonymize={!row.allowed || (row.allowed && !row.anonymized)}
           onListUpdated={onListUpdated}
-          selected={[row]}
+          selectedField={row.field}
+          selectedFields={selectedFields}
+          handleRowChecked={handleRowChecked}
         />
       );
     },
@@ -72,6 +80,7 @@ export const getColumns = ({
           showLabel={false}
           compressed={compressed}
           onChange={() => {
+            handleRowChecked(field);
             onListUpdated([
               {
                 field,
@@ -96,15 +105,16 @@ export const getColumns = ({
           flush="both"
           iconType={anonymized ? 'eyeClosed' : 'eye'}
           isSelected={anonymized ? true : false}
-          onClick={() =>
+          onClick={() => {
+            handleRowChecked(field);
             onListUpdated([
               {
                 field,
                 operation: anonymized ? 'remove' : 'add',
                 update: rawData == null ? 'defaultAllowReplacement' : 'allowReplacement',
               },
-            ])
-          }
+            ]);
+          }}
         >
           <EuiText size="xs">{anonymized ? i18n.YES : i18n.NO}</EuiText>
         </AnonymizedButton>

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_context_menu_panels/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_context_menu_panels/index.test.ts
@@ -6,33 +6,27 @@
  */
 import { getContextMenuPanels, PRIMARY_PANEL_ID } from '.';
 import * as i18n from '../translations';
-import { ContextEditorRow } from '../types';
 
 describe('getContextMenuPanels', () => {
   const closePopover = jest.fn();
   const onListUpdated = jest.fn();
-  const selected: ContextEditorRow[] = [
-    {
-      allowed: true,
-      anonymized: true,
-      denied: false,
-      field: 'user.name',
-      rawValues: ['jodi'],
-    },
-  ];
+
+  const params = {
+    disableAllow: false,
+    disableAnonymize: false,
+    disableDeny: false,
+    disableUnanonymize: false,
+    closePopover,
+    onListUpdated,
+    selectedField: 'user.name',
+    selectedFields: ['user.name'],
+    handleRowChecked: jest.fn(),
+  };
 
   beforeEach(() => jest.clearAllMocks());
 
   it('the first panel has a `primary-panel-id`', () => {
-    const panels = getContextMenuPanels({
-      disableAllow: false,
-      disableAnonymize: false,
-      disableDeny: false,
-      disableUnanonymize: false,
-      closePopover,
-      onListUpdated,
-      selected,
-    });
+    const panels = getContextMenuPanels(params);
 
     expect(panels[0].id).toEqual(PRIMARY_PANEL_ID);
   });
@@ -42,13 +36,8 @@ describe('getContextMenuPanels', () => {
       const disableAllow = true;
 
       const panels = getContextMenuPanels({
+        ...params,
         disableAllow,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
       });
 
       const allowItem = panels[0].items?.find((item) => item.name === i18n.ALLOW);
@@ -59,15 +48,7 @@ describe('getContextMenuPanels', () => {
     it('is NOT disabled when `disableAlow` is false', () => {
       const disableAllow = false;
 
-      const panels = getContextMenuPanels({
-        disableAllow,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
-      });
+      const panels = getContextMenuPanels({ ...params, disableAllow });
 
       const allowItem = panels[0].items?.find((item) => item.name === i18n.ALLOW);
 
@@ -76,13 +57,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls closePopover when allow is clicked', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const allowItem = panels[0].items?.find((item) => item.name === i18n.ALLOW);
@@ -99,13 +74,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls onListUpdated to add the field to the `allow` list', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const allowItem = panels[0].items?.find((item) => item.name === i18n.ALLOW);
@@ -128,13 +97,8 @@ describe('getContextMenuPanels', () => {
       const disableDeny = true;
 
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
+        ...params,
         disableDeny,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
       });
 
       const denyItem = panels[0].items?.find((item) => item.name === i18n.DENY);
@@ -146,13 +110,8 @@ describe('getContextMenuPanels', () => {
       const disableDeny = false;
 
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
+        ...params,
         disableDeny,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
       });
 
       const denyItem = panels[0].items?.find((item) => item.name === i18n.DENY);
@@ -162,13 +121,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls closePopover when deny is clicked', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const denyByDefaultItem = panels[0].items?.find((item) => item.name === i18n.DENY);
@@ -185,13 +138,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls onListUpdated to remove the field from the `allow` list', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const denyItem = panels[0].items?.find((item) => item.name === i18n.DENY);
@@ -214,13 +161,8 @@ describe('getContextMenuPanels', () => {
       const disableAnonymize = true;
 
       const panels = getContextMenuPanels({
-        disableAllow: false,
+        ...params,
         disableAnonymize,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
       });
 
       const anonymizeItem = panels[0].items?.find((item) => item.name === i18n.ANONYMIZE);
@@ -232,13 +174,8 @@ describe('getContextMenuPanels', () => {
       const disableAnonymize = false;
 
       const panels = getContextMenuPanels({
-        disableAllow: false,
+        ...params,
         disableAnonymize,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
       });
 
       const anonymizeItem = panels[0].items?.find((item) => item.name === i18n.ANONYMIZE);
@@ -248,13 +185,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls closePopover when anonymize is clicked', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const anonymizeItem = panels[0].items?.find((item) => item.name === i18n.ANONYMIZE);
@@ -271,13 +202,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls onListUpdated to add the field to both the `allowReplacement` and `defaultAllowReplacement` lists', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const anonymizeItem = panels[0].items?.find((item) => item.name === i18n.ANONYMIZE);
@@ -300,13 +225,8 @@ describe('getContextMenuPanels', () => {
       const disableUnanonymize = true;
 
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
+        ...params,
         disableUnanonymize,
-        closePopover,
-        onListUpdated,
-        selected,
       });
 
       const unanonymizeItem = panels[0].items?.find((item) => item.name === i18n.UNANONYMIZE);
@@ -318,13 +238,8 @@ describe('getContextMenuPanels', () => {
       const disableUnanonymize = false;
 
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
+        ...params,
         disableUnanonymize,
-        closePopover,
-        onListUpdated,
-        selected,
       });
 
       const unanonymizeItem = panels[0].items?.find((item) => item.name === i18n.UNANONYMIZE);
@@ -334,13 +249,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls closePopover when unanonymize is clicked', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const unAnonymizeItem = panels[0].items?.find((item) => item.name === i18n.UNANONYMIZE);
@@ -357,13 +266,7 @@ describe('getContextMenuPanels', () => {
 
     it('calls onListUpdated to remove the field from the `allowReplacement` list', () => {
       const panels = getContextMenuPanels({
-        disableAllow: false,
-        disableAnonymize: false,
-        disableDeny: false,
-        disableUnanonymize: false,
-        closePopover,
-        onListUpdated,
-        selected,
+        ...params,
       });
 
       const unAnonymizeItem = panels[0].items?.find((item) => item.name === i18n.UNANONYMIZE);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_context_menu_panels/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_context_menu_panels/index.ts
@@ -8,7 +8,9 @@
 import { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 
 import * as i18n from '../translations';
-import { BatchUpdateListItem, ContextEditorRow } from '../types';
+import type { BatchUpdateListItem } from '../types';
+import type { OnListUpdated } from '../../../assistant/settings/use_settings_updater/use_anonymization_updater';
+import type { HandleRowChecked } from '../selection/types';
 
 export const PRIMARY_PANEL_ID = 'primary-panel-id';
 
@@ -19,17 +21,22 @@ export const getContextMenuPanels = ({
   disableUnanonymize,
   closePopover,
   onListUpdated,
-  selected,
+  selectedField,
+  selectedFields,
+  handleRowChecked,
 }: {
   disableAllow: boolean;
   disableAnonymize: boolean;
   disableDeny: boolean;
   disableUnanonymize: boolean;
   closePopover: () => void;
-  onListUpdated: (updates: BatchUpdateListItem[]) => void;
-  selected: ContextEditorRow[];
+  onListUpdated: OnListUpdated;
+  selectedField: string | undefined; // Selected field for a single row, undefined if applies to multiple rows
+  selectedFields: string[]; // Selected fields for the entire table
+  handleRowChecked: HandleRowChecked;
 }): EuiContextMenuPanelDescriptor[] => {
   const nonDefaultsPanelId = PRIMARY_PANEL_ID;
+  const updatedFields = selectedField ? [selectedField] : selectedFields;
 
   const nonDefaultsPanelItems: EuiContextMenuPanelDescriptor[] = [
     {
@@ -42,12 +49,16 @@ export const getContextMenuPanels = ({
           onClick: () => {
             closePopover();
 
-            const updates = selected.map<BatchUpdateListItem>(({ field }) => ({
-              field,
-              operation: 'add',
-              update: 'allow',
-            }));
-
+            const updates: BatchUpdateListItem[] = updatedFields.map<BatchUpdateListItem>(
+              (field) => ({
+                field,
+                operation: 'add',
+                update: 'allow',
+              })
+            );
+            if (selectedField) {
+              handleRowChecked(updates[0].field);
+            }
             onListUpdated(updates);
           },
         },
@@ -58,12 +69,16 @@ export const getContextMenuPanels = ({
           onClick: () => {
             closePopover();
 
-            const updates = selected.map<BatchUpdateListItem>(({ field }) => ({
-              field,
-              operation: 'remove',
-              update: 'allow',
-            }));
-
+            const updates: BatchUpdateListItem[] = updatedFields.map<BatchUpdateListItem>(
+              (field) => ({
+                field,
+                operation: 'remove',
+                update: 'allow',
+              })
+            );
+            if (selectedField) {
+              handleRowChecked(updates[0].field);
+            }
             onListUpdated(updates);
           },
         },
@@ -74,12 +89,16 @@ export const getContextMenuPanels = ({
           onClick: () => {
             closePopover();
 
-            const updates = selected.map<BatchUpdateListItem>(({ field }) => ({
-              field,
-              operation: 'add',
-              update: 'allowReplacement',
-            }));
-
+            const updates: BatchUpdateListItem[] = updatedFields.map<BatchUpdateListItem>(
+              (field) => ({
+                field,
+                operation: 'add',
+                update: 'allowReplacement',
+              })
+            );
+            if (selectedField) {
+              handleRowChecked(updates[0].field);
+            }
             onListUpdated(updates);
           },
         },
@@ -90,12 +109,16 @@ export const getContextMenuPanels = ({
           onClick: () => {
             closePopover();
 
-            const updates = selected.map<BatchUpdateListItem>(({ field }) => ({
-              field,
-              operation: 'remove',
-              update: 'allowReplacement',
-            }));
-
+            const updates: BatchUpdateListItem[] = updatedFields.map<BatchUpdateListItem>(
+              (field) => ({
+                field,
+                operation: 'remove',
+                update: 'allowReplacement',
+              })
+            );
+            if (selectedField) {
+              handleRowChecked(updates[0].field);
+            }
             onListUpdated(updates);
           },
         },

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_rows/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/get_rows/index.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common/impl/schemas';
 import { isAllowed, isAnonymized, isDenied } from '@kbn/elastic-assistant-common';
 import { ContextEditorRow } from '../types';
+import type { FindAnonymizationFieldsClientResponse } from '../selection/types';
 
 export const getRows = ({
   anonymizationFields,
   rawData,
 }: {
-  anonymizationFields?: FindAnonymizationFieldsResponse;
+  anonymizationFields?: FindAnonymizationFieldsClientResponse;
   rawData: Record<string, string[]> | null;
 }): ContextEditorRow[] => {
   if (rawData !== null && typeof rawData === 'object') {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/index.test.tsx
@@ -11,55 +11,102 @@ import React from 'react';
 
 import { ContextEditor } from '.';
 import { TestProviders } from '../../mock/test_providers/test_providers';
+import { SEARCH } from '../../data_anonymization/settings/anonymization_settings_management/use_table';
 
 describe('ContextEditor', () => {
   const allow = Array.from({ length: 20 }, (_, i) => `field${i + 1}`);
-  const anonymizationFields = {
+  const anonymizationAllFields = {
     total: 20,
     page: 1,
     perPage: 1000,
     data: allow.map((f) => ({ id: f, field: f, allowed: true, anonymized: f === 'field1' })),
   };
+  const anonymizationPageFields = {
+    total: 20,
+    page: 1,
+    perPage: 10,
+    data: anonymizationAllFields.data.slice(0, 10),
+  };
   const rawData = allow.reduce(
     (acc, field, index) => ({ ...acc, [field]: [`value${index + 1}`] }),
     {}
   );
-
   const onListUpdated = jest.fn();
+  const mockSelectionActions = {
+    handleSelectAll: jest.fn(),
+    handleUnselectAll: jest.fn(),
+    handlePageUnchecked: jest.fn(),
+    handlePageChecked: jest.fn(),
+    handleRowUnChecked: jest.fn(),
+    handleRowChecked: jest.fn(),
+    setSelectedFields: jest.fn(),
+    setTotalSelectedItems: jest.fn(),
+    setIsSelectAll: jest.fn(),
+  };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    render(
+  const renderComponent = (selectedFields: string[]) => {
+    return render(
       <TestProviders>
         <ContextEditor
-          anonymizationFields={anonymizationFields}
+          anonymizationAllFields={anonymizationAllFields}
+          anonymizationPageFields={anonymizationPageFields}
           onListUpdated={onListUpdated}
           rawData={rawData}
+          onTableChange={jest.fn()}
+          pagination={{
+            pageIndex: 0,
+            pageSize: 10,
+            totalItemCount: anonymizationAllFields.total,
+            pageSizeOptions: [10, 20],
+          }}
+          sorting={{
+            sort: {
+              field: 'field',
+              direction: 'asc',
+            },
+          }}
+          search={SEARCH}
+          handleSearch={jest.fn()}
+          handleTableReset={jest.fn()}
+          handleRowReset={jest.fn()}
+          handlePageReset={jest.fn()}
+          selectionState={{
+            isSelectAll: false,
+            selectedFields,
+            totalSelectedItems: selectedFields.length,
+          }}
+          selectionActions={mockSelectionActions}
         />
       </TestProviders>
     );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('renders the expected selected field count', () => {
+    renderComponent([]);
     expect(screen.getByTestId('selectedFields')).toHaveTextContent('Selected 0 fields');
   });
 
   it('renders the select all fields button with the expected count', () => {
+    renderComponent([]);
     expect(screen.getByTestId('selectAllFields')).toHaveTextContent('Select all 20 fields');
   });
 
-  it('updates the table selection when "Select all n fields" is clicked', async () => {
-    // The table select all checkbox should only select the number of rows visible on the page
-    await userEvent.click(screen.getByTestId('checkboxSelectAll'));
+  it('updates the table selection when page selection is checked', () => {
+    renderComponent(anonymizationPageFields.data.map((field) => field.field));
     expect(screen.getByTestId('selectedFields')).toHaveTextContent('Selected 10 fields');
+  });
 
-    // The select all button should select all rows regardless of visibility
-    await userEvent.click(screen.getByTestId('selectAllFields'));
+  it('updates the table selection when select all is clicked', () => {
+    renderComponent(anonymizationAllFields.data.map((field) => field.field));
     expect(screen.getByTestId('selectedFields')).toHaveTextContent('Selected 20 fields');
   });
 
   it('calls onListUpdated with the expected values when the update button is clicked', async () => {
+    renderComponent(anonymizationPageFields.data.map((field) => field.field));
     await userEvent.click(screen.getAllByTestId('allowed')[0]);
 
     expect(onListUpdated).toHaveBeenCalledWith([

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/selection/table_selection_checkbox.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/selection/table_selection_checkbox.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { EuiCheckbox } from '@elastic/eui';
+import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common';
+import {
+  HandlePageChecked,
+  HandlePageUnchecked,
+  HandleRowChecked,
+  HandleRowUnChecked,
+} from './types';
+import { ContextEditorRow } from '../types';
+
+export const PageSelectionCheckbox = ({
+  anonymizationPageFields = [],
+  selectedFields = [],
+  handlePageChecked,
+  handlePageUnchecked,
+  totalItemCount,
+  handlePageReset,
+}: {
+  anonymizationPageFields?: FindAnonymizationFieldsResponse['data'];
+  selectedFields?: string[];
+  handlePageChecked: HandlePageChecked;
+  handlePageUnchecked: HandlePageUnchecked;
+  totalItemCount: number;
+  handlePageReset: (fields: string[]) => void;
+}) => {
+  const allFieldsOnCurrentPage = useMemo(
+    () => anonymizationPageFields.map((row) => row.field),
+    [anonymizationPageFields]
+  );
+  const [pageSelectionChecked, setPageSelectionChecked] = useState(
+    selectedFields.length > 0 &&
+      allFieldsOnCurrentPage.every((field) => selectedFields.includes(field))
+  );
+
+  useEffect(() => {
+    setPageSelectionChecked(
+      selectedFields.length > 0 &&
+        allFieldsOnCurrentPage.every((field) => selectedFields.includes(field))
+    );
+  }, [selectedFields, allFieldsOnCurrentPage]);
+
+  if (totalItemCount === 0 || allFieldsOnCurrentPage.length === 0) {
+    return null;
+  }
+
+  return (
+    <EuiCheckbox
+      data-test-subj={`checkboxSelectAll`}
+      id={`checkboxSelectAll`}
+      checked={pageSelectionChecked}
+      onChange={(e) => {
+        if (e.target.checked) {
+          setPageSelectionChecked(true);
+          handlePageChecked();
+        } else {
+          setPageSelectionChecked(false);
+          handlePageUnchecked();
+          handlePageReset(allFieldsOnCurrentPage);
+        }
+      }}
+    />
+  );
+};
+
+export const InputCheckbox = ({
+  row,
+  selectedFields = [],
+  handleRowChecked,
+  handleRowUnChecked,
+  handleRowReset,
+}: {
+  row: ContextEditorRow;
+  selectedFields?: string[];
+  handleRowChecked: HandleRowChecked;
+  handleRowUnChecked: HandleRowUnChecked;
+  handleRowReset: (field: string) => void;
+}) => {
+  const [checked, setChecked] = useState(selectedFields.includes(row.field));
+
+  useEffect(() => {
+    setChecked(selectedFields.includes(row.field));
+  }, [selectedFields, row.field]);
+
+  return (
+    <EuiCheckbox
+      data-test-subj={`field-${row.field}`}
+      id={`field-${row.field}`}
+      checked={checked}
+      onChange={(e) => {
+        if (e.target.checked) {
+          setChecked(true);
+          handleRowChecked(row.field);
+        } else {
+          setChecked(false);
+          handleRowUnChecked(row.field);
+          handleRowReset(row.field);
+        }
+      }}
+    />
+  );
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/selection/types.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/selection/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common';
+
+export type HandlePageChecked = () => void;
+export type HandlePageUnchecked = () => void;
+export type HandleRowChecked = (selectedField: string) => void;
+export type HandleRowUnChecked = (selectedField: string) => void;
+export type FindAnonymizationFieldsClientResponse = Omit<
+  FindAnonymizationFieldsResponse,
+  'aggregations' | 'all'
+>;

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/selection/use_selection.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/selection/use_selection.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { FindAnonymizationFieldsClientResponse } from './types';
+
+const EMPTY_CONVERSATIONS_ARRAY: string[] = [];
+
+export type UseSelectionReturn = ReturnType<typeof useSelection>;
+
+export const useSelection = ({
+  anonymizationAllFields,
+  anonymizationPageFields,
+}: {
+  anonymizationAllFields: FindAnonymizationFieldsClientResponse;
+  anonymizationPageFields: FindAnonymizationFieldsClientResponse;
+}) => {
+  const [isSelectAll, setIsSelectAll] = useState(false);
+  const [selectedFields, setSelectedFields] = useState<string[]>(EMPTY_CONVERSATIONS_ARRAY);
+  const [totalSelectedItems, setTotalSelectedItems] = useState(0);
+  const totalItemCount = anonymizationAllFields.total;
+  const allFieldsOnCurrentPage = useMemo(
+    () => anonymizationPageFields.data?.map((field) => field.field) || [],
+    [anonymizationPageFields.data]
+  );
+  const allFields = useMemo(
+    () => anonymizationAllFields.data?.map((field) => field.field) || [],
+    [anonymizationAllFields.data]
+  );
+
+  const handleUnselectAll = useCallback(() => {
+    setIsSelectAll(false);
+    setSelectedFields([]);
+    setTotalSelectedItems(0);
+  }, []);
+
+  const handleSelectAll = useCallback(() => {
+    setIsSelectAll(true);
+    setTotalSelectedItems(totalItemCount);
+    setSelectedFields([...allFields]);
+  }, [allFields, totalItemCount]);
+
+  const handlePageChecked = useCallback(() => {
+    const newlySelectedItems = allFieldsOnCurrentPage.reduce(
+      (acc, currentField) => {
+        if (!selectedFields.includes(currentField)) {
+          acc.push(currentField);
+        }
+        return acc;
+      },
+      [...selectedFields]
+    );
+    setSelectedFields(newlySelectedItems);
+    setTotalSelectedItems(
+      (prev) => prev + selectedFields.filter((field) => !selectedFields.includes(field)).length
+    );
+    if (newlySelectedItems.length === totalItemCount) {
+      setIsSelectAll(true);
+    }
+  }, [allFieldsOnCurrentPage, selectedFields, totalItemCount]);
+
+  const handlePageUnchecked = useCallback(() => {
+    setSelectedFields(selectedFields.filter((field) => !allFieldsOnCurrentPage.includes(field)));
+    setTotalSelectedItems((prev) => (prev || totalItemCount) - allFieldsOnCurrentPage.length);
+
+    setIsSelectAll(false);
+  }, [allFieldsOnCurrentPage, selectedFields, totalItemCount]);
+
+  const handleRowChecked = useCallback(
+    (selectedField: string) => {
+      const newlySelectedItems = selectedFields.includes(selectedField)
+        ? selectedFields
+        : [...selectedFields, selectedField];
+      setSelectedFields(newlySelectedItems);
+      if (newlySelectedItems.length === totalItemCount) {
+        setIsSelectAll(true);
+      }
+      setTotalSelectedItems(newlySelectedItems.length);
+    },
+    [selectedFields, totalItemCount]
+  );
+
+  const handleRowUnChecked = useCallback(
+    (selectedField: string) => {
+      setSelectedFields((prev) => {
+        return prev.filter((item) => item !== selectedField);
+      });
+      setIsSelectAll(false);
+      setTotalSelectedItems((prev) => (prev || totalItemCount) - 1);
+    },
+    [totalItemCount]
+  );
+
+  return {
+    selectionState: {
+      isSelectAll,
+      selectedFields,
+      totalSelectedItems,
+    },
+    selectionActions: {
+      handleUnselectAll,
+      handleSelectAll,
+      handlePageUnchecked,
+      handlePageChecked,
+      handleRowUnChecked,
+      handleRowChecked,
+      setSelectedFields,
+      setIsSelectAll,
+      setTotalSelectedItems,
+    },
+  };
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/toolbar/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/toolbar/index.tsx
@@ -6,53 +6,78 @@
  */
 
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import React from 'react';
+import React, { useCallback } from 'react';
 
+import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common';
 import { BulkActions } from '../bulk_actions';
 import * as i18n from '../translations';
-import { BatchUpdateListItem, ContextEditorRow } from '../types';
+import type { OnListUpdated } from '../../../assistant/settings/use_settings_updater/use_anonymization_updater';
+import type { HandleRowChecked } from '../selection/types';
 
 export interface Props {
-  onListUpdated: (updates: BatchUpdateListItem[]) => void;
-  onSelectAll: () => void;
-  selected: ContextEditorRow[];
+  anonymizationAllFieldsData: FindAnonymizationFieldsResponse['data'];
+  handleRowChecked: HandleRowChecked;
+  handleUnselectAll: () => void;
+  onListUpdated: OnListUpdated;
+  onSelectAll: (totalCount: number) => void;
+  selectedFields: string[];
   totalFields: number;
 }
 
 const ToolbarComponent: React.FC<Props> = ({
+  anonymizationAllFieldsData,
   onListUpdated,
   onSelectAll,
-  selected,
+  handleUnselectAll,
+  selectedFields,
   totalFields,
-}) => (
-  <EuiFlexGroup alignItems="center" data-test-subj="toolbar" gutterSize="none">
-    <EuiFlexItem grow={false}>
-      <EuiText color="subdued" data-test-subj="selectedFields" size="xs">
-        {i18n.SELECTED_FIELDS(selected.length)}
-      </EuiText>
-    </EuiFlexItem>
+  handleRowChecked,
+}) => {
+  const onSelectAllClicked = useCallback(() => {
+    onSelectAll(totalFields);
+  }, [onSelectAll, totalFields]);
+  return (
+    <EuiFlexGroup alignItems="center" data-test-subj="toolbar" gutterSize="none">
+      <EuiFlexItem grow={false}>
+        <EuiText color="subdued" data-test-subj="selectedFields" size="xs">
+          {i18n.SELECTED_FIELDS(selectedFields.length)}
+        </EuiText>
+      </EuiFlexItem>
 
-    <EuiFlexItem grow={false}>
-      <EuiButtonEmpty
-        data-test-subj="selectAllFields"
-        iconType="pagesSelect"
-        onClick={onSelectAll}
-        size="xs"
-      >
-        {i18n.SELECT_ALL_FIELDS(totalFields)}
-      </EuiButtonEmpty>
-    </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        {selectedFields.length === totalFields ? (
+          <EuiButtonEmpty
+            data-test-subj="unselectAllFields"
+            iconType="pagesSelect"
+            onClick={handleUnselectAll}
+            size="xs"
+          >
+            {i18n.UNSELECT_ALL_FIELDS(selectedFields.length)}
+          </EuiButtonEmpty>
+        ) : (
+          <EuiButtonEmpty
+            data-test-subj="selectAllFields"
+            iconType="pagesSelect"
+            onClick={onSelectAllClicked}
+            size="xs"
+          >
+            {i18n.SELECT_ALL_FIELDS(totalFields)}
+          </EuiButtonEmpty>
+        )}
+      </EuiFlexItem>
 
-    <EuiFlexItem grow={false}>
-      <BulkActions
-        appliesTo="multipleRows"
-        disabled={selected.length === 0}
-        onListUpdated={onListUpdated}
-        selected={selected}
-      />
-    </EuiFlexItem>
-  </EuiFlexGroup>
-);
+      <EuiFlexItem grow={false}>
+        <BulkActions
+          appliesTo="multipleRows"
+          disabled={selectedFields.length === 0}
+          onListUpdated={onListUpdated}
+          selectedFields={selectedFields}
+          handleRowChecked={handleRowChecked}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
 
 ToolbarComponent.displayName = 'ToolbarComponent';
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/translations.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor/translations.ts
@@ -88,6 +88,12 @@ export const SELECT_ALL_FIELDS = (totalFields: number) =>
     defaultMessage: 'Select all {totalFields} fields',
   });
 
+export const UNSELECT_ALL_FIELDS = (totalFields: number) =>
+  i18n.translate('xpack.elasticAssistant.dataAnonymizationEditor.contextEditor.unselectAllFields', {
+    defaultMessage: 'Unselect all {totalFields} fields',
+    values: { totalFields },
+  });
+
 export const SELECTED_FIELDS = (selected: number) =>
   i18n.translate('xpack.elasticAssistant.dataAnonymizationEditor.contextEditor.selectedFields', {
     values: { selected },

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/context_editor/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/context_editor/index.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiInMemoryTable } from '@elastic/eui';
+import type { EuiSearchBarProps, EuiTableSelectionType } from '@elastic/eui';
+import React, { useMemo, useState, useRef } from 'react';
+
+import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common/impl/schemas';
+import styled from '@emotion/styled';
+import { BatchUpdateListItem, ContextEditorRow, FIELDS } from '../../context_editor/types';
+import { useAssistantContext } from '../../../assistant_context';
+import { getColumns } from '../../context_editor/get_columns';
+import { ANONYMIZATION_PROMPT_CONTEXT_TABLE_SESSION_STORAGE_KEY } from '../../../assistant_context/constants';
+import {
+  getDefaultTableOptions,
+  useSessionPagination,
+} from '../../../assistant/common/components/assistant_settings_management/pagination/use_session_pagination';
+import { getRows } from '../../context_editor/get_rows';
+import { ALLOWED, ANONYMIZED } from '../../context_editor/translations';
+import { Toolbar } from '../toolbar';
+
+const Wrapper = styled.div`
+  > div > .euiSpacer {
+    block-size: 16px;
+  }
+`;
+
+export interface Props {
+  anonymizationFields: FindAnonymizationFieldsResponse;
+  compressed?: boolean;
+  onListUpdated: (updates: BatchUpdateListItem[]) => void;
+  rawData: Record<string, string[]> | null;
+}
+
+const search: EuiSearchBarProps = {
+  box: {
+    incremental: true,
+  },
+  filters: [
+    {
+      field: FIELDS.ALLOWED,
+      type: 'is',
+      name: ALLOWED,
+    },
+    {
+      field: FIELDS.ANONYMIZED,
+      type: 'is',
+      name: ANONYMIZED,
+    },
+  ],
+};
+
+const ContextEditorComponent: React.FC<Props> = ({
+  anonymizationFields,
+  compressed = true,
+  onListUpdated,
+  rawData,
+}) => {
+  const isAllSelected = useRef(false); // Must be a ref and not state in order not to re-render `selectionValue`, which fires `onSelectionChange` twice
+  const {
+    assistantAvailability: { hasUpdateAIAssistantAnonymization },
+    nameSpace,
+  } = useAssistantContext();
+  const [selected, setSelection] = useState<ContextEditorRow[]>([]);
+  const selectionValue: EuiTableSelectionType<ContextEditorRow> = useMemo(
+    () => ({
+      selectable: () => true,
+      onSelectionChange: (newSelection) => {
+        if (isAllSelected.current === true) {
+          // If passed every possible row (including non-visible ones), EuiInMemoryTable
+          // will fire `onSelectionChange` with only the visible rows - we need to
+          // ignore this call when that happens and continue to pass all rows
+          isAllSelected.current = false;
+        } else {
+          setSelection(newSelection);
+        }
+      },
+      selected,
+    }),
+    [selected]
+  );
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        compressed,
+        handleRowChecked: () => {},
+        hasUpdateAIAssistantAnonymization,
+        onListUpdated,
+        rawData,
+        selectedFields: selected.map((row) => row.field),
+      }),
+    [compressed, hasUpdateAIAssistantAnonymization, onListUpdated, rawData, selected]
+  );
+
+  const rows = useMemo(
+    () =>
+      getRows({
+        anonymizationFields,
+        rawData,
+      }),
+    [anonymizationFields, rawData]
+  );
+
+  const { onTableChange, pagination, sorting } = useSessionPagination<ContextEditorRow, true>({
+    defaultTableOptions: getDefaultTableOptions<ContextEditorRow>({
+      pageSize: 10,
+      sortDirection: 'asc',
+      sortField: 'field',
+    }),
+    nameSpace,
+    storageKey: ANONYMIZATION_PROMPT_CONTEXT_TABLE_SESSION_STORAGE_KEY,
+  });
+
+  const toolbar = useMemo(
+    () => (
+      <Toolbar
+        handleRowChecked={(field) => {
+          const selectedRow = rows.find((row) => row.field === field);
+          if (!selectedRow) return;
+          setSelection((prevSelection) => [...prevSelection, selectedRow]);
+        }}
+        onListUpdated={onListUpdated}
+        selectedFields={selected.map((row) => row.field)}
+      />
+    ),
+    [onListUpdated, rows, selected]
+  );
+
+  return (
+    <Wrapper>
+      <EuiInMemoryTable
+        allowNeutralSort={false}
+        childrenBetween={hasUpdateAIAssistantAnonymization ? toolbar : undefined}
+        columns={columns}
+        compressed={compressed}
+        data-test-subj="contextEditor"
+        itemId={FIELDS.FIELD}
+        items={rows}
+        pagination={pagination}
+        search={search}
+        selection={selectionValue}
+        sorting={sorting}
+        onTableChange={onTableChange}
+      />
+    </Wrapper>
+  );
+};
+
+ContextEditorComponent.displayName = 'ContextEditorComponent';
+export const ContextEditor = React.memo(ContextEditorComponent);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/index.tsx
@@ -31,14 +31,15 @@ import {
   PerformAnonymizationFieldsBulkActionRequestBody,
 } from '@kbn/elastic-assistant-common/impl/schemas';
 import { find, uniqBy } from 'lodash';
-import { ContextEditor } from '../context_editor';
 import { Stats } from '../stats';
 import * as i18n from '../../data_anonymization/settings/anonymization_settings/translations';
 import { SelectedPromptContext } from '../../assistant/prompt_context/types';
 import { BatchUpdateListItem } from '../context_editor/types';
 import { updateSelectedPromptContext, getIsDataAnonymizable } from '../helpers';
 import { useAssistantContext } from '../../assistant_context';
+
 import { bulkUpdateAnonymizationFields } from '../../assistant/api/anonymization_fields/bulk_update_anonymization_fields';
+import { ContextEditor } from './context_editor';
 import { useFetchAnonymizationFields } from '../../assistant/api/anonymization_fields/use_fetch_anonymization_fields';
 
 export interface Props {
@@ -50,10 +51,11 @@ export interface Props {
 const SelectedPromptContextEditorModalComponent = ({ onClose, onSave, promptContext }: Props) => {
   const { euiTheme } = useEuiTheme();
   const { http, toasts } = useAssistantContext();
+
   const [checked, setChecked] = useState(false);
   const checkboxId = useGeneratedHtmlId({ prefix: 'updateSettingPresetsCheckbox' });
 
-  const { data: anonymizationFields, refetch: anonymizationFieldsRefetch } =
+  const { data: anonymizationAllFields, refetch: anonymizationFieldsRefetch } =
     useFetchAnonymizationFields();
   const [contextUpdates, setContextUpdates] = React.useState<BatchUpdateListItem[]>([]);
   const [selectedPromptContext, setSelectedPromptContext] = React.useState(promptContext);
@@ -97,7 +99,7 @@ const SelectedPromptContextEditorModalComponent = ({ onClose, onSave, promptCont
       setAnonymizationFieldsBulkActions((prev) => {
         return updates.reduce<PerformAnonymizationFieldsBulkActionRequestBody>(
           (acc, item) => {
-            const persistedField = find(anonymizationFields.data, ['field', item.field]) as
+            const persistedField = find(anonymizationAllFields.data, ['field', item.field]) as
               | AnonymizationFieldResponse
               | undefined;
 
@@ -130,8 +132,8 @@ const SelectedPromptContextEditorModalComponent = ({ onClose, onSave, promptCont
         );
       });
 
-      setSelectedPromptContext((prev) =>
-        updates.reduce<SelectedPromptContext>(
+      setSelectedPromptContext((prev) => {
+        return updates.reduce<SelectedPromptContext>(
           (acc, { field, operation, update }) =>
             updateSelectedPromptContext({
               field,
@@ -140,10 +142,10 @@ const SelectedPromptContextEditorModalComponent = ({ onClose, onSave, promptCont
               update,
             }),
           prev
-        )
-      );
+        );
+      });
     },
-    [anonymizationFields]
+    [anonymizationAllFields.data]
   );
 
   const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -179,6 +181,7 @@ const SelectedPromptContextEditorModalComponent = ({ onClose, onSave, promptCont
               page: 1,
               perPage: 1000,
               data: [],
+              all: [],
             }
           }
           onListUpdated={onListUpdated}

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/toolbar/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/toolbar/index.test.tsx
@@ -6,10 +6,10 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { Toolbar } from '.';
-import * as i18n from '../translations';
+import { SELECTED_FIELDS } from '../../context_editor/translations';
 
 const selected = ['event.action', 'event.category', 'user.name'];
 
@@ -32,7 +32,7 @@ describe('Toolbar', () => {
     const { getByText } = render(<Toolbar {...defaultProps} selectedFields={selected} />);
 
     const selectedCount = selected.length;
-    const selectedFieldsText = getByText(i18n.SELECTED_FIELDS(selectedCount));
+    const selectedFieldsText = getByText(SELECTED_FIELDS(selectedCount));
 
     expect(selectedFieldsText).toBeInTheDocument();
   });
@@ -51,14 +51,5 @@ describe('Toolbar', () => {
     const bulkActionsButton = getByTestId('bulkActionsButton');
 
     expect(bulkActionsButton).not.toBeDisabled();
-  });
-
-  it('calls onSelectAll when the Select All Fields button is clicked', () => {
-    const { getByText } = render(<Toolbar {...defaultProps} />);
-    const selectAllButton = getByText(i18n.SELECT_ALL_FIELDS(defaultProps.totalFields));
-
-    fireEvent.click(selectAllButton);
-
-    expect(defaultProps.onSelectAll).toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/toolbar/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/context_editor_modal/toolbar/index.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import React from 'react';
+
+import type { OnListUpdated } from '../../../assistant/settings/use_settings_updater/use_anonymization_updater';
+import { HandleRowChecked } from '../../context_editor/selection/types';
+import { SELECTED_FIELDS } from '../../context_editor/translations';
+import { BulkActions } from '../../context_editor/bulk_actions';
+
+export interface Props {
+  handleRowChecked: HandleRowChecked;
+  onListUpdated: OnListUpdated;
+  selectedFields: string[];
+}
+
+const ToolbarComponent: React.FC<Props> = ({ handleRowChecked, onListUpdated, selectedFields }) => {
+  return (
+    <EuiFlexGroup alignItems="center" data-test-subj="toolbar" gutterSize="none">
+      <EuiFlexItem grow={false}>
+        <EuiText color="subdued" data-test-subj="selectedFields" size="xs">
+          {SELECTED_FIELDS(selectedFields.length)}
+        </EuiText>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <BulkActions
+          appliesTo="multipleRows"
+          disabled={selectedFields.length === 0}
+          onListUpdated={onListUpdated}
+          selectedFields={selectedFields}
+          handleRowChecked={handleRowChecked}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+ToolbarComponent.displayName = 'ToolbarComponent';
+
+export const Toolbar = React.memo(ToolbarComponent);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/get_stats/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/get_stats/index.ts
@@ -11,10 +11,16 @@ import { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/impl/s
 import { Stats } from '../helpers';
 
 export const getStats = ({
+  anonymizationFieldsStatus,
   anonymizationFields = [],
   rawData,
   replacements,
 }: {
+  anonymizationFieldsStatus?: {
+    allowed?: { doc_count: number };
+    anonymized?: { doc_count: number };
+    denied?: { doc_count: number };
+  };
   anonymizationFields?: AnonymizationFieldResponse[];
   rawData?: string | Record<string, string[]>;
   replacements?: Replacements;
@@ -26,14 +32,15 @@ export const getStats = ({
     total: 0,
   };
 
-  if (!rawData) {
+  if (!anonymizationFieldsStatus && !rawData) {
+    return ZERO_STATS;
+  }
+
+  if (!rawData && anonymizationFieldsStatus) {
     return {
-      allowed: anonymizationFields.reduce((acc, data) => (data.allowed ? acc + 1 : acc), 0),
-      anonymized: anonymizationFields.reduce((acc, data) => (data.anonymized ? acc + 1 : acc), 0),
-      denied: anonymizationFields.reduce(
-        (acc, data) => (data.allowed === false ? acc + 1 : acc),
-        0
-      ),
+      allowed: anonymizationFieldsStatus.allowed?.doc_count ?? 0,
+      anonymized: anonymizationFieldsStatus.anonymized?.doc_count ?? 0,
+      denied: anonymizationFieldsStatus.denied?.doc_count ?? 0,
       total: anonymizationFields.length,
     };
   } else if (typeof rawData === 'string') {
@@ -46,7 +53,7 @@ export const getStats = ({
       };
     }
   } else {
-    const rawFields = Object.keys(rawData);
+    const rawFields = Object.keys(rawData ?? {});
 
     return rawFields.reduce<Stats>(
       (acc, field) => ({

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/helpers/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/helpers/index.test.ts
@@ -316,9 +316,9 @@ describe('helpers', () => {
       });
       expect(result.contextAnonymizationFields).toEqual({
         data: [
+          { allowed: true, anonymized: false, field: 'user.name', id: 'user.name' },
           { allowed: false, anonymized: true, field: 'event.category', id: 'event.category' },
           { allowed: true, anonymized: false, field: 'event.action', id: 'event.action' },
-          { allowed: true, anonymized: false, field: 'user.name', id: 'user.name' },
         ],
         page: 1,
         perPage: 1000,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/helpers/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/helpers/index.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { FindAnonymizationFieldsResponse } from '@kbn/elastic-assistant-common';
 import { SelectedPromptContext } from '../../assistant/prompt_context/types';
 
 export const getIsDataAnonymizable = (rawData: string | Record<string, string[]>): boolean =>
@@ -44,15 +45,15 @@ export const updateSelectedPromptContext = ({
         ...selectedPromptContext,
         contextAnonymizationFields: {
           ...contextAnonymizationFields,
-          data: [
-            ...contextAnonymizationFields.data.filter((f) => f.field !== field),
-
-            {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              ...contextAnonymizationFields.data.find((f) => f.field === field)!,
-              allowed: operation === 'add',
+          data: contextAnonymizationFields.data.reduce<FindAnonymizationFieldsResponse['data']>(
+            (acc, currentField) => {
+              if (currentField.field === field) {
+                return [...acc, { ...currentField, allowed: operation === 'add' }];
+              }
+              return [...acc, currentField];
             },
-          ],
+            []
+          ),
         },
       };
     case 'allowReplacement':
@@ -60,15 +61,15 @@ export const updateSelectedPromptContext = ({
         ...selectedPromptContext,
         contextAnonymizationFields: {
           ...contextAnonymizationFields,
-          data: [
-            ...contextAnonymizationFields.data.filter((f) => f.field !== field),
-
-            {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              ...contextAnonymizationFields.data.find((f) => f.field === field)!,
-              anonymized: operation === 'add',
+          data: contextAnonymizationFields.data.reduce<FindAnonymizationFieldsResponse['data']>(
+            (acc, currentField) => {
+              if (currentField.field === field) {
+                return [...acc, { ...currentField, anonymized: operation === 'add' }];
+              }
+              return [...acc, currentField];
             },
-          ],
+            []
+          ),
         },
       };
     default:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/stats/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/data_anonymization_editor/stats/index.tsx
@@ -22,6 +22,11 @@ const StatFlexItem = styled(EuiFlexItem)`
 `;
 
 interface Props {
+  anonymizationFieldsStatus?: {
+    allowed?: { doc_count: number };
+    anonymized?: { doc_count: number };
+    denied?: { doc_count: number };
+  };
   isDataAnonymizable: boolean;
   anonymizationFields?: AnonymizationFieldResponse[];
   rawData?: string | Record<string, string[]>;
@@ -32,6 +37,7 @@ interface Props {
 }
 
 const StatsComponent: React.FC<Props> = ({
+  anonymizationFieldsStatus,
   isDataAnonymizable,
   anonymizationFields,
   rawData,
@@ -43,11 +49,12 @@ const StatsComponent: React.FC<Props> = ({
   const { allowed, anonymized, total } = useMemo(
     () =>
       getStats({
+        anonymizationFieldsStatus,
         anonymizationFields,
         rawData,
         replacements,
       }),
-    [anonymizationFields, rawData, replacements]
+    [anonymizationFieldsStatus, anonymizationFields, rawData, replacements]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/find.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/find.ts
@@ -29,8 +29,9 @@ interface FindOptions {
   logger: Logger;
   aggs?: Record<string, AggregationsAggregationContainer>;
   mSearch?: {
-    filter: string;
+    filter?: string;
     perPage: number;
+    aggs?: Record<string, AggregationsAggregationContainer>;
   };
 }
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/anonymization_fields/bulk_actions_route.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/anonymization_fields/bulk_actions_route.test.ts
@@ -200,22 +200,6 @@ describe('Perform bulk action route', () => {
 
       expect(result.ok).toHaveBeenCalled();
     });
-
-    it('rejects payload if there is more than 100 deletes in payload', async () => {
-      const request = requestMock.create({
-        method: 'post',
-        path: ELASTIC_AI_ASSISTANT_ANONYMIZATION_FIELDS_URL_BULK_ACTION,
-        body: {
-          ...getPerformBulkActionSchemaMock(),
-          delete: { ids: Array.from({ length: 101 }).map(() => 'fake-id') },
-        },
-      });
-
-      const response = await server.inject(request, requestContextMock.convertContext(context));
-
-      expect(response.status).toEqual(400);
-      expect(response.body.message).toEqual('More than 100 ids sent for bulk edit action.');
-    });
   });
 });
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/anonymization_fields/bulk_actions_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/anonymization_fields/bulk_actions_route.ts
@@ -24,7 +24,6 @@ import {
   PerformAnonymizationFieldsBulkActionResponse,
 } from '@kbn/elastic-assistant-common/impl/schemas';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
-import { ANONYMIZATION_FIELDS_TABLE_MAX_PAGE_SIZE } from '../../../common/constants';
 import { ElasticAssistantPluginRouter } from '../../types';
 import { buildResponse } from '../utils';
 import {
@@ -145,17 +144,6 @@ export const bulkActionAnonymizationFieldsRoute = (
       ): Promise<IKibanaResponse<PerformAnonymizationFieldsBulkActionResponse>> => {
         const { body } = request;
         const assistantResponse = buildResponse(response);
-
-        const operationsCount =
-          (body?.update ? body.update?.length : 0) +
-          (body?.create ? body.create?.length : 0) +
-          (body?.delete ? body.delete?.ids?.length ?? 0 : 0);
-        if (operationsCount > ANONYMIZATION_FIELDS_TABLE_MAX_PAGE_SIZE) {
-          return assistantResponse.error({
-            body: `More than ${ANONYMIZATION_FIELDS_TABLE_MAX_PAGE_SIZE} ids sent for bulk edit action.`,
-            statusCode: 400,
-          });
-        }
 
         const abortController = new AbortController();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
@@ -93,6 +93,16 @@ jest.mock('../../../services/policies/hooks', () => ({
   ...jest.requireActual('../../../services/policies/hooks'),
   useBulkGetAgentPolicies: jest.fn().mockReturnValue({}),
 }));
+jest.mock(
+  '@kbn/elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields',
+  () => ({
+    useFetchAnonymizationFields: jest.fn().mockReturnValue({
+      data: { data: [], total: 0, page: 1, perPage: 10 },
+      isLoading: false,
+      refetch: jest.fn(),
+    }),
+  })
+);
 const useBulkGetAgentPoliciesMock = useBulkGetAgentPolicies as unknown as jest.Mock<
   DeepPartial<ReturnType<typeof useBulkGetAgentPolicies>>
 >;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Assistant] Migrate Anonymization in-memory table to EuiBasicTable for better selection control  (#222825)](https://github.com/elastic/kibana/pull/222825)