### PR TITLE
[UII] Handle resizing of integration cards grid

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -100,7 +100,7 @@ export const GridColumn = ({
       >
         {({ registerChild }) => (
           <div ref={registerChild} style={style}>
-            <EuiFlexGroup gutterSize="m">
+            <EuiFlexGroup gutterSize="m" responsive={true}>
               {items.map((item) => (
                 <EuiFlexItem
                   key={item.id}
@@ -130,8 +130,13 @@ export const GridColumn = ({
       scrollElement={
         (scrollElementId && document.getElementById(scrollElementId)) ||
         document.getElementById(APP_MAIN_SCROLL_CONTAINER_ID) ||
-        undefined
+        window
       }
+      onResize={() => {
+        if (rowMeasurementCache.current) {
+          rowMeasurementCache.current.clearAll();
+        }
+      }}
     >
       {({ height, isScrolling, onChildScroll, scrollTop }) => (
         // `key` is a hack to re-render the list when the number of items changes, see:


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/228529. This PR adds a `onResize` handler so that cell measurement can be correctly re-computed when the window is resized.

There is a bit of weirdness on some rows just before the XS breakpoint, due to cards with badges (i.e. `Technical preview`). The badges are non-breaking and thus disrupt the flexbox sizing, but I confirmed that this was happening prior to the refactoring above. On XS breakpoint the grid converts to single-card rows:

![Jul-18-2025 12-33-37](https://github.com/user-attachments/assets/d6f42a6d-a1e4-42c4-873b-3c080db548bc)

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)