### PR TITLE
[9.1] [AI4SOC] Added support for the new promotion rule tag (#228232)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -526,4 +526,7 @@ export const AI_FOR_SOC_INTEGRATIONS = [
 /*
  * The tag to mark promotion rules that are related to the AI for SOC integrations
  */
-export const PROMOTION_RULE_TAG = 'Promotion';
+export const PROMOTION_RULE_TAGS = [
+  'Promotion', // This is the legacy tag for promotion rules and can be safely removed once promotion rules go live
+  'Promotion: External Alerts',
+];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_promotion_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_promotion_rules.ts
@@ -17,7 +17,8 @@ import type {
 } from '../../../../../../common/api/detection_engine/prebuilt_rules/bootstrap_prebuilt_rules/bootstrap_prebuilt_rules.gen';
 import { getErrorMessage } from '../../../../../utils/error_helpers';
 import type { EndpointInternalFleetServicesInterface } from '../../../../../endpoint/services/fleet';
-import { AI_FOR_SOC_INTEGRATIONS, PROMOTION_RULE_TAG } from '../../../../../../common/constants';
+import { AI_FOR_SOC_INTEGRATIONS, PROMOTION_RULE_TAGS } from '../../../../../../common/constants';
+import type { PrebuiltRuleAsset } from '../../model/rule_assets/prebuilt_rule_asset';
 
 interface InstallPromotionRulesParams {
   rulesClient: RulesClient;
@@ -69,7 +70,7 @@ export async function installPromotionRules({
   const latestPromotionRules = latestRuleAssets.filter((rule) => {
     // Rule should be tagged as 'Promotion' and should be related to an enabled integration
     return (
-      (rule.tags ?? []).includes(PROMOTION_RULE_TAG) &&
+      isPromotionRule(rule) &&
       rule.related_integrations?.some((integration) =>
         installedIntegrations.has(integration.package)
       )
@@ -144,4 +145,8 @@ export async function installPromotionRules({
     skipped: alreadyUpToDate.length,
     errors: allErrors.size > 0 ? Array.from(allErrors.values()) : [],
   };
+}
+
+function isPromotionRule(rule: PrebuiltRuleAsset): boolean {
+  return (rule.tags ?? []).some((tag) => PROMOTION_RULE_TAGS.includes(tag));
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[AI4SOC] Added support for the new promotion rule tag (#228232)](https://github.com/elastic/kibana/pull/228232)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dmitrii Shevchenko","email":"dmitrii.shevchenko@elastic.co"},"sourceCommit":{"committedDate":"2025-07-17T09:09:52Z","message":"[AI4SOC] Added support for the new promotion rule tag (#228232)\n\n## Summary\n\nAdded support for the new promotion rule tag as discussed here:\n[https://github.com/elastic/detection-rules/pull/4903#discussion\\_r2201961021](https://github.com/elastic/detection-rules/pull/4903#discussion_r2201961021).\n\nFor the time being, both the old `Promotion` tag and the new `Promotion:\nExternal Alerts` tag will be in use to avoid breaking changes. Once the\npromotion rules go live, we can remove support for the old tag.\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>","sha":"ad56fe00fab80982ed8066bc5a5ef91cd2a5e0d4","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Prebuilt Detection Rules","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[AI4SOC] Added support for the new promotion rule tag","number":228232,"url":"https://github.com/elastic/kibana/pull/228232","mergeCommit":{"message":"[AI4SOC] Added support for the new promotion rule tag (#228232)\n\n## Summary\n\nAdded support for the new promotion rule tag as discussed here:\n[https://github.com/elastic/detection-rules/pull/4903#discussion\\_r2201961021](https://github.com/elastic/detection-rules/pull/4903#discussion_r2201961021).\n\nFor the time being, both the old `Promotion` tag and the new `Promotion:\nExternal Alerts` tag will be in use to avoid breaking changes. Once the\npromotion rules go live, we can remove support for the old tag.\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>","sha":"ad56fe00fab80982ed8066bc5a5ef91cd2a5e0d4"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228232","number":228232,"mergeCommit":{"message":"[AI4SOC] Added support for the new promotion rule tag (#228232)\n\n## Summary\n\nAdded support for the new promotion rule tag as discussed here:\n[https://github.com/elastic/detection-rules/pull/4903#discussion\\_r2201961021](https://github.com/elastic/detection-rules/pull/4903#discussion_r2201961021).\n\nFor the time being, both the old `Promotion` tag and the new `Promotion:\nExternal Alerts` tag will be in use to avoid breaking changes. Once the\npromotion rules go live, we can remove support for the old tag.\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>","sha":"ad56fe00fab80982ed8066bc5a5ef91cd2a5e0d4"}}]}] BACKPORT-->