### PR TITLE
[ci] bump disk sizes from 80 -> 85

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -461,7 +461,7 @@ export async function pickTestGroupRunOrder() {
             key: 'jest',
             agents: {
               ...expandAgentQueue('n2-4-spot'),
-              diskSizeGb: 80,
+              diskSizeGb: 85,
             },
             retry: {
               automatic: [


### PR DESCRIPTION
## Summary
Bumps used disk size for Jest tests on `main` too - because we're caching several versions of ES, and other tools, our disk space seems to be running out. We've already bumped in several legacy branches. This one bumps on `main` finally.

<!--ONMERGE {"backportTargets":["8.17"]} ONMERGE-->