### PR TITLE
[onechat] Implement ES|QL tool editing

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/index.ts
@@ -27,6 +27,7 @@ export {
   type EsqlToolFieldTypes,
   type EsqlToolParam,
   type EsqlToolDefinition,
+  type EsqlToolDefinitionWithSchema,
   EsqlToolFieldType,
   idRegexp,
 } from './tools';

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/definition.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/definition.ts
@@ -50,7 +50,8 @@ export interface ToolDefinition<TConfig extends object = Record<string, unknown>
   configuration: TConfig;
 }
 
-export interface ToolDefinitionWithSchema extends ToolDefinition {
+export interface ToolDefinitionWithSchema<TConfig extends object = Record<string, unknown>>
+  extends ToolDefinition<TConfig> {
   /**
    * the JSON schema associated with this tool's input parameters.
    */

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/esql.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/esql.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ToolDefinition } from './definition';
+import { ToolType, type ToolDefinition, type ToolDefinitionWithSchema } from './definition';
 
 /**
  * Common ES Field Types
@@ -36,9 +36,18 @@ export interface EsqlToolParam {
   description: string;
 }
 
-export interface EsqlToolConfig {
+// To make compatible with ToolDefinition['configuration']
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type EsqlToolConfig = {
   query: string;
   params: Record<string, EsqlToolParam>;
-}
+};
 
 export type EsqlToolDefinition = ToolDefinition<EsqlToolConfig>;
+export type EsqlToolDefinitionWithSchema = ToolDefinitionWithSchema<EsqlToolConfig>;
+
+export function isEsqlTool(tool: ToolDefinitionWithSchema): tool is EsqlToolDefinitionWithSchema;
+export function isEsqlTool(tool: ToolDefinition): tool is EsqlToolDefinition;
+export function isEsqlTool(tool: ToolDefinition): boolean {
+  return tool.type === ToolType.esql;
+}

--- a/x-pack/platform/packages/shared/onechat/onechat-common/tools/index.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/tools/index.ts
@@ -24,4 +24,6 @@ export {
   type EsqlToolFieldTypes,
   type EsqlToolParam,
   type EsqlToolDefinition,
+  type EsqlToolDefinitionWithSchema,
+  isEsqlTool,
 } from './esql';

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tool_flyout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tool_flyout.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiLoadingSpinner,
   EuiThemeComputed,
   EuiTitle,
   EuiToolTip,
@@ -62,13 +63,19 @@ const flyoutBodyClass = (euiTheme: EuiThemeComputed) =>
     }
   `;
 
-interface OnechatEsqlToolFlyoutProps {
+export enum OnechatEsqlToolFlyoutMode {
+  Create = 'create',
+  Edit = 'edit',
+}
+
+export interface OnechatEsqlToolFlyoutProps {
+  mode: OnechatEsqlToolFlyoutMode;
   isOpen: boolean;
-  isSaving: boolean;
-  title: string;
+  isSubmitting: boolean;
+  isLoading?: boolean;
   tool?: EsqlToolDefinitionWithSchema;
   onClose: () => void;
-  saveTool: (data: OnechatEsqlToolFormData) => Promise<void>;
+  submit: (data: OnechatEsqlToolFormData) => Promise<void>;
 }
 
 const getDefaultValues = (): OnechatEsqlToolFormData => ({
@@ -80,12 +87,13 @@ const getDefaultValues = (): OnechatEsqlToolFormData => ({
 });
 
 export const OnechatEsqlToolFlyout: React.FC<OnechatEsqlToolFlyoutProps> = ({
-  title,
+  mode,
   isOpen,
-  isSaving,
+  isLoading,
+  isSubmitting,
   tool,
   onClose,
-  saveTool,
+  submit: saveTool,
 }) => {
   const resolver = useEsqlToolFormValidationResolver();
   const form = useForm<OnechatEsqlToolFormData>({
@@ -113,8 +121,6 @@ export const OnechatEsqlToolFlyout: React.FC<OnechatEsqlToolFlyoutProps> = ({
   const esqlToolFormId = useGeneratedHtmlId({
     prefix: 'esqlToolForm',
   });
-
-  const isSubmitting = isSaving;
 
   const handleClear = useCallback(() => {
     reset(getDefaultValues());
@@ -156,11 +162,25 @@ export const OnechatEsqlToolFlyout: React.FC<OnechatEsqlToolFlyoutProps> = ({
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id={esqlToolFlyoutTitleId}>{title}</h2>
+            <h2 id={esqlToolFlyoutTitleId}>
+              {mode === OnechatEsqlToolFlyoutMode.Create
+                ? i18n.translate('xpack.onechat.tools.newEsqlTool.title', {
+                    defaultMessage: 'New ES|QL tool',
+                  })
+                : i18n.translate('xpack.onechat.tools.editEsqlTool.title', {
+                    defaultMessage: 'Edit ES|QL tool',
+                  })}
+            </h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody css={flyoutBodyClass(euiTheme)}>
-          <OnechatEsqlToolForm formId={esqlToolFormId} saveTool={saveTool} />
+          {isLoading ? (
+            <EuiFlexGroup justifyContent="center" alignItems="center">
+              <EuiLoadingSpinner size="xxl" />
+            </EuiFlexGroup>
+          ) : (
+            <OnechatEsqlToolForm formId={esqlToolFormId} saveTool={saveTool} />
+          )}
         </EuiFlyoutBody>
         <EuiFlyoutFooter>
           <EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/esql_tools.tsx
@@ -20,6 +20,7 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { formatOnechatErrorMessage } from '@kbn/onechat-browser';
 import { EsqlToolDefinitionWithSchema } from '@kbn/onechat-common';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useCreateToolFlyout } from '../../../hooks/tools/use_create_tools';
@@ -125,7 +126,7 @@ export const OnechatEsqlTools: React.FC = () => {
   );
 
   const onDeleteError = useCallback(
-    (toolId: string) => {
+    (error: Error, toolId: string) => {
       addErrorToast({
         title: i18n.translate('xpack.onechat.tools.deleteToolErrorToast', {
           defaultMessage: 'Unable to delete tool "{toolId}"',
@@ -133,6 +134,7 @@ export const OnechatEsqlTools: React.FC = () => {
             toolId,
           },
         }),
+        text: formatOnechatErrorMessage(error),
       });
     },
     [addErrorToast]
@@ -155,13 +157,17 @@ export const OnechatEsqlTools: React.FC = () => {
     });
   }, [addSuccessToast]);
 
-  const handleCreateError = useCallback(() => {
-    addErrorToast({
-      title: i18n.translate('xpack.onechat.tools.createEsqlToolErrorToast', {
-        defaultMessage: 'Unable to create ES|QL tool',
-      }),
-    });
-  }, [addErrorToast]);
+  const handleCreateError = useCallback(
+    (error: Error) => {
+      addErrorToast({
+        title: i18n.translate('xpack.onechat.tools.createEsqlToolErrorToast', {
+          defaultMessage: 'Unable to create ES|QL tool',
+        }),
+        text: formatOnechatErrorMessage(error),
+      });
+    },
+    [addErrorToast]
+  );
 
   const {
     isOpen: isCreateToolFlyoutOpen,
@@ -189,13 +195,17 @@ export const OnechatEsqlTools: React.FC = () => {
     });
   }, [addSuccessToast]);
 
-  const handleEditError = useCallback(() => {
-    addErrorToast({
-      title: i18n.translate('xpack.onechat.tools.editEsqlToolErrorToast', {
-        defaultMessage: 'Unable to update ES|QL tool',
-      }),
-    });
-  }, [addErrorToast]);
+  const handleEditError = useCallback(
+    (error: Error) => {
+      addErrorToast({
+        title: i18n.translate('xpack.onechat.tools.editEsqlToolErrorToast', {
+          defaultMessage: 'Unable to update ES|QL tool',
+        }),
+        text: formatOnechatErrorMessage(error),
+      });
+    },
+    [addErrorToast]
+  );
 
   const {
     isOpen: isEditToolFlyoutOpen,

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_create_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_create_tools.ts
@@ -6,24 +6,29 @@
  */
 
 import { ToolDefinitionWithSchema } from '@kbn/onechat-common';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useState } from 'react';
-import { CreateToolPayload } from '../../../../common/http_api/tools';
+import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { CreateToolPayload, CreateToolResponse } from '../../../../common/http_api/tools';
 import { queryKeys } from '../../query_keys';
+import { useFlyoutState } from '../use_flyout_state';
 import { useOnechatServices } from '../use_onechat_service';
+
+type CreateToolMutationOptions = UseMutationOptions<CreateToolResponse, Error, CreateToolPayload>;
+type CreateToolMutationSuccessCallback = NonNullable<CreateToolMutationOptions['onSuccess']>;
+type CreateToolMutationErrorCallback = NonNullable<CreateToolMutationOptions['onError']>;
 
 export const useCreateTool = ({
   onSuccess,
   onError,
 }: {
-  onSuccess?: (tool: ToolDefinitionWithSchema) => void;
-  onError?: (error: Error) => void;
+  onSuccess?: CreateToolMutationSuccessCallback;
+  onError?: CreateToolMutationErrorCallback;
 }) => {
   const queryClient = useQueryClient();
   const { toolsService } = useOnechatServices();
 
-  const { mutateAsync, isLoading } = useMutation({
-    mutationFn: (tool: CreateToolPayload) => toolsService.create(tool),
+  const { mutateAsync, isLoading } = useMutation<CreateToolResponse, Error, CreateToolPayload>({
+    mutationFn: (tool) => toolsService.create(tool),
     onSuccess,
     onError,
     onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.tools.all }),
@@ -32,45 +37,36 @@ export const useCreateTool = ({
   return { createTool: mutateAsync, isLoading };
 };
 
+export type CreateToolSuccessCallback = (tool: ToolDefinitionWithSchema) => void;
+export type CreateToolErrorCallback = (error: Error) => void;
+
 export const useCreateToolFlyout = ({
   onSuccess,
   onError,
 }: {
-  onSuccess?: (tool: ToolDefinitionWithSchema) => void;
-  onError?: (error: Error) => void;
+  onSuccess?: CreateToolSuccessCallback;
+  onError?: CreateToolErrorCallback;
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const { isOpen, openFlyout, closeFlyout } = useFlyoutState();
 
-  const handleSuccess = (tool: ToolDefinitionWithSchema) => {
-    setIsOpen(false);
-    onSuccess?.(tool);
-  };
+  const handleSuccess = useCallback<CreateToolMutationSuccessCallback>(
+    (tool) => {
+      closeFlyout();
+      onSuccess?.(tool);
+    },
+    [closeFlyout, onSuccess]
+  );
 
-  const { createTool: createToolMutation, isLoading } = useCreateTool({
+  const { createTool, isLoading: isSubmitting } = useCreateTool({
     onSuccess: handleSuccess,
     onError,
   });
 
-  const openFlyout = useCallback(() => {
-    setIsOpen(true);
-  }, []);
-
-  const closeFlyout = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
-  const saveTool = useCallback(
-    async (toolData: CreateToolPayload) => {
-      await createToolMutation(toolData);
-    },
-    [createToolMutation]
-  );
-
   return {
     isOpen,
-    isLoading,
+    isSubmitting,
     openFlyout,
-    saveTool,
+    submit: createTool,
     closeFlyout,
   };
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_create_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_create_tools.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolDefinitionWithSchema } from '@kbn/onechat-common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { CreateToolPayload } from '../../../../common/http_api/tools';
+import { queryKeys } from '../../query_keys';
+import { useOnechatServices } from '../use_onechat_service';
+
+export const useCreateTool = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (tool: ToolDefinitionWithSchema) => void;
+  onError?: (error: Error) => void;
+}) => {
+  const queryClient = useQueryClient();
+  const { toolsService } = useOnechatServices();
+
+  const { mutateAsync, isLoading } = useMutation({
+    mutationFn: (tool: CreateToolPayload) => toolsService.create(tool),
+    onSuccess,
+    onError,
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.tools.all }),
+  });
+
+  return { createTool: mutateAsync, isLoading };
+};
+
+export const useCreateToolFlyout = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (tool: ToolDefinitionWithSchema) => void;
+  onError?: (error: Error) => void;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleSuccess = (tool: ToolDefinitionWithSchema) => {
+    setIsOpen(false);
+    onSuccess?.(tool);
+  };
+
+  const { createTool: createToolMutation, isLoading } = useCreateTool({
+    onSuccess: handleSuccess,
+    onError,
+  });
+
+  const openFlyout = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closeFlyout = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const saveTool = useCallback(
+    async (toolData: CreateToolPayload) => {
+      await createToolMutation(toolData);
+    },
+    [createToolMutation]
+  );
+
+  return {
+    isOpen,
+    isLoading,
+    openFlyout,
+    saveTool,
+    closeFlyout,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
@@ -39,7 +39,7 @@ export const useDeleteToolModal = ({
   onError,
 }: {
   onSuccess?: (toolId: string) => void;
-  onError?: (toolId: string) => void;
+  onError?: (error: Error, toolId: string) => void;
 }) => {
   const [deleteToolId, setDeleteToolId] = useState<string | null>(null);
 
@@ -51,7 +51,7 @@ export const useDeleteToolModal = ({
 
   const onDeleteSuccess: DeleteToolSuccessCallback = (data, { toolId }) => {
     if (!data.success) {
-      onError?.(toolId);
+      onError?.(new Error('Delete operation failed. API returned: { success: false }'), toolId);
       return;
     }
 
@@ -59,8 +59,8 @@ export const useDeleteToolModal = ({
     setDeleteToolId(null);
   };
 
-  const onDeleteError: DeleteToolErrorCallback = (_, { toolId }) => {
-    onError?.(toolId);
+  const onDeleteError: DeleteToolErrorCallback = (error, { toolId }) => {
+    onError?.(error, toolId);
   };
 
   const { deleteTool: deleteToolMutation, isLoading } = useDeleteTool({

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
@@ -5,27 +5,41 @@
  * 2.0.
  */
 
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { DeleteToolResponse } from '../../../../common/http_api/tools';
 import { queryKeys } from '../../query_keys';
 import { useOnechatServices } from '../use_onechat_service';
 
-type DeleteToolSuccessCallback = (data: DeleteToolResponse, variables: { toolId: string }) => void;
-type DeleteToolErrorCallback = (error: Error, variables: { toolId: string }) => void;
+interface DeleteToolMutationVariables {
+  toolId: string;
+}
+
+type DeleteToolMutationOptions = UseMutationOptions<
+  DeleteToolResponse,
+  Error,
+  DeleteToolMutationVariables
+>;
+
+type DeleteToolMutationSuccessCallback = NonNullable<DeleteToolMutationOptions['onSuccess']>;
+type DeleteToolMutationErrorCallback = NonNullable<DeleteToolMutationOptions['onError']>;
 
 export const useDeleteTool = ({
   onSuccess,
   onError,
 }: {
-  onSuccess?: DeleteToolSuccessCallback;
-  onError?: DeleteToolErrorCallback;
+  onSuccess?: DeleteToolMutationSuccessCallback;
+  onError?: DeleteToolMutationErrorCallback;
 }) => {
   const queryClient = useQueryClient();
   const { toolsService } = useOnechatServices();
 
-  const { mutateAsync, isLoading } = useMutation({
-    mutationFn: ({ toolId }: { toolId: string }) => toolsService.delete({ toolId }),
+  const { mutateAsync, isLoading } = useMutation<
+    DeleteToolResponse,
+    Error,
+    DeleteToolMutationVariables
+  >({
+    mutationFn: ({ toolId }) => toolsService.delete({ toolId }),
     onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.tools.all }),
     onSuccess,
     onError,
@@ -34,12 +48,18 @@ export const useDeleteTool = ({
   return { deleteTool: mutateAsync, isLoading };
 };
 
+export type DeleteToolSuccessCallback = (toolId: string) => void;
+export type DeleteToolErrorCallback = (
+  error: Error,
+  variables: DeleteToolMutationVariables
+) => void;
+
 export const useDeleteToolModal = ({
   onSuccess,
   onError,
 }: {
-  onSuccess?: (toolId: string) => void;
-  onError?: (error: Error, toolId: string) => void;
+  onSuccess?: DeleteToolSuccessCallback;
+  onError?: DeleteToolErrorCallback;
 }) => {
   const [deleteToolId, setDeleteToolId] = useState<string | null>(null);
 
@@ -49,9 +69,9 @@ export const useDeleteToolModal = ({
     setDeleteToolId(toolId);
   }, []);
 
-  const onDeleteSuccess: DeleteToolSuccessCallback = (data, { toolId }) => {
+  const onDeleteSuccess: DeleteToolMutationSuccessCallback = (data, { toolId }) => {
     if (!data.success) {
-      onError?.(new Error('Delete operation failed. API returned: { success: false }'), toolId);
+      onError?.(new Error('Delete operation failed. API returned: { success: false }'), { toolId });
       return;
     }
 
@@ -59,8 +79,8 @@ export const useDeleteToolModal = ({
     setDeleteToolId(null);
   };
 
-  const onDeleteError: DeleteToolErrorCallback = (error, { toolId }) => {
-    onError?.(error, toolId);
+  const onDeleteError: DeleteToolMutationErrorCallback = (error, { toolId }) => {
+    onError?.(error, { toolId });
   };
 
   const { deleteTool: deleteToolMutation, isLoading } = useDeleteTool({

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_delete_tools.ts
@@ -81,7 +81,7 @@ export const useDeleteToolModal = ({
   }, []);
 
   return {
-    isModalOpen,
+    isOpen: isModalOpen,
     isLoading,
     toolId: deleteToolId,
     deleteTool,

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_edit_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_edit_tools.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EsqlToolDefinitionWithSchema, ToolDefinitionWithSchema } from '@kbn/onechat-common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { UpdateToolPayload, UpdateToolResponse } from '../../../../common/http_api/tools';
+import { queryKeys } from '../../query_keys';
+import { useOnechatServices } from '../use_onechat_service';
+
+export const useEditTool = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (tool: UpdateToolResponse) => void;
+  onError?: (error: Error) => void;
+}) => {
+  const queryClient = useQueryClient();
+  const { toolsService } = useOnechatServices();
+
+  const { mutateAsync, isLoading } = useMutation({
+    mutationFn: ({ toolId, tool }: { toolId: string; tool: UpdateToolPayload }) =>
+      toolsService.update(toolId, tool),
+    onSuccess,
+    onError,
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.tools.all }),
+  });
+
+  return { updateTool: mutateAsync, isLoading };
+};
+
+export const useEditToolFlyout = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (tool: EsqlToolDefinitionWithSchema) => void;
+  onError?: (error: Error) => void;
+}) => {
+  const [editingTool, setEditingTool] = useState<EsqlToolDefinitionWithSchema | null>(null);
+
+  const handleSuccess = (tool: ToolDefinitionWithSchema) => {
+    setEditingTool(null);
+    onSuccess?.(tool as EsqlToolDefinitionWithSchema);
+  };
+
+  const { updateTool, isLoading } = useEditTool({
+    onSuccess: handleSuccess,
+    onError,
+  });
+
+  const openFlyout = useCallback((tool: EsqlToolDefinitionWithSchema) => {
+    setEditingTool(tool);
+  }, []);
+
+  const closeFlyout = useCallback(() => {
+    setEditingTool(null);
+  }, []);
+
+  const saveTool = useCallback(
+    async (toolData: UpdateToolPayload) => {
+      if (!editingTool) return;
+      await updateTool({ toolId: editingTool.id, tool: toolData });
+    },
+    [updateTool, editingTool]
+  );
+
+  return {
+    isOpen: !!editingTool,
+    tool: editingTool,
+    isLoading,
+    openFlyout,
+    closeFlyout,
+    saveTool,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { ToolDefinitionWithSchema, ToolType } from '@kbn/onechat-common';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ToolType } from '@kbn/onechat-common';
+import { EsqlToolDefinitionWithSchema, isEsqlTool } from '@kbn/onechat-common/tools/esql';
+import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { CreateToolPayload } from '../../../../common/http_api/tools';
 import { queryKeys } from '../../query_keys';
 import { useOnechatServices } from '../use_onechat_service';
 
@@ -37,26 +37,10 @@ export const useBaseTools = () => {
 export const useEsqlTools = () => {
   const { tools, ...rest } = useOnechatTools();
 
-  const esqlTools = useMemo(() => tools.filter((tool) => tool.type === ToolType.esql), [tools]);
+  const esqlTools = useMemo(
+    // inferred type predicates are implemented in Typescript 5.5
+    () => tools.filter(isEsqlTool) as EsqlToolDefinitionWithSchema[],
+    [tools]
+  );
   return { tools: esqlTools, ...rest };
-};
-
-export const useCreateTool = ({
-  onSuccess,
-  onError,
-}: {
-  onSuccess?: (tool: ToolDefinitionWithSchema) => void;
-  onError?: (error: Error) => void;
-}) => {
-  const queryClient = useQueryClient();
-  const { toolsService } = useOnechatServices();
-
-  const { mutateAsync, isLoading } = useMutation({
-    mutationFn: (tool: CreateToolPayload) => toolsService.create(tool),
-    onSuccess,
-    onError,
-    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.tools.all }),
-  });
-
-  return { createTool: mutateAsync, isLoading };
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools.ts
@@ -44,3 +44,20 @@ export const useEsqlTools = () => {
   );
   return { tools: esqlTools, ...rest };
 };
+
+export const useOnechatTool = (toolId?: string) => {
+  const { toolsService } = useOnechatServices();
+
+  const {
+    data: tool,
+    isLoading,
+    error,
+  } = useQuery({
+    enabled: !!toolId,
+    queryKey: queryKeys.tools.byId(toolId),
+    // toolId! is safe because of the enabled check above
+    queryFn: () => toolsService.get({ toolId: toolId! }),
+  });
+
+  return { tool: tool as EsqlToolDefinitionWithSchema | undefined, isLoading, error };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_flyout_state.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_flyout_state.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useState } from 'react';
+
+export const useFlyoutState = (initialIsOpen = false) => {
+  const [isOpen, setIsOpen] = useState(initialIsOpen);
+
+  const openFlyout = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closeFlyout = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return { isOpen, openFlyout, closeFlyout };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/query_keys.ts
@@ -20,5 +20,6 @@ export const queryKeys = {
   },
   tools: {
     all: ['tools', 'list'] as const,
+    byId: (toolId?: string) => ['tools', toolId],
   },
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/transform_esql_form_data.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/transform_esql_form_data.test.ts
@@ -5,14 +5,22 @@
  * 2.0.
  */
 
-import { ToolType } from '@kbn/onechat-common';
+import { EsqlToolDefinition, ToolType } from '@kbn/onechat-common';
 import { CreateToolPayload } from '../../../common/http_api/tools';
-import { transformEsqlFormData } from './transform_esql_form_data';
+import {
+  transformEsqlFormDataForCreate,
+  transformEsqlFormDataForUpdate,
+  transformEsqlToolToFormData,
+  transformFormDataToEsqlTool,
+} from './transform_esql_form_data';
 import { OnechatEsqlToolFormData } from '../components/tools/esql/form/types/esql_tool_form_types';
 
 describe('transformEsqlFormData', () => {
-  it('should transform ES|QL form data to a create tool payload', () => {
-    const formData: OnechatEsqlToolFormData = {
+  let mockFormData: OnechatEsqlToolFormData;
+  let mockTool: EsqlToolDefinition;
+
+  beforeEach(() => {
+    mockFormData = {
       name: 'my-test-tool',
       description: 'A tool for testing.',
       esql: 'FROM my_index | LIMIT 10 | WHERE field1 == ?param1 AND field2 == ?param2',
@@ -23,7 +31,7 @@ describe('transformEsqlFormData', () => {
       tags: ['test', 'esql'],
     };
 
-    const expectedPayload: CreateToolPayload = {
+    mockTool = {
       id: 'my-test-tool',
       description: 'A tool for testing.',
       configuration: {
@@ -42,64 +50,114 @@ describe('transformEsqlFormData', () => {
       type: ToolType.esql,
       tags: ['test', 'esql'],
     };
-
-    const result = transformEsqlFormData(formData);
-    expect(result).toEqual(expectedPayload);
   });
 
-  it('should handle empty params and tags', () => {
-    const formData: OnechatEsqlToolFormData = {
-      name: 'simple-test-tool',
-      description: 'A simple tool with no params or tags.',
-      esql: 'FROM other_index',
-      params: [],
-      tags: [],
-    };
-
-    const expectedPayload: CreateToolPayload = {
-      id: 'simple-test-tool',
-      description: 'A simple tool with no params or tags.',
-      configuration: {
-        query: 'FROM other_index',
-        params: {},
-      },
-      type: ToolType.esql,
-      tags: [],
-    };
-
-    const result = transformEsqlFormData(formData);
-    expect(result).toEqual(expectedPayload);
+  describe('transformEsqlToolToFormData', () => {
+    it('should transform an ES|QL tool to form data', () => {
+      const result = transformEsqlToolToFormData(mockTool);
+      expect(result).toEqual(mockFormData);
+    });
   });
 
-  it('should filter out params that are not used in the ES|QL query', () => {
-    const formData: OnechatEsqlToolFormData = {
-      name: 'my-test-tool',
-      description: 'A tool for testing.',
-      esql: 'FROM my_index | LIMIT 10 | WHERE field1 == ?param1',
-      params: [
-        { name: 'param1', type: 'text', description: 'A string parameter.' },
-        { name: 'param2', type: 'long', description: 'A number parameter.' },
-      ],
-      tags: ['test', 'esql'],
-    };
+  describe('transformFormDataToEsqlTool', () => {
+    it('should transform form data to an ES|QL tool', () => {
+      const result = transformFormDataToEsqlTool(mockFormData);
+      expect(result).toEqual(mockTool);
+    });
 
-    const expectedPayload: CreateToolPayload = {
-      id: 'my-test-tool',
-      description: 'A tool for testing.',
-      configuration: {
-        query: 'FROM my_index | LIMIT 10 | WHERE field1 == ?param1',
-        params: {
-          param1: {
-            type: 'text',
-            description: 'A string parameter.',
+    it('should filter out unused params', () => {
+      mockFormData.esql = 'FROM my_index | LIMIT 10 | WHERE field1 == ?param1';
+      mockFormData.params.push({
+        name: 'unusedParam',
+        description: 'An unused parameter.',
+        type: 'text',
+      });
+
+      const expectedTool = mockTool;
+      expectedTool.configuration.query = 'FROM my_index | LIMIT 10 | WHERE field1 == ?param1';
+      expectedTool.configuration.params = {
+        param1: {
+          description: 'A string parameter.',
+          type: 'text',
+        },
+      };
+
+      const result = transformFormDataToEsqlTool(mockFormData);
+
+      expect(result).toEqual(expectedTool);
+    });
+  });
+
+  describe('transformEsqlFormDataForCreate', () => {
+    it('should transform ES|QL form data to a create tool payload', () => {
+      const expectedPayload: CreateToolPayload = mockTool;
+
+      const result = transformEsqlFormDataForCreate(mockFormData);
+      expect(result).toEqual(expectedPayload);
+    });
+
+    it('should handle empty params and tags', () => {
+      const formData: OnechatEsqlToolFormData = {
+        name: 'simple-test-tool',
+        description: 'A simple tool with no params or tags.',
+        esql: 'FROM other_index',
+        params: [],
+        tags: [],
+      };
+
+      const expectedPayload: CreateToolPayload = {
+        id: 'simple-test-tool',
+        description: 'A simple tool with no params or tags.',
+        configuration: {
+          query: 'FROM other_index',
+          params: {},
+        },
+        type: ToolType.esql,
+        tags: [],
+      };
+
+      const result = transformEsqlFormDataForCreate(formData);
+      expect(result).toEqual(expectedPayload);
+    });
+
+    it('should filter out params that are not used in the ES|QL query', () => {
+      const formData: OnechatEsqlToolFormData = {
+        name: 'my-test-tool',
+        description: 'A tool for testing.',
+        esql: 'FROM my_index | LIMIT 10 | WHERE field1 == ?param1',
+        params: [
+          { name: 'param1', type: 'text', description: 'A string parameter.' },
+          { name: 'param2', type: 'long', description: 'A number parameter.' },
+        ],
+        tags: ['test', 'esql'],
+      };
+
+      const expectedPayload: CreateToolPayload = {
+        id: 'my-test-tool',
+        description: 'A tool for testing.',
+        configuration: {
+          query: 'FROM my_index | LIMIT 10 | WHERE field1 == ?param1',
+          params: {
+            param1: {
+              type: 'text',
+              description: 'A string parameter.',
+            },
           },
         },
-      },
-      type: ToolType.esql,
-      tags: ['test', 'esql'],
-    };
+        type: ToolType.esql,
+        tags: ['test', 'esql'],
+      };
 
-    const result = transformEsqlFormData(formData);
-    expect(result).toEqual(expectedPayload);
+      const result = transformEsqlFormDataForCreate(formData);
+      expect(result).toEqual(expectedPayload);
+    });
+  });
+  describe('transformEsqlFormDataForUpdate', () => {
+    it('should transform ES|QL form data to an update tool payload', () => {
+      const { id, type, ...toolWithoutIdAndType } = mockTool;
+
+      const result = transformEsqlFormDataForUpdate(mockFormData);
+      expect(result).toEqual(toolWithoutIdAndType);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/onechat/public/application/utils/transform_esql_form_data.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/utils/transform_esql_form_data.ts
@@ -6,16 +6,36 @@
  */
 
 import { getESQLQueryVariables } from '@kbn/esql-utils';
-import { EsqlToolFieldTypes, ToolType } from '@kbn/onechat-common';
-import { CreateToolPayload } from '../../../common/http_api/tools';
+import { EsqlToolDefinition, EsqlToolFieldTypes, ToolType } from '@kbn/onechat-common';
+import { omit } from 'lodash';
+import { CreateToolPayload, UpdateToolPayload } from '../../../common/http_api/tools';
 import { OnechatEsqlToolFormData } from '../components/tools/esql/form/types/esql_tool_form_types';
 
 /**
- * Transforms ES|QL form data into a payload for the create tools API.
- * @param data - The ES|QL form data to transform.
- * @returns The payload for the create tools API.
+ * Transforms an ES|QL tool into its UI form representation.
+ * @param tool - The ES|QL tool to transform.
+ * @returns The ES|QL tool form data.
  */
-export const transformEsqlFormData = (data: OnechatEsqlToolFormData): CreateToolPayload => {
+export const transformEsqlToolToFormData = (tool: EsqlToolDefinition): OnechatEsqlToolFormData => {
+  return {
+    name: tool.id,
+    description: tool.description,
+    esql: tool.configuration.query,
+    tags: tool.tags,
+    params: Object.entries(tool.configuration.params).map(([name, { type, description }]) => ({
+      name,
+      type,
+      description,
+    })),
+  };
+};
+
+/**
+ * Transforms ES|QL tool form data into a `ToolDefinition` entity.
+ * @param data - The ES|QL form data to transform.
+ * @returns The transformed data as an ES|QL tool.
+ */
+export const transformFormDataToEsqlTool = (data: OnechatEsqlToolFormData): EsqlToolDefinition => {
   const esqlParams = new Set(getESQLQueryVariables(data.esql));
   return {
     id: data.name,
@@ -35,4 +55,26 @@ export const transformEsqlFormData = (data: OnechatEsqlToolFormData): CreateTool
     type: ToolType.esql,
     tags: data.tags,
   };
+};
+
+/**
+ * Transforms ES|QL form data into a payload for the create tools API.
+ * @param data - The ES|QL form data to transform.
+ * @returns The payload for the create tools API.
+ */
+export const transformEsqlFormDataForCreate = (
+  data: OnechatEsqlToolFormData
+): CreateToolPayload => {
+  return transformFormDataToEsqlTool(data);
+};
+
+/**
+ * Transforms ES|QL tool form data into a payload for the update tool API.
+ * @param data - The ES|QL form data to transform.
+ * @returns The payload for the update tool API.
+ */
+export const transformEsqlFormDataForUpdate = (
+  data: OnechatEsqlToolFormData
+): UpdateToolPayload => {
+  return omit(transformFormDataToEsqlTool(data), ['id', 'type']);
 };


### PR DESCRIPTION
## Summary

Adds the ability to edit ES|QL tools from the tools page, leveraging the existing flyout UI used when creating new ES|QL tools.

https://github.com/user-attachments/assets/7d80a2a2-ac66-41c2-9c7a-4b7de941451f


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

