### PR TITLE
[8.18] [Security Solution] Improve bulk actions API reference docs (#228712)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -8523,7 +8523,7 @@ paths:
               type: object
               properties:
                 objects:
-                  description: Array of `rule_id` fields. Exports all rules when unspecified.
+                  description: Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -49668,7 +49668,13 @@ components:
             - delete
           type: string
         ids:
+<<<<<<< HEAD
           description: Array of rule IDs
+=======
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49686,7 +49692,13 @@ components:
             - disable
           type: string
         ids:
+<<<<<<< HEAD
           description: Array of rule IDs
+=======
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49716,7 +49728,13 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
+<<<<<<< HEAD
           description: Array of rule IDs
+=======
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49807,7 +49825,13 @@ components:
           minItems: 1
           type: array
         ids:
+<<<<<<< HEAD
           description: Array of rule IDs
+=======
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49830,7 +49854,13 @@ components:
             - enable
           type: string
         ids:
+<<<<<<< HEAD
           description: Array of rule IDs
+=======
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49850,7 +49880,13 @@ components:
             - export
           type: string
         ids:
+<<<<<<< HEAD
           description: Array of rule IDs
+=======
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49860,6 +49896,53 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    Security_Detections_API_BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    Security_Detections_API_BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: Object that describes applying a manual gap fill action for the specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
@@ -49868,7 +49951,13 @@ components:
             - run
           type: string
         ids:
+<<<<<<< HEAD
           description: Array of rule IDs
+=======
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -49668,13 +49668,9 @@ components:
             - delete
           type: string
         ids:
-<<<<<<< HEAD
-          description: Array of rule IDs
-=======
           description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49692,13 +49688,9 @@ components:
             - disable
           type: string
         ids:
-<<<<<<< HEAD
-          description: Array of rule IDs
-=======
           description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49728,13 +49720,9 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-<<<<<<< HEAD
-          description: Array of rule IDs
-=======
           description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49825,13 +49813,9 @@ components:
           minItems: 1
           type: array
         ids:
-<<<<<<< HEAD
-          description: Array of rule IDs
-=======
           description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49854,13 +49838,9 @@ components:
             - enable
           type: string
         ids:
-<<<<<<< HEAD
-          description: Array of rule IDs
-=======
           description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49880,13 +49860,9 @@ components:
             - export
           type: string
         ids:
-<<<<<<< HEAD
-          description: Array of rule IDs
-=======
           description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1
@@ -49896,53 +49872,6 @@ components:
           type: string
       required:
         - action
-<<<<<<< HEAD
-=======
-    Security_Detections_API_BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    Security_Detections_API_BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
-          description: Object that describes applying a manual gap fill action for the specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
@@ -49951,13 +49880,9 @@ components:
             - run
           type: string
         ids:
-<<<<<<< HEAD
-          description: Array of rule IDs
-=======
           description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
           items:
             type: string
           minItems: 1

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -38706,7 +38706,9 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38724,7 +38726,9 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38755,7 +38759,9 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38847,7 +38853,9 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38870,7 +38878,9 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38890,7 +38900,9 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38908,7 +38920,9 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -38706,9 +38706,7 @@ components:
             - delete
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38726,9 +38724,7 @@ components:
             - disable
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38759,9 +38755,7 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38853,9 +38847,7 @@ components:
           minItems: 1
           type: array
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38878,9 +38870,7 @@ components:
             - enable
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38900,9 +38890,7 @@ components:
             - export
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38912,53 +38900,6 @@ components:
           type: string
       required:
         - action
-<<<<<<< HEAD
-=======
-    Security_Detections_API_BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    Security_Detections_API_BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
-          description: Object that describes applying a manual gap fill action for the specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
@@ -38967,9 +38908,7 @@ components:
             - run
           type: string
         ids:
-          description: |
-            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-            Only valid when query property is undefined.
+          description: Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -13255,7 +13255,7 @@ paths:
               type: object
               properties:
                 objects:
-                  description: Array of `rule_id` fields. Exports all rules when unspecified.
+                  description: Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -38706,7 +38706,9 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38724,7 +38726,9 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38755,7 +38759,9 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38847,7 +38853,9 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38870,7 +38878,9 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38890,7 +38900,9 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -38900,6 +38912,53 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    Security_Detections_API_BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    Security_Detections_API_BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: Object that describes applying a manual gap fill action for the specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
@@ -38908,7 +38967,9 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description: |
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -109,9 +109,11 @@ export const BulkActionBase = z.object({
    * Query to filter rules.
    */
   query: z.string().optional(),
-  /**
-   * Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
-   */
+  /** 
+      * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+Only valid when query property is undefined.
+ 
+      */
   ids: z.array(z.string()).min(1).optional(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -109,9 +109,11 @@ export const BulkActionBase = z.object({
    * Query to filter rules.
    */
   query: z.string().optional(),
-  /**
-   * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
-   */
+  /** 
+      * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+Only valid when query property is undefined.
+ 
+      */
   ids: z.array(z.string()).min(1).optional(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -109,11 +109,9 @@ export const BulkActionBase = z.object({
    * Query to filter rules.
    */
   query: z.string().optional(),
-  /** 
-      * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
-Only valid when query property is undefined.
- 
-      */
+  /**
+   * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here. Only valid when query property is undefined.
+   */
   ids: z.array(z.string()).min(1).optional(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
@@ -1142,7 +1142,7 @@ components:
           description: Query to filter rules.
         ids:
           type: array
-          description:
+          description: |
             Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
             Only valid when query property is undefined.
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
@@ -1142,7 +1142,9 @@ components:
           description: Query to filter rules.
         ids:
           type: array
-          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
+          description:
+            Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
+            Only valid when query property is undefined.
           minItems: 1
           items:
             type: string

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
@@ -39,7 +39,7 @@ export type ExportRulesRequestBody = z.infer<typeof ExportRulesRequestBody>;
 export const ExportRulesRequestBody = z
   .object({
     /**
-     * Array of `rule_id` fields. Exports all rules when unspecified.
+     * Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
      */
     objects: z.array(
       z.object({

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.schema.yaml
@@ -72,7 +72,7 @@ paths:
                     properties:
                       rule_id:
                         $ref: '../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleSignatureId'
-                  description: Array of `rule_id` fields. Exports all rules when unspecified.
+                  description: Array of objects with a rule's `rule_id` field. Do not use rule's `id` here. Exports all rules when unspecified.
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -5049,11 +5049,10 @@ components:
             - delete
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -5071,11 +5070,10 @@ components:
             - disable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -5106,11 +5104,10 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -5208,11 +5205,10 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -5235,11 +5231,10 @@ components:
             - enable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -5259,60 +5254,10 @@ components:
             - export
           type: string
         ids:
-          description: >
-            Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-<<<<<<< HEAD
-=======
-    BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
           description: >-
-            Object that describes applying a manual gap fill action for the
-            specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -5322,8 +5267,6 @@ components:
           type: string
       required:
         - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -5332,11 +5275,10 @@ components:
             - run
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -3183,8 +3183,8 @@ paths:
               properties:
                 objects:
                   description: >-
-                    Array of `rule_id` fields. Exports all rules when
-                    unspecified.
+                    Array of objects with a rule's `rule_id` field. Do not use
+                    rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -5049,9 +5049,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5069,9 +5071,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5102,9 +5106,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5202,9 +5208,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5227,9 +5235,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5249,9 +5259,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5261,6 +5273,57 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: >-
+            Object that describes applying a manual gap fill action for the
+            specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -5269,9 +5332,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -5049,10 +5049,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5070,10 +5071,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5104,10 +5106,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5205,10 +5208,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5231,10 +5235,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5254,10 +5259,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -5275,10 +5281,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -2705,8 +2705,8 @@ paths:
               properties:
                 objects:
                   description: >-
-                    Array of `rule_id` fields. Exports all rules when
-                    unspecified.
+                    Array of objects with a rule's `rule_id` field. Do not use
+                    rule's `id` here. Exports all rules when unspecified.
                   items:
                     type: object
                     properties:
@@ -4031,9 +4031,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4051,9 +4053,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4084,9 +4088,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4184,9 +4190,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4209,9 +4217,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4231,9 +4241,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4243,6 +4255,57 @@ components:
           type: string
       required:
         - action
+<<<<<<< HEAD
+=======
+    BulkGapsFillingSkipReason:
+      enum:
+        - NO_GAPS_TO_FILL
+      type: string
+    BulkManualRuleFillGaps:
+      type: object
+      properties:
+        action:
+          enum:
+            - fill_gaps
+          type: string
+        fill_gaps:
+          description: >-
+            Object that describes applying a manual gap fill action for the
+            specified time range.
+          type: object
+          properties:
+            end_date:
+              description: End date of the manual gap fill
+              type: string
+            start_date:
+              description: Start date of the manual gap fill
+              type: string
+          required:
+            - start_date
+            - end_date
+        gaps_range_end:
+          description: Gaps range end, valid only when query is provided
+          type: string
+        gaps_range_start:
+          description: Gaps range start, valid only when query is provided
+          type: string
+        ids:
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
+          items:
+            type: string
+          minItems: 1
+          type: array
+        query:
+          description: Query to filter rules.
+          type: string
+      required:
+        - action
+        - fill_gaps
+>>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -4251,9 +4314,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
-            Array of rule IDs. Array of rule IDs to which a bulk action will be
-            applied. Only valid when query property is undefined.
+          description: >
+            Array of rule `id`s to which a bulk action will be applied. Do not
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4031,10 +4031,11 @@ components:
             - delete
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4052,10 +4053,11 @@ components:
             - disable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4086,10 +4088,11 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4187,10 +4190,11 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4213,10 +4217,11 @@ components:
             - enable
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4236,10 +4241,11 @@ components:
             - export
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
@@ -4257,10 +4263,11 @@ components:
             - run
           type: string
         ids:
-          description: >-
+          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here. Only valid when query property is
-            undefined.
+            use rule's `rule_id` here.
+
+            Only valid when query property is undefined.
           items:
             type: string
           minItems: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4031,11 +4031,10 @@ components:
             - delete
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4053,11 +4052,10 @@ components:
             - disable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4088,11 +4086,10 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4190,11 +4187,10 @@ components:
           minItems: 1
           type: array
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4217,11 +4213,10 @@ components:
             - enable
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4241,60 +4236,10 @@ components:
             - export
           type: string
         ids:
-          description: >
-            Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
-          items:
-            type: string
-          minItems: 1
-          type: array
-        query:
-          description: Query to filter rules.
-          type: string
-      required:
-        - action
-<<<<<<< HEAD
-=======
-    BulkGapsFillingSkipReason:
-      enum:
-        - NO_GAPS_TO_FILL
-      type: string
-    BulkManualRuleFillGaps:
-      type: object
-      properties:
-        action:
-          enum:
-            - fill_gaps
-          type: string
-        fill_gaps:
           description: >-
-            Object that describes applying a manual gap fill action for the
-            specified time range.
-          type: object
-          properties:
-            end_date:
-              description: End date of the manual gap fill
-              type: string
-            start_date:
-              description: Start date of the manual gap fill
-              type: string
-          required:
-            - start_date
-            - end_date
-        gaps_range_end:
-          description: Gaps range end, valid only when query is provided
-          type: string
-        gaps_range_start:
-          description: Gaps range start, valid only when query is provided
-          type: string
-        ids:
-          description: >
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1
@@ -4304,8 +4249,6 @@ components:
           type: string
       required:
         - action
-        - fill_gaps
->>>>>>> 642f6b328be ([Security Solution] Improve bulk actions API reference docs (#228712))
     BulkManualRuleRun:
       type: object
       properties:
@@ -4314,11 +4257,10 @@ components:
             - run
           type: string
         ids:
-          description: >
+          description: >-
             Array of rule `id`s to which a bulk action will be applied. Do not
-            use rule's `rule_id` here.
-
-            Only valid when query property is undefined.
+            use rule's `rule_id` here. Only valid when query property is
+            undefined.
           items:
             type: string
           minItems: 1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Solution] Improve bulk actions API reference docs (#228712)](https://github.com/elastic/kibana/pull/228712)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-07-28T21:33:13Z","message":"[Security Solution] Improve bulk actions API reference docs (#228712)\n\n## Summary\n\nThis PR improves description on rule bulk action `ids` to make it clear rule's saved object ID is used.","sha":"642f6b328be19a4e542a57c9cdfd6874e6c5978d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rule Management","backport:version","v8.18.0","v9.2.0","v9.1.1","v8.19.1"],"title":"[Security Solution] Improve bulk actions API reference docs","number":228712,"url":"https://github.com/elastic/kibana/pull/228712","mergeCommit":{"message":"[Security Solution] Improve bulk actions API reference docs (#228712)\n\n## Summary\n\nThis PR improves description on rule bulk action `ids` to make it clear rule's saved object ID is used.","sha":"642f6b328be19a4e542a57c9cdfd6874e6c5978d"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228712","number":228712,"mergeCommit":{"message":"[Security Solution] Improve bulk actions API reference docs (#228712)\n\n## Summary\n\nThis PR improves description on rule bulk action `ids` to make it clear rule's saved object ID is used.","sha":"642f6b328be19a4e542a57c9cdfd6874e6c5978d"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229720","number":229720,"state":"MERGED","mergeCommit":{"sha":"055164ffbfafe4e5d0036a5fb02c0de708278e40","message":"[9.1] [Security Solution] Improve bulk actions API reference docs (#228712) (#229720)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Improve bulk actions API reference docs\n(#228712)](https://github.com/elastic/kibana/pull/228712)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/229719","number":229719,"state":"MERGED","mergeCommit":{"sha":"318e91ad64bd45623693add648026170033ea142","message":"[8.19] [Security Solution] Improve bulk actions API reference docs (#228712) (#229719)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Improve bulk actions API reference docs\n(#228712)](https://github.com/elastic/kibana/pull/228712)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}}]}] BACKPORT-->