### PR TITLE
🌊 Streams: Rename unwired to classic

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -52136,14 +52136,14 @@
                                           "ingest": {
                                             "additionalProperties": false,
                                             "properties": {
-                                              "unwired": {
+                                              "classic": {
                                                 "additionalProperties": false,
                                                 "properties": {},
                                                 "type": "object"
                                               }
                                             },
                                             "required": [
-                                              "unwired"
+                                              "classic"
                                             ],
                                             "type": "object"
                                           }
@@ -58162,14 +58162,14 @@
                           },
                           {
                             "properties": {
-                              "unwired": {
+                              "classic": {
                                 "additionalProperties": false,
                                 "properties": {},
                                 "type": "object"
                               }
                             },
                             "required": [
-                              "unwired"
+                              "classic"
                             ],
                             "type": "object"
                           }

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -51727,14 +51727,14 @@
                                           "ingest": {
                                             "additionalProperties": false,
                                             "properties": {
-                                              "unwired": {
+                                              "classic": {
                                                 "additionalProperties": false,
                                                 "properties": {},
                                                 "type": "object"
                                               }
                                             },
                                             "required": [
-                                              "unwired"
+                                              "classic"
                                             ],
                                             "type": "object"
                                           }
@@ -57753,14 +57753,14 @@
                           },
                           {
                             "properties": {
-                              "unwired": {
+                              "classic": {
                                 "additionalProperties": false,
                                 "properties": {},
                                 "type": "object"
                               }
                             },
                             "required": [
-                              "unwired"
+                              "classic"
                             ],
                             "type": "object"
                           }

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -48340,12 +48340,12 @@ paths:
                                           additionalProperties: false
                                           type: object
                                           properties:
-                                            unwired:
+                                            classic:
                                               additionalProperties: false
                                               type: object
                                               properties: {}
                                           required:
-                                            - unwired
+                                            - classic
                                       required:
                                         - ingest
                           required:
@@ -52166,12 +52166,12 @@ paths:
                             - processing
                         - type: object
                           properties:
-                            unwired:
+                            classic:
                               additionalProperties: false
                               type: object
                               properties: {}
                           required:
-                            - unwired
+                            - classic
               required:
                 - ingest
       responses: {}

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -51861,12 +51861,12 @@ paths:
                                           additionalProperties: false
                                           type: object
                                           properties:
-                                            unwired:
+                                            classic:
                                               additionalProperties: false
                                               type: object
                                               properties: {}
                                           required:
-                                            - unwired
+                                            - classic
                                       required:
                                         - ingest
                           required:
@@ -55687,12 +55687,12 @@ paths:
                             - processing
                         - type: object
                           properties:
-                            unwired:
+                            classic:
                               additionalProperties: false
                               type: object
                               properties: {}
                           required:
-                            - unwired
+                            - classic
               required:
                 - ingest
       responses: {}

--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -9,7 +9,7 @@ export { Streams } from './src/models/streams';
 export { IngestBase } from './src/models/ingest/base';
 export { Ingest } from './src/models/ingest';
 export { WiredIngest } from './src/models/ingest/wired';
-export { UnwiredIngest } from './src/models/ingest/unwired';
+export { ClassicIngest } from './src/models/ingest/classic';
 export { Group } from './src/models/group';
 
 export {
@@ -107,7 +107,7 @@ export { findInheritedLifecycle, findInheritingStreams } from './src/helpers/lif
 
 export {
   type IngestStreamLifecycle,
-  type UnwiredIngestStreamEffectiveLifecycle,
+  type ClassicIngestStreamEffectiveLifecycle,
   type IlmPolicyPhases,
   type IlmPolicyPhase,
   type IlmPolicyHotPhase,

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/hierarchy_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/hierarchy_helpers.ts
@@ -15,7 +15,7 @@ export function getIndexPatternsForStream(stream: Streams.all.Definition | undef
   if (!stream) {
     return undefined;
   }
-  if (Streams.UnwiredStream.Definition.is(stream)) {
+  if (Streams.ClassicStream.Definition.is(stream)) {
     return [stream.name];
   }
   const dataStreamOfDefinition = stream.name;

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.test.ts
@@ -34,16 +34,16 @@ describe('isRootStreamDefinition', () => {
     expect(isRootStreamDefinition(nonRootWired)).toBe(false);
   });
 
-  it('returns false for an unwired stream definition even with a root name', () => {
-    const unwired = {
+  it('returns false for a classic stream definition even with a root name', () => {
+    const classic = {
       name: 'logs-test-default',
       description: '',
       ingest: {
         lifecycle: { inherit: {} },
         processing: [],
-        unwired: {},
+        classic: {},
       },
     };
-    expect(isRootStreamDefinition(unwired)).toBe(false);
+    expect(isRootStreamDefinition(classic)).toBe(false);
   });
 });

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/classic.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/classic.test.ts
@@ -5,60 +5,60 @@
  * 2.0.
  */
 
-import { UnwiredStream } from './unwired';
+import { ClassicStream } from './classic';
 
-describe('UnwiredStream', () => {
+describe('ClassicStream', () => {
   describe('Definition', () => {
     it.each([
       {
-        name: 'unwired-stream',
+        name: 'classic-stream',
         description: '',
         ingest: {
           lifecycle: {
             inherit: {},
           },
           processing: [],
-          unwired: {},
+          classic: {},
         },
       },
     ])('is valid', (val) => {
-      expect(UnwiredStream.Definition.is(val)).toBe(true);
-      expect(UnwiredStream.Definition.right.parse(val)).toEqual(val);
+      expect(ClassicStream.Definition.is(val)).toBe(true);
+      expect(ClassicStream.Definition.right.parse(val)).toEqual(val);
     });
 
     it.each([
       {
-        name: 'unwired-stream',
+        name: 'classic-stream',
         description: null,
         ingest: {
           lifecycle: {
             inherit: {},
           },
           processing: [],
-          unwired: {},
+          classic: {},
         },
       },
       {
-        name: 'unwired-stream',
+        name: 'classic-stream',
         description: '',
         ingest: {
-          unwired: {},
+          classic: {},
         },
       },
       {
-        name: 'unwired-stream',
+        name: 'classic-stream',
         description: '',
         ingest: {
           lifecycle: {
             inherit: {},
           },
           processing: [],
-          unwired: {},
+          classic: {},
           wired: {},
         },
       },
     ])('is not valid', (val) => {
-      expect(UnwiredStream.Definition.is(val as any)).toBe(false);
+      expect(ClassicStream.Definition.is(val as any)).toBe(false);
     });
   });
 
@@ -66,14 +66,14 @@ describe('UnwiredStream', () => {
     it.each([
       {
         stream: {
-          name: 'unwired-stream',
+          name: 'classic-stream',
           description: '',
           ingest: {
             lifecycle: {
               inherit: {},
             },
             processing: [],
-            unwired: {},
+            classic: {},
           },
         },
         effective_lifecycle: {
@@ -90,9 +90,9 @@ describe('UnwiredStream', () => {
         dashboards: [],
         queries: [],
       },
-    ] satisfies UnwiredStream.GetResponse[])('is valid', (val) => {
-      expect(UnwiredStream.GetResponse.is(val)).toBe(true);
-      expect(UnwiredStream.GetResponse.right.parse(val)).toEqual(val);
+    ] satisfies ClassicStream.GetResponse[])('is valid', (val) => {
+      expect(ClassicStream.GetResponse.is(val)).toBe(true);
+      expect(ClassicStream.GetResponse.right.parse(val)).toEqual(val);
     });
 
     it.each([
@@ -104,7 +104,7 @@ describe('UnwiredStream', () => {
               inherit: {},
             },
             processing: [],
-            unwired: {},
+            classic: {},
           },
         },
         effective_lifecycle: {
@@ -122,7 +122,7 @@ describe('UnwiredStream', () => {
         queries: [],
       },
     ])('is not valid', (val) => {
-      expect(UnwiredStream.GetResponse.is(val as any)).toBe(false);
+      expect(ClassicStream.GetResponse.is(val as any)).toBe(false);
     });
   });
 
@@ -138,13 +138,13 @@ describe('UnwiredStream', () => {
               inherit: {},
             },
             processing: [],
-            unwired: {},
+            classic: {},
           },
         },
       },
     ])('is valid', (val) => {
-      expect(UnwiredStream.UpsertRequest.is(val)).toBe(true);
-      expect(UnwiredStream.UpsertRequest.right.parse(val)).toEqual(val);
+      expect(ClassicStream.UpsertRequest.is(val)).toBe(true);
+      expect(ClassicStream.UpsertRequest.right.parse(val)).toEqual(val);
     });
 
     it.each([
@@ -159,12 +159,12 @@ describe('UnwiredStream', () => {
               inherit: {},
             },
             processing: [],
-            unwired: {},
+            classic: {},
           },
         },
       },
     ])('is not valid', (val) => {
-      expect(UnwiredStream.UpsertRequest.is(val as any)).toBe(false);
+      expect(ClassicStream.UpsertRequest.is(val as any)).toBe(false);
     });
   });
 });

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/classic.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/classic.ts
@@ -7,8 +7,8 @@
 import { z } from '@kbn/zod';
 import { IngestBase, IngestBaseStream } from './base';
 import {
-  UnwiredIngestStreamEffectiveLifecycle,
-  unwiredIngestStreamEffectiveLifecycleSchema,
+  ClassicIngestStreamEffectiveLifecycle,
+  classicIngestStreamEffectiveLifecycleSchema,
 } from './lifecycle';
 import { ElasticsearchAssets, elasticsearchAssetsSchema } from './common';
 import { Validation, validation } from '../validation/validation';
@@ -17,50 +17,50 @@ import { BaseStream } from '../base';
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
-export interface IngestUnwired {
-  unwired: {};
+export interface IngestClassic {
+  classic: {};
 }
 
-export const IngestUnwired: z.Schema<IngestUnwired> = z.object({
-  unwired: z.object({}),
+export const IngestClassic: z.Schema<IngestClassic> = z.object({
+  classic: z.object({}),
 });
 
-export type UnwiredIngest = IngestBase & IngestUnwired;
+export type ClassicIngest = IngestBase & IngestClassic;
 
-export const UnwiredIngest: Validation<IngestBase, UnwiredIngest> = validation(
+export const ClassicIngest: Validation<IngestBase, ClassicIngest> = validation(
   IngestBase.right,
-  z.intersection(IngestBase.right, IngestUnwired)
+  z.intersection(IngestBase.right, IngestClassic)
 );
 
-export namespace UnwiredStream {
+export namespace ClassicStream {
   export interface Definition extends IngestBaseStream.Definition {
-    ingest: UnwiredIngest;
+    ingest: ClassicIngest;
   }
 
-  export type Source = IngestBaseStream.Source<UnwiredStream.Definition>;
+  export type Source = IngestBaseStream.Source<ClassicStream.Definition>;
 
   export interface GetResponse extends IngestBaseStream.GetResponse<Definition> {
     elasticsearch_assets?: ElasticsearchAssets;
     data_stream_exists: boolean;
-    effective_lifecycle: UnwiredIngestStreamEffectiveLifecycle;
+    effective_lifecycle: ClassicIngestStreamEffectiveLifecycle;
   }
 
   export type UpsertRequest = IngestBaseStream.UpsertRequest<Definition>;
 
   export interface Model {
-    Definition: UnwiredStream.Definition;
-    Source: UnwiredStream.Source;
-    GetResponse: UnwiredStream.GetResponse;
-    UpsertRequest: UnwiredStream.UpsertRequest;
+    Definition: ClassicStream.Definition;
+    Source: ClassicStream.Source;
+    GetResponse: ClassicStream.GetResponse;
+    UpsertRequest: ClassicStream.UpsertRequest;
   }
 }
 
-export const UnwiredStream: ModelValidation<BaseStream.Model, UnwiredStream.Model> =
+export const ClassicStream: ModelValidation<BaseStream.Model, ClassicStream.Model> =
   modelValidation(BaseStream, {
     Definition: z.intersection(
       IngestBaseStream.Definition.right,
       z.object({
-        ingest: IngestUnwired,
+        ingest: IngestClassic,
       })
     ),
     Source: z.intersection(IngestBaseStream.Source.right, z.object({})),
@@ -69,7 +69,7 @@ export const UnwiredStream: ModelValidation<BaseStream.Model, UnwiredStream.Mode
       z.object({
         elasticsearch_assets: z.optional(elasticsearchAssetsSchema),
         data_stream_exists: z.boolean(),
-        effective_lifecycle: unwiredIngestStreamEffectiveLifecycleSchema,
+        effective_lifecycle: classicIngestStreamEffectiveLifecycleSchema,
       })
     ),
     UpsertRequest: z.intersection(IngestBaseStream.UpsertRequest.right, z.object({})),

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/index.ts
@@ -9,29 +9,29 @@ import { BaseStream } from '../base';
 import { IngestBase } from './base';
 import { ModelValidation, joinValidation } from '../validation/model_validation';
 import { Validation, validation } from '../validation/validation';
-import { UnwiredIngest, UnwiredStream } from './unwired';
+import { ClassicIngest, ClassicStream } from './classic';
 import { WiredIngest, WiredStream } from './wired';
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace IngestStream {
   export namespace all {
-    export type UpsertRequest = WiredStream.UpsertRequest | UnwiredStream.UpsertRequest;
+    export type UpsertRequest = WiredStream.UpsertRequest | ClassicStream.UpsertRequest;
 
-    export type Source = WiredStream.Source | UnwiredStream.Source;
-    export type Definition = WiredStream.Definition | UnwiredStream.Definition;
-    export type GetResponse = WiredStream.GetResponse | UnwiredStream.GetResponse;
+    export type Source = WiredStream.Source | ClassicStream.Source;
+    export type Definition = WiredStream.Definition | ClassicStream.Definition;
+    export type GetResponse = WiredStream.GetResponse | ClassicStream.GetResponse;
 
-    export type Model = WiredStream.Model | UnwiredStream.Model;
+    export type Model = WiredStream.Model | ClassicStream.Model;
   }
 
   export const all: ModelValidation<BaseStream.Model, IngestStream.all.Model> = joinValidation(
     BaseStream,
-    [WiredStream, UnwiredStream]
+    [WiredStream, ClassicStream]
   );
 }
 
-export type Ingest = WiredIngest | UnwiredIngest;
+export type Ingest = WiredIngest | ClassicIngest;
 export const Ingest: Validation<IngestBase, Ingest> = validation(
   IngestBase.right,
-  z.union([WiredIngest.right, UnwiredIngest.right])
+  z.union([WiredIngest.right, ClassicIngest.right])
 );

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
@@ -45,14 +45,14 @@ export type WiredIngestStreamEffectiveLifecycle = (
   | IngestStreamLifecycleILM
 ) & { from: string };
 
-export type UnwiredIngestStreamEffectiveLifecycle =
+export type ClassicIngestStreamEffectiveLifecycle =
   | IngestStreamLifecycle
   | IngestStreamLifecycleError
   | IngestStreamLifecycleDisabled;
 
 export type IngestStreamEffectiveLifecycle =
   | WiredIngestStreamEffectiveLifecycle
-  | UnwiredIngestStreamEffectiveLifecycle;
+  | ClassicIngestStreamEffectiveLifecycle;
 
 const dslLifecycleSchema = z.object({
   dsl: z.object({ data_retention: z.optional(NonEmptyString) }),
@@ -68,14 +68,14 @@ export const ingestStreamLifecycleSchema: z.Schema<IngestStreamLifecycle> = z.un
   inheritLifecycleSchema,
 ]);
 
-export const unwiredIngestStreamEffectiveLifecycleSchema: z.Schema<UnwiredIngestStreamEffectiveLifecycle> =
+export const classicIngestStreamEffectiveLifecycleSchema: z.Schema<ClassicIngestStreamEffectiveLifecycle> =
   z.union([ingestStreamLifecycleSchema, disabledLifecycleSchema, errorLifecycleSchema]);
 
 export const wiredIngestStreamEffectiveLifecycleSchema: z.Schema<WiredIngestStreamEffectiveLifecycle> =
   z.union([dslLifecycleSchema, ilmLifecycleSchema]).and(z.object({ from: NonEmptyString }));
 
 export const ingestStreamEffectiveLifecycleSchema: z.Schema<IngestStreamEffectiveLifecycle> =
-  z.union([unwiredIngestStreamEffectiveLifecycleSchema, wiredIngestStreamEffectiveLifecycleSchema]);
+  z.union([classicIngestStreamEffectiveLifecycleSchema, wiredIngestStreamEffectiveLifecycleSchema]);
 
 export const isDslLifecycle = createIsNarrowSchema(
   ingestStreamEffectiveLifecycleSchema,
@@ -83,7 +83,7 @@ export const isDslLifecycle = createIsNarrowSchema(
 );
 
 export const isErrorLifecycle = createIsNarrowSchema(
-  unwiredIngestStreamEffectiveLifecycleSchema,
+  classicIngestStreamEffectiveLifecycleSchema,
   errorLifecycleSchema
 );
 

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.test.ts
@@ -62,7 +62,7 @@ describe('WiredStream', () => {
             inherit: {},
           },
           processing: [],
-          unwired: {},
+          classic: {},
           wired: {
             fields: {},
             routing: [],

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/streams.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/streams.ts
@@ -9,7 +9,7 @@ import { ModelValidation, joinValidation } from './validation/model_validation';
 import { BaseStream } from './base';
 import { GroupStream as nGroupStream } from './group';
 import { IngestStream } from './ingest';
-import { UnwiredStream as nUnwiredStream } from './ingest/unwired';
+import { ClassicStream as nClassicStream } from './ingest/classic';
 import { WiredStream as nWiredStream } from './ingest/wired';
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -18,7 +18,7 @@ export namespace Streams {
   export import ingest = IngestStream;
 
   export import WiredStream = nWiredStream;
-  export import UnwiredStream = nUnwiredStream;
+  export import ClassicStream = nClassicStream;
   export import GroupStream = nGroupStream;
 
   export namespace all {
@@ -37,5 +37,5 @@ export namespace Streams {
 
 Streams.ingest = IngestStream;
 Streams.WiredStream = nWiredStream;
-Streams.UnwiredStream = nUnwiredStream;
+Streams.ClassicStream = nClassicStream;
 Streams.GroupStream = nGroupStream;

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -168,7 +168,7 @@ export class StreamsClient {
    * such as data streams. That means it deletes all data
    * belonging to wired streams.
    *
-   * It does NOT delete unwired streams.
+   * It does NOT delete classic streams.
    */
   async disableStreams(): Promise<DisableStreamsResponse> {
     try {
@@ -524,14 +524,14 @@ export class StreamsClient {
    */
   private getDataStreamAsIngestStream(
     dataStream: IndicesDataStream
-  ): Streams.UnwiredStream.Definition {
-    const definition: Streams.UnwiredStream.Definition = {
+  ): Streams.ClassicStream.Definition {
+    const definition: Streams.ClassicStream.Definition = {
       name: dataStream.name,
       description: '',
       ingest: {
         lifecycle: { inherit: {} },
         processing: [],
-        unwired: {},
+        classic: {},
       },
     };
 
@@ -592,10 +592,10 @@ export class StreamsClient {
   }
 
   /**
-   * Lists all unmanaged streams (unwired streams without a
+   * Lists all unmanaged streams (classic streams without a
    * stored definition).
    */
-  private async getUnmanagedDataStreams(): Promise<Streams.UnwiredStream.Definition[]> {
+  private async getUnmanagedDataStreams(): Promise<Streams.ClassicStream.Definition[]> {
     const response = await wrapEsCall(
       this.dependencies.scopedClusterClient.asCurrentUser.indices.getDataStream()
     );
@@ -606,7 +606,7 @@ export class StreamsClient {
       ingest: {
         lifecycle: { inherit: {} },
         processing: [],
-        unwired: {},
+        classic: {},
       },
     }));
   }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/get_effective_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/get_effective_lifecycle.ts
@@ -19,7 +19,7 @@ export async function getEffectiveLifecycle({
   streamsClient: StreamsClient;
   dataStream: IndicesDataStream;
 }) {
-  if (Streams.UnwiredStream.Definition.is(definition)) {
+  if (Streams.ClassicStream.Definition.is(definition)) {
     return getDataStreamLifecycle(dataStream);
   }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
@@ -28,7 +28,7 @@ import { FailedToPlanElasticsearchActionsError } from '../errors/failed_to_plan_
 import { InsufficientPermissionsError } from '../../errors/insufficient_permissions_error';
 import type { StateDependencies } from '../types';
 import { getRequiredPermissionsForActions } from './required_permissions';
-import { translateUnwiredStreamPipelineActions } from './translate_unwired_stream_pipeline_actions';
+import { translateClassicStreamPipelineActions } from './translate_classic_stream_pipeline_actions';
 import type {
   ActionsByType,
   DeleteComponentTemplateAction,
@@ -81,7 +81,7 @@ export class ExecutionPlan {
     try {
       this.actionsByType = Object.assign(this.actionsByType, groupBy(elasticsearchActions, 'type'));
 
-      await translateUnwiredStreamPipelineActions(
+      await translateClassicStreamPipelineActions(
         this.actionsByType,
         this.dependencies.scopedClusterClient
       );

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.test.ts
@@ -8,12 +8,12 @@
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import {
   MANAGED_BY_STREAMS,
-  translateUnwiredStreamPipelineActions,
-} from './translate_unwired_stream_pipeline_actions';
+  translateClassicStreamPipelineActions,
+} from './translate_classic_stream_pipeline_actions';
 import { ActionsByType } from './types';
 import { ASSET_VERSION } from '../../../../../common/constants';
 
-describe('translateUnwiredStreamPipelineActions', () => {
+describe('translateClassicStreamPipelineActions', () => {
   describe('createStreamsManagedPipeline', () => {
     it('translates a single append action to a single upsert action', async () => {
       const actionsByType = emptyActionsByType();
@@ -47,7 +47,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -71,7 +71,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
               version: ASSET_VERSION,
               _meta: {
                 description:
-                  'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                  'Streams managed pipeline to connect Classic streams to the Streams layer',
                 managed: true,
                 managed_by: 'streams',
               },
@@ -155,7 +155,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -188,7 +188,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
               version: ASSET_VERSION,
               _meta: {
                 description:
-                  'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                  'Streams managed pipeline to connect Classic streams to the Streams layer',
                 managed: true,
                 managed_by: 'streams',
               },
@@ -290,7 +290,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
           ],
         }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -314,7 +314,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
               version: ASSET_VERSION,
               _meta: {
                 description:
-                  'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                  'Streams managed pipeline to connect Classic streams to the Streams layer',
                 managed: true,
                 managed_by: 'streams',
               },
@@ -339,7 +339,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
               version: ASSET_VERSION,
               _meta: {
                 description:
-                  'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                  'Streams managed pipeline to connect Classic streams to the Streams layer',
                 managed: true,
                 managed_by: 'streams',
               },
@@ -442,7 +442,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -522,7 +522,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
               managed_by: MANAGED_BY_STREAMS,
               managed: true,
               description:
-                'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                'Streams managed pipeline to connect Classic streams to the Streams layer',
             },
           },
         };
@@ -539,7 +539,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -574,7 +574,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
                 managed_by: 'streams',
                 managed: true,
                 description:
-                  'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                  'Streams managed pipeline to connect Classic streams to the Streams layer',
               },
             },
           },
@@ -628,7 +628,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
               managed_by: MANAGED_BY_STREAMS,
               managed: true,
               description:
-                'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                'Streams managed pipeline to connect Classic streams to the Streams layer',
             },
           },
         };
@@ -645,7 +645,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -671,7 +671,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
                 managed_by: 'streams',
                 managed: true,
                 description:
-                  'Streams managed pipeline to connect Unwired streams to the Streams layer',
+                  'Streams managed pipeline to connect Classic streams to the Streams layer',
               },
             },
           },
@@ -735,7 +735,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -806,7 +806,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -900,7 +900,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),
@@ -995,7 +995,7 @@ describe('translateUnwiredStreamPipelineActions', () => {
         ],
       }));
 
-      await translateUnwiredStreamPipelineActions(actionsByType, clusterClient);
+      await translateClassicStreamPipelineActions(actionsByType, clusterClient);
 
       expect(actionsByType).toEqual({
         ...emptyActionsByType(),

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.ts
@@ -20,23 +20,23 @@ import type {
 
 export const MANAGED_BY_STREAMS = 'streams';
 
-type UnwiredStreamPipelineAction =
+type ClassicStreamPipelineAction =
   | AppendProcessorToIngestPipelineAction
   | DeleteProcessorFromIngestPipelineAction;
 
 /**
- * UnwiredStreams sometimes share index templates and ingest pipelines (user managed or Streams managed)
+ * ClassicStreams sometimes share index templates and ingest pipelines (user managed or Streams managed)
  * In order to modify this pipelines in an atomic way and be able to clean up any Streams managed pipeline when no longer needed
  * We need to translate some actions
  */
-export async function translateUnwiredStreamPipelineActions(
+export async function translateClassicStreamPipelineActions(
   actionsByType: ActionsByType,
   scopedClusterClient: IScopedClusterClient
 ) {
   const maybeActions = [
     ...actionsByType.append_processor_to_ingest_pipeline,
     ...actionsByType.delete_processor_from_ingest_pipeline,
-  ] as UnwiredStreamPipelineAction[];
+  ] as ClassicStreamPipelineAction[];
 
   if (maybeActions.length === 0) {
     return;
@@ -82,7 +82,7 @@ async function createStreamsManagedPipeline({
   actionsByType,
   scopedClusterClient,
 }: {
-  actions: UnwiredStreamPipelineAction[];
+  actions: ClassicStreamPipelineAction[];
   actionsByType: ActionsByType;
   scopedClusterClient: IScopedClusterClient;
 }) {
@@ -97,13 +97,13 @@ async function createStreamsManagedPipeline({
 
   actionsByType.upsert_ingest_pipeline.push({
     type: 'upsert_ingest_pipeline',
-    // All of these are UnwiredStreams so take any stream name to use for the ordering of operations
+    // All of these are ClassicStreams so take any stream name to use for the ordering of operations
     stream: actions[0].dataStream,
     request: {
       id: pipelineName,
       processors: actions.map((action) => action.processor),
       _meta: {
-        description: `Streams managed pipeline to connect Unwired streams to the Streams layer`,
+        description: `Streams managed pipeline to connect Classic streams to the Streams layer`,
         managed: true,
         managed_by: MANAGED_BY_STREAMS,
       },
@@ -152,7 +152,7 @@ async function updateExistingStreamsManagedPipeline({
 }: {
   pipelineName: string;
   pipeline: IngestPipeline;
-  actions: UnwiredStreamPipelineAction[];
+  actions: ClassicStreamPipelineAction[];
   actionsByType: ActionsByType;
   scopedClusterClient: IScopedClusterClient;
 }) {
@@ -177,7 +177,7 @@ async function updateExistingStreamsManagedPipeline({
   if (processors.length !== 0) {
     actionsByType.upsert_ingest_pipeline.push({
       type: 'upsert_ingest_pipeline',
-      // All of these are UnwiredStreams so take any stream name to use for the ordering of operations
+      // All of these are ClassicStreams so take any stream name to use for the ordering of operations
       stream: actions[0].dataStream,
       request: {
         id: pipelineName,
@@ -241,7 +241,7 @@ async function updateExistingUserManagedPipeline({
   scopedClusterClient,
 }: {
   pipelineName: string;
-  actions: UnwiredStreamPipelineAction[];
+  actions: ClassicStreamPipelineAction[];
   actionsByType: ActionsByType;
   scopedClusterClient: IScopedClusterClient;
 }) {
@@ -272,7 +272,7 @@ async function updateExistingUserManagedPipeline({
 
   actionsByType.upsert_ingest_pipeline.push({
     type: 'upsert_ingest_pipeline',
-    // All of these are UnwiredStreams so take any stream name to use for the ordering of operations
+    // All of these are ClassicStreams so take any stream name to use for the ordering of operations
     stream: actions[0].dataStream,
     request: {
       id: targetPipelineName,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/state.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/state.test.ts
@@ -9,7 +9,7 @@
 
 import { State } from './state';
 import { GroupStream } from './streams/group_stream';
-import { UnwiredStream } from './streams/unwired_stream';
+import { ClassicStream } from './streams/classic_stream';
 import { WiredStream } from './streams/wired_stream';
 import * as streamFromDefinition from './stream_active_record/stream_from_definition';
 import {
@@ -49,13 +49,13 @@ describe('State', () => {
         },
       },
     };
-    const unwiredStream: Streams.UnwiredStream.Definition = {
-      name: 'unwired_stream',
+    const classicStream: Streams.ClassicStream.Definition = {
+      name: 'classic_stream',
       description: '',
       ingest: {
         lifecycle: { inherit: {} },
         processing: [],
-        unwired: {},
+        classic: {},
       },
     };
     const groupStream: Streams.GroupStream.Definition = {
@@ -68,7 +68,7 @@ describe('State', () => {
 
     searchMock.mockImplementationOnce(() => ({
       hits: {
-        hits: [{ _source: wiredStream }, { _source: unwiredStream }, { _source: groupStream }],
+        hits: [{ _source: wiredStream }, { _source: classicStream }, { _source: groupStream }],
         total: { value: 3 },
       },
     }));
@@ -77,7 +77,7 @@ describe('State', () => {
 
     expect(currentState.all().length).toEqual(3);
     expect(currentState.get('wired_stream') instanceof WiredStream).toEqual(true);
-    expect(currentState.get('unwired_stream') instanceof UnwiredStream).toEqual(true);
+    expect(currentState.get('classic_stream') instanceof ClassicStream).toEqual(true);
     expect(currentState.get('group_stream') instanceof GroupStream).toEqual(true);
 
     const clonedState = currentState.clone();

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_from_definition.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_from_definition.ts
@@ -8,7 +8,7 @@
 import { Streams } from '@kbn/streams-schema';
 import type { StateDependencies } from '../types';
 import type { StreamActiveRecord } from './stream_active_record';
-import { UnwiredStream } from '../streams/unwired_stream';
+import { ClassicStream } from '../streams/classic_stream';
 import { WiredStream } from '../streams/wired_stream';
 import { GroupStream } from '../streams/group_stream';
 
@@ -19,8 +19,8 @@ export function streamFromDefinition(
 ): StreamActiveRecord {
   if (Streams.WiredStream.Definition.is(definition)) {
     return new WiredStream(definition, dependencies);
-  } else if (Streams.UnwiredStream.Definition.is(definition)) {
-    return new UnwiredStream(definition, dependencies);
+  } else if (Streams.ClassicStream.Definition.is(definition)) {
+    return new ClassicStream(definition, dependencies);
   } else if (Streams.GroupStream.Definition.is(definition)) {
     return new GroupStream(definition, dependencies);
   }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
@@ -27,23 +27,23 @@ import type {
 } from '../stream_active_record/stream_active_record';
 import { StreamActiveRecord } from '../stream_active_record/stream_active_record';
 
-interface UnwiredStreamChanges extends StreamChanges {
+interface ClassicStreamChanges extends StreamChanges {
   processing: boolean;
   lifecycle: boolean;
 }
 
-export class UnwiredStream extends StreamActiveRecord<Streams.UnwiredStream.Definition> {
-  protected _changes: UnwiredStreamChanges = {
+export class ClassicStream extends StreamActiveRecord<Streams.ClassicStream.Definition> {
+  protected _changes: ClassicStreamChanges = {
     processing: false,
     lifecycle: false,
   };
 
-  constructor(definition: Streams.UnwiredStream.Definition, dependencies: StateDependencies) {
+  constructor(definition: Streams.ClassicStream.Definition, dependencies: StateDependencies) {
     super(definition, dependencies);
   }
 
-  protected doClone(): StreamActiveRecord<Streams.UnwiredStream.Definition> {
-    return new UnwiredStream(cloneDeep(this._definition), this.dependencies);
+  protected doClone(): StreamActiveRecord<Streams.ClassicStream.Definition> {
+    return new ClassicStream(cloneDeep(this._definition), this.dependencies);
   }
 
   protected async doHandleUpsertChange(
@@ -55,7 +55,7 @@ export class UnwiredStream extends StreamActiveRecord<Streams.UnwiredStream.Defi
       return { cascadingChanges: [], changeStatus: this.changeStatus };
     }
 
-    if (!Streams.UnwiredStream.Definition.is(definition)) {
+    if (!Streams.ClassicStream.Definition.is(definition)) {
       throw new StatusError('Cannot change stream types', 400);
     }
 
@@ -65,7 +65,7 @@ export class UnwiredStream extends StreamActiveRecord<Streams.UnwiredStream.Defi
 
     if (
       startingStateStreamDefinition &&
-      !Streams.UnwiredStream.Definition.is(startingStateStreamDefinition)
+      !Streams.ClassicStream.Definition.is(startingStateStreamDefinition)
     ) {
       throw new StatusError('Unexpected starting state stream type', 400);
     }
@@ -118,7 +118,7 @@ export class UnwiredStream extends StreamActiveRecord<Streams.UnwiredStream.Defi
             isValid: false,
             errors: [
               new Error(
-                `Cannot create Unwired stream ${this.definition.name} due to existing index`
+                `Cannot create Classic stream ${this.definition.name} due to existing index`
               ),
             ],
           };
@@ -129,7 +129,7 @@ export class UnwiredStream extends StreamActiveRecord<Streams.UnwiredStream.Defi
             isValid: false,
             errors: [
               new Error(
-                `Cannot create Unwired stream ${this.definition.name} due to missing backing Data Stream`
+                `Cannot create Classic stream ${this.definition.name} due to missing backing Data Stream`
               ),
             ],
           };
@@ -148,9 +148,9 @@ export class UnwiredStream extends StreamActiveRecord<Streams.UnwiredStream.Defi
     return { isValid: true, errors: [] };
   }
 
-  // The actions append_processor_to_ingest_pipeline and delete_processor_from_ingest_pipeline are unique to UnwiredStreams
-  // Because there is no guarantee that there is a dedicated index template and ingest pipeline for UnwiredStreams
-  // These actions are merged across UnwiredStream instances as part of ExecutionPlan.plan()
+  // The actions append_processor_to_ingest_pipeline and delete_processor_from_ingest_pipeline are unique to ClassicStreams
+  // Because there is no guarantee that there is a dedicated index template and ingest pipeline for ClassicStreams
+  // These actions are merged across ClassicStream instances as part of ExecutionPlan.plan()
   // This is to enable us to clean up any pipeline Streams creates when it is no longer needed
   protected async doDetermineCreateActions(): Promise<ElasticsearchAction[]> {
     const actions: ElasticsearchAction[] = [];
@@ -184,7 +184,7 @@ export class UnwiredStream extends StreamActiveRecord<Streams.UnwiredStream.Defi
   protected async doDetermineUpdateActions(
     desiredState: State,
     startingState: State,
-    startingStateStream: UnwiredStream
+    startingStateStream: ClassicStream
   ): Promise<ElasticsearchAction[]> {
     const actions: ElasticsearchAction[] = [];
     if (this._changes.processing && this._definition.ingest.processing.length > 0) {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/group_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/group_stream.ts
@@ -139,7 +139,7 @@ export class GroupStream extends StreamActiveRecord<Streams.GroupStream.Definiti
       if (!Streams.ingest.all.Definition.is(memberStream.definition)) {
         return {
           isValid: false,
-          errors: [new Error(`Member stream ${member} is neither a wired nor an unwired stream`)],
+          errors: [new Error(`Member stream ${member} is neither a wired nor an classic stream`)],
         };
       }
     }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -430,7 +430,7 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
 
     if (conflicts.length !== 0) {
       throw new NameTakenError(
-        `Cannot create stream "${definitionName}" due to hierarchical conflicts caused by existing unwired stream definition, index or data stream: [${conflicts.join(
+        `Cannot create stream "${definitionName}" due to hierarchical conflicts caused by existing classic stream definition, index or data stream: [${conflicts.join(
           ', '
         )}]`
       );
@@ -440,7 +440,7 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
   private async isStreamNameTaken(name: string): Promise<boolean> {
     try {
       const definition = await this.dependencies.streamsClient.getStream(name);
-      return Streams.UnwiredStream.Definition.is(definition);
+      return Streams.ClassicStream.Definition.is(definition);
     } catch (error) {
       if (!isDefinitionNotFoundError(error)) {
         throw error;

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/stream_crud.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/stream_crud.ts
@@ -12,7 +12,7 @@ import {
   IngestPipeline,
 } from '@elastic/elasticsearch/lib/api/types';
 import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
-import { UnwiredIngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
+import { ClassicIngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
 import { DefinitionNotFoundError } from './errors/definition_not_found_error';
 
 interface BaseParams {
@@ -21,7 +21,7 @@ interface BaseParams {
 
 export function getDataStreamLifecycle(
   dataStream: IndicesDataStream | null
-): UnwiredIngestStreamEffectiveLifecycle {
+): ClassicIngestStreamEffectiveLifecycle {
   if (!dataStream) {
     return { error: { message: 'Data stream not found' } };
   }

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
@@ -8,7 +8,7 @@
 import { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
 import { z } from '@kbn/zod';
 import { estypes } from '@elastic/elasticsearch';
-import { Streams, UnwiredIngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
+import { Streams, ClassicIngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
 import { processAsyncInChunks } from '../../../../utils/process_async_in_chunks';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import { createServerRoute } from '../../../create_server_route';
@@ -16,7 +16,7 @@ import { getDataStreamLifecycle } from '../../../../lib/streams/stream_crud';
 
 export interface ListStreamDetail {
   stream: Streams.all.Definition;
-  effective_lifecycle: UnwiredIngestStreamEffectiveLifecycle;
+  effective_lifecycle: ClassicIngestStreamEffectiveLifecycle;
   data_stream?: estypes.IndicesDataStream;
 }
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/route.ts
@@ -41,9 +41,9 @@ export const unmanagedAssetDetailsRoute = createServerRoute({
 
     const stream = await streamsClient.getStream(params.path.name);
 
-    if (!Streams.UnwiredStream.Definition.is(stream)) {
+    if (!Streams.ClassicStream.Definition.is(stream)) {
       throw new WrongStreamTypeError(
-        `Stream definition for ${params.path.name} is not an unwired stream`
+        `Stream definition for ${params.path.name} is not an classic stream`
       );
     }
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
@@ -68,7 +68,7 @@ export async function readStream({
     streamsClient.getPrivileges(name),
   ]);
 
-  if (Streams.UnwiredStream.Definition.is(streamDefinition)) {
+  if (Streams.ClassicStream.Definition.is(streamDefinition)) {
     return {
       stream: streamDefinition,
       privileges,
@@ -83,7 +83,7 @@ export async function readStream({
       effective_lifecycle: getDataStreamLifecycle(dataStream),
       dashboards,
       queries,
-    } satisfies Streams.UnwiredStream.GetResponse;
+    } satisfies Streams.ClassicStream.GetResponse;
   }
 
   const inheritedFields = addAliasesForNamespacedFields(

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
@@ -100,7 +100,7 @@ export const editStreamRoute = createServerRoute({
     const { streamsClient } = await getScopedClients({ request });
 
     if (
-      !Streams.UnwiredStream.UpsertRequest.is(params.body) &&
+      !Streams.ClassicStream.UpsertRequest.is(params.body) &&
       !(await streamsClient.isStreamsEnabled())
     ) {
       throw badData('Streams are not enabled for Wired and Group streams.');

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/ingest/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/ingest/route.ts
@@ -10,7 +10,7 @@ import { z } from '@kbn/zod';
 import { StreamQuery, Streams } from '@kbn/streams-schema';
 import { Ingest } from '@kbn/streams-schema/src/models/ingest';
 import { WiredIngest } from '@kbn/streams-schema/src/models/ingest/wired';
-import { UnwiredIngest } from '@kbn/streams-schema/src/models/ingest/unwired';
+import { ClassicIngest } from '@kbn/streams-schema/src/models/ingest/classic';
 import { STREAMS_API_PRIVILEGES } from '../../../../common/constants';
 import { createServerRoute } from '../../create_server_route';
 import { ASSET_ID, ASSET_TYPE } from '../../../lib/streams/assets/fields';
@@ -80,7 +80,7 @@ async function updateWiredIngest({
   });
 }
 
-async function updateUnwiredIngest({
+async function updateClassicIngest({
   streamsClient,
   assetClient,
   name,
@@ -89,7 +89,7 @@ async function updateUnwiredIngest({
   streamsClient: StreamsClient;
   assetClient: AssetClient;
   name: string;
-  ingest: UnwiredIngest;
+  ingest: ClassicIngest;
 }) {
   const { dashboards, queries } = await getAssets({
     name,
@@ -98,13 +98,13 @@ async function updateUnwiredIngest({
 
   const definition = await streamsClient.getStream(name);
 
-  if (!Streams.UnwiredStream.Definition.is(definition)) {
-    throw badData(`Can't update unwired capabilities of a non-unwired stream`);
+  if (!Streams.ClassicStream.Definition.is(definition)) {
+    throw badData(`Can't update classic capabilities of a non-classic stream`);
   }
 
   const { name: _name, ...stream } = definition;
 
-  const upsertRequest: Streams.UnwiredStream.UpsertRequest = {
+  const upsertRequest: Streams.ClassicStream.UpsertRequest = {
     dashboards,
     queries,
     stream: {
@@ -199,7 +199,7 @@ const upsertIngestRoute = createServerRoute({
       return await updateWiredIngest({ streamsClient, assetClient, name, ingest });
     }
 
-    return await updateUnwiredIngest({ streamsClient, assetClient, name, ingest });
+    return await updateClassicIngest({ streamsClient, assetClient, name, ingest });
   },
 });
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/index.tsx
@@ -33,7 +33,7 @@ function useLifecycleState({
 
   const lifecycleActions = useMemo(() => {
     const actions: Array<{ name: string; action: LifecycleEditAction }> = [];
-    const isUnwired = Streams.UnwiredStream.GetResponse.is(definition);
+    const isClassic = Streams.ClassicStream.GetResponse.is(definition);
 
     actions.push({
       name: i18n.translate('xpack.streams.streamDetailLifecycle.setRetentionDays', {
@@ -51,7 +51,7 @@ function useLifecycleState({
       });
     }
 
-    if (isUnwired || !isRoot(definition.stream.name)) {
+    if (isClassic || !isRoot(definition.stream.name)) {
       actions.push({
         name: i18n.translate('xpack.streams.streamDetailLifecycle.resetToDefault', {
           defaultMessage: 'Reset to default',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/modal.tsx
@@ -379,8 +379,8 @@ function IlmModal({
 function InheritModal({ definition, ...options }: ModalOptions) {
   if (Streams.WiredStream.GetResponse.is(definition)) {
     return <InheritModalWired definition={definition} {...options} />;
-  } else if (Streams.UnwiredStream.GetResponse.is(definition)) {
-    return <InheritModalUnwired definition={definition} {...options} />;
+  } else if (Streams.ClassicStream.GetResponse.is(definition)) {
+    return <InheritModalClassic definition={definition} {...options} />;
   }
 }
 
@@ -454,12 +454,12 @@ function InheritModalWired({
   );
 }
 
-function InheritModalUnwired({
+function InheritModalClassic({
   definition,
   closeModal,
   updateInProgress,
   updateLifecycle,
-}: ModalOptions & { definition: Streams.UnwiredStream.GetResponse }) {
+}: ModalOptions & { definition: Streams.ClassicStream.GetResponse }) {
   const modalTitleId = useGeneratedHtmlId();
 
   return (
@@ -473,7 +473,7 @@ function InheritModalUnwired({
       </EuiModalHeader>
 
       <EuiModalBody>
-        {i18n.translate('xpack.streams.streamDetailLifecycle.defaultLifecycleUnwiredDesc', {
+        {i18n.translate('xpack.streams.streamDetailLifecycle.defaultLifecycleClassicDesc', {
           defaultMessage:
             'All custom retention settings for this stream will be removed, resetting it to use the configuration of the template.',
         })}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic.tsx
@@ -34,7 +34,7 @@ export function ClassicStreamDetailManagement({
   definition,
   refreshDefinition,
 }: {
-  definition: Streams.UnwiredStream.GetResponse;
+  definition: Streams.ClassicStream.GetResponse;
   refreshDefinition: () => void;
 }) {
   const {
@@ -58,7 +58,7 @@ export function ClassicStreamDetailManagement({
                 values: { streamId: key },
               })}
               <EuiBadgeGroup gutterSize="s">
-                {Streams.UnwiredStream.Definition.is(definition.stream) && <ClassicStreamBadge />}
+                {Streams.ClassicStream.Definition.is(definition.stream) && <ClassicStreamBadge />}
                 <LifecycleBadge lifecycle={definition.effective_lifecycle} />
               </EuiBadgeGroup>
             </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/unmanaged_elasticsearch_assets.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/unmanaged_elasticsearch_assets.tsx
@@ -20,7 +20,7 @@ export function UnmanagedElasticsearchAssets({
   definition,
   refreshDefinition,
 }: {
-  definition: Streams.UnwiredStream.GetResponse;
+  definition: Streams.ClassicStream.GetResponse;
   refreshDefinition: () => void;
 }) {
   const {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
@@ -103,7 +103,7 @@ export function Wrapper({
               <EuiFlexItem grow={true}>
                 <EuiFlexGroup alignItems="center" gutterSize="s">
                   <DiscoverBadgeButton definition={definition} />
-                  {Streams.UnwiredStream.GetResponse.is(definition) && <ClassicStreamBadge />}
+                  {Streams.ClassicStream.GetResponse.is(definition) && <ClassicStreamBadge />}
                   <LifecycleBadge lifecycle={definition.effective_lifecycle} />
                 </EuiFlexGroup>
               </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_view/index.tsx
@@ -91,7 +91,7 @@ export function StreamDetailView() {
           <EuiFlexGroup gutterSize="s" alignItems="center">
             {key}
             <EuiBadgeGroup gutterSize="s">
-              {Streams.UnwiredStream.GetResponse.is(definition) && <ClassicStreamBadge />}
+              {Streams.ClassicStream.GetResponse.is(definition) && <ClassicStreamBadge />}
               <LifecycleBadge lifecycle={definition.effective_lifecycle} />
             </EuiBadgeGroup>
           </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
@@ -118,7 +118,7 @@ export function asTrees(streams: ListStreamDetail[]): StreamTree[] {
         ...streamDetail,
         name: streamDetail.stream.name,
         children: [],
-        type: Streams.UnwiredStream.Definition.is(streamDetail.stream)
+        type: Streams.ClassicStream.Definition.is(streamDetail.stream)
           ? 'classic'
           : isRootStreamDefinition(streamDetail.stream)
           ? 'root'

--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_list/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_list/index.tsx
@@ -58,7 +58,7 @@ export function asTrees(streams: Streams.all.Definition[]) {
         name: stream.name,
         children: [],
         stream,
-        type: Streams.UnwiredStream.Definition.is(stream)
+        type: Streams.ClassicStream.Definition.is(stream)
           ? 'classic'
           : isRootStreamDefinition(stream)
           ? 'root'

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/classic.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/classic.ts
@@ -52,7 +52,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         ingest: {
           lifecycle: { inherit: {} },
           processing: [],
-          unwired: {},
+          classic: {},
         },
       });
     });
@@ -81,7 +81,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
                     },
                   },
                 ],
-                unwired: {},
+                classic: {},
               },
             },
           },
@@ -99,7 +99,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       expect(getResponse.status).to.eql(200);
 
       const body = getResponse.body;
-      Streams.UnwiredStream.GetResponse.asserts(body);
+      Streams.ClassicStream.GetResponse.asserts(body);
 
       const {
         dashboards,
@@ -128,7 +128,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
               },
             },
           ],
-          unwired: {},
+          classic: {},
         },
       });
 
@@ -174,7 +174,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
               ingest: {
                 lifecycle: { inherit: {} },
                 processing: [],
-                unwired: {},
+                classic: {},
               },
             },
           },
@@ -270,7 +270,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
                   },
                 },
               ],
-              unwired: {},
+              classic: {},
             },
           },
         });
@@ -314,7 +314,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
                   },
                 },
               ],
-              unwired: {},
+              classic: {},
             },
           },
         });
@@ -436,7 +436,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
                       },
                     },
                   ],
-                  unwired: {},
+                  classic: {},
                 },
               },
             },
@@ -491,7 +491,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
                 ingest: {
                   lifecycle: { inherit: {} },
                   processing: [],
-                  unwired: {},
+                  classic: {},
                 },
               },
             },
@@ -580,7 +580,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         const classicStream = getResponse.body.streams.find(
           (stream) => stream.name === ORPHANED_STREAM_NAME
         );
-        expect(Streams.UnwiredStream.Definition.is(classicStream!)).to.be(true);
+        expect(Streams.ClassicStream.Definition.is(classicStream!)).to.be(true);
       });
 
       it('should still return the stream on internal listing API', async () => {
@@ -589,7 +589,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         const classicStream = getResponse.body.streams.find(
           (stream) => stream.stream.name === ORPHANED_STREAM_NAME
         );
-        expect(Streams.UnwiredStream.Definition.is(classicStream!.stream)).to.be(true);
+        expect(Streams.ClassicStream.Definition.is(classicStream!.stream)).to.be(true);
       });
 
       it('should allow deleting', async () => {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/discover.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/discover.ts
@@ -64,7 +64,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         ingest: {
           lifecycle: { inherit: {} },
           processing: [],
-          unwired: {},
+          classic: {},
         },
       });
     });

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/flush_config.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/flush_config.ts
@@ -38,7 +38,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       function getChildNames(stream: Streams.all.Definition): string[] {
         if (
           Streams.GroupStream.Definition.is(stream) ||
-          Streams.UnwiredStream.Definition.is(stream)
+          Streams.ClassicStream.Definition.is(stream)
         )
           return [];
         return stream.ingest.wired.routing.map((r) => r.destination);

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/group_streams.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/group_streams.ts
@@ -202,7 +202,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(response.body.streams.some((stream) => stream.name === 'test-group')).to.eql(true);
       });
 
-      it('unsuccessfully creates a group stream with the same name as a unwired stream', async () => {
+      it('unsuccessfully creates a group stream with the same name as a classic stream', async () => {
         await esClient.index({ index: 'metrics-test-test', document: { '@timestamp': '2025' } });
         await apiClient
           .fetch('PUT /api/streams/{name} 2023-10-31', {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/lifecycle.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/lifecycle.ts
@@ -438,14 +438,14 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       }
     });
 
-    describe('Unwired streams update', () => {
-      const unwiredPutBody: Streams.UnwiredStream.UpsertRequest = {
+    describe('Classic streams update', () => {
+      const classicPutBody: Streams.ClassicStream.UpsertRequest = {
         stream: {
           description: '',
           ingest: {
             lifecycle: { inherit: {} },
             processing: [],
-            unwired: {},
+            classic: {},
           },
         },
         dashboards: [],
@@ -490,11 +490,11 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       };
 
       it('inherit falls back to template dsl configuration', async () => {
-        const indexName = 'unwired-stream-inherit-dsl';
+        const indexName = 'classic-stream-inherit-dsl';
         await createDataStream(indexName, { dsl: { data_retention: '77d' } });
 
         // initially set to inherit which is a noop
-        await putStream(apiClient, indexName, unwiredPutBody);
+        await putStream(apiClient, indexName, classicPutBody);
         await esClient.indices.rollover({ alias: indexName });
         await expectLifecycle([indexName], { dsl: { data_retention: '77d' } });
 
@@ -505,7 +505,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           stream: {
             description: '',
             ingest: {
-              ...unwiredPutBody.stream.ingest,
+              ...classicPutBody.stream.ingest,
               lifecycle: { dsl: { data_retention: '2d' } },
             },
           },
@@ -513,12 +513,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         await expectLifecycle([indexName], { dsl: { data_retention: '2d' } });
 
         // inherit sets the lifecycle back to the template configuration
-        await putStream(apiClient, indexName, unwiredPutBody, 200);
+        await putStream(apiClient, indexName, classicPutBody, 200);
         await expectLifecycle([indexName], { dsl: { data_retention: '77d' } });
       });
 
       it('overrides dsl retention', async () => {
-        const indexName = 'unwired-stream-override-dsl';
+        const indexName = 'classic-stream-override-dsl';
         await createDataStream(indexName, { dsl: { data_retention: '77d' } });
 
         await putStream(apiClient, indexName, {
@@ -527,7 +527,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           stream: {
             description: '',
             ingest: {
-              ...unwiredPutBody.stream.ingest,
+              ...classicPutBody.stream.ingest,
               lifecycle: { dsl: { data_retention: '11d' } },
             },
           },
@@ -538,7 +538,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
       if (isServerless) {
         it('does not support ilm', async () => {
-          const indexName = 'unwired-stream-no-ilm';
+          const indexName = 'classic-stream-no-ilm';
           await createDataStream(indexName, { dsl: { data_retention: '2d' } });
 
           await putStream(
@@ -560,7 +560,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         });
       } else {
         it('updates from ilm to dsl', async () => {
-          const indexName = 'unwired-stream-ilm-to-dsl';
+          const indexName = 'classic-stream-ilm-to-dsl';
           await createDataStream(indexName, { ilm: { policy: 'my-policy' } });
 
           await putStream(apiClient, indexName, {
@@ -569,7 +569,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             stream: {
               description: '',
               ingest: {
-                ...unwiredPutBody.stream.ingest,
+                ...classicPutBody.stream.ingest,
                 lifecycle: { dsl: { data_retention: '1d' } },
               },
             },
@@ -579,7 +579,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         });
 
         it('updates from dsl to ilm', async () => {
-          const indexName = 'unwired-stream-dsl-to-ilm';
+          const indexName = 'classic-stream-dsl-to-ilm';
           await createDataStream(indexName, { dsl: { data_retention: '10d' } });
 
           await putStream(apiClient, indexName, {
@@ -588,7 +588,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             stream: {
               description: '',
               ingest: {
-                ...unwiredPutBody.stream.ingest,
+                ...classicPutBody.stream.ingest,
                 lifecycle: { ilm: { policy: 'my-policy' } },
               },
             },
@@ -598,12 +598,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         });
 
         it('inherit falls back to template dsl or ilm configuration', async () => {
-          const indexName = 'unwired-stream-inherit-dsl-ilm';
+          const indexName = 'classic-stream-inherit-dsl-ilm';
           const templateLifecycle = { ilm: { policy: 'my-policy' } };
           await createDataStream(indexName, templateLifecycle);
 
           // initially set to inherit which is a noop
-          await putStream(apiClient, indexName, unwiredPutBody);
+          await putStream(apiClient, indexName, classicPutBody);
           await esClient.indices.rollover({ alias: indexName });
           await expectLifecycle([indexName], templateLifecycle);
 
@@ -614,7 +614,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             stream: {
               description: '',
               ingest: {
-                ...unwiredPutBody.stream.ingest,
+                ...classicPutBody.stream.ingest,
                 lifecycle: { dsl: { data_retention: '2d' } },
               },
             },
@@ -622,7 +622,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           await expectLifecycle([indexName], { dsl: { data_retention: '2d' } });
 
           // inherit sets the lifecycle back to the template configuration
-          await putStream(apiClient, indexName, unwiredPutBody);
+          await putStream(apiClient, indexName, classicPutBody);
           await expectLifecycle([indexName], templateLifecycle);
 
           // update the template to use a new ilm policy
@@ -642,12 +642,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         });
 
         it('inherit falls back to template disabled configuration', async () => {
-          const indexName = 'unwired-stream-inherit-disabled';
+          const indexName = 'classic-stream-inherit-disabled';
           const templateLifecycle = { disabled: {} };
           await createDataStream(indexName, templateLifecycle);
 
           // initially set to inherit which is a noop
-          await putStream(apiClient, indexName, unwiredPutBody);
+          await putStream(apiClient, indexName, classicPutBody);
           await esClient.indices.rollover({ alias: indexName });
           await expectLifecycle([indexName], templateLifecycle);
 
@@ -658,7 +658,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             stream: {
               description: '',
               ingest: {
-                ...unwiredPutBody.stream.ingest,
+                ...classicPutBody.stream.ingest,
                 lifecycle: { dsl: { data_retention: '2d' } },
               },
             },
@@ -672,7 +672,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             stream: {
               description: '',
               ingest: {
-                ...unwiredPutBody.stream.ingest,
+                ...classicPutBody.stream.ingest,
                 lifecycle: { ilm: { policy: 'my-policy' } },
               },
             },
@@ -680,7 +680,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           await expectLifecycle([indexName], { ilm: { policy: 'my-policy' } });
 
           // inherit sets the lifecycle back to the template configuration
-          await putStream(apiClient, indexName, unwiredPutBody);
+          await putStream(apiClient, indexName, classicPutBody);
           await expectLifecycle([indexName], templateLifecycle);
         });
       }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
@@ -57,11 +57,11 @@ const streamDefinition = {
         },
       },
     ],
-    unwired: {},
+    classic: {},
   },
 };
 
-const expectedStreamsResponse: Streams.UnwiredStream.Definition = {
+const expectedStreamsResponse: Streams.ClassicStream.Definition = {
   name: TEST_STREAM_NAME,
   description: '',
   ingest: {
@@ -81,7 +81,7 @@ const expectedStreamsResponse: Streams.UnwiredStream.Definition = {
         },
       },
     ],
-    unwired: {},
+    classic: {},
   },
 };
 

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/significant_events.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/significant_events.ts
@@ -69,14 +69,14 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
     });
 
-    describe('Unwired streams update', () => {
-      const unwiredPutBody: Streams.UnwiredStream.UpsertRequest = {
+    describe('Classic streams update', () => {
+      const classicPutBody: Streams.ClassicStream.UpsertRequest = {
         stream: {
           description: '',
           ingest: {
             lifecycle: { inherit: {} },
             processing: [],
-            unwired: {},
+            classic: {},
           },
         },
         dashboards: [],
@@ -115,15 +115,15 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       };
 
       it('updates the queries', async () => {
-        const indexName = 'unwired-stream-queries';
+        const indexName = 'classic-stream-queries';
         const clean = await createDataStream(indexName, { dsl: { data_retention: '77d' } });
-        await putStream(apiClient, indexName, unwiredPutBody);
+        await putStream(apiClient, indexName, classicPutBody);
 
         let streamDefinition = await getStream(apiClient, indexName);
         expect(streamDefinition.queries.length).to.eql(0);
 
         await putStream(apiClient, indexName, {
-          ...unwiredPutBody,
+          ...classicPutBody,
           queries: [{ id: 'aaa', title: 'OOM Error', kql: { query: "message: 'OOM Error'" } }],
         });
 


### PR DESCRIPTION
We decided to go with "classic" as the official wording. This PR renames all occurrences of unwired to classic, in code and on the API. This is a breaking change, but it's acceptable in this case.