### PR TITLE
Extended RBAC for workflows

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/types/latest.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/latest.ts
@@ -22,6 +22,7 @@ export type {
   WorkflowExecutionDto,
   WorkflowExecutionListDto,
   WorkflowExecutionListItemDto,
+  WorkflowListItemAction,
 
   // commands
   CreateWorkflowCommand,

--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -180,3 +180,13 @@ export interface WorkflowExecutionEngineModel
   /** Serialized graphlib.Graph */
   executionGraph?: any;
 }
+
+export interface WorkflowListItemAction {
+  isPrimary?: boolean;
+  type: string;
+  color: string;
+  name: string;
+  icon: string;
+  description: string;
+  onClick: (item: WorkflowListItemDto) => void;
+}

--- a/src/platform/plugins/shared/workflows_management/common/components/access_denied.tsx
+++ b/src/platform/plugins/shared/workflows_management/common/components/access_denied.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { EuiBadge, EuiEmptyPrompt } from '@elastic/eui';
+import React from 'react';
+
+interface AccessDeniedParams {
+  requirements?: string[];
+}
+
+export const AccessDenied = ({ requirements }: AccessDeniedParams): JSX.Element => {
+  return (
+    <EuiEmptyPrompt
+      iconType="securityApp"
+      title={
+        <h2>
+          {i18n.translate('platform.plugins.shared.workflows_management.ui.accessDenied', {
+            defaultMessage: 'Access Denied',
+          })}
+        </h2>
+      }
+      body={
+        <>
+          <p>
+            {i18n.translate('platform.plugins.shared.workflows_management.ui.noPermissions', {
+              defaultMessage: 'You don’t have permission to view this page:',
+            })}
+          </p>
+          <p>
+            {requirements &&
+              requirements.map((requirement) => {
+                return (
+                  <EuiBadge color="danger" key={requirement}>
+                    {requirement}
+                  </EuiBadge>
+                );
+              })}
+          </p>
+        </>
+      }
+    />
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/kibana.jsonc
+++ b/src/platform/plugins/shared/workflows_management/kibana.jsonc
@@ -17,7 +17,8 @@
       "actions",
       "workflowsExecutionEngine",
       "features",
-      "security"
+      "security",
+      "spaces"
     ]
   }
 }

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/index.tsx
@@ -24,8 +24,9 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { ExecutionStatus, WorkflowListItemAction, WorkflowListItemDto } from '@kbn/workflows';
+import { ExecutionStatus, WorkflowListItemDto } from '@kbn/workflows';
 import { Link } from 'react-router-dom';
+import { Action } from '@elastic/eui/src/components/basic_table/action_types';
 import { useWorkflowActions } from '../../../entities/workflows/model/useWorkflowActions';
 import { useWorkflows } from '../../../entities/workflows/model/useWorkflows';
 
@@ -88,7 +89,7 @@ export function WorkflowList() {
   );
 
   const getAvailableActions = useCallback(() => {
-    const availableActions: WorkflowListItemAction[] = [];
+    const availableActions: Array<Action<WorkflowListItemDto>> = [];
 
     if (canExecuteWorkflow) {
       availableActions.push({

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import { BarSeries, Chart, ScaleType, Settings } from '@elastic/charts';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiBadge,
   EuiBasicTable,
@@ -23,19 +24,21 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { ExecutionStatus, WorkflowListItemDto } from '@kbn/workflows';
-import React, { useCallback, useMemo, useState } from 'react';
+import { ExecutionStatus, WorkflowListItemAction, WorkflowListItemDto } from '@kbn/workflows';
 import { Link } from 'react-router-dom';
 import { useWorkflowActions } from '../../../entities/workflows/model/useWorkflowActions';
 import { useWorkflows } from '../../../entities/workflows/model/useWorkflows';
 
 export function WorkflowList() {
   const { euiTheme } = useEuiTheme();
-  const { notifications } = useKibana().services;
+  const { application, notifications } = useKibana().services;
   const { data: workflows, isLoading: isLoadingWorkflows, error } = useWorkflows();
   const { deleteWorkflows, runWorkflow } = useWorkflowActions();
 
   const [selectedItems, setSelectedItems] = useState<WorkflowListItemDto[]>([]);
+
+  const canExecuteWorkflow = application?.capabilities.executeWorkflow;
+  const canDeleteWorkflow = application?.capabilities.executeWorkflow;
 
   const deleteSelectedWorkflows = () => {
     if (selectedItems.length === 0) {
@@ -83,6 +86,33 @@ export function WorkflowList() {
     },
     [deleteWorkflows]
   );
+
+  const getAvailableActions = useCallback(() => {
+    const availableActions: WorkflowListItemAction[] = [];
+
+    if (canExecuteWorkflow) {
+      availableActions.push({
+        isPrimary: true,
+        type: 'icon',
+        color: 'primary',
+        name: 'Run',
+        icon: 'play',
+        description: 'Run',
+        onClick: (item: WorkflowListItemDto) => handleRunWorkflow(item),
+      });
+    }
+    if (canDeleteWorkflow) {
+      availableActions.push({
+        type: 'icon',
+        color: 'danger',
+        name: 'Delete',
+        icon: 'trash',
+        description: 'Delete',
+        onClick: (item: WorkflowListItemDto) => handleDeleteWorkflow(item),
+      });
+    }
+    return availableActions;
+  }, [canExecuteWorkflow, canDeleteWorkflow, handleRunWorkflow, handleDeleteWorkflow]);
 
   const columns = useMemo<Array<EuiBasicTableColumn<WorkflowListItemDto>>>(
     () => [
@@ -188,33 +218,14 @@ export function WorkflowList() {
       },
       {
         name: 'Actions',
-        actions: [
-          {
-            isPrimary: true,
-            type: 'icon',
-            color: 'primary',
-            name: 'Run',
-            icon: 'play',
-            description: 'Run',
-            onClick: (item) => handleRunWorkflow(item),
-          },
-          {
-            type: 'icon',
-            color: 'danger',
-            name: 'Delete',
-            icon: 'trash',
-            description: 'Delete',
-            onClick: (item) => handleDeleteWorkflow(item),
-          },
-        ],
+        actions: getAvailableActions(),
       },
     ],
     [
+      getAvailableActions,
       euiTheme.colors.vis.euiColorVis0,
       euiTheme.colors.vis.euiColorVis1,
       euiTheme.colors.vis.euiColorVis6,
-      handleDeleteWorkflow,
-      handleRunWorkflow,
     ]
   );
 
@@ -238,14 +249,16 @@ export function WorkflowList() {
   return (
     <>
       <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
-        <EuiButton
-          color="danger"
-          iconType="trash"
-          onClick={deleteSelectedWorkflows}
-          isDisabled={selectedItems.length === 0}
-        >
-          Delete {selectedItems.length || 'selected'} workflows
-        </EuiButton>
+        {canDeleteWorkflow && (
+          <EuiButton
+            color="danger"
+            iconType="trash"
+            onClick={deleteSelectedWorkflows}
+            isDisabled={selectedItems.length === 0}
+          >
+            Delete {selectedItems.length || 'selected'} workflows
+          </EuiButton>
+        )}
       </EuiFlexGroup>
       <EuiSpacer />
       <EuiBasicTable

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
@@ -20,7 +20,6 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { WorkflowYaml } from '@kbn/workflows';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useWorkflowActions } from '../../entities/workflows/model/useWorkflowActions';
 import { useWorkflowDetail } from '../../entities/workflows/model/useWorkflowDetail';

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { WorkflowYaml } from '@kbn/workflows';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useWorkflowActions } from '../../entities/workflows/model/useWorkflowActions';
 import { useWorkflowDetail } from '../../entities/workflows/model/useWorkflowDetail';
@@ -31,8 +32,11 @@ import { TestWorkflowModal } from '../../features/run_workflow/ui/test_workflow_
 
 export function WorkflowDetailPage({ id }: { id: string }) {
   const { application, chrome, notifications } = useKibana().services;
-  const { data: workflow, isLoading: isLoadingWorkflow, error } = useWorkflowDetail(id);
-
+  const {
+    data: workflow,
+    isLoading: isLoadingWorkflow,
+    error: workflowError,
+  } = useWorkflowDetail(id);
   const [workflowEventModalOpen, setWorkflowEventModalOpen] = useState(false);
   const [testWorkflowModalOpen, setTestWorkflowModalOpen] = useState(false);
 
@@ -125,12 +129,14 @@ export function WorkflowDetailPage({ id }: { id: string }) {
     return (
       <EuiFlexGroup>
         <EuiFlexItem>
-          <WorkflowEditor
-            workflowId={workflow?.id ?? ''}
-            value={workflowYaml}
-            onChange={handleChange}
-            hasChanges={hasChanges}
-          />
+          {workflow && (
+            <WorkflowEditor
+              workflowId={workflow?.id ?? ''}
+              value={workflowYaml}
+              onChange={handleChange}
+              hasChanges={hasChanges}
+            />
+          )}
         </EuiFlexItem>
       </EuiFlexGroup>
     );
@@ -146,7 +152,7 @@ export function WorkflowDetailPage({ id }: { id: string }) {
     return <EuiLoadingSpinner />;
   }
 
-  if (error) {
+  if (workflowError) {
     return <EuiText>Error loading workflow</EuiText>;
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflows/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflows/index.tsx
@@ -33,6 +33,8 @@ export function WorkflowsPage() {
   const { refetch } = useWorkflows();
   const { createWorkflow } = useWorkflowActions();
 
+  const canCreateWorkflow = application?.capabilities.workflowsManagement.createWorkflow;
+
   chrome!.setBreadcrumbs([
     {
       text: i18n.translate('workflows.breadcrumbs.title', { defaultMessage: 'Workflows' }),
@@ -78,13 +80,15 @@ export function WorkflowsPage() {
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFlexGroup>
-              <EuiButton color="text" size="s" onClick={handleCreateWorkflow}>
-                <FormattedMessage
-                  id="workflows.createWorkflowButton"
-                  defaultMessage="Create workflow"
-                  ignoreTag
-                />
-              </EuiButton>
+              {canCreateWorkflow && (
+                <EuiButton color="text" size="s" onClick={handleCreateWorkflow}>
+                  <FormattedMessage
+                    id="workflows.createWorkflowButton"
+                    defaultMessage="Create workflow"
+                    ignoreTag
+                  />
+                </EuiButton>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/src/platform/plugins/shared/workflows_management/server/features.ts
+++ b/src/platform/plugins/shared/workflows_management/server/features.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
+import { i18n } from '@kbn/i18n';
+import { KibanaFeatureScope } from '@kbn/features-plugin/common';
+import { WorkflowsManagementPluginServerDependenciesSetup } from './types';
+
+/**
+ * The order of appearance in the feature privilege page
+ * under the management section.
+ */
+const FEATURE_ORDER = 3000;
+
+export const registerFeatures = (plugins: WorkflowsManagementPluginServerDependenciesSetup) => {
+  plugins.features?.registerKibanaFeature({
+    app: [],
+    category: DEFAULT_APP_CATEGORIES.kibana,
+    id: 'workflowsManagement',
+    name: i18n.translate(
+      'platform.plugins.shared.workflows_management.featureRegistry.workflowsManagementFeatureName',
+      {
+        defaultMessage: 'Workflows Management',
+      }
+    ),
+    order: FEATURE_ORDER,
+    privileges: {
+      all: {
+        app: [],
+        api: ['create', 'update', 'delete', 'read'],
+        savedObject: {
+          all: ['workflows', 'workflow_executions'],
+          read: [],
+        },
+        ui: ['create', 'update', 'delete', 'read', 'execute'],
+      },
+      read: {
+        app: [],
+        api: ['read'],
+        savedObject: {
+          all: [],
+          read: ['workflows', 'workflow_executions'],
+        },
+        ui: ['read'],
+      },
+    },
+    scope: [KibanaFeatureScope.Spaces, KibanaFeatureScope.Security],
+    subFeatures: [
+      {
+        name: i18n.translate(
+          'platform.plugins.shared.workflows_management.featureRegistry.workflowsManagementSubFeatureName',
+          {
+            defaultMessage: 'Workflows Actions',
+          }
+        ),
+        privilegeGroups: [
+          {
+            groupType: 'independent',
+            privileges: [
+              {
+                api: ['workflow:create'],
+                id: 'workflow_create',
+                name: i18n.translate(
+                  'platform.plugins.shared.workflows_management.featureRegistry.createWorkflowSubFeaturePrivilege',
+                  {
+                    defaultMessage: 'Create',
+                  }
+                ),
+                includeIn: 'all',
+                savedObject: {
+                  all: ['workflow'],
+                  read: [],
+                },
+                ui: ['createWorkflow'],
+              },
+              {
+                api: ['workflow:update'],
+                id: 'workflow_update',
+                name: i18n.translate(
+                  'platform.plugins.shared.workflows_management.featureRegistry.updateWorkflowSubFeaturePrivilege',
+                  {
+                    defaultMessage: 'Update',
+                  }
+                ),
+                includeIn: 'all',
+                savedObject: {
+                  all: ['workflow'],
+                  read: [],
+                },
+                ui: ['updateWorkflow'],
+              },
+              {
+                api: ['workflow:delete'],
+                id: 'workflow_delete',
+                name: i18n.translate(
+                  'platform.plugins.shared.workflows_management.featureRegistry.deleteWorkflowSubFeaturePrivilege',
+                  {
+                    defaultMessage: 'Delete',
+                  }
+                ),
+                includeIn: 'all',
+                savedObject: {
+                  all: ['workflow'],
+                  read: [],
+                },
+                ui: ['deleteWorkflow'],
+              },
+              {
+                api: ['workflow:execute'],
+                id: 'workflow_execute',
+                name: i18n.translate(
+                  'platform.plugins.shared.workflows_management.featureRegistry.executeWorkflowSubFeaturePrivilege',
+                  {
+                    defaultMessage: 'Execute',
+                  }
+                ),
+                includeIn: 'all',
+                savedObject: {
+                  all: ['workflow_execution'],
+                  read: ['workflow'],
+                },
+                ui: ['executeWorkflow'],
+              },
+              {
+                api: ['workflow:read'],
+                id: 'workflow_read',
+                name: i18n.translate(
+                  'platform.plugins.shared.workflows_management.featureRegistry.readWorkflowSubFeaturePrivilege',
+                  {
+                    defaultMessage: 'Read',
+                  }
+                ),
+                includeIn: 'read',
+                savedObject: {
+                  read: ['workflow'],
+                  all: [],
+                },
+                ui: ['readWorkflow'],
+              },
+              {
+                api: ['workflow_execution:read'],
+                id: 'workflow_execution_read',
+                name: i18n.translate(
+                  'platform.plugins.shared.workflows_management.featureRegistry.readWorkflowExecutionSubFeaturePrivilege',
+                  {
+                    defaultMessage: 'Read Workflow Execution',
+                  }
+                ),
+                includeIn: 'read',
+                savedObject: {
+                  read: ['workflow_execution'],
+                  all: [],
+                },
+                ui: ['readWorkflowExecution'],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+};

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -7,18 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import {
-  CoreSetup,
-  CoreStart,
-  DEFAULT_APP_CATEGORIES,
-  Logger,
-  Plugin,
-  PluginInitializerContext,
-} from '@kbn/core/server';
+import { CoreSetup, CoreStart, Logger, Plugin, PluginInitializerContext } from '@kbn/core/server';
 
 import { IUnsecuredActionsClient } from '@kbn/actions-plugin/server';
-import { KibanaFeatureScope } from '@kbn/features-plugin/common';
-import { i18n } from '@kbn/i18n';
 import {
   WORKFLOWS_EXECUTION_LOGS_INDEX,
   WORKFLOWS_EXECUTIONS_INDEX,
@@ -37,12 +28,7 @@ import type {
 import { WorkflowsManagementApi } from './workflows_management/workflows_management_api';
 import { defineRoutes } from './workflows_management/workflows_management_routes';
 import { WorkflowsService } from './workflows_management/workflows_management_service';
-
-/**
- * The order of appearance in the feature privilege page
- * under the management section.
- */
-const FEATURE_ORDER = 3000;
+import { registerFeatures } from './features';
 
 export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPluginStart> {
   private readonly logger: Logger;
@@ -126,161 +112,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
     // Register saved object types
     core.savedObjects.registerType(workflowSavedObjectType);
 
-    plugins.features?.registerKibanaFeature({
-      id: 'workflowsManagement',
-      name: i18n.translate(
-        'platform.plugins.shared.workflows_management.featureRegistry.workflowsManagementFeatureName',
-        {
-          defaultMessage: 'Workflows Management',
-        }
-      ),
-      category: DEFAULT_APP_CATEGORIES.management,
-      scope: [KibanaFeatureScope.Spaces, KibanaFeatureScope.Security],
-      app: [],
-      order: FEATURE_ORDER,
-      management: {
-        kibana: ['workflowsManagement'],
-      },
-      privileges: {
-        all: {
-          app: [],
-          api: [],
-          management: {
-            kibana: ['workflowsManagement'],
-          },
-          savedObject: {
-            all: ['workflows', 'workflow_executions'],
-            read: [],
-          },
-          ui: ['create', 'update', 'delete', 'read', 'execute'],
-        },
-        read: {
-          app: [],
-          api: [],
-          management: {
-            kibana: ['workflowsManagement'],
-          },
-          savedObject: {
-            all: [],
-            read: ['workflows', 'workflow_executions'],
-          },
-          ui: ['read'],
-        },
-      },
-      subFeatures: [
-        {
-          name: i18n.translate(
-            'platform.plugins.shared.workflows_management.featureRegistry.workflowsManagementSubFeatureName',
-            {
-              defaultMessage: 'Workflows Actions',
-            }
-          ),
-          privilegeGroups: [
-            {
-              groupType: 'independent',
-              privileges: [
-                {
-                  api: ['workflow:create'],
-                  id: 'workflow_create',
-                  name: i18n.translate(
-                    'platform.plugins.shared.workflows_management.featureRegistry.createWorkflowSubFeaturePrivilege',
-                    {
-                      defaultMessage: 'Create',
-                    }
-                  ),
-                  includeIn: 'all',
-                  savedObject: {
-                    all: ['workflow'],
-                    read: [],
-                  },
-                  ui: ['createWorkflow'],
-                },
-                {
-                  api: ['workflow:update'],
-                  id: 'workflow_update',
-                  name: i18n.translate(
-                    'platform.plugins.shared.workflows_management.featureRegistry.updateWorkflowSubFeaturePrivilege',
-                    {
-                      defaultMessage: 'Update',
-                    }
-                  ),
-                  includeIn: 'all',
-                  savedObject: {
-                    all: ['workflow'],
-                    read: [],
-                  },
-                  ui: ['updateWorkflow'],
-                },
-                {
-                  api: ['workflow:delete'],
-                  id: 'workflow_delete',
-                  name: i18n.translate(
-                    'platform.plugins.shared.workflows_management.featureRegistry.deleteWorkflowSubFeaturePrivilege',
-                    {
-                      defaultMessage: 'Delete',
-                    }
-                  ),
-                  includeIn: 'all',
-                  savedObject: {
-                    all: ['workflow'],
-                    read: [],
-                  },
-                  ui: ['deleteWorkflow'],
-                },
-                {
-                  api: ['workflow:execute'],
-                  id: 'workflow_execute',
-                  name: i18n.translate(
-                    'platform.plugins.shared.workflows_management.featureRegistry.executeWorkflowSubFeaturePrivilege',
-                    {
-                      defaultMessage: 'Execute',
-                    }
-                  ),
-                  includeIn: 'all',
-                  savedObject: {
-                    all: ['workflow_execution'],
-                    read: ['workflow'],
-                  },
-                  ui: ['executeWorkflow'],
-                },
-                {
-                  api: ['workflow:read'],
-                  id: 'workflow_read',
-                  name: i18n.translate(
-                    'platform.plugins.shared.workflows_management.featureRegistry.readWorkflowSubFeaturePrivilege',
-                    {
-                      defaultMessage: 'Read',
-                    }
-                  ),
-                  includeIn: 'all',
-                  savedObject: {
-                    read: ['workflow'],
-                    all: [],
-                  },
-                  ui: ['readWorkflow'],
-                },
-                {
-                  api: ['workflow_execution:read'],
-                  id: 'workflow_execution_read',
-                  name: i18n.translate(
-                    'platform.plugins.shared.workflows_management.featureRegistry.readWorkflowExecutionSubFeaturePrivilege',
-                    {
-                      defaultMessage: 'Read Workflow Execution',
-                    }
-                  ),
-                  includeIn: 'all',
-                  savedObject: {
-                    read: ['workflow_execution'],
-                    all: [],
-                  },
-                  ui: ['readWorkflowExecution'],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+    registerFeatures(plugins);
 
     this.logger.debug('Workflows Management: Creating router');
     const router = core.http.createRouter();
@@ -309,7 +141,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
     this.api = new WorkflowsManagementApi(this.workflowsService);
 
     // Register server side APIs
-    defineRoutes(router, this.api);
+    defineRoutes(router, this.api, this.logger);
 
     return {
       management: this.api,

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -16,6 +16,7 @@ import {
 import { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server/plugin';
 import { WorkflowExecutionEngineModel } from '@kbn/workflows';
+import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface WorkflowsPluginSetup {}
@@ -28,6 +29,7 @@ export interface WorkflowsExecutionEnginePluginStartDeps {
   taskManager: TaskManagerStartContract;
   workflowsExecutionEngine: WorkflowsExecutionEnginePluginStart;
   actions: ActionsPluginStartContract;
+  security?: SecurityPluginStart;
 }
 
 export interface WorkflowsManagementPluginServerDependenciesSetup {

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
@@ -8,17 +8,24 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import type { IRouter } from '@kbn/core/server';
+import { IRouter, Logger } from '@kbn/core/server';
 import { CreateWorkflowCommandSchema } from '@kbn/workflows';
 import { WorkflowsManagementApi, type GetWorkflowsParams } from './workflows_management_api';
 
-export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
+export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logger: Logger) {
   router.get(
     {
       path: '/api/workflows/{id}',
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['read', 'workflow_read'],
+            },
+          ],
         },
       },
       validate: {
@@ -52,12 +59,19 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.post(
     {
       path: '/api/workflows/search',
-      validate: false,
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['read', 'workflow_read'],
+            },
+          ],
         },
       },
+      validate: false,
     },
     async (context, request, response) => {
       try {
@@ -81,9 +95,16 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.post(
     {
       path: '/api/workflows',
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['all', 'workflow_create'],
+            },
+          ],
         },
       },
       validate: {
@@ -107,9 +128,16 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.put(
     {
       path: '/api/workflows/{id}',
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['all', 'workflow_update'],
+            },
+          ],
         },
       },
       validate: {
@@ -138,9 +166,17 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.delete(
     {
       path: '/api/workflows/{id}',
+
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['all', 'workflow_delete'],
+            },
+          ],
         },
       },
       validate: {
@@ -167,9 +203,16 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.delete(
     {
       path: '/api/workflows',
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['all', 'workflow_delete'],
+            },
+          ],
         },
       },
       validate: {
@@ -196,9 +239,16 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.post(
     {
       path: '/api/workflows/{id}/run',
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['all', 'workflow_execute', 'workflow_execution_create'],
+            },
+          ],
         },
       },
       validate: {
@@ -272,9 +322,16 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.get(
     {
       path: '/api/workflowExecutions',
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['read', 'workflow_execution_read'],
+            },
+          ],
         },
       },
       validate: {
@@ -302,9 +359,16 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi) {
   router.get(
     {
       path: '/api/workflowExecutions/{workflowExecutionId}',
+      options: {
+        tags: ['access:workflowsManagement'],
+      },
       security: {
         authz: {
-          requiredPrivileges: ['all'],
+          requiredPrivileges: [
+            {
+              anyRequired: ['read', 'workflow_execution_read'],
+            },
+          ],
         },
       },
       validate: {

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -30,6 +30,8 @@
     "@kbn/workflows-execution-engine",
     "@kbn/task-manager-plugin",
     "@kbn/kibana-utils-plugin",
+    "@kbn/core-application-common",
+    "@kbn/security-plugin-types-server",
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
- **Refactor workflows privileges definition.**
- **Introduce role-based access control for workflows UI features.**
- **Enhance workflows list with conditional buttons/actions based on user permissions.**
- **Remove duplicate constants and centralize feature registration logic.**

## Summary

### Fine-graded permissions for API and UI

<img width="1402" height="1074" alt="image" src="https://github.com/user-attachments/assets/17d1e595-a5b4-4bc5-a067-9b49cc38e31e" /> 
<img width="720" height="251" alt="image" src="https://github.com/user-attachments/assets/e99fbe86-98b8-4f7b-86cc-ef3a61dc828c" />


### Clear required permissions messages
<img width="908" height="532" alt="image" src="https://github.com/user-attachments/assets/e846724a-5f41-40fa-b9b4-b2b86ff32735" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



