### PR TITLE
[8.19] Fix reporting pollEnabled config (#228707)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.test.ts
@@ -130,6 +130,26 @@ describe('CostCapacity', () => {
     ).toBe(4);
   });
 
+  test('availableCapacity returns 0 for the task type when task type with maxConcurrency is 0', () => {
+    const pool = new CostCapacity({ capacity$: of(10), logger });
+
+    const tasksInPool = new Map([
+      ['1', { ...mockTask({}, { type: 'type1' }) }],
+      ['2', { ...mockTask({}, { cost: TaskCost.Tiny }) }],
+      ['3', { ...mockTask() }],
+    ]);
+
+    expect(
+      pool.availableCapacity(tasksInPool, {
+        type: 'type1',
+        maxConcurrency: 0,
+        cost: TaskCost.Normal,
+        createTaskRunner: jest.fn(),
+        timeout: '5m',
+      })
+    ).toBe(0);
+  });
+
   describe('determineTasksToRunBasedOnCapacity', () => {
     test('runs all tasks if there is capacity', () => {
       const pool = new CostCapacity({ capacity$: of(10), logger });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Logger } from '@kbn/core/server';
+import { isNullish } from 'utility-types';
 import { DEFAULT_CAPACITY } from '../config';
 import type { TaskDefinition } from '../task';
 import type { TaskRunner } from '../task_running';
@@ -69,7 +70,7 @@ export class CostCapacity implements ICapacity {
     taskDefinition?: TaskDefinition | null
   ): number {
     const allAvailableCapacity = this.capacity - this.usedCapacity(tasksInPool);
-    if (taskDefinition && taskDefinition.maxConcurrency) {
+    if (taskDefinition && !isNullish(taskDefinition.maxConcurrency)) {
       // calculate the max capacity that can be used for this task type based on cost
       const maxCapacityForType = taskDefinition.maxConcurrency * taskDefinition.cost;
       return Math.max(

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/worker_capacity.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/worker_capacity.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Logger } from '@kbn/core/server';
+import { isNullish } from 'utility-types';
 import type { TaskRunner } from '../task_running';
 import type { CapacityOpts, ICapacity } from './types';
 import type { TaskDefinition } from '../task';
@@ -60,7 +61,7 @@ export class WorkerCapacity implements ICapacity {
     taskDefinition?: TaskDefinition | null
   ): number {
     const allAvailableCapacity = this.capacity - this.usedCapacity(tasksInPool);
-    if (taskDefinition && taskDefinition.maxConcurrency) {
+    if (taskDefinition && !isNullish(taskDefinition.maxConcurrency)) {
       // calculate the max workers that can be used for this task type
       return Math.max(
         Math.min(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix reporting pollEnabled config (#228707)](https://github.com/elastic/kibana/pull/228707)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-22T07:23:56Z","message":"Fix reporting pollEnabled config (#228707)\n\nFixes: #226506\n\nThis PR fixes the bug: `xpack.reporting.queue.pollEnabled` config to be\nignored by the `mget` claim strategy.\n\n## To verify: \n\nSet  `xpack.reporting.queue.pollEnabled: false` in your kibana.yml.\nThen try to generate a report.\nThe task should be successfully created but its status should remain as\n`pending` on the reports page.\n\n<img width=\"999\" height=\"343\" alt=\"Screenshot 2025-07-21 at 02 35 40\"\nsrc=\"https://github.com/user-attachments/assets/0e7d5959-76c4-4519-ac3e-a3ca56f57f37\"\n/>","sha":"8690830b3e4966d9191b9d5d4ce6e573445854d3","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:ResponseOps","v9.2.0"],"title":"Fix reporting pollEnabled config","number":228707,"url":"https://github.com/elastic/kibana/pull/228707","mergeCommit":{"message":"Fix reporting pollEnabled config (#228707)\n\nFixes: #226506\n\nThis PR fixes the bug: `xpack.reporting.queue.pollEnabled` config to be\nignored by the `mget` claim strategy.\n\n## To verify: \n\nSet  `xpack.reporting.queue.pollEnabled: false` in your kibana.yml.\nThen try to generate a report.\nThe task should be successfully created but its status should remain as\n`pending` on the reports page.\n\n<img width=\"999\" height=\"343\" alt=\"Screenshot 2025-07-21 at 02 35 40\"\nsrc=\"https://github.com/user-attachments/assets/0e7d5959-76c4-4519-ac3e-a3ca56f57f37\"\n/>","sha":"8690830b3e4966d9191b9d5d4ce6e573445854d3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228707","number":228707,"mergeCommit":{"message":"Fix reporting pollEnabled config (#228707)\n\nFixes: #226506\n\nThis PR fixes the bug: `xpack.reporting.queue.pollEnabled` config to be\nignored by the `mget` claim strategy.\n\n## To verify: \n\nSet  `xpack.reporting.queue.pollEnabled: false` in your kibana.yml.\nThen try to generate a report.\nThe task should be successfully created but its status should remain as\n`pending` on the reports page.\n\n<img width=\"999\" height=\"343\" alt=\"Screenshot 2025-07-21 at 02 35 40\"\nsrc=\"https://github.com/user-attachments/assets/0e7d5959-76c4-4519-ac3e-a3ca56f57f37\"\n/>","sha":"8690830b3e4966d9191b9d5d4ce6e573445854d3"}}]}] BACKPORT-->