### PR TITLE
[9.1] Change global_search test assertion (#228740)

### DIFF
--- a/x-pack/test/plugin_functional/test_suites/global_search/global_search_providers.ts
+++ b/x-pack/test/plugin_functional/test_suites/global_search/global_search_providers.ts
@@ -28,8 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     }, t);
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/228679
-  describe.skip('GlobalSearch providers', function () {
+  describe('GlobalSearch providers', function () {
     before(async () => {
       await pageObjects.common.navigateToApp('globalSearchTestApp');
     });
@@ -93,7 +92,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     describe('Applications provider', function () {
       it('can search for root-level applications', async () => {
         const results = await findResultsWithApi('discover');
-        expect(results.length).to.be(2);
         expect(results[0].title).to.be('Discover');
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Change global_search test assertion (#228740)](https://github.com/elastic/kibana/pull/228740)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Krzysztof Kowalczyk","email":"krzysztof.kowalczyk@elastic.co"},"sourceCommit":{"committedDate":"2025-07-21T11:43:14Z","message":"Change global_search test assertion (#228740)\n\n## Summary\n\nThe test assertion became incorrect as it seems that an integration was\n[made available](https://github.com/elastic/integrations/pull/14591) for\nversions `>9.1.0`:\n```javascript\n{\n    icon: '/api/fleet/epm/packages/cloud_asset_inventory/1.0.0/img/logo_cloud_security_posture.svg',\n    id: 'cloud_asset_inventory',\n    score: 80,\n    title: 'Cloud Asset Discovery',\n    type: 'integration',\n    url: '/app/integrations/detail/cloud_asset_inventory/overview'\n  }\n```\nThe integration contains the `discover` string in title, which is what\nthe test is looking for. Integrations are fetched via an API and they\nare defined in integration repository.\n\nThis test should NOT check for the length of results as they might\nchange.\n\nCloses: #228679","sha":"19802227747ee5e7022af2f5f8b87cba9f7eff1c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:version","v9.1.0","v9.2.0"],"title":"Change global_search test assertion","number":228740,"url":"https://github.com/elastic/kibana/pull/228740","mergeCommit":{"message":"Change global_search test assertion (#228740)\n\n## Summary\n\nThe test assertion became incorrect as it seems that an integration was\n[made available](https://github.com/elastic/integrations/pull/14591) for\nversions `>9.1.0`:\n```javascript\n{\n    icon: '/api/fleet/epm/packages/cloud_asset_inventory/1.0.0/img/logo_cloud_security_posture.svg',\n    id: 'cloud_asset_inventory',\n    score: 80,\n    title: 'Cloud Asset Discovery',\n    type: 'integration',\n    url: '/app/integrations/detail/cloud_asset_inventory/overview'\n  }\n```\nThe integration contains the `discover` string in title, which is what\nthe test is looking for. Integrations are fetched via an API and they\nare defined in integration repository.\n\nThis test should NOT check for the length of results as they might\nchange.\n\nCloses: #228679","sha":"19802227747ee5e7022af2f5f8b87cba9f7eff1c"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228740","number":228740,"mergeCommit":{"message":"Change global_search test assertion (#228740)\n\n## Summary\n\nThe test assertion became incorrect as it seems that an integration was\n[made available](https://github.com/elastic/integrations/pull/14591) for\nversions `>9.1.0`:\n```javascript\n{\n    icon: '/api/fleet/epm/packages/cloud_asset_inventory/1.0.0/img/logo_cloud_security_posture.svg',\n    id: 'cloud_asset_inventory',\n    score: 80,\n    title: 'Cloud Asset Discovery',\n    type: 'integration',\n    url: '/app/integrations/detail/cloud_asset_inventory/overview'\n  }\n```\nThe integration contains the `discover` string in title, which is what\nthe test is looking for. Integrations are fetched via an API and they\nare defined in integration repository.\n\nThis test should NOT check for the length of results as they might\nchange.\n\nCloses: #228679","sha":"19802227747ee5e7022af2f5f8b87cba9f7eff1c"}}]}] BACKPORT-->