### PR TITLE
[Security Solution][Entity Analytics][PrivMon]Use of i18n for Title and Label translation of PrivMon tiles

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/account_switches_tile/account_switches_tile.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/account_switches_tile/account_switches_tile.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+import { i18n } from '@kbn/i18n';
 import { getAccountSwitchesEsqlCount } from './esql_query';
 import { KeyInsightsTile } from '../common/key_insights_tile';
 
@@ -17,18 +18,12 @@ export const AccountSwitchesTile: React.FC<{ spaceId: string; sourcerDataView: D
 }) => {
   return (
     <KeyInsightsTile
-      title={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.accountSwitches.title"
-          defaultMessage="Account Switches"
-        />
-      }
-      label={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.accountSwitches.label"
-          defaultMessage="Account Switches"
-        />
-      }
+      title={i18n.translate('xpack.securitySolution.privmon.accountSwitches.title', {
+        defaultMessage: 'Account Switches',
+      })}
+      label={i18n.translate('xpack.securitySolution.privmon.accountSwitches.label', {
+        defaultMessage: 'Account Switches',
+      })}
       getEsqlQuery={(namespace) => getAccountSwitchesEsqlCount(namespace, sourcerDataView)}
       id="privileged-user-monitoring-account-switches"
       spaceId={spaceId}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/active_privileged_users_tile/active_privileged_users_tile.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/active_privileged_users_tile/active_privileged_users_tile.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+import { i18n } from '@kbn/i18n';
 import { getActivePrivilegedUsersEsqlCount } from './esql_query';
 import { KeyInsightsTile } from '../common/key_insights_tile';
 
@@ -17,18 +18,12 @@ export const ActivePrivilegedUsersTile: React.FC<{
 }> = ({ spaceId, sourcerDataView }) => {
   return (
     <KeyInsightsTile
-      title={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.activePrivilegedUsers.title"
-          defaultMessage="Active Privileged Users"
-        />
-      }
-      label={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.activePrivilegedUsers.label"
-          defaultMessage="Active Privileged Users"
-        />
-      }
+      title={i18n.translate('xpack.securitySolution.privmon.activePrivilegedUsers.title', {
+        defaultMessage: 'Active Privileged Users',
+      })}
+      label={i18n.translate('xpack.securitySolution.privmon.activePrivilegedUsers.label', {
+        defaultMessage: 'Active Privileged Users',
+      })}
       getEsqlQuery={(namespace: string) =>
         getActivePrivilegedUsersEsqlCount(namespace, sourcerDataView)
       }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/alerts_triggered_tile/alerts_triggered_tile.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/alerts_triggered_tile/alerts_triggered_tile.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { getAlertsTriggeredEsqlCount } from './esql_query';
 import { KeyInsightsTile } from '../common/key_insights_tile';
 import { useSignalIndex } from '../../../../../../detections/containers/detection_engine/alerts/use_signal_index';
@@ -15,18 +16,12 @@ export const AlertsTriggeredTile: React.FC<{ spaceId: string }> = ({ spaceId }) 
   const { signalIndexName: alertsIndexName } = useSignalIndex();
   return (
     <KeyInsightsTile
-      title={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.alertsTriggered.title"
-          defaultMessage="Alerts Triggered"
-        />
-      }
-      label={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.alertsTriggered.label"
-          defaultMessage="Alerts Triggered"
-        />
-      }
+      title={i18n.translate('xpack.securitySolution.privmon.alertsTriggered.title', {
+        defaultMessage: 'Alerts Triggered',
+      })}
+      label={i18n.translate('xpack.securitySolution.privmon.alertsTriggered.label', {
+        defaultMessage: 'Alerts Triggered',
+      })}
       getEsqlQuery={(namespace) => getAlertsTriggeredEsqlCount(namespace, alertsIndexName)}
       id="privileged-user-monitoring-alerts-triggered"
       spaceId={spaceId}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/anomalies_detected_tile/anomalies_detected_tile.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/anomalies_detected_tile/anomalies_detected_tile.tsx
@@ -7,24 +7,19 @@
 
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { getAnomaliesDetectedEsqlQuery } from './esql_query';
 import { KeyInsightsTile } from '../common/key_insights_tile';
 
 export const AnomaliesDetectedTile: React.FC<{ spaceId: string }> = ({ spaceId }) => {
   return (
     <KeyInsightsTile
-      title={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.anomaliesDetected.title"
-          defaultMessage="Anomalies Detected"
-        />
-      }
-      label={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.anomaliesDetected.label"
-          defaultMessage="Anomalies Detected"
-        />
-      }
+      title={i18n.translate('xpack.securitySolution.privmon.anomaliesDetected.title', {
+        defaultMessage: 'Anomalies Detected',
+      })}
+      label={i18n.translate('xpack.securitySolution.privmon.anomaliesDetected.label', {
+        defaultMessage: 'Anomalies Detected',
+      })}
       getEsqlQuery={(namespace) => getAnomaliesDetectedEsqlQuery(namespace)}
       id="privileged-user-monitoring-anomalies-detected"
       spaceId={spaceId}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/authentications_tile/authentications_tile.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/authentications_tile/authentications_tile.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+import { i18n } from '@kbn/i18n';
 import { getAuthenticationsEsqlCount } from './esql_query';
 import { KeyInsightsTile } from '../common/key_insights_tile';
 
@@ -17,18 +18,12 @@ export const AuthenticationsTile: React.FC<{ spaceId: string; sourcerDataView: D
 }) => {
   return (
     <KeyInsightsTile
-      title={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.authentications.title"
-          defaultMessage="Authentications"
-        />
-      }
-      label={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.authentications.label"
-          defaultMessage="Authentications"
-        />
-      }
+      title={i18n.translate('xpack.securitySolution.privmon.authentications.title', {
+        defaultMessage: 'Authentications',
+      })}
+      label={i18n.translate('xpack.securitySolution.privmon.authentications.label', {
+        defaultMessage: 'Authentications',
+      })}
       getEsqlQuery={(namespace) => getAuthenticationsEsqlCount(namespace, sourcerDataView)}
       id="privileged-user-monitoring-authentications"
       spaceId={spaceId}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/common/key_insights_tile.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/common/key_insights_tile.tsx
@@ -20,8 +20,8 @@ const LENS_VISUALIZATION_HEIGHT = 150;
 const LENS_VISUALIZATION_MIN_WIDTH = 220;
 
 interface KeyInsightsTileProps {
-  title: ReactElement;
-  label: ReactElement;
+  title: string;
+  label: string;
   getEsqlQuery: (namespace: string) => string;
   id: string;
   inspectTitle: ReactElement;
@@ -43,13 +43,9 @@ export const KeyInsightsTile: React.FC<KeyInsightsTileProps> = ({
   // Use prop spaceId if provided, otherwise use hook spaceId, fallback to 'default'
   const effectiveSpaceId = propSpaceId || hookSpaceId || 'default';
 
-  // Extract the defaultMessage from FormattedMessage elements
-  const titleString = title.props.defaultMessage;
-  const labelString = label.props.defaultMessage;
-
   const lensAttributes = createKeyInsightsPanelLensAttributes({
-    title: titleString,
-    label: labelString,
+    title,
+    label,
     esqlQuery: getEsqlQuery(effectiveSpaceId),
     dataViewId: 'default-dataview',
     filterQuery,
@@ -91,7 +87,7 @@ export const KeyInsightsTile: React.FC<KeyInsightsTileProps> = ({
       >
         <EuiFlexItem grow={false}>
           <EuiTitle size="xs">
-            <h4>{titleString}</h4>
+            <h4>{title}</h4>
           </EuiTitle>
         </EuiFlexItem>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/granted_rights_tile/granted_rights_tile.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/key_insights_panel/granted_rights_tile/granted_rights_tile.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+import { i18n } from '@kbn/i18n';
 import { getGrantedRightsEsqlCount } from './esql_query';
 import { KeyInsightsTile } from '../common/key_insights_tile';
 
@@ -17,18 +18,12 @@ export const GrantedRightsTile: React.FC<{ spaceId: string; sourcerDataView: Dat
 }) => {
   return (
     <KeyInsightsTile
-      title={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.grantedRights.title"
-          defaultMessage="Granted Rights"
-        />
-      }
-      label={
-        <FormattedMessage
-          id="xpack.securitySolution.privmon.grantedRights.label"
-          defaultMessage="Granted Rights"
-        />
-      }
+      title={i18n.translate('xpack.securitySolution.privmon.grantedRights.title', {
+        defaultMessage: 'Granted Rights',
+      })}
+      label={i18n.translate('xpack.securitySolution.privmon.grantedRights.label', {
+        defaultMessage: 'Granted Rights',
+      })}
       getEsqlQuery={(namespace) => getGrantedRightsEsqlCount(namespace, sourcerDataView)}
       id="privileged-user-monitoring-granted-rights"
       spaceId={spaceId}


### PR DESCRIPTION
## Summary

The title and label for the privmon tiles were always in English.
This PR changes the implementation to use `i18n.translate` which returns a localized string for title and label of privmon tiles based on the user's language settings.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->