### PR TITLE
Change global_search test assertion

### DIFF
--- a/x-pack/test/plugin_functional/test_suites/global_search/global_search_providers.ts
+++ b/x-pack/test/plugin_functional/test_suites/global_search/global_search_providers.ts
@@ -28,9 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     }, t);
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/228679
-  // Failing: See https://github.com/elastic/kibana/issues/228679
-  describe.skip('GlobalSearch providers', function () {
+  describe('GlobalSearch providers', function () {
     before(async () => {
       await pageObjects.common.navigateToApp('globalSearchTestApp');
     });
@@ -94,7 +92,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     describe('Applications provider', function () {
       it('can search for root-level applications', async () => {
         const results = await findResultsWithApi('discover');
-        expect(results.length).to.be(2);
         expect(results[0].title).to.be('Discover');
       });
 


### PR DESCRIPTION
## Summary

The test assertion became incorrect as it seems that an integration was [made available](https://github.com/elastic/integrations/pull/14591) for versions `>=9.1.0`: 
```javascript
{
    icon: '/api/fleet/epm/packages/cloud_asset_inventory/1.0.0/img/logo_cloud_security_posture.svg',
    id: 'cloud_asset_inventory',
    score: 80,
    title: 'Cloud Asset Discovery',
    type: 'integration',
    url: '/app/integrations/detail/cloud_asset_inventory/overview'
}
```
The integration contains the `discover` string in title, which is what the test is looking for. Integrations are fetched via an API and they are defined in the integration repository. 

This test should **NOT** check for the length of results as they might change.

The following assertion:
```javascript
expect(results[0].title).to.be('Discover')
``` 
should always succeed as this is a direct match, which means the result has the highest score and will always appear on top. Eventually this test could be improved to exclude integrations.

Closes: #228679



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->