### PR TITLE
[Infra] Remove the icon from the Anomaly detection link

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/ml/anomaly_detection/anomaly_detection_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/ml/anomaly_detection/anomaly_detection_flyout.tsx
@@ -8,6 +8,7 @@
 import React, { useState, useCallback } from 'react';
 import { EuiHeaderLink, EuiFlyout } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { useMetricsDataViewContext } from '../../../containers/metrics_source';
 import { FlyoutHome } from './flyout_home';
 import { JobSetupScreen } from './job_setup_screen';
@@ -54,12 +55,7 @@ export const AnomalyDetectionFlyout = ({
 
   return (
     <>
-      <EuiHeaderLink
-        color="primary"
-        iconType="machineLearningApp"
-        onClick={openFlyout}
-        data-test-subj="openAnomalyFlyoutButton"
-      >
+      <EuiHeaderLink color="primary" onClick={openFlyout} data-test-subj="openAnomalyFlyoutButton">
         <FormattedMessage
           id="xpack.infra.ml.anomalyDetectionButton"
           defaultMessage="Anomaly detection"
@@ -68,15 +64,21 @@ export const AnomalyDetectionFlyout = ({
       {showFlyout && (
         <MetricHostsModuleProvider
           indexPattern={metricsView?.indices ?? ''}
-          sourceId={'default'}
+          sourceId="default"
           spaceId={space.id}
         >
           <MetricK8sModuleProvider
             indexPattern={metricsView?.indices ?? ''}
-            sourceId={'default'}
+            sourceId="default"
             spaceId={space.id}
           >
-            <EuiFlyout onClose={closeFlyout} data-test-subj="loadMLFlyout">
+            <EuiFlyout
+              onClose={closeFlyout}
+              data-test-subj="loadMLFlyout"
+              aria-label={i18n.translate('xpack.infra.ml.anomalyDetectionFlyoutAriaLabel', {
+                defaultMessage: 'Anomaly detection flyout',
+              })}
+            >
               {screenName === 'home' && (
                 <FlyoutHome
                   hasSetupCapabilities={hasInfraMLSetupCapabilities}


### PR DESCRIPTION
Closes #229879 

## Summary
This PR removes the icon from the Anomaly detection link in the infra apps

|Before|After|
|---------|--------|
| <img width="2100" height="864" alt="image" src="https://github.com/user-attachments/assets/4ad9e9a0-6695-43a1-9e60-08ea2c71538e" /> | <img width="2150" height="966" alt="image" src="https://github.com/user-attachments/assets/c31370cf-73b7-45e7-97a6-ef99d66537be" />|

 Hosts page: 
<img width="3612" height="674" alt="image" src="https://github.com/user-attachments/assets/3a2f2d7d-13fd-4a26-b305-6736395d17bf" />

It also adds a missing aria label pointed by the lint rule