### PR TITLE
[AI4SOC] Remove rules package version override for release

### DIFF
--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -82,9 +82,6 @@ xpack.fleet.integrationsHomeOverride: '/app/security/configurations/integrations
 xpack.fleet.prereleaseEnabledByDefault: true
 xpack.fleet.internal.registry.searchAiLakePackageAllowlistEnabled: true
 
-# Pin the prebuilt rules package version to the version that contains promotion rules
-xpack.securitySolution.prebuiltRulesPackageVersion: '9.1.3-beta.1'
-
 # Elastic Managed LLM
 xpack.actions.preconfigured:
   Elastic-Managed-LLM:


### PR DESCRIPTION
## Summary

A follow-up from https://github.com/elastic/kibana/pull/229726 after successful testing of the `9.1.3-beta.1` package. This removes the setting entirely in preparation for release.

In the interim, the last release version of the package will be installed (`9.1.2`), until `9.1.3` (https://github.com/elastic/detection-rules/pull/4903) is released next week. So testing on QA in the interim will require manually overriding `xpack.securitySolution.prebuiltRulesPackageVersion: '9.1.3-beta.1'`, or manually installing the package via the fleet API ([pre-release from registry](https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-fleet-epm-packages-pkgname-pkgversion), or [zip upload](https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-fleet-epm-packages)).



cc @pborgonovi @tomsonpl @Mikaayenson @xcrzx
