### PR TITLE
[Observability] add fails in MKI tags to custom roles tests

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/burn_rate/consumers_and_privileges.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/burn_rate/consumers_and_privileges.ts
@@ -30,7 +30,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const isServerless = config.get('serverless');
   const kibanaServer = getService('kibanaServer');
 
-  describe('Burn rate rule', () => {
+  describe('Burn rate rule', function () {
+    // Custom roles not yet supported in MKI
+    this.tags(['failsOnMKI']);
+
     let dataForgeConfig: PartialConfig;
     let dataForgeIndices: string[];
     let actionId: string;

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
@@ -109,7 +109,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     describe('Custom threshold - Rule visibility - consumer observability', function () {
       // Custom roles not yet supported in MKI
       this.tags(['failsOnMKI']);
-      
+
       const consumer = 'observability';
 
       it('creates rule successfully', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
@@ -106,7 +106,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
     });
 
-    describe('Custom threshold - Rule visibility - consumer observability', () => {
+    describe('Custom threshold - Rule visibility - consumer observability', function () {
       // Custom roles not yet supported in MKI
       this.tags(['failsOnMKI']);
       

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
@@ -107,7 +107,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     describe('Custom threshold - Rule visibility - consumer observability', () => {
-      const consumer = 'observability';
+      // Custom roles not yet supported in MKI
+      this.tags(['failsOnMKI']);
+
       it('creates rule successfully', async () => {
         const createdRule = await alertingApi.createRule({
           roleAuthc,

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/custom_threshold/consumers_and_privileges.ts
@@ -109,6 +109,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     describe('Custom threshold - Rule visibility - consumer observability', () => {
       // Custom roles not yet supported in MKI
       this.tags(['failsOnMKI']);
+      
+      const consumer = 'observability';
 
       it('creates rule successfully', async () => {
         const createdRule = await alertingApi.createRule({

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/es_query/consumers_and_privileges.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/es_query/consumers_and_privileges.ts
@@ -25,6 +25,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let internalReqHeader: InternalRequestHeader;
 
   describe('Query DSL - Consumers and privileges', function () {
+    // Custom roles not yet supported in MKI
+    this.tags(['failsOnMKI']);
+
     const ALERT_ACTION_INDEX = 'alert-action-es-query';
     const RULE_ALERT_INDEX = '.alerts-stack.alerts-default';
     let ruleId: string;

--- a/x-pack/test_serverless/api_integration/test_suites/observability/platform_security/authorization.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/platform_security/authorization.ts
@@ -11,6 +11,9 @@ export default function ({ getService }: FtrProviderContext) {
   const svlCommonApi = getService('svlCommonApi');
 
   describe('security/authorization', function () {
+    // Custom roles not yet supported in MKI
+    this.tags(['failsOnMKI']);
+
     describe('available features', () => {
       const svlUserManager = getService('svlUserManager');
       const supertestWithoutAuth = getService('supertestWithoutAuth');

--- a/x-pack/test_serverless/functional/test_suites/observability/role_management/custom_role_access.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/role_management/custom_role_access.ts
@@ -19,6 +19,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   let roleAuthc: RoleCredentials;
 
   describe('With custom role', function () {
+    // Custom roles not yet supported in MKI
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'

--- a/x-pack/test_serverless/functional/test_suites/observability/rules/custom_threshold_consumer.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/rules/custom_threshold_consumer.ts
@@ -62,6 +62,9 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   }
 
   describe('Custom threshold rule - consumers', function () {
+    // Custom roles not yet supported in MKI
+    this.tags(['failsOnMKI']);
+
     const ruleIdList: string[] = [];
 
     before(async () => {

--- a/x-pack/test_serverless/functional/test_suites/observability/rules/es_query_consumer.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/rules/es_query_consumer.ts
@@ -61,6 +61,9 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   }
 
   describe('ES Query rule - consumers', function () {
+    // Custom roles not yet supported in MKI
+    this.tags(['failsOnMKI']);
+
     const ruleIdList: string[] = [];
 
     before(async () => {


### PR DESCRIPTION
## Summary

Skips test suites related to custom roles in Observability as custom roles are rolled out.

Once Custom Roles are fully rolled out, we'll unskip these tests.
