### PR TITLE
[Security Solution][Response Ops] - Disable cases analytics index

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -14,7 +14,7 @@ describe('config validation', () => {
         Object {
           "analytics": Object {
             "index": Object {
-              "enabled": true,
+              "enabled": false,
             },
           },
           "enabled": true,

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -27,7 +27,7 @@ export const ConfigSchema = schema.object({
     index: schema.object({
       enabled: offeringBasedSchema({
         serverless: schema.boolean({ defaultValue: false }),
-        traditional: schema.boolean({ defaultValue: true }),
+        traditional: schema.boolean({ defaultValue: false }),
       }),
     }),
   }),


### PR DESCRIPTION
## Summary

Disabling cases analytics index

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->