### PR TITLE
[Entity Analytics] Unskipping tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs/asset_document.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs/asset_document.test.tsx
@@ -18,9 +18,7 @@ import {
   TABLE_TAB_CONTENT_TEST_ID,
 } from '../../../document_details/right/tabs/test_ids';
 
-// FLAKY: https://github.com/elastic/kibana/issues/216735
-// FLAKY: https://github.com/elastic/kibana/issues/216815
-describe.skip('AssetDocumentTab', () => {
+describe('AssetDocumentTab', () => {
   it('renders', () => {
     const { getByTestId } = render(
       <TestProviders>


### PR DESCRIPTION
## Summary

These tests were skipped a few months ago due to flakyness. We've investigated and the suite seems to be stable now. We see no reasons for the flakyness or failures.
As such, we're re-enabling the test suite.


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->