### PR TITLE
[8.19] [Synthetics] Unskip private location test (#229841)

### DIFF
--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/private_location_apis.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/private_location_apis.ts
@@ -18,9 +18,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 import { PrivateLocationTestService } from './services/private_location_test_service';
 
 export default function ({ getService }: FtrProviderContext) {
-  // Failing: See https://github.com/elastic/kibana/issues/229394
-  // Failing: See https://github.com/elastic/kibana/issues/229394
-  describe.skip('PrivateLocationAPI', function () {
+  describe('PrivateLocationAPI', function () {
     this.tags('skipCloud');
     const supertestWithoutAuth = getService('supertestWithoutAuth');
     const supertest = getService('supertest');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Unskip private location test (#229841)](https://github.com/elastic/kibana/pull/229841)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-07-30T05:45:03Z","message":"[Synthetics] Unskip private location test (#229841)\n\nCloses #229394.\nThis test was skipped because of an issue with the package registry that\nnow it's been fixed.","sha":"b98d082c3c788e204cb9fae21c4051fb06688d3a","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","author:obs-ux-management","v9.2.0","v9.1.1","v8.19.1"],"title":"[Synthetics] Unskip private location test","number":229841,"url":"https://github.com/elastic/kibana/pull/229841","mergeCommit":{"message":"[Synthetics] Unskip private location test (#229841)\n\nCloses #229394.\nThis test was skipped because of an issue with the package registry that\nnow it's been fixed.","sha":"b98d082c3c788e204cb9fae21c4051fb06688d3a"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229841","number":229841,"mergeCommit":{"message":"[Synthetics] Unskip private location test (#229841)\n\nCloses #229394.\nThis test was skipped because of an issue with the package registry that\nnow it's been fixed.","sha":"b98d082c3c788e204cb9fae21c4051fb06688d3a"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->