### PR TITLE
[9.1] Fix SLO Plugin test failureUpdate slo_plugin_e2e.sh

### DIFF
--- a/.buildkite/scripts/steps/functional/slo_plugin_e2e.sh
+++ b/.buildkite/scripts/steps/functional/slo_plugin_e2e.sh
@@ -6,7 +6,7 @@ source .buildkite/scripts/common/util.sh
 
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/download_build_artifacts.sh
-.buildkite/scripts/copy_es_snapshot_cache.sh
+.buildkite/scripts/setup_es_snapshot_cache.sh
 
 export JOB=kibana-ux-plugin-synthetics
 


### PR DESCRIPTION
## Summary

Forward-port of #229203

Fixes test failure in `8.19` related to `SLO Plugin @elastic/synthetics Tests`.

The error is say `.buildkite/scripts/copy_es_snapshot_cache.sh` file does not exist.

```
Downloading Distribution
--
  | 2025-07-23 14:22:27 INFO   Searching for artifacts: "kibana-default.tar.gz"
  | 2025-07-23 14:22:28 INFO   Found 1 artifacts. Starting to download to: /opt/buildkite-agent/builds/bk-agent-prod-gcp-1753280263246996201/elastic/kibana-pull-request
  | 2025-07-23 14:22:36 INFO   Successfully downloaded "kibana-default.tar.gz" 367 MiB with SHA256 79a3d2c91a9e86ddb48ef4eb501527d240c7fc083cb7bb2d247e160495580c4c
  | ./.buildkite/scripts/steps/functional/slo_plugin_e2e.sh: line 9: .buildkite/scripts/copy_es_snapshot_cache.sh: No such file or directory
  | 🚨 Error: The command exited with status 127
```

See job failure [here](https://buildkite.com/elastic/kibana-pull-request/builds/322431#01983788-af40-4248-96f0-7cb5c0907c13)