### PR TITLE
Rename AI4SOC to "Elastic AI SOC Engine"

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_header/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_header/translations.ts
@@ -30,7 +30,7 @@ export const ONBOARDING_PAGE_DESCRIPTION = i18n.translate(
 export const ONBOARDING_SEARCH_AI_LAKE_PAGE_TITLE = i18n.translate(
   'xpack.securitySolution.onboarding.searchAILake.title',
   {
-    defaultMessage: `Welcome to Elastic’s AI for the SOC`,
+    defaultMessage: `Welcome to Elastic AI SOC Engine`,
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -544,7 +544,7 @@ export const getDefaultAIConnectorSetting = (connectors: Connector[]): SettingsC
             'xpack.securitySolution.uiSettings.defaultAIConnectorDescription',
             {
               // TODO update this copy, waiting on James Spiteri's input
-              defaultMessage: 'Default AI connector for serverless AI features (AI for SOC)',
+              defaultMessage: 'Default AI connector for serverless AI features (Elastic AI SOC Engine)',
             }
           ),
           type: 'select',

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -544,7 +544,8 @@ export const getDefaultAIConnectorSetting = (connectors: Connector[]): SettingsC
             'xpack.securitySolution.uiSettings.defaultAIConnectorDescription',
             {
               // TODO update this copy, waiting on James Spiteri's input
-              defaultMessage: 'Default AI connector for serverless AI features (Elastic AI SOC Engine)',
+              defaultMessage:
+                'Default AI connector for serverless AI features (Elastic AI SOC Engine)',
             }
           ),
           type: 'select',

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
@@ -18,7 +18,7 @@ import { renderAiSocCallout } from './callout';
 
 const SOLUTION_NAME = i18n.translate(
   'xpack.securitySolutionServerless.aiNavigation.projectType.title',
-  { defaultMessage: 'AI for SOC' }
+  { defaultMessage: 'Elastic AI SOC Engine' }
 );
 
 export const createAiNavigationTree = (): NavigationTreeDefinition => ({

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/translations.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 
 export const SOLUTION_NAME = i18n.translate(
   'xpack.securitySolutionServerless.socNavLinks.projectType.title',
-  { defaultMessage: 'AI for SOC' }
+  { defaultMessage: 'Elastic AI SOC Engine' }
 );
 export const ALERT_SUMMARY = i18n.translate(
   'xpack.securitySolutionServerless.navigation.aiSoc.alertSummary',
@@ -40,6 +40,6 @@ export const CALLOUT_DESCRIPTION = i18n.translate(
 export const CALLOUT_ARIA_LABEL = i18n.translate(
   'xpack.securitySolutionServerless.navigation.aiSoc.callout.ariaLabel',
   {
-    defaultMessage: 'Information about Elastic AI for SOC',
+    defaultMessage: 'Information about Elastic AI SOC Engine',
   }
 );


### PR DESCRIPTION
## Summary

https://github.com/elastic/security-team/issues/13262

The `AI for SOC` tier is renamed to "Elastic AI SOC Engine", EASE for short.

<img width="2558" height="1239" alt="Screenshot 2025-07-22 at 13 54 09" src="https://github.com/user-attachments/assets/2ac8649f-541d-47d2-be09-0db1947d9dd6" />





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->