### PR TITLE
[Search] Root Elasticsearch breadcrumb missing link

### DIFF
--- a/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
@@ -16,6 +16,7 @@ import type { Subscription } from 'rxjs';
 import type { ChromeBreadcrumb, ChromeStyle } from '@kbn/core-chrome-browser';
 import { i18n } from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
+import { SEARCH_HOMEPAGE } from '@kbn/deeplinks-search';
 import type {
   SearchNavigationPluginSetup,
   SearchNavigationPluginStart,
@@ -24,7 +25,6 @@ import type {
   AppPluginStartDependencies,
 } from './types';
 import { classicNavigationFactory } from './classic_navigation';
-import { SEARCH_HOMEPAGE } from '@kbn/deeplinks-search';
 
 export class SearchNavigationPlugin
   implements Plugin<SearchNavigationPluginSetup, SearchNavigationPluginStart>

--- a/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
@@ -24,6 +24,7 @@ import type {
   AppPluginStartDependencies,
 } from './types';
 import { classicNavigationFactory } from './classic_navigation';
+import { SEARCH_HOMEPAGE } from '@kbn/deeplinks-search';
 
 export class SearchNavigationPlugin
   implements Plugin<SearchNavigationPluginSetup, SearchNavigationPluginStart>
@@ -126,12 +127,13 @@ export class SearchNavigationPlugin
   }
 
   private getSearchHomeBreadcrumb(): ChromeBreadcrumb {
-    // TODO: When search_navigation handles solution nav, use the default
     // home deep link for this breadcrumb's path.
+    const homeHref = this.coreStart?.chrome.navLinks.get(SEARCH_HOMEPAGE)?.href;
     return {
       text: i18n.translate('xpack.searchNavigation.breadcrumbs.home.title', {
         defaultMessage: 'Elasticsearch',
       }),
+      href: homeHref,
     };
   }
 }


### PR DESCRIPTION
## Summary

Root Elasticsearch breadcrumb missing link when set from search navigation API.

On the search applications page, the breadcrumb for Elasticsearch had a link back to the home page. This link was missing for the breadcrumbs on the query rules and other pages that use search navigation to set breadcrumbs.

### Before

**Working breadcrumb on the search applications page**
<img width="600" alt="Screenshot 2025-07-31 at 14 41 51" src="https://github.com/user-attachments/assets/dbd168f0-08f9-479c-84a6-f139362aec3c" />

**Broken breadcrumb on the query rules page**
<img width="600" alt="Screenshot 2025-07-31 at 14 42 01" src="https://github.com/user-attachments/assets/aec34891-5c25-447d-b977-f2d2d61babc6" />

### After

**Fixed breadcrumb on the query rules page**
<img width="600" alt="Screenshot 2025-08-01 at 16 41 36" src="https://github.com/user-attachments/assets/4a8fb90b-fad4-4c38-94d0-72488e33a797" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note

Fixes Elasticsearch breadcrumb to include a link to the home page for search pages.




<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->