### PR TITLE
[Synthetics] Unskip private location test

### DIFF
--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/private_location_apis.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/private_location_apis.ts
@@ -18,8 +18,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 import { PrivateLocationTestService } from './services/private_location_test_service';
 
 export default function ({ getService }: FtrProviderContext) {
-  // Failing: See https://github.com/elastic/kibana/issues/229394
-  describe.skip('PrivateLocationAPI', function () {
+  describe('PrivateLocationAPI', function () {
     this.tags('skipCloud');
     const supertestWithoutAuth = getService('supertestWithoutAuth');
     const supertest = getService('supertest');


### PR DESCRIPTION
Closes #229394.
This test was skipped because of an issue with the package registry that now it's been fixed.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->