### PR TITLE
[Discover] Update the logic of selecting a sub field to be used when fetching field stats

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.test.ts
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { stubDataView, stubLogstashDataView } from '@kbn/data-views-plugin/common/data_view.stub';
+import { getFieldForStats } from './field_list_item_stats';
+
+describe('getFieldForStats', () => {
+  it('should return the field itself if no multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    const resultText = getFieldForStats(fieldExtensionText, undefined);
+    expect(resultText).toBe(fieldExtensionText);
+
+    const fieldExtensionKeyword = stubDataView.getFieldByName('machine.os.raw')!;
+    expect(fieldExtensionKeyword.aggregatable).toBe(true);
+    const resultKeyword = getFieldForStats(fieldExtensionKeyword, undefined);
+    expect(resultKeyword).toBe(fieldExtensionKeyword);
+  });
+
+  it('should return an aggregatable field itself even when multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    const fieldExtensionKeyword = stubDataView.getFieldByName('machine.os.raw')!;
+    const fieldExtensionKeyword2 = stubDataView.getFieldByName('bytes')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    expect(fieldExtensionKeyword.aggregatable).toBe(true);
+    expect(fieldExtensionKeyword2.aggregatable).toBe(true);
+    const resultKeyword = getFieldForStats(fieldExtensionKeyword, [
+      { field: fieldExtensionKeyword2, isSelected: false },
+      { field: fieldExtensionText, isSelected: false },
+    ]);
+    expect(resultKeyword).toBe(fieldExtensionKeyword);
+  });
+
+  it('should return an aggregatable field when multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    const fieldExtensionKeyword = stubDataView.getFieldByName('machine.os.raw')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    expect(fieldExtensionKeyword.aggregatable).toBe(true);
+    const resultKeyword = getFieldForStats(fieldExtensionText, [
+      { field: fieldExtensionKeyword, isSelected: false },
+    ]);
+    expect(resultKeyword).toBe(fieldExtensionKeyword);
+  });
+
+  it('should return the field itself when no aggregatable multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    const fieldExtensionText2 = stubLogstashDataView.getFieldByName('hashed')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    expect(fieldExtensionText2.aggregatable).toBe(false);
+    const resultFallback = getFieldForStats(fieldExtensionText, [
+      { field: fieldExtensionText2, isSelected: false },
+    ]);
+    expect(resultFallback).toBe(fieldExtensionText);
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.tsx
@@ -36,14 +36,8 @@ export const UnifiedFieldListItemStats: React.FC<UnifiedFieldListItemStatsProps>
       data: services.data,
       timeRangeUpdatesType: stateService.creationOptions.timeRangeUpdatesType,
     });
-    // prioritize an aggregatable multi field if available or take the parent field
-    const fieldForStats = useMemo(
-      () =>
-        (multiFields?.length &&
-          multiFields.find((multiField) => multiField.field.aggregatable)?.field) ||
-        field,
-      [field, multiFields]
-    );
+
+    const fieldForStats = useMemo(() => getFieldForStats(field, multiFields), [field, multiFields]);
 
     const statsServices: FieldStatsServices = useMemo(
       () => ({
@@ -80,3 +74,18 @@ export const UnifiedFieldListItemStats: React.FC<UnifiedFieldListItemStatsProps>
     );
   }
 );
+
+export const getFieldForStats = (
+  field: DataViewField,
+  multiFields: Array<{ field: DataViewField; isSelected: boolean }> | undefined
+): DataViewField => {
+  if (field.aggregatable) {
+    return field;
+  }
+  // prioritize an aggregatable multi field if available or take the parent field
+  return (
+    (multiFields?.length &&
+      multiFields.find((multiField) => multiField.field.aggregatable)?.field) ||
+    field
+  );
+};


### PR DESCRIPTION
- Fixes https://github.com/elastic/kibana/issues/228952

## Summary

This PR fixes what field is being picked for fetching stats in the sidebar popover. Previously, it was choosing one of the multi fields, now it will choose the parent field first (sidebar groups similar fields and displays them inside the popover).

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->