### PR TITLE
[Streams] Specify ignored_malformed for processing simulation 

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -813,7 +813,7 @@ const computeMappingProperties = (detectedFields: NamedFieldDefinitionConfig[]) 
       if (config.type === 'system') {
         return [];
       }
-      return [[name, config]];
+      return [[name, { ...config, ignore_malformed: false }]];
     })
   );
 };


### PR DESCRIPTION
## 📓 Summary

This work specified the `ignore_malformed: false` mapping property for the simulation of detected fields on the simulation.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->