### PR TITLE
[9.1] [Product doc] Fix logic for product docs installing version higher than the current version (#229704)

### DIFF
--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
@@ -298,5 +298,5 @@ export class PackageInstaller {
 const selectVersion = (currentVersion: string, availableVersions: string[]): string => {
   return availableVersions.includes(currentVersion)
     ? currentVersion
-    : latestVersion(availableVersions);
+    : latestVersion(availableVersions, currentVersion);
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.test.ts
@@ -26,4 +26,8 @@ describe('latestVersion', () => {
   it('accepts versions in a {major.minor} format', () => {
     expect(latestVersion(['9.16', '9.3'])).toEqual('9.16');
   });
+  it('returns the highest version from the list, ignoring versions less than the current version if provided', () => {
+    expect(latestVersion(['8.18', '9.1', '9.16', '9.3'], '8.19')).toEqual('8.18');
+    expect(latestVersion(['8.18', '8.19', '9.1', '9.3'], '9.2')).toEqual('9.1');
+  });
 });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/semver.ts
@@ -7,15 +7,32 @@
 
 import Semver from 'semver';
 
-export const latestVersion = (versions: string[]): string => {
-  let latest: string = versions[0];
-  for (let i = 1; i < versions.length; i++) {
-    const current = versions[i];
-    if (Semver.gt(Semver.coerce(current)!, Semver.coerce(latest)!)) {
-      latest = current;
+/**
+ * @param availableVersions - List of available versions
+ * @param kibanaVer - Kibana version
+ * @returns The latest version from the list
+ * If kibanaVer is provided, return the previous closest version available
+ */
+export const latestVersion = (availableVersions: string[], kibanaVer?: string): string => {
+  const kibanaSemver = kibanaVer ? Semver.coerce(kibanaVer) : undefined;
+  let latest: string | undefined;
+
+  for (const version of availableVersions) {
+    const semver = Semver.coerce(version);
+    if (!semver) continue;
+
+    if (
+      // If a Kibana version is provided,
+      // narrow to only available versions prior to that Kibana version
+      (!kibanaSemver || Semver.lte(semver, kibanaSemver)) &&
+      // Else, grab the newer version from the list
+      (!latest || Semver.gt(semver, Semver.coerce(latest)!))
+    ) {
+      latest = version;
     }
   }
-  return latest;
+
+  return latest ?? availableVersions[0];
 };
 
 export const majorMinor = (version: string): string => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Product doc] Fix logic for product docs installing version higher than the current version (#229704)](https://github.com/elastic/kibana/pull/229704)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Quynh Nguyen (Quinn)","email":"43350163+qn895@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-28T22:54:40Z","message":"[Product doc] Fix logic for product docs installing version higher than the current version (#229704)\n\n## Summary\n\nThis PR fixes the automatic installation of product docs, for when the\nlatest available version is higher than the current Kibana version.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"3081531a5264a828da6a044f4f308bd254aafcb8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix",":ml","backport missing","backport:version","v9.1.0","v9.2.0","v9.1.1"],"title":"[Product doc] Fix logic for product docs installing version higher than the current version","number":229704,"url":"https://github.com/elastic/kibana/pull/229704","mergeCommit":{"message":"[Product doc] Fix logic for product docs installing version higher than the current version (#229704)\n\n## Summary\n\nThis PR fixes the automatic installation of product docs, for when the\nlatest available version is higher than the current Kibana version.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"3081531a5264a828da6a044f4f308bd254aafcb8"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229704","number":229704,"mergeCommit":{"message":"[Product doc] Fix logic for product docs installing version higher than the current version (#229704)\n\n## Summary\n\nThis PR fixes the automatic installation of product docs, for when the\nlatest available version is higher than the current Kibana version.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"3081531a5264a828da6a044f4f308bd254aafcb8"}}]}] BACKPORT-->