### PR TITLE
[9.0] [Discover] Update the logic of selecting a sub field to be used when fetching field stats (#228969)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.test.ts
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { stubDataView, stubLogstashDataView } from '@kbn/data-views-plugin/common/data_view.stub';
+import { getFieldForStats } from './field_list_item_stats';
+
+describe('getFieldForStats', () => {
+  it('should return the field itself if no multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    const resultText = getFieldForStats(fieldExtensionText, undefined);
+    expect(resultText).toBe(fieldExtensionText);
+
+    const fieldExtensionKeyword = stubDataView.getFieldByName('machine.os.raw')!;
+    expect(fieldExtensionKeyword.aggregatable).toBe(true);
+    const resultKeyword = getFieldForStats(fieldExtensionKeyword, undefined);
+    expect(resultKeyword).toBe(fieldExtensionKeyword);
+  });
+
+  it('should return an aggregatable field itself even when multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    const fieldExtensionKeyword = stubDataView.getFieldByName('machine.os.raw')!;
+    const fieldExtensionKeyword2 = stubDataView.getFieldByName('bytes')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    expect(fieldExtensionKeyword.aggregatable).toBe(true);
+    expect(fieldExtensionKeyword2.aggregatable).toBe(true);
+    const resultKeyword = getFieldForStats(fieldExtensionKeyword, [
+      { field: fieldExtensionKeyword2, isSelected: false },
+      { field: fieldExtensionText, isSelected: false },
+    ]);
+    expect(resultKeyword).toBe(fieldExtensionKeyword);
+  });
+
+  it('should return an aggregatable field when multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    const fieldExtensionKeyword = stubDataView.getFieldByName('machine.os.raw')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    expect(fieldExtensionKeyword.aggregatable).toBe(true);
+    const resultKeyword = getFieldForStats(fieldExtensionText, [
+      { field: fieldExtensionKeyword, isSelected: false },
+    ]);
+    expect(resultKeyword).toBe(fieldExtensionKeyword);
+  });
+
+  it('should return the field itself when no aggregatable multiFields are provided', () => {
+    const fieldExtensionText = stubDataView.getFieldByName('machine.os')!;
+    const fieldExtensionText2 = stubLogstashDataView.getFieldByName('hashed')!;
+    expect(fieldExtensionText.aggregatable).toBe(false);
+    expect(fieldExtensionText2.aggregatable).toBe(false);
+    const resultFallback = getFieldForStats(fieldExtensionText, [
+      { field: fieldExtensionText2, isSelected: false },
+    ]);
+    expect(resultFallback).toBe(fieldExtensionText);
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item_stats.tsx
@@ -36,14 +36,8 @@ export const UnifiedFieldListItemStats: React.FC<UnifiedFieldListItemStatsProps>
       data: services.data,
       timeRangeUpdatesType: stateService.creationOptions.timeRangeUpdatesType,
     });
-    // prioritize an aggregatable multi field if available or take the parent field
-    const fieldForStats = useMemo(
-      () =>
-        (multiFields?.length &&
-          multiFields.find((multiField) => multiField.field.aggregatable)?.field) ||
-        field,
-      [field, multiFields]
-    );
+
+    const fieldForStats = useMemo(() => getFieldForStats(field, multiFields), [field, multiFields]);
 
     const statsServices: FieldStatsServices = useMemo(
       () => ({
@@ -80,3 +74,18 @@ export const UnifiedFieldListItemStats: React.FC<UnifiedFieldListItemStatsProps>
     );
   }
 );
+
+export const getFieldForStats = (
+  field: DataViewField,
+  multiFields: Array<{ field: DataViewField; isSelected: boolean }> | undefined
+): DataViewField => {
+  if (field.aggregatable) {
+    return field;
+  }
+  // prioritize an aggregatable multi field if available or take the parent field
+  return (
+    (multiFields?.length &&
+      multiFields.find((multiField) => multiField.field.aggregatable)?.field) ||
+    field
+  );
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Discover] Update the logic of selecting a sub field to be used when fetching field stats (#228969)](https://github.com/elastic/kibana/pull/228969)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2025-07-24T05:56:58Z","message":"[Discover] Update the logic of selecting a sub field to be used when fetching field stats (#228969)\n\n- Fixes https://github.com/elastic/kibana/issues/228952\n\n## Summary\n\nThis PR fixes what field is being picked for fetching stats in the\nsidebar popover. Previously, it was choosing one of the multi fields,\nnow it will choose the parent field first (sidebar groups similar fields\nand displays them inside the popover).\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2e40596a12abc3cd942eb09588895a7b5eafa0e6","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:prev-major","v9.2.0"],"title":"[Discover] Update the logic of selecting a sub field to be used when fetching field stats","number":228969,"url":"https://github.com/elastic/kibana/pull/228969","mergeCommit":{"message":"[Discover] Update the logic of selecting a sub field to be used when fetching field stats (#228969)\n\n- Fixes https://github.com/elastic/kibana/issues/228952\n\n## Summary\n\nThis PR fixes what field is being picked for fetching stats in the\nsidebar popover. Previously, it was choosing one of the multi fields,\nnow it will choose the parent field first (sidebar groups similar fields\nand displays them inside the popover).\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2e40596a12abc3cd942eb09588895a7b5eafa0e6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228969","number":228969,"mergeCommit":{"message":"[Discover] Update the logic of selecting a sub field to be used when fetching field stats (#228969)\n\n- Fixes https://github.com/elastic/kibana/issues/228952\n\n## Summary\n\nThis PR fixes what field is being picked for fetching stats in the\nsidebar popover. Previously, it was choosing one of the multi fields,\nnow it will choose the parent field first (sidebar groups similar fields\nand displays them inside the popover).\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2e40596a12abc3cd942eb09588895a7b5eafa0e6"}},{"url":"https://github.com/elastic/kibana/pull/229237","number":229237,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/229238","number":229238,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/229240","number":229240,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->