### PR TITLE
[9.0] Ensure that the feature flags service is initialized before checking task priorities (#229709)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_priority_check.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_priority_check.test.ts
@@ -10,7 +10,7 @@ import {
   type TestKibanaUtils,
 } from '@kbn/core-test-helpers-kbn-server';
 import type { TaskDefinition, TaskPriority } from '../task';
-import { setupTestServers } from './lib';
+import { setupTestServers, retry } from './lib';
 import type { TaskTypeDictionary } from '../task_type_dictionary';
 
 jest.mock('../task_type_dictionary', () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_priority_check.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_priority_check.test.ts
@@ -9,9 +9,9 @@ import {
   type TestElasticsearchUtils,
   type TestKibanaUtils,
 } from '@kbn/core-test-helpers-kbn-server';
-import { TaskDefinition, TaskPriority } from '../task';
+import type { TaskDefinition, TaskPriority } from '../task';
 import { setupTestServers } from './lib';
-import { TaskTypeDictionary } from '../task_type_dictionary';
+import type { TaskTypeDictionary } from '../task_type_dictionary';
 
 jest.mock('../task_type_dictionary', () => {
   const actual = jest.requireActual('../task_type_dictionary');
@@ -49,12 +49,16 @@ describe('Task priority checks', () => {
   });
 
   it('detects tasks with priority definitions', async () => {
-    const taskTypes = taskTypeDictionary.getAllDefinitions();
-    const taskTypesWithPriority = taskTypes
-      .map((taskType: TaskDefinition) =>
-        !!taskType.priority ? { taskType: taskType.type, priority: taskType.priority } : null
-      )
-      .filter((tt: { taskType: string; priority: TaskPriority } | null) => null != tt);
-    expect(taskTypesWithPriority).toMatchSnapshot();
+    await retry(async () => {
+      const taskTypes = taskTypeDictionary.getAllDefinitions();
+      const taskTypesWithPriority = taskTypes
+        .map((taskType: TaskDefinition) =>
+          !!taskType.priority ? { taskType: taskType.type, priority: taskType.priority } : null
+        )
+        .filter((tt: { taskType: string; priority: TaskPriority } | null) => null != tt);
+
+      expect(taskTypesWithPriority.length).toEqual(2);
+      expect(taskTypesWithPriority).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Ensure that the feature flags service is initialized before checking task priorities (#229709)](https://github.com/elastic/kibana/pull/229709)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-29T14:30:02Z","message":"Ensure that the feature flags service is initialized before checking task priorities (#229709)\n\nFixes: https://github.com/elastic/kibana/issues/228815 \n\nLooks like a racing condition. \nFeature flag for the new task with a priority is [evaluated in the\nplugin setup\n](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts#L187)\nbut it waits for the start services. The test case sometimes runs before\nthe task is enabled.\nAdded a retry in order to be sure that the feature flag for the task is\non, so it gets listed in the tasks with priority list.\n\nNote: The test suite fails on 8.19.","sha":"c6b42d8473f4a7bf99064ff8758de1c1bfddffec","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.2.0","v9.0.5","v9.1.1","v8.19.1"],"title":"Ensure that the feature flags service is initialized before checking task priorities","number":229709,"url":"https://github.com/elastic/kibana/pull/229709","mergeCommit":{"message":"Ensure that the feature flags service is initialized before checking task priorities (#229709)\n\nFixes: https://github.com/elastic/kibana/issues/228815 \n\nLooks like a racing condition. \nFeature flag for the new task with a priority is [evaluated in the\nplugin setup\n](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts#L187)\nbut it waits for the start services. The test case sometimes runs before\nthe task is enabled.\nAdded a retry in order to be sure that the feature flag for the task is\non, so it gets listed in the tasks with priority list.\n\nNote: The test suite fails on 8.19.","sha":"c6b42d8473f4a7bf99064ff8758de1c1bfddffec"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229709","number":229709,"mergeCommit":{"message":"Ensure that the feature flags service is initialized before checking task priorities (#229709)\n\nFixes: https://github.com/elastic/kibana/issues/228815 \n\nLooks like a racing condition. \nFeature flag for the new task with a priority is [evaluated in the\nplugin setup\n](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts#L187)\nbut it waits for the start services. The test case sometimes runs before\nthe task is enabled.\nAdded a retry in order to be sure that the feature flag for the task is\non, so it gets listed in the tasks with priority list.\n\nNote: The test suite fails on 8.19.","sha":"c6b42d8473f4a7bf99064ff8758de1c1bfddffec"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229830","number":229830,"state":"OPEN"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229829","number":229829,"state":"OPEN"}]}] BACKPORT-->