### PR TITLE
[AI4SOC] Update rules package version to latest testing

### DIFF
--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -83,7 +83,7 @@ xpack.fleet.prereleaseEnabledByDefault: true
 xpack.fleet.internal.registry.searchAiLakePackageAllowlistEnabled: true
 
 # Pin the prebuilt rules package version to the version that contains promotion rules
-xpack.securitySolution.prebuiltRulesPackageVersion: '9.1.2-beta.3'
+xpack.securitySolution.prebuiltRulesPackageVersion: '9.1.3-beta.1'
 
 # Elastic Managed LLM
 xpack.actions.preconfigured:


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/229063 that updates the `xpack.securitySolution.prebuiltRulesPackageVersion` AI4DSOC configuration to the latest `9.1.3-beta.1` package release for testing https://github.com/elastic/kibana/issues/228135.

cc @pborgonovi @tomsonpl @Mikaayenson @xcrzx 