### PR TITLE
add loading state install/uninstall product doc

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc.ts
@@ -20,7 +20,7 @@ import { useInstallProductDoc } from './use_install_product_doc';
  * @param inferenceId - The ID of the inference for which to get the product documentation status.
  * @returns An object containing the status of the product documentation, loading state, and methods to install and uninstall the product documentation.
  */
-export type ProductDocStatus = InstallationStatus | 'uninstalling';
+export type ProductDocStatus = InstallationStatus | 'uninstalling' | 'loading';
 
 export function useGetProductDoc(inferenceId: string | undefined) {
   const { productDocBase } = useKibana().services;
@@ -47,6 +47,9 @@ export function useGetProductDoc(inferenceId: string | undefined) {
     if (!inferenceId || data?.inferenceId !== inferenceId) {
       return undefined;
     }
+    if (isLoading || isRefetching) {
+      return 'loading';
+    }
     if (isInstalling) {
       return 'installing';
     }
@@ -54,12 +57,11 @@ export function useGetProductDoc(inferenceId: string | undefined) {
       return 'uninstalling';
     }
     return data?.overall;
-  }, [inferenceId, isInstalling, isUninstalling, data]);
+  }, [inferenceId, isInstalling, isUninstalling, isLoading, isRefetching, data]);
 
   return {
     status,
     refetch,
-    isLoading: isLoading || isRefetching,
     installProductDoc,
     uninstallProductDoc,
   };

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc.ts
@@ -29,7 +29,7 @@ export function useGetProductDoc(inferenceId: string | undefined) {
 
   const { mutateAsync: uninstallProductDoc, isLoading: isUninstalling } = useUninstallProductDoc();
 
-  const { isLoading, data, refetch } = useQuery({
+  const { isLoading, data, refetch, isRefetching } = useQuery({
     networkMode: 'always',
     queryKey: [REACT_QUERY_KEYS.GET_PRODUCT_DOC_STATUS, inferenceId],
     queryFn: async () => {
@@ -59,7 +59,7 @@ export function useGetProductDoc(inferenceId: string | undefined) {
   return {
     status,
     refetch,
-    isLoading,
+    isLoading: isLoading || isRefetching,
     installProductDoc,
     uninstallProductDoc,
   };

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_product_doc.ts
@@ -20,7 +20,7 @@ import { useInstallProductDoc } from './use_install_product_doc';
  * @param inferenceId - The ID of the inference for which to get the product documentation status.
  * @returns An object containing the status of the product documentation, loading state, and methods to install and uninstall the product documentation.
  */
-export type ProductDocStatus = InstallationStatus | 'uninstalling' | 'loading';
+export type ProductDocStatus = InstallationStatus | 'uninstalling';
 
 export function useGetProductDoc(inferenceId: string | undefined) {
   const { productDocBase } = useKibana().services;
@@ -47,9 +47,6 @@ export function useGetProductDoc(inferenceId: string | undefined) {
     if (!inferenceId || data?.inferenceId !== inferenceId) {
       return undefined;
     }
-    if (isLoading || isRefetching) {
-      return 'loading';
-    }
     if (isInstalling) {
       return 'installing';
     }
@@ -57,11 +54,12 @@ export function useGetProductDoc(inferenceId: string | undefined) {
       return 'uninstalling';
     }
     return data?.overall;
-  }, [inferenceId, isInstalling, isUninstalling, isLoading, isRefetching, data]);
+  }, [inferenceId, isInstalling, isUninstalling, data]);
 
   return {
     status,
     refetch,
+    isLoading: isLoading || isRefetching,
     installProductDoc,
     uninstallProductDoc,
   };

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
@@ -24,6 +24,8 @@ import {
   elserTitle,
 } from '@kbn/ai-assistant/src/utils/get_model_options_for_inference_endpoints';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { InstallationStatus } from '@kbn/product-doc-base-plugin/common/install_status';
+import { UseProductDoc } from '../../../hooks/use_product_doc';
 
 jest.mock('../../../hooks/use_install_product_doc', () => ({
   useInstallProductDoc: () => ({
@@ -94,6 +96,14 @@ const createMockKnowledgeBase = (
   ...overrides,
 });
 
+const createProductDoc = (overrides: Partial<UseProductDoc> = {}) => ({
+  status: 'uninstalled' as InstallationStatus,
+  isLoading: false,
+  installProductDoc: jest.fn().mockResolvedValue({} as any),
+  uninstallProductDoc: jest.fn().mockResolvedValue({} as any),
+  ...overrides,
+});
+
 const modelOptions = [
   {
     key: ELSER_ON_ML_NODE_INFERENCE_ID,
@@ -112,12 +122,16 @@ const setupMockGetModelOptions = (options = modelOptions) => {
   mockGetModelOptions.mockReturnValue(options);
 };
 
-const renderComponent = (mockKb: UseKnowledgeBaseResult) => {
+const renderComponent = (mockKb: UseKnowledgeBaseResult, mockProductDoc: UseProductDoc) => {
   const queryClient = new QueryClient();
 
   render(
     <QueryClientProvider client={queryClient}>
-      <ChangeKbModel knowledgeBase={mockKb} />{' '}
+      <ChangeKbModel
+        knowledgeBase={mockKb}
+        productDoc={mockProductDoc}
+        currentlyDeployedInferenceId={ELSER_ON_ML_NODE_INFERENCE_ID}
+      />
     </QueryClientProvider>
   );
 };
@@ -133,7 +147,8 @@ describe('ChangeKbModel', () => {
 
   it('disables the `Update` button when selected model is the same as current and no redeployment needed', () => {
     const mockKb = createMockKnowledgeBase();
-    renderComponent(mockKb);
+    const mockProductDoc = createProductDoc();
+    renderComponent(mockKb, mockProductDoc);
 
     const button = screen.getByTestId('observabilityAiAssistantKnowledgeBaseUpdateModelButton');
     expect(button).toBeDisabled();
@@ -141,7 +156,8 @@ describe('ChangeKbModel', () => {
 
   it('enables the `Update` button when a different model is selected', async () => {
     const mockKb = createMockKnowledgeBase();
-    renderComponent(mockKb);
+    const mockProductDoc = createProductDoc();
+    renderComponent(mockKb, mockProductDoc);
 
     const button = screen.getByTestId('observabilityAiAssistantKnowledgeBaseUpdateModelButton');
     expect(button).toBeDisabled();
@@ -159,7 +175,8 @@ describe('ChangeKbModel', () => {
 
   it('disables the `Update` button when knowledge base is installing', () => {
     const mockKb = createMockKnowledgeBase({ isInstalling: true });
-    renderComponent(mockKb);
+    const mockProductDoc = createProductDoc();
+    renderComponent(mockKb, mockProductDoc);
 
     const button = screen.getByTestId('observabilityAiAssistantKnowledgeBaseUpdateModelButton');
     expect(button).toBeDisabled();
@@ -180,7 +197,8 @@ describe('ChangeKbModel', () => {
           },
         }),
       });
-      renderComponent(mockKb);
+      const mockProductDoc = createProductDoc();
+      renderComponent(mockKb, mockProductDoc);
 
       const dropdown = screen.getByTestId('observabilityAiAssistantKnowledgeBaseModelDropdown');
       expect(dropdown).toHaveTextContent(elserTitle);
@@ -198,7 +216,8 @@ describe('ChangeKbModel', () => {
           },
         }),
       });
-      renderComponent(mockKb);
+      const mockProductDoc = createProductDoc();
+      renderComponent(mockKb, mockProductDoc);
 
       const dropdown = screen.getByTestId('observabilityAiAssistantKnowledgeBaseModelDropdown');
       dropdown.click();
@@ -226,7 +245,8 @@ describe('ChangeKbModel', () => {
           },
         }),
       });
-      renderComponent(mockKb);
+      const mockProductDoc = createProductDoc();
+      renderComponent(mockKb, mockProductDoc);
 
       const dropdown = screen.getByTestId('observabilityAiAssistantKnowledgeBaseModelDropdown');
       dropdown.click();

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -31,10 +31,17 @@ import {
   LEGACY_CUSTOM_INFERENCE_ID,
   useKibana,
 } from '@kbn/observability-ai-assistant-plugin/public';
-import { getMappedInferenceId } from '../../../helpers/inference_utils';
-import { useGetProductDoc } from '../../../hooks/use_get_product_doc';
+import { UseProductDoc } from '../../../hooks/use_product_doc';
 
-export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBaseResult }) {
+export function ChangeKbModel({
+  knowledgeBase,
+  productDoc,
+  currentlyDeployedInferenceId,
+}: {
+  knowledgeBase: UseKnowledgeBaseResult;
+  productDoc: UseProductDoc;
+  currentlyDeployedInferenceId: string | undefined;
+}) {
   const { overlays } = useKibana().services;
 
   const [hasLoadedCurrentModel, setHasLoadedCurrentModel] = useState(false);
@@ -45,12 +52,6 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
   const modelOptions: ModelOptionsData[] = getModelOptionsForInferenceEndpoints({
     endpoints: inferenceEndpoints,
   });
-
-  const currentlyDeployedInferenceId = getMappedInferenceId(
-    knowledgeBase.status.value?.currentInferenceId
-  );
-
-  const { installProductDoc } = useGetProductDoc(currentlyDeployedInferenceId);
 
   const [selectedInferenceId, setSelectedInferenceId] = useState(
     currentlyDeployedInferenceId || ''
@@ -165,7 +166,7 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
             if (isConfirmed) {
               setIsUpdatingModel(true);
               knowledgeBase.install(selectedInferenceId);
-              installProductDoc(selectedInferenceId);
+              productDoc.installProductDoc(selectedInferenceId);
             }
           });
       }
@@ -177,7 +178,7 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
     isSelectedModelCurrentModel,
     overlays,
     confirmationMessages,
-    installProductDoc,
+    productDoc,
   ]);
 
   const superSelectOptions = modelOptions.map((option: ModelOptionsData) => ({

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.test.tsx
@@ -15,19 +15,8 @@ import {
   LEGACY_CUSTOM_INFERENCE_ID,
 } from '@kbn/observability-ai-assistant-plugin/public';
 import { UseKnowledgeBaseResult } from '@kbn/ai-assistant';
-import { useGetProductDoc } from '../../../hooks/use_get_product_doc';
-
-jest.mock('../../../hooks/use_get_product_doc', () => ({
-  useGetProductDoc: jest.fn(),
-}));
-
-jest.mock('../../../hooks/use_install_product_doc', () => ({
-  useInstallProductDoc: () => ({ mutateAsync: jest.fn() }),
-}));
-
-jest.mock('../../../hooks/use_uninstall_product_doc', () => ({
-  useUninstallProductDoc: () => ({ mutateAsync: jest.fn() }),
-}));
+import { UseProductDoc, useProductDoc } from '../../../hooks/use_product_doc';
+import { InstallationStatus } from '@kbn/product-doc-base-plugin/common/install_status';
 
 const createMockStatus = (
   overrides?: Partial<APIReturnType<'GET /internal/observability_ai_assistant/kb/status'>>
@@ -62,12 +51,16 @@ const createMockKnowledgeBase = (
   ...overrides,
 });
 
-describe('ProductDocEntry', () => {
-  it('calls useGetProductDocStatus with ELSER_ON_ML_NODE_INFERENCE_ID when inference ID is LEGACY_CUSTOM_INFERENCE_ID', async () => {
-    (useGetProductDoc as jest.Mock).mockReturnValue({
-      status: 'installed',
-    });
+const createProductDoc = (overrides: Partial<UseProductDoc> = {}) => ({
+  status: 'uninstalled' as InstallationStatus,
+  isLoading: false,
+  installProductDoc: jest.fn().mockResolvedValue({} as any),
+  uninstallProductDoc: jest.fn().mockResolvedValue({} as any),
+  ...overrides,
+});
 
+describe('ProductDocEntry', () => {
+  it('calls useProductDoc with ELSER_ON_ML_NODE_INFERENCE_ID when inference ID is LEGACY_CUSTOM_INFERENCE_ID', async () => {
     const mockKnowledgeBase = createMockKnowledgeBase({
       status: createMockStatus({
         currentInferenceId: LEGACY_CUSTOM_INFERENCE_ID,
@@ -80,28 +73,39 @@ describe('ProductDocEntry', () => {
       }),
     });
 
-    render(<ProductDocEntry knowledgeBase={mockKnowledgeBase} />);
+    const productDoc = createProductDoc();
+
+    render(
+      <ProductDocEntry
+        knowledgeBase={mockKnowledgeBase}
+        productDoc={productDoc}
+        currentlyDeployedInferenceId={undefined}
+      />
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Installed')).toBeInTheDocument();
     });
 
-    expect(useGetProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
+    expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
   });
 
-  it('calls useGetProductDocStatus with the current inference ID when inference ID is not LEGACY_CUSTOM_INFERENCE_ID"', async () => {
+  it('calls useProductDoc with the current inference ID when inference ID is not LEGACY_CUSTOM_INFERENCE_ID"', async () => {
     const mockKnowledgeBase = createMockKnowledgeBase();
+    const productDoc = createProductDoc();
 
-    (useGetProductDoc as jest.Mock).mockReturnValue({
-      status: 'installed',
-    });
-
-    render(<ProductDocEntry knowledgeBase={mockKnowledgeBase} />);
+    render(
+      <ProductDocEntry
+        knowledgeBase={mockKnowledgeBase}
+        productDoc={productDoc}
+        currentlyDeployedInferenceId={undefined}
+      />
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Installed')).toBeInTheDocument();
     });
 
-    expect(useGetProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
+    expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
   });
 });

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.test.tsx
@@ -15,7 +15,7 @@ import {
   LEGACY_CUSTOM_INFERENCE_ID,
 } from '@kbn/observability-ai-assistant-plugin/public';
 import { UseKnowledgeBaseResult } from '@kbn/ai-assistant';
-import { UseProductDoc, useProductDoc } from '../../../hooks/use_product_doc';
+import { UseProductDoc } from '../../../hooks/use_product_doc';
 import { InstallationStatus } from '@kbn/product-doc-base-plugin/common/install_status';
 
 const createMockStatus = (
@@ -60,7 +60,7 @@ const createProductDoc = (overrides: Partial<UseProductDoc> = {}) => ({
 });
 
 describe('ProductDocEntry', () => {
-  it('calls useProductDoc with ELSER_ON_ML_NODE_INFERENCE_ID when inference ID is LEGACY_CUSTOM_INFERENCE_ID', async () => {
+  it('should render the installed state correctly', async () => {
     const mockKnowledgeBase = createMockKnowledgeBase({
       status: createMockStatus({
         currentInferenceId: LEGACY_CUSTOM_INFERENCE_ID,
@@ -73,7 +73,9 @@ describe('ProductDocEntry', () => {
       }),
     });
 
-    const productDoc = createProductDoc();
+    const productDoc = createProductDoc({
+      status: 'installed',
+    });
 
     render(
       <ProductDocEntry
@@ -86,11 +88,9 @@ describe('ProductDocEntry', () => {
     await waitFor(() => {
       expect(screen.getByText('Installed')).toBeInTheDocument();
     });
-
-    expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
   });
 
-  it('calls useProductDoc with the current inference ID when inference ID is not LEGACY_CUSTOM_INFERENCE_ID"', async () => {
+  it('should render the uninstalled state correctly', async () => {
     const mockKnowledgeBase = createMockKnowledgeBase();
     const productDoc = createProductDoc();
 
@@ -103,9 +103,7 @@ describe('ProductDocEntry', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Installed')).toBeInTheDocument();
+      expect(screen.getByText('Install')).toBeInTheDocument();
     });
-
-    expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
   });
 });

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
@@ -87,6 +87,19 @@ export function ProductDocEntry({ knowledgeBase }: { knowledgeBase: UseKnowledge
         </EuiFlexGroup>
       );
     }
+    if (status === 'uninstalling') {
+      return (
+        <EuiFlexGroup justifyContent="flexStart" alignItems="center">
+          <EuiLoadingSpinner size="m" />
+          <EuiText size="s">
+            <FormattedMessage
+              id="xpack.observabilityAiAssistantManagement.settingsPage.uninstallingText"
+              defaultMessage="Uninstalling..."
+            />
+          </EuiText>
+        </EuiFlexGroup>
+      );
+    }
     if (status === 'installed') {
       return (
         <EuiFlexGroup justifyContent="flexStart" alignItems="center">

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
@@ -10,15 +10,12 @@ import {
   EuiButton,
   EuiDescribedFormGroup,
   EuiFormRow,
-  EuiText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHealth,
-  EuiLoadingSpinner,
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { UseKnowledgeBaseResult } from '@kbn/ai-assistant/src/hooks';
 import { getMappedInferenceId } from '../../../helpers/inference_utils';
 import { useKibana } from '../../../hooks/use_kibana';
@@ -31,12 +28,7 @@ export function ProductDocEntry({ knowledgeBase }: { knowledgeBase: UseKnowledge
 
   const canInstallProductDoc = selectedInferenceId !== undefined;
 
-  const {
-    status,
-    isLoading: isStatusLoading,
-    installProductDoc,
-    uninstallProductDoc,
-  } = useGetProductDoc(selectedInferenceId);
+  const { status, installProductDoc, uninstallProductDoc } = useGetProductDoc(selectedInferenceId);
 
   const onClickInstall = useCallback(() => {
     if (!selectedInferenceId) {
@@ -70,36 +62,39 @@ export function ProductDocEntry({ knowledgeBase }: { knowledgeBase: UseKnowledge
       });
   }, [overlays, uninstallProductDoc, selectedInferenceId]);
 
+  const buttonText = useMemo(() => {
+    switch (status) {
+      case 'installing':
+        return i18n.translate(
+          'xpack.observabilityAiAssistantManagement.settingsPage.installingText',
+          { defaultMessage: 'Installing...' }
+        );
+      case 'uninstalling':
+        return i18n.translate(
+          'xpack.observabilityAiAssistantManagement.settingsPage.uninstallingText',
+          { defaultMessage: 'Uninstalling...' }
+        );
+      case 'loading':
+        return i18n.translate('xpack.observabilityAiAssistantManagement.settingsPage.loadingText', {
+          defaultMessage: 'Loading...',
+        });
+      case 'installed':
+        return i18n.translate(
+          'xpack.observabilityAiAssistantManagement.settingsPage.uninstallProductDocButtonLabel',
+          { defaultMessage: 'Uninstall' }
+        );
+      case 'uninstalled':
+      default:
+        return i18n.translate(
+          'xpack.observabilityAiAssistantManagement.settingsPage.installProductDocButtonLabel',
+          { defaultMessage: 'Install' }
+        );
+    }
+  }, [status]);
+
+  const isLoading = status === 'loading' || status === 'installing' || status === 'uninstalling';
+
   const content = useMemo(() => {
-    if (isStatusLoading) {
-      return <EuiLoadingSpinner size="m" />;
-    }
-    if (status === 'installing') {
-      return (
-        <EuiFlexGroup justifyContent="flexStart" alignItems="center">
-          <EuiLoadingSpinner size="m" />
-          <EuiText size="s">
-            <FormattedMessage
-              id="xpack.observabilityAiAssistantManagement.settingsPage.installingText"
-              defaultMessage="Installing..."
-            />
-          </EuiText>
-        </EuiFlexGroup>
-      );
-    }
-    if (status === 'uninstalling') {
-      return (
-        <EuiFlexGroup justifyContent="flexStart" alignItems="center">
-          <EuiLoadingSpinner size="m" />
-          <EuiText size="s">
-            <FormattedMessage
-              id="xpack.observabilityAiAssistantManagement.settingsPage.uninstallingText"
-              defaultMessage="Uninstalling..."
-            />
-          </EuiText>
-        </EuiFlexGroup>
-      );
-    }
     if (status === 'installed') {
       return (
         <EuiFlexGroup justifyContent="flexStart" alignItems="center">
@@ -117,10 +112,7 @@ export function ProductDocEntry({ knowledgeBase }: { knowledgeBase: UseKnowledge
               onClick={onClickUninstall}
               color="warning"
             >
-              {i18n.translate(
-                'xpack.observabilityAiAssistantManagement.settingsPage.uninstallProductDocButtonLabel',
-                { defaultMessage: 'Uninstall' }
-              )}
+              {buttonText}
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -132,11 +124,9 @@ export function ProductDocEntry({ knowledgeBase }: { knowledgeBase: UseKnowledge
         data-test-subj="settingsTabInstallProductDocButton"
         onClick={onClickInstall}
         disabled={!canInstallProductDoc}
+        isLoading={isLoading}
       >
-        {i18n.translate(
-          'xpack.observabilityAiAssistantManagement.settingsPage.installProductDocButtonLabel',
-          { defaultMessage: 'Install' }
-        )}
+        {buttonText}
       </EuiButton>
     );
 
@@ -161,7 +151,7 @@ export function ProductDocEntry({ knowledgeBase }: { knowledgeBase: UseKnowledge
         </EuiFlexItem>
       </EuiFlexGroup>
     );
-  }, [canInstallProductDoc, isStatusLoading, onClickInstall, onClickUninstall, status]);
+  }, [canInstallProductDoc, onClickInstall, onClickUninstall, status, buttonText, isLoading]);
 
   return (
     <EuiDescribedFormGroup

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/product_doc_entry.tsx
@@ -18,11 +18,12 @@ import {
 import { i18n } from '@kbn/i18n';
 import { UseKnowledgeBaseResult } from '@kbn/ai-assistant/src/hooks';
 import { KnowledgeBaseState } from '@kbn/observability-ai-assistant-plugin/public';
+import { InstallationStatus } from '@kbn/product-doc-base-plugin/common/install_status';
 import { getMappedInferenceId } from '../../../helpers/inference_utils';
 import { useKibana } from '../../../hooks/use_kibana';
-import { useGetProductDoc, ProductDocStatus } from '../../../hooks/use_get_product_doc';
+import { useGetProductDoc } from '../../../hooks/use_get_product_doc';
 
-const statusToButtonTextMap: Record<Exclude<ProductDocStatus, 'error'> | 'loading', string> = {
+const statusToButtonTextMap: Record<Exclude<InstallationStatus, 'error'> | 'loading', string> = {
   installing: i18n.translate(
     'xpack.observabilityAiAssistantManagement.settingsPage.installingText',
     { defaultMessage: 'Installing...' }

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
@@ -14,6 +14,7 @@ import {
   E5_SMALL_INFERENCE_ID,
   ELSER_ON_ML_NODE_INFERENCE_ID,
   KnowledgeBaseState,
+  LEGACY_CUSTOM_INFERENCE_ID,
 } from '@kbn/observability-ai-assistant-plugin/public';
 import {
   useKnowledgeBase,
@@ -24,6 +25,7 @@ import { useProductDoc } from '../../../hooks/use_product_doc';
 
 jest.mock('../../../hooks/use_app_context');
 jest.mock('../../../hooks/use_kibana');
+jest.mock('../../../hooks/use_product_doc');
 jest.mock('@kbn/ai-assistant/src/hooks');
 
 const useAppContextMock = useAppContext as jest.Mock;
@@ -151,18 +153,54 @@ describe('SettingsTab', () => {
 
   describe('should call useProductDoc with the correct inference ID', () => {
     it('calls useProductDoc with ELSER_ON_ML_NODE_INFERENCE_ID when inference ID is LEGACY_CUSTOM_INFERENCE_ID', async () => {
+      useKnowledgeBaseMock.mockReturnValue({
+        status: {
+          value: {
+            enabled: true,
+            kbState: KnowledgeBaseState.READY,
+            currentInferenceId: ELSER_ON_ML_NODE_INFERENCE_ID,
+          },
+        },
+        isInstalling: false,
+        isPolling: false,
+        isWarmingUpModel: false,
+      });
       render(<SettingsTab />);
 
       expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
     });
 
     it('calls useProductDoc with the current inference ID when inference ID is not LEGACY_CUSTOM_INFERENCE_ID"', async () => {
+      useKnowledgeBaseMock.mockReturnValue({
+        status: {
+          value: {
+            enabled: true,
+            kbState: KnowledgeBaseState.READY,
+            currentInferenceId: LEGACY_CUSTOM_INFERENCE_ID,
+          },
+        },
+        isInstalling: false,
+        isPolling: false,
+        isWarmingUpModel: false,
+      });
       render(<SettingsTab />);
 
       expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
     });
 
     it('calls useProductDoc with the current inference ID when inference ID is not E5_SMALL_INFERENCE_ID"', async () => {
+      useKnowledgeBaseMock.mockReturnValue({
+        status: {
+          value: {
+            enabled: true,
+            kbState: KnowledgeBaseState.READY,
+            currentInferenceId: E5_SMALL_INFERENCE_ID,
+          },
+        },
+        isInstalling: false,
+        isPolling: false,
+        isWarmingUpModel: false,
+      });
       render(<SettingsTab />);
 
       expect(useProductDoc).toHaveBeenCalledWith(E5_SMALL_INFERENCE_ID);

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
@@ -10,12 +10,17 @@ import { render } from '../../../helpers/test_helper';
 import { SettingsTab } from './settings_tab';
 import { useAppContext } from '../../../hooks/use_app_context';
 import { useKibana } from '../../../hooks/use_kibana';
-import { KnowledgeBaseState } from '@kbn/observability-ai-assistant-plugin/public';
+import {
+  E5_SMALL_INFERENCE_ID,
+  ELSER_ON_ML_NODE_INFERENCE_ID,
+  KnowledgeBaseState,
+} from '@kbn/observability-ai-assistant-plugin/public';
 import {
   useKnowledgeBase,
   useGenAIConnectors,
   useInferenceEndpoints,
 } from '@kbn/ai-assistant/src/hooks';
+import { useProductDoc } from '../../../hooks/use_product_doc';
 
 jest.mock('../../../hooks/use_app_context');
 jest.mock('../../../hooks/use_kibana');
@@ -24,6 +29,7 @@ jest.mock('@kbn/ai-assistant/src/hooks');
 const useAppContextMock = useAppContext as jest.Mock;
 const useKibanaMock = useKibana as jest.Mock;
 const useKnowledgeBaseMock = useKnowledgeBase as jest.Mock;
+const useProductDocMock = useProductDoc as jest.Mock;
 const useGenAIConnectorsMock = useGenAIConnectors as jest.Mock;
 const useInferenceEndpointsMock = useInferenceEndpoints as jest.Mock;
 const navigateToAppMock = jest.fn(() => Promise.resolve());
@@ -60,6 +66,12 @@ describe('SettingsTab', () => {
       isInstalling: false,
       isPolling: false,
       isWarmingUpModel: false,
+    });
+    useProductDocMock.mockReturnValue({
+      status: 'uninstalled',
+      isLoading: false,
+      installProductDoc: jest.fn().mockResolvedValue({}),
+      uninstallProductDoc: jest.fn().mockResolvedValue({}),
     });
     useGenAIConnectorsMock.mockReturnValue({ connectors: [{ id: 'test-connector' }] });
     useInferenceEndpointsMock.mockReturnValue({
@@ -135,5 +147,25 @@ describe('SettingsTab', () => {
 
     expect(getByTestId('observabilityAiAssistantKnowledgeBaseLoadingSpinner')).toBeInTheDocument();
     expect(getByTestId('observabilityAiAssistantKnowledgeBaseUpdateModelButton')).toBeDisabled();
+  });
+
+  describe('should call useProductDoc with the correct inference ID', () => {
+    it('calls useProductDoc with ELSER_ON_ML_NODE_INFERENCE_ID when inference ID is LEGACY_CUSTOM_INFERENCE_ID', async () => {
+      render(<SettingsTab />);
+
+      expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
+    });
+
+    it('calls useProductDoc with the current inference ID when inference ID is not LEGACY_CUSTOM_INFERENCE_ID"', async () => {
+      render(<SettingsTab />);
+
+      expect(useProductDoc).toHaveBeenCalledWith(ELSER_ON_ML_NODE_INFERENCE_ID);
+    });
+
+    it('calls useProductDoc with the current inference ID when inference ID is not E5_SMALL_INFERENCE_ID"', async () => {
+      render(<SettingsTab />);
+
+      expect(useProductDoc).toHaveBeenCalledWith(E5_SMALL_INFERENCE_ID);
+    });
   });
 });

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
@@ -29,6 +29,8 @@ import { useKibana } from '../../../hooks/use_kibana';
 import { UISettings } from './ui_settings';
 import { ProductDocEntry } from './product_doc_entry';
 import { ChangeKbModel } from './change_kb_model';
+import { getMappedInferenceId } from '../../../helpers/inference_utils';
+import { useProductDoc } from '../../../hooks/use_product_doc';
 
 const GoToSpacesButton = ({ getUrlForSpaces }: { getUrlForSpaces: () => string }) => {
   return (
@@ -59,6 +61,11 @@ export function SettingsTab() {
   const { config } = useAppContext();
 
   const knowledgeBase = useKnowledgeBase();
+  const currentlyDeployedInferenceId = getMappedInferenceId(
+    knowledgeBase.status.value?.currentInferenceId
+  );
+  const productDoc = useProductDoc(currentlyDeployedInferenceId);
+
   const connectors = useGenAIConnectors();
 
   const elasticManagedLlm = getElasticManagedLlmConnector(connectors.connectors);
@@ -178,10 +185,20 @@ export function SettingsTab() {
         </EuiFormRow>
       </EuiDescribedFormGroup>
 
-      {productDocBase ? <ProductDocEntry knowledgeBase={knowledgeBase} /> : undefined}
+      {productDocBase ? (
+        <ProductDocEntry
+          knowledgeBase={knowledgeBase}
+          productDoc={productDoc}
+          currentlyDeployedInferenceId={currentlyDeployedInferenceId}
+        />
+      ) : undefined}
 
       {knowledgeBase.status.value?.enabled && connectors.connectors?.length ? (
-        <ChangeKbModel knowledgeBase={knowledgeBase} />
+        <ChangeKbModel
+          knowledgeBase={knowledgeBase}
+          productDoc={productDoc}
+          currentlyDeployedInferenceId={currentlyDeployedInferenceId}
+        />
       ) : undefined}
 
       <UISettings knowledgeBase={knowledgeBase} />

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/common/install_status.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/common/install_status.ts
@@ -7,7 +7,12 @@
 
 import type { ProductName } from '@kbn/product-doc-common';
 
-export type InstallationStatus = 'installed' | 'uninstalled' | 'installing' | 'error';
+export type InstallationStatus =
+  | 'installed'
+  | 'uninstalled'
+  | 'installing'
+  | 'uninstalling'
+  | 'error';
 
 /**
  * DTO representation of the product doc install status SO

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.ts
@@ -99,6 +99,14 @@ export class ProductDocInstallClient {
     });
   }
 
+  async setUninstallationStarted(productName: ProductName, inferenceId: string | undefined) {
+    const objectId = getObjectIdFromProductName(productName, inferenceId);
+    await this.soClient.update<TypeAttributes>(typeName, objectId, {
+      installation_status: 'uninstalling',
+      inference_id: inferenceId,
+    });
+  }
+
   async setInstallationSuccessful(
     productName: ProductName,
     indexName: string,

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/service.mock.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/service.mock.ts
@@ -16,6 +16,7 @@ const createInstallClientMock = (): InstallClientMock => {
     setInstallationSuccessful: jest.fn(),
     setInstallationFailed: jest.fn(),
     setUninstalled: jest.fn(),
+    setUninstallationStarted: jest.fn(),
     getPreviouslyInstalledInferenceIds: jest.fn().mockResolvedValue([]),
   } as unknown as InstallClientMock;
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_manager/doc_manager.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_manager/doc_manager.ts
@@ -211,7 +211,13 @@ const convertTaskStatus = (taskStatus: TaskStatus): InstallationStatus | 'unknow
 };
 
 const getOverallStatus = (statuses: InstallationStatus[]): InstallationStatus => {
-  const statusOrder: InstallationStatus[] = ['error', 'installing', 'uninstalled', 'installed'];
+  const statusOrder: InstallationStatus[] = [
+    'error',
+    'installing',
+    'uninstalling',
+    'uninstalled',
+    'installed',
+  ];
   for (const status of statusOrder) {
     if (statuses.includes(status)) {
       return status;

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.ts
@@ -280,15 +280,16 @@ describe('PackageInstaller', () => {
   describe('uninstallAll', () => {
     it('calls uninstall for all packages', async () => {
       jest.spyOn(packageInstaller, 'uninstallPackage');
-
+      const totalProducts = Object.keys(DocumentationProduct).length;
       await packageInstaller.uninstallAll();
 
-      expect(packageInstaller.uninstallPackage).toHaveBeenCalledTimes(
-        Object.keys(DocumentationProduct).length
-      );
+      expect(productDocClient.setUninstallationStarted).toHaveBeenCalledTimes(totalProducts);
+
+      expect(packageInstaller.uninstallPackage).toHaveBeenCalledTimes(totalProducts);
       Object.values(DocumentationProduct).forEach((productName) => {
         expect(packageInstaller.uninstallPackage).toHaveBeenCalledWith({ productName });
       });
+      expect(productDocClient.setUninstalled).toHaveBeenCalledTimes(totalProducts);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
@@ -290,6 +290,7 @@ export class PackageInstaller {
     const { inferenceId } = params;
     const allProducts = Object.values(DocumentationProduct);
     for (const productName of allProducts) {
+      await this.productDocClient.setUninstallationStarted(productName, inferenceId);
       await this.uninstallPackage({ productName, inferenceId });
     }
   }


### PR DESCRIPTION
Closes [#229460](https://github.com/elastic/kibana/issues/229460)
## Summary

When a user clicks the "Install" or "Uninstall" button for product documentation, add visual feedback in the UI (a spinner) to indicate that an action is in progress. 

### Steps to Reproduce
Navigate Observability AI Assistant settings page

see that Elastic documentation is not yet installed.

Click the Install button.

Observe that the button shows no loading state.

(Similarly, for an installed package, click Uninstall and observe the same lack of feedback).

Expected Behavior
After clicking "Install" or "Uninstall", the button should immediately enter a loading state.

https://github.com/user-attachments/assets/9e9f8fef-bf18-4a6a-96af-c514dae4ffdf


https://github.com/user-attachments/assets/1c36d617-0def-4a6d-af04-bb9ef52c624f


https://github.com/user-attachments/assets/8053cf33-cc69-4d1d-8779-23a361266576



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->