### PR TITLE
[Detection Engine] Skip test in MKI

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rules.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 
 import type {
   ThreatMatchRuleCreateProps,

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rules.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 
 import type {
   ThreatMatchRuleCreateProps,
@@ -1854,7 +1854,8 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('should show "has_exceptions" greater than 1 when rule has attached exceptions', async () => {
+      // installMockPrebuiltRules and then fetching rule seems to not work in MKI
+      it('@skipInServerlessMKI should show "has_exceptions" greater than 1 when rule has attached exceptions', async () => {
         await installMockPrebuiltRules(supertest, es);
         const immutableRule = await fetchRule(supertest, { ruleId: ELASTIC_SECURITY_RULE_ID });
 


### PR DESCRIPTION
Began seeing [failures](https://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/2534#0198337e-5e31-4f04-b26a-c15aeb6eb7e7) in MKI. Testing locally, failure was consistent. Working with the Rules Management team to figure out if  the helpers being used need updating for MKI. 





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->