### PR TITLE
🌊 POC: Wired streams onboarding/migration for existing data/setups

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.ts
@@ -27,6 +27,7 @@ interface IngestWired {
   wired: {
     fields: FieldDefinition;
     routing: RoutingDefinition[];
+    capture_pattern?: string;
   };
 }
 
@@ -34,6 +35,7 @@ const IngestWired: z.Schema<IngestWired> = z.object({
   wired: z.object({
     fields: fieldDefinitionSchema,
     routing: routingDefinitionListSchema,
+    capture_pattern: z.string().optional(),
   }),
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/required_permissions.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/required_permissions.ts
@@ -65,6 +65,8 @@ export function getRequiredPermissionsForActions({
     update_lifecycle,
     upsert_write_index_or_rollover,
     delete_datastream,
+    // TODO
+    update_capture_pattern,
     // we don't need to validate permissions for these actions
     // since they are done by the kibana system user
     upsert_dot_streams_document,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/types.ts
@@ -108,6 +108,15 @@ export interface DeleteDotStreamsDocumentAction {
   };
 }
 
+export interface UpdateCapturePatternAction {
+  type: 'update_capture_pattern';
+  request: {
+    name: string;
+    capturePattern?: string;
+    oldPattern?: string;
+  };
+}
+
 export type ElasticsearchAction =
   | UpsertComponentTemplateAction
   | DeleteComponentTemplateAction
@@ -122,7 +131,8 @@ export type ElasticsearchAction =
   | UpdateLifecycleAction
   | DeleteDatastreamAction
   | UpsertDotStreamsDocumentAction
-  | DeleteDotStreamsDocumentAction;
+  | DeleteDotStreamsDocumentAction
+  | UpdateCapturePatternAction;
 
 export interface ActionsByType {
   upsert_component_template: UpsertComponentTemplateAction[];
@@ -137,6 +147,7 @@ export interface ActionsByType {
   upsert_write_index_or_rollover: UpsertWriteIndexOrRolloverAction[];
   update_lifecycle: UpdateLifecycleAction[];
   delete_datastream: DeleteDatastreamAction[];
+  update_capture_pattern: UpdateCapturePatternAction[];
   upsert_dot_streams_document: UpsertDotStreamsDocumentAction[];
   delete_dot_streams_document: DeleteDotStreamsDocumentAction[];
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_active_record.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_active_record.ts
@@ -154,7 +154,7 @@ export abstract class StreamActiveRecord<
         return this.doDetermineCreateActions();
       }
     } else if (this.changeStatus === 'deleted') {
-      return this.doDetermineDeleteActions();
+      return this.doDetermineDeleteActions(startingState);
     }
 
     throw new Error('Cannot determine Elasticsearch actions for an unchanged stream');
@@ -214,5 +214,5 @@ export abstract class StreamActiveRecord<
     startingState: State,
     startingStateStream: StreamActiveRecord<TDefinition>
   ): Promise<ElasticsearchAction[]>;
-  protected abstract doDetermineDeleteActions(): Promise<ElasticsearchAction[]>;
+  protected abstract doDetermineDeleteActions(startingState: State): Promise<ElasticsearchAction[]>;
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -7,12 +7,31 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexGroup, EuiBetaBadge, EuiLink, EuiPageHeader, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiBetaBadge,
+  EuiLink,
+  EuiPageHeader,
+  useEuiTheme,
+  EuiButton,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiSpacer,
+  EuiModalFooter,
+  EuiCodeBlock,
+  EuiFieldText,
+  EuiCallOut,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import {
   OBSERVABILITY_ONBOARDING_LOCATOR,
   ObservabilityOnboardingLocatorParams,
 } from '@kbn/deeplinks-observability';
+import useObservable from 'react-use/lib/useObservable';
+import { useAbortController, useAbortableAsync } from '@kbn/react-hooks';
 import { useKibana } from '../../hooks/use_kibana';
 import { useStreamsAppFetch } from '../../hooks/use_streams_app_fetch';
 import { StreamsTreeTable } from './tree_table';
@@ -23,7 +42,7 @@ export function StreamListView() {
   const {
     dependencies: {
       start: {
-        streams: { streamsRepositoryClient },
+        streams: { streamsRepositoryClient, status$ },
         share,
       },
     },
@@ -35,6 +54,7 @@ export function StreamListView() {
   const handleAddData = () => {
     onboardingLocator?.navigate({});
   };
+  const streamsEnabled = useObservable(status$);
   const streamsListFetch = useStreamsAppFetch(
     async ({ signal }) => {
       const { streams } = await streamsRepositoryClient.fetch('GET /internal/streams', {
@@ -102,6 +122,20 @@ export function StreamListView() {
       </EuiPageHeader>
 
       <StreamsAppPageTemplate.Body grow>
+        {streamsEnabled?.status === 'disabled' ? (
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup
+              direction="column"
+              alignItems="center"
+              justifyContent="center"
+              style={{ height: '300px' }}
+            >
+              <EuiFlexItem grow={false}>
+                <CapturePrompt />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        ) : null}
         {!streamsListFetch.loading && !streamsListFetch.value?.length ? (
           <StreamsListEmptyPrompt onAddData={handleAddData} />
         ) : (
@@ -109,5 +143,215 @@ export function StreamListView() {
         )}
       </StreamsAppPageTemplate.Body>
     </>
+  );
+}
+
+function CapturePrompt() {
+  const {
+    dependencies: {
+      start: {
+        streams: { streamsRepositoryClient, status$ },
+        share,
+      },
+    },
+    core: { docLinks },
+  } = useKibana();
+  const [didEnable, setDidEnable] = React.useState(false);
+  const [didCapture, setDidCapture] = React.useState(false);
+  const [closedModal, setClosedModal] = React.useState(false);
+  const [capturePattern, setCapturePattern] = React.useState('');
+  const enableSignal = useAbortController().signal;
+
+  const matchingDatastreams = useAbortableAsync(
+    async ({ signal }) => {
+      return streamsRepositoryClient.fetch('GET /internal/streams/_list_data_streams/{pattern}', {
+        signal,
+        params: {
+          path: { pattern: capturePattern || '*' },
+        },
+      });
+    },
+    [streamsRepositoryClient, capturePattern]
+  );
+
+  if (!didEnable) {
+    return (
+      <EuiButton
+        fill
+        onClick={async () => {
+          await streamsRepositoryClient.fetch('POST /api/streams/_enable 2023-10-31', {
+            signal: enableSignal,
+          });
+          setDidEnable(true);
+        }}
+      >
+        Enable wired streams (they are so cool!)
+      </EuiButton>
+    );
+  }
+  if (closedModal) {
+    return null;
+  }
+  return (
+    <EuiModal onClose={() => setClosedModal(true)} aria-label="Onboarding wired streams">
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>Welcome to wired streams!</EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        Wired streams allow you to ...
+        <EuiSpacer />
+        To send data to wired streams, you can configure your shippers:
+        <EuiCodeBlock language="bash">
+          {`# Filebeat example
+          filebeat.inputs:
+            - type: log
+              paths:
+                - /var/log/*.log
+          output.elasticsearch:
+            hosts: ["http://localhost:9200"]
+            logs_stream: true
+
+# Logstash example
+          output {
+            elasticsearch {
+              hosts => ["http://localhost:9200"]
+              index => "logs"
+          }
+        }
+
+# OTel example (via logsstreamprocessor)
+          otelcol:
+            processors:
+              logsstreamprocessor:
+                logs_stream: true
+            exporters:
+              elasticsearch:
+                endpoints: ["http://localhost:9200"]
+            service:
+              pipelines:
+                logs:
+                  processors: [logsstreamprocessor]
+                  exporters: [elasticsearch]
+      `}
+        </EuiCodeBlock>
+        {didCapture && (
+          <EuiCallOut color="success">
+            You are now redirecting data over to the logs stream
+          </EuiCallOut>
+        )}
+        For existing streams, you can also configure a capture pattern to start capturing data:
+        <EuiFieldText
+          placeholder="Enter capture pattern"
+          value={capturePattern}
+          onChange={(e) => setCapturePattern(e.target.value)}
+        />
+        Matching datastreams:
+        {matchingDatastreams.value?.data_streams.length ? (
+          <ul>
+            {matchingDatastreams.value.data_streams.map((ds) => (
+              <li key={ds}>{ds}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No matching datastreams found.</p>
+        )}
+        <EuiButton
+          onClick={async () => {
+            setDidCapture(false);
+            await streamsRepositoryClient.fetch('PUT /api/streams/{name}/_ingest 2023-10-31', {
+              signal: enableSignal,
+              params: {
+                path: { name: 'logs' },
+                body: {
+                  ingest: {
+                    lifecycle: {
+                      dsl: {},
+                    },
+                    processing: [],
+                    wired: {
+                      fields: {
+                        '@timestamp': {
+                          type: 'date',
+                        },
+                        'stream.name': {
+                          type: 'system',
+                        },
+                        'scope.dropped_attributes_count': {
+                          type: 'long',
+                        },
+                        dropped_attributes_count: {
+                          type: 'long',
+                        },
+                        'resource.dropped_attributes_count': {
+                          type: 'long',
+                        },
+                        'resource.schema_url': {
+                          type: 'keyword',
+                        },
+                        'scope.name': {
+                          type: 'keyword',
+                        },
+                        'scope.schema_url': {
+                          type: 'keyword',
+                        },
+                        'scope.version': {
+                          type: 'keyword',
+                        },
+                        observed_timestamp: {
+                          type: 'date',
+                        },
+                        trace_id: {
+                          type: 'keyword',
+                        },
+                        span_id: {
+                          type: 'keyword',
+                        },
+                        event_name: {
+                          type: 'keyword',
+                        },
+                        severity_text: {
+                          type: 'keyword',
+                        },
+                        'body.text': {
+                          type: 'match_only_text',
+                        },
+                        severity_number: {
+                          type: 'long',
+                        },
+                        'resource.attributes.host.name': {
+                          type: 'keyword',
+                        },
+                      },
+
+                      capture_pattern: capturePattern,
+                      routing: [],
+                    },
+                  },
+                },
+              },
+            });
+
+            setDidCapture(true);
+          }}
+        >
+          Start capturing
+        </EuiButton>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButton
+          onClick={() => {
+            setClosedModal(true);
+            if (didEnable) {
+              window.location.reload();
+            }
+          }}
+          fill
+        >
+          Close
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
   );
 }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
@@ -21,6 +21,7 @@ import {
   useEuiTheme,
   EuiBadge,
   EuiFlexGrid,
+  EuiSwitch,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 
@@ -28,6 +29,7 @@ import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { IntegrationCardItem } from '@kbn/fleet-plugin/public';
 import { usePerformanceContext } from '@kbn/ebt-tools';
+import { EuiSwitchEvent } from '@elastic/eui/src/components/form/switch';
 import { ObservabilityOnboardingPricingFeature } from '../../../common/pricing_features';
 import { PackageListSearchForm } from '../package_list_search_form/package_list_search_form';
 import { Category } from './types';
@@ -207,6 +209,19 @@ export const OnboardingFlowForm: FunctionComponent = () => {
 
   return (
     <EuiPanel hasBorder paddingSize="xl">
+      <div>
+      <EuiSwitch
+        label={i18n.translate(
+          'xpack.observability_onboarding.onboardingFlowForm.euiSwitch.useLogsStreamLabel',
+          { defaultMessage: 'Use logs stream' }
+        )}
+        checked={false}
+        onChange={function (event: EuiSwitchEvent): void {
+          throw new Error('Function not implemented.');
+        }}
+      />
+      </div>
+      <EuiSpacer size="l" />
       <EuiTitle size="s" id={categorySelectorTitleId}>
         <strong>
           {i18n.translate(


### PR DESCRIPTION
Exploring part of the migration/onboarding story for wired streams:
* Opt in in the UI
* Showing tutorial for shipper-side configuration
* Allowing to redirect index templates

<img width="2235" height="812" alt="Screenshot 2025-07-22 at 13 42 49" src="https://github.com/user-attachments/assets/c80dcfef-ce5f-433d-b446-0ad67d1a2ddb" />
<img width="928" height="1057" alt="Screenshot 2025-07-22 at 13 43 04" src="https://github.com/user-attachments/assets/f13f33b7-ed73-4528-9401-d32c41e4aa92" />

There are two other parts of the puzzle it didn't mention here:
* Option on a fleet policy / integration to send data to the logs stream
* Regular observability onboarding flows, but for streams