### PR TITLE
[Observability Overview] Add test for no data scenario

### DIFF
--- a/x-pack/solutions/observability/test/functional/services/observability/overview/common.ts
+++ b/x-pack/solutions/observability/test/functional/services/observability/overview/common.ts
@@ -94,7 +94,7 @@ export function ObservabilityOverviewCommonProvider({
     });
   };
 
-  const clickNoDataPrompt = async () => {
+  const clickAddDataButton = async () => {
     await testSubjects.click('o11yOverviewPageAddDataButton');
     await pageObjects.header.waitUntilLoadingHasFinished();
   };
@@ -110,6 +110,6 @@ export function ObservabilityOverviewCommonProvider({
     navigateToOverviewPage,
     openAlertsSectionAndWaitToAppear,
     waitForOverviewNoDataPrompt,
-    clickNoDataPrompt,
+    clickAddDataButton,
   };
 }

--- a/x-pack/solutions/observability/test/functional/services/observability/overview/common.ts
+++ b/x-pack/solutions/observability/test/functional/services/observability/overview/common.ts
@@ -94,6 +94,11 @@ export function ObservabilityOverviewCommonProvider({
     });
   };
 
+  const clickNoDataPrompt = async () => {
+    await testSubjects.click('o11yOverviewPageAddDataButton');
+    await pageObjects.header.waitUntilLoadingHasFinished();
+  };
+
   const getAlertsTableNoDataOrFail = async () => {
     return await testSubjects.existOrFail(ALERTS_TABLE_NO_DATA_SELECTOR);
   };
@@ -105,5 +110,6 @@ export function ObservabilityOverviewCommonProvider({
     navigateToOverviewPage,
     openAlertsSectionAndWaitToAppear,
     waitForOverviewNoDataPrompt,
+    clickNoDataPrompt,
   };
 }

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/overview/alert_table.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/overview/alert_table.ts
@@ -22,10 +22,10 @@ export default ({ getService }: FtrProviderContext) => {
     const rulesService = getService('rules');
 
     describe('Without data', function () {
-      it('navigate and open alerts section', async () => {
+      it('navigates to onboarding page if click on add data', async () => {
         await observability.overview.common.navigateToOverviewPageWithoutAlerts();
         await observability.overview.common.waitForOverviewNoDataPrompt();
-        await observability.overview.common.clickNoDataPrompt();
+        await observability.overview.common.clickAddDataButton();
         const url = await browser.getCurrentUrl();
         expect(url).to.contain('observabilityOnboarding');
       });

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/overview/alert_table.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/overview/alert_table.ts
@@ -12,6 +12,7 @@ const ALL_ALERTS = 10;
 
 export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
+  const browser = getService('browser');
 
   describe('Observability overview >', function () {
     this.tags('includeFirefox');
@@ -24,6 +25,9 @@ export default ({ getService }: FtrProviderContext) => {
       it('navigate and open alerts section', async () => {
         await observability.overview.common.navigateToOverviewPageWithoutAlerts();
         await observability.overview.common.waitForOverviewNoDataPrompt();
+        await observability.overview.common.clickNoDataPrompt();
+        const url = await browser.getCurrentUrl();
+        expect(url).to.contain('observabilityOnboarding');
       });
     });
 


### PR DESCRIPTION
## Summary

Since a bug was introduced in https://github.com/elastic/kibana/pull/226218, which was fixed in https://github.com/elastic/kibana/pull/229332, this PR adds a test that clicks the "Add data" button and checks if it redirects to the onboarding page.

