### PR TITLE
Make workflows and related data space-aware

### DIFF
--- a/packages/kbn-check-mappings-update-cli/current_fields.json
+++ b/packages/kbn-check-mappings-update-cli/current_fields.json
@@ -1292,7 +1292,6 @@
     "description",
     "lastUpdatedBy",
     "name",
-    "spaceId",
     "status",
     "tags",
     "yaml"

--- a/packages/kbn-check-mappings-update-cli/current_fields.json
+++ b/packages/kbn-check-mappings-update-cli/current_fields.json
@@ -1292,6 +1292,7 @@
     "description",
     "lastUpdatedBy",
     "name",
+    "spaceId",
     "status",
     "tags",
     "yaml"

--- a/packages/kbn-check-mappings-update-cli/current_mappings.json
+++ b/packages/kbn-check-mappings-update-cli/current_mappings.json
@@ -4297,15 +4297,6 @@
         },
         "type": "text"
       },
-      "spaceId": {
-        "fields": {
-          "keyword": {
-            "ignore_above": 256,
-            "type": "keyword"
-          }
-        },
-        "type": "keyword"
-      },
       "status": {
         "type": "keyword"
       },

--- a/packages/kbn-check-mappings-update-cli/current_mappings.json
+++ b/packages/kbn-check-mappings-update-cli/current_mappings.json
@@ -4297,6 +4297,15 @@
         },
         "type": "text"
       },
+      "spaceId": {
+        "fields": {
+          "keyword": {
+            "ignore_above": 256,
+            "type": "keyword"
+          }
+        },
+        "type": "keyword"
+      },
       "status": {
         "type": "keyword"
       },

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -266,6 +266,7 @@ export const WorkflowSchema = z.object({
 export type WorkflowYaml = z.infer<typeof WorkflowSchema>;
 
 export const WorkflowContextSchema = z.object({
+  spaceId: z.string(),
   workflowRunId: z.string(),
   event: z.any().optional(),
   consts: z.record(z.string(), z.any()).optional(),

--- a/src/platform/packages/shared/kbn-workflows/types/utils.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/utils.ts
@@ -13,7 +13,10 @@ import { WorkflowStatus } from './v1';
 
 export function transformWorkflowYamlJsontoEsWorkflow(
   workflowDefinition: WorkflowYaml
-): Omit<EsWorkflow, 'id' | 'createdAt' | 'createdBy' | 'lastUpdatedAt' | 'lastUpdatedBy' | 'yaml'> {
+): Omit<
+  EsWorkflow,
+  'spaceId' | 'id' | 'createdAt' | 'createdBy' | 'lastUpdatedAt' | 'lastUpdatedBy' | 'yaml'
+> {
   // TODO: handle merge, if, foreach, etc.
 
   return {

--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -81,7 +81,6 @@ export enum WorkflowStatus {
 }
 
 export interface WorkflowExecutionHistoryModel {
-  spaceId: string;
   id: string;
   workflowId?: string;
   workflowName?: string;
@@ -127,7 +126,6 @@ export interface WorkflowExecutionListDto {
 // TODO: convert to actual elastic document spec
 
 export const EsWorkflowSchema = z.object({
-  spaceId: z.string(),
   id: z.string(),
   name: z.string(),
   description: z.string().optional(),
@@ -157,7 +155,6 @@ export interface UpdatedWorkflowResponseDto {
 }
 
 export interface WorkflowDetailDto {
-  spaceId: string;
   id: string;
   name: string;
   description?: string;
@@ -171,7 +168,6 @@ export interface WorkflowDetailDto {
 }
 
 export interface WorkflowListItemDto {
-  spaceId: string;
   id: string;
   name: string;
   description: string;
@@ -193,7 +189,7 @@ export interface WorkflowListDto {
   results: WorkflowListItemDto[];
 }
 export interface WorkflowExecutionEngineModel
-  extends Pick<EsWorkflow, 'spaceId' | 'id' | 'name' | 'status' | 'definition'> {
+  extends Pick<EsWorkflow, 'id' | 'name' | 'status' | 'definition'> {
   /** Serialized graphlib.Graph */
   executionGraph?: any;
 }

--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -25,6 +25,7 @@ export enum ExecutionStatus {
 }
 
 export interface EsWorkflowExecution {
+  spaceId: string;
   id: string;
   workflowId: string;
   status: ExecutionStatus;
@@ -57,6 +58,7 @@ export interface Provider {
 }
 
 export interface EsWorkflowStepExecution {
+  spaceId: string;
   id: string;
   stepId: string;
   workflowRunId: string;
@@ -79,6 +81,7 @@ export enum WorkflowStatus {
 }
 
 export interface WorkflowExecutionHistoryModel {
+  spaceId: string;
   id: string;
   workflowId?: string;
   workflowName?: string;
@@ -89,12 +92,14 @@ export interface WorkflowExecutionHistoryModel {
 }
 
 export interface WorkflowExecutionLogModel {
+  spaceId: string;
   timestamp: string;
   message: string;
   level: string;
 }
 
 export interface WorkflowExecutionDto {
+  spaceId: string;
   id: string;
   status: ExecutionStatus;
   startedAt: string;
@@ -122,6 +127,7 @@ export interface WorkflowExecutionListDto {
 // TODO: convert to actual elastic document spec
 
 export const EsWorkflowSchema = z.object({
+  spaceId: z.string(),
   id: z.string(),
   name: z.string(),
   description: z.string().optional(),
@@ -151,6 +157,7 @@ export interface UpdatedWorkflowResponseDto {
 }
 
 export interface WorkflowDetailDto {
+  spaceId: string;
   id: string;
   name: string;
   description?: string;
@@ -164,6 +171,7 @@ export interface WorkflowDetailDto {
 }
 
 export interface WorkflowListItemDto {
+  spaceId: string;
   id: string;
   name: string;
   description: string;
@@ -185,7 +193,7 @@ export interface WorkflowListDto {
   results: WorkflowListItemDto[];
 }
 export interface WorkflowExecutionEngineModel
-  extends Pick<EsWorkflow, 'id' | 'name' | 'status' | 'definition'> {
+  extends Pick<EsWorkflow, 'spaceId' | 'id' | 'name' | 'status' | 'definition'> {
   /** Serialized graphlib.Graph */
   executionGraph?: any;
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/connector_executor.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/connector_executor.ts
@@ -17,18 +17,20 @@ export class ConnectorExecutor {
   public async execute(
     connectorType: string,
     connectorName: string,
-    inputs: Record<string, any>
+    inputs: Record<string, any>,
+    spaceId: string
   ): Promise<ActionTypeExecutorResult<unknown>> {
     if (!connectorType) {
       throw new Error('Connector type is required');
     }
 
-    return await this.runConnector(connectorName, inputs);
+    return await this.runConnector(connectorName, inputs, spaceId);
   }
 
   private async runConnector(
     connectorName: string,
-    connectorParams: Record<string, any>
+    connectorParams: Record<string, any>,
+    spaceId: string
   ): Promise<ActionTypeExecutorResult<unknown>> {
     let connectorId: string;
 
@@ -48,7 +50,7 @@ export class ConnectorExecutor {
     return await this.actionsClient.execute({
       id: connectorId,
       params: connectorParams,
-      spaceId: 'default', // Should be space aware
+      spaceId,
       requesterId: 'background_task', // This is a custom ID for testing purposes
     });
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -204,7 +204,7 @@ async function createContainer(
   });
 
   const contextManager = new WorkflowContextManager({
-    spaceId: workflow.spaceId,
+    spaceId: workflowExecution.spaceId,
     workflowRunId: workflowExecution.id,
     workflow: workflowExecution.workflowDefinition,
     event: workflowExecution.context.event,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -107,13 +107,15 @@ export class WorkflowsExecutionEnginePlugin
 
     const executeWorkflow = async (
       workflow: WorkflowExecutionEngineModel,
-      context: Record<string, any>
+      context: Record<string, any>,
+      spaceId: string
     ) => {
       const workflowRunId = context.workflowRunId;
       const workflowCreatedAt = new Date();
 
       const triggeredBy = context.triggeredBy || 'manual'; // 'manual' or 'scheduled'
       const workflowExecution = {
+        spaceId,
         id: workflowRunId,
         workflowId: workflow.id,
         workflowDefinition: workflow.definition,
@@ -203,7 +205,8 @@ async function createContainer(
   });
 
   const contextManager = new WorkflowContextManager({
-    workflowRunId: workflowExecution.id,
+    spaceId,
+        workflowRunId: workflowExecution.id,
     workflow: workflowExecution.workflowDefinition,
     event: workflowExecution.context.event,
     logger,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -107,15 +107,14 @@ export class WorkflowsExecutionEnginePlugin
 
     const executeWorkflow = async (
       workflow: WorkflowExecutionEngineModel,
-      context: Record<string, any>,
-      spaceId: string
+      context: Record<string, any>
     ) => {
       const workflowRunId = context.workflowRunId;
       const workflowCreatedAt = new Date();
 
       const triggeredBy = context.triggeredBy || 'manual'; // 'manual' or 'scheduled'
       const workflowExecution = {
-        spaceId,
+        spaceId: workflow.spaceId,
         id: workflowRunId,
         workflowId: workflow.id,
         workflowDefinition: workflow.definition,
@@ -205,7 +204,7 @@ async function createContainer(
   });
 
   const contextManager = new WorkflowContextManager({
-    spaceId,
+    spaceId: workflow.spaceId,
         workflowRunId: workflowExecution.id,
     workflow: workflowExecution.workflowDefinition,
     event: workflowExecution.context.event,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -114,7 +114,6 @@ export class WorkflowsExecutionEnginePlugin
 
       const triggeredBy = context.triggeredBy || 'manual'; // 'manual' or 'scheduled'
       const workflowExecution = {
-        spaceId: workflow.spaceId,
         id: workflowRunId,
         workflowId: workflow.id,
         workflowDefinition: workflow.definition,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -205,7 +205,7 @@ async function createContainer(
 
   const contextManager = new WorkflowContextManager({
     spaceId: workflow.spaceId,
-        workflowRunId: workflowExecution.id,
+    workflowRunId: workflowExecution.id,
     workflow: workflowExecution.workflowDefinition,
     event: workflowExecution.context.event,
     logger,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
@@ -90,7 +90,8 @@ export class ConnectorStepImpl extends StepBase<ConnectorStep> {
       const output = await this.connectorExecutor.execute(
         stepType,
         step['connector-id']!,
-        renderedInputs
+        renderedInputs,
+        step.spaceId
       );
 
       const { data, status, message } = output;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/step_base.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/step_base.ts
@@ -26,6 +26,7 @@ export interface BaseStep {
   if?: string;
   foreach?: string;
   timeout?: number;
+  spaceId: string;
 }
 
 export type StepDefinition = BaseStep;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -19,8 +19,7 @@ export interface WorkflowsExecutionEnginePluginSetup {}
 export interface WorkflowsExecutionEnginePluginStart {
   executeWorkflow(
     workflow: WorkflowExecutionEngineModel,
-    context: Record<string, any>,
-    spaceId: string
+    context: Record<string, any>
   ): Promise<void>;
 }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -19,7 +19,8 @@ export interface WorkflowsExecutionEnginePluginSetup {}
 export interface WorkflowsExecutionEnginePluginStart {
   executeWorkflow(
     workflow: WorkflowExecutionEngineModel,
-    context: Record<string, any>
+    context: Record<string, any>,
+    spaceId: string
   ): Promise<void>;
 }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -14,6 +14,7 @@ import type { z } from '@kbn/zod';
 import type { WorkflowExecutionRuntimeManager } from './workflow_execution_runtime_manager';
 
 export interface ContextManagerInit {
+  spaceId: string;
   workflowRunId: string;
   workflow: z.infer<typeof WorkflowSchema>;
   event: any;
@@ -33,6 +34,7 @@ export class WorkflowContextManager {
 
   constructor(init: ContextManagerInit) {
     this.context = {
+      spaceId: init.spaceId,
       workflowRunId: init.workflowRunId,
       event: init.event,
       consts: init.workflow.consts || {},

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.test.ts
@@ -82,11 +82,12 @@ describe('getContextSchemaForPath', () => {
     const context = getContextSchemaForPath(definition, workflowGraph, ['steps', 0]);
 
     expect(Object.keys(context.shape).sort()).toEqual(
-      ['workflowRunId', 'now', 'event', 'steps', 'consts'].sort()
+      ['spaceId', 'workflowRunId', 'now', 'event', 'steps', 'consts'].sort()
     );
     expectZodSchemaEqual(
       context,
       z.object({
+        spaceId: z.string(),
         workflowRunId: z.string(),
         now: z.date(),
         event: EventSchema,
@@ -109,6 +110,7 @@ describe('getContextSchemaForPath', () => {
     expectZodSchemaEqual(
       context,
       z.object({
+        spaceId: z.string(),
         workflowRunId: z.string(),
         now: z.date(),
         event: EventSchema,

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
@@ -18,6 +18,7 @@ import { getSchemaAtPath, inferZodType } from '../../../../common/lib/zod_utils'
 
 function getRootContextSchema(definition: WorkflowYaml) {
   return z.object({
+    spaceId: z.string(),
     workflowRunId: z.string(),
     now: z.date(),
     event: EventSchema,

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { WorkflowYaml } from '@kbn/workflows';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { WorkflowYaml } from '@kbn/workflows';
 import React, { useEffect, useMemo, useState } from 'react';

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/index.tsx
@@ -19,7 +19,6 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { WorkflowYaml } from '@kbn/workflows';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { WorkflowYaml } from '@kbn/workflows';
 import React, { useEffect, useMemo, useState } from 'react';

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/get_completion_item_provider.test.ts
@@ -119,7 +119,7 @@ consts:
   apiUrl: "https://api.example.com"
 steps:
   - name: step1
-    type: console.log  
+    type: console.log
     with:
       message: "{{|<-}}"
 `.trim();
@@ -128,6 +128,7 @@ steps:
         'consts',
         'event',
         'now',
+        'spaceId',
         'steps',
         'workflowRunId',
       ]);
@@ -141,7 +142,7 @@ consts:
   apiUrl: "https://api.example.com"
 steps:
   - name: step1
-    type: console.log  
+    type: console.log
     with:
       message: @|<-
 `.trim();
@@ -158,7 +159,7 @@ consts:
   apiUrl: "https://api.example.com"
 steps:
   - name: step1
-    type: console.log  
+    type: console.log
     with:
       message: hey, this is @|<-
 `.trim();
@@ -175,7 +176,7 @@ consts:
   apiUrl: "https://api.example.com"
 steps:
   - name: step1
-    type: console.log  
+    type: console.log
     with:
       message: "@<-"
 `.trim();
@@ -184,6 +185,7 @@ steps:
         'consts',
         'event',
         'now',
+        'spaceId',
         'steps',
         'workflowRunId',
       ]);
@@ -206,7 +208,7 @@ consts:
         body: 'Go look at the activity'
 steps:
   - name: step1
-    type: console.log  
+    type: console.log
     with:
       message: "{{consts.|<-}}"
 `.trim();
@@ -239,7 +241,7 @@ consts:
         body: 'Go look at the activity'
 steps:
   - name: step1
-    type: console.log  
+    type: console.log
     with:
       message: "{{consts.templates[0].|<-}}"
 `.trim();
@@ -263,11 +265,11 @@ consts:
   apiUrl: "https://api.example.com"
 steps:
   - name: step0
-    type: console.log  
+    type: console.log
     with:
       message: "hello"
   - name: step1
-    type: console.log  
+    type: console.log
     with:
       message: "{{steps.|<-}}"
 `.trim();
@@ -288,16 +290,16 @@ steps:
       condition: "{{steps.step0.output.message == 'hello'}}"
     steps:
       - name: first-true-step
-        type: console.log  
+        type: console.log
         with:
           message: "im true"
       - name: second-true-step
-        type: console.log  
+        type: console.log
         with:
           message: "im true, {{steps.|<-}}"
     else:
       - name: false-step
-        type: console.log  
+        type: console.log
         with:
           message: "im unreachable"
 `.trim();
@@ -313,7 +315,7 @@ consts:
   apiUrl: "https://api.example.com"
 steps:
   - name: step0
-    type: console.log  
+    type: console.log
     with:
       message: "{{consts.a|<-}}"
 `.trim();
@@ -329,7 +331,7 @@ consts:
   api-url: "https://api.example.com"
 steps:
   - name: step0
-    type: console.log  
+    type: console.log
     with:
       message: "{{consts.|<-}}"
 `.trim();
@@ -344,7 +346,7 @@ steps:
         api-url: "https://api.example.com"
       steps:
         - name: step0
-          type: console.log  
+          type: console.log
           with:
             message: '{{consts.|<-}}'
       `.trim();

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/api.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/api.test.ts
@@ -33,6 +33,7 @@ describe('Workflows API', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         alerts: [{ _id: 'alert-1', _index: 'test-index' }],
         inputs: { test: 'data' },
       };
@@ -50,6 +51,7 @@ describe('Workflows API', () => {
 
       expect(mockExternalService.runWorkflow).toHaveBeenCalledWith({
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: { test: 'data' },
       });
     });
@@ -57,6 +59,7 @@ describe('Workflows API', () => {
     it('should skip execution when no alerts are provided', async () => {
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         alerts: [],
         inputs: { test: 'data' },
       };
@@ -81,6 +84,7 @@ describe('Workflows API', () => {
     it('should skip execution when alerts is null', async () => {
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         alerts: null as any,
         inputs: { test: 'data' },
       };
@@ -105,6 +109,7 @@ describe('Workflows API', () => {
     it('should skip execution when alerts is undefined', async () => {
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: { test: 'data' },
       };
 
@@ -130,6 +135,7 @@ describe('Workflows API', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         alerts: [{ _id: 'alert-1', _index: 'test-index' }],
         inputs: { test: 'data' },
       };
@@ -144,6 +150,7 @@ describe('Workflows API', () => {
 
       expect(mockExternalService.runWorkflow).toHaveBeenCalledWith({
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: { test: 'data' },
       });
     });
@@ -156,6 +163,7 @@ describe('Workflows API', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         alerts: [{ _id: 'alert-1', _index: 'test-index' }],
       };
 
@@ -172,6 +180,7 @@ describe('Workflows API', () => {
 
       expect(mockExternalService.runWorkflow).toHaveBeenCalledWith({
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: undefined,
       });
     });

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/api.ts
@@ -26,8 +26,8 @@ const run = async ({
     };
   }
 
-  const { workflowId, inputs } = params;
-  const res = await externalService.runWorkflow({ workflowId, inputs });
+  const { workflowId, spaceId, inputs } = params;
+  const res = await externalService.runWorkflow({ workflowId, spaceId, inputs });
   return { workflowRunId: res.workflowRunId, status: res.status };
 };
 

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.test.ts
@@ -63,6 +63,7 @@ describe('Workflows Connector', () => {
           subAction: 'run' as const,
           subActionParams: {
             workflowId: 'test-workflow-id',
+            spaceId: 'default',
             alerts: [{ _id: 'alert-1', _index: 'test-index' }],
             inputs: { test: 'data' },
           },
@@ -86,6 +87,7 @@ describe('Workflows Connector', () => {
 
       expect(mockWorkflowsService).toHaveBeenCalledWith(
         'test-workflow-id',
+        'default',
         { test: 'data' },
         mockRequest
       );

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/service.test.ts
@@ -79,6 +79,7 @@ describe('Workflows Service', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: { test: 'data' },
       };
 
@@ -91,6 +92,7 @@ describe('Workflows Service', () => {
 
       expect(mockWorkflowService).toHaveBeenCalledWith(
         'test-workflow-id',
+        'default',
         { test: 'data' },
         mockRequest
       );
@@ -114,6 +116,7 @@ describe('Workflows Service', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: { test: 'data' },
       };
 
@@ -142,6 +145,7 @@ describe('Workflows Service', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: { test: 'data' },
       };
 
@@ -168,6 +172,7 @@ describe('Workflows Service', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
         inputs: { test: 'data' },
       };
 
@@ -192,6 +197,7 @@ describe('Workflows Service', () => {
 
       const params = {
         workflowId: 'test-workflow-id',
+        spaceId: 'default',
       };
 
       const result = await service.runWorkflow(params);
@@ -201,7 +207,12 @@ describe('Workflows Service', () => {
         status: 'executed',
       });
 
-      expect(mockWorkflowService).toHaveBeenCalledWith('test-workflow-id', {}, mockRequest);
+      expect(mockWorkflowService).toHaveBeenCalledWith(
+        'test-workflow-id',
+        'default',
+        {},
+        mockRequest
+      );
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/service.ts
@@ -17,6 +17,7 @@ import { createServiceError } from './utils';
 // Type for the workflows service function that should be injected
 export type WorkflowsServiceFunction = (
   workflowId: string,
+  spaceId: string,
   inputs: Record<string, unknown>,
   request: KibanaRequest
 ) => Promise<string>;
@@ -32,6 +33,7 @@ export const createExternalService = (
 ): ExternalService => {
   const runWorkflow = async ({
     workflowId,
+    spaceId,
     inputs = {},
   }: RunWorkflowParams): Promise<WorkflowExecutionResponse> => {
     try {
@@ -44,7 +46,7 @@ export const createExternalService = (
       }
 
       // Use the injected service function instead of making HTTP requests
-      const workflowRunId = await runWorkflowService(workflowId, inputs, request);
+      const workflowRunId = await runWorkflowService(workflowId, spaceId, inputs, request);
 
       if (!workflowRunId) {
         throw new Error('Invalid response: missing workflowRunId');

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/types.ts
@@ -16,6 +16,7 @@ export type WorkflowsActionParamsType = ExecutorParams;
 
 export interface RunWorkflowParams {
   workflowId: string;
+  spaceId: string;
   alerts?: any[];
   inputs?: Record<string, unknown>;
   [key: string]: unknown;

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -17,6 +17,7 @@ import type {
 } from '@kbn/core/server';
 
 import type { IUnsecuredActionsClient } from '@kbn/actions-plugin/server';
+import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
 import {
   WORKFLOWS_EXECUTION_LOGS_INDEX,
   WORKFLOWS_EXECUTIONS_INDEX,
@@ -52,6 +53,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
   private workflowTaskScheduler: WorkflowTaskScheduler | null = null;
   private unsecureActionsClient: IUnsecuredActionsClient | null = null;
   private api: WorkflowsManagementApi | null = null;
+  private spaces?: SpacesServiceStart | null = null;
   // TODO: replace with esClient promise from core
 
   constructor(initializerContext: PluginInitializerContext) {
@@ -188,9 +190,10 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
       this.config.logging.console
     );
     this.api = new WorkflowsManagementApi(this.workflowsService);
+    this.spaces = plugins.spaces?.spacesService;
 
     // Register server side APIs
-    defineRoutes(router, this.api, this.logger);
+    defineRoutes(router, this.api, this.logger, this.spaces!);
 
     return {
       management: this.api,

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -71,7 +71,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
       // Create workflows service function for the connector
       const getWorkflowsService = async (request: KibanaRequest) => {
         // Return a function that will be called by the connector
-        return async (workflowId: string, inputs: Record<string, unknown>) => {
+        return async (workflowId: string, spaceId: string, inputs: Record<string, unknown>) => {
           if (!this.api) {
             throw new Error('Workflows management API not initialized');
           }

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -77,7 +77,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
           }
 
           // Get the workflow first
-          const workflow = await this.api.getWorkflow(workflowId);
+          const workflow = await this.api.getWorkflow(workflowId, spaceId);
           if (!workflow) {
             throw new Error(`Workflow not found: ${workflowId}`);
           }

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -83,7 +83,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
           }
 
           // Run the workflow, @tb: maybe switch to scheduler?
-          return await this.api.runWorkflow(workflow, inputs);
+          return await this.api.runWorkflow(workflow, spaceId, inputs);
         };
       };
 
@@ -178,7 +178,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
     const getSavedObjectsClient = () =>
       core
         .getStartServices()
-        .then(([coreStart]) => coreStart.savedObjects.createInternalRepository());
+        .then(([coreStart]) => coreStart.savedObjects.getUnsafeInternalClient());
 
     this.workflowsService = new WorkflowsService(
       esClientPromise,
@@ -205,6 +205,7 @@ export class WorkflowsPlugin implements Plugin<WorkflowsPluginSetup, WorkflowsPl
 
     this.unsecureActionsClient = plugins.actions.getUnsecuredActionsClient();
 
+    // Initialize workflow task scheduler with the start contract
     // Initialize workflow task scheduler with the start contract
     this.workflowTaskScheduler = new WorkflowTaskScheduler(this.logger, plugins.taskManager);
 

--- a/src/platform/plugins/shared/workflows_management/server/saved_objects/workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/saved_objects/workflow.ts
@@ -13,6 +13,7 @@ import type { WorkflowStatus, WorkflowYaml } from '@kbn/workflows';
 export const WORKFLOW_SAVED_OBJECT_TYPE = 'workflow';
 
 export interface WorkflowSavedObjectAttributes {
+  spaceId: string;
   name: string;
   description?: string;
   status: WorkflowStatus;
@@ -31,6 +32,15 @@ export const workflowSavedObjectType: SavedObjectsType<WorkflowSavedObjectAttrib
   mappings: {
     dynamic: false,
     properties: {
+      spaceId: {
+        type: 'keyword',
+        fields: {
+          keyword: {
+            type: 'keyword',
+            ignore_above: 256,
+          },
+        },
+      },
       name: {
         type: 'text',
         fields: {
@@ -85,6 +95,27 @@ export const workflowSavedObjectType: SavedObjectsType<WorkflowSavedObjectAttrib
     }),
   },
   modelVersions: {
+    2: {
+      changes: [
+        {
+          type: 'mappings_addition',
+          addedMappings: {
+            spaceId: { type: 'keyword' },
+          },
+        },
+        {
+          type: 'data_backfill',
+          backfillFn: (doc) => {
+            return {
+              attributes: {
+                ...doc.attributes,
+                spaceId: 'default',
+              },
+            };
+          },
+        },
+      ],
+    },
     1: {
       changes: [],
     },

--- a/src/platform/plugins/shared/workflows_management/server/saved_objects/workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/saved_objects/workflow.ts
@@ -95,7 +95,22 @@ export const workflowSavedObjectType: SavedObjectsType<WorkflowSavedObjectAttrib
     }),
   },
   modelVersions: {
+    1: {
+      changes: [],
+    },
     2: {
+      changes: [
+        {
+          type: 'mappings_addition',
+          addedMappings: {
+            deleted_at: {
+              type: 'date',
+            },
+          },
+        },
+      ],
+    },
+    3: {
       changes: [
         {
           type: 'mappings_addition',
@@ -112,21 +127,6 @@ export const workflowSavedObjectType: SavedObjectsType<WorkflowSavedObjectAttrib
                 spaceId: 'default',
               },
             };
-          },
-        },
-      ],
-    },
-    1: {
-      changes: [],
-    },
-    2: {
-      changes: [
-        {
-          type: 'mappings_addition',
-          addedMappings: {
-            deleted_at: {
-              type: 'date',
-            },
           },
         },
       ],

--- a/src/platform/plugins/shared/workflows_management/server/saved_objects/workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/saved_objects/workflow.ts
@@ -13,7 +13,6 @@ import type { WorkflowStatus, WorkflowYaml } from '@kbn/workflows';
 export const WORKFLOW_SAVED_OBJECT_TYPE = 'workflow';
 
 export interface WorkflowSavedObjectAttributes {
-  spaceId: string;
   name: string;
   description?: string;
   status: WorkflowStatus;
@@ -32,15 +31,6 @@ export const workflowSavedObjectType: SavedObjectsType<WorkflowSavedObjectAttrib
   mappings: {
     dynamic: false,
     properties: {
-      spaceId: {
-        type: 'keyword',
-        fields: {
-          keyword: {
-            type: 'keyword',
-            ignore_above: 256,
-          },
-        },
-      },
       name: {
         type: 'text',
         fields: {
@@ -106,27 +96,6 @@ export const workflowSavedObjectType: SavedObjectsType<WorkflowSavedObjectAttrib
             deleted_at: {
               type: 'date',
             },
-          },
-        },
-      ],
-    },
-    3: {
-      changes: [
-        {
-          type: 'mappings_addition',
-          addedMappings: {
-            spaceId: { type: 'keyword' },
-          },
-        },
-        {
-          type: 'data_backfill',
-          backfillFn: (doc) => {
-            return {
-              attributes: {
-                ...doc.attributes,
-                spaceId: 'default',
-              },
-            };
           },
         },
       ],

--- a/src/platform/plugins/shared/workflows_management/server/scheduler/scheduler_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/scheduler/scheduler_service.ts
@@ -53,8 +53,7 @@ export class SchedulerService {
 
   public async runWorkflow(
     workflow: WorkflowExecutionEngineModel,
-    inputs: Record<string, any>,
-    spaceId: string
+    inputs: Record<string, any>
   ): Promise<string> {
     const executionGraph = convertToWorkflowGraph(workflow.definition);
     workflow.executionGraph = convertToSerializableGraph(executionGraph); // TODO: It's not good approach, it's temporary
@@ -65,7 +64,7 @@ export class SchedulerService {
       inputs,
       event: 'event' in inputs ? inputs.event : undefined,
       triggeredBy: 'manual', // <-- mark as manual
-      spaceId,
+      spaceId: workflow.spaceId,
     };
 
     const taskInstance = {
@@ -89,18 +88,14 @@ export class SchedulerService {
     return workflowRunId;
   }
 
-  public async pushEvent(eventType: string, eventData: Record<string, any>, spaceId: string) {
+  public async pushEvent(eventType: string, eventData: Record<string, any>) {
     try {
       const workflowsToRun = findWorkflowsByTrigger(eventType);
 
       for (const workflow of workflowsToRun) {
-        await this.runWorkflow(
-          workflow,
-          {
-            event: eventData,
-          },
-          spaceId
-        );
+        await this.runWorkflow(workflow, {
+          event: eventData,
+        });
       }
     } catch (error) {
       this.logger.error(`Failed to push event: ${error.message}`);

--- a/src/platform/plugins/shared/workflows_management/server/scheduler/scheduler_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/scheduler/scheduler_service.ts
@@ -53,6 +53,7 @@ export class SchedulerService {
 
   public async runWorkflow(
     workflow: WorkflowExecutionEngineModel,
+    spaceId: string,
     inputs: Record<string, any>
   ): Promise<string> {
     const executionGraph = convertToWorkflowGraph(workflow.definition);
@@ -64,7 +65,7 @@ export class SchedulerService {
       inputs,
       event: 'event' in inputs ? inputs.event : undefined,
       triggeredBy: 'manual', // <-- mark as manual
-      spaceId: workflow.spaceId,
+      spaceId,
     };
 
     const taskInstance = {
@@ -88,12 +89,12 @@ export class SchedulerService {
     return workflowRunId;
   }
 
-  public async pushEvent(eventType: string, eventData: Record<string, any>) {
+  public async pushEvent(eventType: string, spaceId: string, eventData: Record<string, any>) {
     try {
       const workflowsToRun = findWorkflowsByTrigger(eventType);
 
       for (const workflow of workflowsToRun) {
-        await this.runWorkflow(workflow, {
+        await this.runWorkflow(workflow, spaceId, {
           event: eventData,
         });
       }

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
@@ -43,7 +43,7 @@ export function createWorkflowTaskRunner({
   actionsClient: IUnsecuredActionsClient;
 }) {
   return ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => {
-    const { workflowId } = taskInstance.params as WorkflowTaskParams;
+    const { workflowId, spaceId } = taskInstance.params as WorkflowTaskParams;
     const state = taskInstance.state as WorkflowTaskState;
 
     return {
@@ -52,7 +52,7 @@ export function createWorkflowTaskRunner({
 
         try {
           // Get the workflow
-          const workflow = await workflowsService.getWorkflow(workflowId);
+          const workflow = await workflowsService.getWorkflow(workflowId, spaceId);
           if (!workflow) {
             throw new Error(`Workflow ${workflowId} not found`);
           }
@@ -60,6 +60,7 @@ export function createWorkflowTaskRunner({
           // Convert to execution model
           const executionGraph = convertToWorkflowGraph(workflow.definition);
           const workflowExecutionModel: WorkflowExecutionEngineModel = {
+            spaceId,
             id: workflow.id,
             name: workflow.name,
             status: workflow.status,
@@ -79,7 +80,8 @@ export function createWorkflowTaskRunner({
                 source: 'task-manager',
               },
               triggeredBy: 'scheduled', // <-- mark as scheduled
-            }
+            },
+            spaceId
           );
 
           logger.info(

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
@@ -60,7 +60,6 @@ export function createWorkflowTaskRunner({
           // Convert to execution model
           const executionGraph = convertToWorkflowGraph(workflow.definition);
           const workflowExecutionModel: WorkflowExecutionEngineModel = {
-            spaceId,
             id: workflow.id,
             name: workflow.name,
             status: workflow.status,
@@ -73,6 +72,7 @@ export function createWorkflowTaskRunner({
             workflowExecutionModel,
             {
               workflowRunId: `scheduled-${Date.now()}`,
+              spaceId,
               inputs: {},
               event: {
                 type: 'scheduled',

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_runner.ts
@@ -80,8 +80,7 @@ export function createWorkflowTaskRunner({
                 source: 'task-manager',
               },
               triggeredBy: 'scheduled', // <-- mark as scheduled
-            },
-            spaceId
+            }
           );
 
           logger.info(

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -19,8 +19,8 @@ import type {
 import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
 import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
-import type { WorkflowsManagementApi } from './workflows_management/workflows_management_api';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { WorkflowsManagementApi } from './workflows_management/workflows_management_api';
 
 export interface WorkflowsPluginSetup {
   management: WorkflowsManagementApi;

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -20,7 +20,7 @@ import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
 import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 import type { WorkflowsManagementApi } from './workflows_management/workflows_management_api';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 
 export interface WorkflowsPluginSetup {
   management: WorkflowsManagementApi;

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -20,13 +20,18 @@ import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
 import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 import type { WorkflowsManagementApi } from './workflows_management/workflows_management_api';
+import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 
 export interface WorkflowsPluginSetup {
   management: WorkflowsManagementApi;
 }
 
 export interface WorkflowsPluginStart {
-  runWorkflow(workflow: WorkflowExecutionEngineModel, params: Record<string, any>): Promise<string>;
+  runWorkflow(
+    workflow: WorkflowExecutionEngineModel,
+    params: Record<string, any>,
+    spaceId: string
+  ): Promise<string>;
 }
 
 export interface WorkflowsExecutionEnginePluginStartDeps {
@@ -34,6 +39,7 @@ export interface WorkflowsExecutionEnginePluginStartDeps {
   workflowsExecutionEngine: WorkflowsExecutionEnginePluginStart;
   actions: ActionsPluginStartContract;
   security?: SecurityPluginStart;
+  spaces?: SpacesPluginStart;
 }
 
 export interface WorkflowsManagementPluginServerDependenciesSetup {
@@ -41,4 +47,5 @@ export interface WorkflowsManagementPluginServerDependenciesSetup {
   taskManager?: TaskManagerSetupContract;
   actions?: ActionsPluginSetupContract;
   alerting?: AlertingServerSetup;
+  spaces?: SpacesPluginStart;
 }

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -29,8 +29,8 @@ export interface WorkflowsPluginSetup {
 export interface WorkflowsPluginStart {
   runWorkflow(
     workflow: WorkflowExecutionEngineModel,
-    params: Record<string, any>,
-    spaceId: string
+    spaceId: string,
+    params: Record<string, any>
   ): Promise<string>;
 }
 

--- a/src/platform/plugins/shared/workflows_management/server/workflow_event_logger/workflow_event_logger_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflow_event_logger/workflow_event_logger_service.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */

--- a/src/platform/plugins/shared/workflows_management/server/workflow_event_logger/workflow_event_logger_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflow_event_logger/workflow_event_logger_service.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
- */

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/index_mappings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/index_mappings.ts
@@ -13,6 +13,9 @@ import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 export const WORKFLOWS_INDEX_MAPPINGS: MappingTypeMapping = {
   dynamic: false,
   properties: {
+    spaceId: {
+      type: 'keyword',
+    },
     id: {
       type: 'keyword',
     },
@@ -65,6 +68,9 @@ export const WORKFLOWS_INDEX_MAPPINGS: MappingTypeMapping = {
 export const WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS: MappingTypeMapping = {
   dynamic: false,
   properties: {
+    spaceId: {
+      type: 'keyword',
+    },
     id: {
       type: 'keyword',
     },
@@ -106,6 +112,9 @@ export const WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS: MappingTypeMapping = {
 export const WORKFLOWS_STEP_EXECUTIONS_INDEX_MAPPINGS: MappingTypeMapping = {
   dynamic: false,
   properties: {
+    spaceId: {
+      type: 'keyword',
+    },
     id: {
       type: 'keyword',
     },

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/search_step_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/search_step_executions.ts
@@ -46,7 +46,7 @@ export const searchStepExecutions = async ({
           ],
         },
       },
-      sort: 'startedAt:dsc',
+      sort: 'startedAt:desc',
     });
 
     logger.info(

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/search_step_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/search_step_executions.ts
@@ -10,11 +10,12 @@
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { EsWorkflowStepExecution } from '@kbn/workflows';
 
-interface SearchStepExectionsParams {
+interface SearchStepExecutionsParams {
   esClient: ElasticsearchClient;
   logger: Logger;
   stepsExecutionIndex: string;
   workflowExecutionId: string;
+  spaceId: string;
 }
 
 export const searchStepExecutions = async ({
@@ -22,13 +23,28 @@ export const searchStepExecutions = async ({
   logger,
   stepsExecutionIndex,
   workflowExecutionId,
-}: SearchStepExectionsParams): Promise<EsWorkflowStepExecution[]> => {
+  spaceId,
+}: SearchStepExecutionsParams): Promise<EsWorkflowStepExecution[]> => {
   try {
     logger.info(`Searching workflows in index ${stepsExecutionIndex}`);
     const response = await esClient.search<EsWorkflowStepExecution>({
       index: stepsExecutionIndex,
       query: {
-        match: { workflowRunId: workflowExecutionId },
+        bool: {
+          must: [
+            { match: { workflowRunId: workflowExecutionId } },
+            {
+              bool: {
+                should: [
+                  { term: { spaceId } },
+                  // Backward compatibility for objects without spaceId
+                  { bool: { must_not: { exists: { field: 'spaceId' } } } },
+                ],
+                minimum_should_match: 1,
+              },
+            },
+          ],
+        },
       },
       sort: 'startedAt:dsc',
     });

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/search_workflow_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/search_workflow_executions.ts
@@ -52,6 +52,7 @@ function transformToWorkflowExecutionListModel(
     results: response.hits.hits.map((hit) => {
       const workflowExecution = hit._source!;
       return {
+        spaceId: workflowExecution.spaceId,
         id: hit._id!,
         status: workflowExecution.status,
         startedAt: workflowExecution.startedAt,

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
@@ -104,12 +104,13 @@ export class WorkflowsManagementApi {
 
   public async runWorkflow(
     workflow: WorkflowExecutionEngineModel,
+    spaceId: string,
     inputs: Record<string, any>
   ): Promise<string> {
     if (!this.schedulerService) {
       throw new Error('Scheduler service not set');
     }
-    return await this.schedulerService.runWorkflow(workflow, inputs);
+    return await this.schedulerService.runWorkflow(workflow, spaceId, inputs);
   }
 
   public async testWorkflow(
@@ -132,12 +133,12 @@ export class WorkflowsManagementApi {
 
     return await this.schedulerService.runWorkflow(
       {
-        spaceId,
         id: 'test-workflow',
         name: workflowToCreate.name,
         status: workflowToCreate.status,
         definition: workflowToCreate.definition,
       },
+      spaceId,
       inputs
     );
   }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
@@ -104,16 +104,19 @@ export class WorkflowsManagementApi {
 
   public async runWorkflow(
     workflow: WorkflowExecutionEngineModel,
-    inputs: Record<string, any>,
-    spaceId: string
+    inputs: Record<string, any>
   ): Promise<string> {
     if (!this.schedulerService) {
       throw new Error('Scheduler service not set');
     }
-    return await this.schedulerService.runWorkflow(workflow, inputs, spaceId);
+    return await this.schedulerService.runWorkflow(workflow, inputs);
   }
 
-  public async testWorkflow(workflowYaml: string, inputs: Record<string, any>): Promise<string> {
+  public async testWorkflow(
+    workflowYaml: string,
+    inputs: Record<string, any>,
+    spaceId: string
+  ): Promise<string> {
     if (!this.schedulerService) {
       throw new Error('Scheduler service not set');
     }
@@ -129,6 +132,7 @@ export class WorkflowsManagementApi {
 
     return await this.schedulerService.runWorkflow(
       {
+        spaceId,
         id: 'test-workflow',
         name: workflowToCreate.name,
         status: workflowToCreate.status,

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
@@ -69,41 +69,48 @@ export class WorkflowsManagementApi {
     this.schedulerService = schedulerService;
   }
 
-  public async getWorkflows(params: GetWorkflowsParams): Promise<WorkflowListDto> {
-    return await this.workflowsService.searchWorkflows(params);
+  public async getWorkflows(params: GetWorkflowsParams, spaceId: string): Promise<WorkflowListDto> {
+    return await this.workflowsService.searchWorkflows(params, spaceId);
   }
 
-  public async getWorkflow(id: string): Promise<WorkflowDetailDto | null> {
-    return await this.workflowsService.getWorkflow(id);
+  public async getWorkflow(id: string, spaceId: string): Promise<WorkflowDetailDto | null> {
+    return await this.workflowsService.getWorkflow(id, spaceId);
   }
 
   public async createWorkflow(
     workflow: CreateWorkflowCommand,
+    spaceId: string,
     request: KibanaRequest
   ): Promise<WorkflowDetailDto> {
-    return await this.workflowsService.createWorkflow(workflow, request);
+    return await this.workflowsService.createWorkflow(workflow, spaceId, request);
   }
 
   public async updateWorkflow(
     id: string,
     workflow: Partial<EsWorkflow>,
+    spaceId: string,
     request: KibanaRequest
-  ): Promise<UpdatedWorkflowResponseDto> {
-    return await this.workflowsService.updateWorkflow(id, workflow, request);
+  ): Promise<UpdatedWorkflowResponseDto | null> {
+    return await this.workflowsService.updateWorkflow(id, workflow, spaceId, request);
   }
 
-  public async deleteWorkflows(workflowIds: string[], request: KibanaRequest): Promise<void> {
-    return await this.workflowsService.deleteWorkflows(workflowIds, request);
+  public async deleteWorkflows(
+    workflowIds: string[],
+    spaceId: string,
+    request: KibanaRequest
+  ): Promise<void> {
+    return await this.workflowsService.deleteWorkflows(workflowIds, spaceId, request);
   }
 
   public async runWorkflow(
     workflow: WorkflowExecutionEngineModel,
-    inputs: Record<string, any>
+    inputs: Record<string, any>,
+    spaceId: string
   ): Promise<string> {
     if (!this.schedulerService) {
       throw new Error('Scheduler service not set');
     }
-    return await this.schedulerService.runWorkflow(workflow, inputs);
+    return await this.schedulerService.runWorkflow(workflow, inputs, spaceId);
   }
 
   public async testWorkflow(workflowYaml: string, inputs: Record<string, any>): Promise<string> {
@@ -131,22 +138,30 @@ export class WorkflowsManagementApi {
     );
   }
 
-  public async getWorkflowExecutions(workflowId: string): Promise<WorkflowExecutionListDto> {
-    return await this.workflowsService.searchWorkflowExecutions({
-      workflowId,
-    });
+  public async getWorkflowExecutions(
+    workflowId: string,
+    spaceId: string
+  ): Promise<WorkflowExecutionListDto> {
+    return await this.workflowsService.searchWorkflowExecutions(
+      {
+        workflowId,
+      },
+      spaceId
+    );
   }
 
   public async getWorkflowExecution(
-    workflowExecutionId: string
+    workflowExecutionId: string,
+    spaceId: string
   ): Promise<WorkflowExecutionDto | null> {
-    return await this.workflowsService.getWorkflowExecution(workflowExecutionId);
+    return await this.workflowsService.getWorkflowExecution(workflowExecutionId, spaceId);
   }
 
   public async getWorkflowExecutionLogs(
-    params: GetWorkflowExecutionLogsParams
+    params: GetWorkflowExecutionLogsParams,
+    spaceId: string
   ): Promise<WorkflowExecutionLogsDto> {
-    const result = await this.workflowsService.getExecutionLogs(params.executionId);
+    const result = await this.workflowsService.getExecutionLogs(params.executionId, spaceId);
 
     // Transform the logs to match our API format
     return {

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
@@ -290,7 +290,7 @@ export function defineRoutes(
           return response.notFound();
         }
         const { inputs } = request.body as { inputs: Record<string, any> };
-        const workflowRunId = await api.runWorkflow(workflow, inputs, spaceId);
+        const workflowRunId = await api.runWorkflow(workflow, inputs);
         return response.ok({
           body: workflowRunId,
         });

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
@@ -321,9 +321,12 @@ export function defineRoutes(
     },
     async (context, request, response) => {
       try {
+        const spaceId = spaces.getSpaceId(request);
+
         const workflowExecutionId = await api.testWorkflow(
           request.body.workflowYaml,
-          request.body.inputs
+          request.body.inputs,
+          spaceId
         );
 
         return response.ok({

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
@@ -290,7 +290,7 @@ export function defineRoutes(
           return response.notFound();
         }
         const { inputs } = request.body as { inputs: Record<string, any> };
-        const workflowRunId = await api.runWorkflow(workflow, inputs);
+        const workflowRunId = await api.runWorkflow(workflow, spaceId, inputs);
         return response.ok({
           body: workflowRunId,
         });

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_routes.ts
@@ -10,10 +10,16 @@
 import { schema } from '@kbn/config-schema';
 import type { IRouter, Logger } from '@kbn/core/server';
 import { CreateWorkflowCommandSchema } from '@kbn/workflows';
+import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
 import type { WorkflowsManagementApi } from './workflows_management_api';
 import { type GetWorkflowsParams } from './workflows_management_api';
 
-export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logger: Logger) {
+export function defineRoutes(
+  router: IRouter,
+  api: WorkflowsManagementApi,
+  logger: Logger,
+  spaces: SpacesServiceStart
+) {
   router.get(
     {
       path: '/api/workflows/{id}',
@@ -38,7 +44,8 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
-        const workflow = await api.getWorkflow(id);
+        const spaceId = spaces.getSpaceId(request);
+        const workflow = await api.getWorkflow(id, spaceId);
         if (!workflow) {
           return response.notFound({
             body: {
@@ -77,11 +84,16 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { limit, offset } = request.query as GetWorkflowsParams;
+
+        const spaceId = spaces.getSpaceId(request);
         return response.ok({
-          body: await api.getWorkflows({
-            limit,
-            offset,
-          }),
+          body: await api.getWorkflows(
+            {
+              limit,
+              offset,
+            },
+            spaceId
+          ),
         });
       } catch (error) {
         return response.customError({
@@ -114,7 +126,8 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     },
     async (context, request, response) => {
       try {
-        const createdWorkflow = await api.createWorkflow(request.body, request);
+        const spaceId = spaces.getSpaceId(request);
+        const createdWorkflow = await api.createWorkflow(request.body, spaceId, request);
         return response.ok({ body: createdWorkflow });
       } catch (error) {
         return response.customError({
@@ -151,8 +164,13 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
+        const spaceId = spaces.getSpaceId(request);
+        const updated = await api.updateWorkflow(id, request.body, spaceId, request);
+        if (updated === null) {
+          return response.notFound();
+        }
         return response.ok({
-          body: await api.updateWorkflow(id, request.body, request),
+          body: updated,
         });
       } catch (error) {
         return response.customError({
@@ -189,7 +207,8 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
-        await api.deleteWorkflows([id], request);
+        const spaceId = spaces.getSpaceId(request);
+        await api.deleteWorkflows([id], spaceId, request);
         return response.ok();
       } catch (error) {
         return response.customError({
@@ -225,7 +244,8 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { ids } = request.body as { ids: string[] };
-        await api.deleteWorkflows(ids, request);
+        const spaceId = spaces.getSpaceId(request);
+        await api.deleteWorkflows(ids, spaceId, request);
         return response.ok();
       } catch (error) {
         return response.customError({
@@ -264,12 +284,13 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
-        const workflow = await api.getWorkflow(id);
+        const spaceId = spaces.getSpaceId(request);
+        const workflow = await api.getWorkflow(id, spaceId);
         if (!workflow) {
           return response.notFound();
         }
         const { inputs } = request.body as { inputs: Record<string, any> };
-        const workflowRunId = await api.runWorkflow(workflow, inputs);
+        const workflowRunId = await api.runWorkflow(workflow, inputs, spaceId);
         return response.ok({
           body: workflowRunId,
         });
@@ -344,8 +365,9 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { workflowId } = request.query as { workflowId: string };
+        const spaceId = spaces.getSpaceId(request);
         return response.ok({
-          body: await api.getWorkflowExecutions(workflowId),
+          body: await api.getWorkflowExecutions(workflowId, spaceId),
         });
       } catch (error) {
         return response.customError({
@@ -381,7 +403,8 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
     async (context, request, response) => {
       try {
         const { workflowExecutionId } = request.params;
-        const workflowExecution = await api.getWorkflowExecution(workflowExecutionId);
+        const spaceId = spaces.getSpaceId(request);
+        const workflowExecution = await api.getWorkflowExecution(workflowExecutionId, spaceId);
         if (!workflowExecution) {
           return response.notFound();
         }
@@ -423,14 +446,18 @@ export function defineRoutes(router: IRouter, api: WorkflowsManagementApi, logge
       try {
         const { workflowExecutionId } = request.params;
         const { limit, offset, sortField, sortOrder } = request.query;
+        const spaceId = spaces.getSpaceId(request);
 
-        const logs = await api.getWorkflowExecutionLogs({
-          executionId: workflowExecutionId,
-          limit,
-          offset,
-          sortField,
-          sortOrder,
-        });
+        const logs = await api.getWorkflowExecutionLogs(
+          {
+            executionId: workflowExecutionId,
+            limit,
+            offset,
+            sortField,
+            sortOrder,
+          },
+          spaceId
+        );
 
         return response.ok({
           body: logs,

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
@@ -118,12 +118,11 @@ export class WorkflowsService {
     const savedObjectsClient = await this.getSavedObjectsClient();
     const response = await savedObjectsClient.find<WorkflowSavedObjectAttributes>({
       type: WORKFLOW_SAVED_OBJECT_TYPE,
-      filter: `${WORKFLOW_SAVED_OBJECT_TYPE}.attributes.spaceId: "${spaceId}"`,
+      // Exclude deleted workflows (by checking for null/undefined deleted_at) and workflows from other spaces
+      filter: `${WORKFLOW_SAVED_OBJECT_TYPE}.attributes.spaceId: "${spaceId}" AND not ${WORKFLOW_SAVED_OBJECT_TYPE}.attributes.deleted_at: *`,
       perPage: 100,
       sortField: 'updated_at',
       sortOrder: 'desc',
-      // Exclude deleted workflows by checking for null/undefined deleted_at
-      filter: `not ${WORKFLOW_SAVED_OBJECT_TYPE}.attributes.deleted_at: *`,
     });
 
     // Get workflow IDs to fetch execution history

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
@@ -176,7 +176,7 @@ export class WorkflowsService {
       );
 
       return {
-        spaceId: so.id,
+        spaceId: so.attributes.spaceId,
         id: so.id,
         name: so.attributes.name,
         description: so.attributes.description || '',
@@ -403,7 +403,7 @@ export class WorkflowsService {
       })
     );
 
-    // Remove scheduled tasks from deleted workflows
+    // Remove tasks scheduled for deleted workflows
     if (this.taskScheduler) {
       for (const workflow of filteredWorkflows) {
         await this.taskScheduler.unscheduleWorkflowTasks(workflow.id);

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
@@ -527,7 +527,7 @@ export class WorkflowsService {
     }
   }
 
-  public async getExecutionLogs(executionId: string): Promise<LogSearchResult> {
+  public async getExecutionLogs(executionId: string, spaceId: string): Promise<LogSearchResult> {
     const query = {
       bool: {
         must: [

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -34,6 +34,7 @@
     "@kbn/security-plugin-types-server",
     "@kbn/react-kibana-context-render",
     "@kbn/embeddable-plugin",
+    "@kbn/spaces-plugin",
     "@kbn/css-utils",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/alerting-plugin",


### PR DESCRIPTION
## Summary

This PR introduces change to the workflow management and engine, which allows them to be stored and accessed with Space scope. Implementation made by adding and validating spaceId field into the objects.

We aware, that SavedObject where we currently store our workflows has it's own scoping system, but at the moment we are not sure that we will proceed with SO in the future, so using same behaviour as for regular indices.

⚠️  Since this PR updates `workflowExecution`, `workflowsExecutionLogs` and `workflowsExecutionStep` indices, changes will take effect only on newly added objects. If you need to update already existed, you need to perform re-indexing.

This PR contains changes from https://github.com/elastic/kibana/pull/229072, so merging is blocked until RBAC will be merged.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



