### PR TITLE
[9.0] [AI Assistant] Security Assistant settings landed on the wrong page on basic license (#229163)

### DIFF
--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/app_context.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/app_context.tsx
@@ -20,6 +20,7 @@ interface ContextValue extends StartDependencies {
   navigateToApp: CoreStart['application']['navigateToApp'];
   kibanaBranch: string;
   buildFlavor: BuildFlavor;
+  securityAIAssistantEnabled: boolean;
 }
 
 const AppContext = createContext<ContextValue>(null as any);

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/management_section/mount_section.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/management_section/mount_section.tsx
@@ -26,6 +26,7 @@ interface MountParams {
   mountParams: ManagementAppMountParams;
   kibanaBranch: string;
   buildFlavor: BuildFlavor;
+  securityAIAssistantEnabled: boolean;
 }
 
 export const mountManagementSection = async ({
@@ -33,6 +34,7 @@ export const mountManagementSection = async ({
   mountParams,
   kibanaBranch,
   buildFlavor,
+  securityAIAssistantEnabled,
 }: MountParams) => {
   const [coreStart, startDeps] = await core.getStartServices();
   const { element, history, setBreadcrumbs } = mountParams;
@@ -56,6 +58,7 @@ export const mountManagementSection = async ({
               setBreadcrumbs,
               kibanaBranch,
               buildFlavor,
+              securityAIAssistantEnabled,
             }}
           >
             <RouterProvider history={history} router={aIAssistantManagementSelectionRouter as any}>

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/plugin.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/plugin.ts
@@ -83,12 +83,16 @@ export class AIAssistantManagementPlugin
       keywords: ['ai'],
       mount: async (mountParams) => {
         const { mountManagementSection } = await import('./management_section/mount_section');
+        const securityAIAssistantEnabled = !!management?.sections.section.kibana
+          .getAppsEnabled()
+          .find((app) => app.id === 'securityAiAssistantManagement' && app.enabled);
 
         return mountManagementSection({
           core,
           mountParams,
           kibanaBranch: this.kibanaBranch,
           buildFlavor: this.buildFlavor,
+          securityAIAssistantEnabled,
         });
       },
     });

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.test.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.test.tsx
@@ -23,18 +23,26 @@ describe('AiAssistantSelectionPage', () => {
   const generateMockCapabilities = (hasPermission: boolean) =>
     ({
       observabilityAIAssistant: { show: hasPermission },
-      securitySolutionAssistant: { 'ai-assistant': hasPermission },
+      management: {
+        kibana: {
+          aiAssistantManagementSelection: hasPermission,
+        },
+      },
     } as unknown as CoreStart['application']['capabilities']);
 
   const testCapabilities = generateMockCapabilities(true);
 
-  const renderComponent = (capabilities: CoreStart['application']['capabilities']) => {
+  const renderComponent = (
+    capabilities: CoreStart['application']['capabilities'],
+    securityAIAssistantEnabled = true
+  ) => {
     (useAppContext as jest.Mock).mockReturnValue({
       capabilities,
       setBreadcrumbs,
       navigateToApp,
       kibanaBranch: 'main',
       buildFlavor: 'ess',
+      securityAIAssistantEnabled,
     });
     render(<AiAssistantSelectionPage />, {
       wrapper: I18nProvider,
@@ -103,10 +111,12 @@ describe('AiAssistantSelectionPage', () => {
   describe('Security AI Assistant Card', () => {
     describe('when the feature is disabled', () => {
       it('displays the disabled callout', () => {
-        renderComponent(generateMockCapabilities(false));
+        const securityAIAssistantEnabled = false;
+        renderComponent(generateMockCapabilities(false), securityAIAssistantEnabled);
         expect(
           screen.getByTestId('pluginsAiAssistantSelectionPageSecurityDocumentationCallout')
         ).toBeInTheDocument();
+        expect(screen.getByTestId('pluginsAiAssistantSelectionSecurityPageButton')).toBeDisabled();
       });
     });
 

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.tsx
@@ -26,12 +26,21 @@ import { getDocLinks } from '@kbn/doc-links';
 import { useAppContext } from '../../app_context';
 
 export function AiAssistantSelectionPage() {
-  const { capabilities, setBreadcrumbs, navigateToApp, buildFlavor, kibanaBranch } =
-    useAppContext();
+  const {
+    capabilities,
+    setBreadcrumbs,
+    navigateToApp,
+    buildFlavor,
+    kibanaBranch,
+    securityAIAssistantEnabled,
+  } = useAppContext();
+  const aiAssistantManagementSelection =
+    capabilities.management.kibana.aiAssistantManagementSelection;
   const observabilityAIAssistantEnabled = capabilities.observabilityAIAssistant?.show;
-  const securityAIAssistantEnabled = capabilities.securitySolutionAssistant?.['ai-assistant'];
+
   const observabilityDoc = getDocLinks({ buildFlavor, kibanaBranch }).observability.aiAssistant;
   const securityDoc = getDocLinks({ buildFlavor, kibanaBranch }).securitySolution.aiAssistant;
+  const isSecurityAIAssistantEnabled = securityAIAssistantEnabled && aiAssistantManagementSelection;
 
   useEffect(() => {
     setBreadcrumbs([
@@ -148,7 +157,7 @@ export function AiAssistantSelectionPage() {
           <EuiCard
             description={
               <div>
-                {!securityAIAssistantEnabled ? (
+                {!isSecurityAIAssistantEnabled ? (
                   <>
                     <EuiSpacer size="s" />
                     <EuiCallOut
@@ -157,8 +166,7 @@ export function AiAssistantSelectionPage() {
                       title={i18n.translate(
                         'aiAssistantManagementSelection.aiAssistantSelectionPage.securityAi.thisFeatureIsDisabledCallOutLabel',
                         {
-                          defaultMessage:
-                            'This feature is disabled. You can enable it from from Spaces > Features.',
+                          defaultMessage: 'This feature is disabled.',
                         }
                       )}
                       size="s"
@@ -188,26 +196,27 @@ export function AiAssistantSelectionPage() {
                     }}
                   />
                 </p>
-                {securityAIAssistantEnabled && (
+                {
                   <EuiButton
                     data-test-subj="pluginsAiAssistantSelectionSecurityPageButton"
                     iconType="gear"
                     onClick={() =>
                       navigateToApp('management', { path: 'kibana/securityAiAssistantManagement' })
                     }
+                    disabled={!isSecurityAIAssistantEnabled}
                   >
                     {i18n.translate(
                       'aiAssistantManagementSelection.aiAssistantSelectionPage.securityAssistant.manageSettingsButtonLabel',
                       { defaultMessage: 'Manage Settings' }
                     )}
                   </EuiButton>
-                )}
+                }
               </div>
             }
             display="plain"
             hasBorder
             icon={<EuiIcon size="xxl" type="logoSecurity" />}
-            isDisabled={!securityAIAssistantEnabled}
+            isDisabled={!isSecurityAIAssistantEnabled}
             title={i18n.translate(
               'aiAssistantManagementSelection.aiAssistantSelectionPage.securityLabel',
               { defaultMessage: 'Elastic AI Assistant for Security' }

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.test.tsx
@@ -48,6 +48,7 @@ const mockContext = {
   assistantFeatures: { assistantModelEvaluation: true },
   assistantAvailability: {
     isAssistantEnabled: true,
+    isAssistantManagementEnabled: true,
   },
 };
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/assistant_settings_management.tsx
@@ -54,6 +54,8 @@ export const AssistantSettingsManagement: React.FC<Props> = React.memo(
     const {
       assistantFeatures: { assistantModelEvaluation: modelEvaluatorEnabled },
       http,
+      assistantAvailability: { isAssistantManagementEnabled },
+      navigateToApp,
     } = useAssistantContext();
     const { data: connectors } = useLoadConnectors({
       http,
@@ -111,6 +113,10 @@ export const AssistantSettingsManagement: React.FC<Props> = React.memo(
         isSelected: t.id === selectedSettingsTab,
       }));
     }, [onTabChange, selectedSettingsTab, tabsConfig]);
+
+    if (!isAssistantManagementEnabled) {
+      navigateToApp('management');
+    }
 
     return (
       <>

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/types.tsx
@@ -61,6 +61,8 @@ export interface AssistantTelemetry {
 export interface AssistantAvailability {
   // True when user is Enterprise, or Security Complete PLI for serverless. When false, the Assistant is disabled and unavailable
   isAssistantEnabled: boolean;
+  // When true, user has `All` privilege for `Management > AI Assistant`
+  isAssistantManagementEnabled: boolean;
   // When true, the Assistant is hidden and unavailable
   hasAssistantPrivilege: boolean;
   // When true, user has `All` privilege for `Connectors and Actions` (show/execute/delete/save ui capabilities)

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_missing_callout/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_missing_callout/index.test.tsx
@@ -22,6 +22,7 @@ describe('connectorMissingCallout', () => {
         hasUpdateAIAssistantAnonymization: true,
         hasManageGlobalKnowledgeBase: true,
         isAssistantEnabled: true,
+        isAssistantManagementEnabled: true,
       };
 
       it('should show connector privileges required button if no connectors exist', async () => {
@@ -61,6 +62,7 @@ describe('connectorMissingCallout', () => {
         hasUpdateAIAssistantAnonymization: true,
         hasManageGlobalKnowledgeBase: false,
         isAssistantEnabled: true,
+        isAssistantManagementEnabled: true,
       };
 
       it('should show connector privileges required button', async () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
@@ -37,6 +37,7 @@ export const mockAssistantAvailability: AssistantAvailability = {
   hasUpdateAIAssistantAnonymization: true,
   hasManageGlobalKnowledgeBase: true,
   isAssistantEnabled: true,
+  isAssistantManagementEnabled: true,
 };
 
 /** A utility for wrapping children in the providers required to run tests */

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
@@ -54,6 +54,7 @@ const TestExternalProvidersComponent: React.FC<TestExternalProvidersProps> = ({ 
     hasUpdateAIAssistantAnonymization: true,
     hasManageGlobalKnowledgeBase: true,
     isAssistantEnabled: true,
+    isAssistantManagementEnabled: true,
   };
   const queryClient = new QueryClient({
     defaultOptions: {

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/use_assistant_availability/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/use_assistant_availability/index.tsx
@@ -12,6 +12,8 @@ import { ASSISTANT_FEATURE_ID } from '../../../common/constants';
 export interface UseAssistantAvailability {
   // True when user is Enterprise. When false, the Assistant is disabled and unavailable
   isAssistantEnabled: boolean;
+  // When true, user has `All` privilege for `Management > AI Assistant`
+  isAssistantManagementEnabled: boolean;
   // When true, the Assistant is hidden and unavailable
   hasAssistantPrivilege: boolean;
   // When true, user has `All` privilege for `Connectors and Actions` (show/execute/delete/save ui capabilities)
@@ -32,6 +34,8 @@ export const useAssistantAvailability = (): UseAssistantAvailability => {
     capabilities[ASSISTANT_FEATURE_ID]?.updateAIAssistantAnonymization === true;
   const hasManageGlobalKnowledgeBase =
     capabilities[ASSISTANT_FEATURE_ID]?.manageGlobalKnowledgeBaseAIAssistant === true;
+  const hasManageAssistantPrivilege =
+    capabilities?.management?.kibana?.aiAssistantManagementSelection === true;
 
   // Connectors & Actions capabilities as defined in x-pack/plugins/actions/server/feature.ts
   // `READ` ui capabilities defined as: { ui: ['show', 'execute'] }
@@ -48,6 +52,7 @@ export const useAssistantAvailability = (): UseAssistantAvailability => {
     hasConnectorsAllPrivilege,
     hasConnectorsReadPrivilege,
     isAssistantEnabled: isEnterprise,
+    isAssistantManagementEnabled: isEnterprise && hasManageAssistantPrivilege,
     hasUpdateAIAssistantAnonymization,
     hasManageGlobalKnowledgeBase,
   };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
@@ -39,6 +39,7 @@ export const MockAssistantProviderComponent: React.FC<Props> = ({
     hasUpdateAIAssistantAnonymization: true,
     hasManageGlobalKnowledgeBase: true,
     isAssistantEnabled: true,
+    isAssistantManagementEnabled: true,
   };
   const chrome = chromeServiceMock.createStartContract();
   chrome.getChromeStyle$.mockReturnValue(of('classic'));

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/hooks/use_assistant.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/hooks/use_assistant.test.tsx
@@ -35,6 +35,7 @@ describe('useAssistant', () => {
       hasUpdateAIAssistantAnonymization: true,
       hasManageGlobalKnowledgeBase: true,
       isAssistantEnabled: true,
+      isAssistantManagementEnabled: true,
     });
     jest
       .mocked(useAssistantOverlay)
@@ -54,6 +55,7 @@ describe('useAssistant', () => {
       hasUpdateAIAssistantAnonymization: true,
       hasManageGlobalKnowledgeBase: true,
       isAssistantEnabled: true,
+      isAssistantManagementEnabled: true,
     });
     jest
       .mocked(useAssistantOverlay)
@@ -73,6 +75,7 @@ describe('useAssistant', () => {
       hasUpdateAIAssistantAnonymization: true,
       hasManageGlobalKnowledgeBase: true,
       isAssistantEnabled: true,
+      isAssistantManagementEnabled: true,
     });
     jest
       .mocked(useAssistantOverlay)

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -217,6 +217,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         const isAssistantAvailable =
           productFeatureKeys?.has(ProductFeatureAssistantKey.assistant) &&
           license?.hasAtLeast('enterprise');
+
         const assistantManagementApp = management?.sections.section.kibana.getApp(
           'securityAiAssistantManagement'
         );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[AI Assistant] Security Assistant settings landed on the wrong page on basic license (#229163)](https://github.com/elastic/kibana/pull/229163)

