### PR TITLE
[Discover] Fix Drag-n-Drop on Firefox in Lens inline editor flyout

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
@@ -116,7 +116,7 @@ const MaybeWrapper = ({
       size="s"
       hideCloseButton
       css={css`
-        clip-path: polygon(-100% 0, 100% 0, 100% 100%, -100% 100%);
+        clip-path: none; // need to override the eui-flyout clip-path for dnd outside of the flyout
       `}
     >
       {children}


### PR DESCRIPTION
## Summary

This PR adds the `clip-path: none` fix to the ESQL Lens inline flyout in discover. This was missed in #228625.

https://github.com/user-attachments/assets/c6b04ef6-9b4c-40b9-b676-c8b28a26c816

> With the current `clip-path` the scrolling does not work properly, with the default eui-flyout `clip-path` the extra drop targets outside of the flyout are cut off (see below). Setting `clip-path` to `none` fixes both issues.
> ![Zight 2025-07-21 at 2 24 22 PM](https://github.com/user-attachments/assets/08e37305-77a0-4c42-8a7a-4e494443ab6e)


Fixes #227939

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note

Fixes an issue on Firefox where the ESQL inline editor in discover would prevent scrolling.