### PR TITLE
[ES|QL] LOOKUP JOIN: Hover Action, Query Insertion Fix and decorator refresh

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.test.tsx
@@ -31,7 +31,9 @@ describe('appendIndexToJoinCommand', () => {
       { lineNumber: 1, column: 44 } as monaco.Position,
       'new_index'
     );
-    expect(result).toBe('FROM kibana_sample_data_logs | LOOKUP JOIN new_index | LIMIT 10');
+    expect(result).toBe(`FROM kibana_sample_data_logs
+  | LOOKUP JOIN new_index
+  | LIMIT 10`);
   });
 
   it('should append index name to the join command in multi-line query', () => {
@@ -53,9 +55,10 @@ describe('appendIndexToJoinCommand', () => {
       { lineNumber: 1, column: 82 } as monaco.Position,
       'another_index'
     );
-    expect(result).toBe(
-      'FROM kibana_sample_data_logs | LOOKUP JOIN new_index ON some_field | LOOKUP JOIN another_index | LIMIT 10'
-    );
+    expect(result).toBe(`FROM kibana_sample_data_logs
+  | LOOKUP JOIN new_index ON some_field
+  | LOOKUP JOIN another_index
+  | LIMIT 10`);
   });
 
   it('should not append index name if an index argument with the same name is already present', () => {
@@ -73,6 +76,8 @@ describe('appendIndexToJoinCommand', () => {
       { lineNumber: 1, column: 53 } as monaco.Position,
       'new_index_2'
     );
-    expect(result).toBe('FROM kibana_sample_data_logs | LOOKUP JOIN new_index_2 | LIMIT 10');
+    expect(result).toBe(`FROM kibana_sample_data_logs
+  | LOOKUP JOIN new_index_2
+  | LIMIT 10`);
   });
 });

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.test.tsx
@@ -11,6 +11,20 @@ import { appendIndexToJoinCommand } from './create_lookup_index';
 import { monaco } from '@kbn/monaco';
 
 describe('appendIndexToJoinCommand', () => {
+  it('replaces existing index argument', () => {
+    const result = appendIndexToJoinCommand(
+      `FROM kibana_sample_data_ecommerce
+  | EVAL customer_id = TO_LONG(customer_id)
+  | LOOKUP JOIN customer_data ON customer_id | LOOKUP JOIN test1123`,
+      'test1123',
+      'new_index'
+    );
+    expect(result).toBe(`FROM kibana_sample_data_ecommerce
+  | EVAL customer_id = TO_LONG(customer_id)
+  | LOOKUP JOIN customer_data ON customer_id
+  | LOOKUP JOIN new_index`);
+  });
+
   it('should append index name to the join command', () => {
     const result = appendIndexToJoinCommand(
       'FROM kibana_sample_data_logs | LOOKUP JOIN  | LIMIT 10',

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
@@ -204,15 +204,9 @@ export const useLookupIndexCommand = (
 
   const onFlyoutClose = useCallback(
     (initialIndexName: string | undefined, resultIndexName: string, indexCreated: boolean) => {
-      console.log(initialIndexName, '___initialIndexName___');
-      console.log(resultIndexName, '___resultIndexName___');
-      console.log(indexCreated, '___indexCreated___');
-
       if (!indexCreated) return;
 
       const cursorPosition = editorRef.current?.getPosition();
-
-      console.log(cursorPosition, '___cursorPosition___');
 
       if (!initialIndexName && !cursorPosition) {
         throw new Error('Could not find cursor position in the editor');
@@ -326,33 +320,8 @@ export const useLookupIndexCommand = (
     [query.esql, addLookupIndicesDecorator]
   );
 
-  /**
-   * the onClick handler is set only once, hence the reference has to be stable.
-   */
-  const lookupIndexLabelClickHandler = useCallback(
-    async (e: monaco.editor.IEditorMouseEvent) => {
-      const mousePosition = e.target.position;
-      if (!mousePosition) return;
-
-      const currentWord = editorModel.current?.getWordAtPosition(mousePosition);
-      const clickedIndexName = inQueryLookupIndices.current.find((v) =>
-        currentWord?.word.includes(v)
-      );
-
-      const doesIndexExist = (await getLookupIndicesMemoized()).indices.some(
-        (index) => index.name === clickedIndexName
-      );
-
-      if (clickedIndexName) {
-        await openFlyout(clickedIndexName, doesIndexExist);
-      }
-    },
-    [editorModel, getLookupIndicesMemoized, openFlyout]
-  );
-
   return {
     addLookupIndicesDecorator,
     lookupIndexBadgeStyle,
-    lookupIndexLabelClickHandler,
   };
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
@@ -18,6 +18,7 @@ import { type ESQLSource } from '@kbn/esql-ast';
 import { Parser } from '@kbn/esql-ast/src/parser/parser';
 import { memoize } from 'lodash';
 import { IndexAutocompleteItem } from '@kbn/esql-types';
+import { i18n } from '@kbn/i18n';
 import type { ESQLEditorDeps } from '../types';
 
 /**
@@ -81,21 +82,11 @@ export const useLookupIndexCommand = (
 
   const lookupIndexBadgeStyle = css`
     .${lookupIndexBaseBadgeClassName} {
-      cursor: pointer;
-      display: inline-block;
-      vertical-align: middle;
-      padding-block: 0px;
-      padding-inline: 2px;
-      max-inline-size: 100%;
-      font-size: 0.8571rem;
-      line-height: 18px;
-      font-weight: 500;
       white-space: nowrap;
       text-decoration: none;
-      border-radius: 3px;
+      border-radius: ${euiTheme.border.radius.small};
       text-align: start;
-      border-width: 1px;
-      border-style: solid;
+      border-width: ${euiTheme.border.thin};
       color: ${euiTheme.colors.text};
     }
     .${lookupIndexAddBadgeClassName} {
@@ -165,9 +156,13 @@ export const useLookupIndexCommand = (
     [onFlyoutClose, uiActions]
   );
 
-  monaco.editor.registerCommand('esql.lookup_index.create', async (_, indexName) => {
-    await openFlyout(indexName, false);
-  });
+  monaco.editor.registerCommand(
+    'esql.lookup_index.create',
+    async (_, args: { indexName: string; doesIndexExist?: boolean }) => {
+      const { indexName, doesIndexExist } = args;
+      await openFlyout(indexName, doesIndexExist);
+    }
+  );
 
   const getLookupIndicesMemoized = useMemo(
     () => memoize(getLookupIndices ?? (() => Promise.resolve({ indices: [] }))),
@@ -208,6 +203,21 @@ export const useLookupIndexCommand = (
               options: {
                 isWholeLine: false,
                 stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+                hoverMessage: {
+                  value: `[${
+                    isExistingIndex
+                      ? i18n.translate('esqlEditor.lookupIndex.edit', {
+                          defaultMessage: 'Edit lookup index',
+                        })
+                      : i18n.translate('esqlEditor.lookupIndex.create', {
+                          defaultMessage: 'Create lookup index',
+                        })
+                  }](command:esql.lookup_index.create?${encodeURIComponent(
+                    JSON.stringify({ indexName: lookupIndex, doesIndexExist: isExistingIndex })
+                  )})`,
+                  isTrusted: true,
+                },
+
                 inlineClassName:
                   lookupIndexBaseBadgeClassName +
                   ' ' +

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
@@ -257,7 +257,10 @@ export const useLookupIndexCommand = (
     const lineCount = editorModel.current?.getLineCount() || 1;
     for (let i = 1; i <= lineCount; i++) {
       const decorations = editorRef.current?.getLineDecorations(i) ?? [];
-      editorRef?.current?.removeDecorations(decorations.map((d) => d.id));
+      const lookupIndexDecorations = decorations.filter((decoration) =>
+        decoration.options.inlineClassName?.includes(lookupIndexBaseBadgeClassName)
+      );
+      editorRef?.current?.removeDecorations(lookupIndexDecorations.map((d) => d.id));
     }
 
     getLookupIndicesMemoized().then(({ indices: existingIndices }) => {

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
@@ -272,7 +272,7 @@ export const useLookupIndexCommand = (
       editorRef?.current?.removeDecorations(lookupIndexDecorations.map((d) => d.id));
     }
 
-    const existingIndices = await getLookupIndices!();
+    const existingIndices = getLookupIndices ? await getLookupIndices() : { indices: [] };
 
     const lookupIndices: string[] = inQueryLookupIndices.current;
 

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
@@ -21,7 +21,7 @@ import { i18n } from '@kbn/i18n';
 import type { ESQLEditorDeps } from '../types';
 
 /**
- * Replace the index referenced by the JOIN that the user created.
+ * Replace the index name in a join command.
  *
  * @param query             - full ES|QL query
  * @param initialIndexOrPos - either the index name we want to replace OR a Monaco
@@ -44,7 +44,7 @@ export function appendIndexToJoinCommand(
     targetName = initialIndexOrPos.trim();
   }
 
-  // If we came through name-path and it equals new name – nothing to do
+  // If we came through name-path, and it equals new name – nothing to do
   if (typeof initialIndexOrPos === 'string' && targetName === createdIndexName) {
     return query;
   }

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_commands/create_lookup_index.tsx
@@ -207,7 +207,7 @@ export const useLookupIndexCommand = (
         }
       });
 
-      inQueryLookupIndices.current = indexNames;
+      inQueryLookupIndices.current = Array.from(new Set(indexNames));
     },
     [query.esql]
   );
@@ -285,16 +285,9 @@ export const useLookupIndexCommand = (
         editorModel.current?.findMatches(lookupIndex, true, false, true, ' ', true) || [];
 
       matches.forEach((match) => {
-        const range = new monaco.Range(
-          match.range.startLineNumber,
-          match.range.startColumn,
-          match.range.endLineNumber,
-          match.range.endColumn
-        );
-
         editorRef?.current?.createDecorationsCollection([
           {
-            range,
+            range: match.range,
             options: {
               isWholeLine: false,
               stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -590,14 +590,13 @@ export const ESQLEditor = memo(function ESQLEditor({
     [esqlCallbacks, onQueryUpdate]
   );
 
-  const { lookupIndexBadgeStyle, lookupIndexLabelClickHandler, addLookupIndicesDecorator } =
-    useCreateLookupIndexCommand(
-      editor1,
-      editorModel,
-      esqlCallbacks?.getJoinIndices,
-      query,
-      onIndexCreated
-    );
+  const { lookupIndexBadgeStyle, addLookupIndicesDecorator } = useCreateLookupIndexCommand(
+    editor1,
+    editorModel,
+    esqlCallbacks?.getJoinIndices,
+    query,
+    onIndexCreated
+  );
 
   const queryRunButtonProperties = useMemo(() => {
     if (allowQueryCancellation && isLoading) {
@@ -927,7 +926,6 @@ export const ESQLEditor = memo(function ESQLEditor({
                       if (datePickerOpenStatusRef.current) {
                         setPopoverPosition({});
                       }
-                      await lookupIndexLabelClickHandler(e);
                     });
 
                     editor.onDidFocusEditorText(() => {

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -582,20 +582,12 @@ export const ESQLEditor = memo(function ESQLEditor({
     application?.currentAppId$,
   ]);
 
-  const onIndexCreated = useCallback(
-    async (resultQueryString: string) => {
-      onQueryUpdate(resultQueryString);
-      await esqlCallbacks.getJoinIndices?.();
-    },
-    [esqlCallbacks, onQueryUpdate]
-  );
-
   const { lookupIndexBadgeStyle, addLookupIndicesDecorator } = useCreateLookupIndexCommand(
     editor1,
     editorModel,
     esqlCallbacks?.getJoinIndices,
     query,
-    onIndexCreated
+    onQueryUpdate
   );
 
   const queryRunButtonProperties = useMemo(() => {
@@ -901,13 +893,12 @@ export const ESQLEditor = memo(function ESQLEditor({
                   onChange={onQueryUpdate}
                   onFocus={() => setLabelInFocus(true)}
                   onBlur={() => setLabelInFocus(false)}
-                  editorDidMount={(editor) => {
+                  editorDidMount={async (editor) => {
                     editor1.current = editor;
                     const model = editor.getModel();
                     if (model) {
                       editorModel.current = model;
-                      // TODO add decorator here
-                      addLookupIndicesDecorator();
+                      await addLookupIndicesDecorator();
                     }
 
                     monaco.languages.setLanguageConfiguration(ESQL_LANG_ID, {

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -582,24 +582,6 @@ export const ESQLEditor = memo(function ESQLEditor({
     application?.currentAppId$,
   ]);
 
-  const onLookupIndexCreate = useCallback(
-    async (resultQuery: string) => {
-      if (esqlCallbacks?.getJoinIndices) {
-        await esqlCallbacks?.getJoinIndices();
-      }
-      onQueryUpdate(resultQuery);
-    },
-    [esqlCallbacks, onQueryUpdate]
-  );
-
-  const { lookupIndexBadgeStyle, addLookupIndicesDecorator } = useCreateLookupIndexCommand(
-    editor1,
-    editorModel,
-    esqlCallbacks?.getJoinIndices,
-    query,
-    onLookupIndexCreate
-  );
-
   const queryRunButtonProperties = useMemo(() => {
     if (allowQueryCancellation && isLoading) {
       return {
@@ -680,6 +662,28 @@ export const ESQLEditor = memo(function ESQLEditor({
       }
     },
     [parseMessages, dataErrorsControl?.enabled]
+  );
+
+  const onLookupIndexCreate = useCallback(
+    async (resultQuery: string) => {
+      if (esqlCallbacks?.getJoinIndices) {
+        // forces refresh
+        await esqlCallbacks?.getJoinIndices();
+      }
+      onQueryUpdate(resultQuery);
+      // Need to force validation, as the query might be unchanged,
+      // but the lookup index was created
+      await queryValidation({ active: true });
+    },
+    [esqlCallbacks, onQueryUpdate, queryValidation]
+  );
+
+  const { lookupIndexBadgeStyle, addLookupIndicesDecorator } = useCreateLookupIndexCommand(
+    editor1,
+    editorModel,
+    esqlCallbacks?.getJoinIndices,
+    query,
+    onLookupIndexCreate
   );
 
   useDebounceWithOptions(

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -582,12 +582,22 @@ export const ESQLEditor = memo(function ESQLEditor({
     application?.currentAppId$,
   ]);
 
+  const onLookupIndexCreate = useCallback(
+    async (resultQuery: string) => {
+      if (esqlCallbacks?.getJoinIndices) {
+        await esqlCallbacks?.getJoinIndices();
+      }
+      onQueryUpdate(resultQuery);
+    },
+    [esqlCallbacks, onQueryUpdate]
+  );
+
   const { lookupIndexBadgeStyle, addLookupIndicesDecorator } = useCreateLookupIndexCommand(
     editor1,
     editorModel,
     esqlCallbacks?.getJoinIndices,
     query,
-    onQueryUpdate
+    onLookupIndexCreate
   );
 
   const queryRunButtonProperties = useMemo(() => {
@@ -949,7 +959,10 @@ export const ESQLEditor = memo(function ESQLEditor({
                       onLayoutChangeRef.current(layoutInfoEvent);
                     });
 
-                    editor.onDidChangeModelContent(showSuggestionsIfEmptyQuery);
+                    editor.onDidChangeModelContent(async () => {
+                      await addLookupIndicesDecorator();
+                      showSuggestionsIfEmptyQuery();
+                    });
 
                     // Auto-focus the editor and move the cursor to the end.
                     if (!disableAutoFocus) {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fork/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fork/autocomplete.test.ts
@@ -269,6 +269,7 @@ describe('FORK Autocomplete', () => {
 
         test('lookup join after command name', async () => {
           await forkExpectSuggestions('FROM a | FORK (LOOKUP JOIN ', [
+            '',
             'join_index ',
             'join_index_with_alias ',
             'lookup_index ',

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
@@ -102,7 +102,7 @@ describe('JOIN Autocomplete', () => {
 
       expect(createIndexCommandSuggestion).toEqual({
         command: {
-          arguments: [''],
+          arguments: [{ indexName: '' }],
           id: 'esql.lookup_index.create',
           title: 'Click to create',
         },
@@ -131,7 +131,7 @@ describe('JOIN Autocomplete', () => {
 
       expect(createIndexCommandSuggestion).toEqual({
         command: {
-          arguments: ['new_join_index'],
+          arguments: [{ indexName: 'new_join_index' }],
           id: 'esql.lookup_index.create',
           title: 'Click to create',
         },

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/functions.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/functions.ts
@@ -461,7 +461,7 @@ export function getLookupIndexCreateSuggestion(indexName?: string): ISuggestionI
         }
       ),
 
-      arguments: [indexName],
+      arguments: [{ indexName }],
     },
   } as ISuggestionItem;
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/207330

> ⚠️ **Note for reviewers:** This PR is targeting the [feature branch](https://github.com/elastic/kibana/tree/feature/lookup-join-ux)


- Adds a hover action for opening the LOOKUP INDEX flyout
<img width="468" height="203" alt="image" src="https://github.com/user-attachments/assets/44e08b7e-d2b6-4eaf-a2f2-278596eec3cd" />

<img width="550" height="197" alt="image" src="https://github.com/user-attachments/assets/dffae7ce-78de-4ff4-bb19-15e00df82e63" />

- Fixes insertion of the created index name into the query, and prettifies the query
- Refreshes LOOKUP INDEX decorators on flyout close 

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
