### PR TITLE
[Spacetime] stubbed APIs for calling deobfuscation

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
@@ -23,6 +23,7 @@ import {
   PROCESSOR_EVENT,
   PROCESSOR_NAME,
   SERVICE_NAME,
+  SERVICE_VERSION,
   TIMESTAMP_US,
   TRACE_ID,
   TRANSACTION_ID,
@@ -81,6 +82,7 @@ export async function getErrorSampleDetails({
     TIMESTAMP_US,
     AT_TIMESTAMP,
     SERVICE_NAME,
+    SERVICE_VERSION,
     ERROR_ID,
     ERROR_GROUP_ID,
   ] as const);

--- a/x-pack/solutions/observability/plugins/apm/server/routes/mobile/get_android_crash_deobfuscated.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/mobile/get_android_crash_deobfuscated.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// import { termQuery } from '@kbn/observability-plugin/server';
+// import { SERVICE_NAME } from '../../../common/es_fields/apm';
+import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+
+export async function getAndroidCrashDeobfuscated({
+  apmEventClient,
+  serviceName,
+  buildId,
+  stacktrace,
+}: {
+  apmEventClient: APMEventClient;
+  serviceName: string;
+  buildId: string;
+  stacktrace: string[];
+}) {
+  // return await apmEventClient.search('get_android_crash_deobfuscated', {
+  //   apm: {
+  //     sources: [
+  //       {
+  //         documentType: ApmDocumentType.ErrorEvent,
+  //         rollupInterval: RollupInterval.None,
+  //       },
+  //     ],
+  //   },
+  //   track_total_hits: false,
+  //   size: 0,
+  //   query: {
+  //     bool: {
+  //       filter: [...termQuery(SERVICE_NAME, serviceName), ...termQuery('buildId', buildId)],
+  //     },
+  //   },
+  // });
+  return '';
+}

--- a/x-pack/solutions/observability/plugins/apm/server/routes/mobile/get_android_crash_deobfuscated.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/mobile/get_android_crash_deobfuscated.ts
@@ -13,26 +13,20 @@ export async function getAndroidCrashDeobfuscated({
   esClient,
   serviceName,
   buildId,
-  stacktrace,
+  className,
 }: {
   esClient: EsClient;
   serviceName: string;
   buildId: string;
-  stacktrace: string[];
-}): Promise<Array<SearchResponse<any, any>>> {
-  const queryPromises: Array<Promise<SearchResponse<any, any>>> = [];
-  for (const line of stacktrace) {
-    queryPromises.push(
-      esClient.search({
-        index: `android-sourcmap-${serviceName}-${buildId}`,
-        query: {
-          bool: {
-            filter: [{ terms: { stackframe: line } }],
-          },
-        },
-        size: 1,
-      })
-    );
-  }
-  return Promise.all(queryPromises);
+  className: string;
+}): Promise<SearchResponse<any, any>> {
+  return esClient.search({
+    index: `remote_cluster:androidmap-${serviceName}-${buildId}`,
+    query: {
+      ids: {
+        values: [className],
+      },
+    },
+    size: 1,
+  });
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/mobile/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/mobile/route.ts
@@ -80,23 +80,23 @@ const androidCrashDeobfuscationRoute = createApmServerRoute({
       serviceName: t.string,
       buildId: t.string,
     }),
-    body: t.type({
-      stacktrace: t.array(t.string),
+    query: t.type({
+      className: t.string,
     }),
   }),
   security: { authz: { requiredPrivileges: ['apm'] } },
-  handler: async (resources): Promise<{ deobfuscatedStacktrace: string }> => {
-    const apmEventClient = await getApmEventClient(resources);
-    const { params } = resources;
+  handler: async (resources): Promise<{ any: any }> => {
+    const { context, params } = resources;
+    const coreContext = await context.core;
+    const esClient = coreContext.elasticsearch.client.asCurrentUser;
     const { serviceName, buildId } = params.path;
-    const { stacktrace } = params.body;
-    const deobfuscatedStacktrace = await getAndroidCrashDeobfuscated({
+    const { className } = params.query;
+    return await getAndroidCrashDeobfuscated({
       serviceName,
       buildId,
-      stacktrace,
-      apmEventClient,
+      className,
+      esClient,
     });
-    return { deobfuscatedStacktrace };
   },
 });
 

--- a/x-pack/solutions/observability/plugins/apm/server/routes/mobile/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/mobile/route.ts
@@ -32,6 +32,7 @@ import type { MobileMostUsedChartResponse } from './get_mobile_most_used_charts'
 import { getMobileMostUsedCharts } from './get_mobile_most_used_charts';
 import { mobileErrorRoutes } from './errors/route';
 import { mobileCrashRoutes } from './crashes/route';
+import { getAndroidCrashDeobfuscated } from './get_android_crash_deobfuscated';
 
 const mobileFiltersRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/services/{serviceName}/mobile/filters',
@@ -69,6 +70,33 @@ const mobileFiltersRoute = createApmServerRoute({
       apmEventClient,
     });
     return { mobileFilters: filters };
+  },
+});
+
+const androidCrashDeobfuscationRoute = createApmServerRoute({
+  endpoint: 'POST /internal/apm/mobile-services/{serviceName}/deobfuscate/{buildId}',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+      buildId: t.string,
+    }),
+    body: t.type({
+      stacktrace: t.array(t.string),
+    }),
+  }),
+  security: { authz: { requiredPrivileges: ['apm'] } },
+  handler: async (resources): Promise<{ deobfuscatedStacktrace: string }> => {
+    const apmEventClient = await getApmEventClient(resources);
+    const { params } = resources;
+    const { serviceName, buildId } = params.path;
+    const { stacktrace } = params.body;
+    const deobfuscatedStacktrace = await getAndroidCrashDeobfuscated({
+      serviceName,
+      buildId,
+      stacktrace,
+      apmEventClient,
+    });
+    return { deobfuscatedStacktrace };
   },
 });
 
@@ -382,6 +410,7 @@ const mobileDetailedStatisticsByField = createApmServerRoute({
 });
 
 export const mobileRouteRepository = {
+  ...androidCrashDeobfuscationRoute,
   ...mobileErrorRoutes,
   ...mobileCrashRoutes,
   ...mobileFiltersRoute,


### PR DESCRIPTION
## Summary
Adds new API stub for deobfuscating android stack traces with UI element. 
Todos include:
 * defining the structure of new index for sourcemaps
 * use `CallApmAPI` or different caller?
 * how do we identify the correct sourcemap, somekind of build id?

Todos: make button only available for android crashes. 

<img width="1109" height="1123" alt="Screenshot 2025-07-21 at 13 32 49" src="https://github.com/user-attachments/assets/f90e309f-528e-430c-b70a-e0ed6c4bf713" />






