### PR TITLE
[SecuritySolution] Remove the panel around EnableRiskScore 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/risk_level_panel/index.tsx
@@ -79,11 +79,7 @@ export const RiskLevelsPrivilegedUsersPanel: React.FC<{ spaceId: string }> = ({ 
   const isDisabled = !hasEngineBeenInstalled && !isLoading;
 
   if (isDisabled) {
-    return (
-      <EuiPanel hasBorder>
-        <EnableRiskScore isDisabled={isDisabled} entityType={EntityType.user} />
-      </EuiPanel>
-    );
+    return <EnableRiskScore isDisabled={isDisabled} entityType={EntityType.user} />;
   }
 
   return (


### PR DESCRIPTION
## Summary

Remove the panel around EnableRiskScore
<img width="1262" height="830" alt="Screenshot 2025-07-17 at 15 07 12" src="https://github.com/user-attachments/assets/650ab4a2-a5e5-48f2-b5e0-86374bb11449" />



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->