### PR TITLE
[9.1] [Response Ops][Event Log] Using fixed doc ID for alerting event log docs (#229463)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.test.ts
@@ -223,15 +223,18 @@ describe('AlertingEventLogger', () => {
       alertingEventLogger.initialize({ context: ruleContext, runDate, ruleData });
 
       expect(eventLogger.logEvent).toHaveBeenCalledTimes(1);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith({
-        ...event,
-        event: {
-          ...event.event,
-          action: EVENT_LOG_ACTIONS.executeStart,
-          start: runDate.toISOString(),
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(
+        {
+          ...event,
+          event: {
+            ...event.event,
+            action: EVENT_LOG_ACTIONS.executeStart,
+            start: runDate.toISOString(),
+          },
+          message: `rule execution start: "${ruleData.id}"`,
         },
-        message: `rule execution start: "${ruleData.id}"`,
-      });
+        expect.any(String)
+      );
 
       expect(eventLogger.startTiming).toHaveBeenCalledTimes(1);
       expect(eventLogger.startTiming).toHaveBeenCalledWith(event, new Date(mockNow));
@@ -655,7 +658,7 @@ describe('AlertingEventLogger', () => {
         ruleData
       );
 
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(event);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(event, expect.any(String));
     });
 
     test('should throw error if backfill fields provided when execution type is not backfill', () => {
@@ -687,26 +690,29 @@ describe('AlertingEventLogger', () => {
         executionType.BACKFILL
       );
 
-      expect(eventLogger.logEvent).toHaveBeenCalledWith({
-        ...event,
-        kibana: {
-          ...event.kibana,
-          alert: {
-            ...event.kibana?.alert,
-            rule: {
-              ...event.kibana?.alert?.rule,
-              execution: {
-                ...event.kibana?.alert?.rule?.execution,
-                backfill: {
-                  id: 'abc',
-                  start: '2024-03-13T00:00:00.000Z',
-                  interval: '1h',
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(
+        {
+          ...event,
+          kibana: {
+            ...event.kibana,
+            alert: {
+              ...event.kibana?.alert,
+              rule: {
+                ...event.kibana?.alert?.rule,
+                execution: {
+                  ...event.kibana?.alert?.rule?.execution,
+                  backfill: {
+                    id: 'abc',
+                    start: '2024-03-13T00:00:00.000Z',
+                    interval: '1h',
+                  },
                 },
               },
             },
           },
         },
-      });
+        expect.any(String)
+      );
     });
   });
 
@@ -723,7 +729,7 @@ describe('AlertingEventLogger', () => {
 
       const event = createAlertRecord(ruleContext, ruleData, [alertSO], alert);
 
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(event);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(event, expect.any(String));
     });
 
     test('should throw if trying to log alerts for backfill executions when no rule data is set', () => {
@@ -759,26 +765,29 @@ describe('AlertingEventLogger', () => {
         alert
       );
 
-      expect(eventLogger.logEvent).toHaveBeenCalledWith({
-        ...event,
-        rule: {
-          ...event.rule,
-          id: 'bbb',
-          name: 'rule-name',
-        },
-        kibana: {
-          ...event.kibana,
-          alert: {
-            ...event.kibana?.alert,
-            rule: {
-              ...event.kibana?.alert?.rule,
-              consumer: 'my-new-consumer',
-              revision: 10,
-              rule_type_id: 'test',
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(
+        {
+          ...event,
+          rule: {
+            ...event.rule,
+            id: 'bbb',
+            name: 'rule-name',
+          },
+          kibana: {
+            ...event.kibana,
+            alert: {
+              ...event.kibana?.alert,
+              rule: {
+                ...event.kibana?.alert?.rule,
+                consumer: 'my-new-consumer',
+                revision: 10,
+                rule_type_id: 'test',
+              },
             },
           },
         },
-      });
+        expect.any(String)
+      );
     });
   });
 
@@ -806,7 +815,7 @@ describe('AlertingEventLogger', () => {
 
       const event = createActionExecuteRecord(ruleContext, ruleData, [alertSO], action);
 
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(event);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(event, expect.any(String));
     });
 
     test('should log action event with uuid', () => {
@@ -815,7 +824,7 @@ describe('AlertingEventLogger', () => {
 
       const event = createActionExecuteRecord(ruleContext, ruleData, [alertSO], action);
 
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(event);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(event, expect.any(String));
     });
   });
 
@@ -840,7 +849,7 @@ describe('AlertingEventLogger', () => {
       alertingEventLogger.done({});
 
       const event = initializeExecuteRecord(ruleContextWithScheduleDelay, ruleData, [alertSO]);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(event);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(event, expect.any(String));
     });
 
     test('should set fields from execution status if provided', () => {
@@ -860,7 +869,7 @@ describe('AlertingEventLogger', () => {
         },
       };
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution status if execution status is error', () => {
@@ -898,7 +907,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution status if execution status is error and uses "unknown" if no reason is provided', () => {
@@ -936,7 +945,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution status if execution status is error and does not overwrite existing error message', () => {
@@ -978,7 +987,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution status if execution status is warning', () => {
@@ -1012,7 +1021,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution status if execution status is warning and uses "unknown" if no reason is provided', () => {
@@ -1046,7 +1055,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution status if execution status is warning and uses existing message if no message is provided', () => {
@@ -1082,7 +1091,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from backfill if provided', () => {
@@ -1146,7 +1155,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from backfill even when no rule data is provided', () => {
@@ -1208,7 +1217,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution metrics if provided', () => {
@@ -1261,7 +1270,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution timings if provided', () => {
@@ -1307,7 +1316,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields from execution metrics and timings if both provided', () => {
@@ -1378,7 +1387,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('should set fields to 0 execution metrics are provided but undefined', () => {
@@ -1418,7 +1427,7 @@ describe('AlertingEventLogger', () => {
       };
 
       expect(alertingEventLogger.getEvent()).toEqual(loggedEvent);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(loggedEvent, expect.any(String));
     });
 
     test('overwrites the message when the final status is error', () => {
@@ -1489,7 +1498,7 @@ describe('AlertingEventLogger', () => {
       };
 
       const event = createGapRecord(ruleContext, ruleData, [alertSO], gap);
-      expect(eventLogger.logEvent).toHaveBeenCalledWith(event);
+      expect(eventLogger.logEvent).toHaveBeenCalledWith(event, expect.any(String));
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import * as uuid from 'uuid';
 import type { IEvent, IEventLogger, InternalFields } from '@kbn/event-log-plugin/server';
 import { millisToNanos, SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import type { BulkResponse } from '@elastic/elasticsearch/lib/api/types';
@@ -198,7 +199,7 @@ export class AlertingEventLogger {
       },
       message: `rule execution start: "${ruleData.id}"`,
     };
-    this.eventLogger.logEvent(executeStartEvent);
+    this.logEventWithFixedUuid(executeStartEvent);
   }
 
   public getStartAndDuration(): { start?: Date; duration?: string | number } {
@@ -321,7 +322,7 @@ export class AlertingEventLogger {
       updateEvent(executeTimeoutEvent, { backfill });
     }
 
-    this.eventLogger.logEvent(executeTimeoutEvent);
+    this.logEventWithFixedUuid(executeTimeoutEvent);
   }
 
   public logAlert(alert: AlertOpts) {
@@ -329,7 +330,7 @@ export class AlertingEventLogger {
       throw new Error('AlertingEventLogger not initialized');
     }
 
-    this.eventLogger.logEvent(
+    this.logEventWithFixedUuid(
       createAlertRecord(this.context, this.ruleData, this.relatedSavedObjects, alert)
     );
   }
@@ -339,7 +340,7 @@ export class AlertingEventLogger {
       throw new Error('AlertingEventLogger not initialized');
     }
 
-    this.eventLogger.logEvent(
+    this.logEventWithFixedUuid(
       createActionExecuteRecord(this.context, this.ruleData, this.relatedSavedObjects, action)
     );
   }
@@ -392,7 +393,7 @@ export class AlertingEventLogger {
       updateEvent(this.event, { backfill });
     }
 
-    this.eventLogger.logEvent(this.event);
+    this.logEventWithFixedUuid(this.event);
   }
 
   public reportGap({
@@ -411,7 +412,7 @@ export class AlertingEventLogger {
       range: gap,
     });
 
-    this.eventLogger.logEvent(
+    this.logEventWithFixedUuid(
       createGapRecord(this.context, this.ruleData, this.relatedSavedObjects, gapToReport.toObject())
     );
   }
@@ -436,6 +437,10 @@ export class AlertingEventLogger {
         internalFields: doc.internalFields,
       }))
     );
+  }
+
+  private logEventWithFixedUuid(event: IEvent) {
+    this.eventLogger.logEvent(event, uuid.v4());
   }
 }
 

--- a/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.test.ts
@@ -58,6 +58,20 @@ describe('indexDocument', () => {
     });
   });
 
+  test('should call cluster client bulk with given doc and id', async () => {
+    // @ts-expect-error
+    clusterClientAdapter.indexDocument({ id: 'abc', body: { message: 'foo' }, index: 'event-log' });
+
+    await retryUntil('cluster client bulk called', () => {
+      return clusterClient.bulk.mock.calls.length !== 0;
+    });
+
+    expect(clusterClient.bulk).toHaveBeenCalledWith({
+      body: [{ create: { _id: 'abc' } }, { message: 'foo' }],
+      index: 'kibana-event-log-ds',
+    });
+  });
+
   test('should log an error when cluster client throws an error', async () => {
     clusterClient.bulk.mockRejectedValue(new Error('expected failure'));
     clusterClientAdapter.indexDocument({ body: { message: 'foo' }, index: 'event-log' });

--- a/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.ts
@@ -44,6 +44,10 @@ export interface Doc {
   internalFields?: InternalFields;
 }
 
+export type DocWithOptionalId = Doc & {
+  id?: string;
+};
+
 type Wait = () => Promise<boolean>;
 
 export interface ConstructorOpts {
@@ -135,6 +139,7 @@ export interface QueryEventsBySavedObjectSearchAfterResult {
 export class ClusterClientAdapter<
   TDoc extends {
     body: AliasAny;
+    id?: string;
     index: string;
     internalFields?: InternalFields;
   } = Doc
@@ -241,7 +246,12 @@ export class ClusterClientAdapter<
     for (const doc of docs) {
       if (doc.body === undefined) continue;
 
-      bulkBody.push({ create: {} });
+      if (doc.id) {
+        bulkBody.push({ create: { _id: doc.id } });
+      } else {
+        bulkBody.push({ create: {} });
+      }
+
       bulkBody.push(doc.body);
     }
 

--- a/x-pack/platform/plugins/shared/event_log/server/event_logger.test.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/event_logger.test.ts
@@ -101,6 +101,42 @@ describe('EventLogger', () => {
     expect(timeStampValue).toBeLessThanOrEqual(dateEnd);
   });
 
+  test('method logEvent() passes through doc ID if defined', async () => {
+    service.registerProviderActions('test-provider', ['test-action-1']);
+    eventLogger = service.getLogger({
+      event: { provider: 'test-provider', action: 'test-action-1' },
+    });
+
+    const dateStart = new Date().valueOf();
+    eventLogger.logEvent({}, 'abc');
+    const event = await waitForLogEvent(systemLogger);
+    const dateEnd = new Date().valueOf();
+
+    expect(event).toMatchObject({
+      id: 'abc',
+      event: {
+        provider: 'test-provider',
+        action: 'test-action-1',
+      },
+      '@timestamp': expect.stringMatching(/.*/),
+      ecs: {
+        version: ECS_VERSION,
+      },
+      kibana: {
+        server_uuid: '424-24-2424',
+        version: '1.0.1',
+      },
+    });
+
+    const $timeStamp = event!['@timestamp']!;
+    const timeStamp = new Date($timeStamp);
+    expect(timeStamp).not.toBeNaN();
+
+    const timeStampValue = timeStamp.valueOf();
+    expect(timeStampValue).toBeGreaterThanOrEqual(dateStart);
+    expect(timeStampValue).toBeLessThanOrEqual(dateEnd);
+  });
+
   test('method logEvent() merges event data', async () => {
     service.registerProviderActions('test-provider', ['a', 'b']);
     eventLogger = service.getLogger({

--- a/x-pack/platform/plugins/shared/event_log/server/types.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/types.ts
@@ -101,7 +101,7 @@ export interface IEventLogClient {
 }
 
 export interface IEventLogger {
-  logEvent(properties: IEvent): void;
+  logEvent(properties: IEvent, id?: string): void;
   startTiming(event: IEvent, startTime?: Date): void;
   stopTiming(event: IEvent): void;
   updateEvents(

--- a/x-pack/platform/test/alerting_api_integration/common/lib/get_event_log.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/lib/get_event_log.ts
@@ -30,7 +30,6 @@ interface GetEventLogParams {
   provider: string;
   actions: Map<string, { gte: number } | { equal: number }>;
   filter?: string;
-  collapseByExecutionUUid?: boolean;
 }
 
 // Return event log entries given the specified parameters; for the `actions`
@@ -38,7 +37,7 @@ interface GetEventLogParams {
 export async function getEventLog(
   params: GetEventLogParams
 ): Promise<IValidatedEventInternalDocInfo[]> {
-  const { getService, spaceId, type, id, provider, actions, collapseByExecutionUUid } = params;
+  const { getService, spaceId, type, id, provider, actions } = params;
   const supertest = getService('supertest');
 
   const spacePrefix = getUrlPrefix(spaceId);
@@ -57,23 +56,11 @@ export async function getEventLog(
     .filter((event) => event?.event?.action)
     .filter((event) => actions.has(event?.event?.action!));
 
-  const actionExecutionUuidMap = new Map<string, number>();
   const foundActions = events
-    .map((event) => ({
-      action: event?.event?.action,
-      uuid: event?.kibana?.alert?.rule?.execution?.uuid,
-    }))
-    .reduce((actionsSum, evt) => {
-      if (evt.action) {
-        if (collapseByExecutionUUid === true) {
-          const key = `${evt.action}${evt.uuid}`;
-          if (!actionExecutionUuidMap.has(key)) {
-            actionExecutionUuidMap.set(key, 1);
-            actionsSum.set(evt.action, 1 + (actionsSum.get(evt.action) ?? 0));
-          }
-        } else {
-          actionsSum.set(evt.action, 1 + (actionsSum.get(evt.action) ?? 0));
-        }
+    .map((event) => event?.event?.action)
+    .reduce((actionsSum, action) => {
+      if (action) {
+        actionsSum.set(action, 1 + (actionsSum.get(action) ?? 0));
       }
       return actionsSum;
     }, new Map<string, number>());

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/api_key.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/api_key.ts
@@ -242,7 +242,6 @@ export default function apiKeyBackfillTests({ getService }: FtrProviderContext) 
           id: backfillId,
           provider: 'alerting',
           actions: new Map([['execute-backfill', { equal: schedule.length }]]),
-          collapseByExecutionUUid: true,
         });
       });
 

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner.ts
@@ -171,8 +171,7 @@ export default function createBackfillTaskRunnerTests({ getService }: FtrProvide
         getService,
         backfillId,
         spaceId,
-        new Map([['execute-backfill', { equal: 4 }]]),
-        true // collapse by execution UUID
+        new Map([['execute-backfill', { equal: 4 }]])
       );
 
       // each execute-backfill event should have these fields
@@ -425,8 +424,7 @@ export default function createBackfillTaskRunnerTests({ getService }: FtrProvide
         new Map([
           ['execute-timeout', { equal: 1 }],
           ['execute-backfill', { equal: 1 }],
-        ]),
-        true // collapse by execution UUID
+        ])
       );
 
       // each event log event should have these fields
@@ -567,8 +565,7 @@ export default function createBackfillTaskRunnerTests({ getService }: FtrProvide
         getService,
         backfillId,
         spaceId,
-        new Map([['execute-backfill', { equal: 4 }]]),
-        true
+        new Map([['execute-backfill', { equal: 4 }]])
       );
 
       // each event log event should have these fields

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner_with_actions.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner_with_actions.ts
@@ -116,8 +116,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
         getService,
         backfillId,
         spaceId,
-        new Map([['execute-backfill', { equal: 4 }]]),
-        true // collapse by execution uuid
+        new Map([['execute-backfill', { equal: 4 }]])
       );
 
       await retry.try(async () => {
@@ -179,8 +178,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
         getService,
         backfillId,
         spaceId,
-        new Map([['execute-backfill', { equal: 4 }]]),
-        true // collapse by execution uuid
+        new Map([['execute-backfill', { equal: 4 }]])
       );
 
       await retry.try(async () => {
@@ -243,8 +241,7 @@ export default function scheduleBackfillTests({ getService }: FtrProviderContext
         getService,
         backfillId,
         spaceId,
-        new Map([['execute-backfill', { equal: 4 }]]),
-        true // collapse by execution uuid
+        new Map([['execute-backfill', { equal: 4 }]])
       );
 
       // since we want to check that no actions were executed and they might take a bit to run

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/test_utils.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/test_utils.ts
@@ -62,8 +62,7 @@ export async function waitForEventLogDocs(
   getService: FtrProviderContext['getService'],
   id: string,
   spaceId: string,
-  actions: Map<string, { gte: number } | { equal: number }>,
-  collapseByExecutionUUid?: boolean
+  actions: Map<string, { gte: number } | { equal: number }>
 ) {
   return await retry.try(async () => {
     return await getEventLog({
@@ -73,7 +72,6 @@ export async function waitForEventLogDocs(
       id,
       provider: 'alerting',
       actions,
-      collapseByExecutionUUid,
     });
   });
 }

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/find.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/find.ts
@@ -18,8 +18,7 @@ export default function findGapsTests({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  // Failing: See https://github.com/elastic/kibana/issues/225982
-  describe.skip('find gaps', () => {
+  describe('find gaps', () => {
     const objectRemover = new ObjectRemover(supertest);
     const searchStart = '2024-01-01T00:00:00.000Z';
     const searchEnd = '2024-01-31T00:00:00.000Z';

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/update_gaps.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/update_gaps.ts
@@ -17,8 +17,7 @@ export default function updateGapsTests({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const retry = getService('retry');
 
-  // Failing: See https://github.com/elastic/kibana/issues/224475
-  describe.skip('update gaps', () => {
+  describe('update gaps', () => {
     const objectRemover = new ObjectRemover(supertest);
     const gapStart = moment().subtract(14, 'days').startOf('day').toISOString();
     const gapEnd = moment().subtract(13, 'days').startOf('day').toISOString();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Response Ops][Event Log] Using fixed doc ID for alerting event log docs (#229463)](https://github.com/elastic/kibana/pull/229463)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-07-29T14:01:33Z","message":"[Response Ops][Event Log] Using fixed doc ID for alerting event log docs (#229463)\n\nResolves https://github.com/elastic/kibana/issues/64240\n\n## Summary\n\nWe've been having some test flakiness that, upon close inspection, seems\nto be caused by duplicate event log documents getting indexed, where the\ncontents of the document are exactly the same but the ID is different.\nThe thinking is that this could be caused by temporary network flakiness\nduring the tests that cause the event log bulk indexing to retry\nunnecessarily. To address, this, we add the option to index an event log\ndocument with a fixed ID and pre-set the ID in the\n`AlertingEventLogger`. With this change, the flaky gap tests we've been\nseeing should be resolved and we can revert a test hack we did to fix\nsome flaky backfill tests in this PR:\nhttps://github.com/elastic/kibana/pull/223132\n\nFlaky test runner runs:\n\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8858\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8871\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8873\n\nFlaky gap test issues:\n*\n[https://github.com/elastic/kibana/issues/228652](https://github.com/elastic/kibana/issues/228652)\n*\n[https://github.com/elastic/kibana/issues/227792](https://github.com/elastic/kibana/issues/227792)\n*\n[https://github.com/elastic/kibana/issues/227296](https://github.com/elastic/kibana/issues/227296)\n*\n[https://github.com/elastic/kibana/issues/226753](https://github.com/elastic/kibana/issues/226753)\n*\n[https://github.com/elastic/kibana/issues/226220](https://github.com/elastic/kibana/issues/226220)\n*\n[https://github.com/elastic/kibana/issues/225982](https://github.com/elastic/kibana/issues/225982)\n*\n[https://github.com/elastic/kibana/issues/224554](https://github.com/elastic/kibana/issues/224554)\n*\n[https://github.com/elastic/kibana/issues/224396](https://github.com/elastic/kibana/issues/224396)\n*\n[https://github.com/elastic/kibana/issues/224153](https://github.com/elastic/kibana/issues/224153)\n*\n[https://github.com/elastic/kibana/issues/223895](https://github.com/elastic/kibana/issues/223895)\n*\n[https://github.com/elastic/kibana/issues/223131](https://github.com/elastic/kibana/issues/223131)\n*\n[https://github.com/elastic/kibana/issues/221997](https://github.com/elastic/kibana/issues/221997)\n*\n[https://github.com/elastic/kibana/issues/221136](https://github.com/elastic/kibana/issues/221136)\n*\n[https://github.com/elastic/kibana/issues/220543](https://github.com/elastic/kibana/issues/220543)\n*\n[https://github.com/elastic/kibana/issues/220075](https://github.com/elastic/kibana/issues/220075)\n*\n[https://github.com/elastic/kibana/issues/219387](https://github.com/elastic/kibana/issues/219387)\n*\n[https://github.com/elastic/kibana/issues/219235](https://github.com/elastic/kibana/issues/219235)\n*\n[https://github.com/elastic/kibana/issues/208749](https://github.com/elastic/kibana/issues/208749)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"96ef21fc99412117a1101bdbf39fc18c327ac2e2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","Feature:EventLog","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.0.5","v8.18.5"],"title":"[Response Ops][Event Log] Using fixed doc ID for alerting event log docs","number":229463,"url":"https://github.com/elastic/kibana/pull/229463","mergeCommit":{"message":"[Response Ops][Event Log] Using fixed doc ID for alerting event log docs (#229463)\n\nResolves https://github.com/elastic/kibana/issues/64240\n\n## Summary\n\nWe've been having some test flakiness that, upon close inspection, seems\nto be caused by duplicate event log documents getting indexed, where the\ncontents of the document are exactly the same but the ID is different.\nThe thinking is that this could be caused by temporary network flakiness\nduring the tests that cause the event log bulk indexing to retry\nunnecessarily. To address, this, we add the option to index an event log\ndocument with a fixed ID and pre-set the ID in the\n`AlertingEventLogger`. With this change, the flaky gap tests we've been\nseeing should be resolved and we can revert a test hack we did to fix\nsome flaky backfill tests in this PR:\nhttps://github.com/elastic/kibana/pull/223132\n\nFlaky test runner runs:\n\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8858\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8871\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8873\n\nFlaky gap test issues:\n*\n[https://github.com/elastic/kibana/issues/228652](https://github.com/elastic/kibana/issues/228652)\n*\n[https://github.com/elastic/kibana/issues/227792](https://github.com/elastic/kibana/issues/227792)\n*\n[https://github.com/elastic/kibana/issues/227296](https://github.com/elastic/kibana/issues/227296)\n*\n[https://github.com/elastic/kibana/issues/226753](https://github.com/elastic/kibana/issues/226753)\n*\n[https://github.com/elastic/kibana/issues/226220](https://github.com/elastic/kibana/issues/226220)\n*\n[https://github.com/elastic/kibana/issues/225982](https://github.com/elastic/kibana/issues/225982)\n*\n[https://github.com/elastic/kibana/issues/224554](https://github.com/elastic/kibana/issues/224554)\n*\n[https://github.com/elastic/kibana/issues/224396](https://github.com/elastic/kibana/issues/224396)\n*\n[https://github.com/elastic/kibana/issues/224153](https://github.com/elastic/kibana/issues/224153)\n*\n[https://github.com/elastic/kibana/issues/223895](https://github.com/elastic/kibana/issues/223895)\n*\n[https://github.com/elastic/kibana/issues/223131](https://github.com/elastic/kibana/issues/223131)\n*\n[https://github.com/elastic/kibana/issues/221997](https://github.com/elastic/kibana/issues/221997)\n*\n[https://github.com/elastic/kibana/issues/221136](https://github.com/elastic/kibana/issues/221136)\n*\n[https://github.com/elastic/kibana/issues/220543](https://github.com/elastic/kibana/issues/220543)\n*\n[https://github.com/elastic/kibana/issues/220075](https://github.com/elastic/kibana/issues/220075)\n*\n[https://github.com/elastic/kibana/issues/219387](https://github.com/elastic/kibana/issues/219387)\n*\n[https://github.com/elastic/kibana/issues/219235](https://github.com/elastic/kibana/issues/219235)\n*\n[https://github.com/elastic/kibana/issues/208749](https://github.com/elastic/kibana/issues/208749)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"96ef21fc99412117a1101bdbf39fc18c327ac2e2"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.0","8.18"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229820","number":229820,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229463","number":229463,"mergeCommit":{"message":"[Response Ops][Event Log] Using fixed doc ID for alerting event log docs (#229463)\n\nResolves https://github.com/elastic/kibana/issues/64240\n\n## Summary\n\nWe've been having some test flakiness that, upon close inspection, seems\nto be caused by duplicate event log documents getting indexed, where the\ncontents of the document are exactly the same but the ID is different.\nThe thinking is that this could be caused by temporary network flakiness\nduring the tests that cause the event log bulk indexing to retry\nunnecessarily. To address, this, we add the option to index an event log\ndocument with a fixed ID and pre-set the ID in the\n`AlertingEventLogger`. With this change, the flaky gap tests we've been\nseeing should be resolved and we can revert a test hack we did to fix\nsome flaky backfill tests in this PR:\nhttps://github.com/elastic/kibana/pull/223132\n\nFlaky test runner runs:\n\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8858\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8871\n*\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8873\n\nFlaky gap test issues:\n*\n[https://github.com/elastic/kibana/issues/228652](https://github.com/elastic/kibana/issues/228652)\n*\n[https://github.com/elastic/kibana/issues/227792](https://github.com/elastic/kibana/issues/227792)\n*\n[https://github.com/elastic/kibana/issues/227296](https://github.com/elastic/kibana/issues/227296)\n*\n[https://github.com/elastic/kibana/issues/226753](https://github.com/elastic/kibana/issues/226753)\n*\n[https://github.com/elastic/kibana/issues/226220](https://github.com/elastic/kibana/issues/226220)\n*\n[https://github.com/elastic/kibana/issues/225982](https://github.com/elastic/kibana/issues/225982)\n*\n[https://github.com/elastic/kibana/issues/224554](https://github.com/elastic/kibana/issues/224554)\n*\n[https://github.com/elastic/kibana/issues/224396](https://github.com/elastic/kibana/issues/224396)\n*\n[https://github.com/elastic/kibana/issues/224153](https://github.com/elastic/kibana/issues/224153)\n*\n[https://github.com/elastic/kibana/issues/223895](https://github.com/elastic/kibana/issues/223895)\n*\n[https://github.com/elastic/kibana/issues/223131](https://github.com/elastic/kibana/issues/223131)\n*\n[https://github.com/elastic/kibana/issues/221997](https://github.com/elastic/kibana/issues/221997)\n*\n[https://github.com/elastic/kibana/issues/221136](https://github.com/elastic/kibana/issues/221136)\n*\n[https://github.com/elastic/kibana/issues/220543](https://github.com/elastic/kibana/issues/220543)\n*\n[https://github.com/elastic/kibana/issues/220075](https://github.com/elastic/kibana/issues/220075)\n*\n[https://github.com/elastic/kibana/issues/219387](https://github.com/elastic/kibana/issues/219387)\n*\n[https://github.com/elastic/kibana/issues/219235](https://github.com/elastic/kibana/issues/219235)\n*\n[https://github.com/elastic/kibana/issues/208749](https://github.com/elastic/kibana/issues/208749)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"96ef21fc99412117a1101bdbf39fc18c327ac2e2"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->