### PR TITLE
[WIP] Heatmap chart for traces

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/get_modified_vis_attrivutes.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/get_modified_vis_attrivutes.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+
+export const getModifiedVisAttributes = (
+  esql: string,
+  prevAttributes: TypedLensByValueInput['attributes']
+): TypedLensByValueInput['attributes'] => {
+  const prevState = prevAttributes.state;
+  const prevTextBased = prevState.datasourceStates.textBased;
+  const prevLayers = prevTextBased?.layers;
+  const layerId = Object.keys(prevLayers || {})[0];
+  if (prevTextBased === undefined || prevLayers === undefined || layerId === undefined) {
+    return prevAttributes;
+  }
+
+  return {
+    title: 'Duration Heatmap by Timestamp',
+    references: [],
+    visualizationType: 'lnsHeatmap',
+    state: {
+      ...prevState,
+      datasourceStates: {
+        textBased: {
+          ...prevTextBased,
+          layers: {
+            [layerId]: {
+              ...prevLayers[layerId],
+              query: { esql },
+              columns: [
+                ...prevLayers[layerId].columns,
+                {
+                  columnId: 'duration_bucket',
+                  fieldName: 'duration_bucket',
+                  label: 'duration bucket(ms)',
+                  customLabel: true,
+                  meta: { type: 'number' },
+                },
+              ],
+            },
+          },
+        },
+      },
+      query: { esql },
+      visualization: {
+        layerId,
+        layerType: 'data',
+        shape: 'heatmap',
+        legend: {
+          isVisible: false,
+        },
+        xAccessor: 'timestamp',
+        yAccessor: 'duration_bucket',
+        valueAccessor: 'results',
+        gridConfig: {
+          xAxisLabelRotation: 10,
+          isCellLabelVisible: false,
+          isYAxisLabelVisible: true,
+          isXAxisLabelVisible: true,
+          isYAxisTitleVisible: true,
+          isXAxisTitleVisible: true,
+          type: 'heatmap_grid',
+        },
+      },
+    },
+  };
+};


### PR DESCRIPTION
Problems I could not solve with the current extension:

1. Too many ticks on x-axis.
<img width="1967" height="307" alt="Screenshot 2025-07-31 at 13 08 07" src="https://github.com/user-attachments/assets/8a35fe59-9935-4a2f-bcd9-1931f7919c13" />

---

2. Too many ticks on y-axis
<img width="2234" height="710" alt="Screenshot 2025-07-31 at 15 54 16" src="https://github.com/user-attachments/assets/b566e9b8-fc51-461d-acc2-5c7e8e3a456f" />

---

- ESQL doesn't have a histogram bucket aggregation, so I needed to manually bucket the duration per milliseconds. But that sometimes creates way too many buckets making it harder to read the values.
- The current Discover extension to replace the doc count bar chart expects us to edit a Lens config, the config though doesn't have all the options for me to optimize the chart the way I would like.

This is how I'd expect the chart to render: (although the y-axis still has too many buckets)
<img width="1093" height="424" alt="Screenshot 2025-07-31 at 14 27 12" src="https://github.com/user-attachments/assets/ac2b5692-5921-480b-8730-cb1bde1a0a0e" />

