### PR TITLE
refactor: replace grok template with direct processor creation and add regex escaping

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/kv/validate.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/kv/validate.ts
@@ -68,7 +68,10 @@ export async function handleHeaderValidate({
 }: HandleKVNodeParams): Promise<Partial<KVState>> {
   const grokPattern = state.grokPattern;
   const grokProcessor = createGrokProcessor([grokPattern]);
-  const pipeline = { processors: grokProcessor, on_failure: [createPassthroughFailureProcessor()] };
+  const pipeline = {
+    processors: [grokProcessor],
+    on_failure: [createPassthroughFailureProcessor()],
+  };
 
   const { pipelineResults, errors } = (await testPipeline(state.logSamples, pipeline, client)) as {
     pipelineResults: GrokResult[];
@@ -81,7 +84,7 @@ export async function handleHeaderValidate({
 
   const kvLogMessages: string[] = pipelineResults.map((entry) => entry.message);
   const additionalProcessors = state.additionalProcessors;
-  additionalProcessors.push(grokProcessor[0]);
+  additionalProcessors.push(grokProcessor);
 
   return {
     kvLogMessages,

--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/unstructured/validate.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/unstructured/validate.ts
@@ -22,7 +22,10 @@ export async function handleUnstructuredValidate({
   const currentPattern = state.currentPattern;
   const grokPatterns = state.grokPatterns;
   const grokProcessor = createGrokProcessor([...grokPatterns, currentPattern]);
-  const pipeline = { processors: grokProcessor, on_failure: [createPassthroughFailureProcessor()] };
+  const pipeline = {
+    processors: [grokProcessor],
+    on_failure: [createPassthroughFailureProcessor()],
+  };
 
   const packageName = state.packageName;
   const dataStreamName = state.dataStreamName;
@@ -61,7 +64,7 @@ export async function handleUnstructuredValidate({
     .map((log) => log[dataStreamName])
     .map((log) => JSON.stringify(log));
   const additionalProcessors = state.additionalProcessors;
-  additionalProcessors.push(grokProcessor[0]);
+  additionalProcessors.push(grokProcessor);
 
   return {
     jsonSamples,

--- a/x-pack/platform/plugins/shared/automatic_import/server/templates/processors/grok.yml.njk
+++ b/x-pack/platform/plugins/shared/automatic_import/server/templates/processors/grok.yml.njk
@@ -1,6 +1,0 @@
-  - grok:
-      field: message
-      patterns:
-      {% for grokPattern in grokPatterns %}
-        - '{{ grokPattern }}'{% endfor %}
-      tag: 'grok_header_pattern'

--- a/x-pack/platform/plugins/shared/automatic_import/server/util/processors.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/util/processors.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createGrokProcessor } from './processors';
+
+describe('processors utilities', () => {
+  describe('createGrokProcessor', () => {
+    it('should escape special characters in grok patterns while preserving grok syntax', () => {
+      const patterns = [
+        '[%{TIMESTAMP_ISO8601:timestamp}] %{GREEDYDATA:message}',
+        'message with (parentheses) and %{WORD:action}',
+        'message with {braces} and %{DATA:field}',
+        'message with * asterisk',
+        'message with + plus',
+        'message with ? question',
+        'message with . dot',
+      ];
+
+      const processor = createGrokProcessor(patterns);
+
+      expect(processor).toHaveProperty('grok');
+      expect(processor.grok).toHaveProperty('patterns');
+      expect(processor.grok).toHaveProperty('field', 'message');
+      expect(processor.grok).toHaveProperty('tag', 'grok_header_pattern');
+
+      const grokPatterns = processor.grok.patterns as string[];
+
+      // Verify literal brackets are escaped but grok patterns are preserved
+      expect(grokPatterns[0]).toContain('\\[%{TIMESTAMP_ISO8601:timestamp}\\]');
+      expect(grokPatterns[0]).toContain('%{GREEDYDATA:message}');
+
+      // Verify parentheses are escaped but grok patterns are preserved
+      expect(grokPatterns[1]).toContain('\\(parentheses\\)');
+      expect(grokPatterns[1]).toContain('%{WORD:action}');
+
+      // Verify braces are escaped but grok patterns are preserved
+      expect(grokPatterns[2]).toContain('\\{braces\\}');
+      expect(grokPatterns[2]).toContain('%{DATA:field}');
+
+      // Verify other special characters are escaped
+      expect(grokPatterns[3]).toContain('\\*');
+      expect(grokPatterns[4]).toContain('\\+');
+      expect(grokPatterns[5]).toContain('\\?');
+      expect(grokPatterns[6]).toContain('\\.');
+    });
+
+    it('should handle complex real-world syslog patterns', () => {
+      const patterns = [
+        '[18/Feb/2025:22:39:16 +0000] CONNECT conn=20597223 from=%{IP:source_ip}:%{INT:source_port} to=%{IP:dest_ip}:%{INT:dest_port} protocol=%{WORD:protocol}',
+        '<%{POSINT:priority}>%{NUMBER:version} %{TIMESTAMP_ISO8601:timestamp} %{HOSTNAME:hostname} %{PROG:program}[%{POSINT:pid}]: %{GREEDYDATA:message}',
+      ];
+
+      const processor = createGrokProcessor(patterns);
+      const grokPatterns = processor.grok.patterns as string[];
+
+      // First pattern: brackets should be escaped but grok patterns preserved
+      expect(grokPatterns[0]).toContain('\\[18/Feb/2025:22:39:16 \\+0000\\]');
+      expect(grokPatterns[0]).toContain('%{IP:source_ip}');
+      expect(grokPatterns[0]).toContain('%{INT:source_port}');
+
+      // Second pattern: < and > should be escaped but grok patterns preserved
+      expect(grokPatterns[1]).toContain('\\<%{POSINT:priority}\\>');
+      expect(grokPatterns[1]).toContain('%{TIMESTAMP_ISO8601:timestamp}');
+      expect(grokPatterns[1]).toContain('\\[%{POSINT:pid}\\]');
+    });
+
+    it('should handle patterns with no special characters', () => {
+      const patterns = ['simple message with %{GREEDYDATA:content}'];
+
+      const processor = createGrokProcessor(patterns);
+      const grokPatterns = processor.grok.patterns as string[];
+
+      // Should preserve the pattern as-is
+      expect(grokPatterns[0]).toBe('simple message with %{GREEDYDATA:content}');
+    });
+
+    it('should handle empty patterns array', () => {
+      const processor = createGrokProcessor([]);
+
+      expect(processor).toHaveProperty('grok');
+      expect(processor.grok.patterns).toEqual([]);
+    });
+
+    it('should handle patterns with only grok syntax', () => {
+      const patterns = ['%{TIMESTAMP_ISO8601:timestamp} %{HOSTNAME:host} %{GREEDYDATA:message}'];
+
+      const processor = createGrokProcessor(patterns);
+      const grokPatterns = processor.grok.patterns as string[];
+
+      // Should preserve grok patterns exactly
+      expect(grokPatterns[0]).toBe(
+        '%{TIMESTAMP_ISO8601:timestamp} %{HOSTNAME:host} %{GREEDYDATA:message}'
+      );
+    });
+
+    it('should handle mixed literal and grok pattern braces correctly', () => {
+      const patterns = [
+        'literal {brace} with %{WORD:field} and more {text}',
+        'nested patterns %{DATA:field1} within %{GREEDYDATA:field2}',
+      ];
+
+      const processor = createGrokProcessor(patterns);
+      const grokPatterns = processor.grok.patterns as string[];
+
+      // Literal braces should be escaped, grok patterns should not
+      expect(grokPatterns[0]).toBe('literal \\{brace\\} with %{WORD:field} and more \\{text\\}');
+      expect(grokPatterns[1]).toBe('nested patterns %{DATA:field1} within %{GREEDYDATA:field2}');
+    });
+
+    it('should handle all common special characters', () => {
+      const patterns = [
+        'chars: [brackets] (parens) {braces} *asterisk +plus ?question .dot ^caret $dollar |pipe',
+      ];
+
+      const processor = createGrokProcessor(patterns);
+      const grokPatterns = processor.grok.patterns as string[];
+
+      expect(grokPatterns[0]).toBe(
+        'chars: \\[brackets\\] \\(parens\\) \\{braces\\} \\*asterisk \\+plus \\?question \\.dot \\^caret \\$dollar \\|pipe'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Release Notes

Fixed Automatic Import failing to process logs with special characters like square brackets. The feature now correctly handles complex unstructured syslog patterns that previously caused parsing errors.

## Summary

Fixes grok pattern escaping bug in Automatic Import feature to handle complex unstructured logs with special characters.

**Reference:** [a comment in #222834.](https://github.com/elastic/kibana/issues/222834#issuecomment-3066643575)

**Problem:** The automatic import feature was failing to process logs containing special characters like square brackets, causing grok pattern parsing errors. Users reported that simple logs like `Jun 29 07:07:00 mcp4 anacron[4797]: Normal exit (1 job run)` would fail because the `[4797]` brackets were not properly escaped for regex processing.

**Solution:** 
- Added intelligent escaping function `escapeGrokPattern()` that escapes special regex characters while preserving grok pattern syntax
- Removed dependency on `grok.yml.njk` template and moved to direct TypeScript object creation
- Fixed breaking changes in validation functions to handle single processor objects
- Added comprehensive test coverage with real-world examples

**Technical Changes:**
- Modified `x-pack/platform/plugins/shared/automatic_import/server/util/processors.ts` to add escaping logic and eliminate template dependency
- Updated `x-pack/platform/plugins/shared/automatic_import/server/graphs/unstructured/validate.ts` and `x-pack/platform/plugins/shared/automatic_import/server/graphs/kv/validate.ts` to handle API changes
- Added extensive test suite in `x-pack/platform/plugins/shared/automatic_import/server/util/processors.test.ts` covering edge cases
- Removed `x-pack/platform/plugins/shared/automatic_import/server/templates/processors/grok.yml.njk` template file

**Examples of patterns now handled correctly:**
```
Before: [18/Feb/2025:22:39:16 +0000] CONNECT conn=20597223  → PARSING ERROR ❌
After:  \[18/Feb/2025:22:39:16 \+0000\] CONNECT conn=20597223 → WORKS ✅

Before: anacron[4797]: Normal exit  → PARSING ERROR ❌  
After:  anacron\[4797\]: Normal exit → WORKS ✅
```

### Checklist

- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Medium Risk: Regression in grok pattern processing**
  - *Severity:* Low - Limited impact to Automatic Import feature only. 
  - *Probability:* Medium – real-life LLMs might generate their own escaping. 
  - *Mitigation:* Comprehensive test suite with 7 test scenarios covering real-world patterns, edge cases, and all special characters. All existing tests (551 total) continue to pass. More testing is needed for different LLMs though.

- **Low Risk: Performance impact from escaping function**
  - *Severity:* Minimal - Function only processes small grok pattern strings during import
  - *Mitigation:* Efficient regex-based implementation with minimal overhead. Only runs during import process, not during log ingestion.

- [x] All risks identified are low severity with appropriate mitigations in place
- [x] Comprehensive test coverage validates the fix works correctly
- [x] No data loss or user-facing breaking changes introduced

