### PR TITLE
[9.1] [Security Solution Cypress] Configure cypress es_archiver tasks to allow usage of platform archives (#230008)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/machine_learning_rule.cy.ts
@@ -82,7 +82,7 @@ describe(
 
       describe('when ML jobs have run', () => {
         before(() => {
-          cy.task('esArchiverLoad', { archiveName: '../auditbeat/hosts', type: 'ftr' });
+          cy.task('esArchiverLoad', { archiveName: 'auditbeat/hosts', type: 'platform' });
           setupMlModulesWithRetry({ moduleName: 'security_linux_v3' });
           forceStartDatafeeds({ jobIds: [jobId] });
           cy.task('esArchiverLoad', { archiveName: 'anomalies', type: 'ftr' });
@@ -90,7 +90,7 @@ describe(
 
         after(() => {
           cy.task('esArchiverUnload', { archiveName: 'anomalies', type: 'ftr' });
-          cy.task('esArchiverUnload', { archiveName: '../auditbeat/hosts', type: 'ftr' });
+          cy.task('esArchiverUnload', { archiveName: 'auditbeat/hosts', type: 'platform' });
         });
 
         describe('when not all jobs are running', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
@@ -55,12 +55,16 @@ describe(
       );
       // ensure no ML jobs are started before the test
       machineLearningJobIds.forEach((j) => forceStopAndCloseJob({ jobId: j }));
+      cy.task('esArchiverLoad', { archiveName: 'auditbeat/hosts', type: 'platform' });
+    });
+
+    after(() => {
+      cy.task('esArchiverUnload', { archiveName: 'auditbeat/hosts', type: 'platform' });
     });
 
     beforeEach(() => {
       login();
       deleteAlertsAndRules();
-      cy.task('esArchiverLoad', { archiveName: '../auditbeat/hosts', type: 'ftr' });
       setupMlModulesWithRetry({ moduleName: 'security_linux_v3' });
       forceStartDatafeeds({ jobIds: [jobId] });
       cy.task('esArchiverLoad', { archiveName: 'anomalies', type: 'ftr' });

--- a/x-pack/test/security_solution_cypress/cypress/support/es_archiver.ts
+++ b/x-pack/test/security_solution_cypress/cypress/support/es_archiver.ts
@@ -26,10 +26,7 @@ function createKibanaUrlWithAuth({ url, username, password }: ClientOptions) {
   return clientUrl.toString();
 }
 
-export const esArchiver = (
-  on: Cypress.PluginEvents,
-  config: Cypress.PluginConfigOptions
-): EsArchiver => {
+export const esArchiver = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): void => {
   const log = new ToolingLog({ level: 'verbose', writeTo: process.stdout });
 
   const isServerless = config.env.IS_SERVERLESS;
@@ -66,26 +63,29 @@ export const esArchiver = (
       : {}),
   });
 
-  const esArchiverInstance = new EsArchiver({
-    log,
-    client,
-    kbnClient,
-    baseDir: '../es_archives',
-  });
-
-  const ftrEsArchiverInstance = new EsArchiver({
-    log,
-    client,
-    kbnClient,
-    baseDir: '../../../solutions/security/test/fixtures/es_archives/security_solution',
-  });
+  const esArchiverFactory = (baseDir: string) =>
+    new EsArchiver({
+      log,
+      client,
+      kbnClient,
+      baseDir,
+    });
+  const cypressEsArchiverInstance = esArchiverFactory('../es_archives');
+  const ftrEsArchiverInstance = esArchiverFactory(
+    '../../../solutions/security/test/fixtures/es_archives/security_solution'
+  );
+  const platformEsArchiverInstance = esArchiverFactory(
+    '../../../platform/test/fixtures/es_archives'
+  );
 
   on('task', {
     esArchiverLoad: async ({ archiveName, type = 'cypress', ...options }) => {
       if (type === 'cypress') {
-        return esArchiverInstance.load(archiveName, options);
+        return cypressEsArchiverInstance.load(archiveName, options);
       } else if (type === 'ftr') {
         return ftrEsArchiverInstance.load(archiveName, options);
+      } else if (type === 'platform') {
+        return platformEsArchiverInstance.load(archiveName, options);
       } else {
         throw new Error(
           `Unable to load the specified archive: ${JSON.stringify({ archiveName, type, options })}`
@@ -94,14 +94,14 @@ export const esArchiver = (
     },
     esArchiverUnload: async ({ archiveName, type = 'cypress' }) => {
       if (type === 'cypress') {
-        return esArchiverInstance.unload(archiveName);
+        return cypressEsArchiverInstance.unload(archiveName);
       } else if (type === 'ftr') {
         return ftrEsArchiverInstance.unload(archiveName);
+      } else if (type === 'platform') {
+        return platformEsArchiverInstance.unload(archiveName);
       } else {
         throw new Error('It is not possible to unload the archive.');
       }
     },
   });
-
-  return esArchiverInstance;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution Cypress] Configure cypress es_archiver tasks to allow usage of platform archives (#230008)](https://github.com/elastic/kibana/pull/230008)

* Closes #229859
* Closes #229861
* Closes #229860

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryland Herrick","email":"ryalnd@gmail.com"},"sourceCommit":{"committedDate":"2025-07-31T15:06:33Z","message":"[Security Solution Cypress] Configure cypress es_archiver tasks to allow usage of platform archives (#230008)\n\n## Summary\n\nWork done as part of https://github.com/elastic/kibana-team/issues/1503\nmoved archives to different locations, and consequently our usage of the\n\"platform\" archives within cypress stopped working.\n\nWhile the solution in FTR tests is currently to fully-qualify the path\nto the archive, I'm continuing with the \"categorized\" approach we've\ntaken with cypress, where the `type` argument denotes the base directory\nin which to search.\n\nA more robust solution might search in all of these places, in order, if\nthe path is ambiguous, but for now this will fix the immediate problem.\n\nAddresses the following `failed-test` issues:\n\n* Closes #229859\n* Closes #229861\n* Closes #229860\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n* These are not flaky tests, but consistent failures. Regardless, I\ntriggered a 10x build just in case:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8936\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cba15ef5bd482603e1a2b668c344cde63e7d7b3d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detection Engine","backport:version","v9.2.0","v9.1.1","v8.19.1"],"title":"[Security Solution Cypress] Configure cypress es_archiver tasks to allow usage of platform archives","number":230008,"url":"https://github.com/elastic/kibana/pull/230008","mergeCommit":{"message":"[Security Solution Cypress] Configure cypress es_archiver tasks to allow usage of platform archives (#230008)\n\n## Summary\n\nWork done as part of https://github.com/elastic/kibana-team/issues/1503\nmoved archives to different locations, and consequently our usage of the\n\"platform\" archives within cypress stopped working.\n\nWhile the solution in FTR tests is currently to fully-qualify the path\nto the archive, I'm continuing with the \"categorized\" approach we've\ntaken with cypress, where the `type` argument denotes the base directory\nin which to search.\n\nA more robust solution might search in all of these places, in order, if\nthe path is ambiguous, but for now this will fix the immediate problem.\n\nAddresses the following `failed-test` issues:\n\n* Closes #229859\n* Closes #229861\n* Closes #229860\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n* These are not flaky tests, but consistent failures. Regardless, I\ntriggered a 10x build just in case:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8936\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cba15ef5bd482603e1a2b668c344cde63e7d7b3d"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230008","number":230008,"mergeCommit":{"message":"[Security Solution Cypress] Configure cypress es_archiver tasks to allow usage of platform archives (#230008)\n\n## Summary\n\nWork done as part of https://github.com/elastic/kibana-team/issues/1503\nmoved archives to different locations, and consequently our usage of the\n\"platform\" archives within cypress stopped working.\n\nWhile the solution in FTR tests is currently to fully-qualify the path\nto the archive, I'm continuing with the \"categorized\" approach we've\ntaken with cypress, where the `type` argument denotes the base directory\nin which to search.\n\nA more robust solution might search in all of these places, in order, if\nthe path is ambiguous, but for now this will fix the immediate problem.\n\nAddresses the following `failed-test` issues:\n\n* Closes #229859\n* Closes #229861\n* Closes #229860\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n* These are not flaky tests, but consistent failures. Regardless, I\ntriggered a 10x build just in case:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8936\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cba15ef5bd482603e1a2b668c344cde63e7d7b3d"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->