### PR TITLE
Add accessibility labels to rules selection checkboxes

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/rules_table.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/rules_table.test.tsx
@@ -141,4 +141,21 @@ describe('RulesTable', () => {
       ],
     });
   });
+
+  it('renders checkboxes with proper aria-labels for accessibility', () => {
+    render(
+      <Wrapper>
+        <RulesTable {...mockProps} />
+      </Wrapper>
+    );
+
+    // Check that the "select all" checkbox has an aria-label
+    const selectAllCheckbox = screen.getByLabelText('Select all rules on current page');
+    expect(selectAllCheckbox).toBeInTheDocument();
+
+    // Check that individual rule checkboxes have aria-labels with rule names
+    const mockRuleName = selectRulesMock[0].metadata.name;
+    const ruleCheckbox = screen.getByLabelText(`Select rule: ${mockRuleName}`);
+    expect(ruleCheckbox).toBeInTheDocument();
+  });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -189,6 +189,9 @@ const getColumns = ({
             ? onChangeDeselectAllThisPageFn()
             : onChangeSelectAllThisPageFn();
         }}
+        aria-label={i18n.translate('xpack.csp.rules.rulesTable.selectAllRulesAriaLabel', {
+          defaultMessage: 'Select all rules on current page',
+        })}
       />
     ),
     width: '40px',
@@ -211,6 +214,10 @@ const getColumns = ({
                   )
                 );
           }}
+          aria-label={i18n.translate('xpack.csp.rules.rulesTable.selectRuleAriaLabel', {
+            defaultMessage: 'Select rule: {ruleName}',
+            values: { ruleName: item.metadata?.name || item.metadata?.id },
+          })}
         />
       );
     },


### PR DESCRIPTION
## Summary

Initially implemented by Copilot in https://github.com/elastic/kibana/pull/228830 , needed to close that one due to bad rebase.

Fixed missing form labels on rule selection checkboxes in the Security Rules Benchmarks Individual page by adding proper aria-label attributes to comply with WCAG 4.1.2: Name, Role, Value requirements.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


