### PR TITLE
[9.1] [scout] support log level override (#228841)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
@@ -12,7 +12,6 @@ export { createScoutConfig } from './config';
 export { getEsArchiver } from './es_archiver';
 export { createKbnUrl } from './kibana_url';
 export { createSamlSessionManager } from './saml_auth';
-export { getLogger } from './logger';
 
 export type { KibanaUrl } from './kibana_url';
 export type { SamlSessionManager } from '@kbn/test';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/core_fixtures.ts
@@ -17,13 +17,12 @@ import {
   createSamlSessionManager,
   createScoutConfig,
   KibanaUrl,
-  getLogger,
-  ScoutLogger,
   createElasticsearchCustomRole,
   createCustomRole,
   ElasticsearchRoleDescriptor,
   KibanaRole,
 } from '../../../common/services';
+import { ScoutLogger } from '../../../common/services/logger';
 import type { ScoutTestOptions } from '../../types';
 import type { ScoutTestConfig } from '.';
 
@@ -65,7 +64,9 @@ export const coreWorkerFixtures = base.extend<
       const workersCount = workerInfo.config.workers;
       const loggerContext =
         workersCount === 1 ? 'scout-worker' : `scout-worker-${workerInfo.parallelIndex + 1}`;
-      use(getLogger(loggerContext));
+      // The log level is resolved inside the ScoutLogger constructor, which checks the argument,
+      // then SCOUT_LOG_LEVEL, then LOG_LEVEL, and finally defaults to 'info'.
+      use(new ScoutLogger(loggerContext));
     },
     { scope: 'worker' },
   ],

--- a/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/data_ingestion.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/data_ingestion.ts
@@ -9,17 +9,17 @@
 
 import { FullConfig } from 'playwright/test';
 import {
-  getLogger,
   getEsArchiver,
   createScoutConfig,
   measurePerformanceAsync,
   getEsClient,
   getKbnClient,
 } from '../../common';
+import { ScoutLogger } from '../../common/services/logger';
 import { ScoutTestOptions } from '../types';
 
 export async function ingestTestDataHook(config: FullConfig, archives: string[]) {
-  const log = getLogger();
+  const log = new ScoutLogger('scout: global hook');
 
   if (archives.length === 0) {
     log.debug('[setup] no test data to ingest');

--- a/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/synthtrace_ingestion.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/synthtrace_ingestion.ts
@@ -18,14 +18,9 @@ import type {
   Serializable,
   SynthtraceGenerator,
 } from '@kbn/apm-synthtrace-client';
-import {
-  getLogger,
-  createScoutConfig,
-  measurePerformanceAsync,
-  getEsClient,
-  ScoutLogger,
-  EsClient,
-} from '../../common';
+
+import { createScoutConfig, measurePerformanceAsync, getEsClient, EsClient } from '../../common';
+import { ScoutLogger } from '../../common/services/logger';
 import { ScoutTestOptions } from '../types';
 import {
   getApmSynthtraceEsClient,
@@ -65,7 +60,7 @@ const getSynthtraceClient = (
  * @deprecated Use `globalSetupHook` and synthtrace fixtures instead
  */
 export async function ingestSynthtraceDataHook(config: FullConfig, data: SynthtraceIngestionData) {
-  const log = getLogger();
+  const log = new ScoutLogger('scout: global hook');
 
   const { apm, infra } = data;
   const hasApmData = apm.length > 0;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[scout] support log level override (#228841)](https://github.com/elastic/kibana/pull/228841)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-07-22T20:25:49Z","message":"[scout] support log level override (#228841)\n\n## Summary\n\n- default log level for Playwright fixtures is `info` , afaik default\nfor FTR and other scripts (but for now to better understand performance\nissues we pass `debug` through `node scripts/scout`, to be reverted for\nGA)\n- `node scripts/scout` will propagate log level from cli flag (e.g.\n--debug) with `SCOUT_LOG_LEVEL` env variable to playwright exec command\n- since some Team may not use `scripts/scout` command, they can set\n`LOG_LEVEL` variable to override to whatever level is needed\nif both `LOG_LEVEL` and `SCOUT_LOG_LEVEL` are set, the later has\npriority (important for us, shouldn't block others)\n\n### Playwright Integration:\n* Replaced the use of `getLogger` with the updated `ScoutLogger` call in\nPlaywright worker fixtures, enabling log level configuration via\nenvironment variables.\n* Modified the Playwright test runner to propagate the log level to the\ntest environment using the `SCOUT_LOG_LEVEL` variable.\n\n---------\n\nCo-authored-by: David Olaru <dolaru@vaevixen.com>","sha":"d76a5befa5ec73425b44c10b24f66a19556a7e83","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.1.0","v8.19.0","ci:scout-ui-tests","v9.2.0"],"title":"[scout] support log level override","number":228841,"url":"https://github.com/elastic/kibana/pull/228841","mergeCommit":{"message":"[scout] support log level override (#228841)\n\n## Summary\n\n- default log level for Playwright fixtures is `info` , afaik default\nfor FTR and other scripts (but for now to better understand performance\nissues we pass `debug` through `node scripts/scout`, to be reverted for\nGA)\n- `node scripts/scout` will propagate log level from cli flag (e.g.\n--debug) with `SCOUT_LOG_LEVEL` env variable to playwright exec command\n- since some Team may not use `scripts/scout` command, they can set\n`LOG_LEVEL` variable to override to whatever level is needed\nif both `LOG_LEVEL` and `SCOUT_LOG_LEVEL` are set, the later has\npriority (important for us, shouldn't block others)\n\n### Playwright Integration:\n* Replaced the use of `getLogger` with the updated `ScoutLogger` call in\nPlaywright worker fixtures, enabling log level configuration via\nenvironment variables.\n* Modified the Playwright test runner to propagate the log level to the\ntest environment using the `SCOUT_LOG_LEVEL` variable.\n\n---------\n\nCo-authored-by: David Olaru <dolaru@vaevixen.com>","sha":"d76a5befa5ec73425b44c10b24f66a19556a7e83"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228841","number":228841,"mergeCommit":{"message":"[scout] support log level override (#228841)\n\n## Summary\n\n- default log level for Playwright fixtures is `info` , afaik default\nfor FTR and other scripts (but for now to better understand performance\nissues we pass `debug` through `node scripts/scout`, to be reverted for\nGA)\n- `node scripts/scout` will propagate log level from cli flag (e.g.\n--debug) with `SCOUT_LOG_LEVEL` env variable to playwright exec command\n- since some Team may not use `scripts/scout` command, they can set\n`LOG_LEVEL` variable to override to whatever level is needed\nif both `LOG_LEVEL` and `SCOUT_LOG_LEVEL` are set, the later has\npriority (important for us, shouldn't block others)\n\n### Playwright Integration:\n* Replaced the use of `getLogger` with the updated `ScoutLogger` call in\nPlaywright worker fixtures, enabling log level configuration via\nenvironment variables.\n* Modified the Playwright test runner to propagate the log level to the\ntest environment using the `SCOUT_LOG_LEVEL` variable.\n\n---------\n\nCo-authored-by: David Olaru <dolaru@vaevixen.com>","sha":"d76a5befa5ec73425b44c10b24f66a19556a7e83"}}]}] BACKPORT-->