### PR TITLE
[SecuritySolution] Refactor query gen

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/hooks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/hooks.tsx
@@ -10,6 +10,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import { encode } from '@kbn/rison';
+import * as E from 'fp-ts/Either';
 import { useAppToasts } from '../../../../../common/hooks/use_app_toasts';
 import { useSpaceId } from '../../../../../common/hooks/use_space_id';
 import {
@@ -88,16 +89,15 @@ export const usePrivilegedUserActivityParams = (
             indexPattern,
             fields
           )
-        : undefined,
+        : E.left({
+            error: 'GenerateEsqlSource requires spaceId, indexPattern, fields to be defined',
+          }),
     [selectedToggleOption, spaceId, indexPattern, fields]
   );
 
-  const generateTableQuery = useMemo(
-    () => (esqlSource ? generateListESQLQuery(esqlSource) : undefined),
-    [esqlSource]
-  );
+  const generateTableQuery = useMemo(() => generateListESQLQuery(esqlSource), [esqlSource]);
   const generateVisualizationQuery = useMemo(
-    () => (esqlSource ? generateVisualizationESQLQuery(esqlSource) : undefined),
+    () => generateVisualizationESQLQuery(esqlSource),
     [esqlSource]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_user_activity/index.tsx
@@ -17,7 +17,7 @@ import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
-import { isRight } from 'fp-ts/Either';
+import { getOrElse, isRight } from 'fp-ts/Either';
 import { useGlobalTime } from '../../../../../common/containers/use_global_time';
 import { useQueryToggle } from '../../../../../common/containers/query_toggle';
 import { LinkAnchor } from '../../../../../common/components/links';
@@ -69,8 +69,9 @@ export const UserActivityPrivilegedUsersPanel: React.FC<{
   const [selectedStackByOption, setSelectedStackByOption] = useState(defaultStackByOption);
   const toggleOptions = useToggleOptions();
 
-  const tableQuery = generateTableQuery && generateTableQuery('@timestamp', 'DESC', 100);
-  const discoverPath = useDiscoverPath(tableQuery && isRight(tableQuery) ? tableQuery.right : '');
+  const tableQuery = generateTableQuery('@timestamp', 'DESC', 100);
+  const getOrEmptyString = getOrElse(() => '');
+  const discoverPath = useDiscoverPath(getOrEmptyString(tableQuery));
 
   return (
     <EuiPanel hasBorder hasShadow={false} data-test-subj="severity-level-panel">
@@ -84,7 +85,7 @@ export const UserActivityPrivilegedUsersPanel: React.FC<{
         outerDirection="column"
         hideSubtitle
       >
-        {tableQuery && isRight(tableQuery) && (
+        {isRight(tableQuery) && (
           <LinkAnchor
             href={getAppUrl({
               appId: 'discover',
@@ -126,19 +127,18 @@ export const UserActivityPrivilegedUsersPanel: React.FC<{
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer size="m" />
-          {generateVisualizationQuery && generateTableQuery && (
-            <EsqlDashboardPanel<TableItemType>
-              title={TITLE}
-              stackByField={selectedStackByOption.value}
-              timerange={{ from, to }}
-              getLensAttributes={getLensAttributes}
-              generateVisualizationQuery={generateVisualizationQuery}
-              generateTableQuery={generateTableQuery}
-              columns={columns}
-              pageSize={PAGE_SIZE}
-              showInspectTable={true}
-            />
-          )}
+
+          <EsqlDashboardPanel<TableItemType>
+            title={TITLE}
+            stackByField={selectedStackByOption.value}
+            timerange={{ from, to }}
+            getLensAttributes={getLensAttributes}
+            generateVisualizationQuery={generateVisualizationQuery}
+            generateTableQuery={generateTableQuery}
+            columns={columns}
+            pageSize={PAGE_SIZE}
+            showInspectTable={true}
+          />
         </>
       )}
     </EuiPanel>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helper.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helper.test.ts
@@ -80,7 +80,7 @@ describe('removeInvalidForkBranchesFromESQL', () => {
     const esql = 'FROM test-index | FORK (WHERE not_a_field IS NULL) (WHERE not_a_field IS NULL)';
     const invalidFields = removeInvalidForkBranchesFromESQL(fields, esql);
 
-    expect(invalidFields).toEqual(left(['not_a_field']));
+    expect(invalidFields).toEqual(left({ invalidFields: ['not_a_field'] }));
   });
 
   it('should remove fork and insert valid branch into root if only one valid branch exists', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helpers.ts
@@ -22,7 +22,11 @@ export const getPrivilegedMonitorUsersJoin = (
   | RENAME event_timestamp AS @timestamp
   | WHERE user.is_privileged == true`;
 
-export type EsqlQueryOrInvalidFields = E.Right<string> | E.Left<string[]>;
+export type EsqlQueryOrInvalidFields =
+  | E.Right<string>
+  | E.Left<
+      { invalidFields: string[]; error?: undefined } | { error: string; invalidFields?: undefined }
+    >;
 export const getPrivilegeMonitrUsersJoinNoTimestamp = (
   namespace: string
 ) => `| LOOKUP JOIN ${getPrivilegedMonitorUsersIndex(namespace)} ON user.name
@@ -84,7 +88,7 @@ export function removeInvalidForkBranchesFromESQL(
       });
     });
 
-    return E.left(Array.from(invalidFields));
+    return E.left({ invalidFields: Array.from(invalidFields) });
   }
 
   // When FORK has only one valid branch we need to remove the fork command from query and add the valid branch back to the root

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/queries/helpers.ts
@@ -22,11 +22,10 @@ export const getPrivilegedMonitorUsersJoin = (
   | RENAME event_timestamp AS @timestamp
   | WHERE user.is_privileged == true`;
 
-export type EsqlQueryOrInvalidFields =
-  | E.Right<string>
-  | E.Left<
-      { invalidFields: string[]; error?: undefined } | { error: string; invalidFields?: undefined }
-    >;
+export type EsqlQueryOrInvalidFields = E.Either<
+  { invalidFields: string[]; error?: undefined } | { error: string; invalidFields?: undefined },
+  string
+>;
 export const getPrivilegeMonitrUsersJoinNoTimestamp = (
   namespace: string
 ) => `| LOOKUP JOIN ${getPrivilegedMonitorUsersIndex(namespace)} ON user.name

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.test.tsx
@@ -158,7 +158,7 @@ describe('EsqlDashboardPanel', () => {
   });
 
   it('render invalid fields when the query is invalid', () => {
-    const invalidQuery = left(['invalidField1', 'invalidField2']);
+    const invalidQuery = left({ invalidFields: ['invalidField1', 'invalidField2'] });
 
     render(
       <EsqlDashboardPanel

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
@@ -120,7 +120,7 @@ export const EsqlDashboardPanel = <TableItemType extends Record<string, string>>
         />
         <EuiSpacer size="s" />
         <ul>
-          {visualizationQuery.left.map((field, index) => (
+          {visualizationQuery.left.invalidFields?.map((field, index) => (
             <li key={index}>{field}</li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary

Depends on https://github.com/elastic/kibana/pull/228621

Refactor the ESQL query generator function to avoid null checks and ensure it never returns null.
The feature behaviour should not change.

# How to test
* Start kibana
* On doc gen repository `yarn start privileged-user-monitoring`
* Upload the CSV
* All visualizations should work



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->