### PR TITLE
[ES|QL] Check license for command suggestions

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/change_point/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/change_point/index.ts
@@ -33,6 +33,5 @@ export const changePointCommand: ICommand = {
       '… | CHANGE_POINT value ON timestamp',
       '… | CHANGE_POINT value ON timestamp AS type, pvalue',
     ],
-    license: 'platinum',
   },
 };

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/change_point/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/change_point/index.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { i18n } from '@kbn/i18n';
-import type { ICommandMethods } from '../../registry';
+import type { ICommand, ICommandMethods } from '../../registry';
 import { autocomplete } from './autocomplete';
 import { columnsAfter } from './columns_after';
 import { validate } from './validate';
@@ -19,7 +19,7 @@ const changePointCommandMethods: ICommandMethods<ICommandContext> = {
   columnsAfter,
 };
 
-export const changePointCommand = {
+export const changePointCommand: ICommand = {
   name: 'change_point',
   methods: changePointCommandMethods,
   metadata: {
@@ -33,5 +33,6 @@ export const changePointCommand = {
       '… | CHANGE_POINT value ON timestamp',
       '… | CHANGE_POINT value ON timestamp AS type, pvalue',
     ],
+    license: 'platinum',
   },
 };

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.license.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.license.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { setup } from './helpers';
+import { getCallbackMocks } from '../../__tests__/helpers';
+
+export function getLicenseMock(level: string) {
+  return {
+    hasAtLeast: (requiredLevel: string) => level === requiredLevel,
+  };
+}
+
+describe('autocomplete.suggest', () => {
+  describe('license-based command suggestions', () => {
+    test('should suggest change_point command with platinum license', async () => {
+      const { suggest } = await setup();
+
+      const suggestions = await suggest('FROM a | /', {
+        callbacks: {
+          ...getCallbackMocks(),
+          getLicense: async () => getLicenseMock('platinum'),
+        },
+      });
+
+      const changePointSuggestion = suggestions.find((s) => s.text === 'CHANGE_POINT ');
+      expect(changePointSuggestion).toBeDefined();
+    });
+
+    test('should not suggest change_point command with basic license', async () => {
+      const { suggest } = await setup();
+
+      const suggestions = await suggest('FROM a | /', {
+        callbacks: {
+          ...getCallbackMocks(),
+          getLicense: async () => getLicenseMock('basic'),
+        },
+      });
+
+      const changePointSuggestion = suggestions.find((s) => s.text === 'CHANGE_POINT ');
+      expect(changePointSuggestion).toBeUndefined();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -273,7 +273,8 @@ export function createCustomCallbackMocks(
     sourceIndices: string[];
     matchField: string;
     enrichFields: string[];
-  }>
+  }>,
+  customLicenseType = 'platinum'
 ): ESQLCallbacks {
   const finalColumnsSinceLastCommand =
     customColumnsSinceLastCommand ||
@@ -303,7 +304,9 @@ export function createCustomCallbackMocks(
       return { recommendedQueries: [], recommendedFields: [] };
     }),
     getInferenceEndpoints: jest.fn(async () => ({ inferenceEndpoints })),
-    getLicense: jest.fn(),
+    getLicense: jest.fn(async () => ({
+      hasAtLeast: (requiredLevel: string) => customLicenseType === requiredLevel,
+    })),
   };
 }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -30,7 +30,7 @@ import {
   GetColumnsByTypeFn,
   ISuggestionItem,
 } from '@kbn/esql-ast/src/commands_registry/types';
-import { ESQLVariableType } from '@kbn/esql-types';
+import { ESQLLicenseType, ESQLVariableType } from '@kbn/esql-types';
 import { isSourceCommand } from '../shared/helpers';
 import { collectUserDefinedColumns } from '../shared/user_defined_columns';
 import { getAstContext } from '../shared/context';
@@ -69,11 +69,21 @@ export async function suggest(
   const getVariables = resourceRetriever?.getVariables;
   const getSources = getSourcesHelper(resourceRetriever);
 
+  const license = await resourceRetriever?.getLicense?.();
+  const hasMinimumLicenseRequired = license?.hasAtLeast;
+
   if (astContext.type === 'newCommand') {
     // propose main commands here
     // resolve particular commands suggestions after
     // filter source commands if already defined
-    const commands = esqlCommandRegistry.getAllCommandNames();
+    const commands = esqlCommandRegistry
+      .getAllCommands()
+      .filter((command) => {
+        const licenseInstance = command.metadata?.license;
+        return !licenseInstance || hasMinimumLicenseRequired?.(licenseInstance);
+      })
+      .map((command) => command.name);
+
     const suggestions = getCommandAutocompleteDefinitions(commands);
     if (!ast.length) {
       // Display the recommended queries if there are no commands (empty state)
@@ -139,7 +149,8 @@ export async function suggest(
       getFieldsByType,
       getFieldsMap,
       resourceRetriever,
-      offset
+      offset,
+      hasMinimumLicenseRequired
     );
     return commandsSpecificSuggestions;
   }
@@ -206,7 +217,8 @@ async function getSuggestionsWithinCommandExpression(
   getColumnsByType: GetColumnsByTypeFn,
   getFieldsMap: GetFieldsMapFn,
   callbacks?: ESQLCallbacks,
-  offset?: number
+  offset?: number,
+  hasMinimumLicenseRequired?: (minimumLicenseRequired: ESQLLicenseType) => boolean
 ) {
   const innerText = fullText.substring(0, offset);
   const commandDefinition = esqlCommandRegistry.getCommandByName(astContext.command.name);
@@ -214,10 +226,6 @@ async function getSuggestionsWithinCommandExpression(
   if (!commandDefinition) {
     return [];
   }
-
-  // resolve the license promise
-  const license = await callbacks?.getLicense?.();
-  const hasMinimumLicenseRequired = license?.hasAtLeast;
 
   // collect all fields + userDefinedColumns to suggest
   const fieldsMap: Map<string, ESQLFieldWithMetadata> = await getFieldsMap();

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -69,8 +69,8 @@ export async function suggest(
   const getVariables = resourceRetriever?.getVariables;
   const getSources = getSourcesHelper(resourceRetriever);
 
-  const license = await resourceRetriever?.getLicense?.();
-  const hasMinimumLicenseRequired = license?.hasAtLeast;
+  const licenseInstance = await resourceRetriever?.getLicense?.();
+  const hasMinimumLicenseRequired = licenseInstance?.hasAtLeast;
 
   if (astContext.type === 'newCommand') {
     // propose main commands here
@@ -79,8 +79,10 @@ export async function suggest(
     const commands = esqlCommandRegistry
       .getAllCommands()
       .filter((command) => {
-        const licenseInstance = command.metadata?.license;
-        return !licenseInstance || hasMinimumLicenseRequired?.(licenseInstance);
+        const license = command.metadata?.license;
+        return (
+          !license || hasMinimumLicenseRequired?.(license.toLocaleLowerCase() as ESQLLicenseType)
+        );
       })
       .map((command) => command.name);
 


### PR DESCRIPTION
## Summary

This PR is part of https://github.com/elastic/kibana/issues/216791

Provide command suggestions  based on the user's minimum license level for ESQL commands

example:
Basic license hide Categorize
<img width="1018" height="127" alt="basic" src="https://github.com/user-attachments/assets/d89f2cdf-e3fa-47e7-b466-70d99e4e241b" />


Trial license show Categorize
<img width="920" height="120" alt="trial" src="https://github.com/user-attachments/assets/21faef97-93ee-49b3-b18e-9296aae0cdc2" />


to test this feat:

start with trial license and verify
change license to basic ( From the sidebar -> stack management -> license management -> then change to basic)
verify with basic license


