### PR TITLE
[8.19] [Synthetics] Add ignore_unavailable to SyntheticsEsClient (#229290)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
@@ -93,6 +93,7 @@ describe('SyntheticsEsClient', () => {
   describe('search', () => {
     it('should call baseESClient.search with correct parameters', async () => {
       const mockSearchParams = {
+        ignore_unavailable: true,
         body: {
           query: {
             match_all: {},
@@ -128,6 +129,7 @@ describe('SyntheticsEsClient', () => {
 
     it('should throw an error if baseESClient.search throws an error', async () => {
       const mockSearchParams = {
+        ignore_unavailable: true,
         body: {
           query: {
             match_all: {},
@@ -152,6 +154,7 @@ describe('SyntheticsEsClient', () => {
     it('should call baseESClient.count with correct parameters', async () => {
       const mockCountParams = {
         index: 'example',
+        ignore_unavailable: true,
       };
 
       const result = await syntheticsEsClient.count(mockCountParams);
@@ -173,6 +176,7 @@ describe('SyntheticsEsClient', () => {
 
     it('should throw an error if baseESClient.count throws an error', async () => {
       const mockCountParams = {
+        ignore_unavailable: true,
         index: 'example',
       };
       const mockError = new Error('Count error');

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
@@ -76,7 +76,7 @@ export class SyntheticsEsClient {
     let res: any;
     let esError: any;
 
-    const esParams = { index: SYNTHETICS_INDEX_PATTERN, ...params };
+    const esParams = { index: SYNTHETICS_INDEX_PATTERN, ignore_unavailable: true, ...params };
     const startTime = process.hrtime();
     const startTimeNow = Date.now();
 
@@ -156,7 +156,11 @@ export class SyntheticsEsClient {
         this.inspectableEsQueries.push(
           getInspectResponse({
             esError,
-            esRequestParams: { index: SYNTHETICS_INDEX_PATTERN, ...request },
+            esRequestParams: {
+              index: SYNTHETICS_INDEX_PATTERN,
+              ignore_unavailable: true,
+              ...request,
+            },
             esRequestStatus: RequestStatus.OK,
             esResponse: res?.body.responses[index],
             kibanaRequest: this.request!,
@@ -179,7 +183,7 @@ export class SyntheticsEsClient {
     let res: any;
     let esError: any;
 
-    const esParams = { index: SYNTHETICS_INDEX_PATTERN, ...params };
+    const esParams = { index: SYNTHETICS_INDEX_PATTERN, ignore_unavailable: true, ...params };
     const startTime = process.hrtime();
 
     try {

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
@@ -188,6 +188,7 @@ describe('getNetworkEvents', () => {
       Array [
         Array [
           Object {
+            "ignore_unavailable": true,
             "body": Object {
               "query": Object {
                 "bool": Object {

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
@@ -188,7 +188,6 @@ describe('getNetworkEvents', () => {
       Array [
         Array [
           Object {
-            "ignore_unavailable": true,
             "body": Object {
               "query": Object {
                 "bool": Object {
@@ -214,6 +213,7 @@ describe('getNetworkEvents', () => {
               "size": 1000,
               "track_total_hits": true,
             },
+            "ignore_unavailable": true,
             "index": "synthetics-*",
           },
           Object {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Add ignore_unavailable to SyntheticsEsClient (#229290)](https://github.com/elastic/kibana/pull/229290)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bena Kansara","email":"69037875+benakansara@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-28T10:16:24Z","message":"[Synthetics] Add ignore_unavailable to SyntheticsEsClient (#229290)\n\nWhen one or more indices are closed, user cannot view their Synthetics\nmonitors, which fail with \"Unable to get synthetic monitor status: An\ninternal server error occurred. Check Kibana server logs for details.\".\n\nThe API call `/internal/synthetics/overview_status` fails with below\nerror:\n\n```\nindex_closed_exception\n\tRoot causes:\n\t\tindex_closed_exception: closed\n```\n\nIn this PR, I added `ignore_unavailable: true` to `SyntheticsEsClient`\nto allow API to perform partial reads on the data stream and ignore\nclosed indices.","sha":"4b3e649af1cd9ccb93baef3745dc31b5320ceb21","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management","v9.2.0"],"title":"[Synthetics] Add ignore_unavailable to SyntheticsEsClient","number":229290,"url":"https://github.com/elastic/kibana/pull/229290","mergeCommit":{"message":"[Synthetics] Add ignore_unavailable to SyntheticsEsClient (#229290)\n\nWhen one or more indices are closed, user cannot view their Synthetics\nmonitors, which fail with \"Unable to get synthetic monitor status: An\ninternal server error occurred. Check Kibana server logs for details.\".\n\nThe API call `/internal/synthetics/overview_status` fails with below\nerror:\n\n```\nindex_closed_exception\n\tRoot causes:\n\t\tindex_closed_exception: closed\n```\n\nIn this PR, I added `ignore_unavailable: true` to `SyntheticsEsClient`\nto allow API to perform partial reads on the data stream and ignore\nclosed indices.","sha":"4b3e649af1cd9ccb93baef3745dc31b5320ceb21"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229290","number":229290,"mergeCommit":{"message":"[Synthetics] Add ignore_unavailable to SyntheticsEsClient (#229290)\n\nWhen one or more indices are closed, user cannot view their Synthetics\nmonitors, which fail with \"Unable to get synthetic monitor status: An\ninternal server error occurred. Check Kibana server logs for details.\".\n\nThe API call `/internal/synthetics/overview_status` fails with below\nerror:\n\n```\nindex_closed_exception\n\tRoot causes:\n\t\tindex_closed_exception: closed\n```\n\nIn this PR, I added `ignore_unavailable: true` to `SyntheticsEsClient`\nto allow API to perform partial reads on the data stream and ignore\nclosed indices.","sha":"4b3e649af1cd9ccb93baef3745dc31b5320ceb21"}}]}] BACKPORT-->