### PR TITLE
[Workspace Chrome] Fix link editor flyout footer in new layout

### DIFF
--- a/src/platform/plugins/private/links/public/components/editor/links_editor.tsx
+++ b/src/platform/plugins/private/links/public/components/editor/links_editor.tsx
@@ -356,7 +356,7 @@ const styles = {
     return css({
       '.linkEditor': {
         maxInlineSize: `calc(${euiTheme.size.xs} * 125)`,
-        height: 'calc(100vh - var(--euiFixedHeadersOffset, 0))',
+        height: 'var(--kbn-application--content-height)',
         position: 'fixed',
         display: 'flex',
         inlineSize: '50vw',


### PR DESCRIPTION
## Summary

Fix the issue where the link editor footer is not visible in the new layout while maintaining backward compatibility.

<img width="1026" height="1644" alt="Screenshot 2025-07-21 at 10 29 51" src="https://github.com/user-attachments/assets/b7882f2b-5ab9-444f-80e1-60515c8b4c57" />


Fyi, here is more info on new layout and differences explaining why this no longer works: https://docs.google.com/document/d/1nQc-yfwE3ckbHzK9KQTuOzM5RxNYtAGIqtrOZvzKXKA/edit?tab=t.y010l4hcbtf6#heading=h.1aeqpap2m310


to test with new layout: 


```
feature_flags.overrides:
  core.chrome.layoutType: 'grid'
```