### PR TITLE
[Cases] Ignore resource_already_exists_exception errors when creating an analytics index.

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.test.ts
@@ -7,7 +7,8 @@
 
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
-import { DiagnosticResult, errors as esErrors } from '@elastic/elasticsearch';
+import type { DiagnosticResult } from '@elastic/elasticsearch';
+import { errors as esErrors } from '@elastic/elasticsearch';
 
 import { AnalyticsIndex } from './analytics_index';
 import type {

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/analytics_index.ts
@@ -134,6 +134,11 @@ export class AnalyticsIndex {
         await this.updateIndexMapping();
       }
     } catch (error) {
+      if (error.body?.error?.type === 'resource_already_exists_exception') {
+        this.logDebug('Index already exists. Skipping creation.');
+        return;
+      }
+
       this.handleError('Failed to create the index.', error);
     }
   }


### PR DESCRIPTION
## Summary

In serverless, we have seen a few times a scenario where, on startup, some node tries to create a cases analytics index when it already exists. This is not really a problem, so logging it as an error should be avoided.

In this PR, the `AnalyticsIndex` class ignores `ResponseError`s from elasticsearch where the type is `resource_already_exists_exception`.

[I added a unit test, but this change has been verified in this test PR where several serverless deployments were created.](https://github.com/elastic/kibana/pull/228191)




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->