### PR TITLE
[AI Assistant] Hide `Reset Conversation` option on New Chat.

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.test.tsx
@@ -15,15 +15,22 @@ import {
 } from '../../../mock/test_providers/test_providers';
 import { SettingsContextMenu } from './settings_context_menu';
 import { AI_ASSISTANT_MENU } from './translations';
-import { alertConvo, conversationWithContentReferences } from '../../../mock/conversation';
+import {
+  alertConvo,
+  conversationWithContentReferences,
+  customConvo,
+  welcomeConvo,
+} from '../../../mock/conversation';
 import { SecurityPageName } from '@kbn/deeplinks-security';
 import { KNOWLEDGE_BASE_TAB } from '../const';
-
+const props = {
+  selectedConversation: welcomeConvo,
+};
 describe('SettingsContextMenu', () => {
   it('renders an accessible menu button icon', () => {
     render(
       <TestProviders>
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -33,7 +40,7 @@ describe('SettingsContextMenu', () => {
   it('renders all menu items', async () => {
     render(
       <TestProviders>
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -44,10 +51,24 @@ describe('SettingsContextMenu', () => {
     expect(screen.getByTestId('clear-chat')).toBeInTheDocument();
   });
 
+  it('renders menu items without clear-chat when empty convo', async () => {
+    render(
+      <TestProviders>
+        <SettingsContextMenu selectedConversation={customConvo} />
+      </TestProviders>
+    );
+
+    await userEvent.click(screen.getByTestId('chat-context-menu'));
+    expect(screen.getByTestId('alerts-to-analyze')).toBeInTheDocument();
+    expect(screen.getByTestId('anonymize-values')).toBeInTheDocument();
+    expect(screen.getByTestId('show-citations')).toBeInTheDocument();
+    expect(screen.queryByTestId('clear-chat')).not.toBeInTheDocument();
+  });
+
   it('triggers the reset conversation modal when clicking RESET_CONVERSATION', async () => {
     render(
       <TestProviders>
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -60,7 +81,7 @@ describe('SettingsContextMenu', () => {
   it('disables the anonymize values switch when no anonymized fields are present', async () => {
     render(
       <TestProviders>
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -86,7 +107,7 @@ describe('SettingsContextMenu', () => {
   it('disables the show citations switch when no citations are present', async () => {
     render(
       <TestProviders>
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -113,7 +134,7 @@ describe('SettingsContextMenu', () => {
     const mockNavigateToApp = jest.fn();
     render(
       <TestProviders providerContext={{ navigateToApp: mockNavigateToApp }}>
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -135,7 +156,7 @@ describe('SettingsContextMenu', () => {
         }}
         providerContext={{ navigateToApp: mockNavigateToApp }}
       >
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -151,7 +172,7 @@ describe('SettingsContextMenu', () => {
     const mockNavigateToApp = jest.fn();
     render(
       <TestProviders providerContext={{ navigateToApp: mockNavigateToApp }}>
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 
@@ -173,7 +194,7 @@ describe('SettingsContextMenu', () => {
         }}
         providerContext={{ navigateToApp: mockNavigateToApp }}
       >
-        <SettingsContextMenu />
+        <SettingsContextMenu {...props} />
       </TestProviders>
     );
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
@@ -365,6 +365,7 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
         showDestroyModal,
         euiTheme.size.m,
         euiTheme.size.xs,
+        selectedConversationExists,
         selectedConversationHasCitations,
         selectedConversationHasAnonymizedValues,
       ]

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
@@ -160,6 +160,11 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
       [selectedConversation]
     );
 
+    const selectedConversationExists = useMemo(
+      () => selectedConversation && selectedConversation.id !== '',
+      [selectedConversation]
+    );
+
     const items = useMemo(
       () => [
         <EuiContextMenuItem
@@ -327,20 +332,23 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiContextMenuItem>
-
-          <EuiHorizontalRule margin="none" />
-          <EuiContextMenuItem
-            aria-label={'clear-chat'}
-            key={'clear-chat'}
-            onClick={showDestroyModal}
-            icon={'refresh'}
-            data-test-subj={'clear-chat'}
-            css={css`
-              color: ${euiTheme.colors.textDanger};
-            `}
-          >
-            {i18n.RESET_CONVERSATION}
-          </EuiContextMenuItem>
+          {selectedConversationExists && (
+            <>
+              <EuiHorizontalRule margin="none" />
+              <EuiContextMenuItem
+                aria-label={'clear-chat'}
+                key={'clear-chat'}
+                onClick={showDestroyModal}
+                icon={'refresh'}
+                data-test-subj={'clear-chat'}
+                css={css`
+                  color: ${euiTheme.colors.textDanger};
+                `}
+              >
+                {i18n.RESET_CONVERSATION}
+              </EuiContextMenuItem>
+            </>
+          )}
         </EuiPanel>,
       ],
       [


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/221251

Hides the reset conversation button on new chats, since there is no conversation to reset.

### Before
<img width="516" height="323" alt="Screenshot 2025-08-01 at 11 22 35 AM" src="https://github.com/user-attachments/assets/a8c4d335-005b-44b8-ba0f-245aff4ea285" />


### After
<img width="516" height="345" alt="Screenshot 2025-08-01 at 11 22 11 AM" src="https://github.com/user-attachments/assets/72d1f6e4-4173-4a51-8ff3-384c2280f648" />


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->