### PR TITLE
[OneDiscover] Make sure that contextual profiles have unique and valid ids

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_enabled_profile_providers.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_enabled_profile_providers.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createEsqlDataSource } from '../../../common/data_sources';
+import { FEATURE_ID_1, FEATURE_ID_2, createContextAwarenessMocks } from '../__mocks__';
+import { createExampleRootProfileProvider } from './example/example_root_profile';
+import { registerEnabledProfileProviders } from './register_enabled_profile_providers';
+import type { CellRenderersExtensionParams } from '../types';
+
+const exampleRootProfileProvider = createExampleRootProfileProvider();
+
+describe('registerEnabledProfileProviders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should register all profile providers', async () => {
+    const { rootProfileServiceMock, rootProfileProviderMock, profileProviderServices } =
+      createContextAwarenessMocks({
+        shouldRegisterProviders: false,
+      });
+
+    registerEnabledProfileProviders({
+      profileService: rootProfileServiceMock,
+      providers: [rootProfileProviderMock],
+      enabledExperimentalProfileIds: [],
+      services: profileProviderServices,
+    });
+    const context = await rootProfileServiceMock.resolve({ solutionNavId: null });
+    const profile = rootProfileServiceMock.getProfile({ context });
+    const baseImpl = () => ({});
+    profile.getCellRenderers?.(baseImpl)({} as unknown as CellRenderersExtensionParams);
+    expect(rootProfileProviderMock.profile.getCellRenderers).toHaveBeenCalledTimes(1);
+    expect(rootProfileProviderMock.profile.getCellRenderers).toHaveBeenCalledWith(baseImpl, {
+      context,
+    });
+  });
+
+  it('should not register experimental profile providers by default', async () => {
+    jest.spyOn(exampleRootProfileProvider.profile, 'getCellRenderers');
+    const { rootProfileServiceMock, profileProviderServices } = createContextAwarenessMocks({
+      shouldRegisterProviders: false,
+    });
+    registerEnabledProfileProviders({
+      profileService: rootProfileServiceMock,
+      providers: [exampleRootProfileProvider],
+      enabledExperimentalProfileIds: [],
+      services: profileProviderServices,
+    });
+    const context = await rootProfileServiceMock.resolve({ solutionNavId: null });
+    const profile = rootProfileServiceMock.getProfile({ context });
+    const baseImpl = () => ({});
+    profile.getCellRenderers?.(baseImpl)({} as unknown as CellRenderersExtensionParams);
+    expect(exampleRootProfileProvider.profile.getCellRenderers).not.toHaveBeenCalled();
+    expect(profile).toMatchObject({});
+  });
+
+  it('should register experimental profile providers when enabled by config', async () => {
+    jest.spyOn(exampleRootProfileProvider.profile, 'getCellRenderers');
+    const { rootProfileServiceMock, rootProfileProviderMock, profileProviderServices } =
+      createContextAwarenessMocks({
+        shouldRegisterProviders: false,
+      });
+    registerEnabledProfileProviders({
+      profileService: rootProfileServiceMock,
+      providers: [exampleRootProfileProvider],
+      enabledExperimentalProfileIds: [exampleRootProfileProvider.profileId],
+      services: profileProviderServices,
+    });
+    const context = await rootProfileServiceMock.resolve({ solutionNavId: null });
+    const profile = rootProfileServiceMock.getProfile({ context });
+    const baseImpl = () => ({});
+    profile.getCellRenderers?.(baseImpl)({} as unknown as CellRenderersExtensionParams);
+    expect(exampleRootProfileProvider.profile.getCellRenderers).toHaveBeenCalledTimes(1);
+    expect(exampleRootProfileProvider.profile.getCellRenderers).toHaveBeenCalledWith(baseImpl, {
+      context,
+    });
+    expect(rootProfileProviderMock.profile.getCellRenderers).not.toHaveBeenCalled();
+  });
+
+  it('should register restricted profile when product feature is available', async () => {
+    const {
+      rootProfileServiceMock,
+      dataSourceProfileServiceMock,
+      dataSourceProfileProviderMock,
+      profileProviderServices,
+    } = createContextAwarenessMocks({
+      shouldRegisterProviders: false,
+    });
+
+    // Mock feature availability
+    jest
+      .spyOn(profileProviderServices.core.pricing, 'isFeatureAvailable')
+      .mockImplementation((featureId) => {
+        if (featureId === FEATURE_ID_1) {
+          return true;
+        }
+        return false;
+      });
+
+    // Sanity check
+    expect(profileProviderServices.core.pricing.isFeatureAvailable(FEATURE_ID_1)).toBeTruthy();
+
+    registerEnabledProfileProviders({
+      profileService: dataSourceProfileServiceMock,
+      providers: [dataSourceProfileProviderMock],
+      enabledExperimentalProfileIds: [],
+      services: profileProviderServices,
+    });
+    const rootContext = await rootProfileServiceMock.resolve({ solutionNavId: null });
+    const dataSourceContext = await dataSourceProfileServiceMock.resolve({
+      rootContext,
+      dataSource: createEsqlDataSource(),
+      query: { esql: 'from my-example-logs' },
+    });
+
+    const profile = dataSourceProfileServiceMock.getProfile({ context: dataSourceContext });
+    const baseImpl = () => ({});
+    profile.getCellRenderers?.(baseImpl)({} as unknown as CellRenderersExtensionParams);
+    expect(dataSourceProfileProviderMock.profile.getCellRenderers).toHaveBeenCalledTimes(1);
+    expect(dataSourceProfileProviderMock.profile.getCellRenderers).toHaveBeenCalledWith(baseImpl, {
+      context: dataSourceContext,
+    });
+  });
+
+  it('should not register restricted profile when product feature is not available', async () => {
+    const {
+      rootProfileServiceMock,
+      dataSourceProfileServiceMock,
+      dataSourceProfileProviderMock,
+      profileProviderServices,
+    } = createContextAwarenessMocks({
+      shouldRegisterProviders: false,
+    });
+
+    // Mock feature availability
+    jest
+      .spyOn(profileProviderServices.core.pricing, 'isFeatureAvailable')
+      .mockImplementation((featureId) => {
+        if (featureId === FEATURE_ID_2) {
+          return true;
+        }
+        return false;
+      });
+
+    // Sanity check
+    expect(profileProviderServices.core.pricing.isFeatureAvailable(FEATURE_ID_1)).not.toBeTruthy();
+
+    registerEnabledProfileProviders({
+      profileService: dataSourceProfileServiceMock,
+      providers: [dataSourceProfileProviderMock],
+      enabledExperimentalProfileIds: [],
+      services: profileProviderServices,
+    });
+    const rootContext = await rootProfileServiceMock.resolve({ solutionNavId: null });
+    const dataSourceContext = await dataSourceProfileServiceMock.resolve({
+      rootContext,
+      dataSource: createEsqlDataSource(),
+      query: { esql: 'from my-example-logs' },
+    });
+
+    const profile = dataSourceProfileServiceMock.getProfile({ context: dataSourceContext });
+    const baseImpl = () => ({});
+    profile.getCellRenderers?.(baseImpl)({} as unknown as CellRenderersExtensionParams);
+    expect(dataSourceProfileProviderMock.profile.getCellRenderers).not.toHaveBeenCalled();
+    expect(profile).toMatchObject({});
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_enabled_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_enabled_profile_providers.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { BaseProfileProvider, BaseProfileService } from '../profile_service';
+import type { DiscoverServices } from '../../build_services';
+
+/**
+ * Register enabled profile providers to the provided profile service
+ * @param options Register enabled profile providers options
+ */
+export const registerEnabledProfileProviders = <
+  TProvider extends BaseProfileProvider<{}, {}>,
+  TService extends BaseProfileService<TProvider>
+>({
+  profileService,
+  providers: availableProviders,
+  enabledExperimentalProfileIds = [],
+  services,
+}: {
+  /**
+   * Profile service to register providers
+   */
+  profileService: TService;
+  /**
+   * Array of available profile providers
+   */
+  providers: TProvider[];
+  /**
+   * Array of experimental profile IDs which are enabled in `kibana.yml`
+   */
+  enabledExperimentalProfileIds?: string[];
+  services: DiscoverServices;
+}) => {
+  for (const provider of availableProviders) {
+    const checkForExperimentalProfile =
+      !provider.isExperimental || enabledExperimentalProfileIds.includes(provider.profileId);
+    const checkForProductFeature =
+      !provider.restrictedToProductFeature ||
+      services.core.pricing.isFeatureAvailable(provider.restrictedToProductFeature);
+
+    if (checkForExperimentalProfile && checkForProductFeature) {
+      profileService.registerProvider(provider);
+    }
+  }
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -12,7 +12,7 @@ import type {
   DocumentProfileService,
   RootProfileService,
 } from '../profiles';
-import type { BaseProfileProvider, BaseProfileService } from '../profile_service';
+import { registerEnabledProfileProviders } from './register_enabled_profile_providers';
 import { createExampleDataSourceProfileProvider } from './example/example_data_source_profile/profile';
 import { createExampleDocumentProfileProvider } from './example/example_document_profile';
 import {
@@ -86,46 +86,6 @@ export const registerProfileProviders = async ({
     enabledExperimentalProfileIds,
     services,
   });
-};
-
-/**
- * Register enabled profile providers to the provided profile service
- * @param options Register enabled profile providers options
- */
-export const registerEnabledProfileProviders = <
-  TProvider extends BaseProfileProvider<{}, {}>,
-  TService extends BaseProfileService<TProvider>
->({
-  profileService,
-  providers: availableProviders,
-  enabledExperimentalProfileIds = [],
-  services,
-}: {
-  /**
-   * Profile service to register providers
-   */
-  profileService: TService;
-  /**
-   * Array of available profile providers
-   */
-  providers: TProvider[];
-  /**
-   * Array of experimental profile IDs which are enabled in `kibana.yml`
-   */
-  enabledExperimentalProfileIds?: string[];
-  services: DiscoverServices;
-}) => {
-  for (const provider of availableProviders) {
-    const checkForExperimentalProfile =
-      !provider.isExperimental || enabledExperimentalProfileIds.includes(provider.profileId);
-    const checkForProductFeature =
-      !provider.restrictedToProductFeature ||
-      services.core.pricing.isFeatureAvailable(provider.restrictedToProductFeature);
-
-    if (checkForExperimentalProfile && checkForProductFeature) {
-      profileService.registerProvider(provider);
-    }
-  }
 };
 
 /**


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/204253

## Summary

This PR adds tests to validate that the defined profile ids are unique and correspond to the specified context level.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



