### PR TITLE
[Vega] Change Vega editor inactiveSelectionBackground color in dark mode to match Monaco Editor dark theme

### DIFF
--- a/src/platform/plugins/private/vis_types/vega/public/components/vega_vis_editor.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/components/vega_vis_editor.tsx
@@ -50,16 +50,22 @@ function format(
 }
 
 const vegaVisStyles = {
-  base: css({
-    '&.vgaEditor': {
-      width: '100%',
-      flexGrow: 1,
-
-      '.kibanaCodeEditor': {
+  base: ({ colorMode }: UseEuiTheme) =>
+    css({
+      '&.vgaEditor': {
         width: '100%',
+        flexGrow: 1,
+
+        '.kibanaCodeEditor': {
+          width: '100%',
+        },
+        ...(colorMode === 'DARK' && {
+          '.monaco-editor': {
+            '--vscode-editor-inactiveSelectionBackground': '#3a3d41',
+          },
+        }),
       },
-    },
-  }),
+    }),
   editorActions: ({ euiTheme }: UseEuiTheme) =>
     css({
       position: 'absolute',

--- a/src/platform/plugins/private/vis_types/vega/public/components/vega_vis_editor.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/components/vega_vis_editor.tsx
@@ -59,6 +59,7 @@ const vegaVisStyles = {
         '.kibanaCodeEditor': {
           width: '100%',
         },
+        // See discussion: https://github.com/elastic/kibana/issues/228296#issuecomment-3126033291
         ...(colorMode === 'DARK' && {
           '.monaco-editor': {
             '--vscode-editor-inactiveSelectionBackground': '#3a3d41',

--- a/src/platform/plugins/private/vis_types/vega/public/components/vega_vis_editor.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/components/vega_vis_editor.tsx
@@ -50,23 +50,16 @@ function format(
 }
 
 const vegaVisStyles = {
-  base: ({ colorMode }: UseEuiTheme) =>
-    css({
-      '&.vgaEditor': {
-        width: '100%',
-        flexGrow: 1,
+  base: css({
+    '&.vgaEditor': {
+      width: '100%',
+      flexGrow: 1,
 
-        '.kibanaCodeEditor': {
-          width: '100%',
-        },
-        // See discussion: https://github.com/elastic/kibana/issues/228296#issuecomment-3126033291
-        ...(colorMode === 'DARK' && {
-          '.monaco-editor': {
-            '--vscode-editor-inactiveSelectionBackground': '#3a3d41',
-          },
-        }),
+      '.kibanaCodeEditor': {
+        width: '100%',
       },
-    }),
+    },
+  }),
   editorActions: ({ euiTheme }: UseEuiTheme) =>
     css({
       position: 'absolute',
@@ -78,8 +71,21 @@ const vegaVisStyles = {
     }),
 };
 
+const monacoOverride = {
+  override: ({ colorMode }: UseEuiTheme) =>
+    css({
+      // See discussion: https://github.com/elastic/kibana/issues/228296#issuecomment-3126033291
+      ...(colorMode === 'DARK' && {
+        '.monaco-editor': {
+          '--vscode-editor-inactiveSelectionBackground': '#3a3d41',
+        },
+      }),
+    }),
+};
+
 function VegaVisEditor({ stateParams, setValue }: VisEditorOptionsProps<VisParams>) {
   const styles = useMemoCss(vegaVisStyles);
+  const monacoStyles = useMemoCss(monacoOverride);
   const [languageId, setLanguageId] = useState<string>();
 
   useMount(() => {
@@ -134,6 +140,7 @@ function VegaVisEditor({ stateParams, setValue }: VisEditorOptionsProps<VisParam
         <VegaActionsMenu formatHJson={formatHJson} formatJson={formatJson} />
       </div>
       <CodeEditor
+        classNameCss={monacoStyles.override}
         width="100%"
         height="100%"
         languageId={languageId}


### PR DESCRIPTION
## Summary

This PR fixes wrong color being used for when you have text selected in Vega editor and the editor isn't focused. After the change, the color matches the default value used in Monaco Editor dark theme.

| Before | After |
|--------|-------|
| <img width="373" height="995" alt="Before" src="https://github.com/user-attachments/assets/183684db-a1f4-43b4-bc1d-f3c5e9c1193d" /> | <img width="371" height="946" alt="After" src="https://github.com/user-attachments/assets/ee965d26-8016-45af-b6f1-1ed86953467c" /> |

Closes: #228296 





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->