### PR TITLE
[ML] Remove annotations after Typescript upgrade `5.4.5` 

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/explorer_charts/utils/draw_anomaly_explorer_charts_cursor.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/explorer_charts/utils/draw_anomaly_explorer_charts_cursor.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import d3 from 'd3';
-import type { PartialTheme } from '@elastic/charts';
+import type { Theme } from '@elastic/charts';
 import type { PointerEvent } from '@elastic/charts';
 import { CHART_HEIGHT } from '../constants';
 interface ChartScales {
@@ -18,7 +18,7 @@ export function drawCursor(
   chartId: string,
   config: { plotEarliest: number; plotLatest: number },
   chartScales: ChartScales,
-  chartTheme: PartialTheme
+  chartTheme: Theme
 ) {
   if (!chartScales) return;
   const { lineChartXScale, margin: updatedMargin } = chartScales;
@@ -28,12 +28,7 @@ export function drawCursor(
   if (!chartElement || !lineChartXScale) return;
   chartElement.select('.ml-anomaly-chart-cursor-line').remove();
 
-  const crosshairLine = chartTheme?.crosshair?.line ?? {
-    visible: true,
-    stroke: '#69707D',
-    strokeWidth: 1,
-    dash: [4, 4],
-  };
+  const crosshairLine = chartTheme.crosshair.line;
   const cursorData =
     cursor &&
     cursor.type === 'Over' &&
@@ -57,8 +52,6 @@ export function drawCursor(
       const xPosition = lineChartXScale(ts);
       return `M${xPosition},${CHART_HEIGHT} ${xPosition},0`;
     })
-    // Use elastic chart's cursor line style if possible
-    // @ts-expect-error upgrade typescript v5.4.5
     .style('stroke', crosshairLine.stroke)
     .style('stroke-width', `${crosshairLine.strokeWidth}px`)
     .style('stroke-dasharray', crosshairLine.dash?.join(',') ?? '4,4')

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/start_datafeed_modal/time_range_selector/time_range_selector.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/start_datafeed_modal/time_range_selector/time_range_selector.js
@@ -118,7 +118,6 @@ export class TimeRangeSelector extends Component {
         index: 2,
         label: startLabels[2],
         body: (
-          // eslint-disable-next-line no-use-before-define
           <DatePickerWithInput
             date={datePickerTimes.start}
             onChange={this.setStartTime}
@@ -148,7 +147,6 @@ export class TimeRangeSelector extends Component {
           />
         ),
         body: (
-          // eslint-disable-next-line no-use-before-define
           <DatePickerWithInput
             date={datePickerTimes.end}
             onChange={this.setEndTime}


### PR DESCRIPTION
Removes TS annotations after https://github.com/elastic/kibana/pull/227746


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->