### PR TITLE
Upgrade `@fast-check/jest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1430,7 +1430,7 @@
     "@elastic/synthetics": "^1.18.2",
     "@emotion/babel-preset-css-prop": "^11.11.0",
     "@emotion/jest": "^11.11.0",
-    "@fast-check/jest": "^2.1.0",
+    "@fast-check/jest": "^2.1.1",
     "@frsource/cypress-plugin-visual-regression-diff": "^3.3.10",
     "@huggingface/hub": "^2.2.0",
     "@jest/console": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,10 +2848,10 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-9.7.0.tgz#1cf1fecfcad5e2da2332140bf3b5f23cc1c2a7f4"
   integrity sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==
 
-"@fast-check/jest@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@fast-check/jest/-/jest-2.1.0.tgz#67585ede285267dc9efc3ac3e05c41879887980a"
-  integrity sha512-9ZVvFnngR0EpfxWoGrq/e9ERrDv3qqE4RXVnn/mGv5Rn33LoDcIfg7xjqVREsyhGcwegEKeL0KJlrWzWiOBV8A==
+"@fast-check/jest@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@fast-check/jest/-/jest-2.1.1.tgz#0c0959f8f37f4155c5de7a19888c398542240be9"
+  integrity sha512-t9m3u3tikj/+Ph+gRLGb7fFS/aqnIafsAc6qhXIFJytkqOFRSF70Y5yUUyTtR0idcb6Ald7AnC0AChLCLxv2Tg==
   dependencies:
     fast-check "^3.0.0 || ^4.0.0"
 


### PR DESCRIPTION
## Summary

Part of the packages listed in https://github.com/elastic/kibana/pull/201607

https://github.com/dubzzz/fast-check/blob/main/packages/jest/CHANGELOG.md


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->