### PR TITLE
fix: correct backtick syntax in grok fields

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/kv/constants.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/kv/constants.ts
@@ -20,7 +20,7 @@ export const KV_HEADER_EXAMPLE_LOGS = [
     header: '[18/Feb/2025:22:39:16 +0000] CONNECT',
     structuredBody: 'conn=20597223 from=10.1.1.1:1234 to=10.2.3.4:4389 protocol=LDAP',
     grok_pattern:
-      '[%{HTTPDATE:`{packageName}.{dataStreamName}.`timestamp}] %{WORD:`{packageName}.{dataStreamName}`action}s%{GREEDYDATA:message}',
+      '[%{HTTPDATE:{packageName}.{dataStreamName}.timestamp}] %{WORD:{packageName}.{dataStreamName}.action}s%{GREEDYDATA:message}',
   },
   {
     example:
@@ -29,7 +29,7 @@ export const KV_HEADER_EXAMPLE_LOGS = [
     structuredBody:
       'operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.1.1.1, resourceType=USER, resourcePath=users/07972d16-b173-4c99-803d-90f211080f40',
     grok_pattern:
-      '%{TIMESTAMP_ISO8601:`{packageName}.{dataStreamName}.`timestamp} %{LOGLEVEL:`{packageName}.{dataStreamName}`loglevel} [%{DATA:`{packageName}.{dataStreamName}`logsource}] (%{DATA:`{packageName}.{dataStreamName}`task})s%{GREEDYDATA:message}',
+      '%{TIMESTAMP_ISO8601:{packageName}.{dataStreamName}.timestamp} %{LOGLEVEL:{packageName}.{dataStreamName}.loglevel} [%{DATA:{packageName}.{dataStreamName}.logsource}] (%{DATA:{packageName}.{dataStreamName}.task})s%{GREEDYDATA:message}',
   },
 ];
 

--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/kv/prompts.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/kv/prompts.ts
@@ -85,7 +85,7 @@ Also look for special characters around the timestamp in Custom Format, Like a t
  - Pattern Efficiency: Ensure that both the regex and the grok pattern are as efficient as possible while still accurately capturing the header components. Avoid overly complex or overly broad patterns that could capture unintended data.
  - Make sure to map the remaining message body to \'message\' in grok pattern.
  - If there are special characters between header and message body like space character, make sure to include that character in the header grok pattern
- - Make sure to add \`{packageName}.{dataStreamName}\` as a prefix to each field in the pattern. Refer to example response.
+ - Make sure to add \'{packageName}.{dataStreamName}\' as a prefix to each field in the pattern. Refer to example response.
  - Do not respond with anything except the processor as a JSON object enclosed with 3 backticks (\`), see example response above. Use strict JSON response format.
  </guidelines>
 
@@ -136,7 +136,7 @@ You ALWAYS follow these guidelines when writing your response:
  <guidelines>
  - Do not parse the message part in the regex. Just the header part should be in regex and grok_pattern.
  - Make sure to map the remaining message body to \'message\' in grok pattern.
- - Make sure to add \`{packageName}.{dataStreamName}\` as a prefix to each field in the pattern. Refer to example response.
+ - Make sure to add \'{packageName}.{dataStreamName}\' as a prefix to each field in the pattern. Refer to example response.
  - Do not respond with anything except the processor as a JSON object enclosed with 3 backticks (\`), see example response above. Use strict JSON response format.
  </guidelines>
 

--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/unstructured/prompts.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/unstructured/prompts.ts
@@ -43,7 +43,7 @@ export const GROK_MAIN_PROMPT = ChatPromptTemplate.fromMessages([
  You ALWAYS follow these guidelines when writing your response:
  <guidelines>
  - Make sure to map the remaining message part to \'message\' in grok pattern.
- - Make sure to add \`{packageName}.{dataStreamName}\` as a prefix to each field in the pattern. Refer to example response.
+ - Make sure to add \'{packageName}.{dataStreamName}\` as a prefix to each field in the pattern. Refer to example response.
  - Do not respond with anything except the processor as a JSON object enclosed with 3 backticks (\`), see example response above. Use strict JSON response format.
  </guidelines>
 


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



