### PR TITLE
fix type errors from merge race

### DIFF
--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
@@ -271,8 +271,8 @@ export const getFieldStatsChartEmbeddableFactory = (
             flyoutProps: {
               hideCloseButton: true,
               'data-test-subj': 'fieldStatisticsInitializerFlyout',
+              focusedPanelId: uuid,
             },
-            uuid,
             loadContent: async ({ closeFlyout }) => {
               const { EmbeddableFieldStatsUserInput } = await import(
                 './field_stats_embeddable_input'

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
@@ -132,8 +132,8 @@ export const getChangePointChartEmbeddableFactory = (
             flyoutProps: {
               'data-test-subj': 'aiopsChangePointChartEmbeddableInitializer',
               'aria-labelledby': 'changePointConfig',
+              focusedPanelId: uuid,
             },
-            uuid,
             loadContent: async ({ closeFlyout }) => {
               const { EmbeddableChangePointUserInput } = await import(
                 './change_point_config_input'

--- a/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
@@ -63,8 +63,8 @@ export function createAddChangePointChartAction(
         flyoutProps: {
           'data-test-subj': 'aiopsChangePointChartEmbeddableInitializer',
           'aria-labelledby': 'changePointConfig',
+          focusedPanelId: context.embeddable.uuid,
         },
-        uuid: context.embeddable.uuid,
         loadContent: async ({ closeFlyout }) => {
           const { EmbeddableChangePointUserInput } = await import(
             '../embeddables/change_point_chart/change_point_config_input'


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/228747 and https://github.com/elastic/kibana/pull/228454 got into a merge race condition, causing type issues on main now.

moving: `uuid` -> `flyoutProps.focusedPanelId`

cc: @mbondyra - is this an appropriate fix?