### PR TITLE
[Dashboard] fix rendering panels when defer below the fold setting is on and we focus/unfocus a panel

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid_item.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid_item.tsx
@@ -10,7 +10,10 @@
 import { EuiLoadingChart, UseEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
-import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
+import {
+  useBatchedPublishingSubjects,
+  useStateFromPublishingSubject,
+} from '@kbn/presentation-publishing';
 import classNames from 'classnames';
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
@@ -196,20 +199,14 @@ export const ObservedItem = React.forwardRef<HTMLDivElement, Props>((props, pane
 
 export const DashboardGridItem = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
   const dashboardApi = useDashboardApi();
-  const [focusedPanelId, viewMode] = useBatchedPublishingSubjects(
-    dashboardApi.focusedPanelId$,
-    dashboardApi.viewMode$
-  );
+  const viewMode = useStateFromPublishingSubject(dashboardApi.viewMode$);
 
   const deferBelowFoldEnabled = useMemo(
     () => presentationUtilService.labsService.isProjectEnabled('labs:dashboard:deferBelowFold'),
     []
   );
 
-  const isEnabled =
-    viewMode !== 'print' &&
-    deferBelowFoldEnabled &&
-    (!focusedPanelId || focusedPanelId === props.id);
+  const isEnabled = viewMode !== 'print' && deferBelowFoldEnabled;
 
   return isEnabled ? <ObservedItem ref={ref} {...props} /> : <Item ref={ref} {...props} />;
 });


### PR DESCRIPTION
Summary
Fixes https://github.com/elastic/kibana/issues/229569

This is a simple fix for a rarely used feature — if it were more common, we’d have noticed how broken it is sooner. 

I assume that the initial idea for the removed line is that when a focusedPanelId is defined, only that panel should refresh. This didn’t work as expected, so with this fix we keep only refreshing panels that are inside the viewport.

There’s probably a cleaner approach, but for now this keeps things working. I remember @ThomThomson was recently working on improvements here, so we might replace this altogether soon.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->