### PR TITLE
[8.19] [Discover][Unified Waterfall] Warn on incomplete trace data for Trace Waterfall v2 (#228983)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/focused_trace_waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/focused_trace_waterfall/index.tsx
@@ -67,21 +67,22 @@ function getTraceItems(items: NonNullable<FocusedTrace['traceItems']>) {
 
 export function FocusedTraceWaterfall({ items, onErrorClick }: Props) {
   const reparentedItems = reparentDocumentToRoot(items.traceItems);
-  if (!reparentedItems) {
-    return null;
-  }
-  const traceItems = getTraceItems(reparentedItems);
+  const traceItems = reparentedItems ? getTraceItems(reparentedItems) : [];
 
   return (
     <>
       <TraceWaterfall
         traceItems={traceItems}
         showAccordion={false}
-        highlightedTraceId={reparentedItems.focusedTraceDoc.id}
+        highlightedTraceId={reparentedItems?.focusedTraceDoc.id}
         onErrorClick={onErrorClick}
       />
-      <EuiSpacer />
-      <TraceSummary summary={items.summary} />
+      {reparentedItems ? (
+        <>
+          <EuiSpacer />
+          <TraceSummary summary={items.summary} />
+        </>
+      ) : null}
     </>
   );
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx
@@ -18,6 +18,7 @@ import type { OnErrorClick, OnNodeClick } from './trace_waterfall_context';
 import { TraceWaterfallContextProvider, useTraceWaterfallContext } from './trace_waterfall_context';
 import type { TraceWaterfallItem } from './use_trace_waterfall';
 import type { IWaterfallGetRelatedErrorsHref } from '../../app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
+import { TraceWarning } from './trace_warning';
 
 export interface Props {
   traceItems: TraceItem[];
@@ -51,7 +52,9 @@ export function TraceWaterfall({
       getRelatedErrorsHref={getRelatedErrorsHref}
       isEmbeddable={isEmbeddable}
     >
-      <TraceWaterfallComponent />
+      <TraceWarning>
+        <TraceWaterfallComponent />
+      </TraceWarning>
     </TraceWaterfallContextProvider>
   );
 }
@@ -60,14 +63,9 @@ function TraceWaterfallComponent() {
   const { euiTheme } = useEuiTheme();
   const {
     duration,
-    rootItem,
     margin: { left, right },
     isEmbeddable,
   } = useTraceWaterfallContext();
-
-  if (!rootItem) {
-    return null;
-  }
 
   return (
     <div style={{ position: 'relative' }}>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiCallOut } from '@elastic/eui';
+import { useTraceWaterfallContext } from './trace_waterfall_context';
+
+const FALLBACK_WARNING = i18n.translate(
+  'xpack.apm.traceWaterfallContext.warningMessage.fallbackWarning',
+  {
+    defaultMessage:
+      'The trace document is incomplete and not all spans have arrived yet. Try refreshing the page or adjusting the time range.',
+  }
+);
+
+export function TraceWarning({ children }: { children: React.ReactNode }) {
+  const { rootItem } = useTraceWaterfallContext();
+
+  return !rootItem ? <EuiCallOut color="warning" size="s" title={FALLBACK_WARNING} /> : children;
+}

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/trace_waterfall/trace_waterfall_embeddable.tsx
@@ -55,7 +55,7 @@ export function TraceWaterfallEmbeddable({
       <EuiFlexItem>
         <TraceWaterfall
           traceItems={data?.traceItems!}
-          onClick={(id) => onNodeClick?.(id)}
+          onClick={onNodeClick}
           scrollElement={scrollElement}
           getRelatedErrorsHref={getRelatedErrorsHref}
           isEmbeddable


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][Unified Waterfall] Warn on incomplete trace data for Trace Waterfall v2 (#228983)](https://github.com/elastic/kibana/pull/228983)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-07-30T15:09:01Z","message":"[Discover][Unified Waterfall] Warn on incomplete trace data for Trace Waterfall v2 (#228983)\n\n(Redo and updated version of #227290)\n\n## Summary\n\nAdds a warning to the Discover trace widgets (Focused/Full) when they\ncannot render the traces due to incomplete data/missing spans.\nCurrently, this is for cases where no data is able to be shown, and\nexpanding this to cover more cases such as partial rendering is outside\nof the scope of this PR (as that will require changing how the data is\nprocessed to support the partial rendering case). That will be handled\nin a follow-up issue/PR.\n\n|     | Screenshots |\n| -- | ------------- |\n| Focused Waterfall |\n![image](https://github.com/user-attachments/assets/393361d9-d08a-41d2-b4d6-e35d328461ef)\n|\n| Full Waterfall |\n![image](https://github.com/user-attachments/assets/58dddfe6-f8f5-4e06-b70b-c53117783c33)\n|\n\n## How to test\n\n- Ensure space is set to Observability mode, navigate to Discover,\nswitch to ES|QL mode and target an index with processed OTEL traces. For\nexample with edge-oblt-ccs: `remote_cluster:traces-generic.otel-default`\n- Select the newest/freshest span/transaction and open the overview.\n- If the focused waterfall doesn't render, it should show a callout.\nGoing to the full waterfall should show a callout in most cases if the\nfocused waterfal shows a callout.\n- Refreshing the time range should load more data, and if the same span\nis selected, the callout should disappear as the full data is likely to\nbe present.","sha":"db01ee5bc84680066e51edb7bf00dc01d67a1fbf","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v8.19.0","v9.2.0","v9.1.1"],"title":"[Discover][Unified Waterfall] Warn on incomplete trace data for Trace Waterfall v2","number":228983,"url":"https://github.com/elastic/kibana/pull/228983","mergeCommit":{"message":"[Discover][Unified Waterfall] Warn on incomplete trace data for Trace Waterfall v2 (#228983)\n\n(Redo and updated version of #227290)\n\n## Summary\n\nAdds a warning to the Discover trace widgets (Focused/Full) when they\ncannot render the traces due to incomplete data/missing spans.\nCurrently, this is for cases where no data is able to be shown, and\nexpanding this to cover more cases such as partial rendering is outside\nof the scope of this PR (as that will require changing how the data is\nprocessed to support the partial rendering case). That will be handled\nin a follow-up issue/PR.\n\n|     | Screenshots |\n| -- | ------------- |\n| Focused Waterfall |\n![image](https://github.com/user-attachments/assets/393361d9-d08a-41d2-b4d6-e35d328461ef)\n|\n| Full Waterfall |\n![image](https://github.com/user-attachments/assets/58dddfe6-f8f5-4e06-b70b-c53117783c33)\n|\n\n## How to test\n\n- Ensure space is set to Observability mode, navigate to Discover,\nswitch to ES|QL mode and target an index with processed OTEL traces. For\nexample with edge-oblt-ccs: `remote_cluster:traces-generic.otel-default`\n- Select the newest/freshest span/transaction and open the overview.\n- If the focused waterfall doesn't render, it should show a callout.\nGoing to the full waterfall should show a callout in most cases if the\nfocused waterfal shows a callout.\n- Refreshing the time range should load more data, and if the same span\nis selected, the callout should disappear as the full data is likely to\nbe present.","sha":"db01ee5bc84680066e51edb7bf00dc01d67a1fbf"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228983","number":228983,"mergeCommit":{"message":"[Discover][Unified Waterfall] Warn on incomplete trace data for Trace Waterfall v2 (#228983)\n\n(Redo and updated version of #227290)\n\n## Summary\n\nAdds a warning to the Discover trace widgets (Focused/Full) when they\ncannot render the traces due to incomplete data/missing spans.\nCurrently, this is for cases where no data is able to be shown, and\nexpanding this to cover more cases such as partial rendering is outside\nof the scope of this PR (as that will require changing how the data is\nprocessed to support the partial rendering case). That will be handled\nin a follow-up issue/PR.\n\n|     | Screenshots |\n| -- | ------------- |\n| Focused Waterfall |\n![image](https://github.com/user-attachments/assets/393361d9-d08a-41d2-b4d6-e35d328461ef)\n|\n| Full Waterfall |\n![image](https://github.com/user-attachments/assets/58dddfe6-f8f5-4e06-b70b-c53117783c33)\n|\n\n## How to test\n\n- Ensure space is set to Observability mode, navigate to Discover,\nswitch to ES|QL mode and target an index with processed OTEL traces. For\nexample with edge-oblt-ccs: `remote_cluster:traces-generic.otel-default`\n- Select the newest/freshest span/transaction and open the overview.\n- If the focused waterfall doesn't render, it should show a callout.\nGoing to the full waterfall should show a callout in most cases if the\nfocused waterfal shows a callout.\n- Refreshing the time range should load more data, and if the same span\nis selected, the callout should disappear as the full data is likely to\nbe present.","sha":"db01ee5bc84680066e51edb7bf00dc01d67a1fbf"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->