### PR TITLE
[index management] Component template api performance fixes

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/common/lib/component_template_serialization.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/component_template_serialization.ts
@@ -72,25 +72,27 @@ export function deserializeComponentTemplate(
 }
 
 export function deserializeComponentTemplateList(
-  componentTemplateEs: ComponentTemplateFromEs,
+  componentTemplatesEs: ComponentTemplateFromEs[],
   indexTemplatesEs: TemplateFromEs[]
 ) {
-  const { name, component_template: componentTemplate } = componentTemplateEs;
-  const { template, _meta, deprecated } = componentTemplate;
-
   const indexTemplatesToUsedBy = getIndexTemplatesToUsedBy(indexTemplatesEs);
 
-  const componentTemplateListItem: ComponentTemplateListItem = {
-    name,
-    usedBy: indexTemplatesToUsedBy[name] || [],
-    isDeprecated: Boolean(deprecated === true),
-    isManaged: Boolean(_meta?.managed === true),
-    hasSettings: hasEntries(template.settings),
-    hasMappings: hasEntries(template.mappings),
-    hasAliases: hasEntries(template.aliases),
-  };
+  return componentTemplatesEs.map((componentTemplateEs) => {
+    const { name, component_template: componentTemplate } = componentTemplateEs;
+    const { template, _meta, deprecated } = componentTemplate;
 
-  return componentTemplateListItem;
+    const componentTemplateListItem: ComponentTemplateListItem = {
+      name,
+      usedBy: indexTemplatesToUsedBy[name] || [],
+      isDeprecated: Boolean(deprecated === true),
+      isManaged: Boolean(_meta?.managed === true),
+      hasSettings: hasEntries(template.settings),
+      hasMappings: hasEntries(template.mappings),
+      hasAliases: hasEntries(template.aliases),
+    };
+
+    return componentTemplateListItem;
+  });
 }
 
 export function serializeComponentTemplate(

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_get_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_get_route.ts
@@ -36,12 +36,13 @@ export function registerGetAllRoute({ router, lib: { handleEsError } }: RouteDep
       const { client } = (await context.core).elasticsearch;
 
       try {
-        const { component_templates: componentTemplates } =
-          await client.asCurrentUser.cluster.getComponentTemplate();
+        const [{ component_templates: componentTemplates }, { index_templates: indexTemplates }] =
+          await Promise.all([
+            client.asCurrentUser.cluster.getComponentTemplate(),
+            client.asCurrentUser.indices.getIndexTemplate(),
+          ]);
 
-        const { index_templates: indexTemplates } =
-          await client.asCurrentUser.indices.getIndexTemplate();
-
+        /*
         const body = componentTemplates.map((componentTemplate) => {
           const deserializedComponentTemplateListItem = deserializeComponentTemplateList(
             componentTemplate as ComponentTemplateFromEs,
@@ -50,6 +51,13 @@ export function registerGetAllRoute({ router, lib: { handleEsError } }: RouteDep
           );
           return deserializedComponentTemplateListItem;
         });
+        */
+
+        const body = deserializeComponentTemplateList(
+          componentTemplates as ComponentTemplateFromEs[],
+          // @ts-expect-error TemplateSerialized.index_patterns not compatible with IndicesIndexTemplate.index_patterns
+          indexTemplates
+        );
 
         return response.ok({ body });
       } catch (error) {
@@ -77,13 +85,11 @@ export function registerGetAllRoute({ router, lib: { handleEsError } }: RouteDep
       const { name } = request.params;
 
       try {
-        const { component_templates: componentTemplates } =
-          await client.asCurrentUser.cluster.getComponentTemplate({
-            name,
-          });
-
-        const { index_templates: indexTemplates } =
-          await client.asCurrentUser.indices.getIndexTemplate();
+        const [{ component_templates: componentTemplates }, { index_templates: indexTemplates }] =
+          await Promise.all([
+            client.asCurrentUser.cluster.getComponentTemplate({ name }),
+            client.asCurrentUser.indices.getIndexTemplate(),
+          ]);
 
         return response.ok({
           // @ts-expect-error TemplateSerialized.index_patterns not compatible with IndicesIndexTemplate.index_patterns

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_get_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/component_templates/register_get_route.ts
@@ -42,17 +42,6 @@ export function registerGetAllRoute({ router, lib: { handleEsError } }: RouteDep
             client.asCurrentUser.indices.getIndexTemplate(),
           ]);
 
-        /*
-        const body = componentTemplates.map((componentTemplate) => {
-          const deserializedComponentTemplateListItem = deserializeComponentTemplateList(
-            componentTemplate as ComponentTemplateFromEs,
-            // @ts-expect-error TemplateSerialized.index_patterns not compatible with IndicesIndexTemplate.index_patterns
-            indexTemplates
-          );
-          return deserializedComponentTemplateListItem;
-        });
-        */
-
         const body = deserializeComponentTemplateList(
           componentTemplates as ComponentTemplateFromEs[],
           // @ts-expect-error TemplateSerialized.index_patterns not compatible with IndicesIndexTemplate.index_patterns


### PR DESCRIPTION
## Summary

This implements two performance improvements - first, firing both requests in parallel instead of in sequence. The second one, doing the real work - for each component template the list of index templates was being transformed via `map`. If you have hundreds of one and thousands of another it gets VERY slow. 30s on my machine but up to a minute for a customer. 

After this change the performance went from 30s to 500ms.

Python script for generating necessary set of component and index templates - 
[new_import.py.txt](https://github.com/user-attachments/files/21340591/new_import.py.txt)

Run the above script against main and open the component template tab - it will be VERY slow. Now do it against this branch. Hopefully you notice a significant speed increase.

Closes https://github.com/elastic/kibana/issues/228267

---

Release note

Index Management component template tab speed increase


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->