### PR TITLE
[Console] Remove immer dependency

### DIFF
--- a/src/platform/plugins/shared/console/public/application/stores/editor.test.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/editor.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { reducer, initialValue, Action, Store } from './editor';
+import { DevToolsSettings, DEFAULT_SETTINGS } from '../../services';
+import { TextObject } from '../../../common/text_object';
+import { SHELL_TAB_ID } from '../containers/main/constants';
+import { MonacoEditorActionsProvider } from '../containers/editor/monaco_editor_actions_provider';
+import { RestoreMethod } from '../../types';
+
+describe('editor store', () => {
+  it('should return initial state when no action matches', () => {
+    const action = { type: 'unknown' } as any;
+    const newState = reducer(initialValue, action);
+    expect(newState).toBe(initialValue);
+  });
+
+  it('should handle setInputEditor action with immutability', () => {
+    const mockEditor = {} as MonacoEditorActionsProvider;
+    const action: Action = { type: 'setInputEditor', payload: mockEditor };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.ready).toBe(true);
+
+    // Verify immutability
+    expect(initialValue.ready).toBe(false);
+  });
+
+  it('should handle updateSettings action and replace settings completely', () => {
+    const newSettings: DevToolsSettings = {
+      ...DEFAULT_SETTINGS,
+      fontSize: 16,
+      autocomplete: { fields: false, indices: false, templates: false, dataStreams: false },
+    };
+
+    const action: Action = { type: 'updateSettings', payload: newSettings };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.settings).toBe(newSettings);
+    expect(newState.settings.fontSize).toBe(16);
+
+    // Verify original settings unchanged
+    expect(initialValue.settings).toBe(DEFAULT_SETTINGS);
+  });
+
+  it('should handle setCurrentTextObject action', () => {
+    const mockTextObject: TextObject = {
+      id: 'test-id',
+      text: 'GET /_search',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const action: Action = { type: 'setCurrentTextObject', payload: mockTextObject };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.currentTextObject).toBe(mockTextObject);
+    expect(initialValue.currentTextObject).toBe(null);
+  });
+
+  it('should handle setRequestToRestore action and change view', () => {
+    const restorePayload = {
+      request: 'GET /_search\n{}',
+      restoreMethod: RestoreMethod.RESTORE,
+    };
+
+    const stateWithDifferentView: Store = {
+      ...initialValue,
+      currentView: 'history',
+    };
+
+    const action: Action = { type: 'setRequestToRestore', payload: restorePayload };
+    const newState = reducer(stateWithDifferentView, action);
+
+    expect(newState).not.toBe(stateWithDifferentView);
+    expect(newState.restoreRequestFromHistory).toBe(restorePayload);
+    expect(newState.currentView).toBe(SHELL_TAB_ID);
+
+    // Verify original state unchanged
+    expect(stateWithDifferentView.currentView).toBe('history');
+    expect(stateWithDifferentView.restoreRequestFromHistory).toBe(null);
+  });
+
+  it('should handle setCurrentView action', () => {
+    const action: Action = { type: 'setCurrentView', payload: 'history' };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.currentView).toBe('history');
+    expect(initialValue.currentView).toBe(SHELL_TAB_ID);
+  });
+
+  it('should handle clearRequestToRestore action', () => {
+    const stateWithRestore: Store = {
+      ...initialValue,
+      restoreRequestFromHistory: {
+        request: 'GET /',
+        restoreMethod: RestoreMethod.RESTORE,
+      },
+    };
+
+    const action: Action = { type: 'clearRequestToRestore' };
+    const newState = reducer(stateWithRestore, action);
+
+    expect(newState).not.toBe(stateWithRestore);
+    expect(newState.restoreRequestFromHistory).toBe(null);
+    expect(stateWithRestore.restoreRequestFromHistory).not.toBe(null);
+  });
+
+  it('should handle setFileToImport action', () => {
+    const fileContent = 'GET /_search\n{\n  "query": { "match_all": {} }\n}';
+    const action: Action = { type: 'setFileToImport', payload: fileContent };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.fileToImport).toBe(fileContent);
+    expect(initialValue.fileToImport).toBe(null);
+  });
+
+  it('should ensure deep cloning for nested objects', () => {
+    const stateWithNested: Store = {
+      ...initialValue,
+      settings: {
+        ...DEFAULT_SETTINGS,
+        autocomplete: { fields: true, indices: true, templates: true, dataStreams: true },
+      },
+    };
+
+    const newSettings: DevToolsSettings = {
+      ...DEFAULT_SETTINGS,
+      autocomplete: { fields: false, indices: false, templates: false, dataStreams: false },
+    };
+
+    const action: Action = { type: 'updateSettings', payload: newSettings };
+    const newState = reducer(stateWithNested, action);
+
+    // Verify deep immutability
+    expect(stateWithNested.settings.autocomplete.fields).toBe(true);
+    expect(newState.settings.autocomplete.fields).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/stores/editor.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/editor.ts
@@ -8,8 +8,7 @@
  */
 
 import { Reducer } from 'react';
-import { produce } from 'immer';
-import { identity } from 'fp-ts/function';
+import { cloneDeep } from 'lodash';
 import { DevToolsSettings, DEFAULT_SETTINGS } from '../../services';
 import { TextObject } from '../../../common/text_object';
 import { SHELL_TAB_ID } from '../containers/main/constants';
@@ -25,17 +24,14 @@ export interface Store {
   fileToImport: string | null;
 }
 
-export const initialValue: Store = produce<Store>(
-  {
-    ready: false,
-    settings: DEFAULT_SETTINGS,
-    currentTextObject: null,
-    currentView: SHELL_TAB_ID,
-    restoreRequestFromHistory: null,
-    fileToImport: null,
-  },
-  identity
-);
+export const initialValue: Store = {
+  ready: false,
+  settings: DEFAULT_SETTINGS,
+  currentTextObject: null,
+  currentView: SHELL_TAB_ID,
+  restoreRequestFromHistory: null,
+  fileToImport: null,
+};
 
 export type Action =
   | { type: 'setInputEditor'; payload: MonacoEditorActionsProvider }
@@ -46,46 +42,47 @@ export type Action =
   | { type: 'clearRequestToRestore' }
   | { type: 'setFileToImport'; payload: string | null };
 
-export const reducer: Reducer<Store, Action> = (state, action) =>
-  produce<Store>(state, (draft) => {
-    if (action.type === 'setInputEditor') {
-      if (action.payload) {
-        draft.ready = true;
-      }
-      return;
-    }
+export const reducer: Reducer<Store, Action> = (state, action) => {
+  const draft = cloneDeep(state);
 
-    if (action.type === 'updateSettings') {
-      draft.settings = action.payload;
-      return;
+  if (action.type === 'setInputEditor') {
+    if (action.payload) {
+      draft.ready = true;
     }
-
-    if (action.type === 'setCurrentTextObject') {
-      draft.currentTextObject = action.payload;
-      return;
-    }
-
-    if (action.type === 'setRequestToRestore') {
-      // Store the request and change the current view to the shell
-      draft.restoreRequestFromHistory = action.payload;
-      draft.currentView = SHELL_TAB_ID;
-      return;
-    }
-
-    if (action.type === 'setCurrentView') {
-      draft.currentView = action.payload;
-      return;
-    }
-
-    if (action.type === 'clearRequestToRestore') {
-      draft.restoreRequestFromHistory = null;
-      return;
-    }
-
-    if (action.type === 'setFileToImport') {
-      draft.fileToImport = action.payload;
-      return;
-    }
-
     return draft;
-  });
+  }
+
+  if (action.type === 'updateSettings') {
+    draft.settings = action.payload;
+    return draft;
+  }
+
+  if (action.type === 'setCurrentTextObject') {
+    draft.currentTextObject = action.payload;
+    return draft;
+  }
+
+  if (action.type === 'setRequestToRestore') {
+    // Store the request and change the current view to the shell
+    draft.restoreRequestFromHistory = action.payload;
+    draft.currentView = SHELL_TAB_ID;
+    return draft;
+  }
+
+  if (action.type === 'setCurrentView') {
+    draft.currentView = action.payload;
+    return draft;
+  }
+
+  if (action.type === 'clearRequestToRestore') {
+    draft.restoreRequestFromHistory = null;
+    return draft;
+  }
+
+  if (action.type === 'setFileToImport') {
+    draft.fileToImport = action.payload;
+    return draft;
+  }
+
+  return state;
+};

--- a/src/platform/plugins/shared/console/public/application/stores/embeddable_console.test.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/embeddable_console.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { reducer, initialValue } from './embeddable_console';
+import {
+  EmbeddableConsoleView,
+  EmbeddedConsoleAction,
+  EmbeddedConsoleStore,
+} from '../../types/embeddable_console';
+
+describe('embeddable_console store', () => {
+  it('should return initial state when no action matches', () => {
+    const action = { type: 'unknown' } as any;
+    const newState = reducer(initialValue, action);
+    expect(newState).toBe(initialValue);
+  });
+
+  it('should handle open action to Console view', () => {
+    const action: EmbeddedConsoleAction = { type: 'open' };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.consoleHasBeenOpened).toBe(true);
+    expect(newState.view).toBe(EmbeddableConsoleView.Console);
+    expect(newState.loadFromContent).toBeUndefined();
+
+    // Verify immutability
+    expect(initialValue.consoleHasBeenOpened).toBe(false);
+    expect(initialValue.view).toBe(EmbeddableConsoleView.Closed);
+  });
+
+  it('should handle open action to Alternate view with content', () => {
+    const content = 'GET /_search\n{\n  "query": { "match_all": {} }\n}';
+    const action: EmbeddedConsoleAction = {
+      type: 'open',
+      payload: { alternateView: true, content },
+    };
+
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.consoleHasBeenOpened).toBe(true);
+    expect(newState.view).toBe(EmbeddableConsoleView.Alternate);
+    expect(newState.loadFromContent).toBe(content);
+  });
+
+  it('should not create new state when opening same view', () => {
+    const stateWithOpenConsole: EmbeddedConsoleStore = {
+      consoleHasBeenOpened: true,
+      view: EmbeddableConsoleView.Console,
+    };
+
+    const action: EmbeddedConsoleAction = { type: 'open' };
+    const newState = reducer(stateWithOpenConsole, action);
+
+    expect(newState).toBe(stateWithOpenConsole); // Same reference, no clone
+  });
+
+  it('should handle close action', () => {
+    const stateWithOpenConsole: EmbeddedConsoleStore = {
+      consoleHasBeenOpened: true,
+      view: EmbeddableConsoleView.Console,
+      loadFromContent: 'some content',
+    };
+
+    const action: EmbeddedConsoleAction = { type: 'close' };
+    const newState = reducer(stateWithOpenConsole, action);
+
+    expect(newState).not.toBe(stateWithOpenConsole);
+    expect(newState.view).toBe(EmbeddableConsoleView.Closed);
+    expect(newState.loadFromContent).toBeUndefined();
+    expect(newState.consoleHasBeenOpened).toBe(true); // This stays true
+
+    // Verify immutability
+    expect(stateWithOpenConsole.view).toBe(EmbeddableConsoleView.Console);
+    expect(stateWithOpenConsole.loadFromContent).toBe('some content');
+  });
+
+  it('should not create new state when closing already closed console', () => {
+    const action: EmbeddedConsoleAction = { type: 'close' };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).toBe(initialValue); // Same reference, no clone
+  });
+
+  it('should handle switching between views', () => {
+    const stateWithConsoleView: EmbeddedConsoleStore = {
+      consoleHasBeenOpened: true,
+      view: EmbeddableConsoleView.Console,
+    };
+
+    const action: EmbeddedConsoleAction = {
+      type: 'open',
+      payload: { alternateView: true },
+    };
+
+    const newState = reducer(stateWithConsoleView, action);
+
+    expect(newState).not.toBe(stateWithConsoleView);
+    expect(newState.view).toBe(EmbeddableConsoleView.Alternate);
+    expect(stateWithConsoleView.view).toBe(EmbeddableConsoleView.Console);
+  });
+
+  it('should preserve consoleHasBeenOpened flag after closing', () => {
+    let state = initialValue;
+
+    // Open console
+    state = reducer(state, { type: 'open' });
+    expect(state.consoleHasBeenOpened).toBe(true);
+
+    // Close console
+    state = reducer(state, { type: 'close' });
+    expect(state.consoleHasBeenOpened).toBe(true); // Still true
+    expect(state.view).toBe(EmbeddableConsoleView.Closed);
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/stores/embeddable_console.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/embeddable_console.ts
@@ -8,8 +8,7 @@
  */
 
 import { Reducer } from 'react';
-import { produce } from 'immer';
-import { identity } from 'fp-ts/function';
+import { cloneDeep } from 'lodash';
 
 import {
   EmbeddableConsoleView,
@@ -17,35 +16,33 @@ import {
   EmbeddedConsoleStore,
 } from '../../types/embeddable_console';
 
-export const initialValue: EmbeddedConsoleStore = produce<EmbeddedConsoleStore>(
-  {
-    consoleHasBeenOpened: false,
-    view: EmbeddableConsoleView.Closed,
-  },
-  identity
-);
+export const initialValue: EmbeddedConsoleStore = {
+  consoleHasBeenOpened: false,
+  view: EmbeddableConsoleView.Closed,
+};
 
-export const reducer: Reducer<EmbeddedConsoleStore, EmbeddedConsoleAction> = (state, action) =>
-  produce<EmbeddedConsoleStore>(state, (draft) => {
-    switch (action.type) {
-      case 'open':
-        const newView = action.payload?.alternateView
-          ? EmbeddableConsoleView.Alternate
-          : EmbeddableConsoleView.Console;
-        if (state.view !== newView) {
-          draft.consoleHasBeenOpened = true;
-          draft.view = newView;
-          draft.loadFromContent = action.payload?.content;
-          return draft;
-        }
-        break;
-      case 'close':
-        if (state.view !== EmbeddableConsoleView.Closed) {
-          draft.view = EmbeddableConsoleView.Closed;
-          draft.loadFromContent = undefined;
-          return draft;
-        }
-        break;
-    }
-    return state;
-  });
+export const reducer: Reducer<EmbeddedConsoleStore, EmbeddedConsoleAction> = (state, action) => {
+  switch (action.type) {
+    case 'open':
+      const newView = action.payload?.alternateView
+        ? EmbeddableConsoleView.Alternate
+        : EmbeddableConsoleView.Console;
+      if (state.view !== newView) {
+        const draft = cloneDeep(state);
+        draft.consoleHasBeenOpened = true;
+        draft.view = newView;
+        draft.loadFromContent = action.payload?.content;
+        return draft;
+      }
+      break;
+    case 'close':
+      if (state.view !== EmbeddableConsoleView.Closed) {
+        const draft = cloneDeep(state);
+        draft.view = EmbeddableConsoleView.Closed;
+        draft.loadFromContent = undefined;
+        return draft;
+      }
+      break;
+  }
+  return state;
+};

--- a/src/platform/plugins/shared/console/public/application/stores/request.test.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/request.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { reducer, initialValue, Actions, Store } from './request';
+import { RequestResult } from '../hooks/use_send_current_request/send_request';
+import { BaseResponseType } from '../../types/common';
+
+describe('request store', () => {
+  it('should return initial state when no action matches', () => {
+    const action = { type: 'unknown' } as any;
+    const newState = reducer(initialValue, action);
+    expect(newState).toBe(initialValue);
+  });
+
+  it('should handle sendRequest action and create new state object', () => {
+    const action: Actions = { type: 'sendRequest', payload: undefined };
+    const newState = reducer(initialValue, action);
+
+    expect(newState).not.toBe(initialValue);
+    expect(newState.requestInFlight).toBe(true);
+    expect(newState.lastResult.data).toBe(null);
+
+    // Verify immutability - original state unchanged
+    expect(initialValue.requestInFlight).toBe(false);
+  });
+
+  it('should handle requestSuccess action with proper immutability', () => {
+    const mockData: RequestResult[] = [
+      {
+        response: {
+          value: 'test response',
+          statusCode: 200,
+          statusText: 'OK',
+          timeMs: 100,
+          contentType: 'application/json' as BaseResponseType,
+        },
+        request: { data: 'test', method: 'GET', path: '/test' },
+      },
+    ];
+
+    const action: Actions = { type: 'requestSuccess', payload: { data: mockData } };
+    const stateWithRequest: Store = {
+      requestInFlight: true,
+      lastResult: { data: null },
+    };
+
+    const newState = reducer(stateWithRequest, action);
+
+    expect(newState).not.toBe(stateWithRequest);
+    expect(newState.requestInFlight).toBe(false);
+    expect(newState.lastResult.data).toBe(mockData);
+
+    // Verify immutability
+    expect(stateWithRequest.requestInFlight).toBe(true);
+    expect(stateWithRequest.lastResult.data).toBe(null);
+  });
+
+  it('should handle requestFail action and preserve error', () => {
+    const errorResult: RequestResult<string> = {
+      response: {
+        value: 'Network error',
+        statusCode: 500,
+        statusText: 'Internal Server Error',
+        timeMs: 100,
+        contentType: 'application/json' as BaseResponseType,
+      },
+      request: { data: 'test', method: 'GET', path: '/test' },
+    };
+
+    const action: Actions = { type: 'requestFail', payload: errorResult };
+    const stateWithRequest: Store = {
+      requestInFlight: true,
+      lastResult: { data: null },
+    };
+
+    const newState = reducer(stateWithRequest, action);
+
+    expect(newState).not.toBe(stateWithRequest);
+    expect(newState.requestInFlight).toBe(false);
+    expect(newState.lastResult.error).toBe(errorResult);
+    expect(newState.lastResult.data).toBe(null);
+  });
+
+  it('should handle cleanRequest action', () => {
+    const stateWithData: Store = {
+      requestInFlight: true,
+      lastResult: {
+        data: [
+          {
+            response: {
+              value: 'test',
+              statusCode: 200,
+              statusText: 'OK',
+              timeMs: 50,
+              contentType: 'application/json' as BaseResponseType,
+            },
+            request: { data: '', method: 'GET', path: '/' },
+          },
+        ],
+        error: {
+          response: {
+            value: 'Error',
+            statusCode: 400,
+            statusText: 'Bad Request',
+            timeMs: 10,
+            contentType: 'application/json' as BaseResponseType,
+          },
+          request: { data: '', method: 'GET', path: '/' },
+        },
+      },
+    };
+
+    const action: Actions = { type: 'cleanRequest', payload: undefined };
+    const newState = reducer(stateWithData, action);
+
+    expect(newState).not.toBe(stateWithData);
+    expect(newState.requestInFlight).toBe(false);
+    expect(newState.lastResult.data).toBe(null);
+    expect(newState.lastResult.error).toBeUndefined();
+
+    // Verify original state unchanged
+    expect(stateWithData.requestInFlight).toBe(true);
+    expect(stateWithData.lastResult.data).not.toBe(null);
+  });
+
+  it('should handle nested object updates without affecting original state', () => {
+    const initialStateWithData: Store = {
+      requestInFlight: false,
+      lastResult: {
+        data: [
+          {
+            response: {
+              value: 'original',
+              statusCode: 200,
+              statusText: 'OK',
+              timeMs: 75,
+              contentType: 'application/json' as BaseResponseType,
+            },
+            request: { data: '', method: 'GET', path: '/' },
+          },
+        ],
+      },
+    };
+
+    const action: Actions = { type: 'sendRequest', payload: undefined };
+    const newState = reducer(initialStateWithData, action);
+
+    // Deep immutability check
+    expect(initialStateWithData.lastResult.data).toBeTruthy();
+    expect(newState.lastResult.data).toBe(null);
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/stores/request.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/request.ts
@@ -8,8 +8,7 @@
  */
 
 import { Reducer } from 'react';
-import { produce } from 'immer';
-import { identity } from 'fp-ts/function';
+import { cloneDeep } from 'lodash';
 import { BaseResponseType } from '../../types/common';
 import { RequestResult } from '../hooks/use_send_current_request/send_request';
 
@@ -32,37 +31,37 @@ const initialResultValue = {
   type: 'unknown' as BaseResponseType,
 };
 
-export const initialValue: Store = produce<Store>(
-  {
-    requestInFlight: false,
-    lastResult: initialResultValue,
-  },
-  identity
-);
+export const initialValue: Store = {
+  requestInFlight: false,
+  lastResult: initialResultValue,
+};
 
-export const reducer: Reducer<Store, Actions> = (state, action) =>
-  produce<Store>(state, (draft) => {
-    if (action.type === 'sendRequest') {
-      draft.requestInFlight = true;
-      draft.lastResult = initialResultValue;
-      return;
-    }
+export const reducer: Reducer<Store, Actions> = (state, action) => {
+  const draft = cloneDeep(state);
 
-    if (action.type === 'requestSuccess') {
-      draft.requestInFlight = false;
-      draft.lastResult = action.payload;
-      return;
-    }
+  if (action.type === 'sendRequest') {
+    draft.requestInFlight = true;
+    draft.lastResult = initialResultValue;
+    return draft;
+  }
 
-    if (action.type === 'requestFail') {
-      draft.requestInFlight = false;
-      draft.lastResult = { ...initialResultValue, error: action.payload };
-      return;
-    }
+  if (action.type === 'requestSuccess') {
+    draft.requestInFlight = false;
+    draft.lastResult = action.payload;
+    return draft;
+  }
 
-    if (action.type === 'cleanRequest') {
-      draft.requestInFlight = false;
-      draft.lastResult = initialResultValue;
-      return;
-    }
-  });
+  if (action.type === 'requestFail') {
+    draft.requestInFlight = false;
+    draft.lastResult = { ...initialResultValue, error: action.payload };
+    return draft;
+  }
+
+  if (action.type === 'cleanRequest') {
+    draft.requestInFlight = false;
+    draft.lastResult = initialResultValue;
+    return draft;
+  }
+
+  return state;
+};


### PR DESCRIPTION
Partially addresses https://github.com/elastic/kibana/issues/208213

## Summary

This PR removes the plugins dependency on immer's produce function from the store files. The produce calls have been replaced with lodash's `cloneDeep` function (already imported) followed by direct object mutations. This maintains the exact same functionality while avoiding the extra dependency.