### PR TITLE
[AI4SOC] Assorted integrations bug fixes

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/back_link.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/back_link.tsx
@@ -32,7 +32,10 @@ export function BackLink({ queryParams, integrationsPath }: Props) {
   const appId = returnAppId && returnPath ? returnAppId : 'integrations';
   const path = returnAppId && returnPath ? returnPath : integrationsPath;
 
-  const message = returnPath ? BACK_TO_SELECTION : BACK_TO_INTEGRATIONS;
+  // Maintain 'Back to integrations' for the AI4SOC integrations page
+  const message = returnPath?.includes('/configurations/integrations')
+    ? BACK_TO_INTEGRATIONS
+    : BACK_TO_SELECTION;
 
   return (
     <>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/back_link.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/back_link.tsx
@@ -33,9 +33,10 @@ export function BackLink({ queryParams, integrationsPath }: Props) {
   const path = returnAppId && returnPath ? returnPath : integrationsPath;
 
   // Maintain 'Back to integrations' for the AI4SOC integrations page
-  const message = returnPath?.includes('/configurations/integrations')
-    ? BACK_TO_INTEGRATIONS
-    : BACK_TO_SELECTION;
+  const message =
+    !returnPath || returnPath.includes('/configurations/integrations')
+      ? BACK_TO_INTEGRATIONS
+      : BACK_TO_SELECTION;
 
   return (
     <>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/integrations/components/security_integrations_grid_tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/integrations/components/security_integrations_grid_tabs.tsx
@@ -214,7 +214,7 @@ export const SecurityIntegrationsGridTabs = React.memo<SecurityIntegrationsGridT
               showControls={false}
               showSearchTools={selectedTab.showSearchTools}
               sortByFeaturedIntegrations={selectedTab.sortByFeaturedIntegrations}
-              spacer={false}
+              spacer={TopCallout ? true : false}
             />
           </Suspense>
         </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
@@ -98,7 +98,9 @@ export const useEnhancedIntegrationCards = (
         applyCategoryBadgeAndStyling(card, {
           ...options,
           hasDataStreams: activeIntegrations.some(({ name }) => name === card.name),
-          returnPath: `${CONFIGURATIONS_PATH}/integrations/${IntegrationsFacets.available}`,
+          returnPath:
+            options?.returnPath ??
+            `${CONFIGURATIONS_PATH}/integrations/${IntegrationsFacets.available}`,
         })
       ),
     [sorted, options, activeIntegrations]

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/search_ai_lake/hooks/integrations/use_enhanced_integration_cards.tsx
@@ -98,6 +98,7 @@ export const useEnhancedIntegrationCards = (
         applyCategoryBadgeAndStyling(card, {
           ...options,
           hasDataStreams: activeIntegrations.some(({ name }) => name === card.name),
+          returnPath: `${CONFIGURATIONS_PATH}/integrations/${IntegrationsFacets.available}`,
         })
       ),
     [sorted, options, activeIntegrations]

--- a/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/integrations/components/integrations_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/integrations/components/integrations_page.tsx
@@ -73,7 +73,7 @@ export const IntegrationsPage = React.memo<IntegrationsGridProps>(
               showControls={false}
               showSearchTools={true}
               sortByFeaturedIntegrations={false}
-              spacer={false}
+              spacer={true}
             />
           </EuiFlexItem>
         </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Fixing a couple of bugs with the AI4SOC integrations page:

1. Ensuring we have spacing between the search bar and the tiles on the AI4SOC browse page
2. Ensuring we have spacing between the callout and the tiles on the onboarding page
3. Fixing the back link on the integration overview page to maintain the correct space
4. Adding an override so we maintain the 'Back to integrations' text on the back button while utilizing the custom routing logic for the AI4SOC browse page

### Screen shots / recordings

#### Issue 1

Before
<img width="1724" height="548" alt="Screenshot 2025-07-29 at 1 33 27 PM" src="https://github.com/user-attachments/assets/f2b37c5f-771f-43c1-ba94-cd936362ed5c" />

After
<img width="1723" height="625" alt="Screenshot 2025-07-29 at 1 33 47 PM" src="https://github.com/user-attachments/assets/ec98db68-22e8-4128-9a9c-1f4b90ffe57d" />

#### Issue 2

Before
<img width="1174" height="471" alt="Screenshot 2025-07-30 at 9 11 16 AM" src="https://github.com/user-attachments/assets/6aabc2e4-02f3-4451-8735-4bac12870247" />

After
<img width="1189" height="478" alt="Screenshot 2025-07-30 at 9 10 53 AM" src="https://github.com/user-attachments/assets/87c37e8d-e609-4a33-9fe0-09c4a23c2712" />


#### Issue 3

https://github.com/user-attachments/assets/f925c659-2deb-4351-b01a-28c33b145ef8


#### Issue 4

https://github.com/user-attachments/assets/83cdbab8-ea6c-4f37-9bd2-4241c732a842

Still 'Back to integrations' when not using the custom return query params
<img width="1330" height="759" alt="Screenshot 2025-07-29 at 2 48 58 PM" src="https://github.com/user-attachments/assets/b271a8c6-d568-44cc-9d4e-db198a021d04" />

Still working correctly from the onboarding page as well

https://github.com/user-attachments/assets/d7a36260-79e2-4632-8886-6fcb3579b45f

Relates
- https://github.com/elastic/kibana/issues/229716
- https://github.com/elastic/kibana/issues/229818
- https://github.com/elastic/kibana/issues/220748