### PR TITLE
Ignores kbn-data-forge package from codeql scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -121,6 +121,7 @@ paths-ignore:
   - x-pack/packages/ai-infra/product-doc-artifact-builder
   - x-pack/packages/kbn-synthetics-private-location
   - x-pack/platform/packages/shared/kbn-ai-tools-cli
+  - x-pack/platform/packages/shared/kbn-data-forge
   - x-pack/platform/packages/shared/kbn-inference-cli
   - x-pack/platform/packages/shared/kbn-kibana-api-cli
   - x-pack/platform/packages/shared/kbn-sample-parser


### PR DESCRIPTION
This package is only used for development data generation and the hard-coded value is modeled after[ a similar hard-coded value in the kbn-cli-dev-mode package](https://github.com/elastic/kibana/blob/fa0500c346389758fb09935be246752dcdbbb6f3/packages/kbn-cli-dev-mode/src/base_path_proxy/http1.ts#L74), which is already ignored from these scans.


<!--ONMERGE {"backportTargets":["8.19","9.2"]} ONMERGE-->