### PR TITLE
[Discover] Fix "Body cell lines" display option handling when default value is `-1`

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -873,7 +873,8 @@ const InternalUnifiedDataTable = ({
     storage,
     consumer,
     key: 'dataGridHeaderRowHeight',
-    configRowHeight: configHeaderRowHeight ?? 1,
+    defaultRowHeight: 1,
+    configRowHeight: configHeaderRowHeight,
     rowHeightState: headerRowHeightState,
     onUpdateRowHeight: onUpdateHeaderRowHeight,
   });
@@ -883,7 +884,8 @@ const InternalUnifiedDataTable = ({
       storage,
       consumer,
       key: 'dataGridRowHeight',
-      configRowHeight: configRowHeight ?? ROWS_HEIGHT_OPTIONS.default,
+      defaultRowHeight: ROWS_HEIGHT_OPTIONS.default,
+      configRowHeight,
       rowHeightState,
       onUpdateRowHeight,
     });

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
@@ -281,7 +281,7 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
         onChangeRowHeightLines,
       });
       fireEvent.change(screen.getByRole('spinbutton'), { target: { value: 5 } });
-      expect(onChangeRowHeightLines).toHaveBeenCalledWith(5);
+      expect(onChangeRowHeightLines).toHaveBeenCalledWith(5, true);
       await userEvent.click(screen.getByRole('button', { name: 'Auto' }));
       expect(onChangeRowHeight).toHaveBeenCalledWith('auto');
     });
@@ -310,7 +310,7 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
         onChangeHeaderRowHeightLines,
       });
       fireEvent.change(screen.getByRole('spinbutton'), { target: { value: 3 } });
-      expect(onChangeHeaderRowHeightLines).toHaveBeenCalledWith(3);
+      expect(onChangeHeaderRowHeightLines).toHaveBeenCalledWith(3, true);
       await userEvent.click(screen.getByRole('button', { name: 'Auto' }));
       expect(onChangeHeaderRowHeight).toHaveBeenCalledWith('auto');
     });

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
@@ -21,15 +21,15 @@ export const RANGE_STEP_SAMPLE_SIZE = 10;
 export interface UnifiedDataTableAdditionalDisplaySettingsProps {
   rowHeight: RowHeightSettingsProps['rowHeight'];
   onChangeRowHeight?: (rowHeight: RowHeightSettingsProps['rowHeight']) => void;
-  onChangeRowHeightLines?: (rowHeightLines: number) => void;
+  onChangeRowHeightLines?: (rowHeightLines: number, isValid: boolean) => void;
   headerRowHeight: RowHeightSettingsProps['rowHeight'];
   onChangeHeaderRowHeight?: (headerRowHeight: RowHeightSettingsProps['rowHeight']) => void;
-  onChangeHeaderRowHeightLines?: (headerRowHeightLines: number) => void;
+  onChangeHeaderRowHeightLines?: (headerRowHeightLines: number, isValid: boolean) => void;
   maxAllowedSampleSize?: number;
   sampleSize: number;
   onChangeSampleSize?: (sampleSize: number) => void;
-  lineCountInput: number;
-  headerLineCountInput: number;
+  lineCountInput: number | undefined;
+  headerLineCountInput: number | undefined;
   densityControl?: React.ReactNode;
 }
 

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.tsx
@@ -36,10 +36,10 @@ const idPrefix = htmlIdGenerator()();
 export function RowHeightSettings({
   lineCountInput,
   label,
-  rowHeight,
+  rowHeight = RowHeightMode.custom,
   onChangeRowHeight,
   onChangeLineCountInput,
-  maxRowHeight,
+  maxRowHeight = 20,
   ['data-test-subj']: dataTestSubj,
 }: RowHeightSettingsProps) {
   const rowHeightModeOptions = [
@@ -74,7 +74,7 @@ export function RowHeightSettings({
             legend={label}
             buttonSize="compressed"
             options={rowHeightModeOptions}
-            idSelected={`${idPrefix}${rowHeight ?? RowHeightMode.custom}`}
+            idSelected={`${idPrefix}${rowHeight}`}
             onChange={(optionId) => {
               const newMode = optionId.replace(idPrefix, '') as RowHeightSettingsProps['rowHeight'];
               onChangeRowHeight(newMode);
@@ -89,7 +89,7 @@ export function RowHeightSettings({
               onChangeLineCountInput(lineCount, e.target.checkValidity());
             }}
             min={1}
-            max={maxRowHeight ?? 20}
+            max={maxRowHeight}
             required
             step={1}
             disabled={rowHeight !== RowHeightMode.custom}

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.tsx
@@ -22,12 +22,12 @@ export enum RowHeightMode {
   custom = 'custom',
 }
 export interface RowHeightSettingsProps {
-  lineCountInput: number;
+  lineCountInput: number | undefined;
   rowHeight?: RowHeightMode;
   maxRowHeight?: number;
   label: string;
   onChangeRowHeight: (newHeightMode: RowHeightMode | undefined) => void;
-  onChangeLineCountInput: (newRowHeightLines: number) => void;
+  onChangeLineCountInput: (newRowHeightLines: number, isValid: boolean) => void;
   'data-test-subj'?: string;
 }
 
@@ -86,10 +86,11 @@ export function RowHeightSettings({
             value={lineCountInput}
             onChange={(e) => {
               const lineCount = Number(e.currentTarget.value);
-              onChangeLineCountInput(lineCount);
+              onChangeLineCountInput(lineCount, e.target.checkValidity());
             }}
             min={1}
             max={maxRowHeight ?? 20}
+            required
             step={1}
             disabled={rowHeight !== RowHeightMode.custom}
             data-test-subj={`${dataTestSubj}_lineCountNumber`}

--- a/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.test.tsx
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react';
+import { RenderHookResult, act, renderHook } from '@testing-library/react';
 import { createLocalStorageMock } from '../../__mocks__/local_storage_mock';
-import { useRowHeight } from './use_row_height';
+import { UseRowHeightProps, useRowHeight } from './use_row_height';
 import { RowHeightMode } from '../components/row_height_settings';
 
 const CONFIG_ROW_HEIGHT = 3;
@@ -18,12 +18,16 @@ const renderRowHeightHook = (
   {
     previousRowHeight,
     previousConfigRowHeight,
+    configRowHeight = CONFIG_ROW_HEIGHT,
+    defaultRowHeight = CONFIG_ROW_HEIGHT,
     rowHeightState,
     onUpdateRowHeight,
   }: {
     previousRowHeight?: number;
     previousConfigRowHeight?: number;
     rowHeightState?: number;
+    configRowHeight?: number;
+    defaultRowHeight?: number;
     onUpdateRowHeight?: (rowHeight: number) => void;
   } = { previousRowHeight: 5, previousConfigRowHeight: CONFIG_ROW_HEIGHT }
 ) => {
@@ -32,20 +36,23 @@ const renderRowHeightHook = (
       ? { ['discover:dataGridRowHeight']: { previousRowHeight, previousConfigRowHeight } }
       : {};
   const storage = createLocalStorageMock(storageValue);
-  const initialProps = {
+  const initialProps: UseRowHeightProps = {
     storage,
     consumer: 'discover',
     key: 'dataGridRowHeight',
-    defaultRowHeight: CONFIG_ROW_HEIGHT,
-    configRowHeight: CONFIG_ROW_HEIGHT,
+    defaultRowHeight,
+    configRowHeight,
     rowHeightState,
     onUpdateRowHeight,
   };
-
+  let hook!: RenderHookResult<ReturnType<typeof useRowHeight>, UseRowHeightProps>;
+  act(() => {
+    hook = renderHook(useRowHeight, { initialProps });
+  });
   return {
     storage,
     initialProps,
-    hook: renderHook(useRowHeight, { initialProps }),
+    hook,
   };
 };
 
@@ -108,13 +115,17 @@ describe('useRowHeightsOptions', () => {
       storage,
       hook: { result },
     } = renderRowHeightHook({ onUpdateRowHeight });
-    result.current.onChangeRowHeight?.(RowHeightMode.auto);
+    act(() => {
+      result.current.onChangeRowHeight?.(RowHeightMode.auto);
+    });
     expect(storage.get('discover:dataGridRowHeight')).toEqual({
       previousRowHeight: -1,
       previousConfigRowHeight: CONFIG_ROW_HEIGHT,
     });
     expect(onUpdateRowHeight).toHaveBeenLastCalledWith(-1);
-    result.current.onChangeRowHeight?.(RowHeightMode.custom);
+    act(() => {
+      result.current.onChangeRowHeight?.(RowHeightMode.custom);
+    });
     expect(storage.get('discover:dataGridRowHeight')).toEqual({
       previousRowHeight: CONFIG_ROW_HEIGHT,
       previousConfigRowHeight: CONFIG_ROW_HEIGHT,
@@ -128,7 +139,9 @@ describe('useRowHeightsOptions', () => {
       storage,
       hook: { result },
     } = renderRowHeightHook({ onUpdateRowHeight });
-    result.current.onChangeRowHeightLines?.(2, true);
+    act(() => {
+      result.current.onChangeRowHeightLines?.(2, true);
+    });
     expect(storage.get('discover:dataGridRowHeight')).toEqual({
       previousRowHeight: 2,
       previousConfigRowHeight: CONFIG_ROW_HEIGHT,
@@ -146,5 +159,131 @@ describe('useRowHeightsOptions', () => {
     hook.rerender({ ...initialProps, rowHeightState: 3 });
     expect(hook.result.current.rowHeight).toEqual(RowHeightMode.custom);
     expect(hook.result.current.rowHeightLines).toEqual(3);
+  });
+
+  it('should use configRowHeight for lineCountInput when rowHeightState is below 1', () => {
+    const {
+      hook: { result },
+    } = renderRowHeightHook({
+      rowHeightState: -1,
+      configRowHeight: 4,
+    });
+    expect(result.current.rowHeight).toEqual(RowHeightMode.auto);
+    expect(result.current.rowHeightLines).toEqual(-1);
+    expect(result.current.lineCountInput).toEqual(4);
+  });
+
+  it('should use defaultRowHeight for lineCountInput when rowHeightState and configRowHeight are below 1', () => {
+    const {
+      hook: { result },
+    } = renderRowHeightHook({
+      rowHeightState: -1,
+      configRowHeight: -1,
+      defaultRowHeight: 5,
+    });
+    expect(result.current.rowHeight).toEqual(RowHeightMode.auto);
+    expect(result.current.rowHeightLines).toEqual(-1);
+    expect(result.current.lineCountInput).toEqual(5);
+  });
+
+  it('should not update rowHeightState but update lineCountInput when newRowHeightLines is invalid', () => {
+    const onUpdateRowHeight = jest.fn();
+    const {
+      hook: { result },
+    } = renderRowHeightHook({ onUpdateRowHeight });
+    act(() => {
+      result.current.onChangeRowHeightLines?.(42, false);
+    });
+    expect(onUpdateRowHeight).not.toHaveBeenCalled();
+    expect(result.current.lineCountInput).toEqual(42);
+  });
+
+  it('should set lineCountInput to undefined when newRowHeightLines is 0 and invalid', () => {
+    const onUpdateRowHeight = jest.fn();
+    const {
+      hook: { result },
+    } = renderRowHeightHook({ onUpdateRowHeight });
+    act(() => {
+      result.current.onChangeRowHeightLines?.(0, false);
+    });
+    expect(onUpdateRowHeight).not.toHaveBeenCalled();
+    expect(result.current.lineCountInput).toBeUndefined();
+  });
+
+  it('should reset invalid lineCountInput to last valid rowHeightLines when switching from custom to auto', () => {
+    let rowHeightState = -1;
+    const { hook, initialProps } = renderRowHeightHook({
+      rowHeightState,
+      onUpdateRowHeight: (newRowHeight) => {
+        rowHeightState = newRowHeight;
+      },
+    });
+    act(() => {
+      hook.result.current.onChangeRowHeightLines?.(10, true);
+      hook.rerender({ ...initialProps, rowHeightState });
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.custom);
+    expect(hook.result.current.rowHeightLines).toEqual(10);
+    expect(hook.result.current.lineCountInput).toEqual(10);
+    act(() => {
+      hook.result.current.onChangeRowHeightLines?.(42, false);
+      hook.rerender({ ...initialProps, rowHeightState });
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.custom);
+    expect(hook.result.current.rowHeightLines).toEqual(10);
+    expect(hook.result.current.lineCountInput).toEqual(42);
+    act(() => {
+      hook.result.current.onChangeRowHeight?.(RowHeightMode.auto);
+      hook.rerender({ ...initialProps, rowHeightState });
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.auto);
+    expect(hook.result.current.rowHeightLines).toEqual(-1);
+    expect(hook.result.current.lineCountInput).toEqual(10);
+  });
+
+  it('should update rowHeightLines to last lineCountInput when switching from auto to custom', () => {
+    let rowHeightState = 10;
+    const { hook, initialProps } = renderRowHeightHook({
+      rowHeightState,
+      onUpdateRowHeight: (newRowHeight) => {
+        rowHeightState = newRowHeight;
+      },
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.custom);
+    expect(hook.result.current.rowHeightLines).toEqual(10);
+    expect(hook.result.current.lineCountInput).toEqual(10);
+    act(() => {
+      hook.result.current.onChangeRowHeight?.(RowHeightMode.auto);
+      hook.rerender({ ...initialProps, rowHeightState });
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.auto);
+    expect(hook.result.current.rowHeightLines).toEqual(-1);
+    expect(hook.result.current.lineCountInput).toEqual(10);
+    act(() => {
+      hook.result.current.onChangeRowHeight?.(RowHeightMode.custom);
+      hook.rerender({ ...initialProps, rowHeightState });
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.custom);
+    expect(hook.result.current.rowHeightLines).toEqual(10);
+    expect(hook.result.current.lineCountInput).toEqual(10);
+  });
+
+  it('should sync lineCountInput with rowHeightLines when rowHeightState changes by consumer in custom mode', () => {
+    let rowHeightState = 10;
+    const { hook, initialProps } = renderRowHeightHook({
+      rowHeightState,
+      onUpdateRowHeight: (newRowHeight) => {
+        rowHeightState = newRowHeight;
+      },
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.custom);
+    expect(hook.result.current.rowHeightLines).toEqual(10);
+    expect(hook.result.current.lineCountInput).toEqual(10);
+    act(() => {
+      hook.rerender({ ...initialProps, rowHeightState: 15 });
+    });
+    expect(hook.result.current.rowHeight).toEqual(RowHeightMode.custom);
+    expect(hook.result.current.rowHeightLines).toEqual(15);
+    expect(hook.result.current.lineCountInput).toEqual(15);
   });
 });

--- a/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.test.tsx
@@ -36,6 +36,7 @@ const renderRowHeightHook = (
     storage,
     consumer: 'discover',
     key: 'dataGridRowHeight',
+    defaultRowHeight: CONFIG_ROW_HEIGHT,
     configRowHeight: CONFIG_ROW_HEIGHT,
     rowHeightState,
     onUpdateRowHeight,
@@ -127,7 +128,7 @@ describe('useRowHeightsOptions', () => {
       storage,
       hook: { result },
     } = renderRowHeightHook({ onUpdateRowHeight });
-    result.current.onChangeRowHeightLines?.(2);
+    result.current.onChangeRowHeightLines?.(2, true);
     expect(storage.get('discover:dataGridRowHeight')).toEqual({
       previousRowHeight: 2,
       previousConfigRowHeight: CONFIG_ROW_HEIGHT,

--- a/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.ts
@@ -20,7 +20,7 @@ import {
 import { ROWS_HEIGHT_OPTIONS } from '../constants';
 import { RowHeightMode, RowHeightSettingsProps } from '../components/row_height_settings';
 
-interface UseRowHeightProps {
+export interface UseRowHeightProps {
   storage: Storage;
   consumer: string;
   key: string;

--- a/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_row_height.ts
@@ -9,6 +9,8 @@
 
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import usePrevious from 'react-use/lib/usePrevious';
+import useLatest from 'react-use/lib/useLatest';
 import { isValidRowHeight } from '../utils/validate_row_height';
 import {
   DataGridOptionsRecord,
@@ -22,7 +24,8 @@ interface UseRowHeightProps {
   storage: Storage;
   consumer: string;
   key: string;
-  configRowHeight: number;
+  defaultRowHeight: number;
+  configRowHeight?: number;
   rowHeightState?: number;
   onUpdateRowHeight?: (rowHeight: number) => void;
 }
@@ -84,7 +87,8 @@ export const useRowHeight = ({
   storage,
   consumer,
   key,
-  configRowHeight,
+  defaultRowHeight,
+  configRowHeight = defaultRowHeight,
   rowHeightState,
   onUpdateRowHeight,
 }: UseRowHeightProps) => {
@@ -98,38 +102,70 @@ export const useRowHeight = ({
     });
   }, [configRowHeight, consumer, key, rowHeightState, storage]);
 
-  const [lineCountInput, setLineCountInput] = useState(
-    rowHeightLines < 0 ? configRowHeight : rowHeightLines
+  const getAdjustedLineCount = useCallback(
+    (lineCount: number | undefined) => {
+      return lineCount !== undefined && lineCount > 0
+        ? lineCount
+        : configRowHeight > 0
+        ? configRowHeight
+        : defaultRowHeight;
+    },
+    [configRowHeight, defaultRowHeight]
   );
 
-  const rowHeight = useMemo<RowHeightSettingsProps['rowHeight']>(() => {
+  const [lineCountInput, setLineCountInput] = useState<number | undefined>(
+    getAdjustedLineCount(rowHeightLines)
+  );
+
+  const rowHeight = useMemo(() => {
     return rowHeightLines === ROWS_HEIGHT_OPTIONS.auto ? RowHeightMode.auto : RowHeightMode.custom;
   }, [rowHeightLines]);
 
   const onChangeRowHeight = useCallback(
     (newRowHeight: RowHeightSettingsProps['rowHeight']) => {
       const newRowHeightLines =
-        newRowHeight === RowHeightMode.auto ? ROWS_HEIGHT_OPTIONS.auto : lineCountInput;
+        newRowHeight === RowHeightMode.auto
+          ? ROWS_HEIGHT_OPTIONS.auto
+          : getAdjustedLineCount(lineCountInput);
 
       updateStoredRowHeight(newRowHeightLines, configRowHeight, storage, consumer, key);
       onUpdateRowHeight?.(newRowHeightLines);
     },
-    [configRowHeight, consumer, key, onUpdateRowHeight, storage, lineCountInput]
+    [
+      configRowHeight,
+      consumer,
+      getAdjustedLineCount,
+      key,
+      lineCountInput,
+      onUpdateRowHeight,
+      storage,
+    ]
   );
 
   const onChangeRowHeightLines = useCallback(
-    (newRowHeightLines: number) => {
-      updateStoredRowHeight(newRowHeightLines, configRowHeight, storage, consumer, key);
-      onUpdateRowHeight?.(newRowHeightLines);
+    (newRowHeightLines: number, isValid: boolean) => {
+      if (isValid) {
+        updateStoredRowHeight(newRowHeightLines, configRowHeight, storage, consumer, key);
+        onUpdateRowHeight?.(newRowHeightLines);
+      }
+
+      setLineCountInput(newRowHeightLines === 0 ? undefined : newRowHeightLines);
     },
     [configRowHeight, consumer, key, onUpdateRowHeight, storage]
   );
 
+  const prevRowHeight = useLatest(usePrevious(rowHeight) ?? rowHeight);
+  const prevRowHeightLines = useLatest(usePrevious(rowHeightLines) ?? rowHeightLines);
+
   useEffect(() => {
-    if (rowHeight === RowHeightMode.custom) {
-      setLineCountInput(rowHeightLines > 0 ? rowHeightLines : configRowHeight);
+    if (rowHeight === RowHeightMode.auto && prevRowHeight.current === RowHeightMode.custom) {
+      // If switching from custom to auto, reset the line count input to the last valid line count
+      setLineCountInput(getAdjustedLineCount(prevRowHeightLines.current));
+    } else if (rowHeight === RowHeightMode.custom) {
+      // If row height lines change while in custom mode (e.g. by consumer), sync the line count input
+      setLineCountInput(getAdjustedLineCount(rowHeightLines));
     }
-  }, [rowHeightLines, configRowHeight, rowHeight]);
+  }, [getAdjustedLineCount, prevRowHeight, prevRowHeightLines, rowHeight, rowHeightLines]);
 
   return {
     rowHeight,


### PR DESCRIPTION
## Summary

This PR fixes the handling of the "Body cell lines" display option in Discover when the default value is set to `-1` in Advanced Settings. It will now set the cell lines input to a default value instead of `-1` in this case, and will not prevent users from switching from "Auto" to "Custom" mode. Additionally, some changes were made to the validation to address some bugs and improve the UX:
- Manually setting a value of `-1` does not automatically switch to "Auto" mode and cause the user to get stuck again.
- The last valid input value will be restored when switching from "Custom" to "Auto" with an invalid value.
- Deleting the current value allows users to actually clear the input and enter a new value instead of it automatically being reset to `1` or `0`.

Fixes #228682.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->