### PR TITLE
[ES Query] Fix loading saved query's query in the rule definition

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/search_source_expression_form.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/search_source_expression_form.tsx
@@ -162,9 +162,12 @@ export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProp
   // Saved query
   const onSavedQuery = useCallback((newSavedQuery: SavedQuery) => {
     setSavedQuery(newSavedQuery);
-    const newFilters = newSavedQuery.attributes.filters;
+    const { filters: newFilters, query: newQuery } = newSavedQuery.attributes;
     if (newFilters) {
       dispatch({ type: 'filter', payload: newFilters });
+    }
+    if (newQuery) {
+      dispatch({ type: 'query', payload: newQuery });
     }
   }, []);
 


### PR DESCRIPTION
## Summary

I noticed that the query field is not loaded correctly when we use a saved query in the ES Query rule type, as shown below:

### Before
https://github.com/user-attachments/assets/379e1da2-ab4b-4358-b43d-2079fcb6c90c

### After
https://github.com/user-attachments/assets/6e44d2d4-a1de-4c9e-aba0-a39690617379


