### PR TITLE
chore(streams): use ESQL for significant events related queries

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
@@ -11,15 +11,15 @@ import {
   SignificantEventsPreviewResponse,
 } from '@kbn/streams-schema';
 import { z } from '@kbn/zod';
-import { SecurityError } from '../../../lib/streams/errors/security_error';
 import {
   STREAMS_API_PRIVILEGES,
   STREAMS_TIERED_SIGNIFICANT_EVENT_FEATURE,
 } from '../../../../common/constants';
+import { SecurityError } from '../../../lib/streams/errors/security_error';
 import { createServerRoute } from '../../create_server_route';
+import { assertEnterpriseLicense } from '../../utils/assert_enterprise_license';
 import { previewSignificantEvents } from './preview_significant_events';
 import { readSignificantEventsFromAlertsIndices } from './read_significant_events_from_alerts_indices';
-import { assertEnterpriseLicense } from '../../utils/assert_enterprise_license';
 
 // Make sure strings are expected for input, but still converted to a
 // Date, without breaking the OpenAPI generator
@@ -143,15 +143,10 @@ const readSignificantEventsRoute = createServerRoute({
     }
 
     const { name } = params.path;
-    const { from, to, bucketSize } = params.query;
+    const { from, to } = params.query;
 
     return await readSignificantEventsFromAlertsIndices(
-      {
-        name,
-        from,
-        to,
-        bucketSize,
-      },
+      { name, from, to },
       { assetClient, scopedClusterClient }
     );
   },

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
@@ -76,7 +76,7 @@ const previewSignificantEventsRoute = createServerRoute({
     const {
       body: { query },
       path: { name },
-      query: { bucketSize, from, to },
+      query: { from, to },
     } = params;
 
     const definition = await streamsClient.getStream(name);
@@ -84,7 +84,6 @@ const previewSignificantEventsRoute = createServerRoute({
     return await previewSignificantEvents(
       {
         definition,
-        bucketSize,
         from,
         to,
         query,


### PR DESCRIPTION
Resolves https://github.com/elastic/streams-program/issues/422

Blocked by https://github.com/elastic/elasticsearch/issues/111483

## Summary

This PR migrates the preview and read sig events API to use ES|QL instead of ES search API.

Since stats by bucket does not extend the empty bucket with a zero count, the change point command might have a different behaviour than when used with search api.