### PR TITLE
[8.19] [APM][Unified Waterfall] Update getUnprocessedOtelErrors to query related errors instead of trace errors (#228750)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/otel.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/otel.ts
@@ -6,6 +6,7 @@
  */
 
 export const STATUS_CODE = 'status.code';
+export const OTEL_EVENT_NAME = 'event_name';
 export const ERROR_MESSAGE = 'error.message';
 export const EXCEPTION_TYPE = 'exception.type';
 export const EXCEPTION_MESSAGE = 'exception.message';

--- a/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
@@ -250,6 +250,8 @@ exports[`Error OBSERVER_VERSION 1`] = `"whatever"`;
 
 exports[`Error OBSERVER_VERSION_MAJOR 1`] = `8`;
 
+exports[`Error OTEL_EVENT_NAME 1`] = `"otel event name"`;
+
 exports[`Error OTEL_SPAN_LINKS 1`] = `undefined`;
 
 exports[`Error OTEL_SPAN_LINKS_SPAN_ID 1`] = `undefined`;
@@ -640,6 +642,8 @@ exports[`Span OBSERVER_LISTENING 1`] = `undefined`;
 exports[`Span OBSERVER_VERSION 1`] = `"whatever"`;
 
 exports[`Span OBSERVER_VERSION_MAJOR 1`] = `8`;
+
+exports[`Span OTEL_EVENT_NAME 1`] = `"otel event name"`;
 
 exports[`Span OTEL_SPAN_LINKS 1`] = `undefined`;
 
@@ -1041,6 +1045,8 @@ exports[`Transaction OBSERVER_LISTENING 1`] = `undefined`;
 exports[`Transaction OBSERVER_VERSION 1`] = `"whatever"`;
 
 exports[`Transaction OBSERVER_VERSION_MAJOR 1`] = `8`;
+
+exports[`Transaction OTEL_EVENT_NAME 1`] = `"otel event name"`;
 
 exports[`Transaction OTEL_SPAN_LINKS 1`] = `undefined`;
 

--- a/x-pack/solutions/observability/plugins/apm/common/es_fields/es_fields.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/es_fields/es_fields.test.ts
@@ -72,6 +72,7 @@ describe('Transaction', () => {
     container: {
       id: 'container1234567890abcdef',
     },
+    event_name: 'otel event name',
   };
 
   matchSnapshot(transaction);
@@ -127,6 +128,7 @@ describe('Span', () => {
     transaction: {
       id: 'transaction id',
     },
+    event_name: 'otel event name',
   };
 
   matchSnapshot(span);
@@ -190,6 +192,7 @@ describe('Error', () => {
       id: 'transaction id',
       type: 'request',
     },
+    event_name: 'otel event name',
   };
 
   matchSnapshot(errorDoc);

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/create_es_client/create_logs_client/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/create_es_client/create_logs_client/index.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
+import type { InferSearchResponseOf } from '@kbn/es-types';
+import type { APMRouteHandlerResources } from '../../../../routes/apm_routes/register_apm_server_routes';
+
+interface LogsClientSearchRequest {
+  query: QueryDslQueryContainer;
+  fields: string[];
+}
+
+export interface LogsClient {
+  search: <T = unknown>(props: LogsClientSearchRequest) => Promise<InferSearchResponseOf<T>>;
+}
+
+export const createLogsClient = async (
+  resources: APMRouteHandlerResources
+): Promise<LogsClient> => {
+  const { context } = resources;
+  const core = await context.core;
+  const { savedObjects } = core;
+
+  const logsDataAccess = await resources.plugins.logsDataAccess.start();
+  const logSourcesService =
+    await logsDataAccess.services.logSourcesServiceFactory.getLogSourcesService(
+      savedObjects.client
+    );
+
+  const [logsIndexPattern, esClient] = await Promise.all([
+    logSourcesService.getFlattenedLogSources(),
+    core.elasticsearch.client.asCurrentUser,
+  ]);
+
+  async function search<T = unknown>(
+    props: LogsClientSearchRequest
+  ): Promise<InferSearchResponseOf<T>> {
+    const response = await esClient.search({
+      index: logsIndexPattern,
+      size: 1000,
+      track_total_hits: false,
+      query: props.query,
+      fields: props.fields,
+    });
+    return response as InferSearchResponseOf<T>;
+  }
+  return {
+    search,
+  };
+};

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
@@ -7,19 +7,17 @@
 
 import type { APMEventClient } from '@kbn/apm-data-access-plugin/server';
 import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { existsQuery, rangeQuery, termQuery } from '@kbn/observability-plugin/server';
 import {
-  ERROR_MESSAGE,
   EXCEPTION_MESSAGE,
   EXCEPTION_TYPE,
-  PROCESSOR_EVENT,
   SPAN_ID,
-  STATUS_CODE,
   TRACE_ID,
+  OTEL_EVENT_NAME,
 } from '../../../common/es_fields/apm';
 import { asMutableArray } from '../../../common/utils/as_mutable_array';
 import { getApmTraceError } from './get_trace_items';
+import type { LogsClient } from '../../lib/helpers/create_es_client/create_logs_client';
 
 export interface UnifiedTraceErrors {
   apmErrors: Awaited<ReturnType<typeof getApmTraceError>>;
@@ -29,89 +27,78 @@ export interface UnifiedTraceErrors {
 
 export async function getUnifiedTraceErrors({
   apmEventClient,
+  logsClient,
   end,
   start,
   traceId,
 }: {
   apmEventClient: APMEventClient;
+  logsClient: LogsClient;
   traceId: string;
   start: number;
   end: number;
 }): Promise<UnifiedTraceErrors> {
-  const [apmErrors, unprocessedOtelError] = await Promise.all([
+  const [apmErrors, unprocessedOtelErrors] = await Promise.all([
     getApmTraceError({ apmEventClient, traceId, start, end }),
-    getUnprocessedOtelErrors({ apmEventClient, traceId, start, end }),
+    getUnprocessedOtelErrors({ logsClient, traceId, start, end }),
   ]);
 
   return {
     apmErrors,
-    unprocessedOtelErrors: unprocessedOtelError,
-    totalErrors: apmErrors.length + unprocessedOtelError.length,
+    unprocessedOtelErrors,
+    totalErrors: apmErrors.length + unprocessedOtelErrors.length,
   };
 }
 
-export const optionalFields = asMutableArray([
-  SPAN_ID,
-  ERROR_MESSAGE,
-  EXCEPTION_TYPE,
-  EXCEPTION_MESSAGE,
-] as const);
+export const requiredFields = asMutableArray([SPAN_ID, EXCEPTION_TYPE, EXCEPTION_MESSAGE] as const);
 
 async function getUnprocessedOtelErrors({
-  apmEventClient,
+  logsClient,
   end,
   start,
   traceId,
 }: {
-  apmEventClient: APMEventClient;
+  logsClient: LogsClient;
   traceId: string;
   start: number;
   end: number;
 }) {
-  const response = await apmEventClient.search(
-    'get_unprocessed_errors_docs',
-    {
-      apm: { events: [ProcessorEvent.span, ProcessorEvent.transaction, ProcessorEvent.error] },
-      body: {
-        track_total_hits: false,
-        size: 1000,
-        query: {
-          bool: {
-            must: [
-              {
-                bool: {
-                  filter: [...rangeQuery(start, end), ...termQuery(TRACE_ID, traceId)],
-                  must_not: existsQuery(PROCESSOR_EVENT),
-                  should: [
-                    ...termQuery(STATUS_CODE, 'Error'),
-                    ...existsQuery(ERROR_MESSAGE),
-                    ...existsQuery(EXCEPTION_TYPE),
-                    ...existsQuery(EXCEPTION_MESSAGE),
-                  ],
-                  minimum_should_match: 1,
-                },
-              },
-            ],
-          },
-        },
-        fields: optionalFields,
+  const response = await logsClient.search({
+    query: {
+      bool: {
+        filter: [...rangeQuery(start, end), ...termQuery(TRACE_ID, traceId)],
+        should: [
+          ...termQuery(OTEL_EVENT_NAME, 'exception'),
+          ...existsQuery(EXCEPTION_TYPE),
+          ...existsQuery(EXCEPTION_MESSAGE),
+        ],
+        minimum_should_match: 1,
       },
     },
-    { skipProcessorEventFilter: true }
-  );
-
-  return response.hits.hits.map((hit) => {
-    const event = unflattenKnownApmEventFields(hit.fields);
-
-    return {
-      id: event.span?.id,
-      error: {
-        message: event.error?.message,
-        exception: {
-          type: event.exception?.type,
-          message: event.exception?.message,
-        },
-      },
-    };
+    fields: requiredFields,
   });
+
+  return response.hits.hits
+    .map((hit) => {
+      const event = unflattenKnownApmEventFields(hit.fields, requiredFields);
+      if (!event) return null;
+
+      return {
+        id: event.span?.id,
+        error: {
+          exception: {
+            type: event.exception?.type,
+            message: event.exception?.message,
+          },
+        },
+      };
+    })
+    .filter(
+      (
+        doc
+      ): doc is {
+        id: string;
+        error: { exception: { type: string; message: string } };
+      } => !!doc
+    );
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
@@ -45,7 +45,7 @@ describe('getErrorCountByDocId', () => {
       apmErrors: [{ parent: { id: undefined } }],
       unprocessedOtelErrors: [{ id: undefined }],
       totalErrors: 0,
-    } as UnifiedTraceErrors;
+    } as unknown as UnifiedTraceErrors;
 
     expect(getErrorCountByDocId(unifiedTraceErrors)).toEqual({});
   });

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
@@ -36,6 +36,7 @@ import { getTraceSamplesByQuery } from './get_trace_samples_by_query';
 import { getTraceSummaryCount } from './get_trace_summary_count';
 import { getUnifiedTraceItems } from './get_unified_trace_items';
 import { getUnifiedTraceErrors } from './get_unified_trace_errors';
+import { createLogsClient } from '../../lib/helpers/create_es_client/create_logs_client';
 
 const tracesRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/traces',
@@ -141,11 +142,19 @@ const unifiedTracesByIdRoute = createApmServerRoute({
     traceItems: TraceItem[];
   }> => {
     const apmEventClient = await getApmEventClient(resources);
+    const logsClient = await createLogsClient(resources);
+
     const { params, config } = resources;
     const { traceId } = params.path;
     const { start, end } = params.query;
 
-    const unifiedTraceErrors = await getUnifiedTraceErrors({ apmEventClient, traceId, start, end });
+    const unifiedTraceErrors = await getUnifiedTraceErrors({
+      apmEventClient,
+      logsClient,
+      traceId,
+      start,
+      end,
+    });
 
     const traceItems = await getUnifiedTraceItems({
       apmEventClient,
@@ -180,11 +189,18 @@ const focusedTraceRoute = createApmServerRoute({
     summary: { services: number; traceEvents: number; errors: number };
   }> => {
     const apmEventClient = await getApmEventClient(resources);
+    const logsClient = await createLogsClient(resources);
     const { params, config } = resources;
     const { traceId, docId } = params.path;
     const { start, end } = params.query;
 
-    const unifiedTraceErrors = await getUnifiedTraceErrors({ apmEventClient, traceId, start, end });
+    const unifiedTraceErrors = await getUnifiedTraceErrors({
+      apmEventClient,
+      logsClient,
+      traceId,
+      start,
+      end,
+    });
 
     const [traceItems, traceSummaryCount] = await Promise.all([
       getUnifiedTraceItems({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM][Unified Waterfall] Update getUnprocessedOtelErrors to query related errors instead of trace errors (#228750)](https://github.com/elastic/kibana/pull/228750)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2025-07-23T10:53:29Z","message":"[APM][Unified Waterfall] Update getUnprocessedOtelErrors to query related errors instead of trace errors (#228750)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/228412\n\nThis PR updates `getUnprocessedOtelErrors` to query for `event_name` ==\n\"exception\" in the logs indices, instead of checking for `status.code`\n== \"Error\" in the traces indices.\n\nTo support this change, we're now fetching the logs index patterns from\nthe `logsDataAccess` plugin to ensure we're querying the correct log\nsources.\n\n|Before|After|\n|-|-|\n|We were getting redundant information of the errors on the\nwaterfall:<br><br><img width=\"1819\" height=\"127\" alt=\"Screenshot\n2025-07-21 at 13 29 31\"\nsrc=\"https://github.com/user-attachments/assets/a54c48ec-35b2-412c-899f-60095b9459d0\"\n/>|<img width=\"1901\" height=\"137\" alt=\"Screenshot 2025-07-21 at 13 11\n24\"\nsrc=\"https://github.com/user-attachments/assets/5799956d-80be-4807-aa14-03d4aa4599bd\"\n/>|","sha":"1ab15cf0aa87bc28e24f098acefabb801316e256","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[APM][Unified Waterfall] Update getUnprocessedOtelErrors to query related errors instead of trace errors","number":228750,"url":"https://github.com/elastic/kibana/pull/228750","mergeCommit":{"message":"[APM][Unified Waterfall] Update getUnprocessedOtelErrors to query related errors instead of trace errors (#228750)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/228412\n\nThis PR updates `getUnprocessedOtelErrors` to query for `event_name` ==\n\"exception\" in the logs indices, instead of checking for `status.code`\n== \"Error\" in the traces indices.\n\nTo support this change, we're now fetching the logs index patterns from\nthe `logsDataAccess` plugin to ensure we're querying the correct log\nsources.\n\n|Before|After|\n|-|-|\n|We were getting redundant information of the errors on the\nwaterfall:<br><br><img width=\"1819\" height=\"127\" alt=\"Screenshot\n2025-07-21 at 13 29 31\"\nsrc=\"https://github.com/user-attachments/assets/a54c48ec-35b2-412c-899f-60095b9459d0\"\n/>|<img width=\"1901\" height=\"137\" alt=\"Screenshot 2025-07-21 at 13 11\n24\"\nsrc=\"https://github.com/user-attachments/assets/5799956d-80be-4807-aa14-03d4aa4599bd\"\n/>|","sha":"1ab15cf0aa87bc28e24f098acefabb801316e256"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229099","number":229099,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228750","number":228750,"mergeCommit":{"message":"[APM][Unified Waterfall] Update getUnprocessedOtelErrors to query related errors instead of trace errors (#228750)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/228412\n\nThis PR updates `getUnprocessedOtelErrors` to query for `event_name` ==\n\"exception\" in the logs indices, instead of checking for `status.code`\n== \"Error\" in the traces indices.\n\nTo support this change, we're now fetching the logs index patterns from\nthe `logsDataAccess` plugin to ensure we're querying the correct log\nsources.\n\n|Before|After|\n|-|-|\n|We were getting redundant information of the errors on the\nwaterfall:<br><br><img width=\"1819\" height=\"127\" alt=\"Screenshot\n2025-07-21 at 13 29 31\"\nsrc=\"https://github.com/user-attachments/assets/a54c48ec-35b2-412c-899f-60095b9459d0\"\n/>|<img width=\"1901\" height=\"137\" alt=\"Screenshot 2025-07-21 at 13 11\n24\"\nsrc=\"https://github.com/user-attachments/assets/5799956d-80be-4807-aa14-03d4aa4599bd\"\n/>|","sha":"1ab15cf0aa87bc28e24f098acefabb801316e256"}}]}] BACKPORT-->