### PR TITLE
[onechat] rewrite tool IDs for MCP endpoint

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/index.ts
@@ -24,6 +24,7 @@ export {
   toolToLangchain,
   toolIdentifierFromToolCall,
   sanitizeToolId,
+  createToolIdMappings,
   type ToolIdMapping,
   type ToolsAndMappings,
 } from './tools';

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/langchain/tools.ts
@@ -60,7 +60,7 @@ export const sanitizeToolId = (toolId: string): string => {
  *
  * Handles id sanitization (e.g. removing dot prefixes), and potential id conflict.
  */
-export const createToolIdMappings = (tools: ExecutableTool[]): ToolIdMapping => {
+export const createToolIdMappings = <T extends { id: string }>(tools: T[]): ToolIdMapping => {
   const toolIds = new Set<string>();
   const mapping: ToolIdMapping = new Map();
 

--- a/x-pack/platform/plugins/shared/onechat/server/routes/mcp.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/mcp.ts
@@ -8,6 +8,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { schema } from '@kbn/config-schema';
+import { createToolIdMappings } from '@kbn/onechat-genai-utils/langchain';
 import { apiPrivileges } from '../../common/features';
 import type { RouteDependencies } from './types';
 import { getHandlerWrapper } from './wrap_handler';
@@ -67,10 +68,12 @@ export function registerMCPRoutes({ router, getInternalServices, logger }: Route
             const registry = await toolService.getRegistry({ request });
             const tools = await registry.list({});
 
+            const idMapping = createToolIdMappings(tools);
+
             // Expose tools scoped to the request
             for (const tool of tools) {
               server.tool(
-                tool.id,
+                idMapping.get(tool.id) ?? tool.id,
                 tool.description,
                 tool.schema.shape,
                 async (args: { [x: string]: any }) => {


### PR DESCRIPTION
## Summary

Rewrite tool ids for the MCP endpoint, similar to what we do internally when calling LLMs in our framework, to ensure IDs are LLM-compatible.