### PR TITLE
[7.17] Remove github-checks-reporter

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -61,12 +61,6 @@ if is_pr; then
     export ELASTIC_APM_ACTIVE=false
   fi
 
-  if [[ "${GITHUB_STEP_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
-    export CHECKS_REPORTER_ACTIVE=true
-  else
-    export CHECKS_REPORTER_ACTIVE=false
-  fi
-
   # These can be removed once we're not supporting Jenkins and Buildkite at the same time
   # These are primarily used by github checks reporter and can be configured via /github_checks_api.json
   export ghprbGhRepository="elastic/kibana"

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -2,15 +2,6 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/vault_fns.sh"
 
-checks-reporter-with-killswitch() {
-  if [ "$CHECKS_REPORTER_ACTIVE" == "true" ] ; then
-    yarn run github-checks-reporter "$@"
-  else
-    arguments=("$@");
-    "${arguments[@]:1}";
-  fi
-}
-
 is_pr() {
   [[ "${GITHUB_PR_NUMBER-}" ]] && return
   false

--- a/.buildkite/scripts/saved_object_field_metrics.sh
+++ b/.buildkite/scripts/saved_object_field_metrics.sh
@@ -6,8 +6,7 @@ source .buildkite/scripts/common/util.sh
 
 echo '--- Default Saved Object Field Metrics'
 cd "$XPACK_DIR"
-checks-reporter-with-killswitch "Capture Kibana Saved Objects field count metrics" \
-  node scripts/functional_tests \
-      --debug --bail \
-      --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-      --config test/saved_objects_field_count/config.ts
+node scripts/functional_tests \
+    --debug --bail \
+    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+    --config test/saved_objects_field_count/config.ts

--- a/.buildkite/scripts/steps/check_types.sh
+++ b/.buildkite/scripts/steps/check_types.sh
@@ -7,5 +7,4 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo --- Check Types
-checks-reporter-with-killswitch "Check Types" \
-  node scripts/type_check
+node scripts/type_check

--- a/.buildkite/scripts/steps/checks/bundle_limits.sh
+++ b/.buildkite/scripts/steps/checks/bundle_limits.sh
@@ -5,6 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Bundle Limits
-
-checks-reporter-with-killswitch "Check Bundle Limits" \
-  node scripts/build_kibana_platform_plugins --validate-limits
+node scripts/build_kibana_platform_plugins --validate-limits

--- a/.buildkite/scripts/steps/checks/commit/commit.sh
+++ b/.buildkite/scripts/steps/checks/commit/commit.sh
@@ -10,5 +10,4 @@ source .buildkite/scripts/common/util.sh
 # If files are more than 200 we will skip it and just use
 # the further ci steps that already check linting and file casing for the entire repo.
 echo --- Quick commit checks
-checks-reporter-with-killswitch "Quick commit checks" \
-  "$(dirname "${0}")/commit_check_runner.sh"
+"$(dirname "${0}")/commit_check_runner.sh"

--- a/.buildkite/scripts/steps/checks/doc_api_changes.sh
+++ b/.buildkite/scripts/steps/checks/doc_api_changes.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Doc API Changes
-checks-reporter-with-killswitch "Check Doc API Changes" \
-  node scripts/check_published_api_changes
+node scripts/check_published_api_changes

--- a/.buildkite/scripts/steps/checks/file_casing.sh
+++ b/.buildkite/scripts/steps/checks/file_casing.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check File Casing
-checks-reporter-with-killswitch "Check File Casing" \
-  node scripts/check_file_casing --quiet
+node scripts/check_file_casing --quiet

--- a/.buildkite/scripts/steps/checks/i18n.sh
+++ b/.buildkite/scripts/steps/checks/i18n.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check i18n
-checks-reporter-with-killswitch "Check i18n" \
-  node scripts/i18n_check --ignore-missing
+node scripts/i18n_check --ignore-missing

--- a/.buildkite/scripts/steps/checks/jest_configs.sh
+++ b/.buildkite/scripts/steps/checks/jest_configs.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Jest Configs
-checks-reporter-with-killswitch "Check Jest Configs" \
-  node scripts/check_jest_configs
+node scripts/check_jest_configs

--- a/.buildkite/scripts/steps/checks/licenses.sh
+++ b/.buildkite/scripts/steps/checks/licenses.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Licenses
-checks-reporter-with-killswitch "Check Licenses" \
-  node scripts/check_licenses --dev
+node scripts/check_licenses --dev

--- a/.buildkite/scripts/steps/checks/plugins_with_circular_deps.sh
+++ b/.buildkite/scripts/steps/checks/plugins_with_circular_deps.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Plugins With Circular Dependencies
-checks-reporter-with-killswitch "Check Plugins With Circular Dependencies" \
-  node scripts/find_plugins_with_circular_deps
+node scripts/find_plugins_with_circular_deps

--- a/.buildkite/scripts/steps/checks/telemetry.sh
+++ b/.buildkite/scripts/steps/checks/telemetry.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Telemetry Schema
-checks-reporter-with-killswitch "Check Telemetry Schema" \
-  node scripts/telemetry_check
+node scripts/telemetry_check

--- a/.buildkite/scripts/steps/checks/test_hardening.sh
+++ b/.buildkite/scripts/steps/checks/test_hardening.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Test Hardening
-checks-reporter-with-killswitch "Test Hardening" \
-  node scripts/test_hardening
+node scripts/test_hardening

--- a/.buildkite/scripts/steps/checks/test_projects.sh
+++ b/.buildkite/scripts/steps/checks/test_projects.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Test Projects
-checks-reporter-with-killswitch "Test Projects" \
-  yarn kbn run test --exclude kibana --oss --skip-kibana-plugins --skip-missing
+yarn kbn run test --exclude kibana --oss --skip-kibana-plugins --skip-missing

--- a/.buildkite/scripts/steps/checks/ts_projects.sh
+++ b/.buildkite/scripts/steps/checks/ts_projects.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check TypeScript Projects
-checks-reporter-with-killswitch "Check TypeScript Projects" \
-  node scripts/check_ts_projects
+node scripts/check_ts_projects

--- a/.buildkite/scripts/steps/checks/validate_ci_groups.sh
+++ b/.buildkite/scripts/steps/checks/validate_ci_groups.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Ensure that all tests are in a CI Group
-checks-reporter-with-killswitch "Ensure that all tests are in a CI Group" \
-  node scripts/ensure_all_tests_in_ci_group
+node scripts/ensure_all_tests_in_ci_group

--- a/.buildkite/scripts/steps/checks/verify_notice.sh
+++ b/.buildkite/scripts/steps/checks/verify_notice.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Verify NOTICE
-checks-reporter-with-killswitch "Verify NOTICE" \
-  node scripts/notice --validate
+node scripts/notice --validate

--- a/.buildkite/scripts/steps/functional/apm_cypress.sh
+++ b/.buildkite/scripts/steps/functional/apm_cypress.sh
@@ -12,7 +12,5 @@ export JOB=kibana-apm-cypress
 echo "--- APM Cypress Tests"
 
 cd "$XPACK_DIR"
-
-checks-reporter-with-killswitch "APM Cypress Tests" \
-  node --openssl-legacy-provider plugins/apm/scripts/test/e2e.js \
+node --openssl-legacy-provider plugins/apm/scripts/test/e2e.js \
   --kibana-install-dir "$KIBANA_BUILD_LOCATION"

--- a/.buildkite/scripts/steps/functional/oss_accessibility.sh
+++ b/.buildkite/scripts/steps/functional/oss_accessibility.sh
@@ -5,9 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/steps/functional/common.sh
 
 echo --- OSS Accessibility Tests
-
-checks-reporter-with-killswitch "Kibana accessibility tests" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --config test/accessibility/config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config test/accessibility/config.ts

--- a/.buildkite/scripts/steps/functional/oss_cigroup.sh
+++ b/.buildkite/scripts/steps/functional/oss_cigroup.sh
@@ -8,9 +8,7 @@ export CI_GROUP=${CI_GROUP:-$((BUILDKITE_PARALLEL_JOB+1))}
 export JOB=kibana-oss-ciGroup${CI_GROUP}
 
 echo "--- OSS CI Group $CI_GROUP"
-
-checks-reporter-with-killswitch "Functional tests / Group ${CI_GROUP}" \
-  node scripts/functional_tests \
-    --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --include-tag "ciGroup$CI_GROUP"
+node scripts/functional_tests \
+  --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --include-tag "ciGroup$CI_GROUP"

--- a/.buildkite/scripts/steps/functional/oss_firefox.sh
+++ b/.buildkite/scripts/steps/functional/oss_firefox.sh
@@ -5,10 +5,8 @@ set -euo pipefail
 source .buildkite/scripts/steps/functional/common.sh
 
 echo --- OSS Firefox Smoke Tests
-
-checks-reporter-with-killswitch "Firefox smoke test" \
-  node scripts/functional_tests \
-    --bail --debug \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --include-tag "includeFirefox" \
-    --config test/functional/config.firefox.js
+node scripts/functional_tests \
+  --bail --debug \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --include-tag "includeFirefox" \
+  --config test/functional/config.firefox.js

--- a/.buildkite/scripts/steps/functional/oss_misc.sh
+++ b/.buildkite/scripts/steps/functional/oss_misc.sh
@@ -8,36 +8,32 @@ source .buildkite/scripts/steps/functional/common.sh
 .buildkite/scripts/build_kibana_plugins.sh
 
 echo --- Plugin Functional Tests
-checks-reporter-with-killswitch "Plugin Functional Tests" \
-  node scripts/functional_tests \
-    --config test/plugin_functional/config.ts \
-    --bail \
-    --debug
+node scripts/functional_tests \
+  --config test/plugin_functional/config.ts \
+  --bail \
+  --debug
 
 echo --- Interpreter Functional Tests
-checks-reporter-with-killswitch "Interpreter Functional Tests" \
-  node scripts/functional_tests \
-    --config test/interpreter_functional/config.ts \
-    --bail \
-    --debug \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION"
+node scripts/functional_tests \
+  --config test/interpreter_functional/config.ts \
+  --bail \
+  --debug \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION"
 
 echo --- Server Integration Tests
-checks-reporter-with-killswitch "Server Integration Tests" \
-  node scripts/functional_tests \
-    --config test/server_integration/http/ssl/config.js \
-    --config test/server_integration/http/ssl_redirect/config.js \
-    --config test/server_integration/http/platform/config.ts \
-    --config test/server_integration/http/ssl_with_p12/config.js \
-    --config test/server_integration/http/ssl_with_p12_intermediate/config.js \
-    --bail \
-    --debug \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION"
+node scripts/functional_tests \
+  --config test/server_integration/http/ssl/config.js \
+  --config test/server_integration/http/ssl_redirect/config.js \
+  --config test/server_integration/http/platform/config.ts \
+  --config test/server_integration/http/ssl_with_p12/config.js \
+  --config test/server_integration/http/ssl_with_p12_intermediate/config.js \
+  --bail \
+  --debug \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION"
 
 # Tests that must be run against source in order to build test plugins
 echo --- Status Integration Tests
-checks-reporter-with-killswitch "Status Integration Tests" \
-  node scripts/functional_tests \
-    --config test/server_integration/http/platform/config.status.ts \
-    --bail \
-    --debug
+node scripts/functional_tests \
+  --config test/server_integration/http/platform/config.status.ts \
+  --bail \
+  --debug

--- a/.buildkite/scripts/steps/functional/performance_sub_playwright.sh
+++ b/.buildkite/scripts/steps/functional/performance_sub_playwright.sh
@@ -23,19 +23,17 @@ sleep 120
 cd "$XPACK_DIR"
 
 # warmup round 1
-checks-reporter-with-killswitch "Run Performance Tests with Playwright Config (Phase: WARMUP)" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --config "test/performance/config.playwright.ts";
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config "test/performance/config.playwright.ts";
 
 export TEST_PERFORMANCE_PHASE=TEST
 export ELASTIC_APM_ACTIVE=true
 
-checks-reporter-with-killswitch "Run Performance Tests with Playwright Config (Phase: TEST)" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --config "test/performance/config.playwright.ts";
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config "test/performance/config.playwright.ts";
 
 kill "$esPid"

--- a/.buildkite/scripts/steps/functional/uptime.sh
+++ b/.buildkite/scripts/steps/functional/uptime.sh
@@ -13,5 +13,4 @@ echo "--- Uptime @elastic/synthetics Tests"
 
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Uptime @elastic/synthetics Tests" \
-  node plugins/uptime/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION"
+node plugins/uptime/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION"

--- a/.buildkite/scripts/steps/functional/xpack_accessibility.sh
+++ b/.buildkite/scripts/steps/functional/xpack_accessibility.sh
@@ -7,9 +7,7 @@ source .buildkite/scripts/steps/functional/common.sh
 cd "$XPACK_DIR"
 
 echo --- Default Accessibility Tests
-
-checks-reporter-with-killswitch "X-Pack accessibility tests" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --config test/accessibility/config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config test/accessibility/config.ts

--- a/.buildkite/scripts/steps/functional/xpack_cigroup.sh
+++ b/.buildkite/scripts/steps/functional/xpack_cigroup.sh
@@ -11,10 +11,9 @@ echo "--- Default CI Group $CI_GROUP"
 
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "X-Pack Chrome Functional tests / Group ${CI_GROUP}" \
-  node scripts/functional_tests \
-    --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --include-tag "ciGroup$CI_GROUP"
+node scripts/functional_tests \
+  --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --include-tag "ciGroup$CI_GROUP"
 
 cd "$KIBANA_DIR"

--- a/.buildkite/scripts/steps/functional/xpack_firefox.sh
+++ b/.buildkite/scripts/steps/functional/xpack_firefox.sh
@@ -8,10 +8,9 @@ cd "$XPACK_DIR"
 
 echo --- Default Firefox Smoke Tests
 
-checks-reporter-with-killswitch "X-Pack firefox smoke test" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --include-tag "includeFirefox" \
-    --config test/functional/config.firefox.js \
-    --config test/functional_embedded/config.firefox.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --include-tag "includeFirefox" \
+  --config test/functional/config.firefox.js \
+  --config test/functional_embedded/config.firefox.ts

--- a/.buildkite/scripts/steps/functional/xpack_saved_object_field_metrics.sh
+++ b/.buildkite/scripts/steps/functional/xpack_saved_object_field_metrics.sh
@@ -10,8 +10,7 @@ source .buildkite/scripts/common/util.sh
 cd "$XPACK_DIR"
 
 echo --- Capture Kibana Saved Objects field count metrics
-checks-reporter-with-killswitch "Capture Kibana Saved Objects field count metrics" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-    --config test/saved_objects_field_count/config.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config test/saved_objects_field_count/config.ts;

--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -7,9 +7,7 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo '--- Lint: stylelint'
-checks-reporter-with-killswitch "Lint: stylelint" \
-  node scripts/stylelint
+node scripts/stylelint
 
 echo '--- Lint: eslint'
-checks-reporter-with-killswitch "Lint: eslint" \
-  node scripts/eslint --no-cache
+node scripts/eslint --no-cache

--- a/.buildkite/scripts/steps/lint_with_types.sh
+++ b/.buildkite/scripts/steps/lint_with_types.sh
@@ -8,5 +8,4 @@ export BUILD_TS_REFS_DISABLE=false
 .buildkite/scripts/bootstrap.sh
 
 echo '--- Lint: eslint (with types)'
-checks-reporter-with-killswitch "Lint: eslint (with types)" \
-  node scripts/eslint_with_types
+node scripts/eslint_with_types

--- a/.buildkite/scripts/steps/test/api_integration.sh
+++ b/.buildkite/scripts/steps/test/api_integration.sh
@@ -9,8 +9,7 @@ is_test_execution_step
 .buildkite/scripts/bootstrap.sh
 
 echo --- API Integration Tests
-checks-reporter-with-killswitch "API Integration Tests" \
-  node scripts/functional_tests \
-    --config test/api_integration/config.js \
-    --bail \
-    --debug
+node scripts/functional_tests \
+  --config test/api_integration/config.js \
+  --bail \
+  --debug

--- a/.buildkite/scripts/steps/test/jest.sh
+++ b/.buildkite/scripts/steps/test/jest.sh
@@ -9,5 +9,4 @@ is_test_execution_step
 .buildkite/scripts/bootstrap.sh
 
 echo '--- Jest'
-checks-reporter-with-killswitch "Jest Unit Tests $((BUILDKITE_PARALLEL_JOB+1))" \
-  .buildkite/scripts/steps/test/jest_parallel.sh jest.config.js
+.buildkite/scripts/steps/test/jest_parallel.sh jest.config.js

--- a/.buildkite/scripts/steps/test/jest_integration.sh
+++ b/.buildkite/scripts/steps/test/jest_integration.sh
@@ -10,5 +10,4 @@ is_test_execution_step
 .buildkite/scripts/copy_es_snapshot_cache.sh
 
 echo '--- Jest Integration Tests'
-checks-reporter-with-killswitch "Jest Integration Tests $((BUILDKITE_PARALLEL_JOB+1))" \
-  .buildkite/scripts/steps/test/jest_parallel.sh jest.integration.config.js
+.buildkite/scripts/steps/test/jest_parallel.sh jest.integration.config.js

--- a/package.json
+++ b/package.json
@@ -442,7 +442,6 @@
     "@cypress/grep": "^3.1.5",
     "@cypress/webpack-preprocessor": "^5.12.2",
     "@elastic/eslint-plugin-eui": "0.0.2",
-    "@elastic/github-checks-reporter": "0.0.20b3",
     "@elastic/makelogs": "^6.1.1",
     "@elastic/synthetics": "~1.0.0",
     "@emotion/babel-preset-css-prop": "^11.11.0",

--- a/src/dev/ci_setup/setup_env.sh
+++ b/src/dev/ci_setup/setup_env.sh
@@ -143,26 +143,6 @@ else
   echo "Chrome not detected, installing default chromedriver binary for the package version"
 fi
 
-### only run on pr jobs for elastic/kibana, checks-reporter doesn't work for other repos
-if [[ "$ghprbPullId" && "$ghprbGhRepository" == 'elastic/kibana' ]] ; then
-  export CHECKS_REPORTER_ACTIVE=true
-fi
-
-###
-### Implements github-checks-reporter kill switch when scripts are called from the command line
-### $@ - all arguments
-###
-function checks-reporter-with-killswitch() {
-  if [ "$CHECKS_REPORTER_ACTIVE" == "true" ] ; then
-    yarn run github-checks-reporter "$@"
-  else
-    arguments=("$@");
-    "${arguments[@]:1}";
-  fi
-}
-
-export -f checks-reporter-with-killswitch
-
 source "$KIBANA_DIR/src/dev/ci_setup/load_env_keys.sh"
 
 ES_DIR="$WORKSPACE/elasticsearch"

--- a/test/scripts/checks/bundle_limits.sh
+++ b/test/scripts/checks/bundle_limits.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Bundle Limits" \
-  node scripts/build_kibana_platform_plugins --validate-limits
+node scripts/build_kibana_platform_plugins --validate-limits

--- a/test/scripts/checks/commit/commit.sh
+++ b/test/scripts/checks/commit/commit.sh
@@ -7,5 +7,4 @@ source src/dev/ci_setup/setup_env.sh
 # the pre-commit hook installation by default.
 # If files are more than 200 we will skip it and just use
 # the further ci steps that already check linting and file casing for the entire repo.
-checks-reporter-with-killswitch "Quick commit checks" \
-  "$(dirname "${0}")/commit_check_runner.sh"
+"$(dirname "${0}")/commit_check_runner.sh"

--- a/test/scripts/checks/doc_api_changes.sh
+++ b/test/scripts/checks/doc_api_changes.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Doc API Changes" \
-  node scripts/check_published_api_changes
+node scripts/check_published_api_changes

--- a/test/scripts/checks/file_casing.sh
+++ b/test/scripts/checks/file_casing.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check File Casing" \
-  node scripts/check_file_casing --quiet
+node scripts/check_file_casing --quiet

--- a/test/scripts/checks/i18n.sh
+++ b/test/scripts/checks/i18n.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check i18n" \
-  node scripts/i18n_check --ignore-missing
+node scripts/i18n_check --ignore-missing

--- a/test/scripts/checks/jest_configs.sh
+++ b/test/scripts/checks/jest_configs.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Jest Configs" \
-  node scripts/check_jest_configs
+node scripts/check_jest_configs

--- a/test/scripts/checks/licenses.sh
+++ b/test/scripts/checks/licenses.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Licenses" \
-  node scripts/check_licenses --dev
+node scripts/check_licenses --dev

--- a/test/scripts/checks/plugins_with_circular_deps.sh
+++ b/test/scripts/checks/plugins_with_circular_deps.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Plugins With Circular Dependencies" \
-  node scripts/find_plugins_with_circular_deps
+node scripts/find_plugins_with_circular_deps

--- a/test/scripts/checks/telemetry.sh
+++ b/test/scripts/checks/telemetry.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Telemetry Schema" \
-  node scripts/telemetry_check
+node scripts/telemetry_check

--- a/test/scripts/checks/test_hardening.sh
+++ b/test/scripts/checks/test_hardening.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Test Hardening" \
-  node scripts/test_hardening
+node scripts/test_hardening

--- a/test/scripts/checks/test_projects.sh
+++ b/test/scripts/checks/test_projects.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Test Projects" \
-  yarn kbn run test --exclude kibana --oss --skip-kibana-plugins --skip-missing
+yarn kbn run test --exclude kibana --oss --skip-kibana-plugins --skip-missing

--- a/test/scripts/checks/ts_projects.sh
+++ b/test/scripts/checks/ts_projects.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check TypeScript Projects" \
-  node scripts/check_ts_projects
+node scripts/check_ts_projects

--- a/test/scripts/checks/type_check_plugin_public_api_docs.sh
+++ b/test/scripts/checks/type_check_plugin_public_api_docs.sh
@@ -2,14 +2,12 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Build TS Refs" \
-  node scripts/build_ts_refs \
+node scripts/build_ts_refs \
     --clean \
     --no-cache \
     --force
 
-checks-reporter-with-killswitch "Check Types" \
-  node scripts/type_check
+node scripts/type_check
 
 echo " -- building api docs"
 node --max-old-space-size=12000 scripts/build_api_docs

--- a/test/scripts/checks/verify_notice.sh
+++ b/test/scripts/checks/verify_notice.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Verify NOTICE" \
-  node scripts/notice --validate
+node scripts/notice --validate

--- a/test/scripts/jenkins_accessibility.sh
+++ b/test/scripts/jenkins_accessibility.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Kibana accessibility tests" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/accessibility/config.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/accessibility/config.ts;

--- a/test/scripts/jenkins_apm_cypress.sh
+++ b/test/scripts/jenkins_apm_cypress.sh
@@ -5,8 +5,7 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running APM cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "APM Cypress Tests" \
- node plugins/apm/scripts/test/e2e.js
+node plugins/apm/scripts/test/e2e.js
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_build_kbn_sample_panel_action.sh
+++ b/test/scripts/jenkins_build_kbn_sample_panel_action.sh
@@ -4,6 +4,6 @@ source src/dev/ci_setup/setup_env.sh
 
 cd test/plugin_functional/plugins/kbn_sample_panel_action;
 if [[ ! -d "target" ]]; then
-  checks-reporter-with-killswitch "Build kbn_sample_panel_action" yarn build;
+  yarn build;
 fi
 cd -;

--- a/test/scripts/jenkins_ci_group.sh
+++ b/test/scripts/jenkins_ci_group.sh
@@ -2,11 +2,10 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Functional tests / Group ${CI_GROUP}" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --include-tag "ciGroup$CI_GROUP"
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --include-tag "ciGroup$CI_GROUP"
 
 if [[ ! "$TASK_QUEUE_PROCESS_ID" && "$CI_GROUP" == "1" ]]; then
   source test/scripts/jenkins_build_kbn_sample_panel_action.sh

--- a/test/scripts/jenkins_firefox_smoke.sh
+++ b/test/scripts/jenkins_firefox_smoke.sh
@@ -2,9 +2,8 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Firefox smoke test" \
-  node scripts/functional_tests \
-    --bail --debug \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --include-tag "includeFirefox" \
-    --config test/functional/config.firefox.js;
+node scripts/functional_tests \
+  --bail --debug \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --include-tag "includeFirefox" \
+  --config test/functional/config.firefox.js;

--- a/test/scripts/jenkins_security_solution_cypress_chrome.sh
+++ b/test/scripts/jenkins_security_solution_cypress_chrome.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running security solution cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Security Solution Cypress Tests (Chrome)" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-   --config test/security_solution_cypress/cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/security_solution_cypress/cli_config.ts
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_security_solution_cypress_firefox.sh
+++ b/test/scripts/jenkins_security_solution_cypress_firefox.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running security solution cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Security Solution Cypress Tests (Firefox)" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-   --config test/security_solution_cypress/config.firefox.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/security_solution_cypress/config.firefox.ts
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_uptime_playwright.sh
+++ b/test/scripts/jenkins_uptime_playwright.sh
@@ -5,8 +5,7 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running Uptime @elastic/synthetics tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Uptime @elastic/synthetics Tests" \
- node plugins/uptime/scripts/e2e.js
+node plugins/uptime/scripts/e2e.js
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_xpack_accessibility.sh
+++ b/test/scripts/jenkins_xpack_accessibility.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_xpack.sh
 
-checks-reporter-with-killswitch "X-Pack accessibility tests" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/accessibility/config.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/accessibility/config.ts;

--- a/test/scripts/jenkins_xpack_ci_group.sh
+++ b/test/scripts/jenkins_xpack_ci_group.sh
@@ -5,8 +5,7 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running functional and api tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "X-Pack Chrome Functional tests / Group ${CI_GROUP}" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --include-tag "ciGroup$CI_GROUP"
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --include-tag "ciGroup$CI_GROUP"

--- a/test/scripts/jenkins_xpack_firefox_smoke.sh
+++ b/test/scripts/jenkins_xpack_firefox_smoke.sh
@@ -2,10 +2,9 @@
 
 source test/scripts/jenkins_test_setup_xpack.sh
 
-checks-reporter-with-killswitch "X-Pack firefox smoke test" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --include-tag "includeFirefox" \
-    --config test/functional/config.firefox.js \
-    --config test/functional_embedded/config.firefox.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --include-tag "includeFirefox" \
+  --config test/functional/config.firefox.js \
+  --config test/functional_embedded/config.firefox.ts;

--- a/test/scripts/jenkins_xpack_saved_objects_field_metrics.sh
+++ b/test/scripts/jenkins_xpack_saved_objects_field_metrics.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_xpack.sh
 
-checks-reporter-with-killswitch "Capture Kibana Saved Objects field count metrics" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/saved_objects_field_count/config.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/saved_objects_field_count/config.ts;

--- a/test/scripts/lint/eslint.sh
+++ b/test/scripts/lint/eslint.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Lint: eslint" \
-  node scripts/eslint --no-cache
+node scripts/eslint --no-cache

--- a/test/scripts/lint/stylelint.sh
+++ b/test/scripts/lint/stylelint.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Lint: stylelint" \
-  node scripts/stylelint
+node scripts/stylelint

--- a/test/scripts/test/api_integration.sh
+++ b/test/scripts/test/api_integration.sh
@@ -2,8 +2,7 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "API Integration Tests" \
-  node scripts/functional_tests \
-    --config test/api_integration/config.js \
-    --bail \
-    --debug
+node scripts/functional_tests \
+  --config test/api_integration/config.js \
+  --bail \
+  --debug

--- a/test/scripts/test/interpreter_functional.sh
+++ b/test/scripts/test/interpreter_functional.sh
@@ -2,9 +2,8 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Interpreter Functional Tests" \
-  node scripts/functional_tests \
-    --config test/interpreter_functional/config.ts \
-    --bail \
-    --debug \
-    --kibana-install-dir $KIBANA_INSTALL_DIR
+node scripts/functional_tests \
+  --config test/interpreter_functional/config.ts \
+  --bail \
+  --debug \
+  --kibana-install-dir $KIBANA_INSTALL_DIR

--- a/test/scripts/test/jest_integration.sh
+++ b/test/scripts/test/jest_integration.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Jest Integration Tests" \
-  node --max-old-space-size=5120 scripts/jest_integration --ci
+node --max-old-space-size=5120 scripts/jest_integration --ci

--- a/test/scripts/test/jest_unit.sh
+++ b/test/scripts/test/jest_unit.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Jest Unit Tests" \
-  node scripts/jest --ci --maxWorkers=6
+node scripts/jest --ci --maxWorkers=6

--- a/test/scripts/test/plugin_functional.sh
+++ b/test/scripts/test/plugin_functional.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Plugin Functional Tests" \
-  node scripts/functional_tests \
-    --config test/plugin_functional/config.ts \
-    --bail \
-    --debug
+node scripts/functional_tests \
+  --config test/plugin_functional/config.ts \
+  --bail \
+  --debug

--- a/test/scripts/test/server_integration.sh
+++ b/test/scripts/test/server_integration.sh
@@ -2,20 +2,18 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Server Integration Tests" \
-  node scripts/functional_tests \
-    --config test/server_integration/http/ssl/config.js \
-    --config test/server_integration/http/ssl_redirect/config.js \
-    --config test/server_integration/http/platform/config.ts \
-    --config test/server_integration/http/ssl_with_p12/config.js \
-    --config test/server_integration/http/ssl_with_p12_intermediate/config.js \
-    --bail \
-    --debug \
-    --kibana-install-dir $KIBANA_INSTALL_DIR
+node scripts/functional_tests \
+  --config test/server_integration/http/ssl/config.js \
+  --config test/server_integration/http/ssl_redirect/config.js \
+  --config test/server_integration/http/platform/config.ts \
+  --config test/server_integration/http/ssl_with_p12/config.js \
+  --config test/server_integration/http/ssl_with_p12_intermediate/config.js \
+  --bail \
+  --debug \
+  --kibana-install-dir $KIBANA_INSTALL_DIR
 
 # Tests that must be run against source in order to build test plugins
-checks-reporter-with-killswitch "Status Integration Tests" \
-  node scripts/functional_tests \
-    --config test/server_integration/http/platform/config.status.ts \
-    --bail \
-    --debug \
+node scripts/functional_tests \
+  --config test/server_integration/http/platform/config.status.ts \
+  --bail \
+  --debug \

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "license": "Elastic-License",
   "scripts": {
-    "github-checks-reporter": "../node_modules/.bin/github-checks-reporter",
     "kbn": "node ../scripts/kbn",
     "start": "node ../scripts/kibana --dev",
     "build": "node --preserve-symlinks ../node_modules/.bin/gulp build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,18 +1643,6 @@
   resolved "https://registry.yarnpkg.com/@elastic/filesaver/-/filesaver-1.1.2.tgz#1998ffb3cd89c9da4ec12a7793bfcae10e30c77a"
   integrity sha512-YZbSufYFBhAj+S2cJgiKALoxIJevqXN2MSr6Yqr42rJdaPuM31cj6pUDwflkql1oDjupqD9la+MfxPFjXI1JFQ==
 
-"@elastic/github-checks-reporter@0.0.20b3":
-  version "0.0.20-b3"
-  resolved "https://registry.yarnpkg.com/@elastic/github-checks-reporter/-/github-checks-reporter-0.0.20-b3.tgz#025ac0e152cda03d947faec190c244fbbe59bdfc"
-  integrity sha512-OmhbddqNkFZMYVQxMqpqLj7NJhqphN+wQb68IeiewxvWXq8NEPaBpaZ9f+nUbixmMY2Q/XA0JgtuE4EhMGIljg==
-  dependencies:
-    "@octokit/app" "^2.2.2"
-    "@octokit/plugin-retry" "^2.2.0"
-    "@octokit/request" "^2.4.2"
-    "@octokit/rest" "^16.23.2"
-    async-retry "^1.2.3"
-    strip-ansi "^5.2.0"
-
 "@elastic/good@^9.0.1-kibana3":
   version "9.0.1-kibana3"
   resolved "https://registry.yarnpkg.com/@elastic/good/-/good-9.0.1-kibana3.tgz#a70c2b30cbb4f44d1cf4a464562e0680322eac9b"
@@ -3543,16 +3531,6 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@octokit/app@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@octokit/app/-/app-2.2.2.tgz#a1b8248f64159eeccbe4000d888fdae4163c4ad8"
-  integrity sha512-nUwS8jW107ROGuI0Tq4Ga+Zno6CovwaS+Oen6BOKJmoFMLqqB3oXeGZ6InkidtdmUNiYhMtNq2lydb0WVLT8Zg==
-  dependencies:
-    "@octokit/request" "^2.1.2"
-    "@types/lru-cache" "^5.1.0"
-    jsonwebtoken "^8.3.0"
-    lru-cache "^5.1.1"
-
 "@octokit/auth-token@^2.4.0":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.4.tgz#ee31c69b01d0378c12fd3ffe406030f3d94d3b56"
@@ -3577,16 +3555,6 @@
     "@octokit/types" "^13.0.0"
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
-
-"@octokit/endpoint@^3.2.0":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-3.2.3.tgz#bd9aea60cd94ce336656b57a5c9cb7f10be8f4f3"
-  integrity sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==
-  dependencies:
-    deepmerge "3.2.0"
-    is-plain-object "^2.0.4"
-    universal-user-agent "^2.0.1"
-    url-template "^2.0.8"
 
 "@octokit/endpoint@^6.0.1":
   version "6.0.6"
@@ -3663,13 +3631,6 @@
     "@octokit/types" "^2.0.1"
     deprecation "^2.3.1"
 
-"@octokit/plugin-retry@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-2.2.0.tgz#11f3957a46ccdb7b7f33caabf8c17e57b25b80b2"
-  integrity sha512-x5Kd8Lke+a4hTDCe5akZxpGmVwu1eeVt2FJX0jeo3CxHGbfHbXb4zhN5quKfGL9oBLV/EdHQIJ6zwIMjuzxOlw==
-  dependencies:
-    bottleneck "^2.15.3"
-
 "@octokit/request-error@^1.0.2":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.2.1.tgz#ede0714c773f32347576c25649dc013ae6b31801"
@@ -3697,18 +3658,6 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^2.1.2", "@octokit/request@^2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-2.4.2.tgz#87c36e820dd1e43b1629f4f35c95b00cd456320b"
-  integrity sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==
-  dependencies:
-    "@octokit/endpoint" "^3.2.0"
-    deprecation "^1.0.1"
-    is-plain-object "^2.0.4"
-    node-fetch "^2.3.0"
-    once "^1.4.0"
-    universal-user-agent "^2.0.1"
-
 "@octokit/request@^5.2.0":
   version "5.4.12"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.12.tgz#b04826fa934670c56b135a81447be2c1723a2ffc"
@@ -3733,7 +3682,7 @@
     "@octokit/types" "^13.1.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^16.23.2", "@octokit/rest@^16.35.0":
+"@octokit/rest@^16.35.0":
   version "16.43.2"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.43.2.tgz#c53426f1e1d1044dee967023e3279c50993dd91b"
   integrity sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==
@@ -6055,11 +6004,6 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
-"@types/lru-cache@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
-  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
-
 "@types/lz-string@^1.3.34":
   version "1.3.34"
   resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.34.tgz#69bfadde419314b4a374bf2c8e58659c035ed0a5"
@@ -8171,13 +8115,6 @@ async-done@^1.2.0, async-done@^1.2.2:
     process-nextick-args "^2.0.0"
     stream-exhaust "^1.0.1"
 
-async-retry@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
-  integrity sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==
-  dependencies:
-    retry "0.12.0"
-
 async-settle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-settle/-/async-settle-1.0.0.tgz#1d0a914bb02575bec8a8f3a74e5080f72b2c0c6b"
@@ -8815,11 +8752,6 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bottleneck@^2.15.3:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.18.0.tgz#41fa63ae185b65435d789d1700334bc48222dacf"
-  integrity sha512-U1xiBRaokw4yEguzikOl0VrnZp6uekjpmfrh6rKtr1D+/jFjYCL6J83ZXlGtlBDwVdTmJJ+4Lg5FpB3xmLSiyA==
-
 bowser@^1.7.3:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
@@ -9045,11 +8977,6 @@ buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
-buffer-equal-constant-time@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
-  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-equal@^1.0.0:
   version "1.0.0"
@@ -11290,11 +11217,6 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
-  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
-
 deepmerge@^4.2.2, deepmerge@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
@@ -11493,11 +11415,6 @@ dependency-tree@^10.0.9:
     filing-cabinet "^4.1.6"
     precinct "^11.0.5"
     typescript "^5.0.4"
-
-deprecation@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-1.0.1.tgz#2df79b79005752180816b7b6e079cbd80490d711"
-  integrity sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==
 
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
@@ -12004,13 +11921,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-ecdsa-sig-formatter@1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
-  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
-  dependencies:
-    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -17450,22 +17360,6 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonwebtoken@^8.3.0:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
-  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
-  dependencies:
-    jws "^3.2.2"
-    lodash.includes "^4.3.0"
-    lodash.isboolean "^3.0.3"
-    lodash.isinteger "^4.0.4"
-    lodash.isnumber "^3.0.3"
-    lodash.isplainobject "^4.0.6"
-    lodash.isstring "^4.0.1"
-    lodash.once "^4.0.0"
-    ms "^2.1.1"
-    semver "^5.6.0"
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -17533,23 +17427,6 @@ just-reduce-object@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/just-reduce-object/-/just-reduce-object-1.1.0.tgz#d29d172264f8511c74462de30d72d5838b6967e6"
   integrity sha512-nGyg7N9FEZsyrGQNilkyVLxKPsf96iel5v0DrozQ19ML+96HntyS/53bOP68iK/kZUGvsL3FKygV8nQYYhgTFw==
-
-jwa@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
-  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
-  dependencies:
-    buffer-equal-constant-time "1.0.1"
-    ecdsa-sig-formatter "1.0.11"
-    safe-buffer "^5.0.1"
-
-jws@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
-  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
-  dependencies:
-    jwa "^1.4.1"
-    safe-buffer "^5.0.1"
 
 kdbush@^3.0.0:
   version "3.0.0"
@@ -17998,16 +17875,6 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash.includes@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
-  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
-
-lodash.isboolean@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
-  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
-
 lodash.isempty@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
@@ -18022,16 +17889,6 @@ lodash.isfunction@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
   integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
-
-lodash.isinteger@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
-  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
-
-lodash.isnumber@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
-  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
 
 lodash.isobject@^3.0.2:
   version "3.0.2"
@@ -18058,7 +17915,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.once@^4.0.0, lodash.once@^4.1.1:
+lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
@@ -19486,7 +19343,7 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@^1.0.1, node-fetch@^2.3.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^1.0.1, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.8.tgz#a68d30b162bc1d8fd71a367e81b997e1f4d4937e"
   integrity sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==
@@ -20119,7 +19976,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-name@^3.0.0, os-name@^3.1.0:
+os-name@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
   integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
@@ -23445,7 +23302,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@0.12.0, retry@^0.12.0:
+retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
@@ -26703,13 +26560,6 @@ unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   dependencies:
     unist-util-visit-parents "^2.0.0"
 
-universal-user-agent@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
-  integrity sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==
-  dependencies:
-    os-name "^3.0.0"
-
 universal-user-agent@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.1.tgz#fd8d6cb773a679a709e967ef8288a31fcc03e557"
@@ -26848,11 +26698,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url-template@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
-  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
We've mostly moved over to fewer checks in favor of PR comments to reduce the number of API calls.  This is already removed on other branches and the application will be shutdown after.
