### PR TITLE
[9.0] [Security Solution] Add detection_rule_upgrade_status to snapshot telemetry (#223086)

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_security.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_security.json
@@ -5636,6 +5636,34 @@
                       }
                     }
                   }
+                },
+                "elastic_detection_rule_upgrade_status": {
+                  "properties": {
+                    "total": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of total upgradeable elastic rules"
+                      }
+                    },
+                    "customized": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of customized upgradeable elastic rules"
+                      }
+                    },
+                    "enabled": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of enabled upgradeable elastic rules"
+                      }
+                    },
+                    "disabled": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of disabled upgradeable elastic rules"
+                      }
+                    }
+                  }
                 }
               }
             },

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/collector.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/collector.ts
@@ -3719,6 +3719,24 @@ export const registerCollector: RegisterCollector = ({
               },
             },
           },
+          elastic_detection_rule_upgrade_status: {
+            total: {
+              type: 'long',
+              _meta: { description: 'The number of total upgradeable elastic rules' },
+            },
+            customized: {
+              type: 'long',
+              _meta: { description: 'The number of customized upgradeable elastic rules' },
+            },
+            enabled: {
+              type: 'long',
+              _meta: { description: 'The number of enabled upgradeable elastic rules' },
+            },
+            disabled: {
+              type: 'long',
+              _meta: { description: 'The number of disabled upgradeable elastic rules' },
+            },
+          },
         },
         ml_jobs: {
           ml_job_usage: {

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_initial_usage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_initial_usage.ts
@@ -10,6 +10,7 @@ import type { DetectionMetrics } from './types';
 import { getInitialMlJobUsage } from './ml_jobs/get_initial_usage';
 import {
   getInitialEventLogUsage,
+  getInitialRuleUpgradeStatus,
   getInitialRulesUsage,
   getInitialSpacesUsage,
 } from './rules/get_initial_usage';
@@ -28,6 +29,7 @@ export const getInitialDetectionMetrics = (): DetectionMetrics => ({
     detection_rule_detail: [],
     detection_rule_usage: getInitialRulesUsage(),
     detection_rule_status: getInitialEventLogUsage(),
+    elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
     spaces_usage: getInitialSpacesUsage(),
   },
   legacy_siem_signals: getInitialLegacySiemSignalsUsage(),

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.test.ts
@@ -34,12 +34,27 @@ import {
 } from './rules/get_metrics.mocks';
 import { getInitialDetectionMetrics } from './get_initial_usage';
 import { getDetectionsMetrics } from './get_metrics';
-import { getInitialRulesUsage, initialAlertSuppression } from './rules/get_initial_usage';
+import {
+  getInitialRuleUpgradeStatus,
+  getInitialRulesUsage,
+  initialAlertSuppression,
+} from './rules/get_initial_usage';
+import { createPrebuiltRuleAssetsClient as createPrebuiltRuleAssetsClientMock } from '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/__mocks__/prebuilt_rule_assets_client';
+
+let mockPrebuiltRuleAssetsClient: ReturnType<typeof createPrebuiltRuleAssetsClientMock>;
+
+jest.mock(
+  '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client',
+  () => ({
+    createPrebuiltRuleAssetsClient: () => mockPrebuiltRuleAssetsClient,
+  })
+);
 
 describe('Detections Usage and Metrics', () => {
   let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
   let mlClient: ReturnType<typeof mlServicesMock.createSetupContract>;
   let savedObjectsClient: ReturnType<typeof savedObjectsClientMock.create>;
+  mockPrebuiltRuleAssetsClient = createPrebuiltRuleAssetsClientMock();
 
   describe('getRuleMetrics()', () => {
     beforeEach(() => {
@@ -62,7 +77,7 @@ describe('Detections Usage and Metrics', () => {
       expect(result).toEqual<DetectionMetrics>(getInitialDetectionMetrics());
     });
 
-    it('returns information with rule, alerts and cases for elastic non-customized rule', async () => {
+    it('returns information with disabled non-customized rule with upgrade, alerts and cases', async () => {
       esClient.search.mockResponseOnce(getEventLogAllRules());
       esClient.search.mockResponseOnce(getEventLogElasticRules());
       esClient.search.mockResponseOnce(getElasticLogCustomRules());
@@ -71,6 +86,12 @@ describe('Detections Usage and Metrics', () => {
       savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
       // Get empty saved object for legacy notification system.
       savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '5',
+        },
+      ]);
 
       const logger = loggingSystemMock.createLogger();
       const result = await getDetectionsMetrics({
@@ -139,18 +160,6 @@ describe('Detections Usage and Metrics', () => {
               legacy_investigation_fields: 0,
               alert_suppression: initialAlertSuppression,
             },
-            elastic_customized_total: {
-              alerts: 0,
-              cases: 0,
-              disabled: 0,
-              enabled: 0,
-              legacy_notifications_enabled: 0,
-              legacy_notifications_disabled: 0,
-              notifications_enabled: 0,
-              notifications_disabled: 0,
-              legacy_investigation_fields: 0,
-              alert_suppression: initialAlertSuppression,
-            },
             elastic_noncustomized_total: {
               alerts: 3400,
               cases: 1,
@@ -164,19 +173,149 @@ describe('Detections Usage and Metrics', () => {
               alert_suppression: initialAlertSuppression,
             },
           },
+          elastic_detection_rule_upgrade_status: {
+            total: 1,
+            customized: 0,
+            enabled: 0,
+            disabled: 1,
+          },
         },
       });
     });
 
-    it('returns information with rule, alerts and cases for elastic customized rule', async () => {
+    it('returns information with enabled non-customized rule with upgrade, alerts and cases', async () => {
       esClient.search.mockResponseOnce(getEventLogAllRules());
       esClient.search.mockResponseOnce(getEventLogElasticRules());
       esClient.search.mockResponseOnce(getElasticLogCustomRules());
       esClient.search.mockResponseOnce(getMockRuleAlertsResponse(3400));
-      savedObjectsClient.find.mockResolvedValueOnce(getMockRuleSearchResponse(true, true));
+      savedObjectsClient.find.mockResolvedValueOnce(
+        getMockRuleSearchResponse(
+          true /* immutable, this means elastic */,
+          false /* customized */,
+          true /* enabled */
+        )
+      );
       savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
       // Get empty saved object for legacy notification system.
       savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '5',
+        },
+      ]);
+
+      const logger = loggingSystemMock.createLogger();
+      const result = await getDetectionsMetrics({
+        eventLogIndex: '',
+        signalsIndex: '',
+        esClient,
+        savedObjectsClient,
+        logger,
+        mlClient,
+        legacySignalsIndex: '',
+      });
+
+      expect(result).toEqual<DetectionMetrics>({
+        ...getInitialDetectionMetrics(),
+        detection_rules: {
+          spaces_usage: {
+            rules_in_spaces: [1],
+            total: 1,
+          },
+          detection_rule_status: getAllEventLogTransform(),
+          detection_rule_detail: [
+            {
+              alert_count_daily: 3400,
+              cases_count_total: 1,
+              created_on: '2021-03-23T17:15:59.634Z',
+              elastic_rule: true,
+              is_customized: false,
+              enabled: true,
+              rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+              rule_name: 'Azure Diagnostic Settings Deletion',
+              rule_type: 'query',
+              rule_version: 4,
+              updated_on: '2021-03-23T17:15:59.634Z',
+              has_legacy_notification: false,
+              has_notification: false,
+              has_legacy_investigation_field: false,
+              has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
+              has_alert_suppression_per_rule_execution: false,
+              has_alert_suppression_per_time_period: false,
+              alert_suppression_fields_count: 0,
+            },
+          ],
+          detection_rule_usage: {
+            ...getInitialRulesUsage(),
+            query: {
+              enabled: 1,
+              disabled: 0,
+              alerts: 3400,
+              cases: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_noncustomized_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+          },
+          elastic_detection_rule_upgrade_status: {
+            total: 1,
+            customized: 0,
+            enabled: 1,
+            disabled: 0,
+          },
+        },
+      });
+    });
+
+    it('returns information with disabled customized rule with upgrade, alerts and cases', async () => {
+      esClient.search.mockResponseOnce(getEventLogAllRules());
+      esClient.search.mockResponseOnce(getEventLogElasticRules());
+      esClient.search.mockResponseOnce(getElasticLogCustomRules());
+      esClient.search.mockResponseOnce(getMockRuleAlertsResponse(3400));
+      savedObjectsClient.find.mockResolvedValueOnce(
+        getMockRuleSearchResponse(
+          true /* immutable (elastic) */,
+          true /* customized */,
+          false /* enabled */
+        )
+      );
+      savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
+      // Get empty saved object for legacy notification system.
+      savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '5', // this makes the rule upgradeable
+        },
+      ]);
 
       const logger = loggingSystemMock.createLogger();
       const result = await getDetectionsMetrics({
@@ -257,10 +396,222 @@ describe('Detections Usage and Metrics', () => {
               legacy_investigation_fields: 0,
               alert_suppression: initialAlertSuppression,
             },
-            elastic_noncustomized_total: {
-              alerts: 0,
-              cases: 0,
+          },
+          elastic_detection_rule_upgrade_status: {
+            total: 1,
+            customized: 1,
+            enabled: 0,
+            disabled: 1,
+          },
+        },
+      });
+    });
+
+    it('returns information with enabled customized rule with upgrade, alerts and cases', async () => {
+      esClient.search.mockResponseOnce(getEventLogAllRules());
+      esClient.search.mockResponseOnce(getEventLogElasticRules());
+      esClient.search.mockResponseOnce(getElasticLogCustomRules());
+      esClient.search.mockResponseOnce(getMockRuleAlertsResponse(3400));
+      savedObjectsClient.find.mockResolvedValueOnce(
+        getMockRuleSearchResponse(
+          true /* immutable (elastic) */,
+          true /* customized */,
+          true /* enabled */
+        )
+      );
+      savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
+      // Get empty saved object for legacy notification system.
+      savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '5', // this makes the rule upgradeable
+        },
+      ]);
+
+      const logger = loggingSystemMock.createLogger();
+      const result = await getDetectionsMetrics({
+        eventLogIndex: '',
+        signalsIndex: '',
+        esClient,
+        savedObjectsClient,
+        logger,
+        mlClient,
+        legacySignalsIndex: '',
+      });
+
+      expect(result).toEqual<DetectionMetrics>({
+        ...getInitialDetectionMetrics(),
+        detection_rules: {
+          spaces_usage: {
+            rules_in_spaces: [1],
+            total: 1,
+          },
+          detection_rule_status: getAllEventLogTransform(),
+          detection_rule_detail: [
+            {
+              alert_count_daily: 3400,
+              cases_count_total: 1,
+              created_on: '2021-03-23T17:15:59.634Z',
+              elastic_rule: true,
+              is_customized: true,
+              enabled: true,
+              rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+              rule_name: 'Azure Diagnostic Settings Deletion',
+              rule_type: 'query',
+              rule_version: 4,
+              updated_on: '2021-03-23T17:15:59.634Z',
+              has_legacy_notification: false,
+              has_notification: false,
+              has_legacy_investigation_field: false,
+              has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
+              has_alert_suppression_per_rule_execution: false,
+              has_alert_suppression_per_time_period: false,
+              alert_suppression_fields_count: 0,
+            },
+          ],
+          detection_rule_usage: {
+            ...getInitialRulesUsage(),
+            query: {
+              enabled: 1,
               disabled: 0,
+              alerts: 3400,
+              cases: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_customized_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+          },
+          elastic_detection_rule_upgrade_status: {
+            total: 1,
+            customized: 1,
+            enabled: 1,
+            disabled: 0,
+          },
+        },
+      });
+    });
+
+    it('returns information with disabled non-customized rule without upgrade, alerts and cases', async () => {
+      esClient.search.mockResponseOnce(getEventLogAllRules());
+      esClient.search.mockResponseOnce(getEventLogElasticRules());
+      esClient.search.mockResponseOnce(getElasticLogCustomRules());
+      esClient.search.mockResponseOnce(getMockRuleAlertsResponse(3400));
+      savedObjectsClient.find.mockResolvedValueOnce(
+        getMockRuleSearchResponse(
+          true /* immutable (elastic) */,
+          true /* customized */,
+          false /* enabled */
+        )
+      );
+      savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
+      // Get empty saved object for legacy notification system.
+      savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '4', // this makes the rule non-upgradeable
+        },
+      ]);
+
+      const logger = loggingSystemMock.createLogger();
+      const result = await getDetectionsMetrics({
+        eventLogIndex: '',
+        signalsIndex: '',
+        esClient,
+        savedObjectsClient,
+        logger,
+        mlClient,
+        legacySignalsIndex: '',
+      });
+
+      expect(result).toEqual<DetectionMetrics>({
+        ...getInitialDetectionMetrics(),
+        detection_rules: {
+          spaces_usage: {
+            rules_in_spaces: [1],
+            total: 1,
+          },
+          detection_rule_status: getAllEventLogTransform(),
+          detection_rule_detail: [
+            {
+              alert_count_daily: 3400,
+              cases_count_total: 1,
+              created_on: '2021-03-23T17:15:59.634Z',
+              elastic_rule: true,
+              is_customized: true,
+              enabled: false,
+              rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+              rule_name: 'Azure Diagnostic Settings Deletion',
+              rule_type: 'query',
+              rule_version: 4,
+              updated_on: '2021-03-23T17:15:59.634Z',
+              has_legacy_notification: false,
+              has_notification: false,
+              has_legacy_investigation_field: false,
+              has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
+              has_alert_suppression_per_rule_execution: false,
+              has_alert_suppression_per_time_period: false,
+              alert_suppression_fields_count: 0,
+            },
+          ],
+          detection_rule_usage: {
+            ...getInitialRulesUsage(),
+            query: {
+              enabled: 0,
+              disabled: 1,
+              alerts: 3400,
+              cases: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 1,
+              enabled: 0,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_customized_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 1,
               enabled: 0,
               legacy_notifications_enabled: 0,
               legacy_notifications_disabled: 0,
@@ -270,19 +621,363 @@ describe('Detections Usage and Metrics', () => {
               alert_suppression: initialAlertSuppression,
             },
           },
+          elastic_detection_rule_upgrade_status: {
+            total: 0,
+            customized: 0,
+            enabled: 0,
+            disabled: 0,
+          },
         },
       });
     });
 
-    it('returns information on non elastic rule', async () => {
+    it('returns information with enabled non-customized rule without upgrade, alerts and cases', async () => {
+      esClient.search.mockResponseOnce(getEventLogAllRules());
+      esClient.search.mockResponseOnce(getEventLogElasticRules());
+      esClient.search.mockResponseOnce(getElasticLogCustomRules());
+      esClient.search.mockResponseOnce(getMockRuleAlertsResponse(3400));
+      savedObjectsClient.find.mockResolvedValueOnce(
+        getMockRuleSearchResponse(
+          true /* immutable, this means elastic */,
+          false /* customized */,
+          true /* enabled */
+        )
+      );
+      savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
+      // Get empty saved object for legacy notification system.
+      savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '4', // this makes the rule non-upgradeable
+        },
+      ]);
+
+      const logger = loggingSystemMock.createLogger();
+      const result = await getDetectionsMetrics({
+        eventLogIndex: '',
+        signalsIndex: '',
+        esClient,
+        savedObjectsClient,
+        logger,
+        mlClient,
+        legacySignalsIndex: '',
+      });
+
+      expect(result).toEqual<DetectionMetrics>({
+        ...getInitialDetectionMetrics(),
+        detection_rules: {
+          spaces_usage: {
+            rules_in_spaces: [1],
+            total: 1,
+          },
+          detection_rule_status: getAllEventLogTransform(),
+          detection_rule_detail: [
+            {
+              alert_count_daily: 3400,
+              cases_count_total: 1,
+              created_on: '2021-03-23T17:15:59.634Z',
+              elastic_rule: true,
+              is_customized: false,
+              enabled: true,
+              rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+              rule_name: 'Azure Diagnostic Settings Deletion',
+              rule_type: 'query',
+              rule_version: 4,
+              updated_on: '2021-03-23T17:15:59.634Z',
+              has_legacy_notification: false,
+              has_notification: false,
+              has_legacy_investigation_field: false,
+              has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
+              has_alert_suppression_per_rule_execution: false,
+              has_alert_suppression_per_time_period: false,
+              alert_suppression_fields_count: 0,
+            },
+          ],
+          detection_rule_usage: {
+            ...getInitialRulesUsage(),
+            query: {
+              enabled: 1,
+              disabled: 0,
+              alerts: 3400,
+              cases: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_noncustomized_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+          },
+          elastic_detection_rule_upgrade_status: {
+            total: 0,
+            customized: 0,
+            enabled: 0,
+            disabled: 0,
+          },
+        },
+      });
+    });
+
+    it('returns information with disabled customized rule without upgrade, alerts and cases', async () => {
+      esClient.search.mockResponseOnce(getEventLogAllRules());
+      esClient.search.mockResponseOnce(getEventLogElasticRules());
+      esClient.search.mockResponseOnce(getElasticLogCustomRules());
+      esClient.search.mockResponseOnce(getMockRuleAlertsResponse(3400));
+      savedObjectsClient.find.mockResolvedValueOnce(
+        getMockRuleSearchResponse(
+          true /* immutable (elastic) */,
+          true /* customized */,
+          false /* enabled */
+        )
+      );
+      savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
+      // Get empty saved object for legacy notification system.
+      savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '4', // this makes the rule non-upgradeable
+        },
+      ]);
+
+      const logger = loggingSystemMock.createLogger();
+      const result = await getDetectionsMetrics({
+        eventLogIndex: '',
+        signalsIndex: '',
+        esClient,
+        savedObjectsClient,
+        logger,
+        mlClient,
+        legacySignalsIndex: '',
+      });
+
+      expect(result).toEqual<DetectionMetrics>({
+        ...getInitialDetectionMetrics(),
+        detection_rules: {
+          spaces_usage: {
+            rules_in_spaces: [1],
+            total: 1,
+          },
+          detection_rule_status: getAllEventLogTransform(),
+          detection_rule_detail: [
+            {
+              alert_count_daily: 3400,
+              cases_count_total: 1,
+              created_on: '2021-03-23T17:15:59.634Z',
+              elastic_rule: true,
+              is_customized: true,
+              enabled: false,
+              rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+              rule_name: 'Azure Diagnostic Settings Deletion',
+              rule_type: 'query',
+              rule_version: 4,
+              updated_on: '2021-03-23T17:15:59.634Z',
+              has_legacy_notification: false,
+              has_notification: false,
+              has_legacy_investigation_field: false,
+              has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
+              has_alert_suppression_per_rule_execution: false,
+              has_alert_suppression_per_time_period: false,
+              alert_suppression_fields_count: 0,
+            },
+          ],
+          detection_rule_usage: {
+            ...getInitialRulesUsage(),
+            query: {
+              enabled: 0,
+              disabled: 1,
+              alerts: 3400,
+              cases: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 1,
+              enabled: 0,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_customized_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 1,
+              enabled: 0,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+          },
+          elastic_detection_rule_upgrade_status: {
+            total: 0,
+            customized: 0,
+            enabled: 0,
+            disabled: 0,
+          },
+        },
+      });
+    });
+
+    it('returns information with enabled customized rule without upgrade, alerts and cases', async () => {
+      esClient.search.mockResponseOnce(getEventLogAllRules());
+      esClient.search.mockResponseOnce(getEventLogElasticRules());
+      esClient.search.mockResponseOnce(getElasticLogCustomRules());
+      esClient.search.mockResponseOnce(getMockRuleAlertsResponse(3400));
+      savedObjectsClient.find.mockResolvedValueOnce(
+        getMockRuleSearchResponse(
+          true /* immutable (elastic) */,
+          true /* customized */,
+          true /* enabled */
+        )
+      );
+      savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
+      // Get empty saved object for legacy notification system.
+      savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([
+        {
+          rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+          version: '4', // this makes the rule non-upgradeable
+        },
+      ]);
+
+      const logger = loggingSystemMock.createLogger();
+      const result = await getDetectionsMetrics({
+        eventLogIndex: '',
+        signalsIndex: '',
+        esClient,
+        savedObjectsClient,
+        logger,
+        mlClient,
+        legacySignalsIndex: '',
+      });
+
+      expect(result).toEqual<DetectionMetrics>({
+        ...getInitialDetectionMetrics(),
+        detection_rules: {
+          spaces_usage: {
+            rules_in_spaces: [1],
+            total: 1,
+          },
+          detection_rule_status: getAllEventLogTransform(),
+          detection_rule_detail: [
+            {
+              alert_count_daily: 3400,
+              cases_count_total: 1,
+              created_on: '2021-03-23T17:15:59.634Z',
+              elastic_rule: true,
+              is_customized: true,
+              enabled: true,
+              rule_id: '5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de',
+              rule_name: 'Azure Diagnostic Settings Deletion',
+              rule_type: 'query',
+              rule_version: 4,
+              updated_on: '2021-03-23T17:15:59.634Z',
+              has_legacy_notification: false,
+              has_notification: false,
+              has_legacy_investigation_field: false,
+              has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
+              has_alert_suppression_per_rule_execution: false,
+              has_alert_suppression_per_time_period: false,
+              alert_suppression_fields_count: 0,
+            },
+          ],
+          detection_rule_usage: {
+            ...getInitialRulesUsage(),
+            query: {
+              enabled: 1,
+              disabled: 0,
+              alerts: 3400,
+              cases: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+            elastic_customized_total: {
+              alerts: 3400,
+              cases: 1,
+              disabled: 0,
+              enabled: 1,
+              legacy_notifications_enabled: 0,
+              legacy_notifications_disabled: 0,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_investigation_fields: 0,
+              alert_suppression: initialAlertSuppression,
+            },
+          },
+          elastic_detection_rule_upgrade_status: {
+            total: 0,
+            customized: 0,
+            enabled: 0,
+            disabled: 0,
+          },
+        },
+      });
+    });
+
+    it('returns information on custom rule', async () => {
       esClient.search.mockResponseOnce(getEventLogAllRules());
       esClient.search.mockResponseOnce(getEventLogElasticRules());
       esClient.search.mockResponseOnce(getElasticLogCustomRules());
       esClient.search.mockResponseOnce(getMockRuleAlertsResponse(800));
-      savedObjectsClient.find.mockResolvedValueOnce(getMockRuleSearchResponse(false));
+      savedObjectsClient.find.mockResolvedValueOnce(getMockRuleSearchResponse(false)); // immutable means 'elastic', non-immutable means 'custom'
       savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
       // Get empty saved object for legacy notification system.
       savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([]); // doesn't matter here, it is a custom rule
+
       const logger = loggingSystemMock.createLogger();
       const result = await getDetectionsMetrics({
         eventLogIndex: '',
@@ -330,19 +1025,21 @@ describe('Detections Usage and Metrics', () => {
               alert_suppression: initialAlertSuppression,
             },
           },
+          elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
         },
       });
     });
 
-    it('returns information with rule, no alerts and no cases', async () => {
+    it('returns information with rule, no alerts and no cases, when no upgrades possible', async () => {
       esClient.search.mockResponseOnce(getEventLogAllRules());
       esClient.search.mockResponseOnce(getEventLogElasticRules());
       esClient.search.mockResponseOnce(getElasticLogCustomRules());
       esClient.search.mockResponseOnce(getMockRuleAlertsResponse(0));
-      savedObjectsClient.find.mockResolvedValueOnce(getMockRuleSearchResponse());
+      savedObjectsClient.find.mockResolvedValueOnce(getMockRuleSearchResponse()); // by default it is immutable which means 'elastic'
       savedObjectsClient.find.mockResolvedValueOnce(getMockAlertCaseCommentsResponse());
       // Get empty saved object for legacy notification system.
       savedObjectsClient.find.mockResolvedValueOnce(getEmptySavedObjectResponse());
+      mockPrebuiltRuleAssetsClient.fetchLatestVersions.mockResolvedValueOnce([]); // provide empty array to indicate no upgrades possible
 
       const logger = loggingSystemMock.createLogger();
       const result = await getDetectionsMetrics({
@@ -436,6 +1133,7 @@ describe('Detections Usage and Metrics', () => {
               alert_suppression: initialAlertSuppression,
             },
           },
+          elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
         },
       });
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/get_metrics.ts
@@ -13,6 +13,7 @@ import { getMlJobMetrics } from './ml_jobs/get_metrics';
 import { getRuleMetrics } from './rules/get_metrics';
 import {
   getInitialEventLogUsage,
+  getInitialRuleUpgradeStatus,
   getInitialRulesUsage,
   getInitialSpacesUsage,
 } from './rules/get_initial_usage';
@@ -59,6 +60,7 @@ export const getDetectionsMetrics = async ({
             detection_rule_detail: [],
             detection_rule_usage: getInitialRulesUsage(),
             detection_rule_status: getInitialEventLogUsage(),
+            elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
             spaces_usage: getInitialSpacesUsage(),
           },
     legacy_siem_signals:

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/ml_jobs/get_metrics.mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/ml_jobs/get_metrics.mocks.ts
@@ -300,7 +300,8 @@ export const getMockMlDatafeedStatsResponse = () => ({
 
 export const getMockRuleSearchResponse = (
   immutable: boolean = true,
-  isCustomized: boolean = false
+  isCustomized: boolean = false,
+  enabled: boolean = false
 ): SavedObjectsFindResponse<RuleSearchResult, never> =>
   ({
     page: 1,
@@ -346,14 +347,14 @@ export const getMockRuleSearchResponse = (
             ruleSource: isCustomized
               ? {
                   type: 'external',
-                  isCustomized: true,
+                  isCustomized,
                 }
               : { type: 'internal' },
           },
           schedule: {
             interval: '5m',
           },
-          enabled: false,
+          enabled,
           actions: [],
           throttle: null,
           notifyWhen: 'onActiveAlert',

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/calculate_rules_upgrade_status.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/calculate_rules_upgrade_status.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { calculateRuleUpgradeStatus } from './calculate_rules_upgrade_status';
+import type { RuleMetric } from './types';
+
+function prepareRuleMetric(isCustomized: boolean, enabled: boolean): RuleMetric {
+  return {
+    rule_name: 'test_rule',
+    rule_id: 'test_rule_id',
+    rule_type: 'query',
+    rule_version: 1,
+    enabled,
+    elastic_rule: true,
+    is_customized: isCustomized,
+    created_on: '2024-01-01T00:00:00Z',
+    updated_on: '2024-01-01T00:00:00Z',
+    alert_count_daily: 0,
+    cases_count_total: 0,
+    has_legacy_notification: false,
+    has_notification: false,
+    has_legacy_investigation_field: false,
+    has_alert_suppression_per_rule_execution: false,
+    has_alert_suppression_per_time_period: false,
+    has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
+    alert_suppression_fields_count: 0,
+    has_exceptions: false,
+    has_response_actions: false,
+    has_response_actions_endpoint: false,
+    has_response_actions_osquery: false,
+  };
+}
+
+describe('calculateRuleUpgradeStatus', () => {
+  it('should return all zeros when given an empty array', () => {
+    const result = calculateRuleUpgradeStatus([]);
+    expect(result).toEqual({
+      total: 0,
+      customized: 0,
+      enabled: 0,
+      disabled: 0,
+    });
+  });
+
+  it('should count total, enabled, disabled, and customized rules correctly', () => {
+    const rules: RuleMetric[] = [
+      prepareRuleMetric(false, false), // not customized, disabled
+      prepareRuleMetric(false, true), // not customized, enabled
+      prepareRuleMetric(true, false), // customized, disabled
+      prepareRuleMetric(true, true), // customized, enabled
+    ];
+    const result = calculateRuleUpgradeStatus(rules);
+    expect(result).toEqual({
+      total: 4,
+      customized: 2,
+      enabled: 2,
+      disabled: 2,
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/calculate_rules_upgrade_status.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/calculate_rules_upgrade_status.test.ts
@@ -28,10 +28,6 @@ function prepareRuleMetric(isCustomized: boolean, enabled: boolean): RuleMetric 
     has_alert_suppression_per_time_period: false,
     has_alert_suppression_missing_fields_strategy_do_not_suppress: false,
     alert_suppression_fields_count: 0,
-    has_exceptions: false,
-    has_response_actions: false,
-    has_response_actions_endpoint: false,
-    has_response_actions_osquery: false,
   };
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/calculate_rules_upgrade_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/calculate_rules_upgrade_status.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getInitialRuleUpgradeStatus } from './get_initial_usage';
+import type { RuleMetric } from './types';
+
+export function calculateRuleUpgradeStatus(upgradeableRules: RuleMetric[]) {
+  return upgradeableRules.reduce((acc, rule) => {
+    acc.total += 1;
+    if (rule.is_customized) {
+      acc.customized += 1;
+    }
+    if (rule.enabled) {
+      acc.enabled += 1;
+    } else {
+      acc.disabled += 1;
+    }
+    return acc;
+  }, getInitialRuleUpgradeStatus());
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
@@ -13,6 +13,7 @@ import type {
   SingleEventMetric,
   AlertSuppressionUsage,
   SpacesUsage,
+  UpgradeableRulesSummary,
 } from './types';
 
 export const initialAlertSuppression: AlertSuppressionUsage = {
@@ -234,4 +235,23 @@ export const getInitialMaxAvgMin = (): MaxAvgMin => ({
   max: 0.0,
   avg: 0.0,
   min: 0.0,
+});
+
+/**
+ * Returns the initial usage statistics for rule upgrade status.
+ *
+ * The returned object contains default values for the total number of upgradeable rules,
+ * the number of customized rules, and the counts of enabled and disabled rules.
+ *
+ * @returns {UpgradeableRulesSummary} An object with initial values for rule upgrade status:
+ * - `total`: The total number of upgradeable rules (default is 0).
+ * - `customized`: The number of customized upgradeable rules (default is 0).
+ * - `enabled`: The number of enabled upgradeable rules (default is 0).
+ * - `disabled`: The number of disabled upgradeable rules (default is 0).
+ */
+export const getInitialRuleUpgradeStatus = (): UpgradeableRulesSummary => ({
+  total: 0,
+  customized: 0,
+  enabled: 0,
+  disabled: 0,
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_metrics.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/get_metrics.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ElasticsearchClient, SavedObjectsClientContract, Logger } from '@kbn/core/server';
+import { createPrebuiltRuleAssetsClient } from '../../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
 import type { RuleAdoption } from './types';
 
 import { updateRuleUsage } from './update_usage';
@@ -14,6 +15,7 @@ import { getAlerts } from '../../queries/get_alerts';
 import { MAX_PER_PAGE, MAX_RESULTS_WINDOW } from '../../constants';
 import {
   getInitialEventLogUsage,
+  getInitialRuleUpgradeStatus,
   getInitialRulesUsage,
   getInitialSpacesUsage,
 } from './get_initial_usage';
@@ -27,6 +29,7 @@ import { getEventLogByTypeAndStatus } from '../../queries/get_event_log_by_type_
 
 // eslint-disable-next-line no-restricted-imports
 import { legacyGetRuleActions } from '../../queries/legacy_get_rule_actions';
+import { calculateRuleUpgradeStatus } from './calculate_rules_upgrade_status';
 
 export interface GetRuleMetricsOptions {
   signalsIndex: string;
@@ -58,6 +61,7 @@ export const getRuleMetrics = async ({
         detection_rule_detail: [],
         detection_rule_usage: getInitialRulesUsage(),
         detection_rule_status: getInitialEventLogUsage(),
+        elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
         spaces_usage: getInitialSpacesUsage(),
       };
     }
@@ -116,6 +120,17 @@ export const getRuleMetrics = async ({
       alertsCounts,
     });
 
+    const ruleAssetsClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
+    const latestRuleVersions = await ruleAssetsClient.fetchLatestVersions();
+    const latestRuleVersionsMap = new Map(latestRuleVersions.map((rule) => [rule.rule_id, rule]));
+
+    const upgradeableRules = rulesCorrelated.filter((rule) => {
+      const latestVersion = latestRuleVersionsMap.get(rule.rule_id);
+      return (
+        latestVersion != null && rule.elastic_rule && rule.rule_version < latestVersion.version
+      );
+    });
+
     // Only bring back rule detail on elastic prepackaged detection rules
     const elasticRuleObjects = rulesCorrelated.filter((hit) => hit.elastic_rule === true);
 
@@ -129,6 +144,7 @@ export const getRuleMetrics = async ({
       detection_rule_detail: elasticRuleObjects,
       detection_rule_usage: rulesUsage,
       detection_rule_status: eventLogMetricsTypeStatus,
+      elastic_detection_rule_upgrade_status: calculateRuleUpgradeStatus(upgradeableRules),
       spaces_usage: getSpacesUsage(ruleResults),
     };
   } catch (e) {
@@ -140,6 +156,7 @@ export const getRuleMetrics = async ({
       detection_rule_detail: [],
       detection_rule_usage: getInitialRulesUsage(),
       detection_rule_status: getInitialEventLogUsage(),
+      elastic_detection_rule_upgrade_status: getInitialRuleUpgradeStatus(),
       spaces_usage: getInitialSpacesUsage(),
     };
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/usage/detections/rules/types.ts
@@ -31,6 +31,14 @@ export interface FeatureTypeUsage {
   legacy_investigation_fields: number;
   alert_suppression: AlertSuppressionUsage;
 }
+
+export interface UpgradeableRulesSummary {
+  total: number;
+  customized: number;
+  enabled: number;
+  disabled: number;
+}
+
 export interface RulesTypeUsage {
   query: FeatureTypeUsage;
   threshold: FeatureTypeUsage;
@@ -54,6 +62,7 @@ export interface RuleAdoption {
   detection_rule_detail: RuleMetric[];
   detection_rule_usage: RulesTypeUsage;
   detection_rule_status: EventLogStatusMetric;
+  elastic_detection_rule_upgrade_status: UpgradeableRulesSummary;
   spaces_usage: SpacesUsage;
 }
 

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/index.ts
@@ -11,6 +11,7 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     loadTestFile(require.resolve('./usage_collector/all_types'));
     loadTestFile(require.resolve('./usage_collector/detection_rules'));
     loadTestFile(require.resolve('./usage_collector/detection_rule_status'));
+    loadTestFile(require.resolve('./usage_collector/detection_rule_upgrade_status'));
     loadTestFile(require.resolve('./usage_collector/detection_rules_legacy_action'));
 
     loadTestFile(require.resolve('./task_based/all_types'));

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_upgrade_status.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_upgrade_status.ts
@@ -1,0 +1,435 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import { getCustomQueryRuleParams, getStats } from '../../../utils';
+import { FtrProviderContext } from '../../../../../ftr_provider_context';
+import {
+  deleteAllPrebuiltRuleAssets,
+  getPrebuiltRulesStatus,
+  createRuleAssetSavedObject,
+  createPrebuiltRuleAssetSavedObjects,
+  installPrebuiltRules,
+} from '../../../utils';
+import { deleteAllRules } from '../../../../../../common/utils/security_solution';
+
+/**
+ * Test suite for detection rule upgrade status telemetry.
+ *
+ * This suite tests the telemetry metrics for upgradeable prebuilt rules,
+ * verifying that the system correctly tracks:
+ * - Total number of upgradeable rules
+ * - Number of customized vs non-customized rules
+ * - Number of enabled vs disabled rules
+ */
+export default ({ getService }: FtrProviderContext): void => {
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const log = getService('log');
+
+  describe('@ess @serverless @skipInServerlessMKI Prebuilt Rules status', () => {
+    describe('snapshot telemetry for upgradeable rules', () => {
+      // Test constants
+      const RULES_COUNT = 4;
+      const INITIAL_TELEMETRY_STATE = {
+        total: 0,
+        customized: 0,
+        enabled: 0,
+        disabled: 0,
+      };
+
+      beforeEach(async () => {
+        await deleteAllPrebuiltRuleAssets(es, log);
+        await deleteAllRules(supertest, log);
+      });
+
+      /**
+       * Creates a set of rule asset saved objects for testing.
+       * Each rule has a unique ID and version number.
+       */
+      const getRuleAssetSavedObjects = () => [
+        createRuleAssetSavedObject({ rule_id: 'rule-1', version: 1 }),
+        createRuleAssetSavedObject({ rule_id: 'rule-2', version: 2 }),
+        createRuleAssetSavedObject({ rule_id: 'rule-3', version: 3 }),
+        createRuleAssetSavedObject({ rule_id: 'rule-4', version: 4 }),
+      ];
+
+      /**
+       * Sets up the initial test environment with prebuilt rules.
+       * This includes creating rule assets and installing them.
+       */
+      const setupInitialRules = async () => {
+        const ruleAssetSavedObjects = getRuleAssetSavedObjects();
+        await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
+        await installPrebuiltRules(es, supertest);
+        return ruleAssetSavedObjects;
+      };
+
+      /**
+       * Customizes a rule with the given parameters.
+       * @param ruleId - The ID of the rule to customize
+       * @param customizations - Custom parameters for the rule
+       */
+      const customizeRule = async (ruleId: string, customizations: Record<string, any>) => {
+        const customRuleParams = getCustomQueryRuleParams({
+          rule_id: ruleId,
+          ...customizations,
+        });
+
+        await supertest
+          .put(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`)
+          .set('kbn-xsrf', 'true')
+          .send(customRuleParams)
+          .expect(200);
+      };
+
+      /**
+       * Creates upgradeable rules by incrementing versions and verifies the setup.
+       * @param ruleAssetSavedObjects - Array of rule assets to make upgradeable
+       * @param ruleIndices - Indices of rules to make upgradeable
+       * @returns The number of upgradeable rules created
+       */
+      const createUpgradeableRules = async (
+        ruleAssetSavedObjects: any[],
+        ruleIndices: number[]
+      ) => {
+        // Clear previous rule assets to reset telemetry state
+        await deleteAllPrebuiltRuleAssets(es, log);
+
+        // Verify initial telemetry state is clean
+        const initialStats = await getStats(supertest, log);
+        expect(initialStats?.detection_rules.elastic_detection_rule_upgrade_status).toEqual(
+          INITIAL_TELEMETRY_STATE
+        );
+
+        // Increment versions for specified rules to make them upgradeable
+        ruleIndices.forEach((index) => {
+          ruleAssetSavedObjects[index]['security-rule'].version += 1;
+        });
+
+        // Recreate rule assets with new versions
+        await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
+
+        // Verify prebuilt rules status shows correct upgrade count
+        const { stats } = await getPrebuiltRulesStatus(es, supertest);
+        expect(stats).toMatchObject({
+          num_prebuilt_rules_installed: RULES_COUNT,
+          num_prebuilt_rules_to_install: 0,
+          num_prebuilt_rules_to_upgrade: ruleIndices.length,
+          num_prebuilt_rules_total_in_package: RULES_COUNT,
+        });
+
+        return ruleIndices.length;
+      };
+
+      /**
+       * Verifies the final telemetry stats match expected values.
+       * @param expectedStats - Expected telemetry statistics
+       */
+      const verifyTelemetryStats = async (expectedStats: {
+        total: number;
+        customized: number;
+        enabled: number;
+        disabled: number;
+      }) => {
+        const telemetryStats = await getStats(supertest, log);
+        expect(telemetryStats?.detection_rules.elastic_detection_rule_upgrade_status).toEqual(
+          expectedStats
+        );
+      };
+
+      /**
+       * Test Case 1: Upgradeable disabled non-customized rules
+       *
+       * This test verifies that telemetry correctly reports stats for rules that are:
+       * - Upgradeable (newer version available)
+       * - Disabled (default state after installation)
+       * - Non-customized (no modifications from original prebuilt rule)
+       *
+       * Expected telemetry: total=2, customized=0, enabled=0, disabled=2
+       */
+      it('should return stats for upgradeable disabled non-customized rules', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // Create 2 upgradeable rules (rule-1 and rule-2) and verify setup
+        await createUpgradeableRules(ruleAssetSavedObjects, [0, 1]);
+
+        // Verify final telemetry shows 2 disabled, non-customized upgradeable rules
+        await verifyTelemetryStats({
+          total: 2,
+          customized: 0,
+          enabled: 0,
+          disabled: 2,
+        });
+      });
+
+      /**
+       * Test Case 2: Upgradeable disabled customized rules
+       *
+       * This test verifies that telemetry correctly reports stats for rules that include:
+       * - One customized rule (rule-1): upgradeable, disabled, and customized
+       * - One non-customized rule (rule-2): upgradeable, disabled, and non-customized
+       *
+       * Expected telemetry: total=2, customized=1, enabled=0, disabled=2
+       */
+      it('should return stats for upgradeable disabled customized rule and upgradeable disabled non-customized rule', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // Customize rule-1 with custom name and description (remains disabled)
+        await customizeRule('rule-1', {
+          name: 'Customized Rule Name',
+          description: 'This is a customized rule description',
+        });
+
+        // Create 2 upgradeable rules (rule-1 customized, rule-2 non-customized)
+        await createUpgradeableRules(ruleAssetSavedObjects, [0, 1]);
+
+        // Verify telemetry shows 1 customized and 1 non-customized disabled rule
+        await verifyTelemetryStats({
+          total: 2,
+          customized: 1,
+          enabled: 0,
+          disabled: 2,
+        });
+      });
+
+      /**
+       * Test Case 3: Mixed scenario - enabled customized and disabled non-customized rules
+       *
+       * This test verifies that telemetry correctly reports stats for a mixed scenario:
+       * - One customized rule (rule-1): upgradeable, enabled, and customized
+       * - One non-customized rule (rule-2): upgradeable, disabled, and non-customized
+       *
+       * This validates that the telemetry system independently tracks both:
+       * - Customization status (customized vs non-customized)
+       * - Enablement status (enabled vs disabled)
+       *
+       * Expected telemetry: total=2, customized=1, enabled=1, disabled=1
+       */
+      it('should return stats for upgradeable enabled customized rule and upgradeable disabled non-customized rule', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // Customize and enable rule-1
+        await customizeRule('rule-1', {
+          name: 'Customized Enabled Rule',
+          description: 'This is a customized and enabled rule',
+          enabled: true,
+        });
+
+        // Create 2 upgradeable rules (rule-1 customized+enabled, rule-2 non-customized+disabled)
+        await createUpgradeableRules(ruleAssetSavedObjects, [0, 1]);
+
+        // Verify telemetry shows mixed states: 1 enabled+customized, 1 disabled+non-customized
+        await verifyTelemetryStats({
+          total: 2,
+          customized: 1,
+          enabled: 1,
+          disabled: 1,
+        });
+      });
+
+      /**
+       * Test Case 4: Edge case - No upgradeable rules
+       *
+       * This test verifies that telemetry correctly reports zero stats when
+       * all rules are up-to-date (no upgrades available).
+       *
+       * Expected telemetry: total=0, customized=0, enabled=0, disabled=0
+       */
+      it('should return zero stats when no rules are upgradeable', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // Customize and enable one rule
+        await customizeRule('rule-1', {
+          name: 'Customized Rule',
+          enabled: true,
+        });
+
+        // Clear rule assets but DON'T increment versions (no upgrades available)
+        await deleteAllPrebuiltRuleAssets(es, log);
+        await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
+
+        // Verify no upgradeable rules exist
+        const { stats } = await getPrebuiltRulesStatus(es, supertest);
+        expect(stats).toMatchObject({
+          num_prebuilt_rules_installed: RULES_COUNT,
+          num_prebuilt_rules_to_install: 0,
+          num_prebuilt_rules_to_upgrade: 0,
+          num_prebuilt_rules_total_in_package: RULES_COUNT,
+        });
+
+        // Verify telemetry shows no upgradeable rules
+        await verifyTelemetryStats({
+          total: 0,
+          customized: 0,
+          enabled: 0,
+          disabled: 0,
+        });
+      });
+
+      /**
+       * Test Case 5: All upgradeable rules are enabled and customized
+       *
+       * This test verifies telemetry when multiple rules are both enabled and customized.
+       *
+       * Expected telemetry: total=3, customized=3, enabled=3, disabled=0
+       */
+      it('should return stats for multiple upgradeable enabled customized rules', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // Customize and enable multiple rules
+        await customizeRule('rule-1', {
+          name: 'Customized Enabled Rule 1',
+          enabled: true,
+        });
+        await customizeRule('rule-2', {
+          name: 'Customized Enabled Rule 2',
+          enabled: true,
+        });
+        await customizeRule('rule-3', {
+          name: 'Customized Enabled Rule 3',
+          enabled: true,
+        });
+
+        // Create 3 upgradeable rules (all customized and enabled)
+        await createUpgradeableRules(ruleAssetSavedObjects, [0, 1, 2]);
+
+        // Verify telemetry shows all rules as enabled and customized
+        await verifyTelemetryStats({
+          total: 3,
+          customized: 3,
+          enabled: 3,
+          disabled: 0,
+        });
+      });
+
+      /**
+       * Test Case 6: All upgradeable rules are enabled but non-customized
+       *
+       * This test verifies telemetry when rules are enabled but not customized.
+       *
+       * Expected telemetry: total=2, customized=0, enabled=2, disabled=0
+       */
+      it('should return stats for upgradeable enabled non-customized rules', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // Enable rules without customizing them (using minimal rule update)
+        await supertest
+          .patch(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('kbn-xsrf', 'true')
+          .send({ rule_id: 'rule-1', enabled: true })
+          .expect(200);
+
+        await supertest
+          .patch(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-2`)
+          .set('kbn-xsrf', 'true')
+          .send({ rule_id: 'rule-2', enabled: true })
+          .expect(200);
+
+        // Create 2 upgradeable rules (enabled but non-customized)
+        await createUpgradeableRules(ruleAssetSavedObjects, [0, 1]);
+
+        // Verify telemetry shows enabled but non-customized rules
+        await verifyTelemetryStats({
+          total: 2,
+          customized: 0,
+          enabled: 2,
+          disabled: 0,
+        });
+      });
+
+      /**
+       * Test Case 7: Comprehensive scenario with all possible states
+       *
+       * This test verifies telemetry with all 4 rules in different states:
+       * - rule-1: enabled + customized
+       * - rule-2: enabled + non-customized
+       * - rule-3: disabled + customized
+       * - rule-4: disabled + non-customized
+       *
+       * Expected telemetry: total=4, customized=2, enabled=2, disabled=2
+       */
+      it('should return stats for comprehensive mixed scenario with all rule states', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // rule-1: enabled + customized
+        await customizeRule('rule-1', {
+          name: 'Enabled Customized Rule',
+          enabled: true,
+        });
+
+        // rule-2: enabled + non-customized
+        await supertest
+          .patch(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-2`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            rule_id: 'rule-2',
+            enabled: true,
+          })
+          .expect(200);
+
+        // rule-3: disabled + customized
+        await customizeRule('rule-3', {
+          name: 'Disabled Customized Rule',
+          // enabled: false is default
+        });
+
+        // rule-4: disabled + non-customized (default state)
+
+        // Make all 4 rules upgradeable
+        await createUpgradeableRules(ruleAssetSavedObjects, [0, 1, 2, 3]);
+
+        // Verify comprehensive telemetry stats
+        await verifyTelemetryStats({
+          total: 4,
+          customized: 2, // rule-1 and rule-3
+          enabled: 2, // rule-1 and rule-2
+          disabled: 2, // rule-3 and rule-4
+        });
+      });
+
+      /**
+       * Test Case 8: Single upgradeable customized enabled rule
+       *
+       * This test verifies telemetry with only one upgradeable rule
+       * that is both customized and enabled.
+       *
+       * Expected telemetry: total=1, customized=1, enabled=1, disabled=0
+       */
+      it('should return stats for single upgradeable enabled customized rule', async () => {
+        // Set up initial rules environment
+        const ruleAssetSavedObjects = await setupInitialRules();
+
+        // Customize and enable only one rule
+        await customizeRule('rule-1', {
+          name: 'Single Customized Enabled Rule',
+          description: 'The only upgradeable rule',
+          enabled: true,
+        });
+
+        // Create only 1 upgradeable rule
+        await createUpgradeableRules(ruleAssetSavedObjects, [0]);
+
+        // Verify telemetry shows single rule stats
+        await verifyTelemetryStats({
+          total: 1,
+          customized: 1,
+          enabled: 1,
+          disabled: 0,
+        });
+      });
+    });
+  });
+};

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rules_legacy_action.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rules_legacy_action.ts
@@ -65,6 +65,7 @@ export default ({ getService }: FtrProviderContext) => {
 
     beforeEach(async () => {
       await createAlertsIndex(supertest, log);
+      await deleteAllRules(supertest, log);
     });
 
     afterEach(async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Add detection_rule_upgrade_status to snapshot telemetry (#223086)](https://github.com/elastic/kibana/pull/223086)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jacek Kolezynski","email":"jacek.kolezynski@elastic.co"},"sourceCommit":{"committedDate":"2025-07-29T05:30:08Z","message":"[Security Solution] Add detection_rule_upgrade_status to snapshot telemetry (#223086)\n\n**Partially addresses:** #140369\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the\nhttps://github.com/elastic/kibana/issues/140369 ticket.\n\nThe requirement covered in this PR is: \"**Number of installed prebuilt\nrules pending update - enabled/disabled/customized?**\"\n\nI am adding detection_rule_upgrade_status field object to the schema for\nsnapshot telemetry. Example:\n\n```\ndetection_rule_upgrade_status\": {\n                    \"total\": 1165,\n                    \"customized\": 3,\n                    \"enabled\": 3,\n                    \"disabled\": 1162\n                  },\n\n```\n\nI am also adding `is_customized` here, which already is part of the\nfirst PR for this ticket, https://github.com/elastic/kibana/pull/222370.\nThat PR is still in review, I wasn't able to merge it before starting\nwork on this requirement, I borrowed part of the other PR code to reuse\nit here. Will make sure it is merged properly.\n\nTesting: \n1. Make sure to have `telemetry.enabled: true` in `kibana.dev.yml`\n2. View the \"Advanced Settings\" -> \"Global Settings\" page, and at the\nbottom find \"cluster data\" link. Click it. It will open a flyout with a\nsnapshot of data sent to Telemetry cluster. Check that the new data is\nthere. Play with some rules, customize them, enable, disable, and\nobserve the changes in the snapshot.\n3. Use Dev Tools in Kibana.\nExecute the following query and verify new data appears in the result:\n```\nPOST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n{ \"unencrypted\": true, \"refreshCache\": true }\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"eb24a0b2ab2f5dcd31d64bac77d9456831cff726","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.2.0"],"title":"[Security Solution] Add detection_rule_upgrade_status to snapshot telemetry","number":223086,"url":"https://github.com/elastic/kibana/pull/223086","mergeCommit":{"message":"[Security Solution] Add detection_rule_upgrade_status to snapshot telemetry (#223086)\n\n**Partially addresses:** #140369\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the\nhttps://github.com/elastic/kibana/issues/140369 ticket.\n\nThe requirement covered in this PR is: \"**Number of installed prebuilt\nrules pending update - enabled/disabled/customized?**\"\n\nI am adding detection_rule_upgrade_status field object to the schema for\nsnapshot telemetry. Example:\n\n```\ndetection_rule_upgrade_status\": {\n                    \"total\": 1165,\n                    \"customized\": 3,\n                    \"enabled\": 3,\n                    \"disabled\": 1162\n                  },\n\n```\n\nI am also adding `is_customized` here, which already is part of the\nfirst PR for this ticket, https://github.com/elastic/kibana/pull/222370.\nThat PR is still in review, I wasn't able to merge it before starting\nwork on this requirement, I borrowed part of the other PR code to reuse\nit here. Will make sure it is merged properly.\n\nTesting: \n1. Make sure to have `telemetry.enabled: true` in `kibana.dev.yml`\n2. View the \"Advanced Settings\" -> \"Global Settings\" page, and at the\nbottom find \"cluster data\" link. Click it. It will open a flyout with a\nsnapshot of data sent to Telemetry cluster. Check that the new data is\nthere. Play with some rules, customize them, enable, disable, and\nobserve the changes in the snapshot.\n3. Use Dev Tools in Kibana.\nExecute the following query and verify new data appears in the result:\n```\nPOST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n{ \"unencrypted\": true, \"refreshCache\": true }\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"eb24a0b2ab2f5dcd31d64bac77d9456831cff726"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229738","number":229738,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229737","number":229737,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/223086","number":223086,"mergeCommit":{"message":"[Security Solution] Add detection_rule_upgrade_status to snapshot telemetry (#223086)\n\n**Partially addresses:** #140369\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the\nhttps://github.com/elastic/kibana/issues/140369 ticket.\n\nThe requirement covered in this PR is: \"**Number of installed prebuilt\nrules pending update - enabled/disabled/customized?**\"\n\nI am adding detection_rule_upgrade_status field object to the schema for\nsnapshot telemetry. Example:\n\n```\ndetection_rule_upgrade_status\": {\n                    \"total\": 1165,\n                    \"customized\": 3,\n                    \"enabled\": 3,\n                    \"disabled\": 1162\n                  },\n\n```\n\nI am also adding `is_customized` here, which already is part of the\nfirst PR for this ticket, https://github.com/elastic/kibana/pull/222370.\nThat PR is still in review, I wasn't able to merge it before starting\nwork on this requirement, I borrowed part of the other PR code to reuse\nit here. Will make sure it is merged properly.\n\nTesting: \n1. Make sure to have `telemetry.enabled: true` in `kibana.dev.yml`\n2. View the \"Advanced Settings\" -> \"Global Settings\" page, and at the\nbottom find \"cluster data\" link. Click it. It will open a flyout with a\nsnapshot of data sent to Telemetry cluster. Check that the new data is\nthere. Play with some rules, customize them, enable, disable, and\nobserve the changes in the snapshot.\n3. Use Dev Tools in Kibana.\nExecute the following query and verify new data appears in the result:\n```\nPOST kbn:/internal/telemetry/clusters/_stats?apiVersion=2\n{ \"unencrypted\": true, \"refreshCache\": true }\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"eb24a0b2ab2f5dcd31d64bac77d9456831cff726"}}]}] BACKPORT-->