### PR TITLE
[Attack discovery] Fixes Connector dropdown for the Elastic LLM and entity badge styles

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -60,9 +60,10 @@ const AttackDiscoveryPageComponent: React.FC = () => {
 
   const { attackDiscoveryAlertsEnabled } = useKibanaFeatureFlags();
 
-  const { http } = useAssistantContext();
+  const { http, inferenceEnabled } = useAssistantContext();
   const { data: aiConnectors } = useLoadConnectors({
     http,
+    inferenceEnabled,
   });
 
   // for showing / hiding anonymized data:

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/mock/mock_connectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/mock/mock_connectors.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AIConnector } from '@kbn/elastic-assistant';
+
+export const getMockConnectors = (): AIConnector[] => [
+  {
+    actionTypeId: '.gen-ai',
+    isPreconfigured: true,
+    isDeprecated: false,
+    referencedByCount: 0,
+    isSystemAction: false,
+    id: 'gpt41Azure',
+    name: 'GPT-4.1',
+  },
+  {
+    actionTypeId: '.gemini',
+    isPreconfigured: true,
+    isDeprecated: false,
+    referencedByCount: 0,
+    isSystemAction: false,
+    id: 'gemini_2_5_pro',
+    name: 'Gemini 2.5 Pro',
+  },
+  {
+    actionTypeId: '.bedrock',
+    isPreconfigured: true,
+    isDeprecated: false,
+    referencedByCount: 0,
+    isSystemAction: false,
+    id: 'pmeClaudeV37SonnetUsEast1',
+    name: 'Claude 3.7 Sonnet',
+  },
+  {
+    actionTypeId: '.inference',
+    isPreconfigured: true,
+    isDeprecated: false,
+    referencedByCount: 0,
+    isSystemAction: false,
+    id: 'elastic-llm',
+    name: 'Elastic LLM',
+  },
+];

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiButtonEmpty, EuiToolTip } from '@elastic/eui';
+import { EuiBadge, EuiButtonEmpty, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
@@ -18,6 +19,7 @@ const contextId = 'FieldMarkdownRenderer';
 export const getFieldMarkdownRenderer = (disableActions: boolean) => {
   const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
     const { openRightPanel } = useExpandableFlyoutApi();
+    const { euiTheme } = useEuiTheme();
 
     const flyoutPanelProps = useMemo(
       () => getFlyoutPanelProps({ contextId, fieldName: name, value }),
@@ -34,6 +36,9 @@ export const getFieldMarkdownRenderer = (disableActions: boolean) => {
       () =>
         flyoutPanelProps != null ? (
           <EuiButtonEmpty
+            css={css`
+              font-size: ${euiTheme.font.scale.s}rem;
+            `}
             data-test-subj="entityButton"
             flush="both"
             onClick={onEntityClick}
@@ -43,7 +48,7 @@ export const getFieldMarkdownRenderer = (disableActions: boolean) => {
           </EuiButtonEmpty>
         ) : null,
 
-      [flyoutPanelProps, onEntityClick, value]
+      [euiTheme.font.scale.s, flyoutPanelProps, onEntityClick, value]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/connector_filter/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/connector_filter/index.test.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+
+import { ConnectorFilter, DESCRIPTION_PLACEHOLDER } from '.';
+import { TestProviders } from '../../../../../../common/mock';
+import { getMockConnectors } from '../../../../mock/mock_connectors';
+
+const aiConnectors = getMockConnectors();
+const connectorNames = aiConnectors.map((c) => c.name);
+
+const defaultProps = {
+  aiConnectors,
+  connectorNames,
+  selectedConnectorNames: [],
+  setSelectedConnectorNames: jest.fn(),
+};
+
+const openConnectorFilter = () => fireEvent.click(screen.getByTestId('connectorFilterButton'));
+
+describe('ConnectorFilter', () => {
+  it('renders the expected number of options', () => {
+    render(
+      <TestProviders>
+        <ConnectorFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    openConnectorFilter();
+
+    expect(screen.getAllByTestId('connectorFilterOption').length).toBe(connectorNames.length);
+  });
+
+  describe('returns the correct description for each connector with a known actionTypeId', () => {
+    const descriptionTable = [
+      { name: 'GPT-4.1', expected: 'OpenAI' },
+      { name: 'Gemini 2.5 Pro', expected: 'Google Gemini' },
+      { name: 'Claude 3.7 Sonnet', expected: 'Amazon Bedrock' },
+    ];
+
+    it.each(descriptionTable)(
+      'renders the $expected description for connector $name',
+      ({ name, expected }) => {
+        render(
+          <TestProviders>
+            <ConnectorFilter {...defaultProps} />
+          </TestProviders>
+        );
+
+        openConnectorFilter();
+
+        // Find the connector option by name using the optionLabel test id
+        const options = screen.getAllByTestId('connectorFilterOption');
+        const option = options.find((opt) => {
+          const label = within(opt).getByTestId('optionLabel');
+          return label.textContent === name;
+        });
+
+        if (!option) {
+          throw new Error(`Connector option with name '${name}' not found`);
+        }
+
+        // check the description:
+        const description = within(option).getByTestId('optionDescription');
+        expect(description).toHaveTextContent(expected);
+      }
+    );
+  });
+
+  it('returns the expected placeholder description for a connector with an unknown actionTypeId', () => {
+    render(
+      <TestProviders>
+        <ConnectorFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    openConnectorFilter();
+
+    // Find the Elastic LLM connector option:
+    const options = screen.getAllByTestId('connectorFilterOption');
+    const elasticLlmOption = options.find((opt) => {
+      const label = within(opt).getByTestId('optionLabel');
+      return label.textContent === 'Elastic LLM'; // <-- has actionTypeId: '.inference', which is not handled by getDescription
+    });
+
+    const description = within(elasticLlmOption!).getByTestId('optionDescription');
+    expect(description).toHaveTextContent(DESCRIPTION_PLACEHOLDER);
+  });
+
+  describe('Deleted badge', () => {
+    it('shows the Deleted badge for the connector when it is missing from aiConnectors', () => {
+      // Remove 'GPT-4.1' from aiConnectors but keep its name in connectorNames:
+      const deletedConnectorName = 'GPT-4.1';
+      const filteredAiConnectors = aiConnectors.filter((c) => c.name !== deletedConnectorName);
+
+      render(
+        <TestProviders>
+          <ConnectorFilter
+            {...defaultProps}
+            aiConnectors={filteredAiConnectors}
+            connectorNames={connectorNames}
+          />
+        </TestProviders>
+      );
+
+      openConnectorFilter();
+
+      // Find the connector option for the deleted connector by its name
+      const deletedOption = screen
+        .getByText(deletedConnectorName)
+        .closest('[data-test-subj="connectorFilterOption"]');
+
+      if (deletedOption == null) {
+        throw new Error(`Connector option with name '${deletedConnectorName}' not found`);
+      }
+
+      expect(
+        within(deletedOption as HTMLElement).getByTestId('deletedConnectorBadge')
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT show the Deleted badge for connectors present in aiConnectors', () => {
+      render(
+        <TestProviders>
+          <ConnectorFilter {...defaultProps} />
+        </TestProviders>
+      );
+
+      openConnectorFilter();
+
+      const options = screen.getAllByTestId('connectorFilterOption');
+
+      // All connectors in defaultProps.aiConnectors should NOT have the badge
+      const connectorNamesSet = new Set(aiConnectors.map((c) => c.name));
+      options.forEach((opt) => {
+        const label = within(opt).getByTestId('optionLabel').textContent;
+        if (connectorNamesSet.has(`${label}`)) {
+          expect(within(opt).queryByTestId('deletedConnectorBadge')).toBeNull();
+        }
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/connector_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/connector_filter/index.tsx
@@ -27,6 +27,8 @@ import * as i18n from '../translations';
 import type { ConnectorFilterOptionData } from '../../types';
 import { useInvalidateFindAttackDiscoveries } from '../../../../use_find_attack_discoveries';
 
+export const DESCRIPTION_PLACEHOLDER = '-';
+
 const LIST_PROPS = {
   isVirtualized: false,
   rowHeight: 60,
@@ -73,7 +75,7 @@ const ConnectorFilterComponent: React.FC<Props> = ({
           return {
             checked: checked ? 'on' : undefined,
             data: {
-              description: getDescription(connector?.actionTypeId),
+              description: getDescription(connector?.actionTypeId) ?? DESCRIPTION_PLACEHOLDER,
               deleted: connector == null,
             },
             label: name,
@@ -119,7 +121,7 @@ const ConnectorFilterComponent: React.FC<Props> = ({
                 data-test-subj="optionDescription"
                 size="s"
               >
-                {option.deleted ? '-' : option.description}
+                {option.description}
               </EuiText>
             </EuiFlexItem>
 
@@ -153,6 +155,7 @@ const ConnectorFilterComponent: React.FC<Props> = ({
     () => (
       <EuiFilterButton
         badgeColor="subdued"
+        data-test-subj="connectorFilterButton"
         disabled={isLoading}
         iconType="arrowDown"
         isSelected={isPopoverOpen}


### PR DESCRIPTION
## [Attack discovery] Fixes Connector dropdown for the Elastic LLM and entity badge styles

This PR fixes the Attack discovery _Connector_ dropdown for the _Elastic LLM_, as reported in the following issues:

- <https://github.com/elastic/kibana/issues/226142>
- <https://github.com/elastic/kibana/issues/226130>

See the _details_ section below for before / after screenshots.

This PR also fixes an entity badge styling issue, as illustrated by the before and after screenshots below:

**Before**

![badge style before](https://github.com/user-attachments/assets/9c9e8612-27be-4dd7-853e-d9da664beda6)

_Above: Before the fix, the entity badge text appears larger than the other badges_

**After**

![badge style after](https://github.com/user-attachments/assets/7b0e1dc9-6d09-429e-9d63-87dbe31354c9)

_Above: After the fix, the entity badge text appears to be the same size as the other badges_

### Details

### Fix for [[Security Solution] [Bug] The pre configured Elastic LLM model shows deleted in the non-default space #226142](https://github.com/elastic/kibana/issues/226142)

**Before**

![deleted connector before](https://github.com/user-attachments/assets/dec90f5b-b36f-49ed-bd26-2d86b3d1fe55)

_Above: Before the fix, the Elastic LLM has a `Deleted` badge_

**After**

![deleted connector before](https://github.com/user-attachments/assets/82f6b383-eee8-4997-8719-3f3ec68b3f17)

_Above: After the fix, the Elastic LLM does NOT have a `Deleted` badge_

### Fix for [[Security Solution] [Bug] The drop down for connectors is having unused space holder for pre configured Elastic LLM model #226130](https://github.com/elastic/kibana/issues/226130)

**Before**

![connector placeholder before](https://github.com/user-attachments/assets/0082be55-77fc-44a5-a2a3-d614d08bcee6)

_Above: Before the fix, the Elastic LLM has an empty description_

**After**

![connector placeholder after](https://github.com/user-attachments/assets/011c4318-7f9b-4a23-a66b-e0b139306ec9)

_Above: After the fix, the Elastic LLM has a `-` placeholder description_


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->