### PR TITLE
[AI4DSOC] Fix last event ingested for sentinel_one integration

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integration_last_alert_ingested.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integration_last_alert_ingested.ts
@@ -48,7 +48,7 @@ export const useIntegrationLastAlertIngested = ({
   // We only keep the event.ingested field as it contains the time we want to display on the Integration card.
   const query = useMemo(
     () => `FROM ${`logs-${integrationName}.alert-default`}
-    | WHERE event.kind == "alert"
+    | WHERE event.kind == "alert" OR event.kind == "event"
     | SORT ${FIELD} DESC
     | KEEP ${FIELD}
     | LIMIT 1`,


### PR DESCRIPTION
## Summary

This PR fixes a very small issue where the last sync value for the `sentinel_one` integration was not showing up, while alerts were clearly fetched and rendered in the alerts table.

<img width="1358" height="681" alt="Screenshot 2025-08-01 at 6 35 46 PM" src="https://github.com/user-attachments/assets/9663a40f-99f4-468b-81cb-2ed128dcab1e" />

Doing some investigation, we discovered that the documents ingested for the integrations like `crowdstrike` and others have the following key/value pair: `event.kind: "alert"`.
For the `sentinel_one` integration though, the `event.kind` field has `event` as a value.

The original ESQL query I wrote to fetch the documents was:
```
FROM ${`logs-${integrationName}.alert-default`}
    | WHERE event.kind == "alert"
    | SORT event.ingested DESC
    | KEEP event.ingested
    | LIMIT 1
```

Updating it to 
```
FROM ${`logs-${integrationName}.alert-default`}
    | WHERE event.kind == "alert" OR event.kind == "event"
    | SORT event.ingested DESC
    | KEEP event.ingested
    | LIMIT 1
```
ensures that we will look at all those documents to see if the index has had some recent activity.

At first we thought we could remove the `| WHERE event.kind == "alert"` section entirely from the query, but we have some documents with a `event.kind: "pipline_error"` which we do NOT want to take into account.

As you can see, for integrations like `crowdstrike`, the document retrieve does not change:
Old:
<img width="594" height="460" alt="Screenshot 2025-08-01 at 6 31 04 PM" src="https://github.com/user-attachments/assets/02ae73d5-e799-4a1c-8a3e-7fc757132410" />
New:
<img width="605" height="415" alt="Screenshot 2025-08-01 at 6 31 17 PM" src="https://github.com/user-attachments/assets/19792837-9b39-442d-92ae-278cf648227d" />


But for `sentinel_one`, the new query fixes the issue:
Old:
<img width="892" height="862" alt="Screenshot 2025-08-01 at 6 30 52 PM" src="https://github.com/user-attachments/assets/018edced-9ee6-4084-b907-70d8128ef8be" />
New:
<img width="616" height="426" alt="Screenshot 2025-08-01 at 6 30 42 PM" src="https://github.com/user-attachments/assets/af2fa68e-71bb-4888-b9f3-f7056b9180b7" />

https://github.com/elastic/kibana/issues/230110


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->