### PR TITLE
[Detection Engine] Unskip tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts
@@ -56,9 +56,7 @@ const getExceptionList2 = () => ({
 
 let exceptionListResponse: Cypress.Response<ExceptionListSchema>;
 
-// Failing: See https://github.com/elastic/kibana/issues/229356
-// Failing: See https://github.com/elastic/kibana/issues/229357
-describe.skip(
+describe(
   'Manage lists from "Shared Exception Lists" page',
   { tags: ['@ess', '@serverless'] },
   () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression.cy.ts
@@ -62,8 +62,7 @@ const esqlRule = getEsqlRule({ rule_id: '6', name: 'ES|QL Rule', enabled: false 
 const thresholdRule = getNewThresholdRule({ rule_id: '7', name: 'Threshold Rule', enabled: false });
 
 // skipInServerlessMKI because of experiment feature flag
-// Failing: See https://github.com/elastic/kibana/issues/229353
-describe.skip(
+describe(
   'Bulk Edit - Alert Suppression',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {


### PR DESCRIPTION
**Fixes: https://github.com/elastic/kibana/issues/229353**
**Fixes: https://github.com/elastic/kibana/issues/229354**

Unskip tests skipped by kibanamachine yesterday. There was an issue upstream that should now be resolved.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->