### PR TITLE
[Fleet] Fix incorrectly removing integration tiles

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
@@ -106,22 +106,11 @@ const packageListToIntegrationsList = (packages: PackageList): PackageList => {
         })
       : [];
 
-    let tiles = filterPolicyTemplatesTiles<PackageListItem>(
+    const tiles = filterPolicyTemplatesTiles<PackageListItem>(
       pkg.policy_templates_behavior,
       topPackage,
       integrationsPolicyTemplates
     );
-
-    // remove tiles that only have data streams of excluded types e.g. aws.ebs, but keep partial matches e.g. aws.cloudfront_logs
-    tiles = tiles.filter((tile) => {
-      return (
-        !tile.integration ||
-        !tile.data_streams ||
-        tile.data_streams.some((dataStream) =>
-          dataStream.dataset.includes(`${tile.name}.${tile.integration}`)
-        )
-      );
-    });
 
     return [...acc, ...tiles];
   }, []);


### PR DESCRIPTION
## Summary

Fix bug introduced in https://github.com/elastic/kibana/pull/227842

Removed logic to filter out child integration tiles as there is no reliable way to say if a tile has no data streams.
E.g. for CSPM, data stream naming doesn't follow the `name.integration` pattern like aws.

This means we can't remove those child tiles that only have metrics data streams.

Before:
<img width="1437" height="1053" alt="image" src="https://github.com/user-attachments/assets/5e69c9e4-60a5-4eb5-9318-12905635871c" />

After:
<img width="1438" height="1073" alt="image" src="https://github.com/user-attachments/assets/bbe285ec-d358-4eef-9ccb-f2e6b62b4021" />

```
{
  "name": "cloud_security_posture",
  "integration": "cspm",
  "data_streams": [
    {
      "type": "logs",
      "dataset": "cloud_security_posture.findings",
      "title": "Cloud Security Posture Findings"
    },
    {
      "type": "logs",
      "dataset": "cloud_security_posture.vulnerabilities",
      "title": "Cloud Vulnerabilities"
    }
  ]
}
```


