### PR TITLE
[Console] Fix flaky onboarding tour test

### DIFF
--- a/src/platform/test/functional/apps/console/_onboarding_tour.ts
+++ b/src/platform/test/functional/apps/console/_onboarding_tour.ts
@@ -104,6 +104,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await browser.refresh();
 
       // Tour should not show after refreshing the browser
+      // Making sure tour stays hidden when skipped even after refresh
       await waitUntilFinishedLoading();
       await expectAllStepsHidden();
     });

--- a/src/platform/test/functional/apps/console/_onboarding_tour.ts
+++ b/src/platform/test/functional/apps/console/_onboarding_tour.ts
@@ -19,8 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'console', 'header']);
   const testSubjects = getService('testSubjects');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/224128
-  describe.skip('console onboarding tour', function describeIndexTests() {
+  describe('console onboarding tour', function describeIndexTests() {
     before(async () => {
       log.debug('navigateTo console');
       await PageObjects.common.navigateToApp('console');
@@ -98,10 +97,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.console.clickSkipTour();
 
       // All steps should now be hidden
+      await waitUntilFinishedLoading();
       await expectAllStepsHidden();
 
-      // Tour should not show after refreshing the browser
+      // Refresh the browser
       await browser.refresh();
+
+      // Tour should not show after refreshing the browser
+      await waitUntilFinishedLoading();
       await expectAllStepsHidden();
     });
 


### PR DESCRIPTION
Closes #224128

## Summary

This PR fixes flaky onboarding tour test in Console.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.