### PR TITLE
[Security solution][Alerts] Fix custom field grouping

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
@@ -30,6 +30,7 @@ import { useDataTableFilters } from '../../../common/hooks/use_data_table_filter
 import { useDeepEqualSelector, useShallowEqualSelector } from '../../../common/hooks/use_selector';
 import { AdditionalFiltersAction } from './additional_filters_action';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 
 const { changeViewMode } = dataTableActions;
 
@@ -48,6 +49,7 @@ const AdditionalToolbarControlsComponent = ({
     SourcererScopeName.detections
   );
 
+  const isNewDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
 
   const groupId = useMemo(() => groupIdSelector(), []);
@@ -79,10 +81,10 @@ const AdditionalToolbarControlsComponent = ({
 
   const fields = useMemo(
     () =>
-      experimentalDataView
+      isNewDataViewPickerEnabled
         ? experimentalDataView.fields.map((field) => field.spec)
         : Object.values(oldSourcererDataView.fields || {}),
-    [experimentalDataView, oldSourcererDataView.fields]
+    [experimentalDataView.fields, isNewDataViewPickerEnabled, oldSourcererDataView.fields]
   );
 
   const groupSelector = useGetGroupSelectorStateless({


### PR DESCRIPTION
## Summary

Fixes #229844

### 🛑 The problem

As shown in #229844, the "custom field" grouping option was not properly working for users. Here's a video of the bug:

https://github.com/user-attachments/assets/93da6835-8fba-4c1e-adcf-06c05080b5dc

### 💡 The solution

As @christineweng suggested in the mentioned issue, the problem occurred because the code was not checking if the new data view was actually enabled via feature flag before using it.

All we had to do was to add the feature flag check and everything is back to normal now. Here's a video of the UI after the fix:


https://github.com/user-attachments/assets/14453957-0c00-430e-b572-cb2666ab774c





<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->