### PR TITLE
[Fleet] Handle Not Found in integration sync remote_status API

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/get_remote_status.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/get_remote_status.ts
@@ -59,8 +59,8 @@ export const getRemoteSyncedIntegrationsInfoByOutputId = async (
       },
       method: 'GET',
     };
-    const url = `${kibanaUrl}/api/fleet/remote_synced_integrations/status`;
-    logger.debug(`Fetching ${kibanaUrl}/api/fleet/remote_synced_integrations/status`);
+    const url = `${kibanaUrl.replace(/\/$/, '')}/api/fleet/remote_synced_integrations/status`;
+    logger.debug(`Fetching ${url}`);
 
     let body;
     let errorMessage;
@@ -79,6 +79,9 @@ export const getRemoteSyncedIntegrationsInfoByOutputId = async (
 
     if (body?.statusCode && body?.message) {
       errorMessage = `GET ${url} failed with status ${body.statusCode}. ${body.message}`;
+    }
+    if (body?.ok === false && body?.message) {
+      errorMessage = `GET ${url} failed with status ${res?.status}: ${body.message}`;
     }
 
     return {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/225954

The `remote_status` API used to poll for the status of integration sync on the remote cluster currently does not handle cases where the Fetch response has `res.ok === false` and a body like `{ ok: false, message: 'Unknown resource.' }`. Such a scenario can happen as reported in https://github.com/elastic/kibana/issues/225954, where the remote Kibana is no longer accessible. This PR adds a check to handle these cases.

I took the opportunity to allow the user to enter a remote Kibana URL with a trailing slash, which previously caused the request to fail.

### Before

Response:
```json
{
  "integrations": []
}
```

<img width="959" height="244" alt="Screenshot 2025-07-21 at 11 24 16" src="https://github.com/user-attachments/assets/0901f385-57a1-4291-8191-1cf7681fc309" />

### After

Response:
```json
{
  "integrations": [],
  "error": "GET https://fleet-testing-1.kb.eu-west-1.aws.qa.cld.elstc.co/api/fleet/remote_synced_integrations/status failed with status 404: Unknown resource."
}
```

<img width="959" height="244" alt="Screenshot 2025-07-21 at 11 21 52" src="https://github.com/user-attachments/assets/de300055-e25d-48cc-8556-c5fb4dcf90c0" />

### Testing

1. Spin up a test remote cluster on cloud.
2. Run a local cluster with this branch:
   * Set up remote ES output with integration sync enabled and the remote cluster Kibana URL. The cluster should connect and the sync status should fail with `Follower index not found`.
3. Delete the remote cluster. The sync status should fail with `404: Unknown resource`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk of incorrect status of integration syncing with remote cluster.





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->