### PR TITLE
Revert "[Discover][UnifiedDataTable] Left align content inside the rendered cell value"

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.scss
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.scss
@@ -7,8 +7,6 @@
 
 .unifiedDataTable__cellValue {
   font-family: $euiCodeFontFamily;
-  display: inline-block;
-  text-align: left;
 }
 
 .unifiedDataTable__cell--expanded {


### PR DESCRIPTION
Reverts elastic/kibana#226562 due to issues with https://github.com/elastic/kibana/issues/229178#issuecomment-3140377497

Closes https://github.com/elastic/kibana/issues/229178

Before:
<img width="1048" height="365" alt="Screenshot 2025-07-31 at 17 49 27" src="https://github.com/user-attachments/assets/5417df3f-674d-4a48-b9e9-69594e1ddb2b" />

After:
<img width="1054" height="392" alt="Screenshot 2025-07-31 at 17 49 56" src="https://github.com/user-attachments/assets/59d116d9-ee6f-4580-a64c-593ac80271d1" />


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->