### PR TITLE
[Fleet] Use `EuiFlexGrid` instead of `EuiFlexGroup` in integrations grid

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -16,7 +16,6 @@ import {
   EuiText,
   EuiAutoSizer,
   EuiSkeletonRectangle,
-  EuiFlexGroup,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { WindowScroller } from 'react-virtualized';
@@ -54,7 +53,7 @@ export const GridColumn = ({
 
   if (isLoading) {
     return (
-      <EuiFlexGrid gutterSize="l" columns={3}>
+      <EuiFlexGrid gutterSize="l" columns={3} alignItems="start">
         {Array.from({ length: 12 }).map((_, index) => (
           <EuiFlexItem key={index} grow={3}>
             <EuiSkeletonRectangle height="160px" width="100%" />
@@ -66,7 +65,13 @@ export const GridColumn = ({
 
   if (!list.length) {
     return (
-      <EuiFlexGrid gutterSize="l" columns={3} data-test-subj="emptyState" style={emptyStateStyles}>
+      <EuiFlexGrid
+        gutterSize="l"
+        columns={3}
+        data-test-subj="emptyState"
+        style={emptyStateStyles}
+        alignItems="start"
+      >
         <EuiFlexItem grow={3}>
           <EuiText>
             <p>
@@ -100,7 +105,7 @@ export const GridColumn = ({
       >
         {({ registerChild }) => (
           <div ref={registerChild} style={style}>
-            <EuiFlexGroup gutterSize="m" responsive={true}>
+            <EuiFlexGrid columns={3} gutterSize="l" alignItems="start">
               {items.map((item) => (
                 <EuiFlexItem
                   key={item.id}
@@ -116,7 +121,7 @@ export const GridColumn = ({
                   <PackageCard {...item} showLabels={showCardLabels} />
                 </EuiFlexItem>
               ))}
-            </EuiFlexGroup>
+            </EuiFlexGrid>
             <EuiSpacer size="m" />
           </div>
         )}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/229818

Aligns the grid implementation across empty states + the virtualized list to show cards in a consistently sized grid. 

## Screen recording

https://github.com/user-attachments/assets/926ff910-07a3-494f-9e4b-f2226a6d41b9

Note the max height difference is currently expected behavior on `main`. I didn't attempt to fix the nonuniform card height due to text content differences. 
