### PR TITLE
[SharedUX] Fix toast counter badge stack order

### DIFF
--- a/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/deduplicate_toasts.test.tsx.snap
+++ b/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/deduplicate_toasts.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TitleWithBadge component renders with string titles 1`] = `
   Welcome!
    
   <EuiNotificationBadge
-    className="css-721pd1-floatTopRight"
+    className="css-1aoydhg-floatTopRight"
     color="subdued"
     size="m"
   >

--- a/src/core/packages/notifications/browser-internal/src/toasts/deduplicate_toasts.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/deduplicate_toasts.tsx
@@ -120,6 +120,7 @@ const floatTopRight = css`
   position: absolute;
   top: -8px;
   right: -8px;
+  z-index: 1;
 `;
 
 /**

--- a/x-pack/platform/plugins/private/canvas/public/components/export_app/__snapshots__/export_app.test.tsx.snap
+++ b/x-pack/platform/plugins/private/canvas/public/components/export_app/__snapshots__/export_app.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`<ExportApp /> renders as expected 1`] = `
                     data-s=""
                   >
                     
-                    .css-721pd1-floatTopRight{position:absolute;top:-8px;right:-8px;}
+                    .css-1aoydhg-floatTopRight{position:absolute;top:-8px;right:-8px;z-index:1;}
                   </style>
                   <style
                     data-emotion="css"
@@ -199,7 +199,7 @@ exports[`<ExportApp /> renders as expected 2`] = `
                     data-s=""
                   >
                     
-                    .css-721pd1-floatTopRight{position:absolute;top:-8px;right:-8px;}
+                    .css-1aoydhg-floatTopRight{position:absolute;top:-8px;right:-8px;z-index:1;}
                   </style>
                   <style
                     data-emotion="css"


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/226225

## Summary
- Fixed the toast counter badge which was positioned behind the toast (toast stack context sets [z-index: 9000](https://github.com/elastic/eui/blob/aa115fbc28a3fc107ebabbb75f6fdae75d32c976/packages/eui-theme-common/src/global_styling/variables/levels.ts#L42-L43))
- Original toast counter PR: https://github.com/elastic/kibana/pull/161738
- As discussed on that PR, a more robust approach would include this counter in the EUI component itself but it seems that it was discarded here: https://github.com/elastic/eui/issues/6945 after Kibana's usecase being covered by this simpler approach

## Visuals
### Before/After Success

<img width="345" height="77" alt="Screenshot 2025-07-24 at 11 27 06" src="https://github.com/user-attachments/assets/47ac83d4-7c4b-4b12-ba34-a1c124fe8780" />

<img width="349" height="78" alt="Screenshot 2025-07-24 at 11 27 54" src="https://github.com/user-attachments/assets/dac9ddf0-c7b2-47a5-971e-d83c67ed54b8" />

### Before/After Info Flavour

<img width="346" height="78" alt="Screenshot 2025-07-24 at 11 36 50" src="https://github.com/user-attachments/assets/72fe86a3-9a76-4517-8d69-4ef544d6ec4b" />

<img width="346" height="77" alt="Screenshot 2025-07-24 at 11 37 20" src="https://github.com/user-attachments/assets/62c8365d-602e-4164-8e69-5afcf1ab9e09" />

### Before/After Success Mobile
<img width="398" height="135" alt="Screenshot 2025-07-24 at 11 29 39" src="https://github.com/user-attachments/assets/7005eefd-6ed3-4a70-8bff-ac02da7b542f" />

<img width="395" height="132" alt="Screenshot 2025-07-24 at 11 28 35" src="https://github.com/user-attachments/assets/567111ce-c798-48e9-be67-ebff31553ac3" />


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->