### PR TITLE
[8.19] fix issue with suggest widget in placements near header (#228842)

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -7,7 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useState, useRef, useCallback, useMemo, useEffect, KeyboardEvent, FC } from 'react';
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  useEffect,
+  type KeyboardEvent,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
 import {
   htmlIdGenerator,
   EuiToolTip,
@@ -21,6 +30,7 @@ import {
   EuiFlexItem,
   useEuiTheme,
 } from '@elastic/eui';
+import { Global } from '@emotion/react';
 import {
   monaco,
   CODE_EDITOR_DEFAULT_THEME_ID,
@@ -539,7 +549,6 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
       className="kibanaCodeEditor"
     >
       {accessibilityOverlayEnabled && renderPrompt()}
-
       <FullScreenDisplay>
         {allowFullScreen || isCopyable ? (
           <div
@@ -560,44 +569,47 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           </div>
         ) : null}
         <UseBug177756ReBroadcastMouseDown>
-          {accessibilityOverlayEnabled && isFullScreen && renderPrompt()}
-          <MonacoEditor
-            theme={theme}
-            language={languageId}
-            value={value}
-            onChange={onChange}
-            width={isFullScreen ? '100vw' : width}
-            height={isFullScreen ? '100vh' : fitToContent ? undefined : height}
-            editorWillMount={_editorWillMount}
-            editorDidMount={_editorDidMount}
-            editorWillUnmount={_editorWillUnmount}
-            options={{
-              padding: allowFullScreen || isCopyable ? { top: 24 } : {},
-              renderLineHighlight: 'none',
-              scrollBeyondLastLine: false,
-              minimap: {
-                enabled: false,
-              },
-              scrollbar: {
-                useShadows: false,
-                // Scroll events are handled only when there is scrollable content. When there is scrollable content, the
-                // editor should scroll to the bottom then break out of that scroll context and continue scrolling on any
-                // outer scrollbars.
-                alwaysConsumeMouseWheel: false,
-              },
-              wordBasedSuggestions: false,
-              wordWrap: 'on',
-              wrappingIndent: 'indent',
-              matchBrackets: 'never',
-              fontFamily: 'Roboto Mono',
-              fontSize: isFullScreen ? 16 : 12,
-              lineHeight: isFullScreen ? 24 : 21,
-              contextmenu: enableCustomContextMenu,
-              // @ts-expect-error, see https://github.com/microsoft/monaco-editor/issues/3829
-              'bracketPairColorization.enabled': false,
-              ...options,
-            }}
-          />
+          <UseBug223981FixRepositionSuggestWidget editor={_editor}>
+            {accessibilityOverlayEnabled && isFullScreen && renderPrompt()}
+            <MonacoEditor
+              theme={theme}
+              language={languageId}
+              value={value}
+              onChange={onChange}
+              width={isFullScreen ? '100vw' : width}
+              height={isFullScreen ? '100vh' : fitToContent ? undefined : height}
+              editorWillMount={_editorWillMount}
+              editorDidMount={_editorDidMount}
+              editorWillUnmount={_editorWillUnmount}
+              options={{
+                padding: allowFullScreen || isCopyable ? { top: 24 } : {},
+                renderLineHighlight: 'none',
+                scrollBeyondLastLine: false,
+                minimap: {
+                  enabled: false,
+                },
+                scrollbar: {
+                  useShadows: false,
+                  // Scroll events are handled only when there is scrollable content. When there is scrollable content, the
+                  // editor should scroll to the bottom then break out of that scroll context and continue scrolling on any
+                  // outer scrollbars.
+                  alwaysConsumeMouseWheel: false,
+                },
+                wordBasedSuggestions: false,
+                wordWrap: 'on',
+                wrappingIndent: 'indent',
+                matchBrackets: 'never',
+                fontFamily: 'Roboto Mono',
+                fontSize: isFullScreen ? 16 : 12,
+                lineHeight: isFullScreen ? 24 : 21,
+                contextmenu: enableCustomContextMenu,
+                fixedOverflowWidgets: true,
+                // @ts-expect-error, see https://github.com/microsoft/monaco-editor/issues/3829
+                'bracketPairColorization.enabled': false,
+                ...options,
+              }}
+            />
+          </UseBug223981FixRepositionSuggestWidget>
         </UseBug177756ReBroadcastMouseDown>
       </FullScreenDisplay>
     </div>
@@ -734,6 +746,64 @@ const useFitToContent = ({
       editor.layout(); // reset the layout that was controlled by the fitToContent
     };
   }, [editor, isFitToContent, minLines, maxLines, isFullScreen]);
+};
+
+/**
+ * @description See {@link https://github.com/elastic/kibana/issues/223981} for the rationale behind this bug fix implementation
+ */
+const UseBug223981FixRepositionSuggestWidget: FC<
+  PropsWithChildren<{ editor: monaco.editor.IStandaloneCodeEditor | null }>
+> = ({ children, editor }) => {
+  const { euiTheme } = useEuiTheme();
+  const suggestWidgetModifierClassName = 'kibanaCodeEditor__suggestWidgetModifier';
+
+  useEffect(() => {
+    // @ts-expect-errors -- "widget" is not part of the TS interface but does exist
+    const suggestionWidget = editor?.getContribution('editor.contrib.suggestController')?.widget
+      ?.value;
+
+    // The "onDidShow" and "onDidHide" is not documented so we guard from possible changes in the underlying lib
+    if (suggestionWidget && suggestionWidget.onDidShow && suggestionWidget.onDidHide) {
+      let $suggestWidgetNode: HTMLElement | null = null;
+
+      // add a className that hides the suggestion widget by default so we might be to correctly position the suggestion widget,
+      // then make it visible
+      ($suggestWidgetNode = suggestionWidget.element?.domNode)?.classList?.add(
+        suggestWidgetModifierClassName
+      );
+
+      let originalTopPosition: string | null = null;
+
+      suggestionWidget.onDidShow(() => {
+        if ($suggestWidgetNode) {
+          originalTopPosition = $suggestWidgetNode.style.top;
+          const headerOffset = `var(--kbn-layout--application-top, var(--euiFixedHeadersOffset, 0px))`;
+          $suggestWidgetNode.style.top = `max(${originalTopPosition}, calc(${headerOffset} + ${euiTheme.size.m}))`;
+          $suggestWidgetNode.classList.remove(suggestWidgetModifierClassName);
+        }
+      });
+      suggestionWidget.onDidHide(() => {
+        if ($suggestWidgetNode) {
+          $suggestWidgetNode.classList.add(suggestWidgetModifierClassName);
+          $suggestWidgetNode.style.top = originalTopPosition ?? '';
+        }
+      });
+    }
+  }, [editor, euiTheme.size.m]);
+
+  return (
+    <React.Fragment>
+      <Global
+        // @ts-expect-error -- it's necessary that we apply the important modifier
+        styles={{
+          [`.${suggestWidgetModifierClassName}`]: {
+            visibility: 'hidden !important',
+          },
+        }}
+      />
+      <React.Fragment>{children}</React.Fragment>
+    </React.Fragment>
+  );
 };
 
 const UseBug177756ReBroadcastMouseDown: FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/platform/test/functional/apps/console/_autocomplete.ts
+++ b/src/platform/test/functional/apps/console/_autocomplete.ts
@@ -245,8 +245,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             await PageObjects.console.sleepForDebouncePeriod();
             log.debug('Key type "%s"', char);
             await PageObjects.console.enterText(char); // e.g. 'P' -> 'Po' -> 'Pos'
-            await retry.waitFor('autocomplete to be visible', () =>
-              PageObjects.console.isAutocompleteVisible()
+            await retry.waitFor(
+              'autocomplete to be visible',
+              async () => await PageObjects.console.isAutocompleteVisible()
             );
             expect(await PageObjects.console.isAutocompleteVisible()).to.be.eql(true);
           }

--- a/src/platform/test/functional/page_objects/console_page.ts
+++ b/src/platform/test/functional/page_objects/console_page.ts
@@ -85,19 +85,27 @@ export class ConsolePageObject extends FtrService {
   public async promptAutocomplete(letter = 'b') {
     const textArea = await this.getTextArea();
     await textArea.type(letter);
-    await this.retry.waitFor('autocomplete to be visible', () => this.isAutocompleteVisible());
+    await this.retry.waitFor(
+      'autocomplete to be visible',
+      async () => await this.isAutocompleteVisible()
+    );
   }
 
   public async isAutocompleteVisible() {
     const element = await this.find.byClassName('suggest-widget').catch(() => null);
     if (!element) return false;
 
-    const attribute = await element.getAttribute('style');
-    return !attribute?.includes('display: none;');
+    return await element.isDisplayed();
   }
 
   public async getAutocompleteSuggestion(index: number) {
     const suggestionsWidget = await this.find.byClassName('suggest-widget');
+
+    await this.retry.waitFor(
+      'verify suggestions widget to be displayed',
+      async () => await suggestionsWidget.isDisplayed()
+    );
+
     const suggestions = await suggestionsWidget.findAllByClassName('monaco-list-row');
     const suggestion = suggestions[index];
     if (!suggestion) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [fix issue with suggest widget in placements near header (#228842)](https://github.com/elastic/kibana/pull/228842)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-22T17:05:32Z","message":"fix issue with suggest widget in placements near header (#228842)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/223981\n\nThis PR fixes the aforementioned issue where the suggest widget would\nappear stacked under the header, the approach that's been taken to\nresolve this issue to have the suggest widget be invisible perform\ncalculations to determine the placement the suggest widget received, we\nthen apply a style that select the max value between the\n`--euiFixedHeadersOffset` property and the value the monaco calculated\nfor it's valid placement.\n\n## Visuals\n\n#### placement before fix\n<img width=\"475\" height=\"382\" alt=\"Screenshot 2025-07-22 at 09 35 21\"\nsrc=\"https://github.com/user-attachments/assets/91a14243-5489-4c94-976f-7905db095d08\"\n/>\n\n#### new placement after fix\n\n![ScreenRecording2025-07-22at09 32 07-ezgif\ncom-optimize](https://github.com/user-attachments/assets/e2795ca4-0030-4bda-8cb0-bcd1b40580de)\n\n\n#### verification discover is not impacted\n<img width=\"1447\" height=\"509\" alt=\"Screenshot 2025-07-21 at 19 43 18\"\nsrc=\"https://github.com/user-attachments/assets/c9833c75-77df-4f06-91c2-0a37bf4c1424\"\n/>\n\n","sha":"3ee6ece56ce6d66687c8fdf952fa20dcbf7063f8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:prev-minor","v9.1.0","v9.2.0"],"title":"fix issue with suggest widget in placements near header","number":228842,"url":"https://github.com/elastic/kibana/pull/228842","mergeCommit":{"message":"fix issue with suggest widget in placements near header (#228842)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/223981\n\nThis PR fixes the aforementioned issue where the suggest widget would\nappear stacked under the header, the approach that's been taken to\nresolve this issue to have the suggest widget be invisible perform\ncalculations to determine the placement the suggest widget received, we\nthen apply a style that select the max value between the\n`--euiFixedHeadersOffset` property and the value the monaco calculated\nfor it's valid placement.\n\n## Visuals\n\n#### placement before fix\n<img width=\"475\" height=\"382\" alt=\"Screenshot 2025-07-22 at 09 35 21\"\nsrc=\"https://github.com/user-attachments/assets/91a14243-5489-4c94-976f-7905db095d08\"\n/>\n\n#### new placement after fix\n\n![ScreenRecording2025-07-22at09 32 07-ezgif\ncom-optimize](https://github.com/user-attachments/assets/e2795ca4-0030-4bda-8cb0-bcd1b40580de)\n\n\n#### verification discover is not impacted\n<img width=\"1447\" height=\"509\" alt=\"Screenshot 2025-07-21 at 19 43 18\"\nsrc=\"https://github.com/user-attachments/assets/c9833c75-77df-4f06-91c2-0a37bf4c1424\"\n/>\n\n","sha":"3ee6ece56ce6d66687c8fdf952fa20dcbf7063f8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/228999","number":228999,"state":"MERGED","mergeCommit":{"sha":"16179be1c3cf70ec4d724f9aef49ef7d75eb5fe0","message":"[9.1] fix issue with suggest widget in placements near header (#228842) (#228999)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [fix issue with suggest widget in placements near header\n(#228842)](https://github.com/elastic/kibana/pull/228842)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228842","number":228842,"mergeCommit":{"message":"fix issue with suggest widget in placements near header (#228842)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/223981\n\nThis PR fixes the aforementioned issue where the suggest widget would\nappear stacked under the header, the approach that's been taken to\nresolve this issue to have the suggest widget be invisible perform\ncalculations to determine the placement the suggest widget received, we\nthen apply a style that select the max value between the\n`--euiFixedHeadersOffset` property and the value the monaco calculated\nfor it's valid placement.\n\n## Visuals\n\n#### placement before fix\n<img width=\"475\" height=\"382\" alt=\"Screenshot 2025-07-22 at 09 35 21\"\nsrc=\"https://github.com/user-attachments/assets/91a14243-5489-4c94-976f-7905db095d08\"\n/>\n\n#### new placement after fix\n\n![ScreenRecording2025-07-22at09 32 07-ezgif\ncom-optimize](https://github.com/user-attachments/assets/e2795ca4-0030-4bda-8cb0-bcd1b40580de)\n\n\n#### verification discover is not impacted\n<img width=\"1447\" height=\"509\" alt=\"Screenshot 2025-07-21 at 19 43 18\"\nsrc=\"https://github.com/user-attachments/assets/c9833c75-77df-4f06-91c2-0a37bf4c1424\"\n/>\n\n","sha":"3ee6ece56ce6d66687c8fdf952fa20dcbf7063f8"}}]}] BACKPORT-->