### PR TITLE
update transform codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -940,7 +940,7 @@ x-pack/platform/plugins/private/runtime_fields @elastic/kibana-management
 x-pack/platform/plugins/private/snapshot_restore @elastic/kibana-management
 x-pack/platform/plugins/private/task_manager_dependencies @elastic/response-ops
 x-pack/platform/plugins/private/telemetry_collection_xpack @elastic/kibana-core
-x-pack/platform/plugins/private/transform @elastic/ml-ui @elastic/kibana-management
+x-pack/platform/plugins/private/transform @elastic/kibana-management
 x-pack/platform/plugins/private/translations @elastic/kibana-localization
 x-pack/platform/plugins/private/upgrade_assistant @elastic/kibana-management
 x-pack/platform/plugins/private/watcher @elastic/kibana-management
@@ -1719,11 +1719,9 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/config.ts @elastic/ml-ui
 /x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/ml/ @elastic/ml-ui
 /x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/ml_rule_types/ @elastic/ml-ui
-/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/ml-ui @elastic/kibana-management
 /x-pack/platform/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
 /x-pack/platform/test/screenshot_creation/services/ml_screenshots.ts @elastic/ml-ui
 /x-pack/test_serverless/**/test_suites/**/ml/ @elastic/ml-ui
-/x-pack/test_serverless/**/test_suites/common/management/transforms/ @elastic/ml-ui @elastic/kibana-management
 /x-pack/test/api_integration/services/ml.ts @elastic/ml-ui
 
 # Security Machine Learning
@@ -1731,19 +1729,23 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 
 # Additional plugins and packages maintained by the ML team.
 /src/platform/test/examples/response_stream/*.ts @elastic/ml-ui
-/x-pack/platform/test/accessibility/apps/group2/transform.ts  @elastic/ml-ui @elastic/kibana-management
 /x-pack/platform/test/api_integration/apis/aiops/ @elastic/ml-ui
-/x-pack/platform/test/api_integration/apis/transform/ @elastic/ml-ui @elastic/kibana-management
 /x-pack/platform/test/api_integration_basic/apis/aiops @elastic/ml-ui
-/x-pack/platform/test/api_integration_basic/apis/transform/ @elastic/ml-ui @elastic/kibana-management
 /x-pack/test/api_integration/services/aiops.ts @elastic/ml-ui
-/x-pack/test/api_integration/services/transform.ts @elastic/ml-ui @elastic/kibana-management
 /x-pack/platform/test/functional/apps/aiops @elastic/ml-ui
-/x-pack/platform/test/functional/apps/transform/ @elastic/ml-ui @elastic/kibana-management
 /x-pack/platform/test/fixtures/es_archives/large_arrays @elastic/ml-ui # Assigned per usages
-/x-pack/platform/test/functional/services/transform @elastic/ml-ui @elastic/kibana-management
 /x-pack/platform/test/functional/services/aiops @elastic/ml-ui
-/x-pack/platform/test/functional_basic/apps/transform/ @elastic/ml-ui @elastic/kibana-management
+
+# Transforms maintained by the Kibana Management team.
+/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/kibana-management
+/x-pack/test_serverless/**/test_suites/common/management/transforms/ @elastic/kibana-management
+/x-pack/platform/test/accessibility/apps/group2/transform.ts @elastic/kibana-management
+/x-pack/platform/test/api_integration/apis/transform/ @elastic/kibana-management
+/x-pack/platform/test/api_integration_basic/apis/transform/ @elastic/kibana-management
+/x-pack/test/api_integration/services/transform.ts @elastic/kibana-management
+/x-pack/platform/test/functional/apps/transform/ @elastic/kibana-management
+/x-pack/platform/test/functional/services/transform @elastic/kibana-management
+/x-pack/platform/test/functional_basic/apps/transform/ @elastic/kibana-management
 
 # Operations
 /src/platform/test/package @elastic/kibana-operations

--- a/x-pack/platform/plugins/private/transform/kibana.jsonc
+++ b/x-pack/platform/plugins/private/transform/kibana.jsonc
@@ -2,7 +2,6 @@
   "type": "plugin",
   "id": "@kbn/transform-plugin",
   "owner": [
-    "@elastic/ml-ui",
     "@elastic/kibana-management"
   ],
   "group": "platform",


### PR DESCRIPTION
## Summary

Follow up to #218808.

Updates CODEOWNERS for transforms so `elastic/kibana-management` are the only code owners.