### PR TITLE
[9.1] [APM] Test array checks fix with sorting (#228663)

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/preview_chart_transaction_duration.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/preview_chart_transaction_duration.spec.ts
@@ -56,8 +56,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     },
   });
 
-  // Failing: See https://github.com/elastic/kibana/issues/228503
-  describe.skip('preview chart transaction duration', () => {
+  describe('preview chart transaction duration', () => {
     describe(`without data loaded`, () => {
       it('transaction_duration (without data)', async () => {
         const options = getOptions();
@@ -203,12 +202,13 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
           expect(response.status).to.be(200);
           expect(response.body.latencyChartPreview.series.length).to.equal(2);
-          expect(
-            response.body.latencyChartPreview.series.map((item: PreviewChartResponseItem) => ({
+          const responseSeries = response.body.latencyChartPreview.series
+            .map((item: PreviewChartResponseItem) => ({
               name: item.name,
               y: item.data[0].y,
             }))
-          ).to.eql([
+            .sort((a, b) => a.name.localeCompare(b.name));
+          expect(responseSeries).to.eql([
             { name: 'synth-go_production_request_GET /apple', y: 10000 },
             { name: 'synth-go_production_request_GET /banana', y: 5000 },
           ]);
@@ -258,12 +258,13 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           });
 
           expect(response.status).to.be(200);
-          expect(
-            response.body.latencyChartPreview.series.map((item: PreviewChartResponseItem) => ({
+          const responseSeries = response.body.latencyChartPreview.series
+            .map((item: PreviewChartResponseItem) => ({
               name: item.name,
               y: item.data[0].y,
             }))
-          ).to.eql([
+            .sort((a, b) => a.name.localeCompare(b.name));
+          expect(responseSeries).to.eql([
             { name: 'synth-go_production_request', y: 7500 },
             { name: 'synth-java_production_request', y: 7500 },
           ]);
@@ -289,15 +290,16 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
           expect(response.status).to.be(200);
           expect(response.body.latencyChartPreview.series.length).to.equal(4);
-          expect(
-            response.body.latencyChartPreview.series.map((item: PreviewChartResponseItem) => ({
+          const responseSeries = response.body.latencyChartPreview.series
+            .map((item: PreviewChartResponseItem) => ({
               name: item.name,
               y: item.data[0].y,
             }))
-          ).to.eql([
+            .sort((a, b) => a.name.localeCompare(b.name));
+          expect(responseSeries).to.eql([
             { name: 'synth-go_production_request_GET /apple', y: 10000 },
-            { name: 'synth-java_production_request_GET /apple', y: 10000 },
             { name: 'synth-go_production_request_GET /banana', y: 5000 },
+            { name: 'synth-java_production_request_GET /apple', y: 10000 },
             { name: 'synth-java_production_request_GET /banana', y: 5000 },
           ]);
         });
@@ -449,12 +451,13 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
           expect(response.status).to.be(200);
           expect(response.body.latencyChartPreview.series.length).to.equal(2);
-          expect(
-            response.body.latencyChartPreview.series.map((item: PreviewChartResponseItem) => ({
+          const responseSeries = response.body.latencyChartPreview.series
+            .map((item: PreviewChartResponseItem) => ({
               name: item.name,
               y: item.data[0].y,
             }))
-          ).to.eql([
+            .sort((a, b) => a.name.localeCompare(b.name));
+          expect(responseSeries).to.eql([
             { name: 'synth-go_production_request_GET /apple', y: 10000 },
             { name: 'synth-go_production_request_GET /banana', y: 5000 },
           ]);
@@ -513,12 +516,13 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           });
 
           expect(response.status).to.be(200);
-          expect(
-            response.body.latencyChartPreview.series.map((item: PreviewChartResponseItem) => ({
+          const responseSeries = response.body.latencyChartPreview.series
+            .map((item: PreviewChartResponseItem) => ({
               name: item.name,
               y: item.data[0].y,
             }))
-          ).to.eql([
+            .sort((a, b) => a.name.localeCompare(b.name));
+          expect(responseSeries).to.eql([
             { name: 'synth-go_production_request', y: 7500 },
             { name: 'synth-java_production_request', y: 7500 },
           ]);
@@ -547,15 +551,16 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
           expect(response.status).to.be(200);
           expect(response.body.latencyChartPreview.series.length).to.equal(4);
-          expect(
-            response.body.latencyChartPreview.series.map((item: PreviewChartResponseItem) => ({
+          const responseSeries = response.body.latencyChartPreview.series
+            .map((item: PreviewChartResponseItem) => ({
               name: item.name,
               y: item.data[0].y,
             }))
-          ).to.eql([
+            .sort((a, b) => a.name.localeCompare(b.name));
+          expect(responseSeries).to.eql([
             { name: 'synth-go_production_request_GET /apple', y: 10000 },
-            { name: 'synth-java_production_request_GET /apple', y: 10000 },
             { name: 'synth-go_production_request_GET /banana', y: 5000 },
+            { name: 'synth-java_production_request_GET /apple', y: 10000 },
             { name: 'synth-java_production_request_GET /banana', y: 5000 },
           ]);
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[APM] Test array checks fix with sorting (#228663)](https://github.com/elastic/kibana/pull/228663)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-07-21T10:37:14Z","message":"[APM] Test array checks fix with sorting (#228663)\n\nCloses #228392 \nCloses [#228392](https://github.com/elastic/kibana/issues/228392)\nCloses [#228503](https://github.com/elastic/kibana/issues/228503)\nCloses [#228495](https://github.com/elastic/kibana/issues/228495)\nCloses [#228379](https://github.com/elastic/kibana/issues/228379)\n\n## Summary\n\nThis PR fixes the flakiness of the tests by sorting the array before\nchecking the values. After an investigation and some runs locally, I say\nthat we have the same values in a different order. Sorting the array\nupfront will solve that issue.","sha":"2bbd59cfa627ddeb1be142872f4e41daba59c9f4","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0","v9.2.0"],"title":"[APM] Test array checks fix with sorting","number":228663,"url":"https://github.com/elastic/kibana/pull/228663","mergeCommit":{"message":"[APM] Test array checks fix with sorting (#228663)\n\nCloses #228392 \nCloses [#228392](https://github.com/elastic/kibana/issues/228392)\nCloses [#228503](https://github.com/elastic/kibana/issues/228503)\nCloses [#228495](https://github.com/elastic/kibana/issues/228495)\nCloses [#228379](https://github.com/elastic/kibana/issues/228379)\n\n## Summary\n\nThis PR fixes the flakiness of the tests by sorting the array before\nchecking the values. After an investigation and some runs locally, I say\nthat we have the same values in a different order. Sorting the array\nupfront will solve that issue.","sha":"2bbd59cfa627ddeb1be142872f4e41daba59c9f4"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228663","number":228663,"mergeCommit":{"message":"[APM] Test array checks fix with sorting (#228663)\n\nCloses #228392 \nCloses [#228392](https://github.com/elastic/kibana/issues/228392)\nCloses [#228503](https://github.com/elastic/kibana/issues/228503)\nCloses [#228495](https://github.com/elastic/kibana/issues/228495)\nCloses [#228379](https://github.com/elastic/kibana/issues/228379)\n\n## Summary\n\nThis PR fixes the flakiness of the tests by sorting the array before\nchecking the values. After an investigation and some runs locally, I say\nthat we have the same values in a different order. Sorting the array\nupfront will solve that issue.","sha":"2bbd59cfa627ddeb1be142872f4e41daba59c9f4"}}]}] BACKPORT-->