### PR TITLE
[@kbn/es] Add ES telemetry secrets

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/settings.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/settings.test.ts
@@ -16,6 +16,8 @@ const mockSettings = [
   'xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret=jwt_secret',
   'xpack.security.http.ssl.keystore.secure_password=some_password',
   'discovery.type=single-node',
+  'telemetry.secret_token=token',
+  'telemetry.api_key=key',
 ];
 
 test('`parseSettings` parses and returns all settings by default', () => {
@@ -26,6 +28,8 @@ test('`parseSettings` parses and returns all settings by default', () => {
     ['xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret', 'jwt_secret'],
     ['xpack.security.http.ssl.keystore.secure_password', 'some_password'],
     ['discovery.type', 'single-node'],
+    ['telemetry.secret_token', 'token'],
+    ['telemetry.api_key', 'key'],
   ]);
 });
 
@@ -37,6 +41,8 @@ test('`parseSettings` parses and returns all settings with `SettingsFilter.All` 
     ['xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret', 'jwt_secret'],
     ['xpack.security.http.ssl.keystore.secure_password', 'some_password'],
     ['discovery.type', 'single-node'],
+    ['telemetry.secret_token', 'token'],
+    ['telemetry.api_key', 'key'],
   ]);
 });
 
@@ -45,6 +51,8 @@ test('`parseSettings` parses and returns only secure settings with `SettingsFilt
     ['xpack.security.authc.realms.oidc.oidc1.rp.client_secret', 'secret'],
     ['xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret', 'jwt_secret'],
     ['xpack.security.http.ssl.keystore.secure_password', 'some_password'],
+    ['telemetry.secret_token', 'token'],
+    ['telemetry.api_key', 'key'],
   ]);
 });
 

--- a/src/platform/packages/shared/kbn-es/src/settings.ts
+++ b/src/platform/packages/shared/kbn-es/src/settings.ts
@@ -14,6 +14,8 @@ const SECURE_SETTINGS_LIST = [
   /^xpack\.security\.authc\.realms\.oidc\.[a-zA-Z0-9_]+\.rp\.client_secret$/,
   /^xpack\.security\.authc\.realms\.jwt\.[a-zA-Z0-9_]+\.client_authentication\.shared_secret$/,
   /^xpack\.security\.http\.ssl\.keystore\.secure_password$/,
+  /^telemetry\.secret_token$/,
+  /^telemetry\.api_key$/,
 ];
 
 function isSecureSetting(settingName: string) {


### PR DESCRIPTION
## Summary

When testing #229447, I noticed that we had no way to easily enable ES telemetry. This PR allows us to run ES with telemetry enabled by providing the settings in the CLI command:

```sh
yarn es snapshot -E telemetry.tracing.enabled=true -E telemetry.agent.server_url=https://apm-host:apm-port -E telemetry.secret_token=[REDACTED]
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




