### PR TITLE
[onechat] Implement tool deletion for ES|QL tools

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/base/base_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/base/base_tools.tsx
@@ -16,7 +16,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { ToolDefinition } from '@kbn/onechat-common';
 import React from 'react';
-import { useOnechatBaseTools } from '../../../hooks/use_tools';
+import { useBaseTools } from '../../../hooks/tools/use_tools';
 import { truncateAtNewline } from '../../../utils/truncate_at_newline';
 import { OnechatToolTags } from '../tags/tool_tags';
 
@@ -24,7 +24,6 @@ const columns: Array<EuiBasicTableColumn<ToolDefinition>> = [
   {
     field: 'id',
     name: i18n.translate('xpack.onechat.tools.toolIdLabel', { defaultMessage: 'Tool' }),
-    valign: 'top',
     render: (id: string) => (
       <EuiText size="s">
         <strong>{id}</strong>
@@ -37,7 +36,6 @@ const columns: Array<EuiBasicTableColumn<ToolDefinition>> = [
       defaultMessage: 'Description',
     }),
     width: '60%',
-    valign: 'top',
     render: (description: string) => {
       return <EuiText size="s">{truncateAtNewline(description)}</EuiText>;
     },
@@ -47,14 +45,13 @@ const columns: Array<EuiBasicTableColumn<ToolDefinition>> = [
     name: i18n.translate('xpack.onechat.tools.tagsLabel', {
       defaultMessage: 'Tags',
     }),
-    width: '15%',
     valign: 'top',
     render: (tags: string[]) => <OnechatToolTags tags={tags} />,
   },
 ];
 
 export const OnechatBaseTools: React.FC = () => {
-  const { tools, isLoading, error } = useOnechatBaseTools();
+  const { tools, isLoading, error } = useBaseTools();
   const errorMessage = error
     ? i18n.translate('xpack.onechat.tools.listToolsErrorMessage', {
         defaultMessage: 'Failed to fetch tools',

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/create_esql_tool_flyout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/create_esql_tool_flyout.tsx
@@ -24,7 +24,7 @@ import { i18n } from '@kbn/i18n';
 import { ToolDefinitionWithSchema } from '@kbn/onechat-common';
 import React, { useCallback, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useOnechatCreateTool } from '../../../hooks/use_tools';
+import { useCreateTool } from '../../../hooks/tools/use_tools';
 import { transformEsqlFormData } from '../../../utils/transform_esql_form_data';
 import { OnechatEsqlToolForm } from './form/esql_tool_form';
 import { useEsqlToolFormValidationResolver } from './form/validation/esql_tool_form_validation';
@@ -107,7 +107,7 @@ export const OnechatCreateEsqlToolFlyout: React.FC<OnechatCreateEsqlToolFlyoutPr
     prefix: 'newEsqlToolForm',
   });
 
-  const { createTool, isLoading: isSubmitting } = useOnechatCreateTool({
+  const { createTool, isLoading: isSubmitting } = useCreateTool({
     onSuccess,
     onError,
   });

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
@@ -21,7 +21,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ToolDefinition } from '@kbn/onechat-common';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useDeleteToolModal } from '../../../hooks/tools/use_delete_tools';
 import { useEsqlTools } from '../../../hooks/tools/use_tools';
 import { useToasts } from '../../../hooks/use_toasts';
@@ -29,7 +29,7 @@ import { truncateAtNewline } from '../../../utils/truncate_at_newline';
 import { OnechatToolTags } from '../tags/tool_tags';
 import { OnechatCreateEsqlToolFlyout } from './create_esql_tool_flyout';
 
-const columns = ({
+const getColumns = ({
   deleteTool,
 }: {
   deleteTool: (toolId: string) => void;
@@ -136,6 +136,8 @@ export const OnechatEsqlTools: React.FC = () => {
     setIsFlyoutOpen(true);
   }, []);
 
+  const columns = useMemo(() => getColumns({ deleteTool }), [deleteTool]);
+
   const deleteEsqlToolTitleId = useGeneratedHtmlId({
     prefix: 'deleteEsqlToolTitle',
   });
@@ -186,7 +188,7 @@ export const OnechatEsqlTools: React.FC = () => {
         <EuiHorizontalRule margin="xs" />
         <EuiInMemoryTable
           loading={isLoadingTools}
-          columns={columns({ deleteTool })}
+          columns={columns}
           items={tools}
           itemId="id"
           error={errorMessage}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
@@ -242,6 +242,7 @@ export const OnechatEsqlTools: React.FC = () => {
               toolId: deleteToolId,
             },
           })}
+          aria-labelledby={deleteEsqlToolTitleId}
           titleProps={{ id: deleteEsqlToolTitleId }}
           onCancel={cancelDelete}
           onConfirm={confirmDelete}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
@@ -9,27 +9,34 @@ import {
   CriteriaWithPagination,
   EuiBasicTableColumn,
   EuiButton,
+  EuiButtonIcon,
+  EuiConfirmModal,
   EuiFlexGroup,
   EuiHorizontalRule,
   EuiInMemoryTable,
   EuiText,
   EuiTitle,
   Search,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ToolDefinition } from '@kbn/onechat-common';
 import React, { useCallback, useState } from 'react';
+import { useDeleteToolModal } from '../../../hooks/tools/use_delete_tools';
+import { useEsqlTools } from '../../../hooks/tools/use_tools';
 import { useToasts } from '../../../hooks/use_toasts';
-import { useOnechatEsqlTools } from '../../../hooks/use_tools';
 import { truncateAtNewline } from '../../../utils/truncate_at_newline';
 import { OnechatToolTags } from '../tags/tool_tags';
 import { OnechatCreateEsqlToolFlyout } from './create_esql_tool_flyout';
 
-const columns: Array<EuiBasicTableColumn<ToolDefinition>> = [
+const columns = ({
+  deleteTool,
+}: {
+  deleteTool: (toolId: string) => void;
+}): Array<EuiBasicTableColumn<ToolDefinition>> => [
   {
     field: 'id',
     name: i18n.translate('xpack.onechat.tools.toolIdLabel', { defaultMessage: 'Tool' }),
-    valign: 'top',
     sortable: true,
     render: (id: string) => (
       <EuiText size="s">
@@ -42,8 +49,7 @@ const columns: Array<EuiBasicTableColumn<ToolDefinition>> = [
     name: i18n.translate('xpack.onechat.tools.toolDescriptionLabel', {
       defaultMessage: 'Description',
     }),
-    width: '60%',
-    valign: 'top',
+    width: '50%',
     render: (description: string) => {
       return <EuiText size="s">{truncateAtNewline(description)}</EuiText>;
     },
@@ -53,17 +59,74 @@ const columns: Array<EuiBasicTableColumn<ToolDefinition>> = [
     name: i18n.translate('xpack.onechat.tools.tagsLabel', {
       defaultMessage: 'Tags',
     }),
-    width: '15%',
     valign: 'top',
     render: (tags: string[]) => <OnechatToolTags tags={tags} />,
+  },
+  {
+    name: i18n.translate('xpack.onechat.tools.actionsLabel', {
+      defaultMessage: 'Actions',
+    }),
+    width: '64px',
+    align: 'center',
+    render: ({ id }: ToolDefinition) => {
+      return (
+        <EuiButtonIcon
+          iconType="trash"
+          color="danger"
+          onClick={() => {
+            deleteTool(id);
+          }}
+          aria-label={i18n.translate('xpack.onechat.tools.deleteToolButtonLabel', {
+            defaultMessage: 'Delete tool',
+          })}
+        />
+      );
+    },
   },
 ];
 
 export const OnechatEsqlTools: React.FC = () => {
-  const { tools, isLoading: isLoadingTools, error: toolsError } = useOnechatEsqlTools();
+  const { tools, isLoading: isLoadingTools, error: toolsError } = useEsqlTools();
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const [pageIndex, setPageIndex] = useState(0);
   const { addSuccessToast, addErrorToast } = useToasts();
+
+  const onDeleteSuccess = useCallback(
+    (toolId: string) => {
+      addSuccessToast({
+        title: i18n.translate('xpack.onechat.tools.deleteToolSuccessToast', {
+          defaultMessage: 'Tool "{toolId}" deleted',
+          values: {
+            toolId,
+          },
+        }),
+      });
+    },
+    [addSuccessToast]
+  );
+
+  const onDeleteError = useCallback(
+    (toolId: string) => {
+      addErrorToast({
+        title: i18n.translate('xpack.onechat.tools.deleteToolErrorToast', {
+          defaultMessage: 'Unable to delete tool "{toolId}"',
+          values: {
+            toolId,
+          },
+        }),
+      });
+    },
+    [addErrorToast]
+  );
+
+  const {
+    isModalOpen: isDeleteModalOpen,
+    isLoading: isDeletingTool,
+    toolId: deleteToolId,
+    deleteTool,
+    confirmDelete,
+    cancelDelete,
+  } = useDeleteToolModal({ onSuccess: onDeleteSuccess, onError: onDeleteError });
 
   const handleCloseFlyout = useCallback(() => {
     setIsFlyoutOpen(false);
@@ -72,6 +135,10 @@ export const OnechatEsqlTools: React.FC = () => {
   const handleOpenFlyout = useCallback(() => {
     setIsFlyoutOpen(true);
   }, []);
+
+  const deleteEsqlToolTitleId = useGeneratedHtmlId({
+    prefix: 'deleteEsqlToolTitle',
+  });
 
   const errorMessage = toolsError
     ? i18n.translate('xpack.onechat.tools.listToolsErrorMessage', {
@@ -119,7 +186,7 @@ export const OnechatEsqlTools: React.FC = () => {
         <EuiHorizontalRule margin="xs" />
         <EuiInMemoryTable
           loading={isLoadingTools}
-          columns={columns}
+          columns={columns({ deleteTool })}
           items={tools}
           itemId="id"
           error={errorMessage}
@@ -153,20 +220,47 @@ export const OnechatEsqlTools: React.FC = () => {
         onSuccess={() => {
           handleCloseFlyout();
           addSuccessToast({
-            title: i18n.translate('xpack.onechat.tools.esqlToolCreationSuccessToast', {
+            title: i18n.translate('xpack.onechat.tools.createEsqlToolSuccessToast', {
               defaultMessage: 'ES|QL tool created',
             }),
           });
         }}
         onError={(error) => {
           addErrorToast({
-            title: i18n.translate('xpack.onechat.tools.esqlToolCreationErrorToast', {
+            title: i18n.translate('xpack.onechat.tools.createEsqlToolErrorToast', {
               defaultMessage: 'Unable to create ES|QL tool',
             }),
             text: error.message,
           });
         }}
       />
+      {isDeleteModalOpen && (
+        <EuiConfirmModal
+          title={i18n.translate('xpack.onechat.tools.deleteEsqlToolTitle', {
+            defaultMessage: 'Delete tool "{toolId}"?',
+            values: {
+              toolId: deleteToolId,
+            },
+          })}
+          titleProps={{ id: deleteEsqlToolTitleId }}
+          onCancel={cancelDelete}
+          onConfirm={confirmDelete}
+          isLoading={isDeletingTool}
+          cancelButtonText={i18n.translate('xpack.onechat.tools.deleteEsqlToolCancelButton', {
+            defaultMessage: 'Cancel',
+          })}
+          confirmButtonText={i18n.translate('xpack.onechat.tools.deleteEsqlToolConfirmButton', {
+            defaultMessage: 'Delete',
+          })}
+          buttonColor="danger"
+        >
+          <EuiText>
+            {i18n.translate('xpack.onechat.tools.deleteEsqlToolConfirmationText', {
+              defaultMessage: "You can't recover deleted data.",
+            })}
+          </EuiText>
+        </EuiConfirmModal>
+      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/form/esql_tool_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/form/esql_tool_form.tsx
@@ -17,7 +17,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { useOnechatToolsTags } from '../../../../hooks/use_tools';
+import { useToolTags } from '../../../../hooks/tools/use_tool_tags';
 import { OnechatEsqlEditorField } from './components/esql_editor_field';
 import { OnechatEsqlToolFormData } from './types/esql_tool_form_types';
 
@@ -28,7 +28,7 @@ export interface OnechatEsqlToolFormProps {
 
 export const OnechatEsqlToolForm = ({ formId, saveTool }: OnechatEsqlToolFormProps) => {
   const { euiTheme } = useEuiTheme();
-  const { tags, isLoading: isLoadingTags } = useOnechatToolsTags();
+  const { tags, isLoading: isLoadingTags } = useToolTags();
   const {
     control,
     handleSubmit,

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/agents/use_agent_edit.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/agents/use_agent_edit.ts
@@ -15,7 +15,7 @@ import {
 } from '@kbn/onechat-common';
 import { useOnechatServices } from '../use_onechat_service';
 import { useOnechatAgentById } from './use_agent_by_id';
-import { useOnechatTools } from '../use_tools';
+import { useOnechatTools } from '../tools/use_tools';
 import { queryKeys } from '../../query_keys';
 
 export type AgentEditState = Omit<AgentDefinition, 'type'>;

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { DeleteToolResponse } from '../../../../common/http_api/tools';
+import { queryKeys } from '../../query_keys';
+import { useOnechatServices } from '../use_onechat_service';
+
+type DeleteToolSuccessCallback = (data: DeleteToolResponse, variables: { toolId: string }) => void;
+type DeleteToolErrorCallback = (error: Error, variables: { toolId: string }) => void;
+
+export const useDeleteTool = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: DeleteToolSuccessCallback;
+  onError?: DeleteToolErrorCallback;
+}) => {
+  const queryClient = useQueryClient();
+  const { toolsService } = useOnechatServices();
+
+  const { mutateAsync, isLoading } = useMutation({
+    mutationFn: ({ toolId }: { toolId: string }) => toolsService.delete({ toolId }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.tools.all }),
+    onSuccess,
+    onError,
+  });
+
+  return { deleteTool: mutateAsync, isLoading };
+};
+
+export const useDeleteToolModal = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (toolId: string) => void;
+  onError?: (toolId: string) => void;
+}) => {
+  const [deleteToolId, setDeleteToolId] = useState<string | null>(null);
+
+  const isModalOpen = deleteToolId !== null;
+
+  const deleteTool = useCallback((toolId: string) => {
+    setDeleteToolId(toolId);
+  }, []);
+
+  const onDeleteSuccess: DeleteToolSuccessCallback = (data, { toolId }) => {
+    if (!data.success) {
+      onError?.(toolId);
+      return;
+    }
+
+    onSuccess?.(toolId);
+    setDeleteToolId(null);
+  };
+
+  const onDeleteError: DeleteToolErrorCallback = (_, { toolId }) => {
+    onError?.(toolId);
+  };
+
+  const { deleteTool: deleteToolMutation, isLoading } = useDeleteTool({
+    onSuccess: onDeleteSuccess,
+    onError: onDeleteError,
+  });
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteToolId) {
+      return;
+    }
+
+    await deleteToolMutation({ toolId: deleteToolId });
+  }, [deleteToolId, deleteToolMutation]);
+
+  const cancelDelete = useCallback(() => {
+    setDeleteToolId(null);
+  }, []);
+
+  return {
+    isModalOpen,
+    isLoading,
+    toolId: deleteToolId,
+    deleteTool,
+    confirmDelete,
+    cancelDelete,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_tags.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tool_tags.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useOnechatTools } from './use_tools';
+
+export const useToolTags = () => {
+  const { tools, isLoading, error } = useOnechatTools();
+
+  const tags = useMemo((): string[] => {
+    if (isLoading || error) return [];
+
+    // Return unique tags across all tools
+    return [
+      ...tools.reduce((tagsSet, tool) => {
+        tool.tags.forEach((tag) => tagsSet.add(tag));
+        return tagsSet;
+      }, new Set<string>()),
+    ];
+  }, [tools, isLoading, error]);
+
+  return { tags, isLoading };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools.ts
@@ -8,9 +8,9 @@
 import { ToolDefinitionWithSchema, ToolType } from '@kbn/onechat-common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { CreateToolPayload } from '../../../common/http_api/tools';
-import { queryKeys } from '../query_keys';
-import { useOnechatServices } from './use_onechat_service';
+import { CreateToolPayload } from '../../../../common/http_api/tools';
+import { queryKeys } from '../../query_keys';
+import { useOnechatServices } from '../use_onechat_service';
 
 export const useOnechatTools = () => {
   const { toolsService } = useOnechatServices();
@@ -27,21 +27,21 @@ export const useOnechatTools = () => {
   return { tools: tools ?? [], isLoading, error };
 };
 
-export const useOnechatBaseTools = () => {
+export const useBaseTools = () => {
   const { tools, ...rest } = useOnechatTools();
 
   const baseTools = useMemo(() => tools.filter((tool) => tool.type === ToolType.builtin), [tools]);
   return { tools: baseTools, ...rest };
 };
 
-export const useOnechatEsqlTools = () => {
+export const useEsqlTools = () => {
   const { tools, ...rest } = useOnechatTools();
 
   const esqlTools = useMemo(() => tools.filter((tool) => tool.type === ToolType.esql), [tools]);
   return { tools: esqlTools, ...rest };
 };
 
-export const useOnechatCreateTool = ({
+export const useCreateTool = ({
   onSuccess,
   onError,
 }: {
@@ -59,22 +59,4 @@ export const useOnechatCreateTool = ({
   });
 
   return { createTool: mutateAsync, isLoading };
-};
-
-export const useOnechatToolsTags = () => {
-  const { tools, isLoading, error } = useOnechatTools();
-
-  const tags = useMemo((): string[] => {
-    if (isLoading || error) return [];
-
-    // Return unique tags across all tools
-    return [
-      ...tools.reduce((tagsSet, tool) => {
-        tool.tags.forEach((tag) => tagsSet.add(tag));
-        return tagsSet;
-      }, new Set<string>()),
-    ];
-  }, [tools, isLoading, error]);
-
-  return { tags, isLoading };
 };


### PR DESCRIPTION
## Summary

Implements ES|QL tool deletion from the ES|QL tools table.


https://github.com/user-attachments/assets/d7af342c-f571-4a66-b07a-2ebd0a5a168d



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



