### PR TITLE
Update publish_oas_docs.sh for 9x-unreleased branch

### DIFF
--- a/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
+++ b/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
@@ -49,6 +49,13 @@ if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   exit 0;
 fi
 
+if [[ "$BUILDKITE_BRANCH" == "9.1" ]]; then
+  BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
+  BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"
+  deploy_to_bump "$(pwd)/oas_docs/output/kibana.yaml" $BUMP_KIBANA_DOC_NAME $BUMP_KIBANA_DOC_TOKEN 9x-unreleased;
+  exit 0;
+fi
+
 if [[ "$BUILDKITE_BRANCH" == "9.0" ]]; then
   BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
   BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"


### PR DESCRIPTION
## Summary

This PR starts pushing the OpenAPI document from the 9.1 branch to the "9x-unreleased" branch in our publishing site.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->