### PR TITLE
[8.19] [Observability/Logs] Fix PDF/PNG reporting timeout for stream embeddable (#229291)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/log_stream/log_stream_react_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/log_stream/log_stream_react_embeddable.tsx
@@ -92,7 +92,7 @@ export function getLogStreamEmbeddableFactory(services: Services) {
               theme$={services.coreStart.theme.theme$}
             >
               <EuiThemeProvider darkMode={darkMode}>
-                <div style={{ width: '100%', position: 'relative' }}>
+                <div data-shared-item="" style={{ width: '100%', position: 'relative' }}>
                   <LogStream
                     logView={{ type: 'log-view-reference', logViewId: 'default' }}
                     startTimestamp={startTimestamp}


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.1` to `8.19`:
 - [[Observability/Logs] Fix PDF/PNG reporting timeout for stream embeddable (#229291)](https://github.com/elastic/kibana/pull/228516)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Stelmach","email":"60304951+rStelmach@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-29T10:25:49Z","message":"[Observability/Logs] Fix PDF/PNG reporting timeout for stream embeddable (#229291)\n\n## Summary\n\nCloses #161316 \n\nPDF/PNG Reporting waits for each dashboard panel to flip\ndata-render-complete=\"true\" on a DOM element that also carries\ndata-shared-item.\nThe deprecated Log Stream embeddable never exposed such an element, so\nReporting timed-out after 60 s and completed “with warnings”.\n\nWith the empty attribute present, Reporting detects render completion\nand finishes without warnings.\n\n\n## How to test 🧪 :\n\n- Make sure you have trial license locally\n- In Stack `Management > Saved objects` import stream embeddable object\n( see below)\n- Add some logs data using synthrace \n- Go to `Dashboards` and Share the dashboard in PDF\n- Go to `Stack Management > Reporting`\n- PDF should be done in few seconds\n\n### Create stream embeddable object:\n\n-\n`{\"attributes\":{\"controlGroupInput\":{\"chainingSystem\":\"HIERARCHICAL\",\"controlStyle\":\"oneLine\",\"ignoreParentSettingsJSON\":\"{\\\"ignoreFilters\\\":false,\\\"ignoreQuery\\\":false,\\\"ignoreTimerange\\\":false,\\\"ignoreValidations\\\":false}\",\"panelsJSON\":\"{}\",\"showApplySelections\":false},\"description\":\"Dashboard\nto test Old Logs Stream\nComponent\",\"kibanaSavedObjectMeta\":{\"searchSourceJSON\":\"{\\\"filter\\\":[],\\\"query\\\":{\\\"query\\\":\\\"\\\",\\\"language\\\":\\\"kuery\\\"}}\"},\"optionsJSON\":\"{\\\"useMargins\\\":true,\\\"syncColors\\\":false,\\\"syncCursor\\\":true,\\\"syncTooltips\\\":false,\\\"hidePanelTitles\\\":false}\",\"panelsJSON\":\"[{\\\"type\\\":\\\"LOG_STREAM_EMBEDDABLE\\\",\\\"title\\\":\\\"Log\nstream\\\",\\\"embeddableConfig\\\":{\\\"timeRange\\\":{\\\"from\\\":\\\"now-1d\\\",\\\"to\\\":\\\"now\\\"},\\\"enhancements\\\":{}},\\\"panelIndex\\\":\\\"007ae236-4c6a-4509-b3e6-0ea82a70a070\\\",\\\"gridData\\\":{\\\"i\\\":\\\"007ae236-4c6a-4509-b3e6-0ea82a70a070\\\",\\\"y\\\":0,\\\"x\\\":0,\\\"w\\\":29,\\\"h\\\":27}}]\",\"timeRestore\":false,\"title\":\"PDF\nReport\ntest\",\"version\":3},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2025-06-16T11:03:19.212Z\",\"created_by\":\"u_aL2aSMHLXN4K3J3Rnm1qbDWzXwMxid2fsn7Icg_S9eU_0\",\"id\":\"c3448139-0e6a-4650-926c-7977a752930e\",\"managed\":false,\"references\":[],\"type\":\"dashboard\",\"typeMigrationVersion\":\"10.2.0\",\"updated_at\":\"2025-06-16T14:23:15.285Z\",\"updated_by\":\"u_aL2aSMHLXN4K3J3Rnm1qbDWzXwMxid2fsn7Icg_S9eU_0\",\"version\":\"WzMxNzI5NywyM10=\"}\n\n{\"excludedObjects\":[],\"excludedObjectsCount\":0,\"exportedCount\":1,\"missingRefCount\":0,\"missingReferences\":[]}`\n\n- Copy that and save the file as .ndjson","sha":"f0ba844ddf77903b0d1af7cfd5134c1096c96959"},"sourcePullRequest":{"labels":[],"title":"Update dependency chromedriver to ^138.0.5 (9.1)","number":228516,"url":"https://github.com/elastic/kibana/pull/228516"},"sourceBranch":"9.1","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->