### PR TITLE
[Security Solution][Entity Analytics][PrivMon]Adding namespace param to defaultMonitoringUsersIndex

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/privilege_monitoring/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/privilege_monitoring/constants.ts
@@ -9,8 +9,9 @@
 export const privilegedMonitorBaseIndexName = '.entity_analytics.monitoring';
 export const ML_ANOMALIES_INDEX = '.ml-anomalies-shared';
 
-// Default index for privileged monitoring users. Not required.
-export const defaultMonitoringUsersIndex = 'entity_analytics.privileged_monitoring';
+// Default index for privileged monitoring users.
+export const defaultMonitoringUsersIndex = (namespace: string) =>
+  `entity_analytics.privileged_monitoring.${namespace}`;
 
 export const PRIVILEGE_MONITORING_PRIVILEGE_CHECK_API =
   '/api/entity_analytics/monitoring/privileges/privileges';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
@@ -122,11 +122,11 @@ export class PrivilegeMonitoringDataClient {
 
     const descriptor = await this.engineClient.init();
     this.log('debug', `Initialized privileged monitoring engine saved object`);
-    // create default index source for privilege monitoring
+    // create default index source for privilege monitoring for each namespace
     const indexSourceDescriptor = await this.monitoringIndexSourceClient.create({
       type: 'index',
       managed: true,
-      indexPattern: defaultMonitoringUsersIndex,
+      indexPattern: defaultMonitoringUsersIndex(this.opts.namespace),
       name: 'default-monitoring-index',
     });
     this.log(


### PR DESCRIPTION
## Summary

While initialising the privMon engine, When an index source was created in a non-default namespace, the index pattern used did not have a namespace in it.

```
[14:08:13.407] [DEBUG] [plugins.securitySolution] [Privileged Monitoring Engine][namespace: privmon-2] Initialized privileged monitoring engine saved object
_[14:08:14.446] [DEBUG] [plugins.securitySolution] [Privileged Monitoring Engine][namespace: privmon-2] Created index source for privilege monitoring: {"type":"index","managed":true,"indexPattern":"entity_analytics.privileged_monitoring","name":"default-monitoring-index","id":"041e67b0-7b6b-4f23-b81b-f9536fe01fe6"}_

[14:08:14.447] [INFO ] [plugins.securitySolution] [Privileged Monitoring Engine][namespace: privmon-2] Privileged user monitoring ingest pipeline already exists.

[14:08:14.447] [INFO ] [plugins.securitySolution] [Privileged Monitoring Engine][namespace: privmon-2] Creating or updating index: .entity_analytics.monitoring.users-privmon-2

[14:08:15.429] [INFO ] [plugins.securitySolution] Scheduling privilege monitoring task with id entity_analytics:monitoring:privileges:engine:privmon-2:1.0.0

```

This PR changes the index sources creation in a way that it will create the index sources with index patterns containing namespace in it.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->