### PR TITLE
[9.0] [Security Solution] Enable debug logging for Rule Management integration tests (#229185)

### DIFF
--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -16,6 +16,11 @@ disabled:
 
   # MKI only configs files
   - x-pack/test_serverless/functional/test_suites/security/config.mki_only.ts
+
+  # Detection Rules Management base configs
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.essentials.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.complete.config.ts
+
   - x-pack/test_serverless/api_integration/test_suites/security/config.ts
   - x-pack/test_serverless/api_integration/test_suites/security/config.feature_flags.ts
   - x-pack/test_serverless/api_integration/test_suites/security/common_configs/config.group1.ts

--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -27,6 +27,10 @@ disabled:
   # Gen AI Evals run weekly via their own pipeline
   - x-pack/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/configs/ess.config.ts
 
+  # Detection Rules Management base configs
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.basic.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.trial.config.ts
+
 defaultQueue: 'n2-4-spot'
 enabled:
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/ess.config.ts

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rule_exceptions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rule_exceptions.ts
@@ -43,7 +43,7 @@ export const importRuleExceptions = async ({
   const {
     errors,
     success,
-    // return only count of exception list items, without count excpetions list
+    // return only count of exception list items, without count exceptions list
     // to be consistent with UI, and users shouldn't know about backend structure
     success_count_exception_list_items: successCount,
   } = await exceptionsClient.importExceptionListAndItemsAsArray({

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/constants.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/constants.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const LOGGING_CONFIG = [
+  {
+    name: 'plugins.securitySolution',
+    level: 'debug',
+  },
+  {
+    name: 'plugins.fleet',
+    level: 'debug',
+  },
+];

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.basic.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.basic.config.ts
@@ -6,17 +6,21 @@
  */
 
 import { FtrConfigProviderContext } from '@kbn/test';
+import { LOGGING_CONFIG } from '../constants';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../configs/ess/rules_management.basic.config')
+    require.resolve('../../../../../config/ess/config.base.basic')
   );
 
   return {
     ...functionalConfig.getAll(),
-    testFiles: [require.resolve('..')],
-    junit: {
-      reportName: 'Rules Management - Rule Read Integration Tests - ESS Env - Basic License',
+    kbnTestServer: {
+      ...functionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...functionalConfig.get('kbnTestServer.serverArgs'),
+        `--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`,
+      ],
     },
   };
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.trial.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.trial.config.ts
@@ -6,17 +6,21 @@
  */
 
 import { FtrConfigProviderContext } from '@kbn/test';
+import { LOGGING_CONFIG } from '../constants';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../configs/ess/rules_management.basic.config')
+    require.resolve('../../../../../config/ess/config.base.trial')
   );
 
   return {
     ...functionalConfig.getAll(),
-    testFiles: [require.resolve('..')],
-    junit: {
-      reportName: 'Rules Management - Rule Read Integration Tests - ESS Env - Basic License',
+    kbnTestServer: {
+      ...functionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...functionalConfig.get('kbnTestServer.serverArgs'),
+        `--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`,
+      ],
     },
   };
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.complete.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.complete.config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CreateTestConfigOptions } from '../../../../../config/serverless/config.base';
+import { createTestConfig } from '../../../../../config/serverless/config.base';
+import { LOGGING_CONFIG } from '../constants';
+
+export function createCompleteTierTestConfig(options: CreateTestConfigOptions) {
+  return createTestConfig({
+    kbnTestServerArgs: [`--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`],
+    ...options,
+  });
+}

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.essentials.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.essentials.config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CreateTestConfigOptions } from '../../../../../config/serverless/config.base.essentials';
+import { createTestConfig } from '../../../../../config/serverless/config.base.essentials';
+import { LOGGING_CONFIG } from '../constants';
+
+export function createEssentialsTierTestConfig(options: CreateTestConfigOptions) {
+  return createTestConfig({
+    kbnTestServerArgs: [`--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`],
+    ...options,
+  });
+}

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped.config.ts
@@ -12,7 +12,7 @@ const PACKAGES_PATH = path.join(path.dirname(__filename), '../../fixtures/packag
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped_large_package.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped_large_package.config.ts
@@ -15,7 +15,7 @@ export const BUNDLED_PACKAGE_DIR = path.join(
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_trial_license.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_trial_license.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../../configs/ess/rules_management.trial.config')
   );
 
   const testConfig = {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/ess_basic_license.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/ess_basic_license.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   const testConfig = {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/serverless_essentials_tier.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/serverless_essentials_tier.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_disabled/configs/ess_basic_license.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_disabled/configs/ess_basic_license.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   const testConfig = {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_disabled/configs/serverless_essentials_tier.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_disabled/configs/serverless_essentials_tier.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   const testConfig = {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/common_fields/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/common_fields/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../../../../config/ess/config.base.trial.ts')
+    require.resolve('../../../../../../configs/ess/rules_management.trial.config')
   );
 
   const testConfig = {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/common_fields/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/common_fields/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/type_specific_fields/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/type_specific_fields/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../../../../config/ess/config.base.trial.ts')
+    require.resolve('../../../../../../configs/ess/rules_management.trial.config')
   );
 
   const testConfig = {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/type_specific_fields/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/diffable_rule_fields/type_specific_fields/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/configs/ess_basic_license.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/configs/ess_basic_license.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   const testConfig = {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/configs/serverless_essentials_tier.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/ml_disabled/configs/serverless_essentials_tier.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/configs/serverless.config.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/configs/serverless.config.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/configs/serverless.config.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/basic_license_essentials_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName: 'Rules management - Rule Management API Integration Tests - Essentials Tier',

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/configs/serverless.config.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/configs/serverless.config.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/basic_license_essentials_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/basic_license_essentials_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/trial_license_complete_tier/configs/serverless.config.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName: 'Rules Management - Rule Read Integration Tests - Serverless Env - Complete Tier',

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.basic')
+    require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/configs/serverless.config.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../../../../../config/serverless/config.base.essentials';
+import { createEssentialsTierTestConfig } from '../../../configs/serverless/rules_management.essentials.config';
 
-export default createTestConfig({
+export default createEssentialsTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName:

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/configs/ess.config.ts
@@ -9,7 +9,7 @@ import { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
-    require.resolve('../../../../../../config/ess/config.base.trial')
+    require.resolve('../../../configs/ess/rules_management.trial.config')
   );
 
   return {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/configs/serverless.config.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { createTestConfig } from '../../../../../../config/serverless/config.base';
+import { createCompleteTierTestConfig } from '../../../configs/serverless/rules_management.complete.config';
 
-export default createTestConfig({
+export default createCompleteTierTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName: 'Rules Management - Rule Update Integration Tests - Serverless Env - Complete Tier',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Enable debug logging for Rule Management integration tests (#229185)](https://github.com/elastic/kibana/pull/229185)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nikita Indik","email":"nikita.indik@elastic.co"},"sourceCommit":{"committedDate":"2025-08-01T08:13:06Z","message":"[Security Solution] Enable debug logging for Rule Management integration tests (#229185)\n\n**Partially addresses: https://github.com/elastic/kibana/issues/229688**\n\n## Summary\nThis PR enables debug logging for all API integration tests owned by the\nRules Management team.\n\nOur team has seen a spike in flaky tests recently. To be able to quickly\ndebug such situations, we want to add debug logging. The logging itself\nwill be added in a follow-up PR. This PR only enables it for all our\ntests.\n\n## Changes\n- Added 4 new FTR base configs:\n- 2 for ESS: `rules_management.basic.config.ts` and\n`rules_management.trial.config.ts`\n- 2 for Serverless: `rules_management.essentials.config.ts` and\n`rules_management.complete.config.ts`\n- These new FTR configs extend existing base configs to enable logging\nfor `securitySolution` and `fleet` plugins on `debug` level.\n- Updated existing test configs to use the new base configs.\n\nNow, debug logs from test suites and the Kibana backend will be visible\nin BuildKite reports when clicking the \"[logs]\" button.\n\n<img width=\"573\" height=\"118\" alt=\"logs_button\"\nsrc=\"https://github.com/user-attachments/assets/eb7de404-d6b9-4402-993d-0b8320ec0e74\"\n/>\n\n⚠️ Please note that debug logs will not appear in the \"FTR Configs\n#<number>\" collapsible sections in BuildKite. They will only be\navailable in \"[logs]\" reports for **failed** tests.","sha":"063d94a2e30b615174acd84cfafdd24cef71dece","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","backport:version","v9.2.0","v9.0.5","v9.1.1","v8.18.5","v8.19.1"],"title":"[Security Solution] Enable debug logging for Rule Management integration tests","number":229185,"url":"https://github.com/elastic/kibana/pull/229185","mergeCommit":{"message":"[Security Solution] Enable debug logging for Rule Management integration tests (#229185)\n\n**Partially addresses: https://github.com/elastic/kibana/issues/229688**\n\n## Summary\nThis PR enables debug logging for all API integration tests owned by the\nRules Management team.\n\nOur team has seen a spike in flaky tests recently. To be able to quickly\ndebug such situations, we want to add debug logging. The logging itself\nwill be added in a follow-up PR. This PR only enables it for all our\ntests.\n\n## Changes\n- Added 4 new FTR base configs:\n- 2 for ESS: `rules_management.basic.config.ts` and\n`rules_management.trial.config.ts`\n- 2 for Serverless: `rules_management.essentials.config.ts` and\n`rules_management.complete.config.ts`\n- These new FTR configs extend existing base configs to enable logging\nfor `securitySolution` and `fleet` plugins on `debug` level.\n- Updated existing test configs to use the new base configs.\n\nNow, debug logs from test suites and the Kibana backend will be visible\nin BuildKite reports when clicking the \"[logs]\" button.\n\n<img width=\"573\" height=\"118\" alt=\"logs_button\"\nsrc=\"https://github.com/user-attachments/assets/eb7de404-d6b9-4402-993d-0b8320ec0e74\"\n/>\n\n⚠️ Please note that debug logs will not appear in the \"FTR Configs\n#<number>\" collapsible sections in BuildKite. They will only be\navailable in \"[logs]\" reports for **failed** tests.","sha":"063d94a2e30b615174acd84cfafdd24cef71dece"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1","8.18","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229185","number":229185,"mergeCommit":{"message":"[Security Solution] Enable debug logging for Rule Management integration tests (#229185)\n\n**Partially addresses: https://github.com/elastic/kibana/issues/229688**\n\n## Summary\nThis PR enables debug logging for all API integration tests owned by the\nRules Management team.\n\nOur team has seen a spike in flaky tests recently. To be able to quickly\ndebug such situations, we want to add debug logging. The logging itself\nwill be added in a follow-up PR. This PR only enables it for all our\ntests.\n\n## Changes\n- Added 4 new FTR base configs:\n- 2 for ESS: `rules_management.basic.config.ts` and\n`rules_management.trial.config.ts`\n- 2 for Serverless: `rules_management.essentials.config.ts` and\n`rules_management.complete.config.ts`\n- These new FTR configs extend existing base configs to enable logging\nfor `securitySolution` and `fleet` plugins on `debug` level.\n- Updated existing test configs to use the new base configs.\n\nNow, debug logs from test suites and the Kibana backend will be visible\nin BuildKite reports when clicking the \"[logs]\" button.\n\n<img width=\"573\" height=\"118\" alt=\"logs_button\"\nsrc=\"https://github.com/user-attachments/assets/eb7de404-d6b9-4402-993d-0b8320ec0e74\"\n/>\n\n⚠️ Please note that debug logs will not appear in the \"FTR Configs\n#<number>\" collapsible sections in BuildKite. They will only be\navailable in \"[logs]\" reports for **failed** tests.","sha":"063d94a2e30b615174acd84cfafdd24cef71dece"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->