### PR TITLE
[ci] remove scout step key to avoid retry failure

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -564,7 +564,6 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
     [
       {
         group: 'Scout Configs',
-        key: 'scout-configs',
         depends_on: ['build'],
         steps: scoutGroups.map(
           ({ title, key, group, usesParallelWorkers }): BuildkiteStep => ({


### PR DESCRIPTION
## Summary

Trying to fix the BK error:

```
2025-07-17 15:21:08 UTC
2025-07-17 15:21:08 ERROR  Unrecoverable error, skipping retries
2025-07-17 15:21:08 UTC
fatal: Failed to upload and process pipeline: Pipeline upload rejected: The key "scout-configs" has already been used by another step in this build
2025-07-17 15:21:08 UTC
CI Stats Error Command failed: buildkite-agent pipeline upload
```

We don't use the `key` at the moment, so let's just remove it and make sure retry won't fail.


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->