### PR TITLE
[Dashboard] do not show or allow resize handle when panel is focused, blurred or expanded

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid.tsx
@@ -290,7 +290,7 @@ const dashboardGridStyles = {
       // drag handle visibility when dashboard is in edit mode or a panel is expanded
       '&.dshLayout-withoutMargins:not(.dshLayout--editing), .dshDashboardGrid__item--expanded, .dshDashboardGrid__item--blurred, .dshDashboardGrid__item--focused':
         {
-          '.embPanel--dragHandle': {
+          '.embPanel--dragHandle, ~.kbnGridPanel--resizeHandle': {
             visibility: 'hidden',
           },
         },


### PR DESCRIPTION
Removes the ability to resize any panels when panel is focused. It looks weird and works weird, so probably shouldn't be there.

Before

https://github.com/user-attachments/assets/b5e082bc-ce12-4c7b-86b4-ffe451b395fb

<img width="1246" height="738" alt="Screenshot 2025-07-17 at 14 35 32" src="https://github.com/user-attachments/assets/d7d1213a-0701-4092-a77e-e84c0ec71739" />



After:
<img width="1253" height="730" alt="Screenshot 2025-07-17 at 14 34 11" src="https://github.com/user-attachments/assets/96e3b142-c5ab-4c0d-ba5a-13f1f4b266e1" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->