### PR TITLE
[Ingest Pipelines] Add extension tree

### DIFF
--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/create_tree_nodes/create_tree_nodes.tsx
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/create_tree_nodes/create_tree_nodes.tsx
@@ -11,11 +11,15 @@ import type { PipelineTreeNode } from '../types';
 import { MAX_TREE_LEVEL } from '../constants';
 import { PipelineTreeNodeLabel, MorePipelinesLabel } from '../tree_node_labels';
 
-const traverseTree = (
+/**
+ * This function takes a {@link PipelineTreeNode} tree of pipeline names, traverses it
+ * recursively, and returns a Node tree that can be passed to an {@link EuiTreeView}.
+ */
+export const createTreeNodesFromPipelines = (
   treeNode: PipelineTreeNode,
   selectedPipeline: string,
   setSelectedPipeline: (pipelineName: string) => void,
-  level: number
+  level: number = 1
 ): Node => {
   const currentNode = {
     id: treeNode.pipelineName,
@@ -51,20 +55,8 @@ const traverseTree = (
   }
   treeNode.children.forEach((node) => {
     currentNode.children!.push(
-      traverseTree(node, selectedPipeline, setSelectedPipeline, level + 1)
+      createTreeNodesFromPipelines(node, selectedPipeline, setSelectedPipeline, level + 1)
     );
   });
   return currentNode;
-};
-
-/**
- * This function takes a {@link PipelineTreeNode} tree of pipeline names, traverses it
- * recursively, and returns a Node tree that can be passed to an {@link EuiTreeView}.
- */
-export const createTreeNodesFromPipelines = (
-  pipelines: PipelineTreeNode,
-  selectedPipeline: string,
-  setSelectedPipeline: (pipelineName: string) => void
-): Node => {
-  return traverseTree(pipelines, selectedPipeline, setSelectedPipeline, 1);
 };

--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.stories.tsx
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.stories.tsx
@@ -12,6 +12,11 @@ import { PipelineStructureTree } from './pipeline_structure_tree';
 const meta: Meta<typeof PipelineStructureTree> = {
   component: PipelineStructureTree,
   title: 'Ingest Pipelines/Pipeline Structure Tree',
+  argTypes: {
+    isSecondary: {
+      name: 'Is tree secondary?',
+    },
+  },
 };
 
 export default meta;
@@ -81,5 +86,6 @@ const pipelineTree = {
 export const Primary: Story = {
   args: {
     pipelineTree,
+    isSecondary: false,
   },
 };

--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.stories.tsx
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.stories.tsx
@@ -13,8 +13,8 @@ const meta: Meta<typeof PipelineStructureTree> = {
   component: PipelineStructureTree,
   title: 'Ingest Pipelines/Pipeline Structure Tree',
   argTypes: {
-    isSecondary: {
-      name: 'Is tree secondary?',
+    isExtension: {
+      name: 'Is the tree an extension of the main tree?',
     },
   },
 };
@@ -86,6 +86,6 @@ const pipelineTree = {
 export const Primary: Story = {
   args: {
     pipelineTree,
-    isSecondary: false,
+    isExtension: false,
   },
 };

--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.tsx
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.tsx
@@ -18,7 +18,7 @@ export interface PipelineStructureTreeProps {
    * Specifies whether the tree is an extension of the main tree; i.e. displayed
    * when the user clicks on the last "+X more pipelines" tree node.
    */
-  isSecondary: boolean;
+  isExtension: boolean;
 }
 
 /**
@@ -29,10 +29,10 @@ export interface PipelineStructureTreeProps {
  */
 export const PipelineStructureTree = ({
   pipelineTree,
-  isSecondary,
+  isExtension,
 }: PipelineStructureTreeProps) => {
   const { euiTheme } = useEuiTheme();
-  const styles = getStyles(euiTheme, isSecondary);
+  const styles = getStyles(euiTheme, isExtension);
 
   const [selectedPipeline, setSelectedPipeline] = useState(pipelineTree.pipelineName);
 
@@ -44,7 +44,7 @@ export const PipelineStructureTree = ({
 
   return (
     <EuiFlexGroup direction="column" gutterSize="none" alignItems="flexStart">
-      {isSecondary && (
+      {isExtension && (
         <EuiFlexItem>
           <EuiButtonEmpty iconType="arrowLeft" onClick={() => {}}>
             <FormattedMessage
@@ -54,7 +54,7 @@ export const PipelineStructureTree = ({
           </EuiButtonEmpty>
         </EuiFlexItem>
       )}
-      <EuiFlexItem css={{ marginLeft: isSecondary ? euiTheme.size.l : '0' }}>
+      <EuiFlexItem css={{ marginLeft: isExtension ? euiTheme.size.l : '0' }}>
         <EuiTreeView items={[treeNode]} showExpansionArrows={true} css={styles} />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.tsx
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.tsx
@@ -6,14 +6,18 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTreeView, useEuiTheme } from "@elastic/eui";
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTreeView, useEuiTheme } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { PipelineTreeNode } from './types';
 import { createTreeNodesFromPipelines } from './create_tree_nodes';
 import { getStyles } from './styles';
-import { FormattedMessage } from "@kbn/i18n-react";
 
 export interface PipelineStructureTreeProps {
   pipelineTree: PipelineTreeNode;
+  /**
+   * Specifies whether the tree is an extension of the main tree; i.e. displayed
+   * when the user clicks on the last "+X more pipelines" tree node.
+   */
   isSecondary: boolean;
 }
 

--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.tsx
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/pipeline_structure_tree.tsx
@@ -6,13 +6,15 @@
  */
 
 import React, { useState } from 'react';
-import { EuiTreeView, useEuiTheme } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTreeView, useEuiTheme } from "@elastic/eui";
 import type { PipelineTreeNode } from './types';
 import { createTreeNodesFromPipelines } from './create_tree_nodes';
 import { getStyles } from './styles';
+import { FormattedMessage } from "@kbn/i18n-react";
 
 export interface PipelineStructureTreeProps {
   pipelineTree: PipelineTreeNode;
+  isSecondary: boolean;
 }
 
 /**
@@ -21,9 +23,12 @@ export interface PipelineStructureTreeProps {
  * corresponding pipelines from the children node.
  * See more at https://www.elastic.co/docs/reference/enrich-processor/pipeline-processor
  */
-export const PipelineStructureTree = ({ pipelineTree }: PipelineStructureTreeProps) => {
+export const PipelineStructureTree = ({
+  pipelineTree,
+  isSecondary,
+}: PipelineStructureTreeProps) => {
   const { euiTheme } = useEuiTheme();
-  const styles = getStyles(euiTheme);
+  const styles = getStyles(euiTheme, isSecondary);
 
   const [selectedPipeline, setSelectedPipeline] = useState(pipelineTree.pipelineName);
 
@@ -33,5 +38,21 @@ export const PipelineStructureTree = ({ pipelineTree }: PipelineStructureTreePro
     setSelectedPipeline
   );
 
-  return <EuiTreeView items={[treeNode]} showExpansionArrows={true} css={styles} />;
+  return (
+    <EuiFlexGroup direction="column" gutterSize="none" alignItems="flexStart">
+      {isSecondary && (
+        <EuiFlexItem>
+          <EuiButtonEmpty iconType="arrowLeft" onClick={() => {}}>
+            <FormattedMessage
+              id="ingestPipelines.pipelineStructureTree.backToMainTreeNodeLabel"
+              defaultMessage="Back to previous pipelines"
+            />
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      )}
+      <EuiFlexItem css={{ marginLeft: isSecondary ? euiTheme.size.l : '0' }}>
+        <EuiTreeView items={[treeNode]} showExpansionArrows={true} css={styles} />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
 };

--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/styles.ts
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/styles.ts
@@ -8,7 +8,7 @@
 import { css } from '@emotion/react';
 import { EuiThemeComputed } from '@elastic/eui';
 
-export const getStyles = (euiTheme: EuiThemeComputed, isSecondary: boolean) => css`
+export const getStyles = (euiTheme: EuiThemeComputed, isExtension: boolean) => css`
   [class*='cssTreeNode-'] {
     background-color: ${euiTheme.colors.backgroundBasePlain};
     padding: ${euiTheme.size.base} ${euiTheme.size.m};
@@ -22,7 +22,7 @@ export const getStyles = (euiTheme: EuiThemeComputed, isSecondary: boolean) => c
   }
 
   [class*='cssTreeNode-children'] {
-    margin-left: ${isSecondary ? euiTheme.size.xl : euiTheme.size.l};
+    margin-left: ${isExtension ? euiTheme.size.xl : euiTheme.size.l};
   }
 
   // We want to disable EUI's logic for activating nodes but EuiTreeViewItems's

--- a/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/styles.ts
+++ b/x-pack/platform/packages/shared/ingest-pipelines/src/components/pipeline_structure_tree/styles.ts
@@ -8,7 +8,7 @@
 import { css } from '@emotion/react';
 import { EuiThemeComputed } from '@elastic/eui';
 
-export const getStyles = (euiTheme: EuiThemeComputed) => css`
+export const getStyles = (euiTheme: EuiThemeComputed, isSecondary: boolean) => css`
   [class*='cssTreeNode-'] {
     background-color: ${euiTheme.colors.backgroundBasePlain};
     padding: ${euiTheme.size.base} ${euiTheme.size.m};
@@ -22,7 +22,7 @@ export const getStyles = (euiTheme: EuiThemeComputed) => css`
   }
 
   [class*='cssTreeNode-children'] {
-    margin-left: ${euiTheme.size.l};
+    margin-left: ${isSecondary ? euiTheme.size.xl : euiTheme.size.l};
   }
 
   // We want to disable EUI's logic for activating nodes but EuiTreeViewItems's


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/227405

## Summary

This PR adds an extension pipeline structure tree, which is displayed when the user clicks the "+X more pipelines".


https://github.com/user-attachments/assets/fdf131bb-bab4-46cf-813d-35164ce442c0

**How to test:**
You can view the component in the Storybook link in the PR build comment or, if testing locally, run `yarn storybook ingest_pipelines`.

