### PR TITLE
[Streams] Udpate processors doc links

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/geoip.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/geoip.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCode, EuiLink } from '@elastic/eui';
 import { GeoIpProcessorConfig, GeoIpProcessorDefinition } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { ConfigDrivenProcessorConfiguration, FieldConfiguration, FieldOptions } from '../types';
 import { getConvertFormStateToConfig, getConvertProcessorToFormState } from '../utils';
 
@@ -109,7 +110,7 @@ export const geoIpProcessorConfig: ConfigDrivenProcessorConfiguration<
       defaultMessage: 'GeoIP',
     }
   ),
-  getDocUrl: (esDocUrl: string) => {
+  getDocUrl: (docLinks: DocLinksStart) => {
     return (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.geoIpHelpText"
@@ -120,7 +121,7 @@ export const geoIpProcessorConfig: ConfigDrivenProcessorConfiguration<
               data-test-subj="streamsAppAvailableProcessorsGeoIpLink"
               external
               target="_blank"
-              href={esDocUrl + 'geoip-processor.html'}
+              href={docLinks.links.ingest.geoip}
             >
               {i18n.translate('xpack.streams.availableProcessors.geoIpLinkLabel', {
                 defaultMessage: 'IPv4 or IPv6 address.',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/geoip.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/geoip.tsx
@@ -121,7 +121,7 @@ export const geoIpProcessorConfig: ConfigDrivenProcessorConfiguration<
               data-test-subj="streamsAppAvailableProcessorsGeoIpLink"
               external
               target="_blank"
-              href={docLinks.links.ingest.geoip}
+              href={docLinks.links.ingest.geoIp}
             >
               {i18n.translate('xpack.streams.availableProcessors.geoIpLinkLabel', {
                 defaultMessage: 'IPv4 or IPv6 address.',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/kv.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/kv.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiLink } from '@elastic/eui';
 import { EuiCode } from '@elastic/eui';
 import { KvProcessorConfig, KvProcessorDefinition } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { ALWAYS_CONDITION } from '../../../../../../util/condition';
 import { ConfigDrivenProcessorConfiguration, FieldConfiguration, FieldOptions } from '../types';
 import { getConvertFormStateToConfig, getConvertProcessorToFormState } from '../utils';
@@ -202,7 +203,7 @@ export const kvProcessorConfig: ConfigDrivenProcessorConfiguration<
       defaultMessage: 'Key-value (KV)',
     }
   ),
-  getDocUrl: (esDocUrl: string) => {
+  getDocUrl: (docLinks: DocLinksStart) => {
     return (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.kvHelpText"
@@ -213,7 +214,7 @@ export const kvProcessorConfig: ConfigDrivenProcessorConfiguration<
               data-test-subj="streamsAppAvailableProcessorsKvLink"
               external
               target="_blank"
-              href={esDocUrl + 'kv-processor.html'}
+              href={docLinks.links.ingest.kv}
             >
               {i18n.translate('xpack.streams.availableProcessors.kvLinkLabel', {
                 defaultMessage: 'foo=bar variety.',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/rename.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/rename.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiLink } from '@elastic/eui';
 import { RenameProcessorConfig, RenameProcessorDefinition } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { ALWAYS_CONDITION } from '../../../../../../util/condition';
 import { ConfigDrivenProcessorConfiguration, FieldConfiguration, FieldOptions } from '../types';
 import { getConvertFormStateToConfig, getConvertProcessorToFormState } from '../utils';
@@ -80,7 +81,7 @@ export const renameProcessorConfig: ConfigDrivenProcessorConfiguration<
       defaultMessage: 'Rename',
     }
   ),
-  getDocUrl: (esDocUrl: string) => {
+  getDocUrl: (docLinks: DocLinksStart) => {
     return (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.renameHelpText"
@@ -91,7 +92,7 @@ export const renameProcessorConfig: ConfigDrivenProcessorConfiguration<
               data-test-subj="streamsAppAvailableProcessorsRenameLink"
               external
               target="_blank"
-              href={esDocUrl + 'rename-processor.html'}
+              href={docLinks.links.ingest.rename}
             >
               {i18n.translate('xpack.streams.availableProcessors.renameLinkLabel', {
                 defaultMessage: 'Renames an existing field.',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/set.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/set.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCode, EuiLink } from '@elastic/eui';
 import { SetProcessorConfig, SetProcessorDefinition } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { ALWAYS_CONDITION } from '../../../../../../util/condition';
 import { ConfigDrivenProcessorConfiguration, FieldConfiguration, FieldOptions } from '../types';
 import { getConvertFormStateToConfig, getConvertProcessorToFormState } from '../utils';
@@ -113,7 +114,7 @@ export const setProcessorConfig: ConfigDrivenProcessorConfiguration<
       defaultMessage: 'Set',
     }
   ),
-  getDocUrl: (esDocUrl: string) => {
+  getDocUrl: (docLinks: DocLinksStart) => {
     return (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.setHelpText"
@@ -124,7 +125,7 @@ export const setProcessorConfig: ConfigDrivenProcessorConfiguration<
               data-test-subj="streamsAppAvailableProcessorsSetLink"
               external
               target="_blank"
-              href={esDocUrl + 'set-processor.html'}
+              href={docLinks.links.ingest.set}
             >
               {i18n.translate('xpack.streams.availableProcessors.setLinkLabel', {
                 defaultMessage: 'Sets one field and associates it with the specified value.',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/url_decode.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/url_decode.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCode, EuiLink } from '@elastic/eui';
 import { UrlDecodeProcessorConfig, UrlDecodeProcessorDefinition } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { ALWAYS_CONDITION } from '../../../../../../util/condition';
 import { ConfigDrivenProcessorConfiguration, FieldConfiguration, FieldOptions } from '../types';
 import { getConvertFormStateToConfig, getConvertProcessorToFormState } from '../utils';
@@ -67,7 +68,7 @@ export const urlDecodeProcessorConfig: ConfigDrivenProcessorConfiguration<
       defaultMessage: 'URL Decode',
     }
   ),
-  getDocUrl: (esDocUrl: string) => {
+  getDocUrl: (docLinks: DocLinksStart) => {
     return (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.urlDecodeHelpText"
@@ -78,7 +79,7 @@ export const urlDecodeProcessorConfig: ConfigDrivenProcessorConfiguration<
               data-test-subj="streamsAppAvailableProcessorsUrlDecodeLink"
               external
               target="_blank"
-              href={esDocUrl + 'urldecode-processor.html'}
+              href={docLinks.links.ingest.urlDecode}
             >
               {i18n.translate('xpack.streams.availableProcessors.urlDecodeLinkLabel', {
                 defaultMessage: 'URL-decodes a string.',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/user_agent.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/configs/user_agent.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCode, EuiLink } from '@elastic/eui';
 import { UserAgentProcessorConfig, UserAgentProcessorDefinition } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { ConfigDrivenProcessorConfiguration, FieldConfiguration, FieldOptions } from '../types';
 import { getConvertFormStateToConfig, getConvertProcessorToFormState } from '../utils';
 
@@ -99,7 +100,7 @@ export const userAgentProcessorConfig: ConfigDrivenProcessorConfiguration<
       defaultMessage: 'User agent',
     }
   ),
-  getDocUrl: (esDocUrl: string) => {
+  getDocUrl: (docLinks: DocLinksStart) => {
     return (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.userAgentHelpText"
@@ -110,7 +111,7 @@ export const userAgentProcessorConfig: ConfigDrivenProcessorConfiguration<
               data-test-subj="streamsAppAvailableProcessorsUserAgentLink"
               external
               target="_blank"
-              href={esDocUrl + 'user-agent-processor.html'}
+              href={docLinks.links.ingest.userAgent}
             >
               {i18n.translate('xpack.streams.availableProcessors.userAgentLinkLabel', {
                 defaultMessage: 'The user_agent processor',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/config_driven/types.ts
@@ -6,6 +6,7 @@
  */
 
 import { ProcessorDefinition } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { configDrivenProcessors } from '.';
 import { WithUIAttributes } from '../../types';
 
@@ -15,7 +16,7 @@ export interface ConfigDrivenProcessorConfiguration<
 > {
   type: ConfigDrivenProcessorType;
   inputDisplay: string;
-  getDocUrl: (esDocUrl: string) => React.ReactNode;
+  getDocUrl: (docLinks: DocLinksStart) => React.ReactNode;
   defaultFormState: FormStateT;
   convertFormStateToConfig: (formState: FormStateT) => ProcessorDefinitionT;
   convertProcessorToFormState: (processor: WithUIAttributes<ProcessorDefinitionT>) => FormStateT;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/processor_type_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/processor_type_selector.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 import { ProcessorType } from '@kbn/streams-schema';
+import { DocLinksStart } from '@kbn/core/public';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { getDefaultFormStateByType } from '../utils';
 import { ProcessorFormState } from '../types';
@@ -22,7 +23,7 @@ import { useStreamEnrichmentSelector } from '../state_management/stream_enrichme
 interface TAvailableProcessor {
   type: ProcessorType;
   inputDisplay: string;
-  getDocUrl: (esDocUrl: string) => React.ReactNode;
+  getDocUrl: (docLinks: DocLinksStart) => React.ReactNode;
 }
 
 type TAvailableProcessors = Record<ProcessorType, TAvailableProcessor>;
@@ -31,7 +32,6 @@ export const ProcessorTypeSelector = ({
   disabled = false,
 }: Pick<EuiSuperSelectProps, 'disabled'>) => {
   const { core } = useKibana();
-  const esDocUrl = core.docLinks.links.elasticsearch.docsBase;
   const getEnrichmentState = useGetStreamEnrichmentState();
 
   const { reset } = useFormContext();
@@ -60,7 +60,7 @@ export const ProcessorTypeSelector = ({
         'xpack.streams.streamDetailView.managementTab.enrichment.processor.typeSelectorLabel',
         { defaultMessage: 'Processor' }
       )}
-      helpText={getProcessorDescription(esDocUrl)(processorType)}
+      helpText={getProcessorDescription(core.docLinks)(processorType)}
     >
       <EuiSuperSelect
         disabled={disabled}
@@ -92,7 +92,7 @@ const availableProcessors: TAvailableProcessors = {
   dissect: {
     type: 'dissect',
     inputDisplay: 'Dissect',
-    getDocUrl: (esDocUrl: string) => (
+    getDocUrl: (docLinks: DocLinksStart) => (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.dissectHelpText"
         defaultMessage="Uses {dissectLink} patterns to extract matches from a field."
@@ -102,7 +102,7 @@ const availableProcessors: TAvailableProcessors = {
               data-test-subj="streamsAppAvailableProcessorsDissectLink"
               external
               target="_blank"
-              href={esDocUrl + 'dissect-processor.html'}
+              href={docLinks.links.ingest.dissect}
             >
               {i18n.translate('xpack.streams.availableProcessors.dissectLinkLabel', {
                 defaultMessage: 'dissect',
@@ -116,7 +116,7 @@ const availableProcessors: TAvailableProcessors = {
   grok: {
     type: 'grok',
     inputDisplay: 'Grok',
-    getDocUrl: (esDocUrl: string) => (
+    getDocUrl: (docLinks: DocLinksStart) => (
       <FormattedMessage
         id="xpack.streams.streamDetailView.managementTab.enrichment.processor.grokHelpText"
         defaultMessage="Uses {grokLink} expressions to extract matches from a field."
@@ -126,7 +126,7 @@ const availableProcessors: TAvailableProcessors = {
               data-test-subj="streamsAppAvailableProcessorsGrokLink"
               external
               target="_blank"
-              href={esDocUrl + 'grok-processor.html'}
+              href={docLinks.links.ingest.grok}
             >
               {i18n.translate('xpack.streams.availableProcessors.grokLinkLabel', {
                 defaultMessage: 'grok',
@@ -150,8 +150,8 @@ const availableProcessors: TAvailableProcessors = {
   },
 };
 
-const getProcessorDescription = (esDocUrl: string) => (type: ProcessorType) =>
-  availableProcessors[type].getDocUrl(esDocUrl);
+const getProcessorDescription = (docLinks: DocLinksStart) => (type: ProcessorType) =>
+  availableProcessors[type].getDocUrl(docLinks);
 
 const processorTypeSelectorOptions = Object.values(availableProcessors).map(
   ({ type, inputDisplay }) => ({ value: type, inputDisplay })


### PR DESCRIPTION
## 📓 Summary

Closes #229250 

After being refactored with https://github.com/elastic/kibana/pull/219286, the new doc links for processors are accessible through the core docLink map. This work fixes the processors' broken links.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->