### PR TITLE
[9.1] [Discover][A11y] Add underline to search result highlights (#228086)

### DIFF
--- a/src/core/packages/application/common/src/global_app_style.tsx
+++ b/src/core/packages/application/common/src/global_app_style.tsx
@@ -89,12 +89,17 @@ export const renderingOverrides = (euiTheme: UseEuiTheme['euiTheme']) => css`
     }
   }
 
-  // Due to pure HTML and the scope being large, we decided to temporarily apply following 3 style blocks globally.
+  // Due to pure HTML and the scope being large, we decided to temporarily apply following 4 style blocks globally.
   // TODO: refactor within github issue #223571
 
   // Styles applied to the span.ffArray__highlight from FieldFormat class that is used to visually distinguish array delimiters when rendering array values as HTML in Kibana field formatters
   .ffArray__highlight {
     color: ${euiTheme.colors.mediumShade};
+  }
+
+  // Styles applied to the span.ffSearch__highlight from FieldFormat class that is used to visually distinguish highlighted string values when rendering string values as HTML in Kibana field formatters
+  .ffSearch__highlight {
+    text-decoration: dotted underline;
   }
 
   // Styles applied to the span.ffString__emptyValue from FieldFormat class that is used to visually distinguish empty string values when rendering string values as HTML in Kibana field formatters

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
@@ -9,7 +9,7 @@
 
 function extractTextAndMarkTags(html: string) {
   const markTags: string[] = [];
-  const cleanText = html.replace(/<\/?mark>/g, (match) => {
+  const cleanText = html.replace(/<\/?mark[^>]*>/g, (match) => {
     markTags.push(match);
     return '';
   });

--- a/src/platform/plugins/shared/field_formats/common/converters/string.test.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/string.test.ts
@@ -124,6 +124,6 @@ describe('String Format', () => {
           },
         })
       )
-    ).toBe('<mark>&lt;img /&gt;</mark>');
+    ).toBe('<mark class="ffSearch__highlight">&lt;img /&gt;</mark>');
   });
 });

--- a/src/platform/plugins/shared/field_formats/common/utils/highlight/html_tags.ts
+++ b/src/platform/plugins/shared/field_formats/common/utils/highlight/html_tags.ts
@@ -9,6 +9,6 @@
 
 // These are the html tags that will replace the highlight tags.
 export const htmlTags = {
-  pre: '<mark>',
+  pre: '<mark class="ffSearch__highlight">',
   post: '</mark>',
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Discover][A11y] Add underline to search result highlights (#228086)](https://github.com/elastic/kibana/pull/228086)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ania Kowalska","email":"63072419+akowalska622@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-22T09:54:02Z","message":"[Discover][A11y] Add underline to search result highlights (#228086)\n\n## Summary\n\nCloses #214592 \n\nThis PR adds `text-decoration: dotted underline` to search result\nhighlights due to accessibility reasons.\n\n<img width=\"1427\" height=\"493\" alt=\"Screenshot 2025-07-15 at 21 08 59\"\nsrc=\"https://github.com/user-attachments/assets/c9edb19a-7a59-4aef-b8fe-91f424f62abf\"\n/>\n\n<img width=\"542\" height=\"774\" alt=\"Screenshot 2025-07-15 at 21 07 50\"\nsrc=\"https://github.com/user-attachments/assets/e7be0fd1-78d0-46a7-abc4-ec6f4652c7ab\"\n/>\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"24e9dc251093713f8d5e1a2585b0f0ad18b63a51","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Platform-Design","Project:Accessibility","WCAG A","release_note:skip","impact:medium","Team:DataDiscovery","defect-level-1","backport:version","v9.1.0","v8.19.0","platform-accessibility","v9.2.0"],"title":"[Discover][A11y] Add underline to search result highlights","number":228086,"url":"https://github.com/elastic/kibana/pull/228086","mergeCommit":{"message":"[Discover][A11y] Add underline to search result highlights (#228086)\n\n## Summary\n\nCloses #214592 \n\nThis PR adds `text-decoration: dotted underline` to search result\nhighlights due to accessibility reasons.\n\n<img width=\"1427\" height=\"493\" alt=\"Screenshot 2025-07-15 at 21 08 59\"\nsrc=\"https://github.com/user-attachments/assets/c9edb19a-7a59-4aef-b8fe-91f424f62abf\"\n/>\n\n<img width=\"542\" height=\"774\" alt=\"Screenshot 2025-07-15 at 21 07 50\"\nsrc=\"https://github.com/user-attachments/assets/e7be0fd1-78d0-46a7-abc4-ec6f4652c7ab\"\n/>\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"24e9dc251093713f8d5e1a2585b0f0ad18b63a51"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228086","number":228086,"mergeCommit":{"message":"[Discover][A11y] Add underline to search result highlights (#228086)\n\n## Summary\n\nCloses #214592 \n\nThis PR adds `text-decoration: dotted underline` to search result\nhighlights due to accessibility reasons.\n\n<img width=\"1427\" height=\"493\" alt=\"Screenshot 2025-07-15 at 21 08 59\"\nsrc=\"https://github.com/user-attachments/assets/c9edb19a-7a59-4aef-b8fe-91f424f62abf\"\n/>\n\n<img width=\"542\" height=\"774\" alt=\"Screenshot 2025-07-15 at 21 07 50\"\nsrc=\"https://github.com/user-attachments/assets/e7be0fd1-78d0-46a7-abc4-ec6f4652c7ab\"\n/>\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"24e9dc251093713f8d5e1a2585b0f0ad18b63a51"}}]}] BACKPORT-->