### PR TITLE
[Fleet] Make installed integrations table full screen

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/index.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo, useState } from 'react';
 import { EuiSpacer } from '@elastic/eui';
-import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 import { Loading } from '../../../../../../components';
 import { useUrlPagination } from '../../../../../../hooks';
@@ -20,12 +20,6 @@ import type { InstalledPackageUIPackageListItem } from './types';
 import { useInstalledIntegrationsActions } from './hooks/use_installed_integrations_actions';
 import { BulkActionContextProvider } from './hooks/use_bulk_actions_context';
 import { PackagePoliciesPanel } from './components/package_policies_panel';
-
-const ContentWrapper = styled.div`
-  max-width: 1200px;
-  margin: auto;
-  height: 100%;
-`;
 
 const InstalledIntegrationsPageContent: React.FunctionComponent = () => {
   // State management
@@ -63,7 +57,12 @@ const InstalledIntegrationsPageContent: React.FunctionComponent = () => {
 
   return (
     <>
-      <ContentWrapper>
+      <div
+        css={css`
+          margin: auto;
+          height: 100%;
+        `}
+      >
         <InstalledIntegrationsSearchBar
           filters={filters}
           customIntegrationsCount={customIntegrationsCount}
@@ -78,7 +77,7 @@ const InstalledIntegrationsPageContent: React.FunctionComponent = () => {
           installedPackages={installedPackages}
           selection={{ selectedItems, setSelectedItems }}
         />
-      </ContentWrapper>
+      </div>
       {viewPoliciesSelectedItem ? (
         <PackagePoliciesPanel installedPackage={viewPoliciesSelectedItem} />
       ) : null}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/226798

## Summary
The new installed integrations table is currently not full width. This PR addresses it.

<img width="2924" height="1502" alt="Screenshot 2025-07-17 at 10 21 15" src="https://github.com/user-attachments/assets/113675a7-e712-41fd-b6a4-0166cf5986b4" />


### Checklist

Check the PR satisfies following conditions. 


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->