### PR TITLE
[9.0] Fix reporting pollEnabled config (#228707)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.test.ts
@@ -52,6 +52,9 @@ jest.mock('../constants', () => ({
     'limitedToTwo',
     'limitedToFive',
     'yawn',
+    'sampleTaskSharedConcurrencyType1',
+    'sampleTaskSharedConcurrencyType2',
+    'sampleTaskZeroMaxConcurrency',
   ],
 }));
 
@@ -2062,6 +2065,50 @@ describe('TaskClaiming', () => {
         `Background task node "${taskPartitioner.getPodName()}" now claiming with assigned partitions`,
         { tags: ['taskClaiming', 'claimAvailableTasksMget'] }
       );
+    });
+
+    test('should not claim the tasks that has 0 maxConcurrency (pollEnabled:false)', async () => {
+      const definitions = new TaskTypeDictionary(mockLogger());
+      definitions.registerTaskDefinitions({
+        foo: {
+          title: 'foo',
+          createTaskRunner: jest.fn(),
+        },
+        bar: {
+          title: 'bar',
+          createTaskRunner: jest.fn(),
+        },
+        baz: {
+          title: 'baz',
+          createTaskRunner: jest.fn(),
+        },
+        sampleTaskZeroMaxConcurrency: {
+          title: 'report',
+          createTaskRunner: jest.fn(),
+          maxConcurrency: 0,
+        },
+      });
+      const { taskClaiming, store } = initialiseTestClaiming({
+        storeOpts: {
+          definitions,
+        },
+        taskClaimingOpts: {
+          maxAttempts: 5,
+        },
+      });
+
+      await taskClaiming.claimAvailableTasksIfCapacityIsAvailable({
+        claimOwnershipUntil: new Date(),
+      });
+
+      const searchQuery = store.msearch.mock.calls[0]?.[0]?.[0].query;
+      const searchQueryMust = searchQuery?.bool?.must;
+
+      expect(Array.isArray(searchQueryMust) && searchQueryMust[1]).toEqual({
+        bool: { must: [{ terms: { 'task.taskType': ['foo', 'bar', 'baz'] } }] },
+      });
+
+      expect(JSON.stringify(searchQuery)).not.toContain('sampleTaskZeroMaxConcurrency');
     });
   });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.test.ts
@@ -130,6 +130,26 @@ describe('CostCapacity', () => {
     ).toBe(4);
   });
 
+  test('availableCapacity returns 0 for the task type when task type with maxConcurrency is 0', () => {
+    const pool = new CostCapacity({ capacity$: of(10), logger });
+
+    const tasksInPool = new Map([
+      ['1', { ...mockTask({}, { type: 'type1' }) }],
+      ['2', { ...mockTask({}, { cost: TaskCost.Tiny }) }],
+      ['3', { ...mockTask() }],
+    ]);
+
+    expect(
+      pool.availableCapacity(tasksInPool, {
+        type: 'type1',
+        maxConcurrency: 0,
+        cost: TaskCost.Normal,
+        createTaskRunner: jest.fn(),
+        timeout: '5m',
+      })
+    ).toBe(0);
+  });
+
   describe('determineTasksToRunBasedOnCapacity', () => {
     test('runs all tasks if there is capacity', () => {
       const pool = new CostCapacity({ capacity$: of(10), logger });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.ts
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { Logger } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
+import { isNullish } from 'utility-types';
 import { DEFAULT_CAPACITY } from '../config';
-import { TaskDefinition } from '../task';
-import { TaskRunner } from '../task_running';
-import { CapacityOpts, ICapacity } from './types';
+import type { TaskDefinition } from '../task';
+import type { TaskRunner } from '../task_running';
+import type { CapacityOpts, ICapacity } from './types';
 import { getCapacityInCost } from './utils';
 
 export class CostCapacity implements ICapacity {
@@ -69,7 +70,7 @@ export class CostCapacity implements ICapacity {
     taskDefinition?: TaskDefinition | null
   ): number {
     const allAvailableCapacity = this.capacity - this.usedCapacity(tasksInPool);
-    if (taskDefinition && taskDefinition.maxConcurrency) {
+    if (taskDefinition && !isNullish(taskDefinition.maxConcurrency)) {
       // calculate the max capacity that can be used for this task type based on cost
       const maxCapacityForType = taskDefinition.maxConcurrency * taskDefinition.cost;
       return Math.max(

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/worker_capacity.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/worker_capacity.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { Logger } from '@kbn/core/server';
-import { TaskRunner } from '../task_running';
-import { CapacityOpts, ICapacity } from './types';
-import { TaskDefinition } from '../task';
+import type { Logger } from '@kbn/core/server';
+import { isNullish } from 'utility-types';
+import type { TaskRunner } from '../task_running';
+import type { CapacityOpts, ICapacity } from './types';
+import type { TaskDefinition } from '../task';
 import { getCapacityInWorkers } from './utils';
 
 export class WorkerCapacity implements ICapacity {
@@ -60,7 +61,7 @@ export class WorkerCapacity implements ICapacity {
     taskDefinition?: TaskDefinition | null
   ): number {
     const allAvailableCapacity = this.capacity - this.usedCapacity(tasksInPool);
-    if (taskDefinition && taskDefinition.maxConcurrency) {
+    if (taskDefinition && !isNullish(taskDefinition.maxConcurrency)) {
       // calculate the max workers that can be used for this task type
       return Math.max(
         Math.min(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Fix reporting pollEnabled config (#228707)](https://github.com/elastic/kibana/pull/228707)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-22T07:23:56Z","message":"Fix reporting pollEnabled config (#228707)\n\nFixes: #226506\n\nThis PR fixes the bug: `xpack.reporting.queue.pollEnabled` config to be\nignored by the `mget` claim strategy.\n\n## To verify: \n\nSet  `xpack.reporting.queue.pollEnabled: false` in your kibana.yml.\nThen try to generate a report.\nThe task should be successfully created but its status should remain as\n`pending` on the reports page.\n\n<img width=\"999\" height=\"343\" alt=\"Screenshot 2025-07-21 at 02 35 40\"\nsrc=\"https://github.com/user-attachments/assets/0e7d5959-76c4-4519-ac3e-a3ca56f57f37\"\n/>","sha":"8690830b3e4966d9191b9d5d4ce6e573445854d3","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:ResponseOps","v9.2.0"],"title":"Fix reporting pollEnabled config","number":228707,"url":"https://github.com/elastic/kibana/pull/228707","mergeCommit":{"message":"Fix reporting pollEnabled config (#228707)\n\nFixes: #226506\n\nThis PR fixes the bug: `xpack.reporting.queue.pollEnabled` config to be\nignored by the `mget` claim strategy.\n\n## To verify: \n\nSet  `xpack.reporting.queue.pollEnabled: false` in your kibana.yml.\nThen try to generate a report.\nThe task should be successfully created but its status should remain as\n`pending` on the reports page.\n\n<img width=\"999\" height=\"343\" alt=\"Screenshot 2025-07-21 at 02 35 40\"\nsrc=\"https://github.com/user-attachments/assets/0e7d5959-76c4-4519-ac3e-a3ca56f57f37\"\n/>","sha":"8690830b3e4966d9191b9d5d4ce6e573445854d3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228707","number":228707,"mergeCommit":{"message":"Fix reporting pollEnabled config (#228707)\n\nFixes: #226506\n\nThis PR fixes the bug: `xpack.reporting.queue.pollEnabled` config to be\nignored by the `mget` claim strategy.\n\n## To verify: \n\nSet  `xpack.reporting.queue.pollEnabled: false` in your kibana.yml.\nThen try to generate a report.\nThe task should be successfully created but its status should remain as\n`pending` on the reports page.\n\n<img width=\"999\" height=\"343\" alt=\"Screenshot 2025-07-21 at 02 35 40\"\nsrc=\"https://github.com/user-attachments/assets/0e7d5959-76c4-4519-ac3e-a3ca56f57f37\"\n/>","sha":"8690830b3e4966d9191b9d5d4ce6e573445854d3"}}]}] BACKPORT-->