### PR TITLE
Add data-test-subj to dropdown options and adjust tests

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
@@ -204,7 +204,7 @@ describe('ChangeKbModel', () => {
       dropdown.click();
 
       const elserOption = await screen.findByTestId(
-        'observabilityAiAssistantKnowledgeBaseModelDropdownOption-' + elserTitle
+        `observabilityAiAssistantKnowledgeBaseModelDropdownOption-${elserTitle}`
       );
       elserOption.click();
 
@@ -232,7 +232,7 @@ describe('ChangeKbModel', () => {
       dropdown.click();
 
       const e5Option = await screen.findByTestId(
-        'observabilityAiAssistantKnowledgeBaseModelDropdownOption-' + e5SmallTitle
+        `observabilityAiAssistantKnowledgeBaseModelDropdownOption-${e5SmallTitle}`
       );
       e5Option.click();
 

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
@@ -203,7 +203,9 @@ describe('ChangeKbModel', () => {
       const dropdown = screen.getByTestId('observabilityAiAssistantKnowledgeBaseModelDropdown');
       dropdown.click();
 
-      const elserOption = await screen.findByText(elserTitle);
+      const elserOption = await screen.findByTestId(
+        'observabilityAiAssistantKnowledgeBaseModelDropdownOption-' + elserTitle
+      );
       elserOption.click();
 
       await waitFor(() => {
@@ -229,7 +231,9 @@ describe('ChangeKbModel', () => {
       const dropdown = screen.getByTestId('observabilityAiAssistantKnowledgeBaseModelDropdown');
       dropdown.click();
 
-      const e5Option = await screen.findByText(e5SmallTitle);
+      const e5Option = await screen.findByTestId(
+        'observabilityAiAssistantKnowledgeBaseModelDropdownOption-' + e5SmallTitle
+      );
       e5Option.click();
 
       await waitFor(() => {

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -186,7 +186,12 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
     dropdownDisplay: (
       <div>
         <strong>{option.label}</strong>
-        <EuiText size="xs" color="subdued" css={{ marginTop: 4 }}>
+        <EuiText
+          size="xs"
+          color="subdued"
+          css={{ marginTop: 4 }}
+          data-test-subj={`observabilityAiAssistantKnowledgeBaseModelDropdownOption-${option.label}`}
+        >
           {option.description}
         </EuiText>
       </div>


### PR DESCRIPTION
## Summary

This test was failing in this backport PR https://github.com/elastic/kibana/pull/228343
After investigating, I found that it's because the `findByText(elserTitle)` was finding 2 elements with that text (the dropdown button itself, and the dropdown option), thus failing. 
In 9.1 and 9.2, for some reason the dropdown was not opening before that findByText was executed, hence there was only 1 instance of that text, but the test was not actually testing clicking the option.

By adding data-test-subj, we ensure that the dropdown is open, and that we are clicking on the right option.
This change has already been made on the backport PR for 8.19, this PR adds it to 9.1 and 9.2.

Tested in 9.2, 9.1 and 8.9 using screen.debug() to check that the drodpown was being opened, and the tests passed on all branches.




<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->