### PR TITLE
[Security Solution Cypress] Configure cypress es_archiver tasks to allow usage of platform archives

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/machine_learning_rule.cy.ts
@@ -39,9 +39,7 @@ import { visit } from '../../../../tasks/navigation';
 import { getDetails } from '../../../../tasks/rule_details';
 import { CREATE_RULE_URL } from '../../../../urls/navigation';
 
-// Failing: See https://github.com/elastic/kibana/issues/229861
-// Failing: See https://github.com/elastic/kibana/issues/229860
-describe.skip(
+describe(
   'Machine Learning Detection Rules - Alert suppression',
   {
     tags: ['@ess', '@serverless'],
@@ -84,7 +82,7 @@ describe.skip(
 
       describe('when ML jobs have run', () => {
         before(() => {
-          cy.task('esArchiverLoad', { archiveName: '../auditbeat/hosts', type: 'ftr' });
+          cy.task('esArchiverLoad', { archiveName: 'auditbeat/hosts', type: 'platform' });
           setupMlModulesWithRetry({ moduleName: 'security_linux_v3' });
           forceStartDatafeeds({ jobIds: [jobId] });
           cy.task('esArchiverLoad', { archiveName: 'anomalies', type: 'ftr' });
@@ -92,7 +90,7 @@ describe.skip(
 
         after(() => {
           cy.task('esArchiverUnload', { archiveName: 'anomalies', type: 'ftr' });
-          cy.task('esArchiverUnload', { archiveName: '../auditbeat/hosts', type: 'ftr' });
+          cy.task('esArchiverUnload', { archiveName: 'auditbeat/hosts', type: 'platform' });
         });
 
         describe('when not all jobs are running', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
@@ -39,8 +39,7 @@ import { visit } from '../../../../tasks/navigation';
 import { assertDetailsNotExist, getDetails } from '../../../../tasks/rule_details';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
 
-// Failing: See https://github.com/elastic/kibana/issues/229859
-describe.skip(
+describe(
   'Machine Learning Detection Rules - Editing',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
@@ -56,12 +55,16 @@ describe.skip(
       );
       // ensure no ML jobs are started before the test
       machineLearningJobIds.forEach((j) => forceStopAndCloseJob({ jobId: j }));
+      cy.task('esArchiverLoad', { archiveName: 'auditbeat/hosts', type: 'platform' });
+    });
+
+    after(() => {
+      cy.task('esArchiverUnload', { archiveName: 'auditbeat/hosts', type: 'platform' });
     });
 
     beforeEach(() => {
       login();
       deleteAlertsAndRules();
-      cy.task('esArchiverLoad', { archiveName: '../auditbeat/hosts', type: 'ftr' });
       setupMlModulesWithRetry({ moduleName: 'security_linux_v3' });
       forceStartDatafeeds({ jobIds: [jobId] });
       cy.task('esArchiverLoad', { archiveName: 'anomalies', type: 'ftr' });

--- a/x-pack/test/security_solution_cypress/cypress/support/es_archiver.ts
+++ b/x-pack/test/security_solution_cypress/cypress/support/es_archiver.ts
@@ -26,10 +26,7 @@ function createKibanaUrlWithAuth({ url, username, password }: ClientOptions) {
   return clientUrl.toString();
 }
 
-export const esArchiver = (
-  on: Cypress.PluginEvents,
-  config: Cypress.PluginConfigOptions
-): EsArchiver => {
+export const esArchiver = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): void => {
   const log = new ToolingLog({ level: 'verbose', writeTo: process.stdout });
 
   const isServerless = config.env.IS_SERVERLESS;
@@ -66,26 +63,29 @@ export const esArchiver = (
       : {}),
   });
 
-  const esArchiverInstance = new EsArchiver({
-    log,
-    client,
-    kbnClient,
-    baseDir: '../es_archives',
-  });
-
-  const ftrEsArchiverInstance = new EsArchiver({
-    log,
-    client,
-    kbnClient,
-    baseDir: '../../../solutions/security/test/fixtures/es_archives/security_solution',
-  });
+  const esArchiverFactory = (baseDir: string) =>
+    new EsArchiver({
+      log,
+      client,
+      kbnClient,
+      baseDir,
+    });
+  const cypressEsArchiverInstance = esArchiverFactory('../es_archives');
+  const ftrEsArchiverInstance = esArchiverFactory(
+    '../../../solutions/security/test/fixtures/es_archives/security_solution'
+  );
+  const platformEsArchiverInstance = esArchiverFactory(
+    '../../../platform/test/fixtures/es_archives'
+  );
 
   on('task', {
     esArchiverLoad: async ({ archiveName, type = 'cypress', ...options }) => {
       if (type === 'cypress') {
-        return esArchiverInstance.load(archiveName, options);
+        return cypressEsArchiverInstance.load(archiveName, options);
       } else if (type === 'ftr') {
         return ftrEsArchiverInstance.load(archiveName, options);
+      } else if (type === 'platform') {
+        return platformEsArchiverInstance.load(archiveName, options);
       } else {
         throw new Error(
           `Unable to load the specified archive: ${JSON.stringify({ archiveName, type, options })}`
@@ -94,14 +94,14 @@ export const esArchiver = (
     },
     esArchiverUnload: async ({ archiveName, type = 'cypress' }) => {
       if (type === 'cypress') {
-        return esArchiverInstance.unload(archiveName);
+        return cypressEsArchiverInstance.unload(archiveName);
       } else if (type === 'ftr') {
         return ftrEsArchiverInstance.unload(archiveName);
+      } else if (type === 'platform') {
+        return platformEsArchiverInstance.unload(archiveName);
       } else {
         throw new Error('It is not possible to unload the archive.');
       }
     },
   });
-
-  return esArchiverInstance;
 };


### PR DESCRIPTION
## Summary

Work done as part of https://github.com/elastic/kibana-team/issues/1503 moved archives to different locations, and consequently our usage of the "platform" archives within cypress stopped working.

While the solution in FTR tests is currently to fully-qualify the path to the archive, I'm continuing with the "categorized" approach we've taken with cypress, where the `type` argument denotes the base directory in which to search.

A more robust solution might search in all of these places, in order, if the path is ambiguous, but for now this will fix the immediate problem.

Addresses the following `failed-test` issues:

* Closes #229859
* Closes #229861
* Closes #229860


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
    * These are not flaky tests, but consistent failures. Regardless, I triggered a 10x build just in case: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8936
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->