### PR TITLE
Change unusedUrlsTask success log to info level

### DIFF
--- a/src/platform/plugins/shared/share/server/unused_urls_task/task.ts
+++ b/src/platform/plugins/shared/share/server/unused_urls_task/task.ts
@@ -47,8 +47,8 @@ export const deleteUnusedUrls = async ({
       namespace,
     });
 
-    logger.debug(
-      `Succesfully deleted ${unusedUrls.length} unused URL(s) in namespace "${namespace}"`
+    logger.info(
+      `Successfully deleted ${unusedUrls.length} unused URL(s) in namespace "${namespace}"`
     );
   } catch (e) {
     throw new Error(`Failed to delete unused URL(s) in namespace "${namespace}": ${e.message}`);


### PR DESCRIPTION
## Summary

This PR fixes a typo and changes logger level for success event to info.
