### PR TITLE
[Detection Engine] Unskip test failure caused by EPR issue

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_gaps/fill_all_rule_gaps.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_gaps/fill_all_rule_gaps.cy.ts
@@ -21,8 +21,7 @@ import { visit } from '../../../../tasks/navigation';
 import { ruleDetailsUrl } from '../../../../urls/rule_details';
 import { goToExecutionLogTab } from '../../../../tasks/rule_details';
 
-// Failing: See https://github.com/elastic/kibana/issues/229344
-describe.skip(
+describe(
   'bulk fill rule gaps',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],


### PR DESCRIPTION
See notes in the [related issue](https://github.com/elastic/kibana/issues/229344) for details, but the upstream issue should now be fixed and this test can be unskipped. 

Closes #229344.


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->