### PR TITLE
[UII] Make integration cards stretch to full row height

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import type { ListRowRenderer } from 'react-virtualized';
 import { List as VirtualizedList, CellMeasurer, CellMeasurerCache } from 'react-virtualized';
 import { css } from '@emotion/react';
@@ -50,6 +50,13 @@ export const GridColumn = ({
       defaultHeight: 150,
     })
   );
+
+  // Reset the row measurement cache when the list changes
+  useEffect(() => {
+    if (rowMeasurementCache.current) {
+      rowMeasurementCache.current.clearAll();
+    }
+  }, [list]);
 
   if (isLoading) {
     return (
@@ -145,9 +152,7 @@ export const GridColumn = ({
       }}
     >
       {({ height, isScrolling, onChildScroll, scrollTop }) => (
-        // `key` is a hack to re-render the list when the number of items changes, see:
-        // https://stackoverflow.com/questions/52769760/react-virtualized-list-item-does-not-re-render-with-changed-props-until-i-scroll
-        <EuiAutoSizer disableHeight key={list.length}>
+        <EuiAutoSizer disableHeight>
           {({ width }) => (
             <VirtualizedList
               tabIndex={-1}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -53,7 +53,7 @@ export const GridColumn = ({
 
   if (isLoading) {
     return (
-      <EuiFlexGrid gutterSize="l" columns={3} alignItems="start">
+      <EuiFlexGrid gutterSize="m" columns={3} alignItems="start">
         {Array.from({ length: 12 }).map((_, index) => (
           <EuiFlexItem key={index} grow={3}>
             <EuiSkeletonRectangle height="160px" width="100%" />
@@ -66,7 +66,7 @@ export const GridColumn = ({
   if (!list.length) {
     return (
       <EuiFlexGrid
-        gutterSize="l"
+        gutterSize="m"
         columns={3}
         data-test-subj="emptyState"
         style={emptyStateStyles}
@@ -105,12 +105,13 @@ export const GridColumn = ({
       >
         {({ registerChild }) => (
           <div ref={registerChild} style={style}>
-            <EuiFlexGrid columns={3} gutterSize="l" alignItems="start">
+            <EuiFlexGrid columns={3} gutterSize="m" alignItems="start">
               {items.map((item) => (
                 <EuiFlexItem
                   key={item.id}
                   // Ensure that cards wrapped in EuiTours/EuiPopovers correctly inherit the full grid row height
                   css={css`
+                    align-self: stretch;
                     & > .euiPopover,
                     & > .euiPopover > .euiCard {
                       height: 100%;


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/229837. This PR makes it so that the flex grid items stretch to the full height of the row. It also fixes some weirdness with overlapping rows when items change (i.e. due to search filter) by clearing the measurement cache.

I also put gutter size back to `m` to be consistent with rest of margins on this page.

<a href="https://www.loom.com/share/ee79f9f2e85d43bd8684dda39f4cc9f2">
  <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/ee79f9f2e85d43bd8684dda39f4cc9f2-09dcb7ba703a3dd5-full-play.gif">
</a>

### Checklist
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.