### PR TITLE
[EASE] Only show supported actions on assistant messages

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/comment_actions/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/comment_actions/index.test.tsx
@@ -12,7 +12,11 @@ import { createMockStore, mockGlobalState, TestProviders } from '../../common/mo
 import { CommentActions } from '.';
 import { updateAndAssociateNode } from '../../timelines/components/notes/helpers';
 import { useKibana } from '../../common/lib/kibana';
+import { useAssistantAvailability } from '../use_assistant_availability';
+import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 
+jest.mock('../../common/hooks/use_experimental_features');
+jest.mock('../use_assistant_availability');
 jest.mock('../../timelines/components/notes/helpers', () => ({
   ...jest.requireActual('../../timelines/components/notes/helpers'),
   updateAndAssociateNode: jest.fn(),
@@ -40,6 +44,13 @@ const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
 };
 
 describe('CommentActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAssistantAvailability as jest.Mock).mockReturnValue({
+      hasSearchAILakeConfigurations: false,
+    });
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+  });
   it('content added to timeline is correct', () => {
     const message: ClientMessage = {
       content: `Only this should be copied! {reference(exampleReferenceId)}`,
@@ -87,5 +98,50 @@ describe('CommentActions', () => {
     const attachments = args.getAttachments();
     expect(attachments).toHaveLength(1);
     expect(attachments[0].comment).toBe('Only this should be copied!');
+  });
+  it('renders all actions when traceData and not EASE', () => {
+    const message: ClientMessage = {
+      content: `Only this should be copied! {reference(exampleReferenceId)}`,
+      role: 'assistant',
+      timestamp: '2025-01-08T10:47:34.578Z',
+      traceData: { traceId: '123' },
+    };
+    const { getByTestId } = render(<CommentActions message={message} />, { wrapper: Wrapper });
+
+    expect(getByTestId('apmTraceButton')).toBeInTheDocument();
+    expect(getByTestId('addMessageContentAsTimelineNote')).toBeInTheDocument();
+    expect(getByTestId('addToExistingCaseButton')).toBeInTheDocument();
+  });
+  it('renders only case and timeline actions when no traceData and not EASE', () => {
+    const message: ClientMessage = {
+      content: `Only this should be copied! {reference(exampleReferenceId)}`,
+      role: 'assistant',
+      timestamp: '2025-01-08T10:47:34.578Z',
+    };
+    const { getByTestId, queryByTestId } = render(<CommentActions message={message} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(queryByTestId('apmTraceButton')).not.toBeInTheDocument();
+    expect(getByTestId('addMessageContentAsTimelineNote')).toBeInTheDocument();
+    expect(getByTestId('addToExistingCaseButton')).toBeInTheDocument();
+  });
+  it('renders only case action when traceData and EASE', () => {
+    (useAssistantAvailability as jest.Mock).mockReturnValue({
+      hasSearchAILakeConfigurations: true,
+    });
+    const message: ClientMessage = {
+      content: `Only this should be copied! {reference(exampleReferenceId)}`,
+      role: 'assistant',
+      timestamp: '2025-01-08T10:47:34.578Z',
+      traceData: { traceId: '123' },
+    };
+    const { getByTestId, queryByTestId } = render(<CommentActions message={message} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(queryByTestId('apmTraceButton')).not.toBeInTheDocument();
+    expect(queryByTestId('addMessageContentAsTimelineNote')).not.toBeInTheDocument();
+    expect(getByTestId('addToExistingCaseButton')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/comment_actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/comment_actions/index.tsx
@@ -11,8 +11,9 @@ import type { ClientMessage } from '@kbn/elastic-assistant';
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { useAssistantContext } from '@kbn/elastic-assistant/impl/assistant_context';
+import { useAssistantContext } from '@kbn/elastic-assistant';
 import { removeContentReferences } from '@kbn/elastic-assistant-common';
+import { useAssistantAvailability } from '../use_assistant_availability';
 import { useKibana, useToasts } from '../../common/lib/kibana';
 import type { Note } from '../../common/lib/note';
 import { appActions } from '../../common/store/actions';
@@ -40,7 +41,7 @@ const CommentActionsComponent: React.FC<Props> = ({ message }) => {
   const { cases } = useKibana().services;
   const dispatch = useDispatch();
   const isModelEvaluationEnabled = useIsExperimentalFeatureEnabled('assistantModelEvaluation');
-
+  const { hasSearchAILakeConfigurations } = useAssistantAvailability();
   const { traceOptions } = useAssistantContext();
 
   const associateNote = useCallback(
@@ -104,8 +105,8 @@ const CommentActionsComponent: React.FC<Props> = ({ message }) => {
   return (
     // APM Trace support is currently behind the Model Evaluation feature flag until wider testing is performed
     <EuiFlexGroup alignItems="center" gutterSize="none">
-      {isModelEvaluationEnabled && apmTraceLink != null && (
-        <EuiFlexItem grow={false}>
+      {isModelEvaluationEnabled && apmTraceLink != null && !hasSearchAILakeConfigurations && (
+        <EuiFlexItem grow={false} data-test-subj="apmTraceButton">
           <EuiToolTip position="top" content={i18n.VIEW_APM_TRACE} disableScreenReaderOutput>
             <EuiButtonIcon
               aria-label={i18n.VIEW_APM_TRACE}
@@ -117,17 +118,19 @@ const CommentActionsComponent: React.FC<Props> = ({ message }) => {
           </EuiToolTip>
         </EuiFlexItem>
       )}
-      <EuiFlexItem grow={false}>
-        <EuiToolTip position="top" content={i18n.ADD_NOTE_TO_TIMELINE}>
-          <EuiButtonIcon
-            aria-label={i18n.ADD_MESSAGE_CONTENT_AS_TIMELINE_NOTE}
-            color="primary"
-            iconType="editorComment"
-            onClick={onAddNoteToTimeline}
-          />
-        </EuiToolTip>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      {!hasSearchAILakeConfigurations && (
+        <EuiFlexItem grow={false} data-test-subj="addMessageContentAsTimelineNote">
+          <EuiToolTip position="top" content={i18n.ADD_NOTE_TO_TIMELINE}>
+            <EuiButtonIcon
+              aria-label={i18n.ADD_MESSAGE_CONTENT_AS_TIMELINE_NOTE}
+              color="primary"
+              iconType="editorComment"
+              onClick={onAddNoteToTimeline}
+            />
+          </EuiToolTip>
+        </EuiFlexItem>
+      )}
+      <EuiFlexItem grow={false} data-test-subj="addToExistingCaseButton">
         <EuiToolTip
           position="top"
           content={i18n.ADD_TO_CASE_EXISTING_CASE}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/220621

Previously, APM and timeline actions were shown in EASE assistant messages.
<img width="518" height="359" alt="Screenshot 2025-08-01 at 10 48 55 AM" src="https://github.com/user-attachments/assets/39148d90-e192-45f1-b814-6dc29780915c" />

These actions are not supported. This PR removes those actions from the UI,
<img width="519" height="353" alt="Screenshot 2025-08-01 at 10 49 18 AM" src="https://github.com/user-attachments/assets/40c1b5ce-ced6-42ba-b8a1-8d6a2ac544ce" />


