### PR TITLE
[Security Solution] Install mock prebuilt rules package in Cypress to reduce flakiness

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
@@ -7,7 +7,8 @@
 
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
 
-import { getNewRule } from '../../../../objects/rule';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
+import { getCustomQueryRuleParams, getNewRule } from '../../../../objects/rule';
 import {
   COLLAPSED_ACTION_BTN,
   RULE_CHECKBOX,
@@ -28,12 +29,16 @@ import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 // TODO: https://github.com/elastic/kibana/issues/164451 We should find a way to make this spec work in Serverless
 // TODO: https://github.com/elastic/kibana/issues/161540
 describe('All rules - read only', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: '1', enabled: false }));
+    createRule(getCustomQueryRuleParams({ rule_id: '1', enabled: false }));
     login(ROLES.t1_analyst);
     visitRulesManagementTable();
-    cy.get(RULE_NAME).should('have.text', getNewRule().name);
+    cy.get(RULE_NAME).should('have.text', getCustomQueryRuleParams().name);
   });
 
   it('Does not display select boxes for rules', () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/coverage_overview/coverage_overview.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/coverage_overview/coverage_overview.cy.ts
@@ -22,9 +22,10 @@ import { createRule } from '../../../../tasks/api_calls/rules';
 import { visit } from '../../../../tasks/navigation';
 import { RULES_COVERAGE_OVERVIEW_URL } from '../../../../urls/rules_management';
 import { createRuleAssetSavedObject } from '../../../../helpers/rules';
-import { getNewRule } from '../../../../objects/rule';
+import { getCustomQueryRuleParams, getNewRule } from '../../../../objects/rule';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../tasks/api_calls/prebuilt_rules';
 import {
@@ -191,6 +192,10 @@ const prebuiltRules = [
 
 // https://github.com/elastic/kibana/issues/179052
 describe('Coverage overview', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   describe('base cases', () => {
     beforeEach(() => {
       login();
@@ -199,7 +204,7 @@ describe('Coverage overview', { tags: ['@ess', '@serverless', '@skipInServerless
       preventPrebuiltRulesPackageInstallation();
       createAndInstallMockedPrebuiltRules(prebuiltRules);
       createRule(
-        getNewRule({
+        getCustomQueryRuleParams({
           rule_id: 'enabled_custom_rule',
           enabled: true,
           name: 'Enabled custom rule',
@@ -207,7 +212,7 @@ describe('Coverage overview', { tags: ['@ess', '@serverless', '@skipInServerless
         })
       );
       createRule(
-        getNewRule({
+        getCustomQueryRuleParams({
           rule_id: 'disabled_custom_rule',
           name: 'Disabled custom rule',
           enabled: false,

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/maintenance_windows/maintenance_window_callout.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/maintenance_windows/maintenance_window_callout.cy.ts
@@ -8,6 +8,7 @@
 import { INTERNAL_ALERTING_API_MAINTENANCE_WINDOW_PATH } from '@kbn/alerting-plugin/common';
 import type { MaintenanceWindowCreateBody } from '@kbn/alerting-plugin/common';
 import type { AsApiContract } from '@kbn/alerting-plugin/server/routes/lib';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
@@ -17,6 +18,10 @@ describe(
   'Maintenance window callout on Rule Management page',
   { tags: ['@ess', '@serverless', '@skipInServerless'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     let maintenanceWindowId = '';
 
     beforeEach(() => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/customization/revert_prebuilt_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/customization/revert_prebuilt_rule.cy.ts
@@ -29,6 +29,7 @@ import {
 } from '../../../../../tasks/api_calls/common';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { createRule, patchRule } from '../../../../../tasks/api_calls/rules';
@@ -44,6 +45,10 @@ describe(
 
   () => {
     describe('Reverting prebuilt rules', () => {
+      before(() => {
+        installMockPrebuiltRulesPackage();
+      });
+
       const PREBUILT_RULE = createRuleAssetSavedObject({
         name: 'Non-customized prebuilt rule',
         rule_id: 'rule_1',
@@ -52,12 +57,13 @@ describe(
       });
 
       beforeEach(() => {
-        login();
         deleteAlertsAndRules();
         deletePrebuiltRulesAssets();
         preventPrebuiltRulesPackageInstallation();
         /* Create a new rule and install it */
         createAndInstallMockedPrebuiltRules([PREBUILT_RULE]);
+
+        login();
         visitRulesManagementTable();
       });
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_error_handling.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_error_handling.cy.ts
@@ -25,6 +25,7 @@ import {
   installPrebuiltRuleAssets,
   createAndInstallMockedPrebuiltRules,
   preventPrebuiltRulesPackageInstallation,
+  installMockPrebuiltRulesPackage,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../../tasks/login';
 import {
@@ -49,6 +50,10 @@ describe(
   'Detection rules, Prebuilt Rules Installation - Error handling',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       deletePrebuiltRulesAssets();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
@@ -18,7 +18,7 @@ import {
 import {
   installAllPrebuiltRulesRequest,
   installPrebuiltRuleAssets,
-  installMockEmptyPrebuiltRulesPackage,
+  installMockPrebuiltRulesPackage,
   installSpecificPrebuiltRulesRequest,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState } from '../../../../../tasks/common';
@@ -26,11 +26,11 @@ import { login } from '../../../../../tasks/login';
 import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
 
 describe(
-  'Detection rules, Prebuilt Rules Installation and Update Notifications',
+  'Detection rules, Prebuilt Rules Install Notifications',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
     before(() => {
-      installMockEmptyPrebuiltRulesPackage();
+      installMockPrebuiltRulesPackage();
     });
 
     beforeEach(() => {
@@ -43,7 +43,7 @@ describe(
     });
 
     describe('No notifications', () => {
-      it('does NOT display install notifications when no prebuilt assets and no rules are installed', () => {
+      it('does NOT display install notifications when no rules are installed', () => {
         visitRulesManagementTable();
 
         cy.get(ADD_ELASTIC_RULES_EMPTY_PROMPT_BTN).should('be.visible');

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_update_authorization.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_update_authorization.cy.ts
@@ -15,6 +15,7 @@ import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   installPrebuiltRuleAssets,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
@@ -73,6 +74,10 @@ describe.skip(
   'Detection rules, Prebuilt Rules Installation and Update - Authorization/RBAC',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       preventPrebuiltRulesPackageInstallation();
     });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_via_fleet.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_via_fleet.cy.ts
@@ -22,7 +22,7 @@ const PREBUILT_RULES_PACKAGE_INSTALLATION_TIMEOUT_MS = 120000; // 2 minutes
 
 // Failing: See https://github.com/elastic/kibana/issues/228945
 describe.skip(
-  'Detection rules, Prebuilt Rules Installation and Update workflow',
+  'Detection rules, Prebuilt Rules Installation Workflow (Real package)',
   { tags: ['@ess', '@serverless'] },
   () => {
     describe('Installation of prebuilt rules package via Fleet', () => {
@@ -36,7 +36,7 @@ describe.skip(
         login();
       });
 
-      it('should install prebuilt rules from the Fleet package', () => {
+      it('installs prebuilt rules from the "security_detection_engine" Fleet package', () => {
         visitAddRulesPage();
 
         // Expect the package to be installed

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_workflow.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_workflow.cy.ts
@@ -19,91 +19,102 @@ import {
 } from '../../../../../screens/alerts_detection_rules';
 import { selectRulesByName } from '../../../../../tasks/alerts_detection_rules';
 import { RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../../../../../screens/breadcrumbs';
-import { installPrebuiltRuleAssets } from '../../../../../tasks/api_calls/prebuilt_rules';
+import {
+  installMockPrebuiltRulesPackage,
+  installPrebuiltRuleAssets,
+} from '../../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../../tasks/login';
+
 import {
   assertInstallationRequestIsComplete,
   assertRuleInstallationSuccessToastShown,
   assertRulesPresentInInstalledRulesTable,
-  clickAddElasticRulesButton,
 } from '../../../../../tasks/prebuilt_rules';
-import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
-import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
+import {
+  deleteAlertsAndRules,
+  deletePrebuiltRulesAssets,
+} from '../../../../../tasks/api_calls/common';
+import { visitAddRulesPage } from '../../../../../tasks/rules_management';
 
-// Failing: See https://github.com/elastic/kibana/issues/182441
-describe.skip(
-  'Detection rules, Prebuilt Rules Installation and Update workflow',
+describe(
+  'Detection rules, Prebuilt Rules Installation Workflow',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
-    describe('Installation of prebuilt rules', () => {
-      const RULE_1 = createRuleAssetSavedObject({
-        name: 'Test rule 1',
-        rule_id: 'rule_1',
-      });
-      const RULE_2 = createRuleAssetSavedObject({
-        name: 'Test rule 2',
-        rule_id: 'rule_2',
-      });
-      beforeEach(() => {
-        login();
-        resetRulesTableState();
-        deleteAlertsAndRules();
-        visitRulesManagementTable();
-        installPrebuiltRuleAssets([RULE_1, RULE_2]);
-        cy.intercept('POST', '/internal/detection_engine/prebuilt_rules/installation/_perform').as(
-          'installPrebuiltRules'
-        );
-        clickAddElasticRulesButton();
-      });
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
 
-      it('should install prebuilt rules one by one', () => {
-        // Attempt to install rules
-        cy.get(getInstallSingleRuleButtonByRuleId(RULE_1['security-rule'].rule_id)).click();
-        // Wait for request to complete
-        assertInstallationRequestIsComplete([RULE_1]);
-        // Assert installation succeeded
-        assertRuleInstallationSuccessToastShown([RULE_1]);
-        // Go back to rules table and assert that the rules are installed
-        cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
-        assertRulesPresentInInstalledRulesTable([RULE_1]);
-      });
+    const RULE_1 = createRuleAssetSavedObject({
+      name: 'Test rule 1',
+      rule_id: 'rule_1',
+    });
+    const RULE_2 = createRuleAssetSavedObject({
+      name: 'Test rule 2',
+      rule_id: 'rule_2',
+    });
 
-      it('should install multiple selected prebuilt rules by selecting them individually', () => {
-        selectRulesByName([RULE_1['security-rule'].name, RULE_2['security-rule'].name]);
-        cy.get(INSTALL_SELECTED_RULES_BUTTON).click();
-        assertInstallationRequestIsComplete([RULE_1, RULE_2]);
-        assertRuleInstallationSuccessToastShown([RULE_1, RULE_2]);
-        // Go back to rules table and assert that the rules are installed
-        cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
-        assertRulesPresentInInstalledRulesTable([RULE_1, RULE_2]);
-      });
+    beforeEach(() => {
+      deleteAlertsAndRules();
+      deletePrebuiltRulesAssets();
+      /* Make sure persisted rules table state is cleared */
+      resetRulesTableState();
+      installPrebuiltRuleAssets([RULE_1, RULE_2]);
 
-      it('should install multiple selected prebuilt rules by selecting all in page', () => {
-        cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
-        cy.get(INSTALL_SELECTED_RULES_BUTTON).click();
-        assertInstallationRequestIsComplete([RULE_1, RULE_2]);
-        assertRuleInstallationSuccessToastShown([RULE_1, RULE_2]);
-        // Go back to rules table and assert that the rules are installed
-        cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
-        assertRulesPresentInInstalledRulesTable([RULE_1, RULE_2]);
-      });
+      cy.intercept('POST', '/internal/detection_engine/prebuilt_rules/installation/_perform').as(
+        'installPrebuiltRules'
+      );
 
-      it('should install all available rules at once', () => {
-        cy.get(INSTALL_ALL_RULES_BUTTON).click();
-        assertInstallationRequestIsComplete([RULE_1, RULE_2]);
-        assertRuleInstallationSuccessToastShown([RULE_1, RULE_2]);
-        // Go back to rules table and assert that the rules are installed
-        cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
-        assertRulesPresentInInstalledRulesTable([RULE_1, RULE_2]);
-      });
+      login();
+      visitAddRulesPage();
+    });
 
-      it('should display an empty screen when all available prebuilt rules have been installed', () => {
-        cy.get(INSTALL_ALL_RULES_BUTTON).click();
-        cy.get(TOASTER).should('be.visible').should('have.text', `2 rules installed successfully.`);
-        cy.get(RULE_CHECKBOX).should('not.exist');
-        cy.get(NO_RULES_AVAILABLE_FOR_INSTALL_MESSAGE).should('exist');
-        cy.get(GO_BACK_TO_RULES_TABLE_BUTTON).should('exist');
-      });
+    it('installs prebuilt rules one by one', () => {
+      // Attempt to install rules
+      cy.get(getInstallSingleRuleButtonByRuleId(RULE_1['security-rule'].rule_id)).click();
+      // Wait for request to complete
+      assertInstallationRequestIsComplete([RULE_1]);
+      // Assert installation succeeded
+      assertRuleInstallationSuccessToastShown([RULE_1]);
+      // Go back to rules table and assert that the rules are installed
+      cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
+      assertRulesPresentInInstalledRulesTable([RULE_1]);
+    });
+
+    it('installs multiple selected prebuilt rules by selecting them individually', () => {
+      selectRulesByName([RULE_1['security-rule'].name, RULE_2['security-rule'].name]);
+      cy.get(INSTALL_SELECTED_RULES_BUTTON).click();
+      assertInstallationRequestIsComplete([RULE_1, RULE_2]);
+      assertRuleInstallationSuccessToastShown([RULE_1, RULE_2]);
+      // Go back to rules table and assert that the rules are installed
+      cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
+      assertRulesPresentInInstalledRulesTable([RULE_1, RULE_2]);
+    });
+
+    it('installs multiple selected prebuilt rules by selecting all in page', () => {
+      cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
+      cy.get(INSTALL_SELECTED_RULES_BUTTON).click();
+      assertInstallationRequestIsComplete([RULE_1, RULE_2]);
+      assertRuleInstallationSuccessToastShown([RULE_1, RULE_2]);
+      // Go back to rules table and assert that the rules are installed
+      cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
+      assertRulesPresentInInstalledRulesTable([RULE_1, RULE_2]);
+    });
+
+    it('installs all available rules at once', () => {
+      cy.get(INSTALL_ALL_RULES_BUTTON).click();
+      assertInstallationRequestIsComplete([RULE_1, RULE_2]);
+      assertRuleInstallationSuccessToastShown([RULE_1, RULE_2]);
+      // Go back to rules table and assert that the rules are installed
+      cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
+      assertRulesPresentInInstalledRulesTable([RULE_1, RULE_2]);
+    });
+
+    it('displays an empty screen when all available prebuilt rules have been installed', () => {
+      cy.get(INSTALL_ALL_RULES_BUTTON).click();
+      cy.get(TOASTER).should('be.visible').should('have.text', `2 rules installed successfully.`);
+      cy.get(RULE_CHECKBOX).should('not.exist');
+      cy.get(NO_RULES_AVAILABLE_FOR_INSTALL_MESSAGE).should('exist');
+      cy.get(GO_BACK_TO_RULES_TABLE_BUTTON).should('exist');
     });
   }
 );

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_workflow.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_workflow.cy.ts
@@ -15,10 +15,9 @@ import {
   NO_RULES_AVAILABLE_FOR_INSTALL_MESSAGE,
   RULE_CHECKBOX,
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
-  TOASTER,
+  SUCCESS_TOASTER_HEADER,
 } from '../../../../../screens/alerts_detection_rules';
 import { selectRulesByName } from '../../../../../tasks/alerts_detection_rules';
-import { RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../../../../../screens/breadcrumbs';
 import {
   installMockPrebuiltRulesPackage,
   installPrebuiltRuleAssets,
@@ -35,6 +34,7 @@ import {
   deletePrebuiltRulesAssets,
 } from '../../../../../tasks/api_calls/common';
 import { visitAddRulesPage } from '../../../../../tasks/rules_management';
+import { RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../../../../../screens/breadcrumbs';
 
 describe(
   'Detection rules, Prebuilt Rules Installation Workflow',
@@ -111,7 +111,9 @@ describe(
 
     it('displays an empty screen when all available prebuilt rules have been installed', () => {
       cy.get(INSTALL_ALL_RULES_BUTTON).click();
-      cy.get(TOASTER).should('be.visible').should('have.text', `2 rules installed successfully.`);
+      cy.get(SUCCESS_TOASTER_HEADER)
+        .should('be.visible')
+        .should('have.text', `2 rules installed successfully`);
       cy.get(RULE_CHECKBOX).should('not.exist');
       cy.get(NO_RULES_AVAILABLE_FOR_INSTALL_MESSAGE).should('exist');
       cy.get(GO_BACK_TO_RULES_TABLE_BUTTON).should('exist');

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
+import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
 import {
   COLLAPSED_ACTION_BTN,
   ELASTIC_RULES_BTN,
@@ -22,7 +23,6 @@ import {
   getRulesManagementTableRows,
   selectAllRules,
   selectRulesByName,
-  waitForPrebuiltDetectionRulesToBeLoaded,
   waitForRuleToUpdate,
 } from '../../../../../tasks/alerts_detection_rules';
 import {
@@ -31,37 +31,39 @@ import {
   enableSelectedRules,
 } from '../../../../../tasks/rules_bulk_actions';
 import {
-  createAndInstallMockedPrebuiltRules,
   getInstalledPrebuiltRulesCount,
-  preventPrebuiltRulesPackageInstallation,
+  installMockPrebuiltRulesPackage,
+  installPrebuiltRuleAssets,
+  installSpecificPrebuiltRulesRequest,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import {
   deleteAlertsAndRules,
   deletePrebuiltRulesAssets,
 } from '../../../../../tasks/api_calls/common';
 import { login } from '../../../../../tasks/login';
-import { visit } from '../../../../../tasks/navigation';
-import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 
-const rules = Array.from(Array(5)).map((_, i) => {
-  return createRuleAssetSavedObject({
+const PREBUILT_RULE_ASSETS = Array.from(Array(5)).map((_, i) =>
+  createRuleAssetSavedObject({
     name: `Test rule ${i + 1}`,
     rule_id: `rule_${i + 1}`,
-  });
-});
+  })
+);
 
 // https://github.com/elastic/kibana/issues/179973
-// Failing: See https://github.com/elastic/kibana/issues/182442
-describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+describe('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
-    login();
     deleteAlertsAndRules();
     deletePrebuiltRulesAssets();
-    preventPrebuiltRulesPackageInstallation();
-    visit(RULES_MANAGEMENT_URL);
-    createAndInstallMockedPrebuiltRules(rules);
-    cy.reload();
-    waitForPrebuiltDetectionRulesToBeLoaded();
+    installPrebuiltRuleAssets(PREBUILT_RULE_ASSETS);
+    installSpecificPrebuiltRulesRequest(PREBUILT_RULE_ASSETS);
+
+    login();
+
+    visitRulesManagementTable();
     disableAutoRefresh();
   });
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
@@ -32,7 +32,7 @@ import {
 } from '../../../../../tasks/rules_bulk_actions';
 import {
   createAndInstallMockedPrebuiltRules,
-  getAvailablePrebuiltRulesCount,
+  getInstalledPrebuiltRulesCount,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import {
@@ -71,7 +71,7 @@ describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerle
       getRulesManagementTableRows().should('have.length.gte', 1);
 
       // Check the correct count of prebuilt rules is displayed
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(ELASTIC_RULES_BTN).should(
           'have.text',
           `Elastic rules (${availablePrebuiltRulesCount})`
@@ -118,7 +118,7 @@ describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerle
       });
 
       it('Deletes and recovers one rule', () => {
-        getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
           const expectedNumberOfRulesAfterDeletion = availablePrebuiltRulesCount - 1;
           const expectedNumberOfRulesAfterRecovering = availablePrebuiltRulesCount;
 
@@ -150,7 +150,7 @@ describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerle
       });
 
       it('Deletes and recovers more than one rule', () => {
-        getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
           const rulesToDelete = ['Test rule 1', 'Test rule 2'] as const;
           const expectedNumberOfRulesAfterDeletion = availablePrebuiltRulesCount - 2;
           const expectedNumberOfRulesAfterRecovering = availablePrebuiltRulesCount;

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_error_handling.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_error_handling.cy.ts
@@ -17,9 +17,9 @@ import {
   UPGRADE_SELECTED_RULES_BUTTON,
 } from '../../../../../screens/alerts_detection_rules';
 import { selectRulesByName } from '../../../../../tasks/alerts_detection_rules';
-import { preventPrebuiltRulesPackageInstallation } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { setUpRuleUpgrades } from '../../../../../tasks/prebuilt_rules/setup_rule_upgrades';
 import { login } from '../../../../../tasks/login';
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import {
   interceptUpgradeRequestToFail,
   assertUpgradeRequestIsComplete,
@@ -33,10 +33,13 @@ describe(
   'Detection rules, Prebuilt Rules Upgrade - Error handling',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       deletePrebuiltRulesAssets();
       deleteAlertsAndRules();
-      preventPrebuiltRulesPackageInstallation();
       login();
     });
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_notifications.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_notifications.cy.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../../../tasks/api_calls/common';
 import {
   installPrebuiltRuleAssets,
-  installMockEmptyPrebuiltRulesPackage,
+  installMockPrebuiltRulesPackage,
   installSpecificPrebuiltRulesRequest,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState } from '../../../../../tasks/common';
@@ -39,7 +39,7 @@ describe(
   () => {
     before(() => {
       // Prevent the real package installation
-      installMockEmptyPrebuiltRulesPackage();
+      installMockPrebuiltRulesPackage();
     });
 
     beforeEach(() => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
 import {
   goToRuleDetailsOf,
@@ -54,6 +55,10 @@ describe(
   'Detection rules, bulk duplicate',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       // Make sure persisted rules table state is cleared

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -104,6 +104,7 @@ import {
 
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { setRowsPerPageTo, sortByTableColumn } from '../../../../../tasks/table_pagination';
@@ -129,6 +130,10 @@ describe(
   'Detection rules, bulk edit',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       // Make sure persisted rules table state is cleared

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -64,6 +64,7 @@ import {
 } from '../../../../../objects/rule';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 
@@ -77,6 +78,10 @@ describe(
   'Detection rules, bulk edit of rule actions',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import {
   RULES_BULK_EDIT_DATA_VIEWS_WARNING,
   RULES_BULK_EDIT_OVERWRITE_DATA_VIEW_CHECKBOX,
@@ -61,6 +62,10 @@ describe(
   'Bulk editing index patterns of rules with a data view only',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     const TESTED_CUSTOM_QUERY_RULE_DATA = getNewRule({
       index: undefined,
       data_view_id: DATA_VIEW_ID,

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression.cy.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
 import { MODAL_CONFIRMATION_BODY } from '../../../../../screens/alerts_detection_rules';
 import { RULES_BULK_EDIT_FORM_TITLE } from '../../../../../screens/rules_bulk_actions';
@@ -66,6 +67,10 @@ describe(
   'Bulk Edit - Alert Suppression',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_basic_ess.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_basic_ess.cy.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
 import { ALERT_SUPPRESSION_RULE_BULK_MENU_ITEM } from '../../../../../screens/rules_bulk_actions';
 import { TOOLTIP } from '../../../../../screens/common';
@@ -24,6 +25,10 @@ import { getNewRule } from '../../../../../objects/rule';
 const queryRule = getNewRule({ rule_id: '1', name: 'Query rule', enabled: false });
 
 describe('Bulk Edit - Alert Suppression, Basic License', { tags: ['@ess'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_essentials_serverless.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_essentials_serverless.cy.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
 import { DEFINITION_DETAILS, SUPPRESS_BY_DETAILS } from '../../../../../screens/rule_details';
 
@@ -43,6 +44,10 @@ describe(
     },
   },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/deletion/rule_delete.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/deletion/rule_delete.cy.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
-import { getNewRule } from '../../../../../objects/rule';
+import { getCustomQueryRuleParams } from '../../../../../objects/rule';
 
 import { RULE_SWITCH } from '../../../../../screens/alerts_detection_rules';
 
@@ -22,10 +23,14 @@ import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
 import { login } from '../../../../../tasks/login';
 
 describe('Rule deletion', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   const testRules = [
-    getNewRule({ rule_id: 'rule1', name: 'Rule 1', enabled: false }),
-    getNewRule({ rule_id: 'rule2', name: 'Rule 2', enabled: false }),
-    getNewRule({ rule_id: 'rule3', name: 'Rule 3', enabled: false }),
+    getCustomQueryRuleParams({ rule_id: 'rule1', name: 'Rule 1', enabled: false }),
+    getCustomQueryRuleParams({ rule_id: 'rule2', name: 'Rule 2', enabled: false }),
+    getCustomQueryRuleParams({ rule_id: 'rule3', name: 'Rule 3', enabled: false }),
   ];
   beforeEach(() => {
     deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
@@ -38,7 +38,7 @@ import { visit } from '../../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 import {
   createAndInstallMockedPrebuiltRules,
-  getAvailablePrebuiltRulesCount,
+  getInstalledPrebuiltRulesCount,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
@@ -118,7 +118,7 @@ describe('Export rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI']
     selectAllRules();
     bulkExportRules();
 
-    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+    getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
       const totalNumberOfRules =
         expectedNumberCustomRulesToBeExported + availablePrebuiltRulesCount;
       cy.get(TOASTER_BODY).should(

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
@@ -39,6 +39,7 @@ import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 import {
   createAndInstallMockedPrebuiltRules,
   getInstalledPrebuiltRulesCount,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
@@ -54,6 +55,10 @@ const prebuiltRules = Array.from(Array(7)).map((_, i) => {
 });
 
 describe('Export rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   const downloadsFolder = Cypress.config('downloadsFolder');
   const RULE_NAME = 'Rule to export';
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/import_rules.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/import_rules.cy.ts
@@ -18,13 +18,20 @@ import {
 import { deleteExceptionList } from '../../../../../tasks/api_calls/exceptions';
 import { login } from '../../../../../tasks/login';
 import { visit } from '../../../../../tasks/navigation';
-import { preventPrebuiltRulesPackageInstallation } from '../../../../../tasks/api_calls/prebuilt_rules';
+import {
+  installMockPrebuiltRulesPackage,
+  preventPrebuiltRulesPackageInstallation,
+} from '../../../../../tasks/api_calls/prebuilt_rules';
 import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 
 const RULES_TO_IMPORT_FILENAME = 'cypress/fixtures/7_16_rules.ndjson';
 const IMPORTED_EXCEPTION_ID = 'b8dfd17f-1e11-41b0-ae7e-9e7f8237de49';
 
 describe('Import rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     preventPrebuiltRulesPackageInstallation();
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
@@ -8,6 +8,7 @@
 import { INTERNAL_ALERTING_API_FIND_RULES_PATH } from '@kbn/alerting-plugin/common';
 import type { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { createRule, snoozeRule as snoozeRuleViaAPI } from '../../../../../tasks/api_calls/rules';
 import { deleteAlertsAndRules, deleteConnectors } from '../../../../../tasks/api_calls/common';
 import { login } from '../../../../../tasks/login';
@@ -43,8 +44,11 @@ import { TOOLTIP } from '../../../../../screens/common';
 
 const RULES_TO_IMPORT_FILENAME = 'cypress/fixtures/7_16_rules.ndjson';
 
-// Failing: See https://github.com/elastic/kibana/issues/228942
-describe.skip('rule snoozing', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+describe('rule snoozing', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -37,6 +38,10 @@ describe(
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
   },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     before(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/common_flows.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/common_flows.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteRuleFromDetailsPage } from '../../../../tasks/alerts_detection_rules';
 import {
   CUSTOM_RULES_BTN,
@@ -57,6 +58,10 @@ describe(
   'Common rule detail flows',
   { tags: ['@ess', '@serverless', '@serverlessQA'] },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/esql_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/esql_rule.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { getEsqlRule } from '../../../../objects/rule';
 
 import {
@@ -28,6 +29,10 @@ describe(
   'Detection ES|QL rules, details view',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     const rule = getEsqlRule();
 
     beforeEach(() => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -29,6 +30,10 @@ describe.skip(
     tags: ['@ess', '@serverless'],
   },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     before(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/gaps.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/gaps.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -47,6 +48,10 @@ describe(
     },
   },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     before(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/non_default_space.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/non_default_space.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { ruleFields } from '../../../../data/detection_engine';
 import { getExistingRule, getNewRule } from '../../../../objects/rule';
@@ -19,6 +20,10 @@ import { visit } from '../../../../tasks/navigation';
 import { ruleDetailsUrl } from '../../../../urls/rule_details';
 
 describe('Non-default space rule detail page', { tags: ['@ess'] }, function () {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   const SPACE_ID = 'test';
 
   beforeEach(() => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { visitRulesManagementTable } from '../../../../tasks/rules_management';
 import {
   REFRESH_RULES_STATUS,
@@ -38,6 +39,10 @@ describe(
   'Rules table: auto-refresh',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { resetRulesTableState } from '../../../../tasks/common';
 import { login } from '../../../../tasks/login';
@@ -31,6 +32,10 @@ import { disableAutoRefresh } from '../../../../tasks/alerts_detection_rules';
 import { getNewRule } from '../../../../objects/rule';
 
 describe('Rules table: filtering', { tags: ['@ess', '@serverless', '@serverlessQA'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     // Make sure persisted rules table state is cleared

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { getNewRule } from '../../../../objects/rule';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
+import { getCustomQueryRuleParams } from '../../../../objects/rule';
 import { RULES_MONITORING_TAB, RULE_NAME } from '../../../../screens/alerts_detection_rules';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
@@ -14,10 +15,14 @@ import { visit } from '../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
 
 describe('Rules table: links', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: 'rule1', enabled: false }));
+    createRule(getCustomQueryRuleParams({ rule_id: 'rule1', enabled: false }));
     visit(RULES_MANAGEMENT_URL);
   });
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_persistent_state.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_persistent_state.cy.ts
@@ -7,6 +7,7 @@
 
 import { encode } from '@kbn/rison';
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState } from '../../../../tasks/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -100,6 +101,10 @@ describe(
   'Rules table: persistent state',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       deleteAlertsAndRules();
       createTestRules();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
@@ -20,6 +20,7 @@ import {
 import {
   getInstalledPrebuiltRulesCount,
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
 } from '../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -39,6 +40,10 @@ describe(
   'Rules table: selection',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       /* Create and install two mock rules */

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
@@ -18,7 +18,7 @@ import {
   waitForPrebuiltDetectionRulesToBeLoaded,
 } from '../../../../tasks/alerts_detection_rules';
 import {
-  getAvailablePrebuiltRulesCount,
+  getInstalledPrebuiltRulesCount,
   createAndInstallMockedPrebuiltRules,
 } from '../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../tasks/login';
@@ -65,7 +65,7 @@ describe(
 
       cy.get(SELECT_ALL_RULES_BTN).click();
 
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
       });
 
@@ -75,7 +75,7 @@ describe(
       // Current selection should be 0 rules
       cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
       // Bulk selection button should be back to displaying all rules
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
       });
     });
@@ -85,7 +85,7 @@ describe(
 
       cy.get(SELECT_ALL_RULES_BTN).click();
 
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
       });
 
@@ -95,7 +95,7 @@ describe(
       // Current selection should be 0 rules
       cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
       // Bulk selection button should be back to displaying all rules
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
       });
     });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import {
   FIRST_RULE,
   RULE_NAME,
@@ -24,6 +25,7 @@ import { visit } from '../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import {
+  getCustomQueryRuleParams,
   getExistingRule,
   getNewOverrideRule,
   getNewRule,
@@ -38,10 +40,14 @@ import { TABLE_FIRST_PAGE, TABLE_SECOND_PAGE } from '../../../../screens/table_p
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 
 describe('Rules table: sorting', { tags: ['@ess', '@serverless', '@serverlessQA'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: '1', enabled: false }));
+    createRule(getCustomQueryRuleParams({ rule_id: '1', enabled: false }));
     createRule(getExistingRule({ rule_id: '2', enabled: false }));
     createRule(getNewOverrideRule({ rule_id: '3', enabled: false }));
     createRule(getNewThresholdRule({ rule_id: '4', enabled: false }));

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -74,19 +74,24 @@ export const installSpecificPrebuiltRulesRequest = (rules: Array<typeof SAMPLE_P
     },
   });
 
-export const getAvailablePrebuiltRulesCount = () => {
-  cy.log('Get prebuilt rules count');
-  return getPrebuiltRulesStatus().then(({ body }) => {
-    const prebuiltRulesCount = body.rules_installed + body.rules_not_installed;
+export const getInstalledPrebuiltRulesCount = () => {
+  cy.log('Get installed prebuilt rules count');
 
-    return prebuiltRulesCount;
-  });
+  return getPrebuiltRulesStatus().then(({ body }) => body.rules_installed);
+};
+
+export const getAvailableToInstallPrebuiltRulesCount = () => {
+  cy.log('Get available to install prebuilt rules count');
+
+  return getPrebuiltRulesStatus().then(
+    ({ body }) => body.rules_installed + body.rules_not_installed
+  );
 };
 
 export const waitTillPrebuiltRulesReadyToInstall = () => {
   cy.waitUntil(
     () => {
-      return getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      return getAvailableToInstallPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         return availablePrebuiltRulesCount > 0;
       });
     },
@@ -214,20 +219,12 @@ const installByUploadPrebuiltRulesPackage = (packagePath: string): void => {
 };
 
 /**
- * Installs an empty mock prebuilt rules package `security_detection_engine`.
- * It's convenient to test functionality when no prebuilt rules are installed nor rule assets are available.
- */
-export const installMockEmptyPrebuiltRulesPackage = (): void => {
-  installByUploadPrebuiltRulesPackage(
-    'security_detection_engine_packages/mock-empty-security_detection_engine-99.0.0.zip'
-  );
-};
-
-/**
  * Installs a prepared mock prebuilt rules package `security_detection_engine`.
  * Installing it up front prevents installing the real package when making API requests.
  */
 export const installMockPrebuiltRulesPackage = (): void => {
+  cy.log('Install mock prebuilt rules package');
+
   installByUploadPrebuiltRulesPackage(
     'security_detection_engine_packages/mock-security_detection_engine-99.0.0.zip'
   );


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/182441**
**Resolves: https://github.com/elastic/kibana/issues/182442**
**Resolves: https://github.com/elastic/kibana/issues/228942**
**Relates to: https://github.com/elastic/kibana/pull/227689**

## Summary

This PR installs mock prebuilt rules package for e2e Cypress test to reduce flakniess caused by accessing to the real EPR. It's similar to the mock package installation in integration tests [PR](https://github.com/elastic/kibana/pull/227689).

**Flaky test runner**
- ESS: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9120
- Serverless: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9121




<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->