### PR TITLE
[Search][Saved Playgrounds] handle missing indices / llm for saved playground

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/components/save_new_playground_button.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/save_new_playground_button.test.tsx
@@ -15,8 +15,7 @@ import {
   SaveNewPlaygroundButtonProps,
 } from './save_new_playground_button';
 import { useKibana } from '../hooks/use_kibana';
-import { PlaygroundForm, PlaygroundFormFields, PlaygroundPageMode } from '../types';
-import { PLUGIN_ID } from '../../common';
+import { PlaygroundForm, PlaygroundFormFields } from '../types';
 import { LOCAL_STORAGE_KEY as PLAYGROUND_SESSION_LOCAL_STORAGE_KEY } from '../providers/unsaved_form_provider';
 
 // Mock dependencies
@@ -43,7 +42,7 @@ jest.mock('./saved_playground/save_playground_modal', () => ({
   ),
 }));
 
-const mockNavigateToApp = jest.fn();
+const mockHistoryPush = jest.fn();
 const mockStorage = {
   removeItem: jest.fn(),
   setItem: jest.fn(),
@@ -109,8 +108,8 @@ describe('SaveNewPlaygroundButton', () => {
   beforeEach(() => {
     (useKibana as jest.Mock).mockReturnValue({
       services: {
-        application: {
-          navigateToApp: mockNavigateToApp,
+        history: {
+          push: mockHistoryPush,
         },
       },
     });
@@ -198,9 +197,7 @@ describe('SaveNewPlaygroundButton', () => {
     fireEvent.click(modalSaveButton);
 
     await waitFor(() => {
-      expect(mockNavigateToApp).toHaveBeenCalledWith(PLUGIN_ID, {
-        path: `/p/test-playground-id/${PlaygroundPageMode.Chat}`,
-      });
+      expect(mockHistoryPush).toHaveBeenCalledWith('/p/test-playground-id/chat');
       expect(mockStorage.removeItem).toHaveBeenCalledWith(PLAYGROUND_SESSION_LOCAL_STORAGE_KEY);
       expect(screen.queryByTestId('save-playground-modal')).not.toBeInTheDocument();
     });
@@ -302,7 +299,7 @@ describe('SaveNewPlaygroundButton', () => {
     fireEvent.click(modalSaveButton);
 
     await waitFor(() => {
-      expect(mockNavigateToApp).toHaveBeenCalledTimes(1);
+      expect(mockHistoryPush).toHaveBeenCalledTimes(1);
       expect(mockStorage.removeItem).toHaveBeenCalledTimes(1);
     });
   });

--- a/x-pack/solutions/search/plugins/search_playground/public/components/save_new_playground_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/save_new_playground_button.tsx
@@ -10,7 +10,6 @@ import { useFormContext } from 'react-hook-form';
 import { EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { PLUGIN_ID } from '../../common';
 import { useKibana } from '../hooks/use_kibana';
 import { LOCAL_STORAGE_KEY as PLAYGROUND_SESSION_LOCAL_STORAGE_KEY } from '../providers/unsaved_form_provider';
 import { PlaygroundForm, PlaygroundPageMode } from '../types';
@@ -27,7 +26,7 @@ export const SaveNewPlaygroundButton = ({
   storage = localStorage,
 }: SaveNewPlaygroundButtonProps) => {
   const [showSavePlaygroundModal, setShowSavePlaygroundModal] = useState<boolean>(false);
-  const { application } = useKibana().services;
+  const { history } = useKibana().services;
   const {
     formState: { errors: formErrors },
   } = useFormContext<PlaygroundForm>();
@@ -42,9 +41,9 @@ export const SaveNewPlaygroundButton = ({
       setShowSavePlaygroundModal(false);
       const path = `/p/${id}/${PlaygroundPageMode.Chat}`;
       storage.removeItem(PLAYGROUND_SESSION_LOCAL_STORAGE_KEY);
-      application.navigateToApp(PLUGIN_ID, { path });
+      history.push(path);
     },
-    [application, storage]
+    [history, storage]
   );
 
   return (

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/invalid_state_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/invalid_state_modal.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   EuiButton,
   EuiModal,
@@ -28,7 +28,6 @@ export interface SavedPlaygroundInvalidStateModalProps {
 enum InvalidPlaygroundType {
   MissingIndices,
   MissingModel,
-  MissingIndicesAndModel,
 }
 
 export const SavedPlaygroundInvalidStateModal = ({
@@ -36,12 +35,16 @@ export const SavedPlaygroundInvalidStateModal = ({
   onClose,
 }: SavedPlaygroundInvalidStateModalProps) => {
   const modalTitleId = useGeneratedHtmlId();
-  const errorsType: InvalidPlaygroundType =
-    errors.missingIndices.length > 0 && errors.missingModel !== undefined
-      ? InvalidPlaygroundType.MissingIndicesAndModel
-      : errors.missingModel !== undefined
-      ? InvalidPlaygroundType.MissingModel
-      : InvalidPlaygroundType.MissingIndices;
+  const errorsTypes = useMemo(() => {
+    const eTypes = new Set<InvalidPlaygroundType>();
+    if (errors.missingIndices.length > 0) {
+      eTypes.add(InvalidPlaygroundType.MissingIndices);
+    }
+    if (errors.missingModel !== undefined) {
+      eTypes.add(InvalidPlaygroundType.MissingModel);
+    }
+    return eTypes;
+  }, [errors]);
   return (
     <EuiModal
       aria-labelledby={modalTitleId}
@@ -50,12 +53,13 @@ export const SavedPlaygroundInvalidStateModal = ({
     >
       <EuiModalHeader>
         <EuiModalHeaderTitle id={modalTitleId}>
-          {errorsType === InvalidPlaygroundType.MissingIndicesAndModel ? (
+          {errorsTypes.has(InvalidPlaygroundType.MissingIndices) &&
+          errorsTypes.has(InvalidPlaygroundType.MissingModel) ? (
             <FormattedMessage
               id="xpack.searchPlayground.savedPlayground.invalidPlayground.title"
               defaultMessage="Invalid playground values"
             />
-          ) : errorsType === InvalidPlaygroundType.MissingModel ? (
+          ) : errorsTypes.has(InvalidPlaygroundType.MissingModel) ? (
             <FormattedMessage
               id="xpack.searchPlayground.savedPlayground.invalidModelConnector.title"
               defaultMessage="AI Connector not found"
@@ -70,8 +74,7 @@ export const SavedPlaygroundInvalidStateModal = ({
       </EuiModalHeader>
       <EuiModalBody>
         <EuiText>
-          {(errorsType === InvalidPlaygroundType.MissingIndicesAndModel ||
-            errorsType === InvalidPlaygroundType.MissingIndices) && (
+          {errorsTypes.has(InvalidPlaygroundType.MissingIndices) && (
             <>
               <p>
                 <FormattedMessage
@@ -86,8 +89,7 @@ export const SavedPlaygroundInvalidStateModal = ({
               </ul>
             </>
           )}
-          {(errorsType === InvalidPlaygroundType.MissingIndicesAndModel ||
-            errorsType === InvalidPlaygroundType.MissingModel) && (
+          {errorsTypes.has(InvalidPlaygroundType.MissingModel) && (
             <p>
               <FormattedMessage
                 id="xpack.searchPlayground.savedPlayground.invalidModelConnector.description"

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/invalid_state_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/invalid_state_modal.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { SavedPlaygroundLoadErrors } from '../../types';
+
+export interface SavedPlaygroundInvalidStateModalProps {
+  errors: SavedPlaygroundLoadErrors;
+  onClose: () => void;
+}
+
+enum InvalidPlaygroundType {
+  MissingIndices,
+  MissingModel,
+  MissingIndicesAndModel,
+}
+
+export const SavedPlaygroundInvalidStateModal = ({
+  errors,
+  onClose,
+}: SavedPlaygroundInvalidStateModalProps) => {
+  const modalTitleId = useGeneratedHtmlId();
+  const errorsType: InvalidPlaygroundType =
+    errors.missingIndices.length > 0 && errors.missingModel !== undefined
+      ? InvalidPlaygroundType.MissingIndicesAndModel
+      : errors.missingModel !== undefined
+      ? InvalidPlaygroundType.MissingModel
+      : InvalidPlaygroundType.MissingIndices;
+  return (
+    <EuiModal
+      aria-labelledby={modalTitleId}
+      onClose={onClose}
+      data-test-subj="edit-playground-name-modal"
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>
+          {errorsType === InvalidPlaygroundType.MissingIndicesAndModel ? (
+            <FormattedMessage
+              id="xpack.searchPlayground.savedPlayground.invalidPlayground.title"
+              defaultMessage="Invalid playground values"
+            />
+          ) : errorsType === InvalidPlaygroundType.MissingModel ? (
+            <FormattedMessage
+              id="xpack.searchPlayground.savedPlayground.invalidModelConnector.title"
+              defaultMessage="AI Connector not found"
+            />
+          ) : (
+            <FormattedMessage
+              id="xpack.searchPlayground.savedPlayground.invalidDataSources.title"
+              defaultMessage="Invalid data sources"
+            />
+          )}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiText>
+          {(errorsType === InvalidPlaygroundType.MissingIndicesAndModel ||
+            errorsType === InvalidPlaygroundType.MissingIndices) && (
+            <>
+              <p>
+                <FormattedMessage
+                  id="xpack.searchPlayground.savedPlayground.invalidDataSources.description"
+                  defaultMessage="Some indices were not found. These indices will be removed from your data source selection for this playground."
+                />
+              </p>
+              <ul>
+                {errors.missingIndices.map((index) => (
+                  <li key={index}>{index}</li>
+                ))}
+              </ul>
+            </>
+          )}
+          {(errorsType === InvalidPlaygroundType.MissingIndicesAndModel ||
+            errorsType === InvalidPlaygroundType.MissingModel) && (
+            <p>
+              <FormattedMessage
+                id="xpack.searchPlayground.savedPlayground.invalidModelConnector.description"
+                defaultMessage="The selected LLM connector for this playground was not found. Please select a different LLM for use with this playground."
+              />
+            </p>
+          )}
+        </EuiText>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton
+          data-test-subj="searchPlaygroundInvalidSavedStateModalCloseButton"
+          onClick={onClose}
+          fill
+        >
+          <FormattedMessage
+            id="xpack.searchPlayground.savedPlayground.invalidPlaygroundModal.close"
+            defaultMessage="OK"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground.tsx
@@ -55,7 +55,7 @@ export const SavedPlayground = () => {
   const [shownModal, setShownModal] = useState<SavedPlaygroundModals>(SavedPlaygroundModals.None);
   const isSearchModeEnabled = useSearchPlaygroundFeatureFlag();
   const { playgroundId, pageMode, viewMode } = useSavedPlaygroundParameters();
-  const { application } = useKibana().services;
+  const { application, history } = useKibana().services;
   const { data: connectors } = useLoadConnectors();
   const { formState, watch } = useFormContext<SavedPlaygroundForm>();
   const playgroundName = watch(SavedPlaygroundFormFields.name);
@@ -66,6 +66,19 @@ export const SavedPlayground = () => {
     hasSelectedIndices: !formState.isLoading && playgroundIndices.length > 0,
     hasConnectors: Boolean(connectors?.length),
   });
+  const navigateToNewPlayground = useCallback(
+    (id: string, page: PlaygroundPageMode, view?: PlaygroundViewMode, searchParams?: string) => {
+      let path = `/p/${id}/${page}`;
+      if (view && view !== PlaygroundViewMode.preview) {
+        path += `/${view}`;
+      }
+      if (searchParams) {
+        path += searchParams;
+      }
+      history.push(path);
+    },
+    [history]
+  );
   const navigateToView = useCallback(
     (id: string, page: PlaygroundPageMode, view?: PlaygroundViewMode, searchParams?: string) => {
       let path = `/p/${id}/${page}`;
@@ -186,7 +199,12 @@ export const SavedPlayground = () => {
           playgroundName={playgroundName}
           onClose={onCloseModal}
           onNavigateToNewPlayground={(id: string) => {
-            navigateToView(id, pageMode ?? PlaygroundPageMode.Chat, viewMode, location.search);
+            navigateToNewPlayground(
+              id,
+              pageMode ?? PlaygroundPageMode.Chat,
+              viewMode,
+              location.search
+            );
           }}
         />
       )}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground.tsx
@@ -13,10 +13,10 @@ import { Route, Routes } from '@kbn/shared-ux-router';
 
 import { PLUGIN_ID } from '../../../common';
 import { useKibana } from '../../hooks/use_kibana';
-import { useLLMsModels } from '../../hooks/use_llms_models';
 import { useLoadConnectors } from '../../hooks/use_load_connectors';
 import { usePlaygroundBreadcrumbs } from '../../hooks/use_playground_breadcrumbs';
 import { useSavedPlaygroundParameters } from '../../hooks/use_saved_playground_parameters';
+import { useSearchPlaygroundFeatureFlag } from '../../hooks/use_search_playground_feature_flag';
 import { useShowSetupPage } from '../../hooks/use_show_setup_page';
 import {
   SAVED_PLAYGROUND_CHAT_PATH,
@@ -42,6 +42,7 @@ import { SavedPlaygroundFetchError } from './saved_playground_fetch_error';
 import { EditPlaygroundNameModal } from './edit_name_modal';
 import { DeletePlaygroundModal } from './delete_playground_modal';
 import { SavePlaygroundModal } from './save_playground_modal';
+import { SearchPlaygroundSetupPage } from '../setup_page/search_playground_setup_page';
 
 enum SavedPlaygroundModals {
   None,
@@ -52,18 +53,17 @@ enum SavedPlaygroundModals {
 
 export const SavedPlayground = () => {
   const [shownModal, setShownModal] = useState<SavedPlaygroundModals>(SavedPlaygroundModals.None);
-  const models = useLLMsModels();
+  const isSearchModeEnabled = useSearchPlaygroundFeatureFlag();
   const { playgroundId, pageMode, viewMode } = useSavedPlaygroundParameters();
   const { application } = useKibana().services;
   const { data: connectors } = useLoadConnectors();
-  // TODO: need to handle errors from Form (loading errors, indices no longer exist etc.)
-  const { formState, watch, setValue } = useFormContext<SavedPlaygroundForm>();
+  const { formState, watch } = useFormContext<SavedPlaygroundForm>();
   const playgroundName = watch(SavedPlaygroundFormFields.name);
   const playgroundIndices = watch(SavedPlaygroundFormFields.indices);
   const summarizationModel = watch(SavedPlaygroundFormFields.summarizationModel);
   usePlaygroundBreadcrumbs(playgroundName);
   const { showSetupPage } = useShowSetupPage({
-    hasSelectedIndices: true, // Saved Playgrounds always have indices ? (at least to be saved)
+    hasSelectedIndices: !formState.isLoading && playgroundIndices.length > 0,
     hasConnectors: Boolean(connectors?.length),
   });
   const navigateToView = useCallback(
@@ -84,43 +84,19 @@ export const SavedPlayground = () => {
   useEffect(() => {
     if (formState.isLoading) return;
     if (pageMode === undefined) {
-      // If there is not a pageMode set we redirect based on if there is a model set in the
-      // saved playground as a best guess for default mode. until we save mode with the playground
-      navigateToView(
-        playgroundId,
-        summarizationModel !== undefined ? PlaygroundPageMode.Chat : PlaygroundPageMode.Search,
-        PlaygroundViewMode.preview
-      );
+      // If there is not a pageMode set we default to Chat mode
+      navigateToView(playgroundId, PlaygroundPageMode.Chat, PlaygroundViewMode.preview);
       return;
     }
     // Handle Unknown modes
     if (!Object.values(PlaygroundPageMode).includes(pageMode)) {
-      navigateToView(
-        playgroundId,
-        summarizationModel !== undefined ? PlaygroundPageMode.Chat : PlaygroundPageMode.Search,
-        PlaygroundViewMode.preview
-      );
+      navigateToView(playgroundId, PlaygroundPageMode.Chat, PlaygroundViewMode.preview);
       return;
     }
     if (!Object.values(PlaygroundViewMode).includes(viewMode)) {
       navigateToView(playgroundId, pageMode, PlaygroundViewMode.preview);
     }
   }, [playgroundId, pageMode, viewMode, summarizationModel, formState.isLoading, navigateToView]);
-  useEffect(() => {
-    // When opening chat mode without a model selected try to select a default model
-    // if one is available.
-    if (formState.isLoading) return;
-    if (
-      pageMode === PlaygroundPageMode.Chat &&
-      summarizationModel === undefined &&
-      models.length > 0
-    ) {
-      const defaultModel = models.find((model) => !model.disabled);
-      if (defaultModel) {
-        setValue(SavedPlaygroundFormFields.summarizationModel, defaultModel);
-      }
-    }
-  }, [formState.isLoading, pageMode, summarizationModel, models, setValue]);
   const { isDirty, dirtyFields } = formState;
   const savedFormIsDirty = useMemo(() => {
     if (!isDirty) return false;
@@ -168,9 +144,9 @@ export const SavedPlayground = () => {
         {showSetupPage ? (
           <>
             <Route path={SAVED_PLAYGROUND_CHAT_PATH} component={ChatSetupPage} />
-            {/* {isSearchModeEnabled && (
-              // TODO: This should be impossible
-            )} */}
+            {isSearchModeEnabled && (
+              <Route path={SAVED_PLAYGROUND_SEARCH_PATH} component={SearchPlaygroundSetupPage} />
+            )}
           </>
         ) : (
           <>
@@ -180,12 +156,16 @@ export const SavedPlayground = () => {
               path={SAVED_PLAYGROUND_CHAT_QUERY_PATH}
               render={() => <SearchQueryMode pageMode={pageMode} />}
             />
-            <Route exact path={SAVED_PLAYGROUND_SEARCH_PATH} component={SearchMode} />
-            <Route
-              exact
-              path={SAVED_PLAYGROUND_SEARCH_QUERY_PATH}
-              render={() => <SearchQueryMode pageMode={pageMode} />}
-            />
+            {isSearchModeEnabled && (
+              <>
+                <Route exact path={SAVED_PLAYGROUND_SEARCH_PATH} component={SearchMode} />
+                <Route
+                  exact
+                  path={SAVED_PLAYGROUND_SEARCH_QUERY_PATH}
+                  render={() => <SearchQueryMode pageMode={pageMode} />}
+                />
+              </>
+            )}
           </>
         )}
       </Routes>

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.ts
@@ -7,9 +7,34 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { IndexName } from '@elastic/elasticsearch/lib/api/types';
+import type { HttpSetup } from '@kbn/core/public';
 import { SearchPlaygroundQueryKeys } from '../../common';
 import { APIRoutes } from '../types';
 import { useKibana } from './use_kibana';
+
+export const IndicesQuery =
+  (http: HttpSetup, query: string = '', exact: boolean = false) =>
+  async () => {
+    try {
+      const response = await http.get<{
+        indices: string[];
+      }>(APIRoutes.GET_INDICES, {
+        query: {
+          search_query: query,
+          exact,
+          size: 100,
+        },
+      });
+
+      return response.indices;
+    } catch (err) {
+      if (err?.response?.status === 404) {
+        return [];
+      }
+
+      throw err;
+    }
+  };
 
 export const useQueryIndices = (
   {
@@ -24,27 +49,7 @@ export const useQueryIndices = (
 
   const { data, isLoading, isFetched } = useQuery({
     queryKey: [SearchPlaygroundQueryKeys.QueryIndices, query],
-    queryFn: async () => {
-      try {
-        const response = await services.http.get<{
-          indices: string[];
-        }>(APIRoutes.GET_INDICES, {
-          query: {
-            search_query: query,
-            exact,
-            size: 100,
-          },
-        });
-
-        return response.indices;
-      } catch (err) {
-        if (err?.response?.status === 404) {
-          return [];
-        }
-
-        throw err;
-      }
-    },
+    queryFn: IndicesQuery(services.http, query, exact),
     initialData: [],
   });
 

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/saved_playground_provider.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/saved_playground_provider.tsx
@@ -67,7 +67,7 @@ const fetchDataForValidation = async (
 const fetchSavedPlayground =
   (playgroundId: string, options: FetchSavedPlaygroundOptions) =>
   async (): Promise<SavedPlaygroundForm> => {
-    const { http, client, setLoadErrors } = options;
+    const { http, setLoadErrors } = options;
     let playgroundResp: PlaygroundResponse;
     try {
       playgroundResp = await http.get<PlaygroundResponse>(

--- a/x-pack/solutions/search/plugins/search_playground/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/types.ts
@@ -276,3 +276,8 @@ export interface SavedPlaygroundRouterParameters {
   pageMode?: PlaygroundPageMode;
   viewMode?: PlaygroundViewMode;
 }
+
+export interface SavedPlaygroundLoadErrors {
+  missingIndices: string[];
+  missingModel?: string;
+}

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playground.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playground.test.ts
@@ -22,6 +22,8 @@ import {
   buildNewSavedPlaygroundFromForm,
   buildSavedPlaygroundFromForm,
   validatePlaygroundName,
+  validateSavedPlaygroundIndices,
+  validateSavedPlaygroundModel,
 } from './saved_playgrounds';
 
 // Mock data
@@ -433,6 +435,38 @@ describe('saved_playgrounds utils', () => {
 
     it('should handle whitespace-only names as empty', () => {
       expect(validatePlaygroundName('   ')).toBe('Playground name is required');
+    });
+  });
+
+  describe('validateSavedPlaygroundIndices', () => {
+    it('should return valid indices and missing indices', () => {
+      const { validIndices, missingIndices } = validateSavedPlaygroundIndices(
+        ['test-index', 'missing-index'],
+        ['test-index']
+      );
+
+      expect(validIndices).toEqual(['test-index']);
+      expect(missingIndices).toEqual(['missing-index']);
+    });
+  });
+
+  describe('validateSavedPlaygroundModel', () => {
+    it('should return undefined for valid models', () => {
+      expect(
+        validateSavedPlaygroundModel(mockPlaygroundResponse.data.summarizationModel, mockLLMModels)
+      ).toBeUndefined();
+    });
+
+    it('should undefined if not model was saved on playground', () => {
+      expect(validateSavedPlaygroundModel(undefined, mockLLMModels)).toBeUndefined();
+    });
+
+    it('should return error for unknown model', () => {
+      const result = validateSavedPlaygroundModel(
+        { connectorId: 'unknown', modelId: 'unknown' },
+        mockLLMModels
+      );
+      expect(result).toBe('unknown');
     });
   });
 });

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playgrounds.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/saved_playgrounds.ts
@@ -186,3 +186,41 @@ export function validatePlaygroundName(name: string): string | null {
   }
   return null;
 }
+
+export function validateSavedPlaygroundIndices(
+  savedIndices: string[],
+  queriedIndices: string[]
+): { validIndices: string[]; missingIndices: string[] } {
+  const validIndices: string[] = [];
+  const missingIndices: string[] = [];
+  for (const index of savedIndices) {
+    if (queriedIndices.includes(index)) {
+      validIndices.push(index);
+    } else {
+      missingIndices.push(index);
+    }
+  }
+  return { validIndices, missingIndices };
+}
+
+export function validateSavedPlaygroundModel(
+  summarizationModel: PlaygroundSavedObject['summarizationModel'],
+  models: LLMModel[]
+): string | undefined {
+  if (summarizationModel && summarizationModel.modelId) {
+    const model = models.find(
+      (llm) =>
+        llm.connectorId === summarizationModel.connectorId &&
+        llm.value === summarizationModel.modelId
+    );
+    if (model === undefined) {
+      return summarizationModel.modelId;
+    }
+  } else if (summarizationModel) {
+    const model = models.find((llm) => llm.connectorId === summarizationModel.connectorId);
+    if (model === undefined) {
+      return summarizationModel.connectorId;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Adds handling for when you open a saved playground with indices or LLM that no longer exists.

### Screenshots
Missing Indices
<img width="1911" height="970" alt="image" src="https://github.com/user-attachments/assets/f75c01c2-6ed4-4e14-a3d9-8239cb7df4ed" />

Missing LLM
<img width="1911" height="970" alt="image" src="https://github.com/user-attachments/assets/2b260bd6-570a-4980-b3fe-44b1835ca5d7" />

### Testing

To test the saved playground view the search mode feature flag should be enabled, either with a config override or via console:

```
POST kbn:/internal/kibana/settings/searchPlayground:searchModeEnabled
{"value": true} 
```

- Create an index
- Create and save a playground
- delete index
- Open saved playground

Repeat by deleting the AI Connector used in the playground

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
