### PR TITLE
Upgrade joi-to-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1246,7 +1246,7 @@
     "isbinaryfile": "4.0.2",
     "jest-diff": "^29.7.0",
     "joi": "^17.13.3",
-    "joi-to-json": "^4.3.0",
+    "joi-to-json": "^4.3.2",
     "jquery": "^3.7.1",
     "js-search": "^1.4.3",
     "js-sha256": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23089,10 +23089,10 @@ jiti@^1.20.0:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
   integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
 
-joi-to-json@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/joi-to-json/-/joi-to-json-4.3.0.tgz#c56131ecf8a772fce89fd98b7f81d7b0fac31dbc"
-  integrity sha512-j6wV/liW2CmPJBJCAsRHegS91JV2QQtg2J/Z/67VfdSvuE65njCx6DrYZY1cw0BXwlxHewpVtiDnY8W0aaNr+A==
+joi-to-json@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/joi-to-json/-/joi-to-json-4.3.2.tgz#b2fba0bd4a1073893238098165ba59207fabcb36"
+  integrity sha512-ZGfdMpCwM2NNgcddh3q2SGtwmIQ5dU5iJJkccUYxZDRMDCO8CJ8VCnND7SkbnvID4YF5dDTM55ElsTGuktUs6Q==
   dependencies:
     combinations "^1.0.0"
     lodash "^4.17.21"


### PR DESCRIPTION
## Summary

Part of the packages listed in https://github.com/elastic/kibana/pull/201607

<details>
<summary>kenspirit/joi-to-json (joi-to-json)</summary>

### [`v4.3.2`](https://redirect.github.com/kenspirit/joi-to-json/blob/HEAD/CHANGELOG.md#432)

[Compare Source](https://redirect.github.com/kenspirit/joi-to-json/compare/8b439158ca3d35a39afdba7dfed7bb03874d17f7...9b47e9d57a0864b576f01ffbdb3718f70d5fa996)

-   Fixes
    -   Allow schemas other than objects in pattern properties ([#&#8203;56](https://redirect.github.com/kenspirit/joi-to-json/issues/56))

### [`v4.3.1`](https://redirect.github.com/kenspirit/joi-to-json/blob/HEAD/CHANGELOG.md#431)

[Compare Source](https://redirect.github.com/kenspirit/joi-to-json/compare/287804ad98ac7df7f43795c5575610616fef357c...8b439158ca3d35a39afdba7dfed7bb03874d17f7)

-   Fixes
    -   Add 'open-api-3.1' in .d.ts Model type ([#&#8203;54](https://redirect.github.com/kenspirit/joi-to-json/issues/54))

</details>


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->