### PR TITLE
[Entity Analytics][Privmon] Deduplicate privileged users from index sync and CSV upload

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/privilege_monitoring_data_client.ts
@@ -555,7 +555,8 @@ export class PrivilegeMonitoringDataClient {
     indexName: string;
     kuery?: string | unknown;
   }): Promise<string[]> {
-    let batchUniqueUsernames: string[] = [];
+    // let batchUniqueUsernames: string[] = [];
+    const allUsernames: string[] = []; // Collect all usernames across batches
     let searchAfter: SortResults | undefined;
     const batchSize = 100;
 
@@ -574,8 +575,8 @@ export class PrivilegeMonitoringDataClient {
       const batchUsernames = hits
         .map((hit) => hit._source?.user?.name)
         .filter((username): username is string => !!username);
-
-      batchUniqueUsernames = uniq(batchUsernames);
+      allUsernames.push(...batchUsernames); // Collect usernames from this batch
+      const batchUniqueUsernames = uniq(batchUsernames); // Ensure uniqueness within the batch
 
       this.log(
         'debug',
@@ -609,7 +610,7 @@ export class PrivilegeMonitoringDataClient {
       }
       searchAfter = hits[hits.length - 1].sort;
     }
-    return batchUniqueUsernames;
+    return uniq(allUsernames); // Return all unique usernames collected across batches
   }
 
   private async findStaleUsersForIndex(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/upsert_batch.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/upsert_batch.ts
@@ -8,6 +8,7 @@
 import type { ElasticsearchClient } from '@kbn/core/server';
 
 import { separate } from 'fp-ts/Array';
+import { uniqBy } from 'lodash';
 import type { Batch, BulkPrivMonUser, BulkBatchProcessingResults, Options } from './types';
 
 export const bulkUpsertBatch =
@@ -16,7 +17,7 @@ export const bulkUpsertBatch =
     const { left: parsingErrors, right: users } = separate(batch.uploaded);
     const res = await esClient.bulk<BulkPrivMonUser>({
       index,
-      operations: users.flatMap((u) => {
+      operations: uniqBy(users, (u) => u.username).flatMap((u) => {
         const id = batch.existingUsers[u.username];
         const timestamp = new Date().toISOString();
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/upsert_batch.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/upsert_batch.ts
@@ -84,7 +84,7 @@ export const bulkUpsertBatch =
         ] as any;
         /* eslint-disable @typescript-eslint/no-explicit-any */
       }) as any,
-      refresh: 'wait_for',
+      refresh: true,
     });
     const stats = res.items.reduce(
       (acc, item, i) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/upsert_batch.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/upsert_batch.ts
@@ -84,7 +84,7 @@ export const bulkUpsertBatch =
         ] as any;
         /* eslint-disable @typescript-eslint/no-explicit-any */
       }) as any,
-      refresh: true,
+      refresh: 'wait_for',
     });
     const stats = res.items.reduce(
       (acc, item, i) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/users/bulk/utils.ts
@@ -16,7 +16,7 @@ export interface Accumulator {
 }
 
 export const accumulateUpsertResults = (
-  acc: Accumulator,
+  acc: BulkProcessingResults,
   processed: BulkBatchProcessingResults
 ): BulkProcessingResults => {
   const { left: errors, right: users } = separate(processed.batch.uploaded);

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/api.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/api.ts
@@ -282,6 +282,28 @@ export default ({ getService }: FtrProviderContext) => {
           }
         });
       });
+
+      it('should only upload unique users from the CSV', async () => {
+        log.info(`Uploading multiple users via CSV with duplicates`);
+        const csv = Array(150).fill('non_unique_user').join('\n');
+        const res = await privMonUtils.bulkUploadUsersCsv(csv);
+        if (res.status !== 200) {
+          log.error(`Failed to upload users via CSV`);
+          log.error(JSON.stringify(res.body));
+        }
+
+        expect(res.status).eql(200);
+
+        const listRes = await api.listPrivMonUsers({
+          query: { kql: `user.name: non_unique_user` },
+        });
+        if (listRes.status !== 200) {
+          log.error(`Listing privmon users failed`);
+          log.error(JSON.stringify(listRes.body));
+        }
+        expect(listRes.status).eql(200);
+        expect(listRes.body.length).to.be(2);
+      });
     });
   });
 };

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/api.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/api.ts
@@ -302,7 +302,7 @@ export default ({ getService }: FtrProviderContext) => {
           log.error(JSON.stringify(listRes.body));
         }
         expect(listRes.status).eql(200);
-        expect(listRes.body.length).to.be(2);
+        expect(listRes.body.length).to.be(1);
       });
     });
   });


### PR DESCRIPTION

## Summary

Deduplicate entities in the same batch with the same user.name so that only one will ever be created during index sync and csv upload.

## CSV upload test

Upload 1k_tiagos.csv, only one tiago should be added. (or 1k_marks.csv to test a diff name)


[1k_tiagos.csv](https://github.com/user-attachments/files/21390988/1k_tiagos.csv)
[1k_marks.csv](https://github.com/user-attachments/files/21391494/1k_marks.csv)


## Index Sync Test
```
# create index with correct mapping
PUT /my-custom-index
{
  "mappings" : {
    "properties": {
      "user.name": {
        "type": "keyword"
      }
    }
  }
}

# mash cmd + enter until there are a few hundred tiagos
POST /_bulk
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }
{ "index": { "_index": "my-custom-index" } }
{ "user": { "name": "tiago" } }

# check how many tiagos you have
GET /my-custom-index/_search?size=0

# now go and add this index as an index sync source, there should only ever be one tiago: 
GET /.entity_analytics.monitoring.users-default/_search
```




<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->