### PR TITLE
🌊 Streams: Fix unwired/classic rename for existing streams

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/migrate_on_read.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/migrate_on_read.ts
@@ -10,11 +10,30 @@ import { BaseStream } from '@kbn/streams-schema/src/models/base';
 
 export function migrateOnRead(definition: Record<string, unknown>): Streams.all.Definition {
   let migratedDefinition = definition;
-  if (typeof definition.description !== 'string') {
+  // Add required description
+  if (typeof migratedDefinition.description !== 'string') {
     migratedDefinition = {
-      ...definition,
+      ...migratedDefinition,
       description: '',
     };
+  }
+  // Rename unwired to classic
+  if (
+    typeof migratedDefinition.ingest === 'object' &&
+    migratedDefinition.ingest &&
+    'unwired' in migratedDefinition.ingest &&
+    typeof migratedDefinition.ingest.unwired === 'object'
+  ) {
+    migratedDefinition = {
+      ...migratedDefinition,
+      ingest: {
+        ...migratedDefinition.ingest,
+        classic: {
+          ...migratedDefinition.ingest.unwired,
+        },
+      },
+    };
+    delete (migratedDefinition.ingest as { unwired?: {} }).unwired;
   }
   Streams.all.Definition.asserts(migratedDefinition as unknown as BaseStream.Definition);
 

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
@@ -57,7 +57,7 @@ const streamDefinition = {
         },
       },
     ],
-    classic: {},
+    unwired: {},
   },
 };
 


### PR DESCRIPTION
Follow-up for https://github.com/elastic/kibana/pull/229755 - I forgot about existing stream definitions in existing clusters. Since we had a similar case before for the introduction of the `description` field, this PR uses the infrastructure put in place back then for migrating existing documents on read.