### PR TITLE
[Security Solution] Unskip Cypress tests for backfill groups

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
@@ -31,8 +31,7 @@ import {
   FIRST_BACKFILL_ID,
 } from '../../../../tasks/api_calls/backfill';
 
-// Failing: See https://github.com/elastic/kibana/issues/229350
-describe.skip(
+describe(
   'Backfill groups',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],


### PR DESCRIPTION
**Fixes: https://github.com/elastic/kibana/issues/229350**

## Summary

The tests were skipped in https://github.com/elastic/kibana/issues/229350#issuecomment-3117121711.

Let's see if the recent issues with EPR and the `security_ai_prompts` package are gone and we can unskip it.

<img width="558" height="352" alt="Screenshot 2025-07-24 at 11 08 14 AM" src="https://github.com/user-attachments/assets/c0c52d91-101f-472c-8198-71c0ae0f1847" />


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->