### PR TITLE
[8.18] [SharedUX] Fix toast counter badge stack order (#229300)

### DIFF
--- a/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/deduplicate_toasts.test.tsx.snap
+++ b/src/core/packages/notifications/browser-internal/src/toasts/__snapshots__/deduplicate_toasts.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TitleWithBadge component renders with string titles 1`] = `
   Welcome!
    
   <EuiNotificationBadge
-    className="css-1f5ny76"
+    className="css-1h39icj"
     color="subdued"
     size="m"
   >

--- a/src/core/packages/notifications/browser-internal/src/toasts/deduplicate_toasts.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/deduplicate_toasts.tsx
@@ -120,6 +120,7 @@ const floatTopRight = css`
   position: absolute;
   top: -8px;
   right: -8px;
+  z-index: 1;
 `;
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[SharedUX] Fix toast counter badge stack order (#229300)](https://github.com/elastic/kibana/pull/229300)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ángeles Martínez Barrio","email":"angeles.martinezbarrio@elastic.co"},"sourceCommit":{"committedDate":"2025-07-29T09:04:24Z","message":"[SharedUX] Fix toast counter badge stack order (#229300)\n\nCloses https://github.com/elastic/kibana/issues/226225\n\n## Summary\n- Fixed the toast counter badge which was positioned behind the toast\n(toast stack context sets [z-index:\n9000](https://github.com/elastic/eui/blob/aa115fbc28a3fc107ebabbb75f6fdae75d32c976/packages/eui-theme-common/src/global_styling/variables/levels.ts#L42-L43))\n- Original toast counter PR:\nhttps://github.com/elastic/kibana/pull/161738\n- As discussed on that PR, a more robust approach would include this\ncounter in the EUI component itself but it seems that it was discarded\nhere: https://github.com/elastic/eui/issues/6945 after Kibana's usecase\nbeing covered by this simpler approach\n\n## Visuals\n### Before/After Success\n\n<img width=\"345\" height=\"77\" alt=\"Screenshot 2025-07-24 at 11 27 06\"\nsrc=\"https://github.com/user-attachments/assets/47ac83d4-7c4b-4b12-ba34-a1c124fe8780\"\n/>\n\n<img width=\"349\" height=\"78\" alt=\"Screenshot 2025-07-24 at 11 27 54\"\nsrc=\"https://github.com/user-attachments/assets/dac9ddf0-c7b2-47a5-971e-d83c67ed54b8\"\n/>\n\n### Before/After Info Flavour\n\n<img width=\"346\" height=\"78\" alt=\"Screenshot 2025-07-24 at 11 36 50\"\nsrc=\"https://github.com/user-attachments/assets/72fe86a3-9a76-4517-8d69-4ef544d6ec4b\"\n/>\n\n<img width=\"346\" height=\"77\" alt=\"Screenshot 2025-07-24 at 11 37 20\"\nsrc=\"https://github.com/user-attachments/assets/62c8365d-602e-4164-8e69-5afcf1ab9e09\"\n/>\n\n### Before/After Success Mobile\n<img width=\"398\" height=\"135\" alt=\"Screenshot 2025-07-24 at 11 29 39\"\nsrc=\"https://github.com/user-attachments/assets/7005eefd-6ed3-4a70-8bff-ac02da7b542f\"\n/>\n\n<img width=\"395\" height=\"132\" alt=\"Screenshot 2025-07-24 at 11 28 35\"\nsrc=\"https://github.com/user-attachments/assets/567111ce-c798-48e9-be67-ebff31553ac3\"\n/>","sha":"96994268de3da116737918e83b21d082d2165ab1","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:SharedUX","backport:all-open","v9.2.0"],"title":"[SharedUX] Fix toast counter badge stack order","number":229300,"url":"https://github.com/elastic/kibana/pull/229300","mergeCommit":{"message":"[SharedUX] Fix toast counter badge stack order (#229300)\n\nCloses https://github.com/elastic/kibana/issues/226225\n\n## Summary\n- Fixed the toast counter badge which was positioned behind the toast\n(toast stack context sets [z-index:\n9000](https://github.com/elastic/eui/blob/aa115fbc28a3fc107ebabbb75f6fdae75d32c976/packages/eui-theme-common/src/global_styling/variables/levels.ts#L42-L43))\n- Original toast counter PR:\nhttps://github.com/elastic/kibana/pull/161738\n- As discussed on that PR, a more robust approach would include this\ncounter in the EUI component itself but it seems that it was discarded\nhere: https://github.com/elastic/eui/issues/6945 after Kibana's usecase\nbeing covered by this simpler approach\n\n## Visuals\n### Before/After Success\n\n<img width=\"345\" height=\"77\" alt=\"Screenshot 2025-07-24 at 11 27 06\"\nsrc=\"https://github.com/user-attachments/assets/47ac83d4-7c4b-4b12-ba34-a1c124fe8780\"\n/>\n\n<img width=\"349\" height=\"78\" alt=\"Screenshot 2025-07-24 at 11 27 54\"\nsrc=\"https://github.com/user-attachments/assets/dac9ddf0-c7b2-47a5-971e-d83c67ed54b8\"\n/>\n\n### Before/After Info Flavour\n\n<img width=\"346\" height=\"78\" alt=\"Screenshot 2025-07-24 at 11 36 50\"\nsrc=\"https://github.com/user-attachments/assets/72fe86a3-9a76-4517-8d69-4ef544d6ec4b\"\n/>\n\n<img width=\"346\" height=\"77\" alt=\"Screenshot 2025-07-24 at 11 37 20\"\nsrc=\"https://github.com/user-attachments/assets/62c8365d-602e-4164-8e69-5afcf1ab9e09\"\n/>\n\n### Before/After Success Mobile\n<img width=\"398\" height=\"135\" alt=\"Screenshot 2025-07-24 at 11 29 39\"\nsrc=\"https://github.com/user-attachments/assets/7005eefd-6ed3-4a70-8bff-ac02da7b542f\"\n/>\n\n<img width=\"395\" height=\"132\" alt=\"Screenshot 2025-07-24 at 11 28 35\"\nsrc=\"https://github.com/user-attachments/assets/567111ce-c798-48e9-be67-ebff31553ac3\"\n/>","sha":"96994268de3da116737918e83b21d082d2165ab1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229300","number":229300,"mergeCommit":{"message":"[SharedUX] Fix toast counter badge stack order (#229300)\n\nCloses https://github.com/elastic/kibana/issues/226225\n\n## Summary\n- Fixed the toast counter badge which was positioned behind the toast\n(toast stack context sets [z-index:\n9000](https://github.com/elastic/eui/blob/aa115fbc28a3fc107ebabbb75f6fdae75d32c976/packages/eui-theme-common/src/global_styling/variables/levels.ts#L42-L43))\n- Original toast counter PR:\nhttps://github.com/elastic/kibana/pull/161738\n- As discussed on that PR, a more robust approach would include this\ncounter in the EUI component itself but it seems that it was discarded\nhere: https://github.com/elastic/eui/issues/6945 after Kibana's usecase\nbeing covered by this simpler approach\n\n## Visuals\n### Before/After Success\n\n<img width=\"345\" height=\"77\" alt=\"Screenshot 2025-07-24 at 11 27 06\"\nsrc=\"https://github.com/user-attachments/assets/47ac83d4-7c4b-4b12-ba34-a1c124fe8780\"\n/>\n\n<img width=\"349\" height=\"78\" alt=\"Screenshot 2025-07-24 at 11 27 54\"\nsrc=\"https://github.com/user-attachments/assets/dac9ddf0-c7b2-47a5-971e-d83c67ed54b8\"\n/>\n\n### Before/After Info Flavour\n\n<img width=\"346\" height=\"78\" alt=\"Screenshot 2025-07-24 at 11 36 50\"\nsrc=\"https://github.com/user-attachments/assets/72fe86a3-9a76-4517-8d69-4ef544d6ec4b\"\n/>\n\n<img width=\"346\" height=\"77\" alt=\"Screenshot 2025-07-24 at 11 37 20\"\nsrc=\"https://github.com/user-attachments/assets/62c8365d-602e-4164-8e69-5afcf1ab9e09\"\n/>\n\n### Before/After Success Mobile\n<img width=\"398\" height=\"135\" alt=\"Screenshot 2025-07-24 at 11 29 39\"\nsrc=\"https://github.com/user-attachments/assets/7005eefd-6ed3-4a70-8bff-ac02da7b542f\"\n/>\n\n<img width=\"395\" height=\"132\" alt=\"Screenshot 2025-07-24 at 11 28 35\"\nsrc=\"https://github.com/user-attachments/assets/567111ce-c798-48e9-be67-ebff31553ac3\"\n/>","sha":"96994268de3da116737918e83b21d082d2165ab1"}},{"url":"https://github.com/elastic/kibana/pull/229761","number":229761,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/229762","number":229762,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->