### PR TITLE
[Fleet] use spaces in auto upgrade task

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
@@ -134,6 +134,7 @@ export async function sendAutomaticUpgradeAgentsActions(
     agents: Agent[];
     version: string;
     upgradeDurationSeconds?: number;
+    spaceId?: string;
   }
 ): Promise<{ actionId: string }> {
   const currentSpaceId = getCurrentNamespace(soClient);
@@ -142,6 +143,6 @@ export async function sendAutomaticUpgradeAgentsActions(
     options.agents,
     {},
     { ...options, isAutomatic: true },
-    currentSpaceId
+    options.spaceId ?? currentSpaceId
   );
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
@@ -124,7 +124,7 @@ export async function sendUpgradeAgentsActions(
     }
   }
 
-  return await upgradeBatch(esClient, givenAgents, outgoingErrors, options, currentSpaceId);
+  return await upgradeBatch(esClient, givenAgents, outgoingErrors, options, [currentSpaceId]);
 }
 
 export async function sendAutomaticUpgradeAgentsActions(
@@ -134,7 +134,7 @@ export async function sendAutomaticUpgradeAgentsActions(
     agents: Agent[];
     version: string;
     upgradeDurationSeconds?: number;
-    spaceId?: string;
+    spaceIds?: string[];
   }
 ): Promise<{ actionId: string }> {
   const currentSpaceId = getCurrentNamespace(soClient);
@@ -143,6 +143,6 @@ export async function sendAutomaticUpgradeAgentsActions(
     options.agents,
     {},
     { ...options, isAutomatic: true },
-    options.spaceId ?? currentSpaceId
+    options.spaceIds ?? [currentSpaceId]
   );
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade_action_runner.ts
@@ -41,7 +41,7 @@ export class UpgradeActionRunner extends ActionRunner {
       agents,
       {},
       this.actionParams! as any,
-      this.actionParams?.spaceId
+      this.actionParams?.spaceId ? [this.actionParams?.spaceId] : undefined
     );
   }
 
@@ -74,9 +74,9 @@ export async function upgradeBatch(
     total?: number;
     isAutomatic?: boolean;
   },
-  spaceId?: string
+  spaceIds?: string[]
 ): Promise<{ actionId: string }> {
-  const soClient = appContextService.getInternalUserSOClientForSpaceId(spaceId);
+  const soClient = appContextService.getInternalUserSOClientForSpaceId(spaceIds?.[0]);
   const errors: Record<Agent['id'], Error> = { ...outgoingErrors };
 
   const hostedPolicies = await getHostedPolicies(soClient, givenAgents);
@@ -181,7 +181,7 @@ export async function upgradeBatch(
 
   const actionId = options.actionId ?? uuidv4();
   const total = options.total ?? givenAgents.length;
-  const namespaces = spaceId ? [spaceId] : [];
+  const namespaces = spaceIds ? spaceIds : [];
 
   await createAgentAction(esClient, {
     id: actionId,

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/automatic_agent_upgrade_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/automatic_agent_upgrade_task.ts
@@ -41,7 +41,7 @@ import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../constants';
 import { AgentStatusKueryHelper, isAgentUpgradeable } from '../../common/services';
 
 export const TYPE = 'fleet:automatic-agent-upgrade-task';
-export const VERSION = '1.0.1';
+export const VERSION = '1.0.2';
 const TITLE = 'Fleet Automatic agent upgrades';
 const SCOPE = ['fleet'];
 const DEFAULT_INTERVAL = '30m';
@@ -199,6 +199,7 @@ export class AutomaticAgentUpgradeTask {
       kuery: `${AGENT_POLICY_SAVED_OBJECT_TYPE}.is_managed:false AND ${AGENT_POLICY_SAVED_OBJECT_TYPE}.required_versions:*`,
       perPage: AGENT_POLICIES_BATCHSIZE,
       fields: ['id', 'required_versions'],
+      spaceId: '*',
     });
     for await (const agentPolicyPageResults of agentPolicyFetcher) {
       this.logger.debug(
@@ -470,6 +471,7 @@ export class AutomaticAgentUpgradeTask {
         await sendAutomaticUpgradeAgentsActions(soClient, esClient, {
           agents: agentsReadyForRetry,
           version,
+          spaceId: agentPolicy.space_ids?.[0],
           ...this.getUpgradeDurationSeconds(agentsReadyForRetry.length),
         });
       }
@@ -532,6 +534,7 @@ export class AutomaticAgentUpgradeTask {
       await sendAutomaticUpgradeAgentsActions(soClient, esClient, {
         agents: agentsForUpgrade,
         version,
+        spaceId: agentPolicy.space_ids?.[0],
         ...this.getUpgradeDurationSeconds(agentsForUpgrade.length),
       });
     }

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/automatic_agent_upgrade_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/automatic_agent_upgrade_task.ts
@@ -471,7 +471,7 @@ export class AutomaticAgentUpgradeTask {
         await sendAutomaticUpgradeAgentsActions(soClient, esClient, {
           agents: agentsReadyForRetry,
           version,
-          spaceId: agentPolicy.space_ids?.[0],
+          spaceIds: agentPolicy.space_ids,
           ...this.getUpgradeDurationSeconds(agentsReadyForRetry.length),
         });
       }
@@ -534,7 +534,7 @@ export class AutomaticAgentUpgradeTask {
       await sendAutomaticUpgradeAgentsActions(soClient, esClient, {
         agents: agentsForUpgrade,
         version,
-        spaceId: agentPolicy.space_ids?.[0],
+        spaceIds: agentPolicy.space_ids,
         ...this.getUpgradeDurationSeconds(agentsForUpgrade.length),
       });
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/228563

Auto upgrade was not querying agent policies from all spaces and the auto upgrade action didn't have the agent policy space set.

To verify:
- Create a space
- Add agent policy, add auto-upgrade version config
- Enroll an agent
- Wait until the task runs to pick up the agent
- Verify that Agent activity shows the auto upgrade action

<img width="1777" height="535" alt="image" src="https://github.com/user-attachments/assets/b22f75d4-8d19-4897-85db-623e029765fb" />
<img width="1776" height="735" alt="image" src="https://github.com/user-attachments/assets/c9378ff9-c1ab-4cf9-a0da-87d4946676e8" />

```
[2025-07-28T14:55:45.915+02:00][INFO ][plugins.fleet.fleet:automatic-agent-upgrade-task:1.0.3] [AutomaticAgentUpgradeTask] runTask() started
[2025-07-28T14:55:45.928+02:00][DEBUG][plugins.fleet.fleet:automatic-agent-upgrade-task:1.0.3] [AutomaticAgentUpgradeTask] Found 2 agent policies with required_versions
[2025-07-28T14:55:45.928+02:00][DEBUG][plugins.fleet.fleet:automatic-agent-upgrade-task:1.0.3] [AutomaticAgentUpgradeTask] Processing agent policy 3d80ef1e-9384-4d65-86ac-d449bd410e4e with required_versions [{"version":"9.0.3","percentage":100}]
[2025-07-28T14:55:45.981+02:00][DEBUG][plugins.fleet.fleet:automatic-agent-upgrade-task:1.0.3] [AutomaticAgentUpgradeTask] Agent policy 3d80ef1e-9384-4d65-86ac-d449bd410e4e: checking candidate agents for upgrade (target version: 9.0.3, percentage: 100)
[2025-07-28T14:55:46.000+02:00][INFO ][plugins.fleet.fleet:automatic-agent-upgrade-task:1.0.3] [AutomaticAgentUpgradeTask] Agent policy 3d80ef1e-9384-4d65-86ac-d449bd410e4e: sending bulk upgrade to 9.0.3 for 1 agents
```

Also added support for multiple `spaceIds` in an agent policy. The action should have the same `spaceIds`, so the action shows up in all spaces where the agent policy is visible.

E.g. agent policy shared in 2 spaces:
<img width="896" height="362" alt="image" src="https://github.com/user-attachments/assets/cf51d83c-967d-4b9b-a199-ae9df624fa7c" />

Auto upgrade action will be visible in 2 spaces:
```
GET .fleet-actions/_search

 {
        "_index": ".fleet-actions-7",
        "_id": "b4d7cfe3-023d-424e-b93a-16dc644c9e5d",
        "_score": 1,
        "_source": {
          "@timestamp": "2025-07-28T14:43:38.203Z",
          "expiration": "2025-08-27T14:43:38.203Z",
          "agents": [
            "bb7faf6f-ef63-48d9-a427-15f53d25f439"
          ],
          "namespaces": [
            "space1",
            "default"
          ],
          "action_id": "8aaef517-9847-43c8-9319-cb4df942d0b7",
          "data": {
            "version": "9.0.3"
          },
          "type": "UPGRADE",
          "total": 1,
          "traceparent": "00-0d4a35048a1ecb756c9c03c311629909-fd9238c857a9fe36-01",
          "is_automatic": true,
          "policyId": "3d80ef1e-9384-4d65-86ac-d449bd410e4e",
```


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->