### PR TITLE
[Background Search] Add background search support to ESQL

### DIFF
--- a/src/platform/packages/shared/kbn-es-types/src/search.ts
+++ b/src/platform/packages/shared/kbn-es-types/src/search.ts
@@ -682,7 +682,6 @@ export interface ESQLSearchParams {
   filter?: unknown;
   locale?: string;
   include_ccs_metadata?: boolean;
-  session_id?: string;
   dropNullColumns?: boolean;
   params?:
     | estypes.ScalarValue[]

--- a/src/platform/packages/shared/kbn-es-types/src/search.ts
+++ b/src/platform/packages/shared/kbn-es-types/src/search.ts
@@ -682,6 +682,7 @@ export interface ESQLSearchParams {
   filter?: unknown;
   locale?: string;
   include_ccs_metadata?: boolean;
+  session_id?: string;
   dropNullColumns?: boolean;
   params?:
     | estypes.ScalarValue[]

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.test.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.test.ts
@@ -41,6 +41,7 @@ describe('getEsqlFn', () => {
       abortSignal: new AbortController().signal,
       inspectorAdapters: {},
       getKibanaRequest: jest.fn(),
+      getSearchSessionId: jest.fn(),
     } as unknown as ExecutionContext;
 
     const result = await esqlFn.fn(input, args, context).toPromise();

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -171,7 +171,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
         descriptionForInspector,
         ignoreGlobalFilters,
       },
-      { abortSignal, inspectorAdapters, getKibanaRequest }
+      { abortSignal, inspectorAdapters, getKibanaRequest, getSearchSessionId }
     ) {
       return defer(() =>
         getStartDependencies(() => {
@@ -272,7 +272,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
             IKibanaSearchResponse<ESQLSearchResponse>
           >(
             { params: { ...params, dropNullColumns: true } },
-            { abortSignal, strategy: ESQL_ASYNC_SEARCH_STRATEGY }
+            { abortSignal, strategy: ESQL_ASYNC_SEARCH_STRATEGY, sessionId: getSearchSessionId() }
           ).pipe(
             catchError((error) => {
               if (!error.attributes) {

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -514,6 +514,7 @@ export class SearchInterceptor {
               rawResponse: esqlResponse,
               isPartial: esqlResponse.is_partial,
               isRunning: esqlResponse.is_running,
+              isRestored,
               requestParams,
               warning,
             };

--- a/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
@@ -12,7 +12,7 @@ import { getSearchStatus } from './get_search_status';
 import type { SearchSessionRequestInfo } from '../../../common';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 
-const getAsUserClientMock = (asyncQueryGet = jest.fn(), status = jest.fn()) => {
+const getEsClientMock = (asyncQueryGet = jest.fn(), status = jest.fn()) => {
   const client = elasticsearchClientMock.createElasticsearchClient();
   return {
     ...client,
@@ -50,7 +50,7 @@ describe('getSearchStatus', () => {
 
       const status = jest.fn().mockResolvedValue(response);
       const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
+      const mockEsClient = getEsClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -59,7 +59,7 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        asUserClient: mockAsUserClient,
+        esClient: mockEsClient,
         asyncId: '123',
         session: getSession({ strategy }),
       });
@@ -84,7 +84,7 @@ describe('getSearchStatus', () => {
 
       const status = jest.fn().mockResolvedValue(response);
       const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
+      const mockEsClient = getEsClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -93,7 +93,7 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        asUserClient: mockAsUserClient,
+        esClient: mockEsClient,
         asyncId: '123',
         session: getSession({ strategy }),
       });
@@ -118,7 +118,7 @@ describe('getSearchStatus', () => {
 
       const status = jest.fn().mockResolvedValue(response);
       const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
+      const mockEsClient = getEsClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -127,7 +127,7 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        asUserClient: mockAsUserClient,
+        esClient: mockEsClient,
         asyncId: '123',
         session: getSession({ strategy }),
       });
@@ -144,7 +144,7 @@ describe('getSearchStatus', () => {
       // Given
       const status = jest.fn().mockRejectedValue(new Error('O_o'));
       const asyncQueryGet = jest.fn().mockRejectedValue(new Error('O_o'));
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
+      const mockEsClient = getEsClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -153,7 +153,7 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        asUserClient: mockAsUserClient,
+        esClient: mockEsClient,
         asyncId: '123',
         session: getSession({ strategy }),
       });
@@ -178,7 +178,7 @@ describe('getSearchStatus', () => {
 
       const status = jest.fn().mockResolvedValue(response);
       const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
+      const mockEsClient = getEsClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -187,7 +187,7 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        asUserClient: mockAsUserClient,
+        esClient: mockEsClient,
         asyncId: '123',
         session: getSession({ strategy }),
       });
@@ -212,7 +212,7 @@ describe('getSearchStatus', () => {
 
       const status = jest.fn().mockResolvedValue(response);
       const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
+      const mockEsClient = getEsClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -221,7 +221,7 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        asUserClient: mockAsUserClient,
+        esClient: mockEsClient,
         asyncId: '123',
         session: getSession({ strategy }),
       });

--- a/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
@@ -9,7 +9,7 @@
 
 import { SearchStatus } from './types';
 import { getSearchStatus } from './get_search_status';
-import { SearchSessionRequestInfo } from '../../../common';
+import type { SearchSessionRequestInfo } from '../../../common';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 
 const getInternalClientMock = (status = jest.fn()) => {

--- a/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
@@ -9,80 +9,248 @@
 
 import { SearchStatus } from './types';
 import { getSearchStatus } from './get_search_status';
+import { SearchSessionRequestInfo } from '../../../common';
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+
+const getInternalClientMock = (status = jest.fn()) => {
+  const client = elasticsearchClientMock.createElasticsearchClient();
+  return { ...client, asyncSearch: { ...client.asyncSearch, status } };
+};
+
+const getAsUserClientMock = (asyncQueryGet = jest.fn()) => {
+  const client = elasticsearchClientMock.createElasticsearchClient();
+  return { ...client, esql: { ...client.esql, asyncQueryGet } };
+};
+
+const getSession = ({
+  strategy = 'some-strategy',
+}: {
+  strategy?: string;
+} = {}): SearchSessionRequestInfo => ({
+  id: '1234',
+  strategy,
+});
 
 describe('getSearchStatus', () => {
-  let mockClient: any;
-  beforeEach(() => {
-    mockClient = {
-      asyncSearch: {
-        status: jest.fn(),
-      },
-    };
-  });
-
-  test('returns a complete status if search is partial and not running', async () => {
-    mockClient.asyncSearch.status.mockResolvedValue({
-      body: {
-        is_partial: true,
-        is_running: false,
-        completion_status: 200,
-      },
-    });
-    const res = await getSearchStatus(mockClient, '123');
-    expect(res.status).toBe(SearchStatus.COMPLETE);
-  });
-
-  test('returns an error status if completion_status is an error', async () => {
-    mockClient.asyncSearch.status.mockResolvedValue({
-      body: {
-        is_partial: false,
-        is_running: false,
-        completion_status: 500,
-      },
-    });
-    const res = await getSearchStatus(mockClient, '123');
-    expect(res.status).toBe(SearchStatus.ERROR);
-  });
-
-  test('returns an error status if gets an ES error', async () => {
-    mockClient.asyncSearch.status.mockResolvedValue({
-      error: {
-        root_cause: {
-          reason: 'not found',
+  describe.each([
+    { strategy: 'esql_async', expectedFunctionCall: 'asyncQueryGet' },
+    {
+      strategy: 'default',
+      expectedFunctionCall: 'status',
+    },
+  ])('when the strategy is $strategy', ({ strategy, expectedFunctionCall }) => {
+    it('returns a complete status if search is partial and not running', async () => {
+      // Given
+      const response = {
+        body: {
+          is_partial: true,
+          is_running: false,
+          completion_status: 200,
         },
-      },
-    });
-    const res = await getSearchStatus(mockClient, '123');
-    expect(res.status).toBe(SearchStatus.ERROR);
-  });
+      };
 
-  test('returns an error status throws', async () => {
-    mockClient.asyncSearch.status.mockRejectedValue(new Error('O_o'));
-    const res = await getSearchStatus(mockClient, '123');
-    expect(res.status).toBe(SearchStatus.ERROR);
-  });
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
 
-  test('returns a complete status', async () => {
-    mockClient.asyncSearch.status.mockResolvedValue({
-      body: {
-        is_partial: false,
-        is_running: false,
-        completion_status: 200,
-      },
-    });
-    const res = await getSearchStatus(mockClient, '123');
-    expect(res.status).toBe(SearchStatus.COMPLETE);
-  });
+      const status = jest.fn().mockResolvedValue(response);
+      const mockClient = getInternalClientMock(status);
 
-  test('returns a running status otherwise', async () => {
-    mockClient.asyncSearch.status.mockResolvedValue({
-      body: {
-        is_partial: false,
-        is_running: true,
-        completion_status: undefined,
-      },
+      const mockFunctions: Record<string, jest.Mock> = {
+        asyncQueryGet,
+        status,
+      };
+
+      // When
+      const res = await getSearchStatus({
+        internalClient: mockClient,
+        asUserClient: mockAsUserClient,
+        asyncId: '123',
+        session: getSession({ strategy }),
+      });
+
+      // Then
+      expect(res.status).toBe(SearchStatus.COMPLETE);
+      expect(mockFunctions[expectedFunctionCall]).toHaveBeenCalledWith(
+        { id: '123' },
+        { meta: true }
+      );
     });
-    const res = await getSearchStatus(mockClient, '123');
-    expect(res.status).toBe(SearchStatus.IN_PROGRESS);
+
+    it('returns an error status if completion_status is an error', async () => {
+      // Given
+      const response = {
+        body: {
+          is_partial: false,
+          is_running: false,
+          completion_status: 500,
+        },
+      };
+
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
+
+      const status = jest.fn().mockResolvedValue(response);
+      const mockClient = getInternalClientMock(status);
+
+      const mockFunctions: Record<string, jest.Mock> = {
+        asyncQueryGet,
+        status,
+      };
+
+      // When
+      const res = await getSearchStatus({
+        internalClient: mockClient,
+        asUserClient: mockAsUserClient,
+        asyncId: '123',
+        session: getSession({ strategy }),
+      });
+
+      // Then
+      expect(res.status).toBe(SearchStatus.ERROR);
+      expect(mockFunctions[expectedFunctionCall]).toHaveBeenCalledWith(
+        { id: '123' },
+        { meta: true }
+      );
+    });
+
+    it('returns an error status if gets an ES error', async () => {
+      // Given
+      const response = {
+        error: {
+          root_cause: {
+            reason: 'not found',
+          },
+        },
+      };
+
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
+
+      const status = jest.fn().mockResolvedValue(response);
+      const mockClient = getInternalClientMock(status);
+
+      const mockFunctions: Record<string, jest.Mock> = {
+        asyncQueryGet,
+        status,
+      };
+
+      // When
+      const res = await getSearchStatus({
+        internalClient: mockClient,
+        asUserClient: mockAsUserClient,
+        asyncId: '123',
+        session: getSession({ strategy }),
+      });
+
+      // Then
+      expect(res.status).toBe(SearchStatus.ERROR);
+      expect(mockFunctions[expectedFunctionCall]).toHaveBeenCalledWith(
+        { id: '123' },
+        { meta: true }
+      );
+    });
+
+    it('returns an error status throws', async () => {
+      // Given
+      const asyncQueryGet = jest.fn().mockRejectedValue(new Error('O_o'));
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
+
+      const status = jest.fn().mockRejectedValue(new Error('O_o'));
+      const mockClient = getInternalClientMock(status);
+
+      const mockFunctions: Record<string, jest.Mock> = {
+        asyncQueryGet,
+        status,
+      };
+
+      // When
+      const res = await getSearchStatus({
+        internalClient: mockClient,
+        asUserClient: mockAsUserClient,
+        asyncId: '123',
+        session: getSession({ strategy }),
+      });
+
+      // Then
+      expect(res.status).toBe(SearchStatus.ERROR);
+      expect(mockFunctions[expectedFunctionCall]).toHaveBeenCalledWith(
+        { id: '123' },
+        { meta: true }
+      );
+    });
+
+    it('returns a complete status', async () => {
+      // Given
+      const response = {
+        body: {
+          is_partial: false,
+          is_running: false,
+          completion_status: 200,
+        },
+      };
+
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
+
+      const status = jest.fn().mockResolvedValue(response);
+      const mockClient = getInternalClientMock(status);
+
+      const mockFunctions: Record<string, jest.Mock> = {
+        asyncQueryGet,
+        status,
+      };
+
+      // When
+      const res = await getSearchStatus({
+        internalClient: mockClient,
+        asUserClient: mockAsUserClient,
+        asyncId: '123',
+        session: getSession({ strategy }),
+      });
+
+      // Then
+      expect(res.status).toBe(SearchStatus.COMPLETE);
+      expect(mockFunctions[expectedFunctionCall]).toHaveBeenCalledWith(
+        { id: '123' },
+        { meta: true }
+      );
+    });
+
+    it('returns a running status otherwise', async () => {
+      // Given
+      const response = {
+        body: {
+          is_partial: false,
+          is_running: true,
+          completion_status: undefined,
+        },
+      };
+
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
+
+      const status = jest.fn().mockResolvedValue(response);
+      const mockClient = getInternalClientMock(status);
+
+      const mockFunctions: Record<string, jest.Mock> = {
+        asyncQueryGet,
+        status,
+      };
+
+      // When
+      const res = await getSearchStatus({
+        internalClient: mockClient,
+        asUserClient: mockAsUserClient,
+        asyncId: '123',
+        session: getSession({ strategy }),
+      });
+
+      // Then
+      expect(res.status).toBe(SearchStatus.IN_PROGRESS);
+      expect(mockFunctions[expectedFunctionCall]).toHaveBeenCalledWith(
+        { id: '123' },
+        { meta: true }
+      );
+    });
   });
 });

--- a/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_search_status.test.ts
@@ -12,14 +12,13 @@ import { getSearchStatus } from './get_search_status';
 import type { SearchSessionRequestInfo } from '../../../common';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 
-const getInternalClientMock = (status = jest.fn()) => {
+const getAsUserClientMock = (asyncQueryGet = jest.fn(), status = jest.fn()) => {
   const client = elasticsearchClientMock.createElasticsearchClient();
-  return { ...client, asyncSearch: { ...client.asyncSearch, status } };
-};
-
-const getAsUserClientMock = (asyncQueryGet = jest.fn()) => {
-  const client = elasticsearchClientMock.createElasticsearchClient();
-  return { ...client, esql: { ...client.esql, asyncQueryGet } };
+  return {
+    ...client,
+    esql: { ...client.esql, asyncQueryGet },
+    asyncSearch: { ...client.asyncSearch, status },
+  };
 };
 
 const getSession = ({
@@ -49,11 +48,9 @@ describe('getSearchStatus', () => {
         },
       };
 
-      const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
-
       const status = jest.fn().mockResolvedValue(response);
-      const mockClient = getInternalClientMock(status);
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -62,7 +59,6 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        internalClient: mockClient,
         asUserClient: mockAsUserClient,
         asyncId: '123',
         session: getSession({ strategy }),
@@ -86,11 +82,9 @@ describe('getSearchStatus', () => {
         },
       };
 
-      const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
-
       const status = jest.fn().mockResolvedValue(response);
-      const mockClient = getInternalClientMock(status);
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -99,7 +93,6 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        internalClient: mockClient,
         asUserClient: mockAsUserClient,
         asyncId: '123',
         session: getSession({ strategy }),
@@ -123,11 +116,9 @@ describe('getSearchStatus', () => {
         },
       };
 
-      const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
-
       const status = jest.fn().mockResolvedValue(response);
-      const mockClient = getInternalClientMock(status);
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -136,7 +127,6 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        internalClient: mockClient,
         asUserClient: mockAsUserClient,
         asyncId: '123',
         session: getSession({ strategy }),
@@ -152,11 +142,9 @@ describe('getSearchStatus', () => {
 
     it('returns an error status throws', async () => {
       // Given
-      const asyncQueryGet = jest.fn().mockRejectedValue(new Error('O_o'));
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
-
       const status = jest.fn().mockRejectedValue(new Error('O_o'));
-      const mockClient = getInternalClientMock(status);
+      const asyncQueryGet = jest.fn().mockRejectedValue(new Error('O_o'));
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -165,7 +153,6 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        internalClient: mockClient,
         asUserClient: mockAsUserClient,
         asyncId: '123',
         session: getSession({ strategy }),
@@ -189,11 +176,9 @@ describe('getSearchStatus', () => {
         },
       };
 
-      const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
-
       const status = jest.fn().mockResolvedValue(response);
-      const mockClient = getInternalClientMock(status);
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -202,7 +187,6 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        internalClient: mockClient,
         asUserClient: mockAsUserClient,
         asyncId: '123',
         session: getSession({ strategy }),
@@ -226,11 +210,9 @@ describe('getSearchStatus', () => {
         },
       };
 
-      const asyncQueryGet = jest.fn().mockResolvedValue(response);
-      const mockAsUserClient = getAsUserClientMock(asyncQueryGet);
-
       const status = jest.fn().mockResolvedValue(response);
-      const mockClient = getInternalClientMock(status);
+      const asyncQueryGet = jest.fn().mockResolvedValue(response);
+      const mockAsUserClient = getAsUserClientMock(asyncQueryGet, status);
 
       const mockFunctions: Record<string, jest.Mock> = {
         asyncQueryGet,
@@ -239,7 +221,6 @@ describe('getSearchStatus', () => {
 
       // When
       const res = await getSearchStatus({
-        internalClient: mockClient,
         asUserClient: mockAsUserClient,
         asyncId: '123',
         session: getSession({ strategy }),

--- a/src/platform/plugins/shared/data/server/search/session/get_search_status.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_search_status.ts
@@ -16,18 +16,16 @@ function requestByStrategy({
   session,
   asyncId,
   asUserClient,
-  internalClient,
 }: {
   session: SearchSessionRequestInfo;
   asyncId: string;
   asUserClient: ElasticsearchClient;
-  internalClient: ElasticsearchClient;
 }) {
   if (session.strategy === 'esql_async') {
     return asUserClient.esql.asyncQueryGet({ id: asyncId }, { meta: true });
   }
 
-  return internalClient.asyncSearch.status(
+  return asUserClient.asyncSearch.status(
     {
       id: asyncId,
     },
@@ -39,12 +37,10 @@ export async function getSearchStatus({
   session,
   asyncId,
   asUserClient,
-  internalClient,
 }: {
   session: SearchSessionRequestInfo;
   asyncId: string;
   asUserClient: ElasticsearchClient;
-  internalClient: ElasticsearchClient;
 }): Promise<SearchSessionRequestStatus> {
   // TODO: Handle strategies other than the default one
   // https://github.com/elastic/kibana/issues/127880
@@ -53,7 +49,6 @@ export async function getSearchStatus({
       session,
       asyncId,
       asUserClient,
-      internalClient,
     });
 
     const response = apiResponse.body;

--- a/src/platform/plugins/shared/data/server/search/session/get_search_status.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_search_status.ts
@@ -15,17 +15,17 @@ import { SearchStatus } from './types';
 function requestByStrategy({
   session,
   asyncId,
-  asUserClient,
+  esClient,
 }: {
   session: SearchSessionRequestInfo;
   asyncId: string;
-  asUserClient: ElasticsearchClient;
+  esClient: ElasticsearchClient;
 }) {
   if (session.strategy === 'esql_async') {
-    return asUserClient.esql.asyncQueryGet({ id: asyncId }, { meta: true });
+    return esClient.esql.asyncQueryGet({ id: asyncId }, { meta: true });
   }
 
-  return asUserClient.asyncSearch.status(
+  return esClient.asyncSearch.status(
     {
       id: asyncId,
     },
@@ -36,11 +36,11 @@ function requestByStrategy({
 export async function getSearchStatus({
   session,
   asyncId,
-  asUserClient,
+  esClient,
 }: {
   session: SearchSessionRequestInfo;
   asyncId: string;
-  asUserClient: ElasticsearchClient;
+  esClient: ElasticsearchClient;
 }): Promise<SearchSessionRequestStatus> {
   // TODO: Handle strategies other than the default one
   // https://github.com/elastic/kibana/issues/127880
@@ -48,7 +48,7 @@ export async function getSearchStatus({
     const apiResponse = await requestByStrategy({
       session,
       asyncId,
-      asUserClient,
+      esClient,
     });
 
     const response = apiResponse.body;

--- a/src/platform/plugins/shared/data/server/search/session/get_search_status.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_search_status.ts
@@ -8,28 +8,56 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { TransportResult } from '@elastic/elasticsearch';
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { SearchSessionRequestStatus } from '../../../common';
+import type { SearchSessionRequestInfo, SearchSessionRequestStatus } from '../../../common';
 import { SearchStatus } from './types';
-import type { AsyncSearchStatusResponse } from '../..';
 
-export async function getSearchStatus(
-  internalClient: ElasticsearchClient,
-  asyncId: string
-): Promise<SearchSessionRequestStatus> {
+function requestByStrategy({
+  session,
+  asyncId,
+  asUserClient,
+  internalClient,
+}: {
+  session: SearchSessionRequestInfo;
+  asyncId: string;
+  asUserClient: ElasticsearchClient;
+  internalClient: ElasticsearchClient;
+}) {
+  if (session.strategy === 'esql_async') {
+    return asUserClient.esql.asyncQueryGet({ id: asyncId }, { meta: true });
+  }
+
+  return internalClient.asyncSearch.status(
+    {
+      id: asyncId,
+    },
+    { meta: true }
+  );
+}
+
+export async function getSearchStatus({
+  session,
+  asyncId,
+  asUserClient,
+  internalClient,
+}: {
+  session: SearchSessionRequestInfo;
+  asyncId: string;
+  asUserClient: ElasticsearchClient;
+  internalClient: ElasticsearchClient;
+}): Promise<SearchSessionRequestStatus> {
   // TODO: Handle strategies other than the default one
   // https://github.com/elastic/kibana/issues/127880
   try {
-    const apiResponse: TransportResult<AsyncSearchStatusResponse> =
-      await internalClient.asyncSearch.status(
-        {
-          id: asyncId,
-        },
-        { meta: true }
-      );
+    const apiResponse = await requestByStrategy({
+      session,
+      asyncId,
+      asUserClient,
+      internalClient,
+    });
+
     const response = apiResponse.body;
-    if (response.completion_status! >= 400) {
+    if ('completion_status' in response && response.completion_status! >= 400) {
       return {
         status: SearchStatus.ERROR,
         error: i18n.translate('data.search.statusError', {

--- a/src/platform/plugins/shared/data/server/search/session/get_session_status.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_session_status.test.ts
@@ -39,12 +39,11 @@ const mockCompletedSearchResponse = {
 
 describe('getSessionStatus', () => {
   beforeEach(() => {
-    deps.internalClient.asyncSearch.status.mockReset();
+    deps.asUserClient.asyncSearch.status.mockReset();
   });
 
   const mockConfig = {} as unknown as SearchSessionsConfigSchema;
   const deps = {
-    internalClient: elasticsearchServiceMock.createElasticsearchClient(),
     asUserClient: elasticsearchServiceMock.createElasticsearchClient(),
   };
   test("returns an in_progress status if there's nothing inside the session", async () => {
@@ -58,7 +57,7 @@ describe('getSessionStatus', () => {
   });
 
   test("returns an error status if there's at least one error", async () => {
-    deps.internalClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
+    deps.asUserClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
       switch (id) {
         case 'a':
           return mockInProgressSearchResponse;
@@ -99,7 +98,7 @@ describe('getSessionStatus', () => {
   });
 
   test('doesnt expire if expire > now', async () => {
-    deps.internalClient.asyncSearch.status.mockResolvedValue(mockInProgressSearchResponse as any);
+    deps.asUserClient.asyncSearch.status.mockResolvedValue(mockInProgressSearchResponse as any);
 
     const session: any = {
       idMapping: {
@@ -126,7 +125,7 @@ describe('getSessionStatus', () => {
   });
 
   test('returns a complete status if all are complete', async () => {
-    deps.internalClient.asyncSearch.status.mockResolvedValue(mockCompletedSearchResponse as any);
+    deps.asUserClient.asyncSearch.status.mockResolvedValue(mockCompletedSearchResponse as any);
 
     const session: any = {
       idMapping: {
@@ -141,7 +140,7 @@ describe('getSessionStatus', () => {
   });
 
   test('returns a running status if some are still running', async () => {
-    deps.internalClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
+    deps.asUserClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
       switch (id) {
         case 'a':
           return mockInProgressSearchResponse;

--- a/src/platform/plugins/shared/data/server/search/session/get_session_status.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_session_status.test.ts
@@ -39,12 +39,12 @@ const mockCompletedSearchResponse = {
 
 describe('getSessionStatus', () => {
   beforeEach(() => {
-    deps.asUserClient.asyncSearch.status.mockReset();
+    deps.esClient.asyncSearch.status.mockReset();
   });
 
   const mockConfig = {} as unknown as SearchSessionsConfigSchema;
   const deps = {
-    asUserClient: elasticsearchServiceMock.createElasticsearchClient(),
+    esClient: elasticsearchServiceMock.createElasticsearchClient(),
   };
   test("returns an in_progress status if there's nothing inside the session", async () => {
     const session: any = {
@@ -57,7 +57,7 @@ describe('getSessionStatus', () => {
   });
 
   test("returns an error status if there's at least one error", async () => {
-    deps.asUserClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
+    deps.esClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
       switch (id) {
         case 'a':
           return mockInProgressSearchResponse;
@@ -98,7 +98,7 @@ describe('getSessionStatus', () => {
   });
 
   test('doesnt expire if expire > now', async () => {
-    deps.asUserClient.asyncSearch.status.mockResolvedValue(mockInProgressSearchResponse as any);
+    deps.esClient.asyncSearch.status.mockResolvedValue(mockInProgressSearchResponse as any);
 
     const session: any = {
       idMapping: {
@@ -125,7 +125,7 @@ describe('getSessionStatus', () => {
   });
 
   test('returns a complete status if all are complete', async () => {
-    deps.asUserClient.asyncSearch.status.mockResolvedValue(mockCompletedSearchResponse as any);
+    deps.esClient.asyncSearch.status.mockResolvedValue(mockCompletedSearchResponse as any);
 
     const session: any = {
       idMapping: {
@@ -140,7 +140,7 @@ describe('getSessionStatus', () => {
   });
 
   test('returns a running status if some are still running', async () => {
-    deps.asUserClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
+    deps.esClient.asyncSearch.status.mockImplementation(async ({ id }): Promise<any> => {
       switch (id) {
         case 'a':
           return mockInProgressSearchResponse;

--- a/src/platform/plugins/shared/data/server/search/session/get_session_status.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_session_status.test.ts
@@ -43,7 +43,10 @@ describe('getSessionStatus', () => {
   });
 
   const mockConfig = {} as unknown as SearchSessionsConfigSchema;
-  const deps = { internalClient: elasticsearchServiceMock.createElasticsearchClient() };
+  const deps = {
+    internalClient: elasticsearchServiceMock.createElasticsearchClient(),
+    asUserClient: elasticsearchServiceMock.createElasticsearchClient(),
+  };
   test("returns an in_progress status if there's nothing inside the session", async () => {
     const session: any = {
       idMapping: {},

--- a/src/platform/plugins/shared/data/server/search/session/get_session_status.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_session_status.ts
@@ -16,7 +16,7 @@ import type { SearchSessionsConfigSchema } from '../../config';
 import { getSearchStatus } from './get_search_status';
 
 export async function getSessionStatus(
-  deps: { asUserClient: ElasticsearchClient },
+  deps: { esClient: ElasticsearchClient },
   session: SearchSessionSavedObjectAttributes,
   config: SearchSessionsConfigSchema
 ): Promise<{ status: SearchSessionStatus; errors?: string[] }> {
@@ -36,7 +36,7 @@ export async function getSessionStatus(
       const status = await getSearchStatus({
         asyncId: s.id,
         session: s,
-        asUserClient: deps.asUserClient,
+        esClient: deps.esClient,
       });
       return {
         ...s,

--- a/src/platform/plugins/shared/data/server/search/session/get_session_status.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_session_status.ts
@@ -16,7 +16,7 @@ import type { SearchSessionsConfigSchema } from '../../config';
 import { getSearchStatus } from './get_search_status';
 
 export async function getSessionStatus(
-  deps: { internalClient: ElasticsearchClient },
+  deps: { internalClient: ElasticsearchClient; asUserClient: ElasticsearchClient },
   session: SearchSessionSavedObjectAttributes,
   config: SearchSessionsConfigSchema
 ): Promise<{ status: SearchSessionStatus; errors?: string[] }> {
@@ -33,7 +33,12 @@ export async function getSessionStatus(
   const searches = Object.values(session.idMapping);
   const searchStatuses = await Promise.all(
     searches.map(async (s) => {
-      const status = await getSearchStatus(deps.internalClient, s.id);
+      const status = await getSearchStatus({
+        internalClient: deps.internalClient,
+        asyncId: s.id,
+        session: s,
+        asUserClient: deps.asUserClient,
+      });
       return {
         ...s,
         ...status,

--- a/src/platform/plugins/shared/data/server/search/session/get_session_status.ts
+++ b/src/platform/plugins/shared/data/server/search/session/get_session_status.ts
@@ -16,7 +16,7 @@ import type { SearchSessionsConfigSchema } from '../../config';
 import { getSearchStatus } from './get_search_status';
 
 export async function getSessionStatus(
-  deps: { internalClient: ElasticsearchClient; asUserClient: ElasticsearchClient },
+  deps: { asUserClient: ElasticsearchClient },
   session: SearchSessionSavedObjectAttributes,
   config: SearchSessionsConfigSchema
 ): Promise<{ status: SearchSessionStatus; errors?: string[] }> {
@@ -34,7 +34,6 @@ export async function getSessionStatus(
   const searchStatuses = await Promise.all(
     searches.map(async (s) => {
       const status = await getSearchStatus({
-        internalClient: deps.internalClient,
         asyncId: s.id,
         session: s,
         asUserClient: deps.asUserClient,

--- a/src/platform/plugins/shared/data/server/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/session_service.test.ts
@@ -26,7 +26,6 @@ const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
 
 describe('SearchSessionService', () => {
   let savedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
-  let elasticsearchClient: ElasticsearchClientMock;
   let asCurrentUserElasticsearchClient: ElasticsearchClientMock;
   let service: SearchSessionService;
 
@@ -65,7 +64,6 @@ describe('SearchSessionService', () => {
   describe('Feature disabled', () => {
     beforeEach(async () => {
       savedObjectsClient = savedObjectsClientMock.create();
-      elasticsearchClient = elasticsearchServiceMock.createElasticsearchClient();
       asCurrentUserElasticsearchClient = elasticsearchServiceMock.createElasticsearchClient();
       const config: ConfigSchema = {
         search: {
@@ -133,7 +131,6 @@ describe('SearchSessionService', () => {
   describe('Feature enabled', () => {
     beforeEach(async () => {
       savedObjectsClient = savedObjectsClientMock.create();
-      elasticsearchClient = elasticsearchServiceMock.createElasticsearchClient();
       const config: ConfigSchema = {
         search: {
           sessions: {
@@ -294,7 +291,6 @@ describe('SearchSessionService', () => {
         const response = await service.find(
           {
             savedObjectsClient,
-            internalElasticsearchClient: elasticsearchClient,
             asCurrentUserElasticsearchClient,
           },
           mockUser1,
@@ -386,7 +382,6 @@ describe('SearchSessionService', () => {
         const response1 = await service.find(
           {
             savedObjectsClient,
-            internalElasticsearchClient: elasticsearchClient,
             asCurrentUserElasticsearchClient,
           },
           mockUser1,
@@ -397,7 +392,6 @@ describe('SearchSessionService', () => {
         const response2 = await service.find(
           {
             savedObjectsClient,
-            internalElasticsearchClient: elasticsearchClient,
             asCurrentUserElasticsearchClient,
           },
           mockUser1,
@@ -580,7 +574,6 @@ describe('SearchSessionService', () => {
         const response = await service.find(
           {
             savedObjectsClient,
-            internalElasticsearchClient: elasticsearchClient,
             asCurrentUserElasticsearchClient,
           },
           null,

--- a/src/platform/plugins/shared/data/server/search/session/session_service.test.ts
+++ b/src/platform/plugins/shared/data/server/search/session/session_service.test.ts
@@ -27,6 +27,7 @@ const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
 describe('SearchSessionService', () => {
   let savedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
   let elasticsearchClient: ElasticsearchClientMock;
+  let asCurrentUserElasticsearchClient: ElasticsearchClientMock;
   let service: SearchSessionService;
 
   const MOCK_STRATEGY = 'ese';
@@ -65,6 +66,7 @@ describe('SearchSessionService', () => {
     beforeEach(async () => {
       savedObjectsClient = savedObjectsClientMock.create();
       elasticsearchClient = elasticsearchServiceMock.createElasticsearchClient();
+      asCurrentUserElasticsearchClient = elasticsearchServiceMock.createElasticsearchClient();
       const config: ConfigSchema = {
         search: {
           sessions: {
@@ -290,7 +292,11 @@ describe('SearchSessionService', () => {
 
         const options = { page: 0, perPage: 5 };
         const response = await service.find(
-          { savedObjectsClient, internalElasticsearchClient: elasticsearchClient },
+          {
+            savedObjectsClient,
+            internalElasticsearchClient: elasticsearchClient,
+            asCurrentUserElasticsearchClient,
+          },
           mockUser1,
           options
         );
@@ -378,14 +384,22 @@ describe('SearchSessionService', () => {
 
         const options1 = { filter: 'foobar' };
         const response1 = await service.find(
-          { savedObjectsClient, internalElasticsearchClient: elasticsearchClient },
+          {
+            savedObjectsClient,
+            internalElasticsearchClient: elasticsearchClient,
+            asCurrentUserElasticsearchClient,
+          },
           mockUser1,
           options1
         );
 
         const options2 = { filter: nodeBuilder.is('foo', 'bar') };
         const response2 = await service.find(
-          { savedObjectsClient, internalElasticsearchClient: elasticsearchClient },
+          {
+            savedObjectsClient,
+            internalElasticsearchClient: elasticsearchClient,
+            asCurrentUserElasticsearchClient,
+          },
           mockUser1,
           options2
         );
@@ -564,7 +578,11 @@ describe('SearchSessionService', () => {
 
         const options = { page: 0, perPage: 5 };
         const response = await service.find(
-          { savedObjectsClient, internalElasticsearchClient: elasticsearchClient },
+          {
+            savedObjectsClient,
+            internalElasticsearchClient: elasticsearchClient,
+            asCurrentUserElasticsearchClient,
+          },
           null,
           options
         );

--- a/src/platform/plugins/shared/data/server/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/server/search/session/session_service.ts
@@ -41,7 +41,6 @@ export interface SearchSessionDependencies {
 }
 
 export interface SearchSessionStatusDependencies extends SearchSessionDependencies {
-  internalElasticsearchClient: ElasticsearchClient;
   asCurrentUserElasticsearchClient: ElasticsearchClient;
 }
 
@@ -162,11 +161,7 @@ export class SearchSessionService implements ISearchSessionService {
   };
 
   public find = async (
-    {
-      savedObjectsClient,
-      internalElasticsearchClient,
-      asCurrentUserElasticsearchClient,
-    }: SearchSessionStatusDependencies,
+    { savedObjectsClient, asCurrentUserElasticsearchClient }: SearchSessionStatusDependencies,
     user: AuthenticatedUser | null,
     options: Omit<SavedObjectsFindOptions, 'type'>
   ): Promise<SearchSessionsFindResponse> => {
@@ -197,7 +192,6 @@ export class SearchSessionService implements ISearchSessionService {
       findResponse.saved_objects.map(async (so) => {
         const sessionStatus = await getSessionStatus(
           {
-            internalClient: internalElasticsearchClient,
             asUserClient: asCurrentUserElasticsearchClient,
           },
           so.attributes,
@@ -379,7 +373,6 @@ export class SearchSessionService implements ISearchSessionService {
 
     const sessionStatus = await getSessionStatus(
       {
-        internalClient: deps.internalElasticsearchClient,
         asUserClient: deps.asCurrentUserElasticsearchClient,
       },
       session.attributes,
@@ -433,12 +426,10 @@ export class SearchSessionService implements ISearchSessionService {
         includedHiddenTypes: [SEARCH_SESSION_TYPE],
       });
 
-      const internalElasticsearchClient = elasticsearch.client.asScoped(request).asInternalUser;
       const asCurrentUserElasticsearchClient = elasticsearch.client.asScoped(request).asCurrentUser;
 
       const deps = {
         savedObjectsClient,
-        internalElasticsearchClient,
         asCurrentUserElasticsearchClient,
       };
       return {

--- a/src/platform/plugins/shared/data/server/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/server/search/session/session_service.ts
@@ -42,6 +42,7 @@ export interface SearchSessionDependencies {
 
 export interface SearchSessionStatusDependencies extends SearchSessionDependencies {
   internalElasticsearchClient: ElasticsearchClient;
+  asCurrentUserElasticsearchClient: ElasticsearchClient;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -161,7 +162,11 @@ export class SearchSessionService implements ISearchSessionService {
   };
 
   public find = async (
-    { savedObjectsClient, internalElasticsearchClient }: SearchSessionStatusDependencies,
+    {
+      savedObjectsClient,
+      internalElasticsearchClient,
+      asCurrentUserElasticsearchClient,
+    }: SearchSessionStatusDependencies,
     user: AuthenticatedUser | null,
     options: Omit<SavedObjectsFindOptions, 'type'>
   ): Promise<SearchSessionsFindResponse> => {
@@ -191,7 +196,10 @@ export class SearchSessionService implements ISearchSessionService {
     const sessionStatuses = await Promise.all(
       findResponse.saved_objects.map(async (so) => {
         const sessionStatus = await getSessionStatus(
-          { internalClient: internalElasticsearchClient },
+          {
+            internalClient: internalElasticsearchClient,
+            asUserClient: asCurrentUserElasticsearchClient,
+          },
           so.attributes,
           this.sessionConfig
         );
@@ -370,7 +378,10 @@ export class SearchSessionService implements ISearchSessionService {
     const session = await this.get(deps, user, sessionId);
 
     const sessionStatus = await getSessionStatus(
-      { internalClient: deps.internalElasticsearchClient },
+      {
+        internalClient: deps.internalElasticsearchClient,
+        asUserClient: deps.asCurrentUserElasticsearchClient,
+      },
       session.attributes,
       this.sessionConfig
     );
@@ -423,7 +434,13 @@ export class SearchSessionService implements ISearchSessionService {
       });
 
       const internalElasticsearchClient = elasticsearch.client.asScoped(request).asInternalUser;
-      const deps = { savedObjectsClient, internalElasticsearchClient };
+      const asCurrentUserElasticsearchClient = elasticsearch.client.asScoped(request).asCurrentUser;
+
+      const deps = {
+        savedObjectsClient,
+        internalElasticsearchClient,
+        asCurrentUserElasticsearchClient,
+      };
       return {
         getId: this.getId.bind(this, deps, user),
         trackId: this.trackId.bind(this, deps, user),

--- a/src/platform/plugins/shared/data/server/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/server/search/session/session_service.ts
@@ -192,7 +192,7 @@ export class SearchSessionService implements ISearchSessionService {
       findResponse.saved_objects.map(async (so) => {
         const sessionStatus = await getSessionStatus(
           {
-            asUserClient: asCurrentUserElasticsearchClient,
+            esClient: asCurrentUserElasticsearchClient,
           },
           so.attributes,
           this.sessionConfig
@@ -373,7 +373,7 @@ export class SearchSessionService implements ISearchSessionService {
 
     const sessionStatus = await getSessionStatus(
       {
-        asUserClient: deps.asCurrentUserElasticsearchClient,
+        esClient: deps.asCurrentUserElasticsearchClient,
       },
       session.attributes,
       this.sessionConfig

--- a/src/platform/plugins/shared/data/tsconfig.json
+++ b/src/platform/plugins/shared/data/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "target/types",
+    "outDir": "target/types"
   },
   "include": [
     "common/**/*",
@@ -59,8 +59,7 @@
     "@kbn/core-execution-context-server",
     "@kbn/data-service-server",
     "@kbn/css-utils",
+    "@kbn/core-elasticsearch-client-server-mocks"
   ],
-  "exclude": [
-    "target/**/*",
-  ]
+  "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_all.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_all.ts
@@ -122,6 +122,7 @@ export function fetchAll(
           expressions,
           scopedProfilesManager,
           timeRange: currentTab.dataRequestParams.timeRangeAbsolute,
+          searchSessionId: params.searchSessionId,
         })
       : fetchDocuments(searchSource, params);
     const fetchType = isEsqlQuery ? 'fetchTextBased' : 'fetchDocuments';

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
@@ -40,6 +40,7 @@ export function fetchEsql({
   data,
   expressions,
   scopedProfilesManager,
+  searchSessionId,
 }: {
   query: Query | AggregateQuery;
   inputQuery?: Query;
@@ -51,6 +52,7 @@ export function fetchEsql({
   data: DataPublicPluginStart;
   expressions: ExpressionsStart;
   scopedProfilesManager: ScopedProfilesManager;
+  searchSessionId?: string;
 }): Promise<RecordsFetchResponse> {
   const props = getTextBasedQueryStateToAstProps({
     query,
@@ -65,6 +67,7 @@ export function fetchEsql({
       if (ast) {
         const contract = expressions.execute(ast, null, {
           inspectorAdapters,
+          searchSessionId,
         });
         abortSignal?.addEventListener('abort', contract.cancel);
         const execution = contract.getData();

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
@@ -192,6 +192,7 @@ export function initializeFetch({
               data: discoverServices.data,
               expressions: discoverServices.expressions,
               scopedProfilesManager,
+              searchSessionId,
             });
             return {
               columnsMeta: result.esqlQueryColumns

--- a/x-pack/platform/test/search_sessions_integration/tests/apps/discover/async_search.ts
+++ b/x-pack/platform/test/search_sessions_integration/tests/apps/discover/async_search.ts
@@ -147,15 +147,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(searchesCountBeforeRestore).to.be(searchesCountAfterRestore); // no new searches started during restore
     });
 
-    it('should should clean the search session when navigating to ESQL mode, and reinitialize when navigating back', async () => {
+    it('should have the search session when navigating to ESQL mode', async () => {
       await common.navigateToApp('discover');
-      await timePicker.setDefaultAbsoluteRange();
-      await header.waitUntilLoadingHasFinished();
-      expect(await searchSessions.exists()).to.be(true);
       await discover.selectTextBaseLang();
-      await header.waitUntilLoadingHasFinished();
-      await searchSessions.missingOrFail();
-      await browser.goBack();
       await header.waitUntilLoadingHasFinished();
       expect(await searchSessions.exists()).to.be(true);
     });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/225696
Closes https://github.com/elastic/kibana/issues/229745

Makes it possible to store ES|QL discover sessions and dashboards as search sessions.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



