### PR TITLE
[Data Usage] Add status code when AutoOps API responds with an error

### DIFF
--- a/x-pack/platform/plugins/private/data_usage/server/services/autoops_api.ts
+++ b/x-pack/platform/plugins/private/data_usage/server/services/autoops_api.ts
@@ -146,7 +146,11 @@ export class AutoOpsAPIService {
               },
             }
           );
-          throw new AutoOpsError(withRequestIdMessage(AUTO_OPS_REQUEST_FAILED_PREFIX));
+          throw new AutoOpsError(
+            withRequestIdMessage(
+              `${AUTO_OPS_REQUEST_FAILED_PREFIX} with status code: ${error.response.status}`
+            )
+          );
         } else if (error.request) {
           // The request was made but no response was received
           this.logger.error(


### PR DESCRIPTION
Add status code when AutoOps API responds with an error so the thrown message is more informative. For example: `[AutoOps API] Request failed with status code: 404`

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->