### PR TITLE
[Backport] Adds 8.17.9 release notes to 8.18

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -14,6 +14,7 @@ Review important information about the {kib} 8.x releases.
 * <<release-notes-8.18.2>>
 * <<release-notes-8.18.1>>
 * <<release-notes-8.18.0>>
+* <<release-notes-8.17.9>>
 * <<release-notes-8.17.8>>
 * <<release-notes-8.17.7>>
 * <<release-notes-8.17.6>>
@@ -645,6 +646,29 @@ Machine Learning::
 * Anomaly Explorer: Fixes handling of job group IDs when opening from dashboard panels ({kibana-pull}203224[#203224]).
 * AiOps: Fixes Log Rate Analysis embeddable error on the Alerts page ({kibana-pull}203093[#203093]).
 * Initializes saved objects on trained model page load ({kibana-pull}201426[#201426]).
+
+[[release-notes-8.17.9]]
+== {kib} 8.17.9
+
+The 8.17.9 release includes the following fixes.
+
+[float]
+[[fixes-v8.17.9]]
+=== Fixes
+Alerting::
+* Fixes an issue causing reports to fail with an invalid header error ({kibana-pull}225919[#225919]).
+Dashboards and Visualizations::
+* Fixes an issue with dashboard sharing links where copied links were not shortened and some users were unable to copy links in new spaces ({kibana-pull}227625[#227625]).
+Data ingestion and Fleet::
+* Fixes error on the **Agents** tab when a tag is added to an agent while the **No Tags** filter is selected ({kibana-pull}225413[#225413]).
+Discover::
+* Prevents selected document from changing when resizing the **Document** flyout with a keyboard ({kibana-pull}225594[#225594]).
+Elastic Observability solution::
+* Sets environment name length when creating an ML job ({kibana-pull}225973[#225973]).
+* Fixes SLO federated view issue when remote clusters and index name listed exceed 4096 bytes ({kibana-pull}224478[#224478]).
+Machine Learning::
+* Fixes the handling of time range in embedded anomaly swim lane ({kibana-pull}225803[#225803]).
+* Resets to the default value when the `lookbackInterval` field is empty ({kibana-pull}225249[#225249]).
 
 [[release-notes-8.17.8]]
 == {kib} 8.17.8


### PR DESCRIPTION
## Backport

This PR backports the following commits to 8.18:

- https://github.com/elastic/kibana/commit/c7c5f4c0e4b0c600e3efa029c2fe0d068eaf03a1