### PR TITLE
[Index Management] Hide Edit data retention bulk action for ILM managed data streams

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/data_streams_tab.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/data_streams_tab.test.ts
@@ -969,6 +969,28 @@ describe('Data Streams tab', () => {
         expect(exists('editDataRetentionButton')).toBe(false);
       });
 
+      test('displays/hides bulk edit data retention depending if data stream fully managed by ILM is selected', async () => {
+        const {
+          find,
+          actions: { selectDataStream, clickManageDataStreamsButton },
+        } = testBed;
+
+        // Select data stream fully managed by ILM
+        selectDataStream('dataStream1', true);
+        clickManageDataStreamsButton();
+        expect(find('bulkEditDataRetentionButton').exists()).toBeFalsy();
+
+        // Select data stream managed by DSL
+        selectDataStream('dataStream2', true);
+        clickManageDataStreamsButton();
+        expect(find('bulkEditDataRetentionButton').exists()).toBeFalsy();
+
+        // Unselect data stream fully managed by ILM
+        selectDataStream('dataStream1', false);
+        clickManageDataStreamsButton();
+        expect(find('bulkEditDataRetentionButton').exists()).toBeTruthy();
+      });
+
       test('when partially managed by dsl but has backing indices managed by ILM should show a warning', async () => {
         const { setLoadDataStreamResponse } = httpRequestsMockHelpers;
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
@@ -288,7 +288,11 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
   const dataStreamActions: EuiContextMenuPanelItemDescriptor[] = [];
 
   if (
-    selection.every((dataStream: DataStream) => dataStream.privileges.manage_data_stream_lifecycle)
+    selection.every(
+      (dataStream: DataStream) =>
+        dataStream.privileges.manage_data_stream_lifecycle &&
+        !isDataStreamFullyManagedByILM(dataStream)
+    )
   ) {
     dataStreamActions.push({
       name: i18n.translate('xpack.idxMgmt.dataStreamList.table.bulkEditDataRetentionButtonLabel', {


### PR DESCRIPTION
Closes #211020

## Summary

This PR fixes an issue where `Edit data retention` bulk action was available when data stream fully managed by ILM was selected.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->