### PR TITLE
[ES|QL]  Incorrect filtering logic when removing comment field

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/scripts/generate_command_definitions.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/scripts/generate_command_definitions.ts
@@ -39,9 +39,7 @@ async function generateElasticsearchCommandDefinitions(): Promise<void> {
 
         return JSON.parse(fileContent);
       })
-      .filter((command) => {
-        Object.entries(command).filter(([key]) => key !== 'comment');
-      });
+      .map(({ comment, ...rest }) => rest);
   } catch (error) {
     const errorMessage =
       error.code === 'ENOENT'


### PR DESCRIPTION
## Summary

The previous implementation incorrectly used .filter() resulting in no actual filtering of the comment field but every row.
Replaced with .map() to properly exclude comment and return a correctly typed object.


test:
- remove the autogenerated  file `src/platform/packages/shared/kbn-esql-ast/src/definitions/generated/commands/commands.ts`
- then run the script 
- a new file commands file will be created