### PR TITLE
[9.0] [Lens][Reporting] Add custom CSS for Lens screenshots (#228603)

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -500,7 +500,7 @@ class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> extends C
       isScreenshotMode && styles.hidden,
     ];
 
-    const classes = classNames('uniSearchBar', {
+    const classes = classNames('uniSearchBar', 'hide-for-sharing', {
       [`uniSearchBar--hidden`]: isScreenshotMode,
       [`uniSearchBar--${this.props.displayStyle}`]: this.props.displayStyle,
     });

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/frame_layout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/frame_layout.tsx
@@ -66,7 +66,7 @@ export function FrameLayout(props: FrameLayoutProps) {
               {props.dataPanel}
             </section>
             <section
-              className={classNames('lnsFrameLayout__pageBody', {
+              className={classNames('lnsFrameLayout__pageBody', 'lnsVisualizationWorkspace_container', {
                 'lnsFrameLayout__pageBody-isFullscreen': isFullscreen,
               })}
               aria-labelledby="workspaceId"

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/frame_layout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/frame_layout.tsx
@@ -66,9 +66,13 @@ export function FrameLayout(props: FrameLayoutProps) {
               {props.dataPanel}
             </section>
             <section
-              className={classNames('lnsFrameLayout__pageBody', 'lnsVisualizationWorkspace_container', {
-                'lnsFrameLayout__pageBody-isFullscreen': isFullscreen,
-              })}
+              className={classNames(
+                'lnsFrameLayout__pageBody',
+                'lnsVisualizationWorkspace_container',
+                {
+                  'lnsFrameLayout__pageBody-isFullscreen': isFullscreen,
+                }
+              )}
               aria-labelledby="workspaceId"
             >
               <EuiScreenReaderOnly>

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -249,6 +249,7 @@ export function WorkspacePanelWrapper({
           alignItems="center"
           justifyContent="center"
           direction="column"
+          className="lnsWorkspacePanelWrapper__contentFlexGroup"
           css={css`
             height: 100%;
           `}

--- a/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.css
+++ b/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.css
@@ -22,3 +22,15 @@
 #globalBannerList {
   display: none;
 }
+
+
+/**
+ * Specific for lens editor workspace screenshotting
+ */
+.lnsWorkspacePanelWrapper__contentFlexGroup {
+  display: block  !important;
+}
+.lnsVisualizationWorkspace_container {
+  padding: 0 !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Lens][Reporting] Add custom CSS for Lens screenshots (#228603)](https://github.com/elastic/kibana/pull/228603)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2025-07-26T19:27:22Z","message":"[Lens][Reporting] Add custom CSS for Lens screenshots (#228603)\n\n## Summary\n\nFix Lens screenshotting issues:\n\n- apply `hide-for-sharing` class to the search bar in lens\n- added two specialized styles for Lens workspace to fix the current\npositioning error by removing the container display flex and\npadding/borders.\n\nWhat is actually doing is removing horizontal and vertical spacing,\ncaused by the current flex layout applied.\n\nI've tried to tracking down a bit more why exactly this is happening,\nbut I didn't want to touch much the current reporting logic. From what I\nsaw the reporting for PNG works like that:\n1- the service receive, together with other info, the current `layout`\nfrom the browser page (consisting in the size of the current\nvisualization)\n2- it creates a puppeter page with a viewport of the same size of the\n`layout.width` and a `scaleFactor`\n3- the setup step, waits for elements to be on the screen, applies the\nand the render is completed\n4- we detect element positions and sizing with a headless-browser size\ncall to getBoundingBoxRect()\n5- the viewport is now is changed again (actually just vertically) to\ncover the entire height from the top to the bottom of the chart\n(computed at step 4)\n6- a screenshot request to the headless browser covering clipping the\nscreen to just the element position, size.\n\nI believe the best way to approach this in the future is, instead of\nchanging the viewport and and clipping where the element is, we can\napply a `position:fixed` push the chart to the top/left corner and\napplying the original `layout` size to the screenshotting element. In\nthis way we are sure that the sizing and clipping is always perfect.\n\n\nfix https://github.com/elastic/kibana/issues/227930\nfix https://github.com/elastic/kibana/issues/219297\n\n---------\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"46808d6debc42d1e0988c1caaf16cd0fabaff448","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Visualizations","Feature:Lens","Feature:Reporting:Screenshot","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.0.5","v8.17.10","v8.19.1"],"title":"[Lens][Reporting] Add custom CSS for Lens screenshots","number":228603,"url":"https://github.com/elastic/kibana/pull/228603","mergeCommit":{"message":"[Lens][Reporting] Add custom CSS for Lens screenshots (#228603)\n\n## Summary\n\nFix Lens screenshotting issues:\n\n- apply `hide-for-sharing` class to the search bar in lens\n- added two specialized styles for Lens workspace to fix the current\npositioning error by removing the container display flex and\npadding/borders.\n\nWhat is actually doing is removing horizontal and vertical spacing,\ncaused by the current flex layout applied.\n\nI've tried to tracking down a bit more why exactly this is happening,\nbut I didn't want to touch much the current reporting logic. From what I\nsaw the reporting for PNG works like that:\n1- the service receive, together with other info, the current `layout`\nfrom the browser page (consisting in the size of the current\nvisualization)\n2- it creates a puppeter page with a viewport of the same size of the\n`layout.width` and a `scaleFactor`\n3- the setup step, waits for elements to be on the screen, applies the\nand the render is completed\n4- we detect element positions and sizing with a headless-browser size\ncall to getBoundingBoxRect()\n5- the viewport is now is changed again (actually just vertically) to\ncover the entire height from the top to the bottom of the chart\n(computed at step 4)\n6- a screenshot request to the headless browser covering clipping the\nscreen to just the element position, size.\n\nI believe the best way to approach this in the future is, instead of\nchanging the viewport and and clipping where the element is, we can\napply a `position:fixed` push the chart to the top/left corner and\napplying the original `layout` size to the screenshotting element. In\nthis way we are sure that the sizing and clipping is always perfect.\n\n\nfix https://github.com/elastic/kibana/issues/227930\nfix https://github.com/elastic/kibana/issues/219297\n\n---------\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"46808d6debc42d1e0988c1caaf16cd0fabaff448"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.17"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229533","number":229533,"state":"MERGED","mergeCommit":{"sha":"371e60c1bd0683004db5da2195b6b952071bca4b","message":"[9.1] [Lens][Reporting] Add custom CSS for Lens screenshots (#228603) (#229533)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Lens][Reporting] Add custom CSS for Lens screenshots\n(#228603)](https://github.com/elastic/kibana/pull/228603)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229532","number":229532,"state":"MERGED","mergeCommit":{"sha":"b9f5c904eb88e69b2027b879177a27281f5f8218","message":"[8.19] [Lens][Reporting] Add custom CSS for Lens screenshots (#228603) (#229532)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Lens][Reporting] Add custom CSS for Lens screenshots\n(#228603)](https://github.com/elastic/kibana/pull/228603)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>"}},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228603","number":228603,"mergeCommit":{"message":"[Lens][Reporting] Add custom CSS for Lens screenshots (#228603)\n\n## Summary\n\nFix Lens screenshotting issues:\n\n- apply `hide-for-sharing` class to the search bar in lens\n- added two specialized styles for Lens workspace to fix the current\npositioning error by removing the container display flex and\npadding/borders.\n\nWhat is actually doing is removing horizontal and vertical spacing,\ncaused by the current flex layout applied.\n\nI've tried to tracking down a bit more why exactly this is happening,\nbut I didn't want to touch much the current reporting logic. From what I\nsaw the reporting for PNG works like that:\n1- the service receive, together with other info, the current `layout`\nfrom the browser page (consisting in the size of the current\nvisualization)\n2- it creates a puppeter page with a viewport of the same size of the\n`layout.width` and a `scaleFactor`\n3- the setup step, waits for elements to be on the screen, applies the\nand the render is completed\n4- we detect element positions and sizing with a headless-browser size\ncall to getBoundingBoxRect()\n5- the viewport is now is changed again (actually just vertically) to\ncover the entire height from the top to the bottom of the chart\n(computed at step 4)\n6- a screenshot request to the headless browser covering clipping the\nscreen to just the element position, size.\n\nI believe the best way to approach this in the future is, instead of\nchanging the viewport and and clipping where the element is, we can\napply a `position:fixed` push the chart to the top/left corner and\napplying the original `layout` size to the screenshotting element. In\nthis way we are sure that the sizing and clipping is always perfect.\n\n\nfix https://github.com/elastic/kibana/issues/227930\nfix https://github.com/elastic/kibana/issues/219297\n\n---------\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"46808d6debc42d1e0988c1caaf16cd0fabaff448"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->