### PR TITLE
[ES|QL] Fixes the font sizes of the footer links

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/feedback_component.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/feedback_component.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexItem, EuiIcon, useEuiTheme, EuiLink, EuiToolTip, EuiFlexGroup } from '@elastic/eui';
+import { EuiFlexItem, EuiIconTip, useEuiTheme, EuiLink, EuiButtonEmpty } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FEEDBACK_LINK } from '@kbn/esql-utils';
 
@@ -25,46 +25,38 @@ export function SubmitFeedbackComponent({ isSpaceReduced }: { isSpaceReduced?: b
             target="_blank"
             data-test-subj="ESQLEditor-feedback-link"
           >
-            <EuiToolTip
-              position="top"
+            <EuiIconTip
+              type="editorComment"
+              color="primary"
+              size="m"
+              css={css`
+                margin-right: ${euiTheme.size.s};
+              `}
               content={i18n.translate('esqlEditor.query.feedback', {
                 defaultMessage: 'Feedback',
               })}
-            >
-              <EuiIcon
-                type="editorComment"
-                color="primary"
-                size="m"
-                css={css`
-                  margin-right: ${euiTheme.size.s};
-                `}
-              />
-            </EuiToolTip>
+              position="top"
+            />
           </EuiLink>
         </EuiFlexItem>
       )}
       {!isSpaceReduced && (
-        <EuiLink
+        <EuiButtonEmpty
+          size="xs"
+          color="primary"
+          flush="both"
           href={FEEDBACK_LINK}
-          external={false}
           target="_blank"
           css={css`
-            font-size: 12px;
             margin-right: ${euiTheme.size.m};
           `}
+          iconType="editorComment"
           data-test-subj="ESQLEditor-feedback-link"
         >
-          <EuiFlexGroup gutterSize="s" alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiIcon type="editorComment" color="primary" size="s" />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              {i18n.translate('esqlEditor.query.submitFeedback', {
-                defaultMessage: 'Submit feedback',
-              })}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiLink>
+          {i18n.translate('esqlEditor.query.submitFeedback', {
+            defaultMessage: 'Submit feedback',
+          })}
+        </EuiButtonEmpty>
       )}
     </>
   );

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
@@ -27,6 +27,7 @@ import {
   EuiText,
   EuiIconTip,
   EuiLink,
+  EuiIcon,
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { cssFavoriteHoverWithinEuiTableRow } from '@kbn/content-management-favorites-public';
@@ -137,42 +138,51 @@ export const getTableColumns = (
           case 'success':
           default:
             return (
-              <EuiIconTip
+              <EuiToolTip
                 position="top"
-                type="checkInCircleFilled"
-                color="success"
-                size="m"
-                data-test-subj="ESQLEditor-queryHistory-success"
                 content={i18n.translate('esqlEditor.query.querieshistory.success', {
                   defaultMessage: 'Query ran successfully',
                 })}
-              />
+              >
+                <EuiIcon
+                  type="checkInCircleFilled"
+                  color="success"
+                  size="m"
+                  data-test-subj="ESQLEditor-queryHistory-success"
+                />
+              </EuiToolTip>
             );
           case 'error':
             return (
-              <EuiIconTip
-                type="error"
-                color="danger"
-                size="m"
+              <EuiToolTip
                 position="top"
-                data-test-subj="ESQLEditor-queryHistory-error"
                 content={i18n.translate('esqlEditor.query.querieshistory.error', {
                   defaultMessage: 'Query failed',
                 })}
-              />
+              >
+                <EuiIcon
+                  type="error"
+                  color="danger"
+                  size="m"
+                  data-test-subj="ESQLEditor-queryHistory-error"
+                />
+              </EuiToolTip>
             );
           case 'warning':
             return (
-              <EuiIconTip
-                type="warning"
-                color="warning"
-                size="m"
-                data-test-subj="ESQLEditor-queryHistory-warning"
+              <EuiToolTip
+                position="top"
                 content={i18n.translate('esqlEditor.query.querieshistory.error', {
                   defaultMessage: 'Query failed',
                 })}
-                position="top"
-              />
+              >
+                <EuiIcon
+                  type="warning"
+                  color="warning"
+                  size="m"
+                  data-test-subj="ESQLEditor-queryHistory-warning"
+                />
+              </EuiToolTip>
             );
         }
       },

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
@@ -12,7 +12,6 @@ import { i18n } from '@kbn/i18n';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   useEuiTheme,
   EuiInMemoryTable,
   EuiBasicTableColumn,
@@ -26,6 +25,8 @@ import {
   EuiTabs,
   EuiNotificationBadge,
   EuiText,
+  EuiIconTip,
+  EuiLink,
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { cssFavoriteHoverWithinEuiTableRow } from '@kbn/content-management-favorites-public';
@@ -53,34 +54,31 @@ export function QueryHistoryAction({
   isHistoryOpen: boolean;
   isSpaceReduced?: boolean;
 }) {
-  const { euiTheme } = useEuiTheme();
   return (
     <>
       {isSpaceReduced && (
         <EuiFlexItem grow={false} data-test-subj="ESQLEditor-toggle-query-history-icon">
-          <EuiToolTip
-            position="top"
-            content={
-              isHistoryOpen
-                ? i18n.translate('esqlEditor.query.hideQueriesLabel', {
-                    defaultMessage: 'Hide recent queries',
-                  })
-                : i18n.translate('esqlEditor.query.showQueriesLabel', {
-                    defaultMessage: 'Show recent queries',
-                  })
-            }
+          <EuiLink
+            onClick={toggleHistory}
+            external={false}
+            data-test-subj="ESQLEditor-feedback-link"
           >
-            <EuiIcon
+            <EuiIconTip
               type="clockCounter"
               color="primary"
               size="m"
-              onClick={toggleHistory}
-              css={css`
-                margin-right: ${euiTheme.size.s};
-                cursor: pointer;
-              `}
+              content={
+                isHistoryOpen
+                  ? i18n.translate('esqlEditor.query.hideQueriesLabel', {
+                      defaultMessage: 'Hide recent queries',
+                    })
+                  : i18n.translate('esqlEditor.query.showQueriesLabel', {
+                      defaultMessage: 'Show recent queries',
+                    })
+              }
+              position="top"
             />
-          </EuiToolTip>
+          </EuiLink>
         </EuiFlexItem>
       )}
       {!isSpaceReduced && (
@@ -139,51 +137,42 @@ export const getTableColumns = (
           case 'success':
           default:
             return (
-              <EuiToolTip
+              <EuiIconTip
                 position="top"
+                type="checkInCircleFilled"
+                color="success"
+                size="m"
+                data-test-subj="ESQLEditor-queryHistory-success"
                 content={i18n.translate('esqlEditor.query.querieshistory.success', {
                   defaultMessage: 'Query ran successfully',
                 })}
-              >
-                <EuiIcon
-                  type="checkInCircleFilled"
-                  color="success"
-                  size="m"
-                  data-test-subj="ESQLEditor-queryHistory-success"
-                />
-              </EuiToolTip>
+              />
             );
           case 'error':
             return (
-              <EuiToolTip
+              <EuiIconTip
+                type="error"
+                color="danger"
+                size="m"
                 position="top"
+                data-test-subj="ESQLEditor-queryHistory-error"
                 content={i18n.translate('esqlEditor.query.querieshistory.error', {
                   defaultMessage: 'Query failed',
                 })}
-              >
-                <EuiIcon
-                  type="error"
-                  color="danger"
-                  size="m"
-                  data-test-subj="ESQLEditor-queryHistory-error"
-                />
-              </EuiToolTip>
+              />
             );
           case 'warning':
             return (
-              <EuiToolTip
-                position="top"
+              <EuiIconTip
+                type="warning"
+                color="warning"
+                size="m"
+                data-test-subj="ESQLEditor-queryHistory-warning"
                 content={i18n.translate('esqlEditor.query.querieshistory.error', {
                   defaultMessage: 'Query failed',
                 })}
-              >
-                <EuiIcon
-                  type="warning"
-                  color="warning"
-                  size="m"
-                  data-test-subj="ESQLEditor-queryHistory-warning"
-                />
-              </EuiToolTip>
+                position="top"
+              />
             );
         }
       },

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
@@ -62,7 +62,7 @@ export function QueryHistoryAction({
           <EuiLink
             onClick={toggleHistory}
             external={false}
-            data-test-subj="ESQLEditor-feedback-link"
+            data-test-subj="ESQLEditor-hide-queries-link"
           >
             <EuiIconTip
               type="clockCounter"


### PR DESCRIPTION
## Summary

Fixes the editor footer links to:

- use the same DOM structure
- the above fixed and the font sizes inconsistency


<img width="794" height="106" alt="image" src="https://github.com/user-attachments/assets/24d77677-ce3f-42b4-8cb1-027ed937c782" />



