### PR TITLE
[Asset Inventory] Initializes generic entities with 26 hours lookback period

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.test.ts
@@ -512,9 +512,27 @@ describe('AssetInventoryDataClient', () => {
   });
 
   describe('enable function', () => {
+    const mockEntityStoreDataClient = {
+      status: jest.fn(),
+      enable: jest.fn(),
+      init: jest.fn(),
+    };
+
+    const mockDataViewService = {
+      get: jest.fn(),
+      createAndSave: jest.fn(),
+    };
+
     beforeEach(() => {
       jest.clearAllMocks();
       uiSettingsClientMock.get.mockResolvedValue(true);
+      (mockSecSolutionContext.getEntityStoreDataClient as jest.Mock).mockReturnValue(
+        mockEntityStoreDataClient
+      );
+      (mockSecSolutionContext.getDataViewsService as jest.Mock).mockReturnValue(
+        mockDataViewService
+      );
+      (mockSecSolutionContext.getSpaceId as jest.Mock).mockReturnValue('default');
     });
 
     it('throws error when uisetting is disabled', async () => {
@@ -523,6 +541,182 @@ describe('AssetInventoryDataClient', () => {
       await expect(
         client.enable(mockSecSolutionContext, {} as InitEntityStoreRequestBody)
       ).rejects.toThrowError('uiSetting');
+    });
+
+    it('enables entity store and generic engine when entity store is not installed', async () => {
+      const requestBodyOverrides = {
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-1d' } } }),
+      } as InitEntityStoreRequestBody;
+
+      mockEntityStoreDataClient.status.mockResolvedValue({
+        status: 'not_installed',
+        engines: [],
+      });
+
+      mockEntityStoreDataClient.enable.mockResolvedValue({ success: true });
+      mockEntityStoreDataClient.init.mockResolvedValue({ success: true });
+
+      // Mock data view installation success
+      mockDataViewService.createAndSave.mockResolvedValue({ id: 'test-data-view' });
+
+      const result = await client.enable(mockSecSolutionContext, requestBodyOverrides);
+
+      // Verify entity store is enabled with non-generic entity types first
+      expect(mockEntityStoreDataClient.enable).toHaveBeenCalledWith({
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-1d' } } }),
+        entityTypes: ['host', 'user', 'service'],
+      });
+
+      // Verify generic engine is initialized with 26h lookback period
+      expect(mockEntityStoreDataClient.init).toHaveBeenCalledWith('generic', {
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-1d' } } }),
+        lookbackPeriod: '26h',
+      });
+
+      // Verify data view installation is attempted (installDataView directly calls createAndSave)
+      expect(mockDataViewService.createAndSave).toHaveBeenCalledWith(
+        {
+          id: 'asset-inventory-default',
+          title: '.entities.*.latest.security_*_default',
+          name: 'Asset Inventory Data View - default',
+          namespaces: ['default'],
+          allowNoIndex: true,
+          timeFieldName: '@timestamp',
+          allowHidden: true,
+        },
+        false,
+        true
+      );
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it('initializes generic engine when entity store is installed but generic engine is missing', async () => {
+      const requestBodyOverrides = {
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-2d' } } }),
+      } as InitEntityStoreRequestBody;
+
+      mockEntityStoreDataClient.status.mockResolvedValue({
+        status: 'installed',
+        engines: [
+          { type: 'host', status: 'started' },
+          { type: 'user', status: 'started' },
+        ],
+      });
+
+      mockEntityStoreDataClient.init.mockResolvedValue({ success: true });
+
+      // Mock data view installation success
+      mockDataViewService.createAndSave.mockResolvedValue({ id: 'test-data-view' });
+
+      const result = await client.enable(mockSecSolutionContext, requestBodyOverrides);
+
+      // Verify entity store enable is NOT called since it's already installed
+      expect(mockEntityStoreDataClient.enable).not.toHaveBeenCalled();
+
+      // Verify generic engine is initialized with 26h lookback period
+      expect(mockEntityStoreDataClient.init).toHaveBeenCalledWith('generic', {
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-2d' } } }),
+        lookbackPeriod: '26h',
+      });
+
+      // Verify data view installation is attempted
+      expect(mockDataViewService.createAndSave).toHaveBeenCalled();
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it('does not initialize generic engine when it already exists', async () => {
+      const requestBodyOverrides = {
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-3d' } } }),
+      } as InitEntityStoreRequestBody;
+
+      mockEntityStoreDataClient.status.mockResolvedValue({
+        status: 'installed',
+        engines: [
+          { type: 'host', status: 'started' },
+          { type: 'user', status: 'started' },
+          { type: 'generic', status: 'started' },
+        ],
+      });
+
+      // Mock data view installation success
+      mockDataViewService.createAndSave.mockResolvedValue({ id: 'test-data-view' });
+
+      const result = await client.enable(mockSecSolutionContext, requestBodyOverrides);
+
+      // Verify entity store enable is NOT called since it's already installed
+      expect(mockEntityStoreDataClient.enable).not.toHaveBeenCalled();
+
+      // Verify generic engine init is NOT called since it already exists
+      expect(mockEntityStoreDataClient.init).not.toHaveBeenCalled();
+
+      // Data view installation should still be attempted
+      expect(mockDataViewService.createAndSave).toHaveBeenCalled();
+
+      expect(result).toBeUndefined();
+    });
+
+    it('handles data view installation errors gracefully', async () => {
+      const requestBodyOverrides = {} as InitEntityStoreRequestBody;
+
+      mockEntityStoreDataClient.status.mockResolvedValue({
+        status: 'not_installed',
+        engines: [],
+      });
+
+      mockEntityStoreDataClient.enable.mockResolvedValue({ success: true });
+      mockEntityStoreDataClient.init.mockResolvedValue({ success: true });
+
+      // Mock data view installation failure
+      mockDataViewService.createAndSave.mockRejectedValue(new Error('Data view creation failed'));
+
+      const result = await client.enable(mockSecSolutionContext, requestBodyOverrides);
+
+      // Verify entity store operations still proceed despite data view error
+      expect(mockEntityStoreDataClient.enable).toHaveBeenCalledWith({
+        entityTypes: ['host', 'user', 'service'],
+      });
+
+      expect(mockEntityStoreDataClient.init).toHaveBeenCalledWith('generic', {
+        lookbackPeriod: '26h',
+      });
+
+      // Verify error is logged but doesn't prevent function completion
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        'Error installing asset inventory data view: Data view creation failed'
+      );
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it('preserves custom request body overrides while adding lookback period', async () => {
+      const requestBodyOverrides = {
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-1h' } } }),
+        indexPattern: 'custom-pattern-*',
+      } as InitEntityStoreRequestBody;
+
+      mockEntityStoreDataClient.status.mockResolvedValue({
+        status: 'installed',
+        engines: [{ type: 'host', status: 'started' }],
+      });
+
+      mockEntityStoreDataClient.init.mockResolvedValue({ success: true });
+
+      // Mock data view installation success
+      mockDataViewService.createAndSave.mockResolvedValue({ id: 'test-data-view' });
+
+      await client.enable(mockSecSolutionContext, requestBodyOverrides);
+
+      // Verify generic engine is initialized with both custom overrides and lookback period
+      expect(mockEntityStoreDataClient.init).toHaveBeenCalledWith('generic', {
+        filter: JSON.stringify({ range: { '@timestamp': { gte: 'now-1h' } } }),
+        indexPattern: 'custom-pattern-*',
+        lookbackPeriod: '26h',
+      });
+
+      // Verify data view installation is attempted
+      expect(mockDataViewService.createAndSave).toHaveBeenCalled();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.test.ts
@@ -409,7 +409,7 @@ describe('AssetInventoryDataClient', () => {
         {
           id: 'asset-inventory-default',
           title: '.entities.*.latest.security_*_default',
-          name: 'Asset Inventory Data View - default ',
+          name: 'Asset Inventory Data View - default',
           namespaces: ['default'],
           allowNoIndex: true,
           timeFieldName: '@timestamp',
@@ -481,7 +481,7 @@ describe('AssetInventoryDataClient', () => {
         {
           id: 'asset-inventory-custom-space',
           title: '.entities.*.latest.security_*_custom-space',
-          name: 'Asset Inventory Data View - custom-space ',
+          name: 'Asset Inventory Data View - custom-space',
           namespaces: ['custom-space'],
           allowNoIndex: true,
           timeFieldName: '@timestamp',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.ts
@@ -149,9 +149,6 @@ export class AssetInventoryDataClient {
 
       let entityStoreEnablementResponse;
 
-      // For Asset Inventory onboarding, the Generic Entities should be initialized with a lookback period of 26 hours
-      // to account for the fact that entity extraction integrations have a default ingest window time of 24 hours
-      // and we want to cover the ingest window time with a buffer of 2 hours.
       const genericRequestBody: InitEntityStoreRequestBody = {
         ...requestBodyOverrides,
         lookbackPeriod: ASSET_INVENTORY_GENERIC_LOOKBACK_PERIOD,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/asset_inventory_data_client.ts
@@ -19,6 +19,7 @@ import {
   ASSET_INVENTORY_DATA_VIEW_ID_PREFIX,
   ASSET_INVENTORY_DATA_VIEW_NAME,
   ASSET_INVENTORY_GENERIC_INDEX_PREFIX,
+  ASSET_INVENTORY_GENERIC_LOOKBACK_PERIOD,
   ASSET_INVENTORY_INDEX_PATTERN,
 } from './constants';
 
@@ -147,11 +148,30 @@ export class AssetInventoryDataClient {
       const entityEngineStatus = entityStoreStatus.status;
 
       let entityStoreEnablementResponse;
+
+      // For Asset Inventory onboarding, the Generic Entities should be initialized with a lookback period of 26 hours
+      // to account for the fact that entity extraction integrations have a default ingest window time of 24 hours
+      // and we want to cover the ingest window time with a buffer of 2 hours.
+      const genericRequestBody: InitEntityStoreRequestBody = {
+        ...requestBodyOverrides,
+        lookbackPeriod: ASSET_INVENTORY_GENERIC_LOOKBACK_PERIOD,
+      };
+
       // If the entity store is not installed, we need to install it.
       if (entityEngineStatus === 'not_installed') {
+        const nonGenericEntityStoreRequestBody: InitEntityStoreRequestBody = {
+          ...requestBodyOverrides,
+          entityTypes: [EntityType.enum.host, EntityType.enum.user, EntityType.enum.service],
+        };
+
+        await secSolutionContext
+          .getEntityStoreDataClient()
+          .enable(nonGenericEntityStoreRequestBody);
+
         entityStoreEnablementResponse = await secSolutionContext
           .getEntityStoreDataClient()
-          .enable(requestBodyOverrides);
+          // @ts-ignore-next-line TS2345
+          .init(EntityType.enum.generic, genericRequestBody);
       } else {
         // If the entity store is already installed, we need to check if the generic engine is installed.
         const genericEntityEngine = entityStoreStatus.engines.find(this.isGenericEntityEngine);
@@ -161,7 +181,7 @@ export class AssetInventoryDataClient {
           entityStoreEnablementResponse = await secSolutionContext
             .getEntityStoreDataClient()
             // @ts-ignore-next-line TS2345
-            .init(EntityType.enum.generic, requestBodyOverrides);
+            .init(EntityType.enum.generic, genericRequestBody);
         }
       }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/constants.ts
@@ -10,4 +10,7 @@ export const ASSET_INVENTORY_DATA_VIEW_ID_PREFIX = 'asset-inventory';
 export const ASSET_INVENTORY_DATA_VIEW_NAME = 'Asset Inventory Data View';
 export const ASSET_INVENTORY_GENERIC_INDEX_PREFIX = '.entities.v1.latest.security_generic_';
 
+// For Asset Inventory onboarding, the Generic Entities should be initialized with a lookback period of 26 hours
+// to account for the fact that entity extraction integrations have a default ingest window time of 24 hours
+// and we want to cover the ingest window time with a buffer of 2 hours.
 export const ASSET_INVENTORY_GENERIC_LOOKBACK_PERIOD = '26h';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/constants.ts
@@ -9,3 +9,5 @@ export const ASSET_INVENTORY_INDEX_PATTERN = '.entities.*.latest.security_*_';
 export const ASSET_INVENTORY_DATA_VIEW_ID_PREFIX = 'asset-inventory';
 export const ASSET_INVENTORY_DATA_VIEW_NAME = 'Asset Inventory Data View';
 export const ASSET_INVENTORY_GENERIC_INDEX_PREFIX = '.entities.v1.latest.security_generic_';
+
+export const ASSET_INVENTORY_GENERIC_LOOKBACK_PERIOD = '26h';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/saved_objects/data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory/saved_objects/data_view.ts
@@ -27,7 +27,7 @@ export const installDataView = async (
       {
         id: currentSpaceDataViewId,
         title: `${indexPattern}${currentSpaceId}`,
-        name: `${dataViewName} - ${currentSpaceId} `,
+        name: `${dataViewName} - ${currentSpaceId}`,
         namespaces: [currentSpaceId],
         allowNoIndex: true,
         timeFieldName: DATA_VIEW_TIME_FIELD,


### PR DESCRIPTION
## Summary

Due to a recent Entity Store performance improvement ([here](https://github.com/elastic/kibana/pull/219825)) related to the large amount of initial data in the host and user entity stores, the default entity store lookback period was reduced to 3 hours. While it's a positive change, it conflicts with many asset/entities retrieval integrations that have a default sync time of 24 hours leading to several documents not appearing during the Asset Inventory onboarding since Generic Entity stores have a lookback of 3 hours.

This PR ensures the generic entities are initialized with a 26-hour lookback period during Asset Inventory onboarding to account for the fact that entity extraction integrations have a default sync window time of 24 hours and we want to cover the ingest window time with a buffer of 2 hours.

This will allow for a smoother onboarding experience in Asset Inventory for users with existing entity data derived from Entity/Asset extraction integrations (Cloud Asset Discovery for example).

## Screenshot

Generic entities are initialized with a lookback period of 26 hours

<img width="1926" height="1610" alt="image" src="https://github.com/user-attachments/assets/5794ddef-9d86-4ddc-8fc8-0956a092efc3" />

Host and user entities are initialized with the default lookback period (3 hours)

<img width="1943" height="1624" alt="image" src="https://github.com/user-attachments/assets/8bdc8d10-88ee-4bf4-a965-887a7ae779d5" />
