### PR TITLE
[Asset Criticality] Immediate reflect asset criticality change in entity index

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/asset_criticality/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/asset_criticality/types.ts
@@ -24,4 +24,8 @@ export interface AssetCriticalityUpsertForBulkUpload extends BaseAssetCriticalit
   criticalityLevel: AssetCriticalityRecord['criticality_level'] | 'unassigned';
 }
 
+export interface AssetCriticalityUpdateEntityDestination extends BaseAssetCriticalityUpsert {
+  criticalityLevel: AssetCriticalityRecord['criticality_level'] | 'deleted';
+}
+
 export * from '../../api/entity_analytics/asset_criticality';

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_asset_inventory_refresh.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_asset_inventory_refresh.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useRefresh } from '@kbn/cloud-security-posture/src/hooks/use_refresh';
+import { QUERY_KEY_ASSET_INVENTORY } from '../constants';
+
+export const useAssetInventoryRefresh = () => {
+  const { refresh: assetInventoryRefresh, isRefreshing: assetInventoryIsRefreshing } =
+    useRefresh(QUERY_KEY_ASSET_INVENTORY);
+
+  return {
+    assetInventoryRefresh,
+    assetInventoryIsRefreshing,
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_asset_inventory_url_state/use_asset_inventory_url_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_asset_inventory_url_state/use_asset_inventory_url_state.ts
@@ -8,7 +8,7 @@ import { type Dispatch, type SetStateAction, useCallback } from 'react';
 import type { BoolQuery, Filter, Query } from '@kbn/es-query';
 import type { CriteriaWithPagination } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
-import { LOCAL_STORAGE_DATA_TABLE_COLUMNS_KEY } from '../../constants';
+import { ASSET_FIELDS, LOCAL_STORAGE_DATA_TABLE_COLUMNS_KEY } from '../../constants';
 import { useUrlQuery } from './use_url_query';
 import { usePageSize } from './use_page_size';
 import { useBaseEsQuery } from './use_base_es_query';
@@ -55,7 +55,7 @@ const getDefaultQuery = ({ query, filters }: AssetsBaseURLQuery) => ({
   query,
   filters,
   pageFilters: [],
-  sort: { field: '@timestamp', direction: 'desc' },
+  sort: { field: ASSET_FIELDS.TIMESTAMP, direction: 'desc' },
   pageIndex: 0,
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
@@ -25,6 +25,7 @@ import { useDataView } from '../hooks/use_data_view';
 import { DataViewContext } from '../hooks/data_view_context';
 
 import {
+  ASSET_FIELDS,
   ASSET_INVENTORY_DATA_VIEW_ID_PREFIX,
   LOCAL_STORAGE_COLUMNS_KEY,
   LOCAL_STORAGE_DATA_TABLE_PAGE_SIZE_KEY,
@@ -37,7 +38,7 @@ const getDefaultQuery = ({ query, filters, pageFilters }: AssetsBaseURLQuery): U
   query,
   filters,
   pageFilters,
-  sort: [['@timestamp', 'desc']],
+  sort: [[ASSET_FIELDS.TIMESTAMP, 'desc', ASSET_FIELDS.ENTITY_NAME, 'asc']],
 });
 
 export const AllAssets = () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_generic_entity_criticality.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_generic_entity_criticality.ts
@@ -6,6 +6,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAssetInventoryRefresh } from '../../../../asset_inventory/hooks/use_asset_inventory_refresh';
 import type {
   CriticalityLevelWithUnassigned,
   IdField,
@@ -16,6 +17,7 @@ import {
   useEntityAnalyticsRoutes,
 } from '../../../../entity_analytics/api/api';
 import type { AssetCriticalityRecord } from '../../../../../common/api/entity_analytics';
+import { GET_GENERIC_ENTITY_QUERY_KEY } from './use_get_generic_entity';
 
 const QUERY_KEY = 'generic-entity-asset-criticality';
 
@@ -37,6 +39,8 @@ export const useGenericEntityCriticality = ({
   const queryClient = useQueryClient();
   const { fetchAssetCriticality, createAssetCriticality, deleteAssetCriticality } =
     useEntityAnalyticsRoutes();
+
+  const { refreshAssetInventory } = useAssetInventoryRefresh();
 
   const genericEntityAssetCriticalityQueryKey = [QUERY_KEY, idField, idValue];
 
@@ -97,7 +101,9 @@ export const useGenericEntityCriticality = ({
     },
 
     onSuccess: () => {
-      queryClient.invalidateQueries(genericEntityAssetCriticalityQueryKey);
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [GET_GENERIC_ENTITY_QUERY_KEY] });
+      refreshAssetInventory();
     },
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_generic_entity_criticality.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_generic_entity_criticality.ts
@@ -40,7 +40,7 @@ export const useGenericEntityCriticality = ({
   const { fetchAssetCriticality, createAssetCriticality, deleteAssetCriticality } =
     useEntityAnalyticsRoutes();
 
-  const { refreshAssetInventory } = useAssetInventoryRefresh();
+  const { assetInventoryRefresh } = useAssetInventoryRefresh();
 
   const genericEntityAssetCriticalityQueryKey = [QUERY_KEY, idField, idValue];
 
@@ -103,7 +103,7 @@ export const useGenericEntityCriticality = ({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
       queryClient.invalidateQueries({ queryKey: [GET_GENERIC_ENTITY_QUERY_KEY] });
-      refreshAssetInventory();
+      assetInventoryRefresh();
     },
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_get_generic_entity.ts
@@ -17,6 +17,8 @@ import { useKibana } from '../../../../common/lib/kibana';
 type GenericEntityRequest = IKibanaSearchRequest<estypes.SearchRequest>;
 type GenericEntityResponse = IKibanaSearchResponse<estypes.SearchResponse<GenericEntityRecord>>;
 
+export const GET_GENERIC_ENTITY_QUERY_KEY = 'get-generic-entity-query-key';
+
 const fetchGenericEntity = async (
   dataService: DataPublicPluginStart,
   docId: string
@@ -37,7 +39,7 @@ export const useGetGenericEntity = (docId: string) => {
   const { data: dataService } = useKibana().services;
 
   const getGenericEntity = useQuery({
-    queryKey: ['use-get-generic-entity-key', docId],
+    queryKey: [GET_GENERIC_ENTITY_QUERY_KEY, docId],
     queryFn: () => fetchGenericEntity(dataService, docId),
     select: (response) => response.rawResponse.hits.hits[0], // extracting result out of ES
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { noop } from 'lodash/fp';
+import { useAssetInventoryRefresh } from '../../../asset_inventory/hooks/use_asset_inventory_refresh';
 import { buildEntityNameFilter } from '../../../../common/search_strategy';
 import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
 import type { Refetch } from '../../../common/types';
@@ -48,6 +49,8 @@ export const ServicePanel = ({ contextID, scopeId, serviceName }: ServicePanelPr
     () => (serviceName ? buildEntityNameFilter(EntityType.service, [serviceName]) : undefined),
     [serviceName]
   );
+
+  const { assetInventoryRefresh } = useAssetInventoryRefresh();
 
   const riskScoreState = useRiskScore({
     riskEntity: EntityType.service,
@@ -99,6 +102,11 @@ export const ServicePanel = ({ contextID, scopeId, serviceName }: ServicePanelPr
     [openDetailsPanel]
   );
 
+  const onAssetCriticalityChange = useCallback(() => {
+    calculateEntityRiskScore();
+    assetInventoryRefresh();
+  }, [assetInventoryRefresh, calculateEntityRiskScore]);
+
   if (observedService.isLoading) {
     return <FlyoutLoading />;
   }
@@ -116,7 +124,7 @@ export const ServicePanel = ({ contextID, scopeId, serviceName }: ServicePanelPr
         observedService={observedService}
         riskScoreState={riskScoreState}
         recalculatingScore={recalculatingScore}
-        onAssetCriticalityChange={calculateEntityRiskScore}
+        onAssetCriticalityChange={onAssetCriticalityChange}
         contextID={contextID}
         scopeId={scopeId}
         openDetailsPanel={openDetailsPanel}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { useAssetInventoryRefresh } from '../../../asset_inventory/hooks/use_asset_inventory_refresh';
 import { useNonClosedAlerts } from '../../../cloud_security_posture/hooks/use_non_closed_alerts';
 import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_refetch_query_by_id';
 import type { Refetch } from '../../../common/types';
@@ -59,6 +60,8 @@ const FIRST_RECORD_PAGINATION = {
 export const UserPanel = ({ contextID, scopeId, userName, isPreviewMode }: UserPanelProps) => {
   const { uiSettings } = useKibana().services;
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
+
+  const { assetInventoryRefresh } = useAssetInventoryRefresh();
 
   const userNameFilterQuery = useMemo(
     () => (userName ? buildUserNamesFilter([userName]) : undefined),
@@ -135,6 +138,11 @@ export const UserPanel = ({ contextID, scopeId, userName, isPreviewMode }: UserP
     [isRiskScoreExist, openDetailsPanel]
   );
 
+  const onAssetCriticalityChange = useCallback(() => {
+    calculateEntityRiskScore();
+    assetInventoryRefresh();
+  }, [assetInventoryRefresh, calculateEntityRiskScore]);
+
   const hasUserDetailsData =
     !!userRiskData?.user.risk ||
     !!managedUser.data?.[ManagedUserDatasetKey.OKTA] ||
@@ -181,7 +189,7 @@ export const UserPanel = ({ contextID, scopeId, userName, isPreviewMode }: UserP
               observedUser={observedUserWithAnomalies}
               riskScoreState={riskScoreState}
               recalculatingScore={recalculatingScore}
-              onAssetCriticalityChange={calculateEntityRiskScore}
+              onAssetCriticalityChange={onAssetCriticalityChange}
               contextID={contextID}
               scopeId={scopeId}
               openDetailsPanel={openDetailsPanel}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
@@ -9,15 +9,23 @@ import { loggingSystemMock, elasticsearchServiceMock } from '@kbn/core/server/mo
 import { Readable } from 'stream';
 import { AssetCriticalityDataClient } from './asset_criticality_data_client';
 import { createOrUpdateIndex } from '../utils/create_or_update_index';
+import { createEventIngestedPipeline } from '../utils/event_ingested_pipeline';
 import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
 import type { AssetCriticalityUpsert } from '../../../../common/entity_analytics/asset_criticality/types';
 import type { ElasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import { CRITICALITY_VALUES } from './constants';
 
 type MockInternalEsClient = ReturnType<
   typeof elasticsearchServiceMock.createScopedClusterClient
 >['asInternalUser'];
 jest.mock('../utils/create_or_update_index', () => ({
   createOrUpdateIndex: jest.fn(),
+}));
+jest.mock('../utils/event_ingested_pipeline', () => ({
+  createEventIngestedPipeline: jest.fn(),
+  getIngestPipelineName: jest.fn(
+    (namespace) => `entity_analytics_create_eventIngest_from_timestamp-pipeline-${namespace}`
+  ),
 }));
 
 describe('AssetCriticalityDataClient', () => {
@@ -36,6 +44,7 @@ describe('AssetCriticalityDataClient', () => {
 
       await assetCriticalityDataClient.init();
 
+      expect(createEventIngestedPipeline).toHaveBeenCalledWith(esClientInternal, 'default');
       expect(createOrUpdateIndex).toHaveBeenCalledWith({
         esClient: esClientInternal,
         logger,
@@ -219,6 +228,85 @@ describe('AssetCriticalityDataClient', () => {
         expect.objectContaining({ ignore_unavailable: true })
       );
     });
+
+    it('applies a post_filter to exclude deleted records', async () => {
+      await subject.search({ query: { match_all: {} } });
+
+      expect(esClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          post_filter: {
+            bool: {
+              must_not: {
+                term: { criticality_level: CRITICALITY_VALUES.DELETED },
+              },
+            },
+          },
+        })
+      );
+    });
+
+    it('applies a default sort by @timestamp', async () => {
+      await subject.search({ query: { match_all: {} } });
+
+      expect(esClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: ['@timestamp'] })
+      );
+    });
+  });
+
+  describe('#searchByKuery()', () => {
+    let esClientMock: MockInternalEsClient;
+    let loggerMock: ReturnType<typeof loggingSystemMock.createLogger>;
+    let subject: AssetCriticalityDataClient;
+
+    beforeEach(() => {
+      esClientMock = elasticsearchServiceMock.createScopedClusterClient().asInternalUser;
+      loggerMock = loggingSystemMock.createLogger();
+      subject = new AssetCriticalityDataClient({
+        esClient: esClientMock,
+        logger: loggerMock,
+        namespace: 'default',
+        auditLogger: mockAuditLogger,
+      });
+    });
+
+    it('converts kuery to elasticsearch query and calls search', async () => {
+      await subject.searchByKuery({ kuery: 'criticality_level: "high_impact"' });
+
+      expect(esClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.any(Object),
+          index: '.asset-criticality.asset-criticality-default',
+        })
+      );
+    });
+
+    it('uses match_all query when no kuery is provided', async () => {
+      await subject.searchByKuery({});
+
+      expect(esClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { match_all: {} },
+        })
+      );
+    });
+
+    it('passes through size, from, and sort parameters', async () => {
+      await subject.searchByKuery({
+        kuery: 'criticality_level: "high_impact"',
+        size: 50,
+        from: 10,
+        sort: [{ '@timestamp': 'desc' }],
+      });
+
+      expect(esClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: 50,
+          from: 10,
+          sort: [{ '@timestamp': 'desc' }],
+        })
+      );
+    });
   });
 
   describe('#upsert()', () => {
@@ -235,6 +323,9 @@ describe('AssetCriticalityDataClient', () => {
         namespace: 'default',
         auditLogger: mockAuditLogger,
       });
+
+      // Mock the updateByQuery method for entity destination updates
+      esClientMock.updateByQuery.mockResolvedValue({ total: 1, updated: 1, failures: [] });
     });
 
     it('created "host" records in the asset criticality index', async () => {
@@ -301,6 +392,123 @@ describe('AssetCriticalityDataClient', () => {
           doc_as_upsert: true,
         })
       );
+    });
+
+    it('updates the entity destination index during upsert for host records', async () => {
+      const record: AssetCriticalityUpsert = {
+        idField: 'host.name',
+        idValue: 'host1',
+        criticalityLevel: 'high_impact',
+      };
+
+      await subject.upsert(record);
+
+      expect(esClientMock.updateByQuery).toHaveBeenCalledWith({
+        index: '.entities.v1.latest.security_host_default',
+        refresh: true,
+        conflicts: 'proceed',
+        query: { term: { 'host.name': 'host1' } },
+        script: {
+          source:
+            'if (ctx._source.asset == null) { ctx._source.asset = [:]; } ctx._source.asset.criticality = params.level;',
+          params: { level: 'high_impact' },
+        },
+      });
+    });
+
+    it('updates the entity destination index during upsert for user records', async () => {
+      const record: AssetCriticalityUpsert = {
+        idField: 'user.name',
+        idValue: 'user1',
+        criticalityLevel: 'medium_impact',
+      };
+
+      await subject.upsert(record);
+
+      expect(esClientMock.updateByQuery).toHaveBeenCalledWith({
+        index: '.entities.v1.latest.security_user_default',
+        refresh: true,
+        conflicts: 'proceed',
+        query: { term: { 'user.name': 'user1' } },
+        script: {
+          source:
+            'if (ctx._source.asset == null) { ctx._source.asset = [:]; } ctx._source.asset.criticality = params.level;',
+          params: { level: 'medium_impact' },
+        },
+      });
+    });
+
+    it('updates the entity destination index during upsert for service records', async () => {
+      const record: AssetCriticalityUpsert = {
+        idField: 'service.name',
+        idValue: 'service1',
+        criticalityLevel: 'low_impact',
+      };
+
+      await subject.upsert(record);
+
+      expect(esClientMock.updateByQuery).toHaveBeenCalledWith({
+        index: '.entities.v1.latest.security_service_default',
+        refresh: true,
+        conflicts: 'proceed',
+        query: { term: { 'service.name': 'service1' } },
+        script: {
+          source:
+            'if (ctx._source.asset == null) { ctx._source.asset = [:]; } ctx._source.asset.criticality = params.level;',
+          params: { level: 'low_impact' },
+        },
+      });
+    });
+
+    it('updates the entity destination index during upsert for generic records', async () => {
+      const record: AssetCriticalityUpsert = {
+        idField: 'entity.id',
+        idValue: 'generic1',
+        criticalityLevel: 'medium_impact',
+      };
+
+      await subject.upsert(record);
+
+      expect(esClientMock.updateByQuery).toHaveBeenCalledWith({
+        index: '.entities.v1.latest.security_generic_default',
+        refresh: true,
+        conflicts: 'proceed',
+        query: { term: { 'entity.id': 'generic1' } },
+        script: {
+          source:
+            'if (ctx._source.asset == null) { ctx._source.asset = [:]; } ctx._source.asset.criticality = params.level;',
+          params: { level: 'medium_impact' },
+        },
+      });
+    });
+
+    it('updates the entity destination index with a different namespace', async () => {
+      const record: AssetCriticalityUpsert = {
+        idField: 'host.name',
+        idValue: 'host1',
+        criticalityLevel: 'high_impact',
+      };
+
+      const subjectWithNamespace = new AssetCriticalityDataClient({
+        esClient: esClientMock,
+        logger: loggerMock,
+        namespace: 'other-namespace',
+        auditLogger: mockAuditLogger,
+      });
+
+      await subjectWithNamespace.upsert(record);
+
+      expect(esClientMock.updateByQuery).toHaveBeenCalledWith({
+        index: '.entities.v1.latest.security_host_other-namespace',
+        refresh: true,
+        conflicts: 'proceed',
+        query: { term: { 'host.name': 'host1' } },
+        script: {
+          source:
+            'if (ctx._source.asset == null) { ctx._source.asset = [:]; } ctx._source.asset.criticality = params.level;',
+          params: { level: 'high_impact' },
+        },
+      });
     });
   });
 
@@ -390,6 +598,218 @@ describe('AssetCriticalityDataClient', () => {
           total: 1,
         },
       });
+    });
+  });
+
+  describe('#get()', () => {
+    let esClientMock: MockInternalEsClient;
+    let loggerMock: ReturnType<typeof loggingSystemMock.createLogger>;
+    let subject: AssetCriticalityDataClient;
+
+    beforeEach(() => {
+      esClientMock = elasticsearchServiceMock.createScopedClusterClient().asInternalUser;
+      loggerMock = loggingSystemMock.createLogger();
+      subject = new AssetCriticalityDataClient({
+        esClient: esClientMock,
+        logger: loggerMock,
+        namespace: 'default',
+        auditLogger: mockAuditLogger,
+      });
+    });
+
+    it('returns undefined for deleted records', async () => {
+      esClientMock.get.mockResolvedValue({
+        _index: '.asset-criticality.asset-criticality-default',
+        _id: 'host.name:host1',
+        _version: 1,
+        _seq_no: 0,
+        _primary_term: 1,
+        found: true,
+        _source: {
+          id_field: 'host.name',
+          id_value: 'host1',
+          criticality_level: CRITICALITY_VALUES.DELETED,
+          '@timestamp': new Date().toISOString(),
+        },
+      });
+
+      const result = await subject.get({ idField: 'host.name', idValue: 'host1' });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the record for non-deleted records', async () => {
+      const mockRecord = {
+        id_field: 'host.name',
+        id_value: 'host1',
+        criticality_level: 'high_impact',
+        '@timestamp': new Date().toISOString(),
+        asset: {
+          criticality: 'high_impact',
+        },
+        host: {
+          name: 'host1',
+          asset: {
+            criticality: 'high_impact',
+          },
+        },
+      };
+
+      esClientMock.get.mockResolvedValue({
+        _index: '.asset-criticality.asset-criticality-default',
+        _id: 'host.name:host1',
+        _version: 1,
+        _seq_no: 0,
+        _primary_term: 1,
+        found: true,
+        _source: mockRecord,
+      });
+
+      const result = await subject.get({ idField: 'host.name', idValue: 'host1' });
+
+      expect(result).toEqual(mockRecord);
+    });
+
+    it('returns undefined for 404 errors', async () => {
+      esClientMock.get.mockRejectedValue({ statusCode: 404 });
+
+      const result = await subject.get({ idField: 'host.name', idValue: 'host1' });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('#delete()', () => {
+    let esClientMock: MockInternalEsClient;
+    let loggerMock: ReturnType<typeof loggingSystemMock.createLogger>;
+    let subject: AssetCriticalityDataClient;
+
+    beforeEach(() => {
+      esClientMock = elasticsearchServiceMock.createScopedClusterClient().asInternalUser;
+      loggerMock = loggingSystemMock.createLogger();
+      subject = new AssetCriticalityDataClient({
+        esClient: esClientMock,
+        logger: loggerMock,
+        namespace: 'default',
+        auditLogger: mockAuditLogger,
+      });
+
+      // Mock the updateByQuery method for entity destination updates
+      esClientMock.updateByQuery.mockResolvedValue({
+        took: 1,
+        timed_out: false,
+        total: 1,
+        updated: 1,
+        deleted: 0,
+        batches: 1,
+        version_conflicts: 0,
+        noops: 0,
+        retries: {
+          bulk: 0,
+          search: 0,
+        },
+        throttled_millis: 0,
+        requests_per_second: -1,
+        throttled_until_millis: 0,
+        failures: [],
+      });
+    });
+
+    it('marks records as deleted instead of physically deleting them', async () => {
+      const existingRecord = {
+        id_field: 'host.name',
+        id_value: 'host1',
+        criticality_level: 'high_impact',
+        '@timestamp': new Date().toISOString(),
+        asset: {
+          criticality: 'high_impact',
+        },
+        host: {
+          name: 'host1',
+          asset: {
+            criticality: 'high_impact',
+          },
+        },
+      };
+
+      esClientMock.get.mockResolvedValue({
+        _index: '.asset-criticality.asset-criticality-default',
+        _id: 'host.name:host1',
+        _version: 1,
+        _seq_no: 0,
+        _primary_term: 1,
+        found: true,
+        _source: existingRecord,
+      });
+
+      const result = await subject.delete({ idField: 'host.name', idValue: 'host1' });
+
+      expect(esClientMock.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'host.name:host1',
+          index: '.asset-criticality.asset-criticality-default',
+          doc: expect.objectContaining({
+            criticality_level: CRITICALITY_VALUES.DELETED,
+            asset: {
+              criticality: CRITICALITY_VALUES.DELETED,
+            },
+            '@timestamp': expect.any(String),
+          }),
+        })
+      );
+
+      expect(result).toEqual(existingRecord);
+    });
+
+    it('updates the entity destination index during delete', async () => {
+      const existingRecord = {
+        id_field: 'host.name',
+        id_value: 'host1',
+        criticality_level: 'high_impact',
+        '@timestamp': new Date().toISOString(),
+        asset: {
+          criticality: 'high_impact',
+        },
+        host: {
+          name: 'host1',
+          asset: {
+            criticality: 'high_impact',
+          },
+        },
+      };
+
+      esClientMock.get.mockResolvedValue({
+        _index: '.asset-criticality.asset-criticality-default',
+        _id: 'host.name:host1',
+        _version: 1,
+        _seq_no: 0,
+        _primary_term: 1,
+        found: true,
+        _source: existingRecord,
+      });
+
+      await subject.delete({ idField: 'host.name', idValue: 'host1' });
+
+      expect(esClientMock.updateByQuery).toHaveBeenCalledWith({
+        index: '.entities.v1.latest.security_host_default',
+        refresh: true,
+        conflicts: 'proceed',
+        query: { term: { 'host.name': 'host1' } },
+        script: {
+          source:
+            'if (ctx._source.asset == null) { ctx._source.asset = [:]; } ctx._source.asset.criticality = params.level;',
+          params: { level: CRITICALITY_VALUES.DELETED },
+        },
+      });
+    });
+
+    it('returns undefined if the record does not exist', async () => {
+      esClientMock.get.mockRejectedValue({ statusCode: 404 });
+
+      const result = await subject.delete({ idField: 'host.name', idValue: 'host1' });
+
+      expect(result).toBeUndefined();
+      expect(esClientMock.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -380,6 +380,8 @@ export class AssetCriticalityDataClient {
     const index = getEntitiesIndexName(entityType, this.options.namespace);
 
     try {
+      // TODO: Change to internal Es client once https://github.com/elastic/elasticsearch/pull/129662 is merged
+      // So users won't require write permissions to the entities index
       await this.options.esClient.updateByQuery({
         index,
         refresh: refresh ? true : false,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/helpers.ts
@@ -85,7 +85,7 @@ type AssetCriticalityRecordWithDeleted = {
     : AssetCriticalityRecord[K];
 };
 
-const entityTypeByIdField = {
+export const entityTypeByIdField = {
   'host.name': 'host',
   'user.name': 'user',
   'service.name': 'service',


### PR DESCRIPTION
## Summary

It closes #226418 and https://github.com/elastic/security-team/issues/11319

This PR focuses on updates to the Asset Criticality feature. The main change was to implement a new method `updateEntityDestination` in `AssetCriticalityDataClient` to update entity destinations in Elasticsearch on criticality changes. This enhances the User Experience as users can immediately see the updated criticality in the experiences that use Dataviews based on the `.entities` indices 

**Other changes:**

* Introduced a new hook `useAssetInventoryRefresh` to manage asset inventory state refreshes. 
* Integrated `useAssetInventoryRefresh` into various components, including `HostPanel`, `ServicePanel`, and `UserPanel`, to trigger asset inventory updates on criticality changes. 
* Standardized query keys in `use_generic_entity_criticality` and `use_get_generic_entity` hooks for consistency and better query management. 
* Replaced hardcoded timestamp fields with `ASSET_FIELDS.TIMESTAMP` for better maintainability. 


## Recording

https://github.com/user-attachments/assets/05c9287a-5834-4217-b1a4-29e0278150d4

