### PR TITLE
[AI4SOC] Pin rules package version for testing purposes

### DIFF
--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -83,7 +83,7 @@ xpack.fleet.prereleaseEnabledByDefault: true
 xpack.fleet.internal.registry.searchAiLakePackageAllowlistEnabled: true
 
 # Pin the prebuilt rules package version to the version that contains promotion rules
-xpack.securitySolution.prebuiltRulesPackageVersion: '9.0.5-beta.1'
+xpack.securitySolution.prebuiltRulesPackageVersion: '9.1.2-beta.3'
 
 # Elastic Managed LLM
 xpack.actions.preconfigured:


### PR DESCRIPTION
### Summary
Pin the prebuilt rules package version to the one containing promotion rules needed for AI4SOC to work.

Note: this is only for test purposes, the package will be removed once AI4SOC is ready to be released and the promotion rules are added to the production rules package.