### PR TITLE
[8.19] [Security Solution] Unskip Cypress tests for backfill groups (#229502)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
@@ -31,9 +31,7 @@ import {
   FIRST_BACKFILL_ID,
 } from '../../../../tasks/api_calls/backfill';
 
-// Failing: See https://github.com/elastic/kibana/issues/229350
-// Failing: See https://github.com/elastic/kibana/issues/229350
-describe.skip(
+describe(
   'Backfill groups',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Unskip Cypress tests for backfill groups (#229502)](https://github.com/elastic/kibana/pull/229502)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgii Gorbachev","email":"georgii.gorbachev@elastic.co"},"sourceCommit":{"committedDate":"2025-07-28T12:03:39Z","message":"[Security Solution] Unskip Cypress tests for backfill groups (#229502)\n\n**Fixes: https://github.com/elastic/kibana/issues/229350**\n\n## Summary\n\nThe tests were skipped in\nhttps://github.com/elastic/kibana/issues/229350#issuecomment-3117121711.\n\nLet's see if the recent issues with EPR and the `security_ai_prompts`\npackage are gone and we can unskip it.\n\n<img width=\"558\" height=\"352\" alt=\"Screenshot 2025-07-24 at 11 08 14 AM\"\nsrc=\"https://github.com/user-attachments/assets/c0c52d91-101f-472c-8198-71c0ae0f1847\"\n/>","sha":"85ffac77de3187d6764ada276934b0151e767478","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Team:Detection Engine","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[Security Solution] Unskip Cypress tests for backfill groups","number":229502,"url":"https://github.com/elastic/kibana/pull/229502","mergeCommit":{"message":"[Security Solution] Unskip Cypress tests for backfill groups (#229502)\n\n**Fixes: https://github.com/elastic/kibana/issues/229350**\n\n## Summary\n\nThe tests were skipped in\nhttps://github.com/elastic/kibana/issues/229350#issuecomment-3117121711.\n\nLet's see if the recent issues with EPR and the `security_ai_prompts`\npackage are gone and we can unskip it.\n\n<img width=\"558\" height=\"352\" alt=\"Screenshot 2025-07-24 at 11 08 14 AM\"\nsrc=\"https://github.com/user-attachments/assets/c0c52d91-101f-472c-8198-71c0ae0f1847\"\n/>","sha":"85ffac77de3187d6764ada276934b0151e767478"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229622","number":229622,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229502","number":229502,"mergeCommit":{"message":"[Security Solution] Unskip Cypress tests for backfill groups (#229502)\n\n**Fixes: https://github.com/elastic/kibana/issues/229350**\n\n## Summary\n\nThe tests were skipped in\nhttps://github.com/elastic/kibana/issues/229350#issuecomment-3117121711.\n\nLet's see if the recent issues with EPR and the `security_ai_prompts`\npackage are gone and we can unskip it.\n\n<img width=\"558\" height=\"352\" alt=\"Screenshot 2025-07-24 at 11 08 14 AM\"\nsrc=\"https://github.com/user-attachments/assets/c0c52d91-101f-472c-8198-71c0ae0f1847\"\n/>","sha":"85ffac77de3187d6764ada276934b0151e767478"}}]}] BACKPORT-->