### PR TITLE
[Legacy Markdown] Do not use legacy markdown in testing dashboard-visualize flows

### DIFF
--- a/src/platform/test/analytics/tests/instrumented_events/from_the_browser/loaded_dashboard.ts
+++ b/src/platform/test/analytics/tests/instrumented_events/from_the_browser/loaded_dashboard.ts
@@ -82,7 +82,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const SAVED_SEARCH_PANEL_TITLE = '[Flights] Flight Log';
       const VIS_PANEL_TITLE = '[Flights] Delay Buckets';
       const MAP_PANEL_TITLE = '[Flights] Origin Time Delayed';
-      const MARKDOWN_PANEL_TITLE = 'Matrix';
+      const VEGA_PANEL_TITLE = 'Vega vis';
 
       before(async () => {
         await PageObjects.common.navigateToApp('dashboards');
@@ -140,26 +140,24 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       /**
-       * Text embeddable
+       * Vega embeddable
        */
-      it('emits when markup is added', async () => {
-        await dashboardAddPanel.clickAddMarkdownPanel();
-        await PageObjects.visEditor.setMarkdownTxt('There is no spoon');
-        await PageObjects.visEditor.clickGo();
-        await PageObjects.visualize.saveVisualizationExpectSuccess(MARKDOWN_PANEL_TITLE, {
+      it('emits when a vega panel is added', async () => {
+        await dashboardAddPanel.clickAddCustomVisualization();
+        await PageObjects.visualize.saveVisualizationExpectSuccess(VEGA_PANEL_TITLE, {
           saveAsNew: false,
           redirectToOrigin: true,
         });
         await checkEmitsOnce();
       });
 
-      it('emits on markup refreshed', async () => {
+      it('emits on vega refreshed', async () => {
         await queryBar.clickQuerySubmitButton();
         await checkEmitsOnce();
       });
 
-      it("doesn't emit when removing markup panel", async () => {
-        await dashboardPanelActions.removePanelByTitle(MARKDOWN_PANEL_TITLE);
+      it("doesn't emit when removing vega panel", async () => {
+        await dashboardPanelActions.removePanelByTitle(VEGA_PANEL_TITLE);
         await checkDoesNotEmit();
       });
 

--- a/src/platform/test/functional/apps/dashboard/group1/edit_embeddable_redirects.ts
+++ b/src/platform/test/functional/apps/dashboard/group1/edit_embeddable_redirects.ts
@@ -90,7 +90,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const newTitle = 'test create panel originatingApp';
       await dashboard.loadSavedDashboard('few panels');
       await dashboard.switchToEditMode();
-      await dashboardAddPanel.clickAddMarkdownPanel();
+      await dashboardAddPanel.clickAddCustomVisualization();
       await visualize.saveVisualizationExpectSuccess(newTitle, {
         saveAsNew: true,
         redirectToOrigin: false,

--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_save.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_save.ts
@@ -105,7 +105,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dashboard.switchToEditMode();
         await dashboard.expectExistsQuickSaveOption();
-        await dashboardAddPanel.clickAddMarkdownPanel();
+        await dashboardAddPanel.clickAddCustomVisualization();
         await visualize.saveVisualizationAndReturn();
         await dashboard.waitForRenderComplete();
         await dashboard.clickQuickSave();

--- a/src/platform/test/functional/apps/dashboard/group5/empty_dashboard.ts
+++ b/src/platform/test/functional/apps/dashboard/group5/empty_dashboard.ts
@@ -16,7 +16,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const dashboardAddPanel = getService('dashboardAddPanel');
   const dashboardVisualizations = getService('dashboardVisualizations');
-  const dashboardExpect = getService('dashboardExpect');
   const { dashboard } = getPageObjects(['dashboard']);
 
   describe('empty dashboard', () => {
@@ -52,11 +51,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should add new visualization from dashboard', async () => {
-      await dashboardVisualizations.createAndAddMarkdown({
-        name: 'Dashboard Test Markdown',
-        markdown: 'Markdown text',
-      });
-      await dashboardExpect.markdownWithValuesExists(['Markdown text']);
+      const originalPanelCount = await dashboard.getPanelCount();
+      await dashboardVisualizations.createAndAddVega('Dashboard Test Vega');
+      expect(await dashboard.getPanelCount()).to.eql(originalPanelCount + 1);
     });
 
     it('should open editor menu when editor button is clicked', async () => {

--- a/src/platform/test/functional/services/dashboard/add_panel.ts
+++ b/src/platform/test/functional/services/dashboard/add_panel.ts
@@ -41,6 +41,10 @@ export class DashboardAddPanelService extends FtrService {
     });
   }
 
+  async clickAddCustomVisualization() {
+    await this.clickEditorMenuButton();
+    await this.clickAddNewPanelFromUIActionLink('Custom visualization');
+  }
   async clickAddMarkdownPanel() {
     await this.clickEditorMenuButton();
     await this.clickAddNewPanelFromUIActionLink('Markdown text');

--- a/src/platform/test/functional/services/dashboard/visualizations.ts
+++ b/src/platform/test/functional/services/dashboard/visualizations.ts
@@ -16,7 +16,6 @@ export class DashboardVisualizationsService extends FtrService {
   private readonly dashboardAddPanel = this.ctx.getService('dashboardAddPanel');
   private readonly dashboard = this.ctx.getPageObject('dashboard');
   private readonly visualize = this.ctx.getPageObject('visualize');
-  private readonly visEditor = this.ctx.getPageObject('visEditor');
   private readonly header = this.ctx.getPageObject('header');
   private readonly discover = this.ctx.getPageObject('discover');
   private readonly timePicker = this.ctx.getPageObject('timePicker');
@@ -87,15 +86,13 @@ export class DashboardVisualizationsService extends FtrService {
     await this.dashboard.waitForRenderComplete();
   }
 
-  async createAndAddMarkdown({ name, markdown }: { name: string; markdown: string }) {
-    this.log.debug(`createAndAddMarkdown(${markdown})`);
+  async createAndAddVega(name: string) {
+    this.log.debug(`createAndAddVega`);
     const inViewMode = await this.dashboard.getIsInViewMode();
     if (inViewMode) {
       await this.dashboard.switchToEditMode();
     }
-    await this.dashboardAddPanel.clickAddMarkdownPanel();
-    await this.visEditor.setMarkdownTxt(markdown);
-    await this.visEditor.clickGo();
+    await this.dashboardAddPanel.clickAddCustomVisualization();
     await this.visualize.saveVisualizationExpectSuccess(name, {
       saveAsNew: false,
       redirectToOrigin: true,

--- a/x-pack/platform/test/functional/apps/dashboard/group1/feature_controls/time_to_visualize_security.ts
+++ b/x-pack/platform/test/functional/apps/dashboard/group1/feature_controls/time_to_visualize_security.ts
@@ -9,17 +9,29 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
-  const { timeToVisualize, timePicker, dashboard, visEditor, visualize, security, header, lens } =
-    getPageObjects([
-      'timeToVisualize',
-      'timePicker',
-      'dashboard',
-      'visEditor',
-      'visualize',
-      'security',
-      'header',
-      'lens',
-    ]);
+  const {
+    timeToVisualize,
+    timePicker,
+    dashboard,
+    visEditor,
+    visualize,
+    security,
+    header,
+    lens,
+    vegaChart,
+    visChart,
+  } = getPageObjects([
+    'timeToVisualize',
+    'timePicker',
+    'dashboard',
+    'visEditor',
+    'visualize',
+    'security',
+    'header',
+    'lens',
+    'vegaChart',
+    'visChart',
+  ]);
 
   const dashboardAddPanel = getService('dashboardAddPanel');
   const dashboardPanelActions = getService('dashboardPanelActions');
@@ -159,9 +171,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     describe('visualize by value works without library save permissions', () => {
-      const originalMarkdownText = 'Original markdown text';
-      const modifiedMarkdownText = 'Modified markdown text';
-
       before(async () => {
         await dashboard.navigateToApp();
         await dashboard.preserveCrossAppState();
@@ -173,9 +182,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await dashboard.clickNewDashboard();
         await dashboard.waitForRenderComplete();
 
-        await dashboardAddPanel.clickAddMarkdownPanel();
-        await visEditor.setMarkdownTxt(originalMarkdownText);
-        await visEditor.clickGo();
+        await dashboardAddPanel.clickAddCustomVisualization();
 
         await visualize.saveVisualizationAndReturn();
         const newPanelCount = await dashboard.getPanelCount();
@@ -185,13 +192,19 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('edits to a by value visualize panel are properly applied', async () => {
         await dashboardPanelActions.clickEdit();
         await header.waitUntilLoadingHasFinished();
-        await visEditor.setMarkdownTxt(modifiedMarkdownText);
-        await visEditor.clickGo();
-        await visualize.saveVisualizationAndReturn();
 
+        const { spec, isValid } = await vegaChart.getSpecAsJSON();
+        expect(isValid).to.be(true);
+        // add SVG renderer to read the Y axis labels
+        const updatedSpec = { ...spec, config: { kibana: { renderer: 'svg' } } };
+        await vegaChart.fillSpec(JSON.stringify(updatedSpec, null, 2));
+        await visEditor.clickGo();
+        await visChart.waitForVisualizationRenderingStabilized();
+
+        await visualize.saveVisualizationAndReturn();
         await dashboard.waitForRenderComplete();
-        const markdownText = await testSubjects.find('markdownBody');
-        expect(await markdownText.getVisibleText()).to.eql(modifiedMarkdownText);
+        const fullDataLabels = await vegaChart.getYAxisLabels();
+        expect(fullDataLabels[0]).to.eql('0');
 
         const newPanelCount = dashboard.getPanelCount();
         expect(newPanelCount).to.eql(1);


### PR DESCRIPTION
### Summary
Legacy Markdown is often used to test some Visualize → Dashboard flows. Since Legacy Markdown is being deprecated, these tests need to move to a different visualization. Vega is a good candidate because it uses the visualize editor wrapper and won’t be deprecated, so the tests have been rewritten to use Vega instead.

#### Related
Flaky test runner: [Build #8902](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8902)