### PR TITLE
[9.1] [Lens][Metric] Fix secondary metric trend when primary metric is non-numeric (#228382)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/metric/dimension_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/metric/dimension_editor.tsx
@@ -381,7 +381,7 @@ function TrendEditor({
             }}
           />
           <EuiSpacer size="s" />
-          {secondaryTrend.baselineValue !== 'primary' ? (
+          {!isPrimaryMetricOptionSelected ? (
             <DebouncedInput
               data-test-subj="lnsMetric_secondary_trend_baseline_input"
               compressed
@@ -422,6 +422,7 @@ function SecondaryMetricEditor({
   const columnName = getColumnByAccessor(accessor, frame.activeData?.[layerId]?.columns)?.name;
   const defaultPrefix = columnName || '';
   const { isNumeric: isNumericType } = getAccessorType(datasource, accessor);
+  const { isNumeric: isPrimaryMetricNumeric } = getAccessorType(datasource, state.metricAccessor);
   const colorMode = getColorMode(state.secondaryTrend, isNumericType);
   const [prevColorConfig, setPrevColorConfig] = useState<{
     static: SecondaryTrendConfigByType<'static'> | undefined;
@@ -446,7 +447,11 @@ function SecondaryMetricEditor({
     [state]
   );
 
-  const prefixConfig = getPrefixSelected(state, { defaultPrefix, colorMode });
+  const prefixConfig = getPrefixSelected(state, {
+    defaultPrefix,
+    colorMode,
+    isPrimaryMetricNumeric,
+  });
 
   return (
     <>

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/metric/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/metric/helpers.ts
@@ -27,7 +27,11 @@ export function getColorMode(
 
 export function getPrefixSelected(
   state: VisualizationDimensionEditorProps<MetricVisualizationState>['state'],
-  { defaultPrefix, colorMode }: { defaultPrefix: string; colorMode: SecondaryTrendType }
+  {
+    defaultPrefix,
+    colorMode,
+    isPrimaryMetricNumeric,
+  }: { defaultPrefix: string; colorMode: SecondaryTrendType; isPrimaryMetricNumeric: boolean }
 ): { mode: 'auto' | 'none' } | { mode: 'custom'; label: string } {
   const isAutoPrefix = state.secondaryPrefix === undefined;
   const hasPrefixOverride =
@@ -36,7 +40,8 @@ export function getPrefixSelected(
     // it is not enabled due to other conflicts (i.e. primary metric is not numeric)
     colorMode === 'dynamic' &&
     state.secondaryTrend?.type === 'dynamic' &&
-    state.secondaryTrend.baselineValue === 'primary';
+    state.secondaryTrend.baselineValue === 'primary' &&
+    isPrimaryMetricNumeric;
 
   if (isAutoPrefix) {
     return hasPrefixOverride
@@ -93,4 +98,26 @@ export function getTrendPalette(
   const palette = getKbnPalettes(theme).get(secondaryTrend.paletteId);
   const colors = palette?.colors(3);
   return (secondaryTrend.reversed ? colors.reverse() : colors) as [string, string, string];
+}
+
+export function getSecondaryDynamicTrendBaselineValue(
+  isPrimaryMetricNumeric: boolean,
+  baselineValue: number | 'primary'
+) {
+  // If primary is not numeric, reset baseline value to 0
+  if (!isPrimaryMetricNumeric && baselineValue === 'primary') return 0;
+  return baselineValue;
+}
+
+export function isSecondaryTrendConfigInvalid(
+  secondaryTrend: MetricVisualizationState['secondaryTrend'],
+  colorMode: SecondaryTrendType,
+  isPrimaryMetricNumeric: boolean
+): boolean {
+  return (
+    colorMode !== secondaryTrend?.type ||
+    (secondaryTrend?.type === 'dynamic' &&
+      secondaryTrend?.baselineValue === 'primary' &&
+      !isPrimaryMetricNumeric)
+  );
 }

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/metric/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/metric/to_expression.ts
@@ -33,6 +33,7 @@ import {
   getDefaultConfigForMode,
   getPrefixSelected,
   getTrendPalette,
+  getSecondaryDynamicTrendBaselineValue,
 } from './helpers';
 import { getAccessorType } from '../../shared_components';
 
@@ -165,6 +166,7 @@ export const toExpression = (
   const secondaryPrefixConfig = getPrefixSelected(state, {
     defaultPrefix: '',
     colorMode: secondaryDynamicColorMode,
+    isPrimaryMetricNumeric: isMetricNumeric,
   });
 
   const secondaryTrendConfig =
@@ -182,9 +184,7 @@ export const toExpression = (
       secondaryTrendConfig.type === 'dynamic' ? secondaryTrendConfig.visuals : undefined,
     secondaryTrendBaseline:
       secondaryTrendConfig.type === 'dynamic'
-        ? isMetricNumeric
-          ? secondaryTrendConfig.baselineValue ?? 0
-          : 0
+        ? getSecondaryDynamicTrendBaselineValue(isMetricNumeric, secondaryTrendConfig.baselineValue)
         : undefined,
     secondaryTrendPalette: getTrendPalette(
       secondaryDynamicColorMode,

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/metric/visualization.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/metric/visualization.test.ts
@@ -1181,7 +1181,7 @@ describe('metric visualization', () => {
         )
       ).toEqual(
         expect.objectContaining({
-          state: expect.objectContaining({ secondaryTrend: getDefaultConfigForMode('static') }),
+          state: expect.objectContaining({ secondaryTrend: getDefaultConfigForMode('dynamic') }),
         })
       );
     });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/metric/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/metric/visualization.tsx
@@ -38,7 +38,12 @@ import { toExpression } from './to_expression';
 import { nonNullable } from '../../utils';
 import { METRIC_NUMERIC_MAX } from '../../user_messages_ids';
 import { MetricVisualizationState, SecondaryTrend } from './types';
-import { getColorMode, getDefaultConfigForMode, getTrendPalette } from './helpers';
+import {
+  getColorMode,
+  getDefaultConfigForMode,
+  getTrendPalette,
+  isSecondaryTrendConfigInvalid,
+} from './helpers';
 import { getAccessorType } from '../../shared_components';
 
 export const DEFAULT_MAX_COLUMNS = 3;
@@ -555,6 +560,7 @@ export const getMetricVisualization = ({
     if (!datasourceLayer) {
       return { state, savedObjectReferences: [] };
     }
+
     // this should clean up the secondary trend state if in conflict
     const { isNumeric: isMetricNumeric } = getAccessorType(datasourceLayer, state.metricAccessor);
     const colorMode = getColorMode(state.secondaryTrend, isMetricNumeric);

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/metric/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/metric/visualization.tsx
@@ -562,19 +562,28 @@ export const getMetricVisualization = ({
     }
 
     // this should clean up the secondary trend state if in conflict
-    const { isNumeric: isMetricNumeric } = getAccessorType(datasourceLayer, state.metricAccessor);
-    const colorMode = getColorMode(state.secondaryTrend, isMetricNumeric);
-    // if there are no conflicts, it's all persistable as is
-    if (colorMode === state.secondaryTrend?.type) {
-      return { state, savedObjectReferences: [] };
+    const { isNumeric: isPrimaryMetricNumeric } = getAccessorType(
+      datasourceLayer,
+      state.metricAccessor
+    );
+    const { isNumeric: isSecondaryMetricNumeric } = getAccessorType(
+      datasourceLayer,
+      state.secondaryMetricAccessor
+    );
+    const colorMode = getColorMode(state.secondaryTrend, isSecondaryMetricNumeric);
+
+    if (isSecondaryTrendConfigInvalid(state.secondaryTrend, colorMode, isPrimaryMetricNumeric)) {
+      return {
+        state: {
+          ...state,
+          secondaryPrefix: undefined,
+          secondaryTrend: getDefaultConfigForMode(colorMode),
+        },
+        savedObjectReferences: [],
+      };
     }
-    return {
-      state: {
-        ...state,
-        secondaryTrend: getDefaultConfigForMode(colorMode),
-      },
-      savedObjectReferences: [],
-    };
+    // if there are no conflicts, it's all persistable as is
+    return { state, savedObjectReferences: [] };
   },
 
   setDimension({ prevState, columnId, groupId }) {

--- a/x-pack/test/functional/apps/lens/group6/metric.ts
+++ b/x-pack/test/functional/apps/lens/group6/metric.ts
@@ -76,6 +76,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   describe('lens metric', () => {
+    const BADGE_SELECTOR = `[data-test-subj^="expressionMetricVis-secondaryMetric-badge-"]`;
+    // get a reference to the badge element
+    const getBadge = async () => await find.byCssSelector(BADGE_SELECTOR);
+
     it('should render a metric', async () => {
       await visualize.navigateToNewVisualization();
       await visualize.clickVisType('lens');
@@ -374,7 +378,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should show a badge for the secondary metric', async () => {
-      const BADGE_SELECTOR = `[data-test-subj^="expressionMetricVis-secondaryMetric-badge-"]`;
       const CUSTOM_STATIC_COLOR_HEX = '#EE72A6';
 
       async function getBackgroundColorForBadge(el: WebElementWrapper | null) {
@@ -428,8 +431,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // now configure a static badge color
       await testSubjects.click('lnsMetric_color_mode_static');
 
-      // get a reference to the badge element
-      const getBadge = async () => await find.byCssSelector(BADGE_SELECTOR);
       const colorPicker = await testSubjects.find('euiColorPickerAnchor');
 
       await colorPicker.clearValue();
@@ -517,6 +518,71 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       // test that there are 39 tiles now
       expect(await lens.getMetricTiles()).to.have.length(N_TILES);
+    });
+
+    it('should replace secondary metric prefix and badge when changing primary metric type to non-numeric', async () => {
+      // Create new metric lens vis
+      await visualize.navigateToNewVisualization();
+      await visualize.clickVisType('lens');
+      await lens.switchToVisualization('lnsMetric', 'Metric');
+
+      // Set primary metric: count of records
+      await lens.configureDimension({
+        dimension: 'lnsMetric_primaryMetricDimensionPanel > lns-empty-dimension',
+        operation: 'count',
+      });
+
+      // Set secondary metric: avg of bytes
+      await lens.configureDimension({
+        dimension: 'lnsMetric_secondaryMetricDimensionPanel > lns-empty-dimension',
+        operation: 'average',
+        field: 'bytes',
+        keepOpen: true,
+      });
+
+      // Set Dynamic color trend with compare to Primary metric
+      await testSubjects.click('lnsMetric_color_mode_dynamic');
+      await testSubjects.click('lnsMetric_secondary_trend_baseline_primary');
+      // Check the Prefix and the Badge text
+      expect(await (await getBadge()).getVisibleText()).to.be(`+8,277.678 ↑`);
+      const secondaryElement = await testSubjects.find('metric-secondary-element');
+      expect(await secondaryElement.getVisibleText()).to.contain('Difference');
+
+      // Save the visualization
+      await lens.save('Metric prefix badge test', false, true);
+
+      // Open in edit mode and change primary metric to last value of ip
+      await visualize.gotoVisualizationLandingPage();
+      await visualize.openSavedVisualization('Metric prefix badge test');
+
+      await lens.openDimensionEditor(
+        'lnsMetric_primaryMetricDimensionPanel > lns-dimensionTrigger'
+      );
+      await lens.configureDimension({
+        dimension: 'lnsMetric_primaryMetricDimensionPanel > lns-dimensionTrigger',
+        operation: 'last_value',
+        field: 'ip',
+        isPreviousIncompatible: true,
+      });
+
+      // The badge text should change and the prefix should be "Average of bytes"
+      expect(await (await getBadge()).getVisibleText()).to.be(`5,727.322 ↑`);
+      const newSecondaryElement = await testSubjects.find('metric-secondary-element');
+      expect(await newSecondaryElement.getVisibleText()).to.contain('Average of bytes');
+
+      // Open secondary metric editor
+      await lens.openDimensionEditor(
+        'lnsMetric_secondaryMetricDimensionPanel > lns-dimensionTrigger'
+      );
+      // Check the compare to has changed to static value and baseline input is visible
+      expect(await testSubjects.isEnabled('lnsMetric_secondary_trend_baseline_static')).to.be(true);
+      expect(await testSubjects.isEnabled('lnsMetric_secondary_trend_baseline_primary')).to.be(
+        false
+      );
+      expect(await testSubjects.isDisplayed('lnsMetric_secondary_trend_baseline_input')).to.be(
+        true
+      );
+      await lens.closeDimensionEditor();
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Lens][Metric] Fix secondary metric trend when primary metric is non-numeric (#228382)](https://github.com/elastic/kibana/pull/228382)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"72010092+andrimal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-21T11:34:38Z","message":"[Lens][Metric] Fix secondary metric trend when primary metric is non-numeric (#228382)\n\n## Summary\nFix #227960 \n\nFixes: \nA. The metric chart with non-numeric primary metric, numeric secondary\nmetric, dynamic trend and `compare to: static value` is saved with the\ncorrect badge which changes based on the static value.\n\n![Kapture 2025-07-17 at 10 48\n45](https://github.com/user-attachments/assets/ae34968e-505d-44b5-aedd-356b01dd2d5d)\n\nB. When changing the primary metric from numeric to non-numeric, and the\nsecondary trend is dynamic with `compare to: primary metric` then:\n - the `compare to` UI button changes to `static value`\n - the input UI is shown and \n - the batch and prefix are correct.\n\n![Kapture 2025-07-17 at 10 54\n45](https://github.com/user-attachments/assets/c75a99b2-ddfe-4db4-8890-483650e86afe)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"393ff5122cb7bc6f5702fec644ca1a88cb972fcf","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Lens][Metric] Fix secondary metric trend when primary metric is non-numeric","number":228382,"url":"https://github.com/elastic/kibana/pull/228382","mergeCommit":{"message":"[Lens][Metric] Fix secondary metric trend when primary metric is non-numeric (#228382)\n\n## Summary\nFix #227960 \n\nFixes: \nA. The metric chart with non-numeric primary metric, numeric secondary\nmetric, dynamic trend and `compare to: static value` is saved with the\ncorrect badge which changes based on the static value.\n\n![Kapture 2025-07-17 at 10 48\n45](https://github.com/user-attachments/assets/ae34968e-505d-44b5-aedd-356b01dd2d5d)\n\nB. When changing the primary metric from numeric to non-numeric, and the\nsecondary trend is dynamic with `compare to: primary metric` then:\n - the `compare to` UI button changes to `static value`\n - the input UI is shown and \n - the batch and prefix are correct.\n\n![Kapture 2025-07-17 at 10 54\n45](https://github.com/user-attachments/assets/c75a99b2-ddfe-4db4-8890-483650e86afe)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"393ff5122cb7bc6f5702fec644ca1a88cb972fcf"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228382","number":228382,"mergeCommit":{"message":"[Lens][Metric] Fix secondary metric trend when primary metric is non-numeric (#228382)\n\n## Summary\nFix #227960 \n\nFixes: \nA. The metric chart with non-numeric primary metric, numeric secondary\nmetric, dynamic trend and `compare to: static value` is saved with the\ncorrect badge which changes based on the static value.\n\n![Kapture 2025-07-17 at 10 48\n45](https://github.com/user-attachments/assets/ae34968e-505d-44b5-aedd-356b01dd2d5d)\n\nB. When changing the primary metric from numeric to non-numeric, and the\nsecondary trend is dynamic with `compare to: primary metric` then:\n - the `compare to` UI button changes to `static value`\n - the input UI is shown and \n - the batch and prefix are correct.\n\n![Kapture 2025-07-17 at 10 54\n45](https://github.com/user-attachments/assets/c75a99b2-ddfe-4db4-8890-483650e86afe)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"393ff5122cb7bc6f5702fec644ca1a88cb972fcf"}}]}] BACKPORT-->