### PR TITLE
[8.19] [ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled (#227860)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/index.ts
@@ -20,6 +20,7 @@ import {
 import { createCasesAnalyticsIndex, scheduleCasesAnalyticsSyncTask } from './cases_index';
 import { createCommentsAnalyticsIndex, scheduleCommentsAnalyticsSyncTask } from './comments_index';
 import { createActivityAnalyticsIndex, scheduleActivityAnalyticsSyncTask } from './activity_index';
+import type { ConfigType } from '../config';
 
 export const createCasesAnalyticsIndexes = ({
   esClient,
@@ -69,13 +70,15 @@ export const registerCasesAnalyticsIndexesTasks = ({
   taskManager,
   logger,
   core,
+  analyticsConfig,
 }: {
   taskManager: TaskManagerSetupContract;
   logger: Logger;
   core: CoreSetup<CasesServerStartDependencies>;
+  analyticsConfig: ConfigType['analytics'];
 }) => {
-  registerCAIBackfillTask({ taskManager, logger, core });
-  registerCAISynchronizationTask({ taskManager, logger, core });
+  registerCAIBackfillTask({ taskManager, logger, core, analyticsConfig });
+  registerCAISynchronizationTask({ taskManager, logger, core, analyticsConfig });
 };
 
 export const scheduleCasesAnalyticsSyncTasks = ({

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_factory.ts
@@ -7,20 +7,28 @@
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { RunContext } from '@kbn/task-manager-plugin/server';
+import type { ConfigType } from '../../../config';
 import { BackfillTaskRunner } from './backfill_task_runner';
 
 interface CaseAnalyticsIndexBackfillTaskFactoryParams {
   logger: Logger;
   getESClient: () => Promise<ElasticsearchClient>;
+  analyticsConfig: ConfigType['analytics'];
 }
 
 export class CaseAnalyticsIndexBackfillTaskFactory {
   private readonly logger: Logger;
   private readonly getESClient: () => Promise<ElasticsearchClient>;
+  private readonly analyticsConfig: ConfigType['analytics'];
 
-  constructor({ logger, getESClient }: CaseAnalyticsIndexBackfillTaskFactoryParams) {
+  constructor({
+    logger,
+    getESClient,
+    analyticsConfig,
+  }: CaseAnalyticsIndexBackfillTaskFactoryParams) {
     this.logger = logger;
     this.getESClient = getESClient;
+    this.analyticsConfig = analyticsConfig;
   }
 
   public create(context: RunContext) {
@@ -28,6 +36,7 @@ export class CaseAnalyticsIndexBackfillTaskFactory {
       taskInstance: context.taskInstance,
       logger: this.logger,
       getESClient: this.getESClient,
+      analyticsConfig: this.analyticsConfig,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.test.ts
@@ -27,6 +27,12 @@ describe('BackfillTaskRunner', () => {
 
   let taskRunner: BackfillTaskRunner;
 
+  const analyticsConfig = {
+    index: {
+      enabled: true,
+    },
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -61,6 +67,7 @@ describe('BackfillTaskRunner', () => {
       logger,
       getESClient,
       taskInstance,
+      analyticsConfig,
     });
 
     const result = await taskRunner.run();
@@ -100,6 +107,7 @@ describe('BackfillTaskRunner', () => {
         logger,
         getESClient,
         taskInstance,
+        analyticsConfig,
       });
 
       try {
@@ -130,6 +138,7 @@ describe('BackfillTaskRunner', () => {
         logger,
         getESClient,
         taskInstance,
+        analyticsConfig,
       });
 
       try {
@@ -142,6 +151,31 @@ describe('BackfillTaskRunner', () => {
         '[.dest-index] Backfill reindex failed. Error: My unrecoverable error',
         { tags: ['cai-backfill', 'cai-backfill-error', '.dest-index'] }
       );
+    });
+  });
+
+  describe('Analytics index disabled', () => {
+    const analyticsConfigDisabled = {
+      index: {
+        enabled: false,
+      },
+    };
+
+    it('does not call the reindex API if analytics is disabled', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      const getESClient = async () => esClient;
+
+      taskRunner = new BackfillTaskRunner({
+        logger,
+        getESClient,
+        taskInstance,
+        analyticsConfig: analyticsConfigDisabled,
+      });
+
+      await taskRunner.run();
+
+      expect(esClient.cluster.health).not.toBeCalled();
+      expect(esClient.reindex).not.toBeCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/backfill_task_runner.ts
@@ -19,12 +19,14 @@ import type {
   IndicesGetMappingResponse,
   QueryDslQueryContainer,
 } from '@elastic/elasticsearch/lib/api/types';
+import type { ConfigType } from '../../../config';
 import { isRetryableEsClientError } from '../../utils';
 
 interface BackfillTaskRunnerFactoryConstructorParams {
   taskInstance: ConcreteTaskInstance;
   getESClient: () => Promise<ElasticsearchClient>;
   logger: Logger;
+  analyticsConfig: ConfigType['analytics'];
 }
 
 export class BackfillTaskRunner implements CancellableTask {
@@ -34,16 +36,28 @@ export class BackfillTaskRunner implements CancellableTask {
   private readonly getESClient: () => Promise<ElasticsearchClient>;
   private readonly logger: Logger;
   private readonly errorSource = TaskErrorSource.FRAMEWORK;
+  private readonly analyticsConfig: ConfigType['analytics'];
 
-  constructor({ taskInstance, getESClient, logger }: BackfillTaskRunnerFactoryConstructorParams) {
+  constructor({
+    taskInstance,
+    getESClient,
+    logger,
+    analyticsConfig,
+  }: BackfillTaskRunnerFactoryConstructorParams) {
     this.sourceIndex = taskInstance.params.sourceIndex;
     this.destIndex = taskInstance.params.destIndex;
     this.sourceQuery = taskInstance.params.sourceQuery;
     this.getESClient = getESClient;
     this.logger = logger;
+    this.analyticsConfig = analyticsConfig;
   }
 
   public async run() {
+    if (!this.analyticsConfig.index.enabled) {
+      this.logDebug('Analytics index is disabled, skipping backfill task.');
+      return;
+    }
+
     const esClient = await this.getESClient();
     try {
       await this.waitForDestIndex(esClient);

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/backfill_task/index.ts
@@ -13,6 +13,7 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { ConfigType } from '../../../config';
 import { ANALYTICS_BACKFILL_TASK_TYPE } from '../../../../common/constants';
 import type { CasesServerStartDependencies } from '../../../types';
 import { CaseAnalyticsIndexBackfillTaskFactory } from './backfill_task_factory';
@@ -22,10 +23,12 @@ export function registerCAIBackfillTask({
   taskManager,
   logger,
   core,
+  analyticsConfig,
 }: {
   taskManager: TaskManagerSetupContract;
   logger: Logger;
   core: CoreSetup<CasesServerStartDependencies>;
+  analyticsConfig: ConfigType['analytics'];
 }) {
   const getESClient = async (): Promise<ElasticsearchClient> => {
     const [{ elasticsearch }] = await core.getStartServices();
@@ -37,7 +40,11 @@ export function registerCAIBackfillTask({
       title: 'Backfill cases analytics indexes.',
       maxAttempts: 3,
       createTaskRunner: (context: RunContext) => {
-        return new CaseAnalyticsIndexBackfillTaskFactory({ getESClient, logger }).create(context);
+        return new CaseAnalyticsIndexBackfillTaskFactory({
+          getESClient,
+          logger,
+          analyticsConfig,
+        }).create(context);
       },
     },
   });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/index.ts
@@ -13,6 +13,7 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
+import type { ConfigType } from '../../../config';
 import { ANALYTICS_SYNCHRONIZATION_TASK_TYPE } from '../../../../common/constants';
 import type { CasesServerStartDependencies } from '../../../types';
 import { AnalyticsIndexSynchronizationTaskFactory } from './synchronization_task_factory';
@@ -23,10 +24,12 @@ export function registerCAISynchronizationTask({
   taskManager,
   logger,
   core,
+  analyticsConfig,
 }: {
   taskManager: TaskManagerSetupContract;
   logger: Logger;
   core: CoreSetup<CasesServerStartDependencies>;
+  analyticsConfig: ConfigType['analytics'];
 }) {
   const getESClient = async (): Promise<ElasticsearchClient> => {
     const [{ elasticsearch }] = await core.getStartServices();
@@ -37,9 +40,11 @@ export function registerCAISynchronizationTask({
     [ANALYTICS_SYNCHRONIZATION_TASK_TYPE]: {
       title: 'Synchronization for the cases analytics index',
       createTaskRunner: (context: RunContext) => {
-        return new AnalyticsIndexSynchronizationTaskFactory({ getESClient, logger }).create(
-          context
-        );
+        return new AnalyticsIndexSynchronizationTaskFactory({
+          getESClient,
+          logger,
+          analyticsConfig,
+        }).create(context);
       },
     },
   });

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_factory.ts
@@ -7,20 +7,28 @@
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { RunContext } from '@kbn/task-manager-plugin/server';
+import type { ConfigType } from '../../../config';
 import { SynchronizationTaskRunner } from './synchronization_task_runner';
 
 interface AnalyticsIndexSynchronizationTaskFactoryParams {
   logger: Logger;
   getESClient: () => Promise<ElasticsearchClient>;
+  analyticsConfig: ConfigType['analytics'];
 }
 
 export class AnalyticsIndexSynchronizationTaskFactory {
   private readonly logger: Logger;
   private readonly getESClient: () => Promise<ElasticsearchClient>;
+  private readonly analyticsConfig: ConfigType['analytics'];
 
-  constructor({ logger, getESClient }: AnalyticsIndexSynchronizationTaskFactoryParams) {
+  constructor({
+    logger,
+    getESClient,
+    analyticsConfig,
+  }: AnalyticsIndexSynchronizationTaskFactoryParams) {
     this.logger = logger;
     this.getESClient = getESClient;
+    this.analyticsConfig = analyticsConfig;
   }
 
   public create(context: RunContext) {
@@ -28,6 +36,7 @@ export class AnalyticsIndexSynchronizationTaskFactory {
       taskInstance: context.taskInstance,
       logger: this.logger,
       getESClient: this.getESClient,
+      analyticsConfig: this.analyticsConfig,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics/tasks/synchronization_task/synchronization_task_runner.test.ts
@@ -47,6 +47,12 @@ describe('SynchronizationTaskRunner', () => {
 
   let taskRunner: SynchronizationTaskRunner;
 
+  const analyticsConfig = {
+    index: {
+      enabled: true,
+    },
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers().setSystemTime(newAttemptTime);
@@ -87,6 +93,7 @@ describe('SynchronizationTaskRunner', () => {
       logger,
       getESClient,
       taskInstance,
+      analyticsConfig,
     });
 
     const result = await taskRunner.run();
@@ -175,6 +182,7 @@ describe('SynchronizationTaskRunner', () => {
         ...taskInstance,
         state: {},
       },
+      analyticsConfig,
     });
 
     const result = await taskRunner.run();
@@ -249,6 +257,7 @@ describe('SynchronizationTaskRunner', () => {
       logger,
       getESClient,
       taskInstance,
+      analyticsConfig,
     });
 
     const result = await taskRunner.run();
@@ -272,6 +281,7 @@ describe('SynchronizationTaskRunner', () => {
       logger,
       getESClient,
       taskInstance,
+      analyticsConfig,
     });
 
     const result = await taskRunner.run();
@@ -346,6 +356,7 @@ describe('SynchronizationTaskRunner', () => {
         logger,
         getESClient,
         taskInstance,
+        analyticsConfig,
       });
 
       try {
@@ -369,6 +380,7 @@ describe('SynchronizationTaskRunner', () => {
         logger,
         getESClient,
         taskInstance,
+        analyticsConfig,
       });
 
       try {
@@ -381,6 +393,31 @@ describe('SynchronizationTaskRunner', () => {
         '[.internal.cases] Synchronization reindex failed. Error: My unrecoverable error',
         { tags: ['cai-synchronization', 'cai-synchronization-error', '.internal.cases'] }
       );
+    });
+  });
+
+  describe('Analytics index disabled', () => {
+    const analyticsConfigDisabled = {
+      index: {
+        enabled: false,
+      },
+    };
+
+    it('does not call the reindex API if analytics is disabled', async () => {
+      const getESClient = async () => esClient;
+
+      taskRunner = new SynchronizationTaskRunner({
+        logger,
+        getESClient,
+        taskInstance,
+        analyticsConfig: analyticsConfigDisabled,
+      });
+
+      await taskRunner.run();
+
+      expect(esClient.tasks.get).not.toBeCalled();
+      expect(esClient.cluster.health).not.toBeCalled();
+      expect(esClient.reindex).not.toBeCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TypeOf } from '@kbn/config-schema';
-import { schema } from '@kbn/config-schema';
+import { schema, offeringBasedSchema } from '@kbn/config-schema';
 import { ALLOWED_MIME_TYPES } from '../common/constants/mime_types';
 
 export const ConfigSchema = schema.object({
@@ -25,7 +25,10 @@ export const ConfigSchema = schema.object({
   }),
   analytics: schema.object({
     index: schema.object({
-      enabled: schema.boolean({ defaultValue: true }),
+      enabled: offeringBasedSchema({
+        serverless: schema.boolean({ defaultValue: false }),
+        traditional: schema.boolean({ defaultValue: true }),
+      }),
     }),
   }),
 });

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -106,6 +106,7 @@ export class CasePlugin
       taskManager: plugins.taskManager,
       logger: this.logger,
       core,
+      analyticsConfig: this.caseConfig.analytics,
     });
 
     this.securityPluginSetup = plugins.security;

--- a/x-pack/platform/test/cases_api_integration/common/config.ts
+++ b/x-pack/platform/test/cases_api_integration/common/config.ts
@@ -118,6 +118,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
             : []),
           '--xpack.ruleRegistry.write.enabled=true',
           '--xpack.ruleRegistry.write.cache.enabled=false',
+          '--xpack.cases.analytics.index.enabled=true',
         ],
       },
     };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled (#227860)](https://github.com/elastic/kibana/pull/227860)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2025-07-15T10:13:51Z","message":"[ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled (#227860)\n\n## Summary\n\nThis PR skips the execution of the CAI tasks if the feature is disabled.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"be184bb8d86ed2ec932d84c063f7536edc85dc7d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","Feature:Cases","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled","number":227860,"url":"https://github.com/elastic/kibana/pull/227860","mergeCommit":{"message":"[ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled (#227860)\n\n## Summary\n\nThis PR skips the execution of the CAI tasks if the feature is disabled.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"be184bb8d86ed2ec932d84c063f7536edc85dc7d"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/227970","number":227970,"state":"MERGED","mergeCommit":{"sha":"ad97bf24b022c2aec8dc19431537fe8e3fcd1ca2","message":"[9.1] [ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled (#227860) (#227970)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[ResponseOps][Cases] Skip the execution of the CAI tasks when the\nfeature is disabled\n(#227860)](https://github.com/elastic/kibana/pull/227860)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Christos Nasikas <christos.nasikas@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227860","number":227860,"mergeCommit":{"message":"[ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled (#227860)\n\n## Summary\n\nThis PR skips the execution of the CAI tasks if the feature is disabled.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"be184bb8d86ed2ec932d84c063f7536edc85dc7d"}},{"url":"https://github.com/elastic/kibana/pull/227968","number":227968,"branch":"deploy-fix@1752473612","state":"MERGED","mergeCommit":{"sha":"5f662c1a33358d066b7c7e56af3924ebd3c279d8","message":"[ResponseOps][Cases] Skip the execution of the CAI tasks when the feature is disabled (#227860) (#227968)\n\n## Summary\n\nCherry-picking https://github.com/elastic/kibana/pull/227860 for the\nemergency release.\n\nCo-authored-by: Christos Nasikas <christos.nasikas@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->