### PR TITLE
Unskip network policy test

### DIFF
--- a/x-pack/platform/test/reporting_api_integration/reporting_and_security/screenshot/network_policy.ts
+++ b/x-pack/platform/test/reporting_api_integration/reporting_and_security/screenshot/network_policy.ts
@@ -16,6 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   /*
    * The tests server config implements a network policy that is designed to disallow the following Canvas worksheet
    */
+
   describe('Network Policy violation', () => {
     before(async () => {
       await reportingAPI.initLogs(); // includes a canvas worksheet with an offending image URL

--- a/x-pack/platform/test/reporting_api_integration/reporting_and_security/screenshot/network_policy.ts
+++ b/x-pack/platform/test/reporting_api_integration/reporting_and_security/screenshot/network_policy.ts
@@ -16,7 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   /*
    * The tests server config implements a network policy that is designed to disallow the following Canvas worksheet
    */
-  describe('Network Policy', () => {
+  describe('Network Policy violation', () => {
     before(async () => {
       await reportingAPI.initLogs(); // includes a canvas worksheet with an offending image URL
     });


### PR DESCRIPTION
Will unskip the test cases skipped only in the old versions.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->