### PR TITLE
[ES|QL] Some fixes in controls creation

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -24,9 +24,10 @@ import {
   getCategorizeColumns,
   getArgsFromRenameFunction,
   getCategorizeField,
+  findClosestColumn,
 } from './query_parsing_helpers';
 import { monaco } from '@kbn/monaco';
-import { parse, walk } from '@kbn/esql-ast';
+import { ESQLColumn, parse, walk } from '@kbn/esql-ast';
 describe('esql query helpers', () => {
   describe('getIndexPatternFromESQLQuery', () => {
     it('should return the index pattern string from esql queries', () => {
@@ -557,6 +558,107 @@ describe('esql query helpers', () => {
     });
   });
 
+  describe('findClosestColumn', () => {
+    const mockColumns: ESQLColumn[] = [
+      {
+        args: [],
+        location: { min: 10, max: 15 },
+        text: 'col1',
+        incomplete: false,
+        parts: ['col1'],
+        quoted: false,
+        name: 'col1',
+        type: 'column',
+      },
+      {
+        args: [],
+        location: { min: 20, max: 25 },
+        text: 'col2',
+        incomplete: false,
+        parts: ['col2'],
+        quoted: false,
+        name: 'col2',
+        type: 'column',
+      },
+      {
+        args: [],
+        location: { min: 30, max: 40 },
+        text: 'col3.sub',
+        incomplete: false,
+        parts: ['col3', 'sub'],
+        quoted: false,
+        name: 'col3.sub',
+        type: 'column',
+      },
+      {
+        args: [],
+        location: { min: 56, max: 63 },
+        text: 'clientip',
+        incomplete: false,
+        parts: ['clientip'],
+        quoted: false,
+        name: 'clientip',
+        type: 'column',
+      },
+    ];
+
+    it('should return undefined if the columns array is empty', () => {
+      const cursor = { lineNumber: 1, column: 5 } as monaco.Position;
+      expect(findClosestColumn([], cursor)).toBeUndefined();
+    });
+
+    it('should return the column if the cursor is exactly at its min boundary', () => {
+      const cursor = { lineNumber: 1, column: 10 } as monaco.Position;
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[0]); // col1
+    });
+
+    it('should return the column if the cursor is exactly at its max boundary', () => {
+      const cursor = { lineNumber: 1, column: 15 } as monaco.Position;
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[0]); // col1
+    });
+
+    it('should return the column if the cursor is inside its range', () => {
+      const cursor = { lineNumber: 1, column: 12 } as monaco.Position;
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[0]); // col1
+
+      const cursor2 = { lineNumber: 1, column: 35 } as monaco.Position;
+      expect(findClosestColumn(mockColumns, cursor2)).toEqual(mockColumns[2]); // col3.sub
+    });
+
+    it('should return the closest column when cursor is between two columns (closer to the first)', () => {
+      const cursor = { lineNumber: 1, column: 17 } as monaco.Position; // 2 units from col1.max, 3 units from col2.min
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[0]); // col1
+    });
+
+    it('should return the closest column when cursor is between two columns (closer to the second)', () => {
+      const cursor = { lineNumber: 1, column: 18 } as monaco.Position; // 3 units from col1.max, 2 units from col2.min
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[1]); // col2
+    });
+
+    it('should return the closest column when cursor is far to the left of all columns', () => {
+      const cursor = { lineNumber: 1, column: 5 } as monaco.Position;
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[0]); // col1
+    });
+
+    it('should return the closest column when cursor is far to the right of all columns', () => {
+      const cursor = { lineNumber: 1, column: 70 } as monaco.Position;
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[3]); // clientip
+    });
+
+    it('should correctly identify column when cursor is just outside max of previous column', () => {
+      const cursor = { lineNumber: 1, column: 26 } as monaco.Position; // Just past col2.max (25)
+      expect(findClosestColumn(mockColumns, cursor)).toEqual(mockColumns[1]); // col2 (closest boundary is 25)
+    });
+
+    it('should prioritize the first found if distances are exactly equal (edge case for between columns)', () => {
+      const equidistantColumns: ESQLColumn[] = [
+        { ...mockColumns[0], location: { min: 10, max: 12 } },
+        { ...mockColumns[1], location: { min: 14, max: 16 } },
+      ];
+      const cursor = { lineNumber: 1, column: 13 } as monaco.Position; // 1 unit from col1.max, 1 unit from col2.min
+      expect(findClosestColumn(equidistantColumns, cursor)).toEqual(equidistantColumns[0]);
+    });
+  });
   describe('getValuesFromQueryField', () => {
     it('should return the values from the query field', () => {
       const queryString = 'FROM my_index | WHERE my_field ==';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -579,6 +579,15 @@ describe('esql query helpers', () => {
       expect(values).toEqual('my_field');
     });
 
+    it('should return the values from the query when we have more than one columns', () => {
+      const queryString = 'FROM my_index | WHERE my_field >= 1200 AND another_field == ';
+      const values = getValuesFromQueryField(queryString, {
+        lineNumber: 1,
+        column: 63,
+      } as monaco.Position);
+      expect(values).toEqual('another_field');
+    });
+
     it('should return the values from the query field with new lines when cursor is not at the end', () => {
       const queryString = 'FROM my_index \n| WHERE my_field >= \n| STATS COUNT(*)';
       const values = getValuesFromQueryField(queryString, {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -231,16 +231,16 @@ const hasQuestionMarkAtEndOrSecondLastPosition = (queryString: string) => {
 /**
  * Finds the column closest to the given cursor position within an array of columns.
  *
- * @param columns An array of column objects.
+ * @param columns An array of ES|QL columns.
  * @param cursorPosition The current cursor position.
  * @returns The column object closest to the cursor, or null if the columns array is empty.
  */
-function findClosestColumn(
+export function findClosestColumn(
   columns: ESQLColumn[],
   cursorPosition?: monaco.Position
-): ESQLColumn | null {
+): ESQLColumn | undefined {
   if (columns.length === 0) {
-    return null;
+    return undefined;
   }
 
   if (!cursorPosition) {
@@ -248,7 +248,7 @@ function findClosestColumn(
   }
 
   const cursorCol = cursorPosition.column;
-  let closestColumn: ESQLColumn | null = null;
+  let closestColumn;
   let minDistance = Infinity;
 
   for (const column of columns) {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/run_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/run_query.ts
@@ -71,14 +71,16 @@ export async function getESQLQueryColumnsRaw({
   search,
   signal,
   timeRange,
+  variables,
 }: {
   esqlQuery: string;
   search: ISearchGeneric;
   signal?: AbortSignal;
   timeRange?: TimeRange;
+  variables?: ESQLControlVariable[];
 }): Promise<ESQLColumn[]> {
   try {
-    const namedParams = getStartEndParams(esqlQuery, timeRange);
+    const namedParams = getNamedParams(esqlQuery, timeRange, variables);
     const response = await lastValueFrom(
       search(
         {
@@ -112,14 +114,22 @@ export async function getESQLQueryColumns({
   search,
   signal,
   timeRange,
+  variables,
 }: {
   esqlQuery: string;
   search: ISearchGeneric;
   signal?: AbortSignal;
   timeRange?: TimeRange;
+  variables?: ESQLControlVariable[];
 }): Promise<DatatableColumn[]> {
   try {
-    const rawColumns = await getESQLQueryColumnsRaw({ esqlQuery, search, signal, timeRange });
+    const rawColumns = await getESQLQueryColumnsRaw({
+      esqlQuery,
+      search,
+      signal,
+      timeRange,
+      variables,
+    });
     const columns = formatESQLColumns(rawColumns) ?? [];
     return columns;
   } catch (error) {

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/identifier_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/identifier_control_form.tsx
@@ -25,6 +25,7 @@ import {
   EsqlControlType,
   type ESQLControlState,
   type ControlWidthOptions,
+  ESQLControlVariable,
 } from '@kbn/esql-types';
 import { aggFunctionDefinitions } from '@kbn/esql-ast/src/definitions/generated/aggregation_functions';
 import { getESQLQueryColumnsRaw } from '@kbn/esql-utils';
@@ -36,6 +37,7 @@ interface IdentifierControlFormProps {
   variableType: ESQLVariableType;
   variableName: string;
   queryString: string;
+  esqlVariables: ESQLControlVariable[];
   setControlState: (state: ESQLControlState) => void;
   cursorPosition?: monaco.Position;
   initialState?: ESQLControlState;
@@ -47,6 +49,7 @@ export function IdentifierControlForm({
   initialState,
   queryString,
   cursorPosition,
+  esqlVariables,
   setControlState,
   search,
 }: IdentifierControlFormProps) {
@@ -78,6 +81,7 @@ export function IdentifierControlForm({
         const queryForFields = getQueryForFields(queryString, cursorPosition);
         getESQLQueryColumnsRaw({
           esqlQuery: queryForFields,
+          variables: esqlVariables,
           search,
         }).then((columns) => {
           if (isMounted()) {
@@ -109,6 +113,7 @@ export function IdentifierControlForm({
       cursorPosition,
       isMounted,
       queryString,
+      esqlVariables,
       search,
       variableType,
     ]

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/index.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/index.tsx
@@ -193,6 +193,7 @@ export function ESQLControlsFlyout({
     ) : (
       <IdentifierControlForm
         variableType={variableType}
+        esqlVariables={esqlVariables}
         variableName={variableName}
         queryString={queryString}
         setControlState={setControlState}


### PR DESCRIPTION
## Summary

This PR fixes 2 bugs

- The first bug is that if I have a visualization with an existing variable

`from index | WHERE field == ?variable`

and try to add a field variable

`from index | WHERE field == ?variable | STATS BY ` --> here select Create control

then the fields are not populated at the dropdown

This is fixing it by just passing the esqlVariables array to the request
<img width="570" height="664" alt="image" src="https://github.com/user-attachments/assets/68340646-5cfd-42c4-9240-fb20d412ca1d" />


- The other bug has to do with the generated query in a control in the following scenario. Let's say you have sometthink like that
```
FROM logst* | WHERE agent.keyword == "meow" 
```

and you want to add an AND with variable

`from index | WHERE field == "meow" AND anotherField ==` --> here select Create control

the generated query is not `from index | STATS BY anotherField` but it is `BY field`

<img width="530" height="516" alt="image" src="https://github.com/user-attachments/assets/f4aa0058-9171-4e3f-aa3e-b95f86f1a60f" />


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


