### PR TITLE
[Response Ops][Connectors] Add missing `pfx` service for external plugins

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
@@ -207,6 +207,7 @@ export class Plugin
     this.connectorServices = {
       validateEmailAddresses: plugins.actions.validateEmailAddresses,
       enabledEmailServices: plugins.actions.enabledEmailServices,
+      isWebhookSslWithPfxEnabled: plugins.actions.isWebhookSslWithPfxEnabled,
     };
 
     ExperimentalFeaturesService.init({ experimentalFeatures: this.experimentalFeatures });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/229582


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->