### PR TITLE
[8.17] [ci] bump disk sizes from 80 -> 85 (#229449)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -486,7 +486,10 @@ export async function pickTestGroupRunOrder() {
             parallelism: unit.count,
             timeout_in_minutes: 120,
             key: 'jest',
-            agents: expandAgentQueue('n2-4-spot'),
+            agents: {
+              ...expandAgentQueue('n2-4-spot'),
+              diskSizeGb: 85,
+            },
             retry: {
               automatic: [
                 { exit_status: '-1', limit: 3 },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[ci] bump disk sizes from 80 -> 85 (#229449)](https://github.com/elastic/kibana/pull/229449)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-07-25T12:04:13Z","message":"[ci] bump disk sizes from 80 -> 85 (#229449)\n\n## Summary\nBumps used disk size for Jest tests on `main` too - because we're\ncaching several versions of ES, and other tools, our disk space seems to\nbe running out. We've already bumped in several legacy branches. This\none bumps on `main` finally.","sha":"ac3ede6598b0a88620277d323f669498d34bc9a8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","skip-ci","backport:version","v9.2.0","v8.17.10"],"title":"[ci] bump disk sizes from 80 -> 85","number":229449,"url":"https://github.com/elastic/kibana/pull/229449","mergeCommit":{"message":"[ci] bump disk sizes from 80 -> 85 (#229449)\n\n## Summary\nBumps used disk size for Jest tests on `main` too - because we're\ncaching several versions of ES, and other tools, our disk space seems to\nbe running out. We've already bumped in several legacy branches. This\none bumps on `main` finally.","sha":"ac3ede6598b0a88620277d323f669498d34bc9a8"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229449","number":229449,"mergeCommit":{"message":"[ci] bump disk sizes from 80 -> 85 (#229449)\n\n## Summary\nBumps used disk size for Jest tests on `main` too - because we're\ncaching several versions of ES, and other tools, our disk space seems to\nbe running out. We've already bumped in several legacy branches. This\none bumps on `main` finally.","sha":"ac3ede6598b0a88620277d323f669498d34bc9a8"}},{"branch":"8.17","label":"v8.17.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->