### PR TITLE
[Synthetics] Fix escape vars template literal inline script !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
@@ -4,8 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { replaceStringWithParams } from './formatting_utils';
+import { inlineSourceFormatter, replaceStringWithParams } from './formatting_utils';
 import { loggerMock } from '@kbn/logging-mocks';
+import { ConfigKey } from '../../../common/constants/monitor_management';
 
 describe('replaceStringWithParams', () => {
   const logger = loggerMock.create();
@@ -237,5 +238,15 @@ describe('replaceStringWithParams', () => {
     const result = replaceStringWithParams({}, { param: '1' }, logger);
 
     expect(result).toEqual({});
+  });
+
+  it(`should replace $ {} with adding $ in start for template literal`, () => {
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: 'const a = ${b}; const c = ${d}',
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+    expect(value).toEqual('const a = $${b}; const c = $${d}');
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -122,3 +122,19 @@ export const formatMWs = (mws?: MaintenanceWindow[], strRes = true) => {
   }
   return JSON.stringify(formatted);
 };
+
+function escapeTemplateLiterals(script: string): string {
+  return script.replace(/\$\{/g, '$$${');
+}
+
+export const inlineSourceFormatter: FormatterFn = (fields, key) => {
+  const value = fields[key] as string;
+  if (!value?.trim()) return value;
+
+  // Re-indent with 2 spaces, but don't include `|-` here
+  try {
+    return escapeTemplateLiterals(value);
+  } catch (e) {
+    return value;
+  }
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -131,7 +131,7 @@ export const inlineSourceFormatter: FormatterFn = (fields, key) => {
   const value = fields[key] as string;
   if (!value?.trim()) return value;
 
-  // Re-indent with 2 spaces, but don't include `|-` here
+  // Escape template literals to prevent unintended interpolation
   try {
     return escapeTemplateLiterals(value);
   } catch (e) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -132,5 +132,5 @@ export const inlineSourceFormatter: FormatterFn = (fields, key) => {
   if (!value?.trim()) return value;
 
   // Escape template literals to prevent unintended interpolation
-  return escapeTemplateLiterals(value);
+  return escapeTemplateLiterals(value).trim();
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -132,9 +132,5 @@ export const inlineSourceFormatter: FormatterFn = (fields, key) => {
   if (!value?.trim()) return value;
 
   // Escape template literals to prevent unintended interpolation
-  try {
-    return escapeTemplateLiterals(value);
-  } catch (e) {
-    return value;
-  }
+  return escapeTemplateLiterals(value);
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/private_formatters/formatting_utils.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { inlineSourceFormatter } from '../formatting_utils';
 import { ConfigKey, MonitorFields } from '../../../../common/runtime_types';
 
 export type FormatterFn = (fields: Partial<MonitorFields>, key: ConfigKey) => string | null;
@@ -53,8 +54,12 @@ export const tlsArrayToYamlFormatter: FormatterFn = (fields, key) => {
 };
 
 export const stringToJsonFormatter: FormatterFn = (fields, key) => {
-  const value = (fields[key] as string) ?? '';
+  if (key === ConfigKey.SOURCE_INLINE) {
+    const value = inlineSourceFormatter(fields, key);
 
+    return value ? JSON.stringify(value) : null;
+  }
+  const value = (fields[key] as string) ?? '';
   return value ? JSON.stringify(value) : null;
 };
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/public_formatters/browser.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/public_formatters/browser.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { inlineSourceFormatter } from '../formatting_utils';
 import { DEFAULT_BROWSER_ADVANCED_FIELDS } from '../../../../common/constants/monitor_defaults';
 import { BrowserFields, ConfigKey } from '../../../../common/runtime_types';
 import { Formatter, commonFormatters } from './common';
@@ -42,7 +43,7 @@ export const browserFormatters: BrowserFormatMap = {
   [ConfigKey.PORT]: null,
   [ConfigKey.URLS]: null,
   [ConfigKey.METADATA]: objectFormatter,
-  [ConfigKey.SOURCE_INLINE]: null,
+  [ConfigKey.SOURCE_INLINE]: inlineSourceFormatter,
   [ConfigKey.THROTTLING_CONFIG]: throttlingFormatter,
   [ConfigKey.JOURNEY_FILTERS_MATCH]: null,
   [ConfigKey.SYNTHETICS_ARGS]: arrayFormatter,


### PR DESCRIPTION
Fixes #225498 

## Summary

Needed to add $ before e.g template ${url} so that it gets escaped during heartbeat vars parsing.

### Before being passed to heartbeat

```
step("blame me",async () =>{
    const url = "https://www.google.com";
    await page.goto(`${url}`);
})
```

### After being passed to heartbeat

```
        step("bname me",async () =>{
            const url = "https://www.google.com";
            await page.goto(`$${url}`);
        })
```

You can take a look at inspect config flyout in monitor form 

<img width="1728" height="879" alt="image" src="https://github.com/user-attachments/assets/0078ff6d-c581-45db-b87e-384b96d52076" />


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->