### PR TITLE
[8.19] bump CI disk sizes from 80 -> 85 for jest

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -487,7 +487,7 @@ export async function pickTestGroupRunOrder() {
             key: 'jest',
             agents: {
               ...expandAgentQueue('n2-4-spot'),
-              diskSizeGb: 80,
+              diskSizeGb: 85,
             },
             retry: {
               automatic: [


### PR DESCRIPTION
## Summary
 increasing the disk size to 85G