### PR TITLE
[9.1] fix dashboard project sticky header offset

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -408,7 +408,7 @@ const topNavStyles = {
         width: '100%',
         position: 'sticky',
         zIndex: euiTheme.levels.mask,
-        top: `var(--euiFixedHeadersOffset, ${euiTheme.size.base})`,
+        top: `var(--kbnAppHeadersOffset, var(--euiFixedHeadersOffset, ${euiTheme.size.base}))`,
         background: euiTheme.colors.backgroundBasePlain,
       },
     }),


### PR DESCRIPTION
## Summary

Fix dashboard toolbar sticky header offset with solution navigation 

This is extracted from https://github.com/elastic/kibana/pull/226581, but without all new layout changes 


Validating the fix:


https://github.com/user-attachments/assets/49543bae-f591-471c-8ad4-4f38c251dd55






