### PR TITLE
[9.1] [Lens] Fix secondary metric styles to prevent wrapping (#227234)

### DIFF
--- a/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/metric_vis.test.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/metric_vis.test.tsx
@@ -310,9 +310,11 @@ describe('MetricVisComponent', function () {
       });
       // for the secondary metric
       const secondaryLabel = table.columns.find((col) => col.id === minPriceColumnId)!.name;
-      expect(
-        screen.getByText(`${secondaryLabel} number-${table.rows[0][minPriceColumnId]}`)
-      ).toBeInTheDocument();
+
+      const secondaryElement = screen.getByTestId('metric-secondary-element');
+      expect(secondaryElement.textContent).toBe(
+        `${secondaryLabel}number-${table.rows[0][minPriceColumnId]}`
+      );
 
       await rerender({
         config: {
@@ -558,10 +560,12 @@ describe('MetricVisComponent', function () {
         },
       });
 
+      let secondaryElements = screen.getAllByTestId('metric-secondary-element');
       for (const row of table.rows) {
-        expect(
-          screen.getByText(new RegExp(`howdy number-${row[minPriceColumnId]}`, 'i'))
-        ).toBeInTheDocument();
+        const regExp = new RegExp(`howdynumber-${row[minPriceColumnId]}`, 'i');
+        expect(secondaryElements.some((element) => regExp.test(element.textContent ?? ''))).toBe(
+          true
+        );
       }
 
       // Now remove the prefix and check the secondary label is there
@@ -573,11 +577,14 @@ describe('MetricVisComponent', function () {
         },
       });
 
+      secondaryElements = screen.getAllByTestId('metric-secondary-element');
+
       const secondaryLabel = table.columns.find((col) => col.id === minPriceColumnId)!.name;
       for (const row of table.rows) {
-        expect(
-          screen.getByText(new RegExp(`${secondaryLabel} number-${row[minPriceColumnId]}`, 'i'))
-        ).toBeInTheDocument();
+        const regExp = new RegExp(`${secondaryLabel}*number-${row[minPriceColumnId]}`, 'i');
+        expect(secondaryElements.some((element) => regExp.test(element.textContent ?? ''))).toBe(
+          true
+        );
       }
     });
 

--- a/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/metric_vis.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/metric_vis.tsx
@@ -298,12 +298,15 @@ export const MetricVis = ({
   return (
     <div
       ref={scrollContainerRef}
-      css={css`
-        height: 100%;
-        width: 100%;
-        overflow-y: auto;
-        ${useEuiScrollBar()}
-      `}
+      css={[
+        styles.layout,
+        css`
+          height: 100%;
+          width: 100%;
+          overflow-y: auto;
+          ${useEuiScrollBar()}
+        `,
+      ]}
     >
       <div
         css={css`
@@ -360,4 +363,18 @@ export const MetricVis = ({
       </div>
     </div>
   );
+};
+
+const styles = {
+  layout: css({
+    '.echMetricText__valuesBlock': {
+      display: 'flex',
+      minWidth: 0,
+      maxWidth: '100%',
+    },
+    '.echMetricText__valuesBlock > div': {
+      minWidth: 'inherit',
+      maxWidth: 'inherit',
+    },
+  }),
 };

--- a/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/secondary_metric.test.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/secondary_metric.test.tsx
@@ -64,7 +64,7 @@ describe('Secondary metric', () => {
       });
       // Test id is the last resource here as the element will be empty
       const el = screen.getByTestId('metric-secondary-element');
-      expect(el).toBeEmptyDOMElement();
+      expect(el.textContent).toBe('');
     });
   });
 

--- a/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/secondary_metric.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_metric/public/components/secondary_metric.tsx
@@ -256,16 +256,44 @@ export function SecondaryMetric({
   const value = metricColumn ? row[metricColumn.id] : undefined;
 
   return (
-    <span data-test-subj="metric-secondary-element">
-      {prefix}
-      {prefix ? ' ' : ''}
-      <SecondaryMetricValue
-        rawValue={value}
-        formattedValue={metricFormatter?.(value)}
-        trendConfig={color ? undefined : trendConfig}
-        color={color}
-        formatter={metricFormatter}
-      />
+    <span css={styles.wrapper} data-test-subj="metric-secondary-element">
+      {prefix && <span css={styles.prefix}>{prefix}</span>}
+      <span css={styles.value}>
+        <SecondaryMetricValue
+          rawValue={value}
+          formattedValue={metricFormatter?.(value)}
+          trendConfig={color ? undefined : trendConfig}
+          color={color}
+          formatter={metricFormatter}
+        />
+      </span>
     </span>
   );
 }
+
+const styles = {
+  wrapper: css({
+    display: 'flex',
+    alignItems: 'center',
+    minWidth: 0,
+    width: '100%',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+  }),
+  prefix: css({
+    flex: '0 1 auto',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
+  value: css({
+    display: 'inline-flex',
+    flex: '1 0 auto',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    minWidth: 0,
+    marginLeft: 4,
+    maxWidth: 'calc(100% - 4px)', // Subtract the marginLeft value
+  }),
+};

--- a/x-pack/platform/test/functional/apps/lens/group3/dashboard_inline_editing.ts
+++ b/x-pack/platform/test/functional/apps/lens/group3/dashboard_inline_editing.ts
@@ -85,6 +85,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('applyFlyoutButton');
       await dashboard.waitForRenderComplete();
       const data = await lens.getMetricVisualizationData();
+      const normalizedData = data.map((item) => ({
+        ...item,
+        ...(item.extraText && { extraText: item.extraText.replace(/\n/g, ' ') }),
+      }));
       const expectedData = [
         {
           title: 'Average of bytes',
@@ -98,8 +102,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         },
       ];
 
-      log.debug(data);
-      expect(data).to.eql(expectedData);
+      log.debug(normalizedData);
+      expect(normalizedData).to.eql(expectedData);
 
       await timeToVisualize.resetNewDashboard();
     });

--- a/x-pack/platform/test/functional/apps/lens/group6/metric.ts
+++ b/x-pack/platform/test/functional/apps/lens/group6/metric.ts
@@ -126,6 +126,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await lens.waitForVisualization('mtrVis');
       const data = await lens.getMetricVisualizationData();
+      const normalizedData = data.map((item) => ({
+        ...item,
+        ...(item.extraText && { extraText: item.extraText.replace(/\n/g, ' ') }),
+      }));
 
       const expectedData = [
         {
@@ -189,7 +193,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           showingBar: false,
         },
       ];
-      expect(data).to.eql(expectedData);
+      expect(normalizedData).to.eql(expectedData);
 
       await lens.openDimensionEditor(
         'lnsMetric_primaryMetricDimensionPanel > lns-dimensionTrigger'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Lens] Fix secondary metric styles to prevent wrapping (#227234)](https://github.com/elastic/kibana/pull/227234)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maria Iriarte","email":"106958839+mariairiartef@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-14T08:39:53Z","message":"[Lens] Fix secondary metric styles to prevent wrapping (#227234)\n\nCloses https://github.com/elastic/kibana/issues/226208\n\n## Summary\n\nThe secondary metric component stays on a single line with proper text\noverflow handling, while giving priority to the value/badge over the\nprefix when space is limited.\n\n<img width=\"1080\" alt=\"Screenshot 2025-07-09 at 14 20 20\"\nsrc=\"https://github.com/user-attachments/assets/dc6cc536-eb74-411d-9237-16ae6713e33e\"\n/>\n\n#### The value/badge can take the whole width\n\n<img width=\"316\" alt=\"Screenshot 2025-07-09 at 14 16 38\"\nsrc=\"https://github.com/user-attachments/assets/1257b677-0983-43c3-a39f-ae038716651b\"\n/>\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c238ede3d4ac816fce88d6c96ecc1f5445a6414a","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Visualizations","Feature:Lens","backport missing","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Lens] Fix secondary metric styles to prevent wrapping","number":227234,"url":"https://github.com/elastic/kibana/pull/227234","mergeCommit":{"message":"[Lens] Fix secondary metric styles to prevent wrapping (#227234)\n\nCloses https://github.com/elastic/kibana/issues/226208\n\n## Summary\n\nThe secondary metric component stays on a single line with proper text\noverflow handling, while giving priority to the value/badge over the\nprefix when space is limited.\n\n<img width=\"1080\" alt=\"Screenshot 2025-07-09 at 14 20 20\"\nsrc=\"https://github.com/user-attachments/assets/dc6cc536-eb74-411d-9237-16ae6713e33e\"\n/>\n\n#### The value/badge can take the whole width\n\n<img width=\"316\" alt=\"Screenshot 2025-07-09 at 14 16 38\"\nsrc=\"https://github.com/user-attachments/assets/1257b677-0983-43c3-a39f-ae038716651b\"\n/>\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c238ede3d4ac816fce88d6c96ecc1f5445a6414a"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/228188","number":228188,"state":"MERGED","mergeCommit":{"sha":"be0f29268950f326aeef95ff3d1ecc612ac7c750","message":"[8.19] [Lens] Fix secondary metric styles to prevent wrapping (#227234) (#228188)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Lens] Fix secondary metric styles to prevent wrapping\n(#227234)](https://github.com/elastic/kibana/pull/227234)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227234","number":227234,"mergeCommit":{"message":"[Lens] Fix secondary metric styles to prevent wrapping (#227234)\n\nCloses https://github.com/elastic/kibana/issues/226208\n\n## Summary\n\nThe secondary metric component stays on a single line with proper text\noverflow handling, while giving priority to the value/badge over the\nprefix when space is limited.\n\n<img width=\"1080\" alt=\"Screenshot 2025-07-09 at 14 20 20\"\nsrc=\"https://github.com/user-attachments/assets/dc6cc536-eb74-411d-9237-16ae6713e33e\"\n/>\n\n#### The value/badge can take the whole width\n\n<img width=\"316\" alt=\"Screenshot 2025-07-09 at 14 16 38\"\nsrc=\"https://github.com/user-attachments/assets/1257b677-0983-43c3-a39f-ae038716651b\"\n/>\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c238ede3d4ac816fce88d6c96ecc1f5445a6414a"}}]}] BACKPORT-->