### PR TITLE
[fix] Storybook controls were broken

### DIFF
--- a/src/platform/packages/shared/shared-ux/button/exit_full_screen/mocks/storybook.ts
+++ b/src/platform/packages/shared/shared-ux/button/exit_full_screen/mocks/storybook.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { ArgTypes } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import type { ArgumentParams } from '@kbn/shared-ux-storybook-mock';
 import { AbstractStorybookMock } from '@kbn/shared-ux-storybook-mock';
@@ -29,9 +30,9 @@ export class StorybookMock extends AbstractStorybookMock<
   PropArguments,
   {}
 > {
-  propArguments = {
+  propArguments: ArgTypes<PropArguments> = {
     toggleChrome: {
-      control: { control: 'boolean' },
+      control: { type: 'boolean' },
       defaultValue: true,
     },
   };

--- a/src/platform/packages/shared/shared-ux/button/exit_full_screen/mocks/storybook.ts
+++ b/src/platform/packages/shared/shared-ux/button/exit_full_screen/mocks/storybook.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ArgTypes } from '@storybook/react';
+import type { ArgTypes } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import type { ArgumentParams } from '@kbn/shared-ux-storybook-mock';
 import { AbstractStorybookMock } from '@kbn/shared-ux-storybook-mock';

--- a/src/platform/packages/shared/shared-ux/button/exit_full_screen/src/exit_full_screen_button.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/button/exit_full_screen/src/exit_full_screen_button.stories.tsx
@@ -18,6 +18,8 @@ import { ExitFullScreenButton as Component } from './exit_full_screen_button';
 
 import mdx from '../README.mdx';
 
+const mock = new ExitFullScreenButtonStorybookMock();
+
 export default {
   title: 'Button/Exit Full Screen Button',
   description:
@@ -27,9 +29,10 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    ...mock.getArguments(),
+  },
 };
-
-const mock = new ExitFullScreenButtonStorybookMock();
 
 export const ExitFullScreenButton = {
   render: (params: ExitFullScreenButtonStorybookParams) => {

--- a/src/platform/packages/shared/shared-ux/card/no_data/impl/src/no_data_card.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/card/no_data/impl/src/no_data_card.stories.tsx
@@ -17,6 +17,10 @@ import { NoDataCardProvider } from './services';
 
 import mdx from '../README.mdx';
 
+const mock = new NoDataCardStorybookMock();
+const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
+
 export default {
   title: 'No Data/Card',
   description: 'A solution-specific wrapper around `EuiCard`, to be used on `NoData` page',
@@ -25,10 +29,8 @@ export default {
       page: mdx,
     },
   },
+  args,
 };
-
-const mock = new NoDataCardStorybookMock();
-const argTypes = mock.getArgumentTypes();
 
 export const Card = {
   render: (params: NoDataCardStorybookParams) => {

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.stories.tsx
@@ -31,6 +31,7 @@ export default {
 
 const mock = new CodeEditorStorybookMock();
 const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
 
 export const Basic = {
   render: (params: CodeEditorStorybookParams) => {
@@ -44,7 +45,7 @@ export const Basic = {
       />
     );
   },
-
+  args,
   argTypes,
 };
 
@@ -87,7 +88,7 @@ export const CustomLogLanguage = {
       </div>
     );
   },
-
+  args,
   argTypes,
 };
 
@@ -250,6 +251,6 @@ const FitToContentComponent = (params: CodeEditorStorybookParams) => {
 
 export const FitToContent = {
   render: (params: CodeEditorStorybookParams) => <FitToContentComponent {...params} />,
-
+  args,
   argTypes,
 };

--- a/src/platform/packages/shared/shared-ux/markdown/impl/markdown_editor.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/markdown/impl/markdown_editor.stories.tsx
@@ -16,6 +16,10 @@ import { EuiFlexItem } from '@elastic/eui';
 import mdx from './README.mdx';
 import { Markdown } from './markdown';
 
+const mock = new MarkdownStorybookMock();
+const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
+
 export default {
   title: 'Markdown/Markdown Editor',
   description: 'A wrapper around `EuiMarkdownEditor`, to be used for markdown within Kibana',
@@ -24,10 +28,9 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
-
-const mock = new MarkdownStorybookMock();
-const argTypes = mock.getArgumentTypes();
 
 export const MarkdownStoryComponent = {
   render: (params: MarkdownStorybookParams) => {
@@ -40,6 +43,4 @@ export const MarkdownStoryComponent = {
       </EuiFlexItem>
     );
   },
-
-  argTypes,
 };

--- a/src/platform/packages/shared/shared-ux/markdown/impl/markdown_format.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/markdown/impl/markdown_format.stories.tsx
@@ -16,6 +16,10 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import mdx from './README.mdx';
 import { Markdown } from './markdown';
 
+const mock = new MarkdownStorybookMock();
+const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
+
 export default {
   title: 'Markdown/Markdown Format',
   description: 'Component to have EuiMarkdownFormat support to be used for markdown within Kibana',
@@ -24,10 +28,9 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
-
-const mock = new MarkdownStorybookMock();
-const argTypes = mock.getArgumentTypes();
 
 export const MarkdownStoryComponent = {
   render: (params: MarkdownStorybookParams) => {
@@ -50,6 +53,4 @@ export const MarkdownStoryComponent = {
       </EuiFlexGroup>
     );
   },
-
-  argTypes,
 };

--- a/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/modal/tabbed/src/tabbed_modal.stories.tsx
@@ -17,13 +17,16 @@ import {
 
 import { TabbedModal, type IModalTabDeclaration } from './tabbed_modal';
 
+const mock = new TabbedModalStorybookMock();
+const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
+
 export default {
   title: 'Modal/Tabbed Modal',
   description: 'A controlled modal component that renders tabs',
+  args,
+  argTypes,
 };
-
-const mock = new TabbedModalStorybookMock();
-const argTypes = mock.getArgumentTypes();
 
 export const TrivialExample = {
   render: (params: TabbedModalStorybookParams) => {
@@ -181,6 +184,4 @@ const NonTrivialExampleComponent = (params: TabbedModalStorybookParams) => {
 
 export const NonTrivialExample = {
   render: (params: TabbedModalStorybookParams) => <NonTrivialExampleComponent {...params} />,
-
-  argTypes,
 };

--- a/src/platform/packages/shared/shared-ux/page/analytics_no_data/impl/src/analytics_no_data_page.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/page/analytics_no_data/impl/src/analytics_no_data_page.stories.tsx
@@ -16,6 +16,8 @@ import { AnalyticsNoDataPageProvider } from './services';
 import mdx from '../README.mdx';
 
 const mock = new AnalyticsNoDataPageStorybookMock();
+const args = mock.getArguments();
+const argTypes = mock.getArgumentTypes();
 
 export default {
   title: 'No Data/Page/Kibana',
@@ -25,6 +27,8 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
 
 export const Analytics = {
@@ -35,6 +39,4 @@ export const Analytics = {
       </AnalyticsNoDataPageProvider>
     );
   },
-
-  argTypes: mock.getArgumentTypes(),
 };

--- a/src/platform/packages/shared/shared-ux/page/kibana_no_data/impl/src/kibana_no_data_page.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/page/kibana_no_data/impl/src/kibana_no_data_page.stories.tsx
@@ -17,6 +17,10 @@ import { KibanaNoDataPage as Component } from './kibana_no_data_page';
 import { KibanaNoDataPageProvider } from './services';
 import mdx from '../README.mdx';
 
+const mock = new KibanaNoDataPageStorybookMock();
+const args = mock.getArguments();
+const argTypes = mock.getArgumentTypes();
+
 export default {
   title: 'No Data/Page/Kibana',
   description: 'A component to display when there is no data available',
@@ -25,9 +29,9 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
-
-const mock = new KibanaNoDataPageStorybookMock();
 
 export const Kibana = {
   render: (params: KibanaNoDataPageStorybookParams) => {
@@ -37,8 +41,6 @@ export const Kibana = {
       </KibanaNoDataPageProvider>
     );
   },
-
-  argTypes: mock.getArgumentTypes(),
 };
 
 export const LoadingState = {

--- a/src/platform/packages/shared/shared-ux/page/kibana_template/impl/src/page_template.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/page/kibana_template/impl/src/page_template.stories.tsx
@@ -52,6 +52,7 @@ export const WithNoDataConfig = {
   },
 
   argTypes: noDataConfigMock.getArgumentTypes(),
+  args: noDataConfigMock.getArguments(),
 };
 
 export const WithSolutionNav = {
@@ -64,6 +65,7 @@ export const WithSolutionNav = {
   },
 
   argTypes: solutionNavMock.getArgumentTypes(),
+  args: solutionNavMock.getArguments(),
 };
 
 export const WithBoth = {
@@ -76,6 +78,7 @@ export const WithBoth = {
   },
 
   argTypes: templateMock.getArgumentTypes(),
+  args: templateMock.getArguments(),
 };
 
 export const WithNeither = {
@@ -88,4 +91,5 @@ export const WithNeither = {
   },
 
   argTypes: innerMock.getArgumentTypes(),
+  args: innerMock.getArguments(),
 };

--- a/src/platform/packages/shared/shared-ux/page/no_data/impl/src/no_data_page.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/page/no_data/impl/src/no_data_page.stories.tsx
@@ -18,6 +18,8 @@ import { NoDataPageProvider } from './services';
 import mdx from '../README.mdx';
 
 const mock = new NoDataPageStorybookMock();
+const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
 
 export default {
   parameters: {
@@ -25,6 +27,8 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
 
 export const NoDataPage = {
@@ -35,6 +39,4 @@ export const NoDataPage = {
       </NoDataPageProvider>
     );
   },
-
-  argTypes: mock.getArgumentTypes(),
 };

--- a/src/platform/packages/shared/shared-ux/page/no_data_config/impl/src/no_data_config_page.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/page/no_data_config/impl/src/no_data_config_page.stories.tsx
@@ -18,6 +18,8 @@ import { NoDataConfigPageProvider } from './services';
 import mdx from '../README.mdx';
 
 const mock = new NoDataConfigPageStorybookMock();
+const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
 
 export default {
   title: 'No Data/Page/No Data Config Page',
@@ -27,6 +29,8 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
 
 export const NoDataConfigPage = {
@@ -37,6 +41,4 @@ export const NoDataConfigPage = {
       </NoDataConfigPageProvider>
     );
   },
-
-  argTypes: mock.getArgumentTypes(),
 };

--- a/src/platform/packages/shared/shared-ux/prompt/no_data_views/impl/src/no_data_views.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/prompt/no_data_views/impl/src/no_data_views.stories.tsx
@@ -17,6 +17,10 @@ import { NoDataViewsPromptProvider } from './services';
 
 import mdx from '../README.mdx';
 
+const mock = new NoDataViewsPromptStorybookMock();
+const argTypes = mock.getArgumentTypes();
+const args = mock.getArguments();
+
 export default {
   title: 'No Data/Prompt',
   description: 'A component to display when there are no user-created data views available.',
@@ -25,9 +29,9 @@ export default {
       page: mdx,
     },
   },
+  args,
+  argTypes,
 };
-
-const mock = new NoDataViewsPromptStorybookMock();
 
 export const CanCreateDataView = {
   render: (params: NoDataViewsPromptStorybookParams) => {
@@ -52,6 +56,8 @@ export const CannotCreateDataView = {
       </NoDataViewsPromptProvider>
     );
   },
-
+  args: {
+    canCreateNewDataView: false, // Disable data view creation button
+  },
   argTypes: mock.getArgumentTypes(),
 };

--- a/src/platform/packages/shared/shared-ux/storybook/mock/src/mocks.ts
+++ b/src/platform/packages/shared/shared-ux/storybook/mock/src/mocks.ts
@@ -122,6 +122,14 @@ export abstract class AbstractStorybookMock<
     };
   }
 
+  getArguments() {
+    const args = this.getArgumentTypes();
+    return (Object.keys(args) as Array<keyof typeof args>).reduce((acc, key) => {
+      acc[key] = this.getArgumentValue(key, {} as ArgumentParams<PropArguments, ServiceArguments>);
+      return acc;
+    }, {} as Record<keyof typeof args, any>);
+  }
+
   /**
    * Given a collection of parameters, return either the value provided by the story,
    * or the default value for the argument definition.


### PR DESCRIPTION
## Summary

As titled.  A recent Storybook upgrade altered the relationship between `args` and `argTypes`.  This fixes it.
