### PR TITLE
[8.19] [Streams 🌊 ] Fix Outcome Preview Table so columns always fill width after resize (#226000)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
@@ -88,11 +88,11 @@ export function PreviewTable({
     return {
       columns: sorting?.fieldName
         ? [
-          {
-            id: sorting?.fieldName || '',
-            direction: sorting?.direction || 'asc',
-          },
-        ]
+            {
+              id: sorting?.fieldName || '',
+              direction: sorting?.direction || 'asc',
+            },
+          ]
         : [],
       onSort: (newSorting) => {
         if (setSorting) {
@@ -138,12 +138,12 @@ export function PreviewTable({
       actions:
         Boolean(setVisibleColumns) || Boolean(setSorting)
           ? {
-            showHide: Boolean(setVisibleColumns),
-            showMoveLeft: Boolean(setVisibleColumns),
-            showMoveRight: Boolean(setVisibleColumns),
-            showSortAsc: Boolean(setSorting),
-            showSortDesc: Boolean(setSorting),
-          }
+              showHide: Boolean(setVisibleColumns),
+              showMoveLeft: Boolean(setVisibleColumns),
+              showMoveRight: Boolean(setVisibleColumns),
+              showSortAsc: Boolean(setSorting),
+              showSortDesc: Boolean(setSorting),
+            }
           : (false as false),
       initialWidth: columnWidths[column],
     }));
@@ -157,7 +157,7 @@ export function PreviewTable({
       columns={gridColumns}
       columnVisibility={{
         visibleColumns,
-        setVisibleColumns: setVisibleColumns || (() => { }),
+        setVisibleColumns: setVisibleColumns || (() => {}),
         canDragAndDropColumns: false,
       }}
       sorting={sortingConfig}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/preview_table/index.tsx
@@ -12,7 +12,8 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { SampleDocument } from '@kbn/streams-schema';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
+import { recalcColumnWidths } from '../stream_detail_enrichment/utils';
 import { SimulationContext } from '../stream_detail_enrichment/state_management/simulation_state_machine';
 
 export function PreviewTable({
@@ -87,11 +88,11 @@ export function PreviewTable({
     return {
       columns: sorting?.fieldName
         ? [
-            {
-              id: sorting?.fieldName || '',
-              direction: sorting?.direction || 'asc',
-            },
-          ]
+          {
+            id: sorting?.fieldName || '',
+            direction: sorting?.direction || 'asc',
+          },
+        ]
         : [],
       onSort: (newSorting) => {
         if (setSorting) {
@@ -105,6 +106,8 @@ export function PreviewTable({
     } as EuiDataGridSorting;
   }, [setSorting, sorting]);
 
+  const [columnWidths, setColumnWidths] = useState<Record<string, number | undefined>>({});
+
   // Derive visibleColumns from canonical order
   const visibleColumns = useMemo(() => {
     if (displayColumns) {
@@ -113,7 +116,21 @@ export function PreviewTable({
     return canonicalColumnOrder;
   }, [canonicalColumnOrder, displayColumns]);
 
-  // Derive gridColumns from canonical order
+  const onColumnResize = useCallback(
+    ({ columnId, width }: { columnId: string; width: number | undefined }) => {
+      setColumnWidths((prev) => {
+        const updated = recalcColumnWidths({
+          columnId,
+          width,
+          prevWidths: prev,
+          visibleColumns,
+        });
+        return updated;
+      });
+    },
+    [visibleColumns]
+  );
+
   const gridColumns = useMemo(() => {
     return canonicalColumnOrder.map((column) => ({
       id: column,
@@ -121,16 +138,16 @@ export function PreviewTable({
       actions:
         Boolean(setVisibleColumns) || Boolean(setSorting)
           ? {
-              showHide: Boolean(setVisibleColumns),
-              showMoveLeft: Boolean(setVisibleColumns),
-              showMoveRight: Boolean(setVisibleColumns),
-              showSortAsc: Boolean(setSorting),
-              showSortDesc: Boolean(setSorting),
-            }
+            showHide: Boolean(setVisibleColumns),
+            showMoveLeft: Boolean(setVisibleColumns),
+            showMoveRight: Boolean(setVisibleColumns),
+            showSortAsc: Boolean(setSorting),
+            showSortDesc: Boolean(setSorting),
+          }
           : (false as false),
-      initialWidth: visibleColumns.length > 10 ? 250 : undefined,
+      initialWidth: columnWidths[column],
     }));
-  }, [canonicalColumnOrder, setSorting, setVisibleColumns, visibleColumns.length]);
+  }, [canonicalColumnOrder, setSorting, setVisibleColumns, columnWidths]);
 
   return (
     <EuiDataGrid
@@ -140,7 +157,7 @@ export function PreviewTable({
       columns={gridColumns}
       columnVisibility={{
         visibleColumns,
-        setVisibleColumns: setVisibleColumns || (() => {}),
+        setVisibleColumns: setVisibleColumns || (() => { }),
         canDragAndDropColumns: false,
       }}
       sorting={sortingConfig}
@@ -149,6 +166,7 @@ export function PreviewTable({
       toolbarVisibility={toolbarVisibility}
       rowCount={documents.length}
       rowHeightsOptions={rowHeightsOptions}
+      onColumnResize={onColumnResize}
       renderCellValue={({ rowIndex, columnId }) => {
         const doc = documents[rowIndex];
         if (!doc || typeof doc !== 'object') {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -45,6 +45,12 @@ export const SPECIALISED_TYPES = ['date', 'dissect', 'grok'];
 interface FormStateDependencies {
   grokCollection: StreamEnrichmentContextType['grokCollection'];
 }
+interface RecalcColumnWidthsParams {
+  columnId: string;
+  width: number | undefined; // undefined -> reset width
+  prevWidths: Record<string, number | undefined>;
+  visibleColumns: string[];
+}
 
 const PRIORITIZED_CONTENT_FIELDS = [
   'message',
@@ -363,4 +369,25 @@ const dataSourceToUrlSchema = (
 export const dataSourceConverter = {
   toUIDefinition: dataSourceToUIDefinition,
   toUrlSchema: dataSourceToUrlSchema,
+};
+
+export const recalcColumnWidths = ({
+  columnId,
+  width,
+  prevWidths,
+  visibleColumns,
+}: RecalcColumnWidthsParams): Record<string, number | undefined> => {
+  const next = { ...prevWidths };
+  if (width === undefined) {
+    delete next[columnId];
+  } else {
+    next[columnId] = width;
+  }
+
+  const allExplicit = visibleColumns.every((c) => next[c] !== undefined);
+  if (allExplicit) {
+    delete next[visibleColumns[visibleColumns.length - 1]];
+  }
+
+  return next;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Streams 🌊 ] Fix Outcome Preview Table so columns always fill width after resize (#226000)](https://github.com/elastic/kibana/pull/226000)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Stelmach","email":"60304951+rStelmach@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-11T12:49:19Z","message":"[Streams 🌊 ] Fix Outcome Preview Table so columns always fill width after resize (#226000)\n\ncloses: #224647\n\n\n## Summary 📚 \n\nPreview Table used to leave a blank gap on the right whenever a column\nwas resized.\nThis PR adapts Discover’s strategy:\n\n- Only store an explicit width for columns the user actually drags.\n- Guarantee at least one column (usually the last) is left width-less so\nEuiDataGrid auto-flexes and always fills the container.\n\n## Demo  📹 \n\n\n\nhttps://github.com/user-attachments/assets/a008df20-2846-4b99-89d0-3924aba7130c\n\n\n## How to test  🧪\n- Open Observability → Streams → any stream (with data).\n- Open `Processing` Tab\n- Drag-resize column widths in Preview Table\n- Open `Manage data sources` button next to `Random Samples` check\n- Expand `Data preview` and drag-resize any column","sha":"fbf670ec64e0c089c11230111854e7559383c8e2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:obs-ux-logs","backport:version","Feature:Streams","v9.1.0","v8.19.0","v9.2.0"],"title":"[Streams 🌊 ] Fix Outcome Preview Table so columns always fill width after resize","number":226000,"url":"https://github.com/elastic/kibana/pull/226000","mergeCommit":{"message":"[Streams 🌊 ] Fix Outcome Preview Table so columns always fill width after resize (#226000)\n\ncloses: #224647\n\n\n## Summary 📚 \n\nPreview Table used to leave a blank gap on the right whenever a column\nwas resized.\nThis PR adapts Discover’s strategy:\n\n- Only store an explicit width for columns the user actually drags.\n- Guarantee at least one column (usually the last) is left width-less so\nEuiDataGrid auto-flexes and always fills the container.\n\n## Demo  📹 \n\n\n\nhttps://github.com/user-attachments/assets/a008df20-2846-4b99-89d0-3924aba7130c\n\n\n## How to test  🧪\n- Open Observability → Streams → any stream (with data).\n- Open `Processing` Tab\n- Drag-resize column widths in Preview Table\n- Open `Manage data sources` button next to `Random Samples` check\n- Expand `Data preview` and drag-resize any column","sha":"fbf670ec64e0c089c11230111854e7559383c8e2"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/226000","number":226000,"mergeCommit":{"message":"[Streams 🌊 ] Fix Outcome Preview Table so columns always fill width after resize (#226000)\n\ncloses: #224647\n\n\n## Summary 📚 \n\nPreview Table used to leave a blank gap on the right whenever a column\nwas resized.\nThis PR adapts Discover’s strategy:\n\n- Only store an explicit width for columns the user actually drags.\n- Guarantee at least one column (usually the last) is left width-less so\nEuiDataGrid auto-flexes and always fills the container.\n\n## Demo  📹 \n\n\n\nhttps://github.com/user-attachments/assets/a008df20-2846-4b99-89d0-3924aba7130c\n\n\n## How to test  🧪\n- Open Observability → Streams → any stream (with data).\n- Open `Processing` Tab\n- Drag-resize column widths in Preview Table\n- Open `Manage data sources` button next to `Random Samples` check\n- Expand `Data preview` and drag-resize any column","sha":"fbf670ec64e0c089c11230111854e7559383c8e2"}}]}] BACKPORT-->