### PR TITLE
Ensure that gaps are always updated with the current backfill

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/update/apply_scheduled_backfills_to_gap.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/update/apply_scheduled_backfills_to_gap.test.ts
@@ -52,17 +52,21 @@ const gap = new Gap({
   },
 });
 
-const testToHaveBeenCalledBefore = (calledFirst: jest.Mock, calledSecond: jest.Mock, timesCalled = 1) => {
+const testToHaveBeenCalledBefore = (
+  calledFirst: jest.Mock,
+  calledSecond: jest.Mock,
+  timesCalled = 1
+) => {
   const calledFirstOrder = calledFirst.mock.invocationCallOrder;
   const calledSecondOrder = calledSecond.mock.invocationCallOrder;
 
-  expect(calledFirstOrder).toHaveLength(timesCalled)
-  expect(calledSecondOrder).toHaveLength(timesCalled)
+  expect(calledFirstOrder).toHaveLength(timesCalled);
+  expect(calledSecondOrder).toHaveLength(timesCalled);
 
   calledFirstOrder.forEach((order, idx) => {
-    expect(order).toBeLessThan(calledSecondOrder[idx])
-  })
-}
+    expect(order).toBeLessThan(calledSecondOrder[idx]);
+  });
+};
 
 describe('applyScheduledBackfillsToGap', () => {
   beforeEach(() => {
@@ -91,7 +95,7 @@ describe('applyScheduledBackfillsToGap', () => {
         logger: mockLogger,
       });
 
-      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock);
     });
 
     test('when there is a scheduled item with an errored task', async () => {
@@ -111,7 +115,10 @@ describe('applyScheduledBackfillsToGap', () => {
         ruleId,
       });
 
-      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({ gap, scheduledItems: scheduledItemsWithFailedTask });
+      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({
+        gap,
+        scheduledItems: scheduledItemsWithFailedTask,
+      });
 
       expect(calculateGapStateFromAllBackfillsMock).toHaveBeenCalledWith({
         gap,
@@ -122,7 +129,7 @@ describe('applyScheduledBackfillsToGap', () => {
         logger: mockLogger,
       });
 
-      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock);
     });
 
     test('when there is a scheduled item with a task that timed out', async () => {
@@ -142,7 +149,10 @@ describe('applyScheduledBackfillsToGap', () => {
         ruleId,
       });
 
-      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({ gap, scheduledItems: scheduledItemsWithFailedTask });
+      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({
+        gap,
+        scheduledItems: scheduledItemsWithFailedTask,
+      });
 
       expect(calculateGapStateFromAllBackfillsMock).toHaveBeenCalledWith({
         gap,
@@ -153,7 +163,7 @@ describe('applyScheduledBackfillsToGap', () => {
         logger: mockLogger,
       });
 
-      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock);
     });
 
     test('when shouldRefetchAllBackfills is true', async () => {
@@ -179,7 +189,7 @@ describe('applyScheduledBackfillsToGap', () => {
         logger: mockLogger,
       });
 
-      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock);
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/update/apply_scheduled_backfills_to_gap.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/update/apply_scheduled_backfills_to_gap.test.ts
@@ -52,6 +52,18 @@ const gap = new Gap({
   },
 });
 
+const testToHaveBeenCalledBefore = (calledFirst: jest.Mock, calledSecond: jest.Mock, timesCalled = 1) => {
+  const calledFirstOrder = calledFirst.mock.invocationCallOrder;
+  const calledSecondOrder = calledSecond.mock.invocationCallOrder;
+
+  expect(calledFirstOrder).toHaveLength(timesCalled)
+  expect(calledSecondOrder).toHaveLength(timesCalled)
+
+  calledFirstOrder.forEach((order, idx) => {
+    expect(order).toBeLessThan(calledSecondOrder[idx])
+  })
+}
+
 describe('applyScheduledBackfillsToGap', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -68,6 +80,8 @@ describe('applyScheduledBackfillsToGap', () => {
         ruleId,
       });
 
+      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({ gap, scheduledItems: [] });
+
       expect(calculateGapStateFromAllBackfillsMock).toHaveBeenCalledWith({
         gap,
         savedObjectsRepository,
@@ -76,7 +90,8 @@ describe('applyScheduledBackfillsToGap', () => {
         actionsClient,
         logger: mockLogger,
       });
-      expect(updateGapFromScheduleMock).not.toHaveBeenCalled();
+
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
     });
 
     test('when there is a scheduled item with an errored task', async () => {
@@ -96,6 +111,8 @@ describe('applyScheduledBackfillsToGap', () => {
         ruleId,
       });
 
+      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({ gap, scheduledItems: scheduledItemsWithFailedTask });
+
       expect(calculateGapStateFromAllBackfillsMock).toHaveBeenCalledWith({
         gap,
         savedObjectsRepository,
@@ -104,7 +121,8 @@ describe('applyScheduledBackfillsToGap', () => {
         actionsClient,
         logger: mockLogger,
       });
-      expect(updateGapFromScheduleMock).not.toHaveBeenCalled();
+
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
     });
 
     test('when there is a scheduled item with a task that timed out', async () => {
@@ -124,6 +142,8 @@ describe('applyScheduledBackfillsToGap', () => {
         ruleId,
       });
 
+      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({ gap, scheduledItems: scheduledItemsWithFailedTask });
+
       expect(calculateGapStateFromAllBackfillsMock).toHaveBeenCalledWith({
         gap,
         savedObjectsRepository,
@@ -132,7 +152,8 @@ describe('applyScheduledBackfillsToGap', () => {
         actionsClient,
         logger: mockLogger,
       });
-      expect(updateGapFromScheduleMock).not.toHaveBeenCalled();
+
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
     });
 
     test('when shouldRefetchAllBackfills is true', async () => {
@@ -147,6 +168,8 @@ describe('applyScheduledBackfillsToGap', () => {
         shouldRefetchAllBackfills: true,
       });
 
+      expect(updateGapFromScheduleMock).toHaveBeenCalledWith({ gap, scheduledItems });
+
       expect(calculateGapStateFromAllBackfillsMock).toHaveBeenCalledWith({
         gap,
         savedObjectsRepository,
@@ -155,7 +178,8 @@ describe('applyScheduledBackfillsToGap', () => {
         actionsClient,
         logger: mockLogger,
       });
-      expect(updateGapFromScheduleMock).not.toHaveBeenCalled();
+
+      testToHaveBeenCalledBefore(updateGapFromScheduleMock, calculateGapStateFromAllBackfillsMock)
     });
   });
 
@@ -171,8 +195,8 @@ describe('applyScheduledBackfillsToGap', () => {
         ruleId,
       });
 
-      expect(calculateGapStateFromAllBackfillsMock).not.toHaveBeenCalled();
       expect(updateGapFromScheduleMock).toHaveBeenCalledWith({ gap, scheduledItems });
+      expect(calculateGapStateFromAllBackfillsMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/update/apply_scheduled_backfills_to_gap.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/update/apply_scheduled_backfills_to_gap.ts
@@ -40,6 +40,16 @@ export const applyScheduledBackfillsToGap = async ({
       scheduleItem.status === adHocRunStatus.ERROR || scheduleItem.status === adHocRunStatus.TIMEOUT
   );
 
+  // Although calculateGapStateFromAllBackfills also calls updateGapFromSchedule,
+  // it's crucial to call updateGapFromSchedule first with the current scheduled items.
+  // This ensures that if a backfill has been deleted, we still update gaps based on any
+  // completed scheduled items it contained. Since deleted backfills aren't returned on refetch,
+  // calculateGapStateFromAllBackfills can't account for them.
+  updateGapFromSchedule({
+    gap,
+    scheduledItems,
+  });
+
   if (hasFailedBackfillTask || scheduledItems.length === 0 || shouldRefetchAllBackfills) {
     await calculateGapStateFromAllBackfills({
       gap,
@@ -49,11 +59,5 @@ export const applyScheduledBackfillsToGap = async ({
       actionsClient,
       logger,
     });
-    return;
   }
-
-  updateGapFromSchedule({
-    gap,
-    scheduledItems,
-  });
 };


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/227440 
During the refactoring done in `applyScheduledBackfillsToGap` [function](https://github.com/elastic/kibana/pull/227231/files#diff-5dcd4dbf7487dd70689928a5b58718647be718ac74dfeac8b03d09b2ba6b06b2R37), the execution order was changed and we would either call `calculateGapStateFromAllBackfills` or `updateGapFromSchedule`. However it is important that we always call `updateGapFromSchedule` with the current backfill specially when a backfill is deleted, because there might be completed scheduled items in it that won't be present when we refetch all backfills using `calculateGapStateFromAllBackfills`.

Before:

https://github.com/user-attachments/assets/3c65c99a-3d8b-40e1-a711-4e261f7b8d36



After:


https://github.com/user-attachments/assets/38951e93-5c64-451b-98df-81734271a7ce



## How to test?
Generate rules, each with gaps using [this tool](https://github.com/elastic/security-documents-generator).
```
yarn start rules --rules 100 -g 100 -c -i"5m"
```

1. Navigate to a rule that has gaps, click on its `execution results` tab and scroll down to see the gaps table.
2. Click on the "fill gap" button of a gap, scroll down to the Manual Runs table and see that a manual run was created.
3. Wait until at least one execution completes and then click on "Stop run"
4. Refresh the gaps table and verify that the gap you were trying to fill appears as `Partially filled` and that the action button says `fill remaining gap` instead of `fill gap`.




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->