### PR TITLE
[9.1] [Security Solution][Sourcerer] Display explore data view as managed (#227230)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -82,6 +82,8 @@ export const DEFAULT_THREAT_INDEX_KEY = 'securitySolution:defaultThreatIndex' as
 export const DEFAULT_THREAT_INDEX_VALUE = ['logs-ti_*'] as const;
 export const DEFAULT_THREAT_MATCH_QUERY = '@timestamp >= "now-30d/d"' as const;
 
+export const EXPLORE_DATA_VIEW_PREFIX = 'explore-data-view' as const;
+
 export const EXPLORE_PATH = '/explore' as const;
 export const DASHBOARDS_PATH = '/dashboards' as const;
 export const MANAGE_PATH = '/manage' as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useRef, useMemo, memo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { DataView } from '@kbn/data-views-plugin/public';
+import { EXPLORE_DATA_VIEW_PREFIX } from '../../../../common/constants';
 import type { SourcererUrlState } from '../../../sourcerer/store/model';
 import { useUpdateUrlParam } from '../../../common/utils/global_query_string';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
@@ -61,7 +62,9 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
   const { adhocDataViews: adhocDataViewSpecs, defaultDataViewId } =
     useSelector(sharedStateSelector);
   const adhocDataViews = useMemo(() => {
-    return adhocDataViewSpecs.map((spec) => new DataView({ spec, fieldFormats }));
+    return adhocDataViewSpecs
+      .filter((spec) => !spec.id?.startsWith(EXPLORE_DATA_VIEW_PREFIX))
+      .map((spec) => new DataView({ spec, fieldFormats }));
   }, [adhocDataViewSpecs, fieldFormats]);
 
   const managedDataViews = useManagedDataViews();

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.test.ts
@@ -58,6 +58,7 @@ describe('useManagedDataViews', () => {
     // Mock the Redux selector
     (useSelector as jest.Mock).mockReturnValue({
       dataViews: mockDataViews,
+      adhocDataViews: [],
       defaultDataViewId: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
       alertDataViewId: DEFAULT_ALERT_DATA_VIEW_ID,
     });
@@ -101,6 +102,7 @@ describe('useManagedDataViews', () => {
     ];
     (useSelector as jest.Mock).mockReturnValue({
       dataViews: mockDataViews,
+      adhocDataViews: [],
       defaultDataViewId: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.ts
@@ -8,6 +8,7 @@
 import { DataView } from '@kbn/data-views-plugin/public';
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
+import { EXPLORE_DATA_VIEW_PREFIX } from '../../../common/constants';
 import { useKibana } from '../../common/lib/kibana';
 import { sharedStateSelector } from '../redux/selectors';
 
@@ -17,6 +18,7 @@ import { sharedStateSelector } from '../redux/selectors';
 export const useManagedDataViews = (): DataView[] => {
   const {
     dataViews: dataViewSpecs,
+    adhocDataViews,
     defaultDataViewId,
     alertDataViewId,
   } = useSelector(sharedStateSelector);
@@ -26,9 +28,14 @@ export const useManagedDataViews = (): DataView[] => {
 
   return useMemo(
     () =>
-      dataViewSpecs
-        .filter((dv) => dv.id === defaultDataViewId || dv.id === alertDataViewId)
+      [...dataViewSpecs, ...adhocDataViews]
+        .filter(
+          (dv) =>
+            dv.id === defaultDataViewId ||
+            dv.id === alertDataViewId ||
+            dv.id?.startsWith(EXPLORE_DATA_VIEW_PREFIX)
+        )
         .map((spec) => new DataView({ spec, fieldFormats })),
-    [dataViewSpecs, defaultDataViewId, alertDataViewId, fieldFormats]
+    [dataViewSpecs, adhocDataViews, defaultDataViewId, alertDataViewId, fieldFormats]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
@@ -7,6 +7,7 @@
 
 import type { DataViewsServicePublic, DataView } from '@kbn/data-views-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import { EXPLORE_DATA_VIEW_PREFIX } from '../../../common/constants';
 
 export const createExploreDataView = async (
   dependencies: {
@@ -21,8 +22,8 @@ export const createExploreDataView = async (
     .join();
 
   return dependencies.dataViews.create({
-    id: `explore-data-view-${(await dependencies.spaces.getActiveSpace()).id}`,
-    name: 'Explore Data View',
+    id: `${EXPLORE_DATA_VIEW_PREFIX}-${(await dependencies.spaces.getActiveSpace()).id}`,
+    name: 'Explore data view',
     title: exploreDataViewPattern,
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Sourcerer] Display explore data view as managed (#227230)](https://github.com/elastic/kibana/pull/227230)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Luke Gmys","email":"11671118+lgestc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-10T09:52:34Z","message":"[Security Solution][Sourcerer] Display explore data view as managed (#227230)\n\n## Summary\n\nThis PR marks Explore Data view with Managed flag, as promised\n@PhilippeOberti\n\n<img width=\"731\" alt=\"Screenshot 2025-07-09 at 14 02 56\"\nsrc=\"https://github.com/user-attachments/assets/45b6ffa9-05d6-4509-ae9e-e6f08997cbd4\"\n/>","sha":"2f49376700181f1f72dfb7ca976f930db29eaac9","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Threat Hunting:Investigations","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Security Solution][Sourcerer] Display explore data view as managed","number":227230,"url":"https://github.com/elastic/kibana/pull/227230","mergeCommit":{"message":"[Security Solution][Sourcerer] Display explore data view as managed (#227230)\n\n## Summary\n\nThis PR marks Explore Data view with Managed flag, as promised\n@PhilippeOberti\n\n<img width=\"731\" alt=\"Screenshot 2025-07-09 at 14 02 56\"\nsrc=\"https://github.com/user-attachments/assets/45b6ffa9-05d6-4509-ae9e-e6f08997cbd4\"\n/>","sha":"2f49376700181f1f72dfb7ca976f930db29eaac9"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227230","number":227230,"mergeCommit":{"message":"[Security Solution][Sourcerer] Display explore data view as managed (#227230)\n\n## Summary\n\nThis PR marks Explore Data view with Managed flag, as promised\n@PhilippeOberti\n\n<img width=\"731\" alt=\"Screenshot 2025-07-09 at 14 02 56\"\nsrc=\"https://github.com/user-attachments/assets/45b6ffa9-05d6-4509-ae9e-e6f08997cbd4\"\n/>","sha":"2f49376700181f1f72dfb7ca976f930db29eaac9"}}]}] BACKPORT-->