### PR TITLE
[SecuritySolution] Do not fire HTTP requests if privmon table is collapsed

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/use_asset_criticality.ts
@@ -50,15 +50,17 @@ export const useAssetCriticalityPrivileges = (
 export const useAssetCriticalityFetchList = ({
   idField,
   idValues,
+  skip = false,
 }: {
   idField: string;
   idValues: string[];
+  skip?: boolean;
 }) => {
   const { fetchAssetCriticalityList } = useEntityAnalyticsRoutes();
   return useQuery<FindAssetCriticalityRecordsResponse>({
     queryKey: [ASSET_CRITICALITY_LIST_KEY],
     queryFn: () => fetchAssetCriticalityList({ idField, idValues }),
-    enabled: idValues.length > 0,
+    enabled: !skip && idValues.length > 0,
   });
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
@@ -98,6 +98,7 @@ export const PrivilegedUsersTable: React.FC<{ spaceId: string }> = ({ spaceId })
     isError: privilegedUsersError,
   } = useQuery({
     queryKey: ['privileged-users-table', privilegedUsersTableQuery, filterQueryWithoutTimerange],
+    enabled: toggleStatus,
     queryFn: async () => {
       return getESQLResults({
         esqlQuery: privilegedUsersTableQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/index.tsx
@@ -144,6 +144,7 @@ export const PrivilegedUsersTable: React.FC<{ spaceId: string }> = ({ spaceId })
   } = useAssetCriticalityFetchList({
     idField: 'user.name',
     idValues: records.map((user) => user['user.name']),
+    skip: !toggleStatus,
   });
 
   const assetCriticalityRecords =


### PR DESCRIPTION
## Summary

I have skipped the most expensive request when the tables collapse, but we still make some lightwait requests, mostly for getting the status. 
Some of these requests could also be skipped, but that would require a more significant change.



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->