### PR TITLE
[docs] Use centrally maintained version variables

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -15,8 +15,6 @@ toc:
   - toc: release-notes
   - toc: extend
 subs:
-  version: "9.0.0"
-  branch: "9.0"
   ecloud:   "Elastic Cloud"
   ech:   "Elastic Cloud Hosted"
   ess:   "Elasticsearch Service"

--- a/docs/extend/external-plugin-functional-tests.md
+++ b/docs/extend/external-plugin-functional-tests.md
@@ -68,7 +68,7 @@ export default async function ({ readConfigFile }) {
 
     // more settings, like timeouts, mochaOpts, etc are
     // defined in the config schema.
-    // https://github.com/elastic/kibana/blob/{{branch}}/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
+    // https://github.com/elastic/kibana/blob/{{version.stack | M.M}}/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
   };
 }
 ```

--- a/docs/reference/kibana-plugins.md
+++ b/docs/reference/kibana-plugins.md
@@ -114,7 +114,7 @@ $ bin/kibana-plugin install x-pack
 You can download official Elastic plugins simply by specifying their name. You can alternatively specify a URL or file path to a specific plugin, as in the following examples:
 
 ```shell subs=true
-$ bin/kibana-plugin install https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-{{version}}.zip
+$ bin/kibana-plugin install https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-{{version.stack}}.zip
 ```
 
 or


### PR DESCRIPTION
Related to https://github.com/elastic/docs-projects/issues/519

Update the docs to use centrally-managed [version variables](https://elastic.github.io/docs-builder/syntax/version-variables/) from docs-builder's [`version.yml` configuration file](https://github.com/elastic/docs-builder/blob/main/config/versions.yml). The Docs team is responsible for updating these version numbers for each release. These version variables will replace `docset`-level version-related `subs` so we don't have to update those values in this repo for every release.

<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->