### PR TITLE
[Security context ] fix query sent from vulnerability flyout to fetch vulnerability to display

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/findings_query_builders.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/findings_query_builders.test.ts
@@ -10,6 +10,7 @@ import {
   AggregationBuckets,
   getVulnerabilitiesAggregationCount,
   VULNERABILITIES_RESULT_EVALUATION,
+  createGetVulnerabilityFindingsQuery,
 } from './findings_query_builders';
 
 describe('getVulnerabilitiesAggregationCount', () => {
@@ -55,5 +56,104 @@ describe('getVulnerabilitiesAggregationCount', () => {
       [VULNERABILITIES_RESULT_EVALUATION.NONE]: 5,
     };
     expect(vulnerabilitiesAggregrationCount).toEqual(result);
+  });
+});
+
+describe('createGetVulnerabilityFindingsQuery', () => {
+  it('should create query with all parameters defined', () => {
+    const vulnerabilityId = 'CVE-2023-1234';
+    const resourceId = 'resource-123';
+    const packageName = 'package-abc';
+    const packageVersion = '1.2.3';
+    const eventId = 'event-456';
+
+    const result = createGetVulnerabilityFindingsQuery(
+      vulnerabilityId,
+      resourceId,
+      packageName,
+      packageVersion,
+      eventId
+    );
+
+    expect(result).toEqual({
+      bool: {
+        filter: [
+          {
+            terms: {
+              'vulnerability.id': ['CVE-2023-1234'],
+            },
+          },
+          {
+            terms: {
+              'resource.id': ['resource-123'],
+            },
+          },
+          {
+            terms: {
+              'package.name': ['package-abc'],
+            },
+          },
+          {
+            terms: {
+              'package.version': ['1.2.3'],
+            },
+          },
+          {
+            terms: {
+              'event.id': ['event-456'],
+            },
+          },
+        ],
+        must_not: [],
+      },
+    });
+  });
+
+  it('should create query with undefined package.version and resource.id fields', () => {
+    const vulnerabilityId = 'CVE-2023-1234';
+    const packageName = 'package-abc';
+    const eventId = 'event-456';
+
+    const result = createGetVulnerabilityFindingsQuery(
+      vulnerabilityId,
+      undefined,
+      packageName,
+      undefined,
+      eventId
+    );
+
+    expect(result).toEqual({
+      bool: {
+        filter: [
+          {
+            terms: {
+              'vulnerability.id': ['CVE-2023-1234'],
+            },
+          },
+          {
+            terms: {
+              'package.name': ['package-abc'],
+            },
+          },
+          {
+            terms: {
+              'event.id': ['event-456'],
+            },
+          },
+        ],
+        must_not: [
+          {
+            exists: {
+              field: 'resource.id',
+            },
+          },
+          {
+            exists: {
+              field: 'package.version',
+            },
+          },
+        ],
+      },
+    });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/findings_query_builders.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/findings_query_builders.ts
@@ -255,12 +255,19 @@ export const createGetVulnerabilityFindingsQuery = (
   eventId?: string | string[]
 ) => {
   const filters: Array<{ terms: Record<string, string[]> }> = [];
+  const mustNotFilters: estypes.QueryDslQueryContainer[] = [];
 
   const addTermFilter = (field: string, value?: string | string[]) => {
     if (value !== undefined) {
       filters.push({
         terms: {
           [field]: Array.isArray(value) ? value : [value],
+        },
+      });
+    } else {
+      mustNotFilters.push({
+        exists: {
+          field,
         },
       });
     }
@@ -275,6 +282,7 @@ export const createGetVulnerabilityFindingsQuery = (
   return {
     bool: {
       filter: filters,
+      must_not: mustNotFilters,
     },
   };
 };


### PR DESCRIPTION

## Summary

This PR fixes the query sent from the flyout to so fields which doesn't exist in the document are also added to the query.
following [issue](https://github.com/elastic/kibana/issues/229536) is fixed.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->