### PR TITLE
[UII] Refactor virtualization of integration cards grid

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -42,7 +42,7 @@ import {
   shouldShowInstallationStatus,
 } from './installation_status';
 
-export type PackageCardProps = IntegrationCardItem & { tabIndex?: number };
+export type PackageCardProps = IntegrationCardItem;
 
 export function PackageCard({
   description,
@@ -75,7 +75,6 @@ export function PackageCard({
   showDescription = true,
   showReleaseBadge = true,
   hasDataStreams,
-  tabIndex,
 }: PackageCardProps) {
   const theme = useEuiTheme();
   let releaseBadge: React.ReactNode | null = null;
@@ -254,7 +253,6 @@ export function PackageCard({
             />
           }
           onClick={onClickProp ?? onCardClick}
-          tabIndex={tabIndex}
         >
           <EuiFlexGroup gutterSize="xs" wrap={true}>
             {showLabels && extraLabelsBadges ? extraLabelsBadges : null}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -42,7 +42,7 @@ import {
   shouldShowInstallationStatus,
 } from './installation_status';
 
-export type PackageCardProps = IntegrationCardItem;
+export type PackageCardProps = IntegrationCardItem & { tabIndex?: number };
 
 export function PackageCard({
   description,
@@ -75,6 +75,7 @@ export function PackageCard({
   showDescription = true,
   showReleaseBadge = true,
   hasDataStreams,
+  tabIndex,
 }: PackageCardProps) {
   const theme = useEuiTheme();
   let releaseBadge: React.ReactNode | null = null;
@@ -253,6 +254,7 @@ export function PackageCard({
             />
           }
           onClick={onClickProp ?? onCardClick}
+          tabIndex={tabIndex}
         >
           <EuiFlexGroup gutterSize="xs" wrap={true}>
             {showLabels && extraLabelsBadges ? extraLabelsBadges : null}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -103,7 +103,6 @@ export const GridColumn = ({
             <EuiFlexGroup gutterSize="m">
               {items.map((item) => (
                 <EuiFlexItem
-                  tabIndex={item.index}
                   key={item.id}
                   // Ensure that cards wrapped in EuiTours/EuiPopovers correctly inherit the full grid row height
                   css={css`
@@ -112,6 +111,7 @@ export const GridColumn = ({
                       height: 100%;
                     }
                   `}
+                  tabIndex={-1}
                 >
                   <PackageCard {...item} showLabels={showCardLabels} />
                 </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -27,7 +27,7 @@ import type { IntegrationCardItem } from '../../screens/home';
 import { PackageCard } from '../package_card';
 
 interface GridColumnProps {
-  list: Array<IntegrationCardItem & { index: number }>;
+  list: IntegrationCardItem[];
   isLoading: boolean;
   showMissingIntegrationMessage?: boolean;
   showCardLabels?: boolean;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -134,7 +134,9 @@ export const GridColumn = ({
       }
     >
       {({ height, isScrolling, onChildScroll, scrollTop }) => (
-        <EuiAutoSizer disableHeight>
+        // `key` is a hack to re-render the list when the number of items changes, see:
+        // https://stackoverflow.com/questions/52769760/react-virtualized-list-item-does-not-re-render-with-changed-props-until-i-scroll
+        <EuiAutoSizer disableHeight key={list.length}>
           {({ width }) => (
             <VirtualizedList
               tabIndex={-1}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -138,7 +138,7 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
     [selectedCategory, setSelectedSubCategory, setUrlandPushHistory]
   );
 
-  const filteredPromotedList: Array<IntegrationCardItem & { index: number }> = useMemo(() => {
+  const filteredPromotedList: IntegrationCardItem[] = useMemo(() => {
     if (isLoading) return [];
 
     const searchResults =
@@ -150,14 +150,9 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
       ? list.filter((item) => searchResults.includes(item[searchIdField]) ?? [])
       : list;
 
-    const promotedList = sortByFeaturedIntegrations
+    return sortByFeaturedIntegrations
       ? promoteFeaturedIntegrations(filteredList, selectedCategory)
       : filteredList;
-
-    return promotedList.map((item, index) => ({
-      ...item,
-      index,
-    }));
   }, [isLoading, list, localSearch, searchTerm, selectedCategory, sortByFeaturedIntegrations]);
   const splitSubcategories = (
     subcategories: CategoryFacet[] | undefined

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -138,7 +138,7 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
     [selectedCategory, setSelectedSubCategory, setUrlandPushHistory]
   );
 
-  const filteredPromotedList = useMemo(() => {
+  const filteredPromotedList: Array<IntegrationCardItem & { index: number }> = useMemo(() => {
     if (isLoading) return [];
 
     const searchResults =
@@ -150,9 +150,14 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
       ? list.filter((item) => searchResults.includes(item[searchIdField]) ?? [])
       : list;
 
-    return sortByFeaturedIntegrations
+    const promotedList = sortByFeaturedIntegrations
       ? promoteFeaturedIntegrations(filteredList, selectedCategory)
       : filteredList;
+
+    return promotedList.map((item, index) => ({
+      ...item,
+      index,
+    }));
   }, [isLoading, list, localSearch, searchTerm, selectedCategory, sortByFeaturedIntegrations]);
   const splitSubcategories = (
     subcategories: CategoryFacet[] | undefined
@@ -291,7 +296,7 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
             {callout}
           </>
         ) : null}
-        {spacer && <EuiSpacer size="s" />}
+        {spacer && <EuiSpacer size="m" />}
         <EuiFlexItem>
           <GridColumn
             emptyStateStyles={emptyStateStyles}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/210015.

The integration cards grid was virtualized in https://github.com/elastic/kibana/pull/165030. This PR fixes navigation through the cards using the keyboard (tabbing) reported in the above bug.

It does so by refactoring the virtualization by only using components from `react-virtualized` library (previously used a mix with `react-window`). The previous manual handling of window size changes etc were replaced with OOTB `react-virtualized` tools. This cleanup results in cleaner rendering of the cards, allowing them to be tab-able correctly.

I also tested that it solves the issue in the original place where the bug was reported, in the Observability onboarding flow that imports this grid:

<img width="1415" height="877" alt="image" src="https://github.com/user-attachments/assets/efdc8ceb-90da-4b98-860e-6f04dd7dddde" />

As this is a significant re-work of a critical path area, I won't backport this fix so that the change can bake in our dev and QA flows before the next release.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
