### PR TITLE
[9.0] [Security Solution] Improve bulk actions API reference docs (#228712)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -51931,53 +51931,6 @@ components:
           type: string
       required:
         - action
-<<<<<<< HEAD
-=======
-    Security_Detections_API_BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    Security_Detections_API_BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
-          description: Object that describes applying a manual gap fill action for the specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -10547,7 +10547,7 @@ paths:
               type: object
               properties:
                 objects:
-                  description: Array of `rule_id` fields. Exports all rules when unspecified.
+                  description: Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -51725,7 +51725,9 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -51743,7 +51745,9 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -51774,7 +51778,9 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -51866,7 +51872,9 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -51889,7 +51897,9 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -51909,7 +51919,9 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -51919,6 +51931,53 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    Security_Detections_API_BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    Security_Detections_API_BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: Object that describes applying a manual gap fill action for the specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
@@ -51927,7 +51986,9 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -58648,9 +58648,7 @@ components:
             - delete
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58668,9 +58666,7 @@ components:
             - disable
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58701,9 +58697,7 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58795,9 +58789,7 @@ components:
           minItems: 1
           type: array
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58820,9 +58812,7 @@ components:
             - enable
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58842,9 +58832,7 @@ components:
             - export
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58854,53 +58842,6 @@ components:
           type: string
       required:
         - action
-<<<<<<< HEAD
-=======
-    Security_Detections_API_BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    Security_Detections_API_BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
-          description: Object that describes applying a manual gap fill action for the specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
@@ -58909,9 +58850,7 @@ components:
             - run
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -11953,7 +11953,7 @@ paths:
               type: object
               properties:
                 objects:
-                  description: Array of `rule_id` fields. Exports all rules when unspecified.
+                  description: Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -58648,7 +58648,9 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58666,7 +58668,9 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58697,7 +58701,9 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58789,7 +58795,9 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58812,7 +58820,9 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58832,7 +58842,9 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58842,6 +58854,53 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    Security_Detections_API_BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    Security_Detections_API_BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: Object that describes applying a manual gap fill action for the specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
@@ -58850,7 +58909,9 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -58648,7 +58648,9 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58666,7 +58668,9 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58697,7 +58701,9 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58789,7 +58795,9 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58812,7 +58820,9 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58832,7 +58842,9 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -58850,7 +58862,9 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -109,9 +109,11 @@ export const BulkActionBase = z.object({
    * Query to filter rules.
    */
   query: z.string().optional(),
-  /**
-   * Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
-   */
+  /** 
+      * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+Only valid when query property is undefined.
+ 
+      */
   ids: z.array(z.string()).min(1).optional(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -109,9 +109,11 @@ export const BulkActionBase = z.object({
    * Query to filter rules.
    */
   query: z.string().optional(),
-  /**
-   * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
-   */
+  /** 
+      * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+Only valid when query property is undefined.
+ 
+      */
   ids: z.array(z.string()).min(1).optional(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -109,11 +109,9 @@ export const BulkActionBase = z.object({
    * Query to filter rules.
    */
   query: z.string().optional(),
-  /** 
-      * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-Only valid when query property is undefined.
- 
-      */
+  /**
+   * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+   */
   ids: z.array(z.string()).min(1).optional(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
@@ -1142,7 +1142,7 @@ components:
           description: Query to filter rules.
         ids:
           type: array
-          description:
+          description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
@@ -1142,7 +1142,9 @@ components:
           description: Query to filter rules.
         ids:
           type: array
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description:
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           minItems: 1
           items:
             type: string

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
@@ -39,7 +39,7 @@ export type ExportRulesRequestBody = z.infer<typeof ExportRulesRequestBody>;
 export const ExportRulesRequestBody = z
   .object({
     /**
-     * Array of `rule_id` fields. Exports all rules when unspecified.
+     * Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
      */
     objects: z.array(
       z.object({

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.schema.yaml
@@ -72,7 +72,7 @@ paths:
                     properties:
                       rule_id:
                         $ref: '../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleSignatureId'
-                  description: Array of `rule_id` fields. Exports all rules when unspecified.
+                  description: Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4701,10 +4701,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4722,10 +4723,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4756,10 +4758,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4857,10 +4860,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4883,10 +4887,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4906,10 +4911,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4927,10 +4933,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -8320,7 +8327,7 @@ components:
         gets applied to an action and determines whether the action should run.
             - `kql` (string, required): A KQL string.
             - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
-
+              
       type: object
     RuleActionFrequency:
       description: >-

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -8320,7 +8320,7 @@ components:
         gets applied to an action and determines whether the action should run.
             - `kql` (string, required): A KQL string.
             - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
-              
+
       type: object
     RuleActionFrequency:
       description: >-

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -2841,8 +2841,8 @@ paths:
               properties:
                 objects:
                   description: >-
-                    Array of `rule_id` fields. Exports all rules when
-                    unspecified.
+                    Array of objects with a rule's `rule_id` field. Do not use
+                    rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -4701,9 +4701,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4721,9 +4723,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4754,9 +4758,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4854,9 +4860,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4879,9 +4887,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4901,9 +4911,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4913,6 +4925,57 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: >-
+            Object that describes applying a manual gap fill action for the
+            specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -4921,9 +4984,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4701,11 +4701,10 @@ components:
             - delete
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4723,11 +4722,10 @@ components:
             - disable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4758,11 +4756,10 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4860,11 +4857,10 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4887,11 +4883,10 @@ components:
             - enable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4911,60 +4906,10 @@ components:
             - export
           type: string
         ids:
-          description: >
-            Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-<<<<<<< HEAD
-=======
-    BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
           description: >-
-            Object that describes applying a manual gap fill action for the
-            specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4974,8 +4919,6 @@ components:
           type: string
       required:
         - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -4984,11 +4927,10 @@ components:
             - run
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -2705,8 +2705,8 @@ paths:
               properties:
                 objects:
                   description: >-
-                    Array of `rule_id` fields. Exports all rules when
-                    unspecified.
+                    Array of objects with a rule's `rule_id` field. Do not use
+                    rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -4031,9 +4031,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4051,9 +4053,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4084,9 +4088,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4184,9 +4190,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4209,9 +4217,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4231,9 +4241,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4243,6 +4255,57 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: >-
+            Object that describes applying a manual gap fill action for the
+            specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -4251,9 +4314,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4031,10 +4031,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4052,10 +4053,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4086,10 +4088,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4187,10 +4190,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4213,10 +4217,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4236,10 +4241,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4257,10 +4263,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4031,11 +4031,10 @@ components:
             - delete
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4053,11 +4052,10 @@ components:
             - disable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4088,11 +4086,10 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4190,11 +4187,10 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4217,11 +4213,10 @@ components:
             - enable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4241,60 +4236,10 @@ components:
             - export
           type: string
         ids:
-          description: >
-            Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-<<<<<<< HEAD
-=======
-    BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
           description: >-
-            Object that describes applying a manual gap fill action for the
-            specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4304,8 +4249,6 @@ components:
           type: string
       required:
         - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -4314,11 +4257,10 @@ components:
             - run
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Improve bulk actions API reference docs (#228712)](https://github.com/elastic/kibana/pull/228712)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-07-28T21:33:13Z","message":"[Security Solution] Improve bulk actions API reference docs (#228712)\n\n## Summary\n\nThis PR improves description on rule bulk action `ids` to make it clear rule's saved object ID is used.","sha":"642f6b328be19a4e542a57c9cdfd6874e6c5978d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rule Management","backport:version","v8.18.0","v9.2.0","v9.1.1","v8.19.1"],"title":"[Security Solution] Improve bulk actions API reference docs","number":228712,"url":"https://github.com/elastic/kibana/pull/228712","mergeCommit":{"message":"[Security Solution] Improve bulk actions API reference docs (#228712)\n\n## Summary\n\nThis PR improves description on rule bulk action `ids` to make it clear rule's saved object ID is used.","sha":"642f6b328be19a4e542a57c9cdfd6874e6c5978d"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228712","number":228712,"mergeCommit":{"message":"[Security Solution] Improve bulk actions API reference docs (#228712)\n\n## Summary\n\nThis PR improves description on rule bulk action `ids` to make it clear rule's saved object ID is used.","sha":"642f6b328be19a4e542a57c9cdfd6874e6c5978d"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229720","number":229720,"state":"MERGED","mergeCommit":{"sha":"055164ffbfafe4e5d0036a5fb02c0de708278e40","message":"[9.1] [Security Solution] Improve bulk actions API reference docs (#228712) (#229720)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Improve bulk actions API reference docs\n(#228712)](https://github.com/elastic/kibana/pull/228712)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229719","number":229719,"state":"MERGED","mergeCommit":{"sha":"318e91ad64bd45623693add648026170033ea142","message":"[8.19] [Security Solution] Improve bulk actions API reference docs (#228712) (#229719)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Improve bulk actions API reference docs\n(#228712)](https://github.com/elastic/kibana/pull/228712)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}}]}] BACKPORT-->