### PR TITLE
[Security Solution] Transfer rule preview tests to Detection Engine (API Integration)

### DIFF
--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -75,6 +75,7 @@ enabled:
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/query/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/threshold/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_gaps/trial_license_complete_tier/configs/serverless.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/configs/serverless_complete_tier.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/configs/serverless.config.ts

--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -62,6 +62,7 @@ enabled:
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/query/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/threshold/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_gaps/trial_license_complete_tier/configs/ess.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/configs/ess_trial_license.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/configs/ess.config.ts

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/configs/ess_trial_license.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/configs/ess_trial_license.config.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(
+    require.resolve('../../../../../config/ess/config.base.trial')
+  );
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('..')],
+    junit: {
+      reportName: 'Detection Engine - Rule Preview Integration Tests - ESS Env - Trial License',
+    },
+  };
+}

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/configs/serverless_complete_tier.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/configs/serverless_complete_tier.config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { createTestConfig } from '../../../../../config/serverless/config.base';
+
+export default createTestConfig({
+  testFiles: [require.resolve('..')],
+  junit: {
+    reportName:
+      'Detection Engine - Rule Preview Integration Tests - Serverless Env - Complete Tier',
+  },
+});

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/index.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { FtrProviderContext } from '../../../../../ftr_provider_context';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('Rules Management - Rule creation APIs', function () {
-    loadTestFile(require.resolve('./create_rules'));
-    loadTestFile(require.resolve('./create_new_terms'));
+  describe('Detection Engine - Rule preview API', function () {
+    loadTestFile(require.resolve('./preview_rules'));
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/preview_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/preview_rules.ts
@@ -9,13 +9,13 @@ import expect from '@kbn/expect';
 
 import { DETECTION_ENGINE_RULES_PREVIEW } from '@kbn/security-solution-plugin/common/constants';
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
-import { getSimplePreviewRule, getSimpleRulePreviewOutput } from '../../../utils';
-import { deleteAllRules } from '../../../../../config/services/detections_response';
+import { getSimplePreviewRule, getSimpleRulePreviewOutput } from '../../utils';
+import { deleteAllRules } from '../../../../config/services/detections_response';
 
-import { createUserAndRole, deleteUserAndRole } from '../../../../../config/services/common';
+import { createUserAndRole, deleteUserAndRole } from '../../../../config/services/common';
 
-import { FtrProviderContext } from '../../../../../ftr_provider_context';
-import { EsArchivePathBuilder } from '../../../../../es_archive_path_builder';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+import { EsArchivePathBuilder } from '../../../../es_archive_path_builder';
 
 export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/229688**
**Addresses: [builds/3018](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3018)**

## Summary

This PR transfers some API Integration tests for Rule Preview under the ownership of @elastic/security-detection-engine who own this area of features. Tests being transferred:

From:

- `x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/preview_rules.ts`

To:

- `x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_preview/preview_rules.ts`

## Flaky test runs

1. [50x ESS + 50x Serverless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8968) 🟢 

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->