### PR TITLE
We will never have "hasDeletedDocs" if there are no delete clauses

### DIFF
--- a/src/core/packages/saved-objects/migration-server-internal/src/zdt/model/stages/cleanup_unknown_and_excluded_docs.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/zdt/model/stages/cleanup_unknown_and_excluded_docs.test.ts
@@ -50,20 +50,6 @@ describe('Stage: cleanupUnknownAndExcludedDocs', () => {
     });
   });
 
-  it('CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS -> CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS_REFRESH when successful with cleanup_not_needed and hasDeletedDocs is true', () => {
-    const state = createState({ hasDeletedDocs: true });
-    const res: StateActionResponse<'CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS'> = Either.right({
-      type: 'cleanup_not_needed',
-    });
-
-    const newState = cleanupUnknownAndExcludedDocs(state, res, context);
-
-    expect(newState).toEqual({
-      ...state,
-      controlState: 'CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS_REFRESH',
-    });
-  });
-
   it('CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS -> OUTDATED_DOCUMENTS_SEARCH_OPEN_PIT when successful with cleanup_not_needed and hasDeletedDocs is false', () => {
     const state = createState();
     const res: StateActionResponse<'CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS'> = Either.right({

--- a/src/core/packages/saved-objects/migration-server-internal/src/zdt/model/stages/cleanup_unknown_and_excluded_docs.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/zdt/model/stages/cleanup_unknown_and_excluded_docs.ts
@@ -38,17 +38,10 @@ export const cleanupUnknownAndExcludedDocs: ModelStage<
     };
   } else if (res.right.type === 'cleanup_not_needed') {
     // let's move to the step after CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS_WAIT_FOR_TASK
-    if (state.hasDeletedDocs) {
-      return {
-        ...state,
-        controlState: 'CLEANUP_UNKNOWN_AND_EXCLUDED_DOCS_REFRESH',
-      };
-    } else {
-      return {
-        ...state,
-        controlState: 'OUTDATED_DOCUMENTS_SEARCH_OPEN_PIT',
-      };
-    }
+    return {
+      ...state,
+      controlState: 'OUTDATED_DOCUMENTS_SEARCH_OPEN_PIT',
+    };
   } else {
     throwBadResponse(state, res.right);
   }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana-team/issues/1740#issuecomment-3097166101

As part of the risky 9.1.0 PR analysis, I've identified a path that will never be executed.


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->