### PR TITLE
[Observability] [Rules] Include `ContentManagement` plugin to allow linked dashboards

### DIFF
--- a/src/platform/plugins/shared/discover/kibana.jsonc
+++ b/src/platform/plugins/shared/discover/kibana.jsonc
@@ -13,6 +13,7 @@
     "server": true,
     "requiredPlugins": [
       "charts",
+      "contentManagement",
       "data",
       "dataViews",
       "discoverShared",

--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -55,6 +55,7 @@ import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { ContentClient } from '@kbn/content-management-plugin/public';
 import type { ObservabilityAIAssistantPublicStart } from '@kbn/observability-ai-assistant-plugin/public';
+import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
 import { noop } from 'lodash';
 import type { NoDataPagePluginStart } from '@kbn/no-data-page-plugin/public';
 import type { AiopsPluginStart } from '@kbn/aiops-plugin/public';
@@ -92,6 +93,7 @@ export interface DiscoverServices {
   i18n: I18nStart;
   capabilities: Capabilities;
   chrome: ChromeStart;
+  contentManagement: ContentManagementPublicStart;
   core: CoreStart;
   data: DataPublicPluginStart;
   discoverShared: DiscoverSharedPublicStart;
@@ -182,6 +184,7 @@ export const buildServices = ({
     addBasePath: core.http.basePath.prepend,
     analytics: core.analytics,
     capabilities: core.application.capabilities,
+    contentManagement: plugins.contentManagement,
     chrome: core.chrome,
     core,
     data: plugins.data,

--- a/x-pack/platform/test/functional/apps/discover/group3/index.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/index.ts
@@ -16,5 +16,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./value_suggestions_non_timebased'));
     loadTestFile(require.resolve('./saved_search_embeddable'));
     loadTestFile(require.resolve('./esql_starred'));
+    loadTestFile(require.resolve('./rule_creation'));
   });
 }

--- a/x-pack/platform/test/functional/apps/discover/group3/rule_creation.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/rule_creation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  describe('Discover rule creation', function () {
+    const esArchiver = getService('esArchiver');
+    const { common } = getPageObjects(['common', 'settings', 'shareSavedObjectsToSpace']);
+    const find = getService('find');
+
+    before('initialize tests', async () => {
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+    });
+    after('clean up archives', async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+    });
+
+    it('navigate to Discover', () => {
+      return common.navigateToApp('discover');
+    });
+
+    it('begin creating rule', async () => {
+      await find.clickByButtonText('Alerts');
+      await find.clickByButtonText('Create search threshold rule');
+      await find.clickByButtonText('Details');
+    });
+
+    it('should have the "Related dashboards" section', async () => {
+      const linkedDashboardsElement = await find.byCssSelector(
+        '[data-test-subj="ruleLinkedDashboards"]'
+      );
+      expect(linkedDashboardsElement).to.be.ok();
+      expect(await linkedDashboardsElement.isDisplayed()).to.be(true);
+    });
+  });
+}

--- a/x-pack/platform/test/functional/apps/discover/group3/rule_creation.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/rule_creation.ts
@@ -10,16 +10,8 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('Discover rule creation', function () {
-    const esArchiver = getService('esArchiver');
     const { common } = getPageObjects(['common', 'settings', 'shareSavedObjectsToSpace']);
     const find = getService('find');
-
-    before('initialize tests', async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
-    });
-    after('clean up archives', async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
-    });
 
     it('navigate to Discover', () => {
       return common.navigateToApp('discover');

--- a/x-pack/solutions/observability/plugins/apm/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/kibana.jsonc
@@ -15,6 +15,7 @@
       "apmDataAccess",
       "data",
       "dashboard",
+      "contentManagement",
       "controls",
       "embeddable",
       "features",

--- a/x-pack/solutions/observability/plugins/infra/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/infra/kibana.jsonc
@@ -14,6 +14,7 @@
       "aiops",
       "alerting",
       "charts",
+      "contentManagement",
       "data",
       "dataViews",
       "dataViewEditor",

--- a/x-pack/solutions/observability/plugins/slo/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/slo/kibana.jsonc
@@ -13,6 +13,7 @@
       "aiops",
       "alerting",
       "charts",
+      "contentManagement",
       "dashboard",
       "data",
       "dataViewEditor",

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_status_alert.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_status_alert.journey.ts
@@ -57,6 +57,7 @@ journey(`CustomStatusAlert`, async ({ page, params }) => {
       }
     });
     await page.getByTestId('ruleFormStep-details').click();
+    expect(await page.getByText('Related dashboards').isVisible()).toBe(true);
     await page.waitForSelector('[data-test-subj="ruleFlyoutFooterSaveButton"]');
     await page.getByTestId('ruleFlyoutFooterSaveButton').click();
     await page.getByTestId('confirmModalConfirmButton').click();

--- a/x-pack/solutions/observability/plugins/synthetics/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/synthetics/kibana.jsonc
@@ -18,6 +18,7 @@
     "requiredPlugins": [
       "actions",
       "alerting",
+      "contentManagement",
       "data",
       "fleet",
       "embeddable",

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_shared_context.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_shared_context.tsx
@@ -39,6 +39,7 @@ export const SyntheticsSharedContext: React.FC<
         ...coreStart,
         ...setupPlugins,
         storage,
+        contentManagement: startPlugins.contentManagement,
         data: startPlugins.data,
         inspector: startPlugins.inspector,
         triggersActionsUi: startPlugins.triggersActionsUi,

--- a/x-pack/solutions/observability/plugins/synthetics/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/plugin.ts
@@ -68,6 +68,7 @@ import { EmbeddableEnhancedPluginStart } from '@kbn/embeddable-enhanced-plugin/p
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
 import { registerSyntheticsEmbeddables } from './apps/embeddables/register_embeddables';
 import { kibanaService } from './utils/kibana_service';
 import { PLUGIN } from '../common/constants/plugin';
@@ -102,6 +103,7 @@ export interface ClientPluginsStart {
   unifiedSearch: UnifiedSearchPublicPluginStart;
   discover: DiscoverStart;
   inspector: InspectorPluginStart;
+  contentManagement: ContentManagementPublicStart;
   embeddable: EmbeddableStart;
   embeddableEnhanced?: EmbeddableEnhancedPluginStart;
   exploratoryView: ExploratoryViewPublicStart;

--- a/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
@@ -119,7 +119,8 @@
     "@kbn/field-formats-plugin",
     "@kbn/core-ui-settings-browser",
     "@kbn/page-attachment-schema",
-    "@kbn/licensing-types"
+    "@kbn/licensing-types",
+    "@kbn/content-management-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/observability/test/functional/apps/apm/feature_controls/apm_rules.ts
+++ b/x-pack/solutions/observability/test/functional/apps/apm/feature_controls/apm_rules.ts
@@ -9,17 +9,11 @@ import expect from '@kbn/expect';
 import { type FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const PageObjects = getPageObjects(['common', 'error', 'security']);
   const testSubjects = getService('testSubjects');
   const find = getService('find');
 
   describe('rules', () => {
-    before(() => esArchiver.load('x-pack/test/functional/es_archives/infra/8.0.0/metrics_and_apm'));
-    after(() =>
-      esArchiver.unload('x-pack/test/functional/es_archives/infra/8.0.0/metrics_and_apm')
-    );
-
     it('navigates to APM app', async () => {
       await PageObjects.common.navigateToApp('apm');
 

--- a/x-pack/solutions/observability/test/functional/apps/apm/feature_controls/apm_rules.ts
+++ b/x-pack/solutions/observability/test/functional/apps/apm/feature_controls/apm_rules.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { type FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const PageObjects = getPageObjects(['common', 'error', 'security']);
+  const testSubjects = getService('testSubjects');
+  const find = getService('find');
+
+  describe('rules', () => {
+    before(() => esArchiver.load('x-pack/test/functional/es_archives/infra/8.0.0/metrics_and_apm'));
+    after(() =>
+      esArchiver.unload('x-pack/test/functional/es_archives/infra/8.0.0/metrics_and_apm')
+    );
+
+    it('navigates to APM app', async () => {
+      await PageObjects.common.navigateToApp('apm');
+
+      await testSubjects.existOrFail('apmMainContainer', {
+        timeout: 10000,
+      });
+    });
+
+    it('opens the APM alerts popover', async () => {
+      await find.clickByButtonText('Alerts');
+      await find.clickByButtonText('Create threshold rule');
+      await find.clickByButtonText('Latency');
+    });
+
+    it('navigates to the Details tab', () => find.clickByButtonText('Details'));
+
+    it('contains the "Related dashboards" section', async () => {
+      const linkedDashboardsElement = await find.byCssSelector(
+        '[data-test-subj="ruleLinkedDashboards"]'
+      );
+      expect(linkedDashboardsElement).to.be.ok();
+      expect(await linkedDashboardsElement.isDisplayed()).to.be(true);
+    });
+  });
+}

--- a/x-pack/solutions/observability/test/functional/apps/apm/feature_controls/index.ts
+++ b/x-pack/solutions/observability/test/functional/apps/apm/feature_controls/index.ts
@@ -12,5 +12,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     this.tags('skipFirefox');
     loadTestFile(require.resolve('./apm_security'));
     loadTestFile(require.resolve('./apm_spaces'));
+    loadTestFile(require.resolve('./apm_rules'));
   });
 }

--- a/x-pack/solutions/observability/test/functional/apps/infra/index.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/index.ts
@@ -11,6 +11,7 @@ export default ({ loadTestFile }: FtrProviderContext) => {
   describe('InfraOps App', function () {
     loadTestFile(require.resolve('./feature_controls'));
     loadTestFile(require.resolve('./page_not_found'));
+    loadTestFile(require.resolve('./rules'));
 
     describe('Metrics UI', function () {
       loadTestFile(require.resolve('./home_page'));

--- a/x-pack/solutions/observability/test/functional/apps/infra/rules.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/rules.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  describe('infra rules', () => {
+    const { common } = getPageObjects(['common']);
+    const find = getService('find');
+
+    it('navigates to infra app', async () => {
+      await common.navigateToApp('infraOps');
+    });
+
+    it('opens the infra alerts popover', async () => {
+      await find.clickByButtonText('Alerts');
+      await find.clickByButtonText('Infrastructure');
+      await find.clickByButtonText('Create inventory rule');
+    });
+
+    it('opens the Details tab', () => find.clickByButtonText('Details'));
+
+    it('contains the "Related dashboards" section', async () => {
+      const linkedDashboardsElement = await find.byCssSelector(
+        '[data-test-subj="ruleLinkedDashboards"]'
+      );
+      expect(linkedDashboardsElement).to.be.ok();
+      expect(await linkedDashboardsElement.isDisplayed()).to.be(true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Resolves #226587.

The create rule flyout is used in numerous places in Kibana. One of the features on the `Detail` tab of this create UI allows the user to link dashboards to the rule at create time.

The `contentManagement` plugin is required for this feature to work. In Discover, APM, Infra, SLO, and Synthetics, this plugin was not previously required. This patch would include `contentManagement` in all these places, so that the linked dashboards feature will be visible.

## Testing

Go to the apps mentioned in this PR:

- Discover _tested_
- APM _tested_
- Infra _tested_
- SLO
- Synthetics _tested_

In each of these cases, ensure you can go through the create rule dialog (you can skip to the Details tab) and ensure you can link dashboards to your rule when you create it.

You should be able to view your Rule in the Alerts page, and see that your dashboard is linked to alerts created by the rule.
