### PR TITLE
[Console] Fix different error code in status badge

### DIFF
--- a/src/platform/plugins/shared/console/public/application/hooks/use_send_current_request/status_code_extraction.test.ts
+++ b/src/platform/plugins/shared/console/public/application/hooks/use_send_current_request/status_code_extraction.test.ts
@@ -59,9 +59,7 @@ describe('Status Code Extraction in sendRequest', () => {
         response: {
           status: 400,
           statusText: 'Bad Request',
-          headers: new Map([
-            ['Content-Type', 'application/json'],
-          ]),
+          headers: new Map([['Content-Type', 'application/json']]),
         },
         body: JSON.stringify({
           statusCode: 400,

--- a/src/platform/plugins/shared/console/public/application/hooks/use_send_current_request/status_code_extraction.test.ts
+++ b/src/platform/plugins/shared/console/public/application/hooks/use_send_current_request/status_code_extraction.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { HttpSetup } from '@kbn/core/public';
+
+jest.unmock('./send_request');
+
+describe('Status Code Extraction in sendRequest', () => {
+  let mockHttp: jest.Mocked<HttpSetup>;
+
+  beforeEach(() => {
+    mockHttp = {
+      post: jest.fn(),
+    } as any;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('extractStatusCodeAndText function behavior', () => {
+    it('should use proxy headers when available for ES requests', async () => {
+      const { sendRequest } = await import('./send_request');
+
+      const mockResponse = {
+        response: {
+          status: 200, // Actual HTTP status
+          statusText: 'OK',
+          headers: new Map([
+            ['x-console-proxy-status-code', '404'], // ES status from proxy
+            ['x-console-proxy-status-text', 'Not Found'],
+            ['Content-Type', 'application/json'],
+          ]),
+        },
+        body: JSON.stringify({ error: 'index_not_found_exception' }),
+      };
+
+      mockHttp.post.mockResolvedValue(mockResponse);
+
+      const result = await sendRequest({
+        http: mockHttp,
+        requests: [{ url: '/_search', method: 'GET', data: ['{}'] }],
+      });
+
+      expect(result[0].response.statusCode).toBe(404); // Should use proxy header
+      expect(result[0].response.statusText).toBe('Not Found');
+    });
+
+    it('should fall back to actual response status when proxy headers are missing', async () => {
+      const { sendRequest } = await import('./send_request');
+
+      const mockResponse = {
+        response: {
+          status: 400,
+          statusText: 'Bad Request',
+          headers: new Map([
+            ['Content-Type', 'application/json'],
+          ]),
+        },
+        body: JSON.stringify({
+          statusCode: 400,
+          error: 'Bad Request',
+          message:
+            "Method must be one of, case insensitive ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'PATCH']. Received 'INVALIDMETHOD'.",
+        }),
+      };
+
+      mockHttp.post.mockResolvedValue(mockResponse);
+
+      const result = await sendRequest({
+        http: mockHttp,
+        requests: [{ url: '/_search', method: 'INVALIDMETHOD', data: ['{}'] }],
+      });
+
+      expect(result[0].response.statusCode).toBe(400); // Should use actual response status, not 500
+      expect(result[0].response.statusText).toBe('Bad Request');
+    });
+
+    it('should handle empty proxy header as missing header', async () => {
+      const { sendRequest } = await import('./send_request');
+
+      const mockResponse = {
+        response: {
+          status: 400,
+          statusText: 'Bad Request',
+          headers: new Map([
+            ['x-console-proxy-status-code', ''], // Empty header value
+            ['Content-Type', 'application/json'],
+          ]),
+        },
+        body: JSON.stringify({ error: 'validation error' }),
+      };
+
+      mockHttp.post.mockResolvedValue(mockResponse);
+
+      const result = await sendRequest({
+        http: mockHttp,
+        requests: [{ url: '/_search', method: 'INVALID', data: ['{}'] }],
+      });
+
+      expect(result[0].response.statusCode).toBe(400); // Should fall back to actual status
+      expect(result[0].response.statusText).toBe('Bad Request');
+    });
+  });
+});


### PR DESCRIPTION
Fix https://github.com/elastic/kibana/issues/219257

## Summary

Resolves an issue where Console showed different status codes in the response badge vs response body when sending requests with invalid HTTP methods.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->