### PR TITLE
[Product doc] Fixes logic for product docs installing version higher than the current version

### DIFF
--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
@@ -298,5 +298,5 @@ export class PackageInstaller {
 const selectVersion = (currentVersion: string, availableVersions: string[]): string => {
   return availableVersions.includes(currentVersion)
     ? currentVersion
-    : latestVersion(availableVersions);
+    : latestVersion(availableVersions, currentVersion);
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.test.ts
@@ -26,4 +26,8 @@ describe('latestVersion', () => {
   it('accepts versions in a {major.minor} format', () => {
     expect(latestVersion(['9.16', '9.3'])).toEqual('9.16');
   });
+  it('returns the highest version from the list, ignoring versions less than the current version if provided', () => {
+    expect(latestVersion(['8.18', '9.1', '9.16', '9.3'], '8.19')).toEqual('8.18');
+    expect(latestVersion(['8.18', '8.19', '9.1', '9.3'], '9.2')).toEqual('9.1');
+  });
 });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.ts
@@ -7,6 +7,12 @@
 
 import Semver from 'semver';
 
+/**
+ * @param availableVersions - List of available versions
+ * @param kibanaVer - Kibana version
+ * @returns The latest version from the list
+ * If kibanaVer is provided, return the previous closest version available
+ */
 export const latestVersion = (availableVersions: string[], kibanaVer?: string): string => {
   const kibanaSemver = kibanaVer ? Semver.coerce(kibanaVer) : undefined;
   let latest: string | undefined;
@@ -16,7 +22,10 @@ export const latestVersion = (availableVersions: string[], kibanaVer?: string): 
     if (!semver) continue;
 
     if (
+      // If a Kibana version is provided,
+      // narrow to only available versions prior to that Kibana version
       (!kibanaSemver || Semver.lte(semver, kibanaSemver)) &&
+      // Else, grab the newer version from the list
       (!latest || Semver.gt(semver, Semver.coerce(latest)!))
     ) {
       latest = version;

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.ts
@@ -7,15 +7,23 @@
 
 import Semver from 'semver';
 
-export const latestVersion = (versions: string[]): string => {
-  let latest: string = versions[0];
-  for (let i = 1; i < versions.length; i++) {
-    const current = versions[i];
-    if (Semver.gt(Semver.coerce(current)!, Semver.coerce(latest)!)) {
-      latest = current;
+export const latestVersion = (availableVersions: string[], kibanaVer?: string): string => {
+  const kibanaSemver = kibanaVer ? Semver.coerce(kibanaVer) : undefined;
+  let latest: string | undefined;
+
+  for (const version of availableVersions) {
+    const semver = Semver.coerce(version);
+    if (!semver) continue;
+
+    if (
+      (!kibanaSemver || Semver.lte(semver, kibanaSemver)) &&
+      (!latest || Semver.gt(semver, Semver.coerce(latest)!))
+    ) {
+      latest = version;
     }
   }
-  return latest;
+
+  return latest ?? availableVersions[0];
 };
 
 export const majorMinor = (version: string): string => {


### PR DESCRIPTION
## Summary

This PR fixes the automatic installation of product docs, for when the latest available version is higher than the current Kibana version. 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->