### PR TITLE
[Security Solution] Fix Cypress test error by forcing enter after typing into input field

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -73,8 +73,7 @@ const expectedExistingSlackMessage = 'Existing slack action';
 const expectedSlackMessage = 'Slack action test message';
 
 // https://github.com/elastic/kibana/issues/179958
-// Failing: See https://github.com/elastic/kibana/issues/227885
-describe.skip(
+describe(
   'Detection rules, bulk edit of rule actions',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/common/rule_actions.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/common/rule_actions.ts
@@ -70,7 +70,7 @@ export const createEmailConnector = () => {
 };
 
 export const fillEmailRuleActionForm = (email: string, subject: string) => {
-  cy.get(EMAIL_ACTION_TO_INPUT).type(email);
+  cy.get(EMAIL_ACTION_TO_INPUT).type(`${email}{enter}`);
   cy.get(EMAIL_ACTION_SUBJECT_INPUT).type(subject);
 };
 


### PR DESCRIPTION
 **Resolves: #227885**

## Summary

Fixing Cypress test issue and unskipping the test.
The fault was introduced most probably by the upgrade of EUI in the following commit. 

```
commit eca0d1c9d4fd511b36787260461eee1dd3c4553f (HEAD)
Author: Arturo Castillo Delgado <arturo.castillo@elastic.co>
Date:   Mon Jul 14 16:25:22 2025 +0200

    Upgrade EUI to v105.0.0 (#226882)
```

In Cypress the fault reported itself by not finding the progress bar icon, but that was due to an issue with filling the `email` input field (which made the flyout not close properly, reporting an input error, and the test was expecting the elements of the rule table below, which was not shown).

I am fixing it by forcing the `enter` key, like it is already done in other places in the code.


# Testing:
Run Cypress test

`yarn cypress:open:ess --spec ./cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
`
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


