### PR TITLE
[9.1] [ES|QL] Add form row labeling to ESQL Editor (#228103)

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -99,6 +99,8 @@ export interface ESQLEditorProps {
   expandToFitQueryOnMount?: boolean;
   /** Allows controlling the switch to toggle data errors in the UI. If not provided the switch will be hidden and data errors visible */
   dataErrorsControl?: DataErrorsControl;
+  /** Optional form field label to show above the query editor */
+  formLabel?: string;
 }
 
 interface ESQLVariableService {

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -175,6 +175,17 @@ export interface CodeEditorProps {
    * this prop allows adding more custom menu actions, on top of the default Cut, Copy, and Paste actions.
    */
   customContextMenuActions?: ContextMenuAction[];
+
+  /**
+   * Optional html id for accessibility labeling
+   */
+  htmlId?: string;
+
+  /**
+   * Callbacks for when editor is focused/blurred
+   */
+  onFocus?: () => void;
+  onBlur?: () => void;
 }
 
 export const CodeEditor: React.FC<CodeEditorProps> = ({
@@ -210,6 +221,9 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   classNameCss,
   enableCustomContextMenu = false,
   customContextMenuActions = [],
+  htmlId,
+  onFocus,
+  onBlur,
 }) => {
   const { euiTheme } = useEuiTheme();
   const { registerContextMenuActions, unregisterContextMenuActions } = useContextMenuUtils();
@@ -241,7 +255,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   const startEditing = useCallback(() => {
     setIsHintActive(false);
     _editor?.focus();
-  }, [_editor]);
+    onFocus?.();
+  }, [_editor, onFocus]);
 
   const stopEditing = useCallback(() => {
     setIsHintActive(true);
@@ -276,7 +291,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
   const onBlurMonaco = useCallback(() => {
     stopEditing();
-  }, [stopEditing]);
+    onBlur?.();
+  }, [stopEditing, onBlur]);
 
   const renderPrompt = useCallback(() => {
     const enterKey = (
@@ -346,12 +362,14 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
                 display: none;
               `,
           ]}
-          id={htmlIdGenerator('codeEditor')()}
+          id={htmlId ?? htmlIdGenerator('codeEditor')()}
           ref={editorHint}
           tabIndex={0}
           role="button"
           onClick={startEditing}
           onKeyDown={onKeyDownHint}
+          onFocus={onFocus}
+          onBlur={onBlur}
           aria-label={i18n.translate('sharedUXPackages.codeEditor.codeEditorEditButton', {
             defaultMessage: '{codeEditorAriaLabel}, activate edit mode',
             values: {
@@ -362,7 +380,17 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         />
       </EuiToolTip>
     );
-  }, [isHintActive, isReadOnly, euiTheme, startEditing, onKeyDownHint, ariaLabel]);
+  }, [
+    isHintActive,
+    isReadOnly,
+    euiTheme,
+    startEditing,
+    onKeyDownHint,
+    ariaLabel,
+    htmlId,
+    onFocus,
+    onBlur,
+  ]);
 
   const _editorWillMount = useCallback<NonNullable<ReactMonacoEditorProps['editorWillMount']>>(
     (__monaco) => {

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -259,32 +259,28 @@ export function ValueControlForm({
     <>
       {controlFlyoutType === EsqlControlType.VALUES_FROM_QUERY && (
         <>
-          <EuiFormRow
-            label={i18n.translate('esql.flyout.valuesQueryEditor.label', {
+          <ESQLLangEditor
+            query={{ esql: valuesQuery }}
+            onTextLangQueryChange={(q) => {
+              setValuesQuery(q.esql);
+            }}
+            hideTimeFilterInfo={true}
+            disableAutoFocus={true}
+            errors={esqlQueryErrors}
+            editorIsInline
+            hideRunQueryText
+            onTextLangQuerySubmit={async (q, a) => {
+              if (q) {
+                await onValuesQuerySubmit(q.esql);
+              }
+            }}
+            isDisabled={false}
+            isLoading={false}
+            hasOutline
+            formLabel={i18n.translate('esql.flyout.valuesQueryEditor.label', {
               defaultMessage: 'Values query',
             })}
-            fullWidth
-          >
-            <ESQLLangEditor
-              query={{ esql: valuesQuery }}
-              onTextLangQueryChange={(q) => {
-                setValuesQuery(q.esql);
-              }}
-              hideTimeFilterInfo={true}
-              disableAutoFocus={true}
-              errors={esqlQueryErrors}
-              editorIsInline
-              hideRunQueryText
-              onTextLangQuerySubmit={async (q, a) => {
-                if (q) {
-                  await onValuesQuerySubmit(q.esql);
-                }
-              }}
-              isDisabled={false}
-              isLoading={false}
-              hasOutline
-            />
-          </EuiFormRow>
+          />
           {queryColumns.length > 0 && (
             <EuiFormRow
               label={i18n.translate('esql.flyout.previewValues.placeholder', {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ES|QL] Add form row labeling to ESQL Editor (#228103)](https://github.com/elastic/kibana/pull/228103)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zac Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-17T20:05:40Z","message":"[ES|QL] Add form row labeling to ESQL Editor (#228103)\n\n## Summary\n\nAdds an accessible `<label>` to the `<ESQLEditor>` component, and aligns\nit next to the optional Run Query button. This required some changes to\nthe SharedUX `<CodeEditor>` to pass html IDs and onFocus/onBlur down as\nnecessary.\n\n| Before | After |\n| --- | --- |\n| <img width=\"497\" height=\"590\" alt=\"Screenshot 2025-07-15 at 4 34\n47 PM\"\nsrc=\"https://github.com/user-attachments/assets/9c62a44d-2070-4694-b804-c8d7f18eacaa\"\n/> | <img width=\"497\" height=\"492\" alt=\"Screenshot 2025-07-15 at 4 33\n23 PM\"\nsrc=\"https://github.com/user-attachments/assets/3fd14f0c-d3db-45b0-8f16-bf6f3d0184ae\"\n/> |\n\nAlso recolors the label when the editor is focused/invalid:\n\n<img width=\"503\" height=\"480\" alt=\"Screenshot 2025-07-15 at 4 33 18 PM\"\nsrc=\"https://github.com/user-attachments/assets/0202a25c-1d01-4c64-af9d-75d0bfe5ca8d\"\n/>\n<img width=\"501\" height=\"290\" alt=\"Screenshot 2025-07-15 at 4 40 05 PM\"\nsrc=\"https://github.com/user-attachments/assets/9545ca13-fbb1-432a-9f82-4d9cc31cf1a0\"\n/>\n\n<img width=\"495\" height=\"655\" alt=\"Screenshot 2025-07-15 at 4 33 04 PM\"\nsrc=\"https://github.com/user-attachments/assets/9dd1a27b-3150-482f-8c09-0f4c18a422ea\"\n/>\n\nTo test, create an ES|QL control on a dashboard and play with the editor\nin the form. (Note that the form will open with the editor already\ninvalid, because the ES|QL editor reports an empty query with nothing\nbut a comment as invalid. This is a [pre-existing\nissue](https://github.com/elastic/kibana/issues/228244) that should be\nfixed in another PR.)","sha":"6744535d68c7d48ec03e9375c5f653764b51a4ba","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Project:Controls","Team:SharedUX","Feature:ES|QL","Team:ESQL","backport:version","v9.2.0","v9.1.1"],"title":"[ES|QL] Add form row labeling to ESQL Editor","number":228103,"url":"https://github.com/elastic/kibana/pull/228103","mergeCommit":{"message":"[ES|QL] Add form row labeling to ESQL Editor (#228103)\n\n## Summary\n\nAdds an accessible `<label>` to the `<ESQLEditor>` component, and aligns\nit next to the optional Run Query button. This required some changes to\nthe SharedUX `<CodeEditor>` to pass html IDs and onFocus/onBlur down as\nnecessary.\n\n| Before | After |\n| --- | --- |\n| <img width=\"497\" height=\"590\" alt=\"Screenshot 2025-07-15 at 4 34\n47 PM\"\nsrc=\"https://github.com/user-attachments/assets/9c62a44d-2070-4694-b804-c8d7f18eacaa\"\n/> | <img width=\"497\" height=\"492\" alt=\"Screenshot 2025-07-15 at 4 33\n23 PM\"\nsrc=\"https://github.com/user-attachments/assets/3fd14f0c-d3db-45b0-8f16-bf6f3d0184ae\"\n/> |\n\nAlso recolors the label when the editor is focused/invalid:\n\n<img width=\"503\" height=\"480\" alt=\"Screenshot 2025-07-15 at 4 33 18 PM\"\nsrc=\"https://github.com/user-attachments/assets/0202a25c-1d01-4c64-af9d-75d0bfe5ca8d\"\n/>\n<img width=\"501\" height=\"290\" alt=\"Screenshot 2025-07-15 at 4 40 05 PM\"\nsrc=\"https://github.com/user-attachments/assets/9545ca13-fbb1-432a-9f82-4d9cc31cf1a0\"\n/>\n\n<img width=\"495\" height=\"655\" alt=\"Screenshot 2025-07-15 at 4 33 04 PM\"\nsrc=\"https://github.com/user-attachments/assets/9dd1a27b-3150-482f-8c09-0f4c18a422ea\"\n/>\n\nTo test, create an ES|QL control on a dashboard and play with the editor\nin the form. (Note that the form will open with the editor already\ninvalid, because the ES|QL editor reports an empty query with nothing\nbut a comment as invalid. This is a [pre-existing\nissue](https://github.com/elastic/kibana/issues/228244) that should be\nfixed in another PR.)","sha":"6744535d68c7d48ec03e9375c5f653764b51a4ba"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228103","number":228103,"mergeCommit":{"message":"[ES|QL] Add form row labeling to ESQL Editor (#228103)\n\n## Summary\n\nAdds an accessible `<label>` to the `<ESQLEditor>` component, and aligns\nit next to the optional Run Query button. This required some changes to\nthe SharedUX `<CodeEditor>` to pass html IDs and onFocus/onBlur down as\nnecessary.\n\n| Before | After |\n| --- | --- |\n| <img width=\"497\" height=\"590\" alt=\"Screenshot 2025-07-15 at 4 34\n47 PM\"\nsrc=\"https://github.com/user-attachments/assets/9c62a44d-2070-4694-b804-c8d7f18eacaa\"\n/> | <img width=\"497\" height=\"492\" alt=\"Screenshot 2025-07-15 at 4 33\n23 PM\"\nsrc=\"https://github.com/user-attachments/assets/3fd14f0c-d3db-45b0-8f16-bf6f3d0184ae\"\n/> |\n\nAlso recolors the label when the editor is focused/invalid:\n\n<img width=\"503\" height=\"480\" alt=\"Screenshot 2025-07-15 at 4 33 18 PM\"\nsrc=\"https://github.com/user-attachments/assets/0202a25c-1d01-4c64-af9d-75d0bfe5ca8d\"\n/>\n<img width=\"501\" height=\"290\" alt=\"Screenshot 2025-07-15 at 4 40 05 PM\"\nsrc=\"https://github.com/user-attachments/assets/9545ca13-fbb1-432a-9f82-4d9cc31cf1a0\"\n/>\n\n<img width=\"495\" height=\"655\" alt=\"Screenshot 2025-07-15 at 4 33 04 PM\"\nsrc=\"https://github.com/user-attachments/assets/9dd1a27b-3150-482f-8c09-0f4c18a422ea\"\n/>\n\nTo test, create an ES|QL control on a dashboard and play with the editor\nin the form. (Note that the form will open with the editor already\ninvalid, because the ES|QL editor reports an empty query with nothing\nbut a comment as invalid. This is a [pre-existing\nissue](https://github.com/elastic/kibana/issues/228244) that should be\nfixed in another PR.)","sha":"6744535d68c7d48ec03e9375c5f653764b51a4ba"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->