### PR TITLE
Changes to intercept display intervals

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -246,6 +246,7 @@ enabled:
   - x-pack/platform/test/functional/apps/ml/memory_usage/config.ts
   - x-pack/platform/test/functional/apps/monitoring/config.ts
   - x-pack/platform/test/functional/apps/painless_lab/config.ts
+  - x-pack/platform/test/functional/apps/product_intercept/config.ts
   - x-pack/platform/test/functional/apps/remote_clusters/config.ts
   - x-pack/platform/test/functional/apps/reporting_management/config.ts
   - x-pack/platform/test/functional/apps/rollup_job/config.ts

--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -273,6 +273,7 @@ enabled:
   - x-pack/platform/test/functional/config.upgrade_assistant.ts
   - x-pack/platform/test/functional_cloud/config.ts
   - x-pack/platform/test/functional_cloud/saml.config.ts
+  - x-pack/platform/test/functional_cloud/intercepts.config.ts
   - x-pack/platform/test/licensing_plugin/config.public.ts
   - x-pack/platform/test/licensing_plugin/config.ts
   - x-pack/platform/test/plugin_functional/config.ts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2970,6 +2970,7 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /src/platform/test/functional/page_objects/settings_page.ts @elastic/appex-sharedux
 /src/platform/test/functional/apps/sharing/*.ts @elastic/appex-sharedux
 /src/platform/test/functional/apps/kibana_overviews @elastic/appex-sharedux
+/x-pack/platform/test/functional/apps/product_intercept @elastic/appex-sharedux
 /src/platform/test/examples/ui_actions/*.ts @elastic/appex-sharedux
 /src/platform/test/examples/state_sync/*.ts @elastic/appex-sharedux
 /src/platform/test/examples/error_boundary/index.ts @elastic/appex-sharedux

--- a/x-pack/platform/plugins/private/intercepts/public/prompter/component/intercept_display_manager/intercept_display_manager.test.tsx
+++ b/x-pack/platform/plugins/private/intercepts/public/prompter/component/intercept_display_manager/intercept_display_manager.test.tsx
@@ -127,7 +127,7 @@ describe('InterceptDisplayManager', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeNull();
 
-    await user.click(screen.getByTestId('productInterceptDismiss'));
+    await user.click(screen.getByTestId('productInterceptDismissButton'));
 
     expect(ackProductIntercept).toHaveBeenCalledWith({
       ackType: 'dismissed',

--- a/x-pack/platform/plugins/private/intercepts/public/prompter/component/intercept_display_manager/intercept_display_manager.tsx
+++ b/x-pack/platform/plugins/private/intercepts/public/prompter/component/intercept_display_manager/intercept_display_manager.tsx
@@ -254,7 +254,7 @@ export function InterceptDisplayManager({
                     <EuiFlexItem>
                       <EuiButtonEmpty
                         size="s"
-                        data-test-subj="productInterceptDismiss"
+                        data-test-subj="productInterceptDismissButton"
                         onClick={dismissProductIntercept}
                         color="text"
                       >

--- a/x-pack/platform/plugins/private/product_intercept/README.md
+++ b/x-pack/platform/plugins/private/product_intercept/README.md
@@ -7,3 +7,8 @@ This plugin exposes no public APIs, but however exposes the following config
 - `xpack.product_intercept.enabled`: Expects a boolean value, determines if the product intercept would be allowed to run given that the intercept plugin is enabled.
 
 - `xpack.product_intercept.interval`: Expects a limited subset of duration string; (d,m,h,s) , denotes the cadence at which a user would be prompted to provide feedback about kibana
+
+- `xpack.product_intercept.upgradeInterceptInterval`: Expects a limited subset of duration string; (d,m,h,s) , denotes the interval at which a user would be prompted to provide feedback about kibana after an upgrade event happens
+
+- `xpack.product_intercept.trialInterceptInterval`: Expects a limited subset of duration string; (d,m,h,s) , denotes the interval at which a user would be prompted to provide feedback about kibana when the user is in trial
+

--- a/x-pack/platform/plugins/private/product_intercept/common/config.ts
+++ b/x-pack/platform/plugins/private/product_intercept/common/config.ts
@@ -14,7 +14,7 @@ import type { PluginConfigDescriptor, ExposedToBrowserDescriptor } from '@kbn/co
  */
 export const configSchema = schema.object({
   /**
-   * Whether the product intercept orchestration is enabled.
+   * Denotes whether the product intercept orchestration is enabled.
    * It's worth noting that if the intercept plugin is disabled this setting will have no effect.
    */
   enabled: schema.boolean({
@@ -22,6 +22,22 @@ export const configSchema = schema.object({
   }),
   interval: schema.string({
     defaultValue: '90d',
+    validate(value) {
+      if (!/^[0-9]+(d|h|m|s)$/.test(value)) {
+        return 'must be a supported duration string';
+      }
+    },
+  }),
+  trialInterceptInterval: schema.string({
+    defaultValue: '7d',
+    validate(value) {
+      if (!/^[0-9]+(d|h|m|s)$/.test(value)) {
+        return 'must be a supported duration string';
+      }
+    },
+  }),
+  upgradeInterceptInterval: schema.string({
+    defaultValue: '7d',
     validate(value) {
       if (!/^[0-9]+(d|h|m|s)$/.test(value)) {
         return 'must be a supported duration string';

--- a/x-pack/platform/plugins/private/product_intercept/common/constants.ts
+++ b/x-pack/platform/plugins/private/product_intercept/common/constants.ts
@@ -12,3 +12,5 @@
 export const TRIGGER_DEF_ID = 'productInterceptTrigger' as const;
 
 export const UPGRADE_TRIGGER_DEF_PREFIX_ID = 'productUpgradeInterceptTrigger' as const;
+
+export const TRIAL_TRIGGER_DEF_ID = 'productTrialInterceptTrigger' as const;

--- a/x-pack/platform/plugins/private/product_intercept/public/components/nps_score_input.tsx
+++ b/x-pack/platform/plugins/private/product_intercept/public/components/nps_score_input.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import {
   EuiButtonGroup,
   EuiButtonGroupProps,
@@ -56,7 +57,9 @@ export function NPSScoreInput({
       }
     >
       <EuiButtonGroup
-        legend="Survey about user satisfaction"
+        legend={i18n.translate('xpack.productIntercept.npsSurvey.legend', {
+          defaultMessage: 'Survey for customer satisfaction score',
+        })}
         type="single"
         options={options}
         idSelected={selectedOption}

--- a/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
@@ -61,7 +61,7 @@ export class ProductInterceptPublicPlugin implements Plugin {
         this.upgradeInterceptSubscription,
       ] = [
         TRIGGER_DEF_ID,
-        TRIAL_TRIGGER_DEF_ID,
+        `${TRIAL_TRIGGER_DEF_ID}:${this.buildVersion}`,
         `${UPGRADE_TRIGGER_DEF_PREFIX_ID}:${this.buildVersion}`,
       ].map((triggerId) =>
         intercepts

--- a/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
@@ -28,6 +28,7 @@ export class ProductInterceptPublicPlugin implements Plugin {
   private readonly telemetry = new PromptTelemetry();
   private interceptSubscription?: Subscription;
   private upgradeInterceptSubscription?: Subscription;
+  private trialInterceptSubscription?: Subscription;
   private readonly buildVersion: string;
 
   constructor(ctx: PluginInitializerContext) {
@@ -54,10 +55,14 @@ export class ProductInterceptPublicPlugin implements Plugin {
       surveyUrl.searchParams.set('pid', String(cloud.serverless.projectId || null));
       surveyUrl.searchParams.set('solution', String(cloud.serverless.projectType || null));
 
-      [this.upgradeInterceptSubscription, this.interceptSubscription] = [
+      [
+        this.interceptSubscription,
+        this.trialInterceptSubscription,
+        this.upgradeInterceptSubscription,
+      ] = [
         TRIGGER_DEF_ID,
-        `${UPGRADE_TRIGGER_DEF_PREFIX_ID}:${this.buildVersion}`,
         TRIAL_TRIGGER_DEF_ID,
+        `${UPGRADE_TRIGGER_DEF_PREFIX_ID}:${this.buildVersion}`,
       ].map((triggerId) =>
         intercepts
           .registerIntercept?.({
@@ -80,7 +85,10 @@ export class ProductInterceptPublicPlugin implements Plugin {
   }
 
   stop() {
-    this.interceptSubscription?.unsubscribe();
-    this.upgradeInterceptSubscription?.unsubscribe();
+    [
+      this.interceptSubscription,
+      this.trialInterceptSubscription,
+      this.upgradeInterceptSubscription,
+    ]?.forEach((subscription) => subscription?.unsubscribe());
   }
 }

--- a/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
@@ -13,7 +13,11 @@ import { InterceptsStart } from '@kbn/intercepts-plugin/public';
 import { type CloudStart } from '@kbn/cloud-plugin/public';
 
 import { PromptTelemetry } from './telemetry';
-import { TRIGGER_DEF_ID, UPGRADE_TRIGGER_DEF_PREFIX_ID } from '../common/constants';
+import {
+  TRIGGER_DEF_ID,
+  UPGRADE_TRIGGER_DEF_PREFIX_ID,
+  TRIAL_TRIGGER_DEF_ID,
+} from '../common/constants';
 
 interface ProductInterceptPluginStartDeps {
   intercepts: InterceptsStart;
@@ -53,6 +57,7 @@ export class ProductInterceptPublicPlugin implements Plugin {
       [this.upgradeInterceptSubscription, this.interceptSubscription] = [
         TRIGGER_DEF_ID,
         `${UPGRADE_TRIGGER_DEF_PREFIX_ID}:${this.buildVersion}`,
+        TRIAL_TRIGGER_DEF_ID,
       ].map((triggerId) =>
         intercepts
           .registerIntercept?.({

--- a/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
@@ -39,8 +39,6 @@ export class ProductInterceptServerPlugin
   private readonly logger: Logger;
   private readonly config: ServerConfigSchema;
   private readonly buildVersion: string;
-  private readonly upgradeInterceptInterval: string = '7d';
-  private readonly trialInterceptInterval: string = '7d';
   private trialEndDate?: Date;
 
   constructor(initContext: PluginInitializerContext<unknown>) {
@@ -66,7 +64,7 @@ export class ProductInterceptServerPlugin
         `${UPGRADE_TRIGGER_DEF_PREFIX_ID}:${this.buildVersion}`,
         () => {
           this.logger.debug('Registering global product upgrade intercept trigger definition');
-          return { triggerAfter: this.upgradeInterceptInterval, isRecurrent: false };
+          return { triggerAfter: this.config.upgradeInterceptInterval, isRecurrent: false };
         }
       );
 
@@ -75,7 +73,7 @@ export class ProductInterceptServerPlugin
         void intercepts.registerTriggerDefinition?.(TRIAL_TRIGGER_DEF_ID, () => {
           this.logger.debug('Registering global product trial intercept trigger definition');
           return {
-            triggerAfter: this.trialInterceptInterval,
+            triggerAfter: this.config.trialInterceptInterval,
             isRecurrent: false,
           };
         });

--- a/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
@@ -70,13 +70,16 @@ export class ProductInterceptServerPlugin
 
       // Register trial intercept only if the trial end date is set and not passed
       if (this.trialEndDate && Date.now() <= this.trialEndDate.getTime()) {
-        void intercepts.registerTriggerDefinition?.(TRIAL_TRIGGER_DEF_ID, () => {
-          this.logger.debug('Registering global product trial intercept trigger definition');
-          return {
-            triggerAfter: this.config.trialInterceptInterval,
-            isRecurrent: false,
-          };
-        });
+        void intercepts.registerTriggerDefinition?.(
+          `${TRIAL_TRIGGER_DEF_ID}:${this.buildVersion}`,
+          () => {
+            this.logger.debug('Registering global product trial intercept trigger definition');
+            return {
+              triggerAfter: this.config.trialInterceptInterval,
+              isRecurrent: false,
+            };
+          }
+        );
       }
     }
 

--- a/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/server/plugin.ts
@@ -39,8 +39,8 @@ export class ProductInterceptServerPlugin
   private readonly logger: Logger;
   private readonly config: ServerConfigSchema;
   private readonly buildVersion: string;
-  private readonly upgradeInterval: string = '14d';
-  private readonly trialInterval: string = '7d';
+  private readonly upgradeInterceptInterval: string = '7d';
+  private readonly trialInterceptInterval: string = '7d';
   private trialEndDate?: Date;
 
   constructor(initContext: PluginInitializerContext<unknown>) {
@@ -66,15 +66,16 @@ export class ProductInterceptServerPlugin
         `${UPGRADE_TRIGGER_DEF_PREFIX_ID}:${this.buildVersion}`,
         () => {
           this.logger.debug('Registering global product upgrade intercept trigger definition');
-          return { triggerAfter: this.upgradeInterval, isRecurrent: false };
+          return { triggerAfter: this.upgradeInterceptInterval, isRecurrent: false };
         }
       );
 
-      if (this.trialEndDate && Date.now() <= this.trialEndDate?.getTime()) {
+      // Register trial intercept only if the trial end date is set and not passed
+      if (this.trialEndDate && Date.now() <= this.trialEndDate.getTime()) {
         void intercepts.registerTriggerDefinition?.(TRIAL_TRIGGER_DEF_ID, () => {
           this.logger.debug('Registering global product trial intercept trigger definition');
           return {
-            triggerAfter: this.trialInterval,
+            triggerAfter: this.trialInterceptInterval,
             isRecurrent: false,
           };
         });

--- a/x-pack/platform/test/functional/apps/product_intercept/config.trial.ts
+++ b/x-pack/platform/test/functional/apps/product_intercept/config.trial.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../config.base.ts'));
+
+  const baseConfig = functionalConfig.getAll();
+
+  return {
+    ...baseConfig,
+    testFiles: [require.resolve('.')],
+    kbnTestServer: {
+      ...baseConfig.kbnTestServer,
+      serverArgs: [
+        ...baseConfig.kbnTestServer.serverArgs,
+        '--license=trial',
+        '--xpack.product_intercept.enabled=true',
+        // Use a shorter interval for testing purposes
+        '--xpack.product_intercept.trialInterceptInterval=10s',
+      ],
+    },
+  };
+}

--- a/x-pack/platform/test/functional/apps/product_intercept/config.ts
+++ b/x-pack/platform/test/functional/apps/product_intercept/config.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../config.base.ts'));
+
+  const baseConfig = functionalConfig.getAll();
+
+  return {
+    ...baseConfig,
+    testFiles: [require.resolve('.')],
+    kbnTestServer: {
+      ...baseConfig.kbnTestServer,
+      serverArgs: [
+        ...baseConfig.kbnTestServer.serverArgs,
+        `--xpack.product_intercept.enabled=true`,
+        // Use a shorter interval for testing purposes
+        `--xpack.product_intercept.interval=10s`,
+      ],
+    },
+  };
+}

--- a/x-pack/platform/test/functional/apps/product_intercept/home_page.ts
+++ b/x-pack/platform/test/functional/apps/product_intercept/home_page.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { TRIGGER_DEF_ID } from '@kbn/product-intercept-plugin/common/constants';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const PageObjects = getPageObjects(['common']);
+  const retry = getService('retry');
+  const testSubjects = getService('testSubjects');
+
+  describe('product Intercept on home screen', () => {
+    const interceptTestId = `intercept-${TRIGGER_DEF_ID}`;
+
+    beforeEach(async () => {
+      await PageObjects.common.navigateToUrl('home');
+    });
+
+    it('gets dismissed, when the not now button is clicked', async () => {
+      await retry.waitFor('wait for product intercept to be displayed', async () => {
+        const intercept = await testSubjects.find(interceptTestId);
+        return intercept.isDisplayed();
+      });
+
+      await testSubjects.click('productInterceptDismissButton');
+
+      // intercept should not be displayed anymore
+      await testSubjects.find(interceptTestId).catch((err) => {
+        expect(err.message).to.ok();
+      });
+    });
+
+    it('displays all available steps', async () => {
+      await retry.waitFor('wait for product intercept to be displayed', async () => {
+        const intercept = await testSubjects.find(interceptTestId);
+        return intercept.isDisplayed();
+      });
+
+      // Navigate to the intercept steps
+      await testSubjects.click('productInterceptProgressionButton');
+
+      let progressionButton:
+        | (ReturnType<typeof testSubjects.find> extends Promise<infer R> ? R : never)
+        | null = null;
+
+      do {
+        // we know there are 5 possible responses, so we can randomly select one of them
+        await testSubjects.click(`nps-${Math.floor(Math.random() * 4) + 1}`);
+        // the progression button is only visible at the start and completion of the survey
+        progressionButton = await testSubjects
+          .find('productInterceptProgressionButton')
+          .catch(() => null);
+      } while (!progressionButton);
+
+      expect(await progressionButton.getVisibleText()).to.be('Close');
+
+      const intercept = await testSubjects.find(interceptTestId);
+
+      expect(/Thanks for the feedback!/.test(await intercept.getVisibleText())).to.be(true);
+    });
+  });
+};

--- a/x-pack/platform/test/functional/apps/product_intercept/index.ts
+++ b/x-pack/platform/test/functional/apps/product_intercept/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('Product Intercept', () => {
+    loadTestFile(require.resolve('./home_page'));
+  });
+}

--- a/x-pack/platform/test/functional_cloud/intercepts.config.ts
+++ b/x-pack/platform/test/functional_cloud/intercepts.config.ts
@@ -8,18 +8,23 @@
 import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const functionalConfig = await readConfigFile(require.resolve('../../config.base.ts'));
+  const functionalCloudConfig = await readConfigFile(require.resolve('./config.ts'));
 
-  const baseConfig = functionalConfig.getAll();
+  const currentDate = new Date(Date.now());
+  const trialEndDate = new Date(currentDate);
+
+  // Set trial end date to one month in the future
+  trialEndDate.setMonth(trialEndDate.getMonth() + 1);
 
   return {
-    ...baseConfig,
-    testFiles: [require.resolve('.')],
+    ...functionalCloudConfig.getAll(),
+    testFiles: [require.resolve('./tests/trial_product_intercepts.ts')],
     kbnTestServer: {
-      ...baseConfig.kbnTestServer,
+      ...functionalCloudConfig.get('kbnTestServer'),
       serverArgs: [
-        ...baseConfig.kbnTestServer.serverArgs,
-        '--license=trial',
+        ...functionalCloudConfig.get('kbnTestServer.serverArgs'),
+        // Set a trial end date for testing
+        `--xpack.cloud.trial_end_date=${trialEndDate.toISOString()}`,
         '--xpack.product_intercept.enabled=true',
         // Use a shorter interval for testing purposes
         '--xpack.product_intercept.trialInterceptInterval=10s',

--- a/x-pack/platform/test/functional_cloud/tests/trial_product_intercepts.ts
+++ b/x-pack/platform/test/functional_cloud/tests/trial_product_intercepts.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { TRIAL_TRIGGER_DEF_ID } from '@kbn/product-intercept-plugin/common/constants';
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const PageObjects = getPageObjects(['common']);
+  const retry = getService('retry');
+  const testSubjects = getService('testSubjects');
+  const find = getService('find');
+
+  describe('Trial Product Intercept on home screen', () => {
+    const trialInterceptSelector = `[data-test-subj*="intercept-${TRIAL_TRIGGER_DEF_ID}"]`;
+
+    before(async () => {
+      // Create role mapping so user gets superuser access
+      await getService('esSupertest')
+        .post('/_security/role_mapping/cloud-saml-kibana')
+        .send({
+          roles: ['superuser'],
+          enabled: true,
+          rules: { field: { 'realm.name': 'cloud-saml-kibana' } },
+        })
+        .expect(200);
+    });
+
+    beforeEach(async () => {
+      await PageObjects.common.navigateToUrl('home');
+    });
+
+    it('gets dismissed, when the not now button is clicked', async () => {
+      await retry.waitFor('wait for product intercept to be displayed', async () => {
+        const intercept = await find.byCssSelector(trialInterceptSelector);
+        return intercept.isDisplayed();
+      });
+
+      await testSubjects.click('productInterceptDismissButton');
+
+      // intercept should not be displayed anymore
+      await find.byCssSelector(trialInterceptSelector).catch((err) => {
+        expect(err.message).to.ok();
+      });
+    });
+
+    it('would not be displayed again, after dismissal', async () => {
+      try {
+        await retry.waitFor('wait for product intercept to be displayed', async () => {
+          const intercept = await find.byCssSelector(trialInterceptSelector);
+          return intercept.isDisplayed();
+        });
+      } catch (err) {
+        expect(err.message).to.ok();
+      }
+    });
+  });
+};

--- a/x-pack/platform/test/tsconfig.json
+++ b/x-pack/platform/test/tsconfig.json
@@ -164,5 +164,6 @@
     "@kbn/console-plugin",
     "@kbn/serverless-common-settings",
     "@kbn/core-saved-objects-import-export-server-internal",
+    "@kbn/product-intercept-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/227331

Adds implementation to support triggering the product intercept in addition to already existing conditions when the user is in trial phase, furthermore the trigger interval for upgrade scenarios have also been changed too.

### How to test this

#### Cloud Trial scenario 
- To validate that non-trial users will not get the configured intercept, we'd want to set the following config in our `kibana.dev.yml` file;

	```yml
	xpack.cloud.id: "ftr_fake_cloud_id:aGVsbG8uY29tOjQ0MyRFUzEyM2FiYyRrYm4xMjNhYmM="
	xpack.cloud.base_url: "https://cloud.elastic.co"
    xpack.product_intercept.enabled: true
    # set a shorter interval for testing purposes
    xpack.product_intercept.trialInterceptInterval: "10s"
	```  
-  Start Kibana and we would not be presented with the product intercept
- Run the snippet below to generate a date 1 month in the future for the `<trialEndDatetoISOString>` value
	```js
	const trialEndDate = new Date(Date.now());

	// Set trial end date to one month in the future
	trialEndDate.setMonth(trialEndDate.getMonth() + 1);
	console.log(trialEndDate.toISOString())
	```
- Now to test that the intercept gets displayed when a user is in trial period, we'd want to set the following config in your `kibana.dev.yml` file;
   ```yml
	xpack.cloud.trial_end_date: "<trialEndDatetoISOString>"
	```
- Load up Kibana, and shortly after you'd be presented with a product intercept, choose whatever interaction you like; dismissal or engagement.
- Verify that you aren't presented with the product intercept after your interaction with the product intercept.


<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->