### PR TITLE
[onechat] sanitize tool ids for conv history

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/index.ts
@@ -23,6 +23,7 @@ export {
   toolsToLangchain,
   toolToLangchain,
   toolIdentifierFromToolCall,
+  sanitizeToolId,
   type ToolIdMapping,
   type ToolsAndMappings,
 } from './tools';

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/to_langchain_messages.ts
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
+import { BaseMessage, AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import {
   ConversationRound,
   RoundInput,
   ToolCallWithResult,
   isToolCallStep,
 } from '@kbn/onechat-common';
-import { BaseMessage, AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { sanitizeToolId } from '@kbn/onechat-genai-utils/langchain';
 
 /**
  * Converts a conversation to langchain format
@@ -69,12 +70,14 @@ const createAssistantMessage = ({ content }: { content: string }): AIMessage => 
 };
 
 export const createToolCallMessages = (toolCall: ToolCallWithResult): [AIMessage, ToolMessage] => {
+  const toolName = sanitizeToolId(toolCall.tool_id);
+
   const toolCallMessage = new AIMessage({
     content: '',
     tool_calls: [
       {
         id: toolCall.tool_call_id,
-        name: toolCall.tool_id,
+        name: toolName,
         args: toolCall.params,
         type: 'tool_call',
       },


### PR DESCRIPTION
## Summary

Fix a bug causing tool calls from previous rounds to not be escaped to a valid LLM format


