### PR TITLE
Change SLO not found error in SLO Burnrate to be user error, not frameework

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/lib/rules/slo_burn_rate/executor.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/rules/slo_burn_rate/executor.test.ts
@@ -35,6 +35,10 @@ import {
 } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
 import { SharePluginStart } from '@kbn/share-plugin/server';
 import { sloDefinitionSchema } from '@kbn/slo-schema';
+import {
+  getErrorSource,
+  TaskErrorSource,
+} from '@kbn/task-manager-plugin/server/task_running/errors';
 import { get } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -190,8 +194,8 @@ describe('BurnRateRuleExecutor', () => {
       soClientMock.find.mockRejectedValue(new SLONotFound('SLO [non-existent] not found'));
       const executor = getRuleExecutor(basePathMock);
 
-      await expect(
-        executor({
+      try {
+        await executor({
           params: someRuleParamsWithWindows({ sloId: 'non-existent' }),
           startedAt: new Date(),
           startedAtOverridden: false,
@@ -199,14 +203,23 @@ describe('BurnRateRuleExecutor', () => {
           executionId: 'irrelevant',
           logger: loggerMock,
           previousStartedAt: null,
-          rule: {} as SanitizedRuleConfig,
+          rule: {
+            id: '123-456',
+            name: 'an slo rule',
+          } as SanitizedRuleConfig,
           spaceId: 'irrelevant',
           state: {},
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           getTimeRange,
           isServerless: false,
-        })
-      ).rejects.toThrowError();
+        });
+        throw new Error('the executor ran successfully, but should not have');
+      } catch (err) {
+        expect(getErrorSource(err)).toBe(TaskErrorSource.USER);
+        expect(err.message).toBe(
+          'Rule "an slo rule" 123-456 is referencing an SLO which cannot be found: "non-existent": SLO [non-existent] not found'
+        );
+      }
     });
 
     it('returns early when the slo is disabled', async () => {


### PR DESCRIPTION
resolves: https://github.com/elastic/kibana/issues/230128

When the SLO Burnrate rule runs, but can't find the actual SLO, it throws an error.  This error, because it's not specifically classified as a "user" error, is classified as a "framework" error.

This code changes the error to provide more information, and to classify it as a "user" error.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->