### PR TITLE
[Oblt Onboarding] Fix auto-detect Host details locator properties

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
@@ -215,8 +215,8 @@ export const AutoDetectPanel: FunctionComponent = () => {
                                         }
                                       ),
                                       href: assetDetailsLocator.getRedirectUrl({
-                                        assetType: 'host',
-                                        assetId: integration.metadata?.hostname,
+                                        entityType: 'host',
+                                        entityId: integration.metadata?.hostname,
                                         assetDetails: {
                                           dateRange: {
                                             from: 'now-15m',


### PR DESCRIPTION
This change fixes the asset details locator after [some properties were renamed](https://github.com/elastic/kibana/pull/227967).