### PR TITLE
[9.1] [SecuritySolution] Improve Privileged user activity dashboards bucket granularity (#229408)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.test.tsx
@@ -94,7 +94,10 @@ describe('EsqlDashboardPanel', () => {
   it('calls generateVisualizationQuery with the selected stackBy option', () => {
     render(<EsqlDashboardPanel {...mockProps} />, { wrapper: TestProviders });
 
-    expect(mockProps.generateVisualizationQuery).toHaveBeenCalledWith('option1');
+    expect(mockProps.generateVisualizationQuery).toHaveBeenCalledWith(
+      'option1',
+      mockProps.timerange
+    );
   });
 
   it('renders the table with the provided columns', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
@@ -48,7 +48,7 @@ export const EsqlDashboardPanel = <TableItemType extends Record<string, string>>
 }: {
   title: ReactNode;
   stackByField: string;
-  generateVisualizationQuery: (stackByValue: string) => string;
+  generateVisualizationQuery: (stackByValue: string, timerange: { from: string; to: string }) => string;
   generateTableQuery: (
     sortField: keyof TableItemType,
     sortDirection: 'asc' | 'desc',
@@ -71,8 +71,8 @@ export const EsqlDashboardPanel = <TableItemType extends Record<string, string>>
   );
 
   const visualizationQuery = useMemo(
-    () => generateVisualizationQuery(stackByField),
-    [generateVisualizationQuery, stackByField]
+    () => generateVisualizationQuery(stackByField, timerange),
+    [generateVisualizationQuery, stackByField, timerange]
   );
 
   const {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/esql_dashboard_panel/esql_dashboard_panel.tsx
@@ -48,7 +48,10 @@ export const EsqlDashboardPanel = <TableItemType extends Record<string, string>>
 }: {
   title: ReactNode;
   stackByField: string;
-  generateVisualizationQuery: (stackByValue: string, timerange: { from: string; to: string }) => string;
+  generateVisualizationQuery: (
+    stackByValue: string,
+    timerange: { from: string; to: string }
+  ) => string;
   generateTableQuery: (
     sortField: keyof TableItemType,
     sortDirection: 'asc' | 'desc',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/__snapshots__/esql_data_generation.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/__snapshots__/esql_data_generation.test.ts.snap
@@ -24,6 +24,5 @@ exports[`esql_data_generation generateVisualizationESQLQuery should generate the
             | EVAL row = SPLIT(data, \\",\\")
             | EVAL privileged_user = MV_SLICE(row, 0), target_user = MV_SLICE(row, 1), right = MV_SLICE(row, 2), ip = MV_SLICE(row, 3), @timestamp = MV_SLICE(row, 4)
             | DROP row
-    | EVAL timestamp=DATE_TRUNC(1 hour, TO_DATETIME(@timestamp))
-    | STATS results = COUNT(*) by timestamp, target_user"
+    | STATS results = COUNT(*) by timestamp = BUCKET(@timestamp, 30, \\"2025-03-06T12:00:00.000Z\\", \\"2025-03-07T11:00:00.000Z\\"), target_user"
 `;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/esql_data_generation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/esql_data_generation.test.ts
@@ -63,7 +63,10 @@ describe('esql_data_generation', () => {
   describe('generateVisualizationESQLQuery', () => {
     it('should generate the correct ESQL query for visualization', () => {
       const generateQuery = generateVisualizationESQLQuery(generateESQLSource());
-      const query = generateQuery('target_user');
+      const query = generateQuery('target_user', {
+        from: '2025-03-06T12:00:00.000Z',
+        to: '2025-03-07T11:00:00.000Z',
+      });
       expect(query).toMatchSnapshot();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/esql_data_generation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/esql_data_generation.ts
@@ -50,7 +50,6 @@ export const generateListESQLQuery =
         | SORT ${String(sortField)} ${sortDirection}
         | LIMIT ${1 + currentPage * PAGE_SIZE}`; // Load one extra item for the pagination
 
-export const generateVisualizationESQLQuery = (esqlSource: string) => (stackByField: string) =>
+export const generateVisualizationESQLQuery = (esqlSource: string) => (stackByField: string, timerange: { from: string; to: string }) =>
   `${esqlSource}
-    | EVAL timestamp=DATE_TRUNC(1 hour, TO_DATETIME(@timestamp))
-    | STATS results = COUNT(*) by timestamp, ${stackByField}`;
+    | STATS results = COUNT(*) by timestamp = BUCKET(@timestamp, 30, "${timerange.from}", "${timerange.to}"), ${stackByField}`

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/esql_data_generation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/components/sample_dashboard/esql_data_generation.ts
@@ -50,6 +50,7 @@ export const generateListESQLQuery =
         | SORT ${String(sortField)} ${sortDirection}
         | LIMIT ${1 + currentPage * PAGE_SIZE}`; // Load one extra item for the pagination
 
-export const generateVisualizationESQLQuery = (esqlSource: string) => (stackByField: string, timerange: { from: string; to: string }) =>
-  `${esqlSource}
-    | STATS results = COUNT(*) by timestamp = BUCKET(@timestamp, 30, "${timerange.from}", "${timerange.to}"), ${stackByField}`
+export const generateVisualizationESQLQuery =
+  (esqlSource: string) => (stackByField: string, timerange: { from: string; to: string }) =>
+    `${esqlSource}
+    | STATS results = COUNT(*) by timestamp = BUCKET(@timestamp, 30, "${timerange.from}", "${timerange.to}"), ${stackByField}`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[SecuritySolution] Improve Privileged user activity dashboards bucket granularity (#229408)](https://github.com/elastic/kibana/pull/229408)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-07-28T13:10:33Z","message":"[SecuritySolution] Improve Privileged user activity dashboards bucket granularity (#229408)\n\n## Summary\n\nImprove Privileged user activity dashboards bucket granularity\n\n### Before\nThe bucket size was always one hour, so when the user picked a long\ntimerange like 3 months, it would produce tiny buckets:\n\n<img width=\"2924\" height=\"930\" alt=\"Screenshot 2025-07-25 at 10 11 47\"\nsrc=\"https://github.com/user-attachments/assets/604b4fdd-6ff8-4c9b-9b95-3aa1f9b23939\"\n/>\n<img width=\"2926\" height=\"914\" alt=\"Screenshot 2025-07-25 at 10 32 24\"\nsrc=\"https://github.com/user-attachments/assets/0a6177fa-5603-491b-9d14-2dbdd7e72bc8\"\n/>\n<img width=\"2922\" height=\"918\" alt=\"Screenshot 2025-07-25 at 10 11 14\"\nsrc=\"https://github.com/user-attachments/assets/54a26762-3d81-44b3-9d72-7845bd414cec\"\n/>\n\n\n### After \nWe are using [ESQL\nBUCKET](https://www.elastic.co/docs/reference/query-languages/esql/functions-operators/grouping-functions),\nwhich automatically selects the bucket size based on the provided\ntimerange. We can also set the maximum bucket size. I chose 30 for no\nparticular reason, except that it looks good 🤷\n\n\n<img width=\"2918\" height=\"922\" alt=\"Screenshot 2025-07-25 at 10 10 23\"\nsrc=\"https://github.com/user-attachments/assets/3f470daf-9e71-449e-b27d-b6d5c2e00df1\"\n/>\n<img width=\"2918\" height=\"984\" alt=\"Screenshot 2025-07-25 at 10 10 11\"\nsrc=\"https://github.com/user-attachments/assets/f731c520-4b54-4667-964a-9bc6551a10be\"\n/>\n<img width=\"2906\" height=\"912\" alt=\"Screenshot 2025-07-25 at 10 10 38\"\nsrc=\"https://github.com/user-attachments/assets/579ad221-236d-4aa8-b485-d8d5d7875e5f\"\n/>\n\n\n\n***All visualisations have generated data for the last 30days\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"57acadcecbfa998a9be7eb752137d60273309af2","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v9.1.0","v9.2.0"],"title":"[SecuritySolution] Improve Privileged user activity dashboards bucket granularity","number":229408,"url":"https://github.com/elastic/kibana/pull/229408","mergeCommit":{"message":"[SecuritySolution] Improve Privileged user activity dashboards bucket granularity (#229408)\n\n## Summary\n\nImprove Privileged user activity dashboards bucket granularity\n\n### Before\nThe bucket size was always one hour, so when the user picked a long\ntimerange like 3 months, it would produce tiny buckets:\n\n<img width=\"2924\" height=\"930\" alt=\"Screenshot 2025-07-25 at 10 11 47\"\nsrc=\"https://github.com/user-attachments/assets/604b4fdd-6ff8-4c9b-9b95-3aa1f9b23939\"\n/>\n<img width=\"2926\" height=\"914\" alt=\"Screenshot 2025-07-25 at 10 32 24\"\nsrc=\"https://github.com/user-attachments/assets/0a6177fa-5603-491b-9d14-2dbdd7e72bc8\"\n/>\n<img width=\"2922\" height=\"918\" alt=\"Screenshot 2025-07-25 at 10 11 14\"\nsrc=\"https://github.com/user-attachments/assets/54a26762-3d81-44b3-9d72-7845bd414cec\"\n/>\n\n\n### After \nWe are using [ESQL\nBUCKET](https://www.elastic.co/docs/reference/query-languages/esql/functions-operators/grouping-functions),\nwhich automatically selects the bucket size based on the provided\ntimerange. We can also set the maximum bucket size. I chose 30 for no\nparticular reason, except that it looks good 🤷\n\n\n<img width=\"2918\" height=\"922\" alt=\"Screenshot 2025-07-25 at 10 10 23\"\nsrc=\"https://github.com/user-attachments/assets/3f470daf-9e71-449e-b27d-b6d5c2e00df1\"\n/>\n<img width=\"2918\" height=\"984\" alt=\"Screenshot 2025-07-25 at 10 10 11\"\nsrc=\"https://github.com/user-attachments/assets/f731c520-4b54-4667-964a-9bc6551a10be\"\n/>\n<img width=\"2906\" height=\"912\" alt=\"Screenshot 2025-07-25 at 10 10 38\"\nsrc=\"https://github.com/user-attachments/assets/579ad221-236d-4aa8-b485-d8d5d7875e5f\"\n/>\n\n\n\n***All visualisations have generated data for the last 30days\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"57acadcecbfa998a9be7eb752137d60273309af2"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229408","number":229408,"mergeCommit":{"message":"[SecuritySolution] Improve Privileged user activity dashboards bucket granularity (#229408)\n\n## Summary\n\nImprove Privileged user activity dashboards bucket granularity\n\n### Before\nThe bucket size was always one hour, so when the user picked a long\ntimerange like 3 months, it would produce tiny buckets:\n\n<img width=\"2924\" height=\"930\" alt=\"Screenshot 2025-07-25 at 10 11 47\"\nsrc=\"https://github.com/user-attachments/assets/604b4fdd-6ff8-4c9b-9b95-3aa1f9b23939\"\n/>\n<img width=\"2926\" height=\"914\" alt=\"Screenshot 2025-07-25 at 10 32 24\"\nsrc=\"https://github.com/user-attachments/assets/0a6177fa-5603-491b-9d14-2dbdd7e72bc8\"\n/>\n<img width=\"2922\" height=\"918\" alt=\"Screenshot 2025-07-25 at 10 11 14\"\nsrc=\"https://github.com/user-attachments/assets/54a26762-3d81-44b3-9d72-7845bd414cec\"\n/>\n\n\n### After \nWe are using [ESQL\nBUCKET](https://www.elastic.co/docs/reference/query-languages/esql/functions-operators/grouping-functions),\nwhich automatically selects the bucket size based on the provided\ntimerange. We can also set the maximum bucket size. I chose 30 for no\nparticular reason, except that it looks good 🤷\n\n\n<img width=\"2918\" height=\"922\" alt=\"Screenshot 2025-07-25 at 10 10 23\"\nsrc=\"https://github.com/user-attachments/assets/3f470daf-9e71-449e-b27d-b6d5c2e00df1\"\n/>\n<img width=\"2918\" height=\"984\" alt=\"Screenshot 2025-07-25 at 10 10 11\"\nsrc=\"https://github.com/user-attachments/assets/f731c520-4b54-4667-964a-9bc6551a10be\"\n/>\n<img width=\"2906\" height=\"912\" alt=\"Screenshot 2025-07-25 at 10 10 38\"\nsrc=\"https://github.com/user-attachments/assets/579ad221-236d-4aa8-b485-d8d5d7875e5f\"\n/>\n\n\n\n***All visualisations have generated data for the last 30days\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"57acadcecbfa998a9be7eb752137d60273309af2"}}]}] BACKPORT-->