### PR TITLE
[8.19] [Discover][Trace profiles] Update error handling strategy with KibanaSectionErrorBoundary (#227664)

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_doc_viewer.tsx
@@ -19,6 +19,9 @@ const hasAnyAttributesField = hasAnyFieldWithPrefixes(attributesPrefixes);
 export const getDocViewer: ObservabilityRootProfileProvider['profile']['getDocViewer'] =
   (prev) => (params) => {
     const prevDocViewer = prev(params);
+    const tabTitle = i18n.translate('discover.docViews.observability.attributesOverview.title', {
+      defaultMessage: 'Attributes',
+    });
 
     return {
       ...prevDocViewer,
@@ -26,9 +29,7 @@ export const getDocViewer: ObservabilityRootProfileProvider['profile']['getDocVi
         if (hasAnyAttributesField(params.record)) {
           registry.add({
             id: 'doc_view_obs_attributes_overview',
-            title: i18n.translate('discover.docViews.observability.attributesOverview.title', {
-              defaultMessage: 'Attributes',
-            }),
+            title: tabTitle,
             order: 9,
             component: (props) => {
               return <UnifiedDocViewerObservabilityAttributesOverview {...props} />;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
@@ -22,15 +22,15 @@ export const createGetDocViewer =
   (prev: (params: DocViewerExtensionParams) => DocViewerExtension) =>
   (params: DocViewerExtensionParams) => {
     const prevDocViewer = prev(params);
-
+    const tabTitle = i18n.translate('discover.docViews.observability.traces.spanOverview.title', {
+      defaultMessage: 'Span overview',
+    });
     return {
       ...prevDocViewer,
       docViewsRegistry: (registry: DocViewsRegistry) => {
         registry.add({
           id: 'doc_view_obs_traces_span_overview',
-          title: i18n.translate('discover.docViews.observability.traces.spanOverview.title', {
-            defaultMessage: 'Span overview',
-          }),
+          title: tabTitle,
           order: 0,
           component: (props) => {
             return <UnifiedDocViewerObservabilityTracesSpanOverview {...props} indexes={indexes} />;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/transaction_document_profile/accessors/doc_viewer.tsx
@@ -22,18 +22,19 @@ export const createGetDocViewer =
   (prev: (params: DocViewerExtensionParams) => DocViewerExtension) =>
   (params: DocViewerExtensionParams) => {
     const prevDocViewer = prev(params);
+    const tabTitle = i18n.translate(
+      'discover.docViews.observability.traces.transactionOverview.title',
+      {
+        defaultMessage: 'Transaction overview',
+      }
+    );
 
     return {
       ...prevDocViewer,
       docViewsRegistry: (registry: DocViewsRegistry) => {
         registry.add({
           id: 'doc_view_obs_traces_transaction_overview',
-          title: i18n.translate(
-            'discover.docViews.observability.traces.transactionOverview.title',
-            {
-              defaultMessage: 'Transaction overview',
-            }
-          ),
+          title: tabTitle,
           order: 0,
           component: (props) => {
             return (

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -110,7 +110,5 @@
     "@kbn/alerts-ui-shared",
     "@kbn/core-pricing-browser-mocks"
   ],
-  "exclude": [
-    "target/**/*"
-  ]
+  "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -17,6 +17,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
 import { SERVICE_NAME_FIELD, SPAN_ID_FIELD, TRANSACTION_ID_FIELD } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
@@ -48,6 +49,8 @@ export const FullScreenWaterfall = ({
   const [spanId, setSpanId] = useState<string | null>(null);
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const overlayMaskRef = useRef<HTMLDivElement>(null);
+  const { euiTheme } = useEuiTheme();
+
   const {
     share: {
       url: { locators },
@@ -107,7 +110,11 @@ export const FullScreenWaterfall = ({
     <>
       <EuiOverlayMask
         maskRef={overlayMaskRef}
-        css={{ paddingBlockEnd: '0 !important', overflowY: 'scroll' }}
+        css={{
+          paddingBlockEnd: '0 !important',
+          overflowY: 'scroll',
+          backgroundColor: `${euiTheme.colors.backgroundBasePlain} !important`,
+        }}
       >
         <EuiFocusTrap css={{ height: '100%', width: '100%' }}>
           <EuiPanel hasShadow={false} css={{ minHeight: '100%', width: '100%' }}>

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/span_flyout/span_flyout_body.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiSkeletonText, EuiTab, EuiTabs } from '@elastic/eui';
+import { EuiErrorBoundary, EuiSkeletonText, EuiTab, EuiTabs } from '@elastic/eui';
 import { DataTableRecord } from '@kbn/discover-utils';
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -83,24 +83,27 @@ export const SpanFlyoutBody = ({ hit, loading, dataView }: SpanFlyoutProps) => {
         <>
           <EuiTabs size="s">{renderTabs()}</EuiTabs>
           <EuiSkeletonText isLoading={loading}>
-            {selectedTabId === tabIds.OVERVIEW &&
-              (isSpan ? (
-                <SpanOverview
-                  hit={hit}
-                  indexes={indexes}
-                  showWaterfall={false}
-                  showActions={false}
-                  dataView={dataView}
-                />
-              ) : (
-                <TransactionOverview
-                  hit={hit}
-                  indexes={indexes}
-                  showWaterfall={false}
-                  showActions={false}
-                  dataView={dataView}
-                />
-              ))}
+            {selectedTabId === tabIds.OVERVIEW && (
+              <EuiErrorBoundary>
+                {isSpan ? (
+                  <SpanOverview
+                    hit={hit}
+                    indexes={indexes}
+                    showWaterfall={false}
+                    showActions={false}
+                    dataView={dataView}
+                  />
+                ) : (
+                  <TransactionOverview
+                    hit={hit}
+                    indexes={indexes}
+                    showWaterfall={false}
+                    showActions={false}
+                    dataView={dataView}
+                  />
+                )}
+              </EuiErrorBoundary>
+            )}
 
             {selectedTabId === tabIds.TABLE && <DocViewerTable hit={hit} dataView={dataView} />}
 

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
@@ -15,6 +15,9 @@ import React from 'react';
 import { BehaviorSubject, map, merge } from 'rxjs';
 import { isEmpty } from 'lodash';
 import { initializeUnsavedChanges } from '@kbn/presentation-containers';
+import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
+import { i18n } from '@kbn/i18n';
+import type { IWaterfallGetRelatedErrorsHref } from '../../../common/waterfall/typings';
 import { ApmEmbeddableContext } from '../embeddable_context';
 import type { EmbeddableDeps } from '../types';
 import { APM_TRACE_WATERFALL_EMBEDDABLE } from './constant';
@@ -200,9 +203,18 @@ export const getApmTraceWaterfallEmbeddableFactory = (deps: EmbeddableDeps) => {
           );
 
           return (
-            <ApmEmbeddableContext deps={deps} rangeFrom={rangeFrom} rangeTo={rangeTo}>
-              {content}
-            </ApmEmbeddableContext>
+            <KibanaSectionErrorBoundary
+              sectionName={i18n.translate(
+                'xpack.apm.embeddable.traceWaterfall.kibanaSectionErrorBoundary.sectionName',
+                {
+                  defaultMessage: 'Trace waterfall',
+                }
+              )}
+            >
+              <ApmEmbeddableContext deps={deps} rangeFrom={rangeFrom} rangeTo={rangeTo}>
+                {content}
+              </ApmEmbeddableContext>
+            </KibanaSectionErrorBoundary>
           );
         },
       };

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
@@ -17,13 +17,12 @@ import { isEmpty } from 'lodash';
 import { initializeUnsavedChanges } from '@kbn/presentation-containers';
 import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
 import { i18n } from '@kbn/i18n';
-import type { IWaterfallGetRelatedErrorsHref } from '../../../common/waterfall/typings';
 import { ApmEmbeddableContext } from '../embeddable_context';
 import type { EmbeddableDeps } from '../types';
 import { APM_TRACE_WATERFALL_EMBEDDABLE } from './constant';
 import { TraceWaterfallEmbeddable } from './trace_waterfall_embeddable';
 import { FocusedTraceWaterfallEmbeddable } from './focused_trace_waterfall_embeddable';
-import type { IWaterfallGetRelatedErrorsHref } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
+import { IWaterfallGetRelatedErrorsHref } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
 
 interface BaseProps {
   traceId: string;

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/react_embeddable_factory.tsx
@@ -22,7 +22,7 @@ import type { EmbeddableDeps } from '../types';
 import { APM_TRACE_WATERFALL_EMBEDDABLE } from './constant';
 import { TraceWaterfallEmbeddable } from './trace_waterfall_embeddable';
 import { FocusedTraceWaterfallEmbeddable } from './focused_trace_waterfall_embeddable';
-import { IWaterfallGetRelatedErrorsHref } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
+import type { IWaterfallGetRelatedErrorsHref } from '../../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
 
 interface BaseProps {
   traceId: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][Trace profiles] Update error handling strategy with KibanaSectionErrorBoundary (#227664)](https://github.com/elastic/kibana/pull/227664)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2025-07-28T09:29:41Z","message":"[Discover][Trace profiles] Update error handling strategy with KibanaSectionErrorBoundary (#227664)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/227611\n\n\nIn relation to [[Meta] Replace EuiErrorBoundary with\nKibanaErrorBoundary/KibanaSectionErrorBoundary](https://github.com/elastic/kibana/issues/225970),\nto ensure we're aligned with the platform's error UI and that errors are\nproperly sent as EBT events, we had to wrap certain parts of our code\nwith the appropriate error boundaries.\n\n### Elements within the flyout\n\n**Embeddable waterfalls**\nIt seems they needed their own handler probably because they are\nembedabbles.\n- Focused\n\n|Before|After|\n|-|-|\n|<img width=\"1917\" height=\"969\" alt=\"Screenshot 2025-07-11 at 15 17 45\"\nsrc=\"https://github.com/user-attachments/assets/bbf3b3b9-f204-4538-8480-696ed188d89d\"\n/>|<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-07-11 at 15 17\n20\"\nsrc=\"https://github.com/user-attachments/assets/db4940ac-0030-4a9f-ba77-4086ae3261c2\"\n/>|\n\n- Full\n\n|Before|After|\n|-|-|\n|<img width=\"1906\" height=\"963\" alt=\"Screenshot 2025-07-11 at 15 20 21\"\nsrc=\"https://github.com/user-attachments/assets/d3cd8592-4358-412d-ae3b-8eee77749243\"\n/>|<img width=\"1903\" height=\"964\" alt=\"Screenshot 2025-07-11 at 15 19\n23\"\nsrc=\"https://github.com/user-attachments/assets/411b00d4-c49d-4805-819d-efa675d6e942\"\n/>|\n\n**Waterfall flyout overview tabs**\n\nWe can’t use `KibanaSectionErrorBoundary` here because the UI of the\n\"Show details\" flyout doesn’t adapt well to the full-screen content\nunderneath. Also, we would need to find a way to access and increase its\n`z-index` so it appears above our content. (The screenshot was taken\nafter modifying the style directly in the browser console.)\n\n<img width=\"1560\" height=\"969\" alt=\"Screenshot 2025-07-24 at 12 46 51\"\nsrc=\"https://github.com/user-attachments/assets/6d10bc88-486e-4100-b81a-da736103496e\"\n/>\n\n\nTo keep the error handling scoped properly for now, I’ve wrapped it in\nthe older `EuiErrorBoundary`. This is a temporary solution until we can\nupdate the whole flow to work smoothly with the new FlyoutSystem.\n\n<img width=\"1562\" height=\"968\" alt=\"Screenshot 2025-07-24 at 12 48 03\"\nsrc=\"https://github.com/user-attachments/assets/3c27c33d-0b4f-4e5f-b62e-d2bcf341ad74\"\n/>\n\n\n## How to test\n- Set up an error in your local code for any of the embeddable\nwaterfalls\n- Go to Discover in an Observability Space\n- Open any trace document (`FROM traces-*`)\n- You'll get the error in the Trace section\n- You can after verify the event logged in `FROM ebt-kibana-* | WHERE\nevent_type == \"fatal-error-react\" `\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd37f6928043e132a4f220aea5054c313fa950a3","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Discover][Trace profiles] Update error handling strategy with KibanaSectionErrorBoundary","number":227664,"url":"https://github.com/elastic/kibana/pull/227664","mergeCommit":{"message":"[Discover][Trace profiles] Update error handling strategy with KibanaSectionErrorBoundary (#227664)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/227611\n\n\nIn relation to [[Meta] Replace EuiErrorBoundary with\nKibanaErrorBoundary/KibanaSectionErrorBoundary](https://github.com/elastic/kibana/issues/225970),\nto ensure we're aligned with the platform's error UI and that errors are\nproperly sent as EBT events, we had to wrap certain parts of our code\nwith the appropriate error boundaries.\n\n### Elements within the flyout\n\n**Embeddable waterfalls**\nIt seems they needed their own handler probably because they are\nembedabbles.\n- Focused\n\n|Before|After|\n|-|-|\n|<img width=\"1917\" height=\"969\" alt=\"Screenshot 2025-07-11 at 15 17 45\"\nsrc=\"https://github.com/user-attachments/assets/bbf3b3b9-f204-4538-8480-696ed188d89d\"\n/>|<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-07-11 at 15 17\n20\"\nsrc=\"https://github.com/user-attachments/assets/db4940ac-0030-4a9f-ba77-4086ae3261c2\"\n/>|\n\n- Full\n\n|Before|After|\n|-|-|\n|<img width=\"1906\" height=\"963\" alt=\"Screenshot 2025-07-11 at 15 20 21\"\nsrc=\"https://github.com/user-attachments/assets/d3cd8592-4358-412d-ae3b-8eee77749243\"\n/>|<img width=\"1903\" height=\"964\" alt=\"Screenshot 2025-07-11 at 15 19\n23\"\nsrc=\"https://github.com/user-attachments/assets/411b00d4-c49d-4805-819d-efa675d6e942\"\n/>|\n\n**Waterfall flyout overview tabs**\n\nWe can’t use `KibanaSectionErrorBoundary` here because the UI of the\n\"Show details\" flyout doesn’t adapt well to the full-screen content\nunderneath. Also, we would need to find a way to access and increase its\n`z-index` so it appears above our content. (The screenshot was taken\nafter modifying the style directly in the browser console.)\n\n<img width=\"1560\" height=\"969\" alt=\"Screenshot 2025-07-24 at 12 46 51\"\nsrc=\"https://github.com/user-attachments/assets/6d10bc88-486e-4100-b81a-da736103496e\"\n/>\n\n\nTo keep the error handling scoped properly for now, I’ve wrapped it in\nthe older `EuiErrorBoundary`. This is a temporary solution until we can\nupdate the whole flow to work smoothly with the new FlyoutSystem.\n\n<img width=\"1562\" height=\"968\" alt=\"Screenshot 2025-07-24 at 12 48 03\"\nsrc=\"https://github.com/user-attachments/assets/3c27c33d-0b4f-4e5f-b62e-d2bcf341ad74\"\n/>\n\n\n## How to test\n- Set up an error in your local code for any of the embeddable\nwaterfalls\n- Go to Discover in an Observability Space\n- Open any trace document (`FROM traces-*`)\n- You'll get the error in the Trace section\n- You can after verify the event logged in `FROM ebt-kibana-* | WHERE\nevent_type == \"fatal-error-react\" `\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd37f6928043e132a4f220aea5054c313fa950a3"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227664","number":227664,"mergeCommit":{"message":"[Discover][Trace profiles] Update error handling strategy with KibanaSectionErrorBoundary (#227664)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/227611\n\n\nIn relation to [[Meta] Replace EuiErrorBoundary with\nKibanaErrorBoundary/KibanaSectionErrorBoundary](https://github.com/elastic/kibana/issues/225970),\nto ensure we're aligned with the platform's error UI and that errors are\nproperly sent as EBT events, we had to wrap certain parts of our code\nwith the appropriate error boundaries.\n\n### Elements within the flyout\n\n**Embeddable waterfalls**\nIt seems they needed their own handler probably because they are\nembedabbles.\n- Focused\n\n|Before|After|\n|-|-|\n|<img width=\"1917\" height=\"969\" alt=\"Screenshot 2025-07-11 at 15 17 45\"\nsrc=\"https://github.com/user-attachments/assets/bbf3b3b9-f204-4538-8480-696ed188d89d\"\n/>|<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-07-11 at 15 17\n20\"\nsrc=\"https://github.com/user-attachments/assets/db4940ac-0030-4a9f-ba77-4086ae3261c2\"\n/>|\n\n- Full\n\n|Before|After|\n|-|-|\n|<img width=\"1906\" height=\"963\" alt=\"Screenshot 2025-07-11 at 15 20 21\"\nsrc=\"https://github.com/user-attachments/assets/d3cd8592-4358-412d-ae3b-8eee77749243\"\n/>|<img width=\"1903\" height=\"964\" alt=\"Screenshot 2025-07-11 at 15 19\n23\"\nsrc=\"https://github.com/user-attachments/assets/411b00d4-c49d-4805-819d-efa675d6e942\"\n/>|\n\n**Waterfall flyout overview tabs**\n\nWe can’t use `KibanaSectionErrorBoundary` here because the UI of the\n\"Show details\" flyout doesn’t adapt well to the full-screen content\nunderneath. Also, we would need to find a way to access and increase its\n`z-index` so it appears above our content. (The screenshot was taken\nafter modifying the style directly in the browser console.)\n\n<img width=\"1560\" height=\"969\" alt=\"Screenshot 2025-07-24 at 12 46 51\"\nsrc=\"https://github.com/user-attachments/assets/6d10bc88-486e-4100-b81a-da736103496e\"\n/>\n\n\nTo keep the error handling scoped properly for now, I’ve wrapped it in\nthe older `EuiErrorBoundary`. This is a temporary solution until we can\nupdate the whole flow to work smoothly with the new FlyoutSystem.\n\n<img width=\"1562\" height=\"968\" alt=\"Screenshot 2025-07-24 at 12 48 03\"\nsrc=\"https://github.com/user-attachments/assets/3c27c33d-0b4f-4e5f-b62e-d2bcf341ad74\"\n/>\n\n\n## How to test\n- Set up an error in your local code for any of the embeddable\nwaterfalls\n- Go to Discover in an Observability Space\n- Open any trace document (`FROM traces-*`)\n- You'll get the error in the Trace section\n- You can after verify the event logged in `FROM ebt-kibana-* | WHERE\nevent_type == \"fatal-error-react\" `\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd37f6928043e132a4f220aea5054c313fa950a3"}}]}] BACKPORT-->