### PR TITLE
[Security Solution] Transfer alert suppression tests to Detection Engine (API Integration)

### DIFF
--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -54,6 +54,7 @@ enabled:
   - x-pack/platform/test/serverless/functional/configs/security/config.group11.ts
   - x-pack/platform/test/serverless/functional/configs/security/config.group12.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/serverless.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/configs/serverless_complete_tier.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/operators_data_types/date_types/basic_license_essentials_tier/configs/serverless.config.ts

--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -40,6 +40,7 @@ disabled:
 defaultQueue: 'n2-4-spot'
 enabled:
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/ess.config.ts
+  - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/configs/ess_trial_license.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/operators_data_types/date_types/basic_license_essentials_tier/configs/ess.config.ts

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/bulk_edit_alert_suppression.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/bulk_edit_alert_suppression.ts
@@ -11,18 +11,18 @@ import {
   BulkActionEditTypeEnum,
 } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management';
 import { AlertSuppressionMissingFieldsStrategyEnum } from '@kbn/security-solution-plugin/common/api/detection_engine/model/rule_schema/common_attributes.gen';
-import { getThresholdRuleForAlertTesting, getCustomQueryRuleParams } from '../../../utils';
-import { createRule, deleteAllRules } from '../../../../../config/services/detections_response';
+import { getThresholdRuleForAlertTesting, getCustomQueryRuleParams } from '../../utils';
+import { createRule, deleteAllRules } from '../../../../config/services/detections_response';
 
-import { FtrProviderContext } from '../../../../../ftr_provider_context';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default ({ getService }: FtrProviderContext): void => {
+  const securitySolutionApi = getService('securitySolutionApi');
   const supertest = getService('supertest');
   const log = getService('log');
-  const securitySolutionApi = getService('securitySolutionApi');
 
   // skips serverless MKI due to feature flag
-  describe('@ess @serverless @skipInServerlessMKI perform_bulk_action suppression', () => {
+  describe('@ess @serverless @skipInServerlessMKI Bulk edit alert suppression', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
     });
@@ -426,6 +426,100 @@ export default ({ getService }: FtrProviderContext): void => {
           .expect(200);
 
         expect(updatedRule.alert_suppression).toEqual(undefined);
+      });
+    });
+
+    describe('In dry-run mode', () => {
+      it('should return error when attempting to apply set_alert_suppression bulk action to a threshold rule', async () => {
+        const createdRule = await createRule(
+          supertest,
+          log,
+          getThresholdRuleForAlertTesting(['*'], 'ruleId')
+        );
+
+        const { body } = await securitySolutionApi
+          .performRulesBulkAction({
+            query: { dry_run: true },
+            body: {
+              ids: [createdRule.id],
+              action: BulkActionTypeEnum.edit,
+              [BulkActionTypeEnum.edit]: [
+                {
+                  type: BulkActionEditTypeEnum.set_alert_suppression,
+                  value: { group_by: ['host.name'], duration: { value: 5, unit: 'm' as const } },
+                },
+              ],
+            },
+          })
+          .expect(500);
+
+        expect(body.attributes.summary).toEqual({
+          failed: 1,
+          skipped: 0,
+          succeeded: 0,
+          total: 1,
+        });
+
+        expect(body.attributes.errors).toHaveLength(1);
+        expect(body.attributes.errors[0]).toEqual({
+          err_code: 'THRESHOLD_RULE_TYPE_IN_SUPPRESSION',
+          message:
+            "Threshold rule doesn't support this action. Use 'set_alert_suppression_for_threshold' action instead",
+          rules: [
+            {
+              id: createdRule.id,
+              name: createdRule.name,
+            },
+          ],
+          status_code: 500,
+        });
+      });
+
+      it('should return error when attempting to apply set_alert_suppression_for_threshold bulk action to a non-threshold rule', async () => {
+        const createdRule = await createRule(
+          supertest,
+          log,
+          getCustomQueryRuleParams({
+            rule_id: 'rule-1',
+          })
+        );
+
+        const { body } = await securitySolutionApi
+          .performRulesBulkAction({
+            query: { dry_run: true },
+            body: {
+              ids: [createdRule.id],
+              action: BulkActionTypeEnum.edit,
+              [BulkActionTypeEnum.edit]: [
+                {
+                  type: BulkActionEditTypeEnum.set_alert_suppression_for_threshold,
+                  value: { duration: { value: 5, unit: 'm' as const } },
+                },
+              ],
+            },
+          })
+          .expect(500);
+
+        expect(body.attributes.summary).toEqual({
+          failed: 1,
+          skipped: 0,
+          succeeded: 0,
+          total: 1,
+        });
+
+        expect(body.attributes.errors).toHaveLength(1);
+        expect(body.attributes.errors[0]).toEqual({
+          err_code: 'UNSUPPORTED_RULE_IN_SUPPRESSION_FOR_THRESHOLD',
+          message:
+            "Rule type doesn't support this action. Use 'set_alert_suppression' action instead.",
+          rules: [
+            {
+              id: createdRule.id,
+              name: createdRule.name,
+            },
+          ],
+          status_code: 500,
+        });
       });
     });
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/configs/ess_trial_license.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/configs/ess_trial_license.config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(
+    require.resolve('../../../../../config/ess/config.base.trial')
+  );
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('..')],
+    junit: {
+      reportName:
+        'Detection Engine - Alert Suppression Integration Tests - ESS Env - Trial License',
+    },
+  };
+}

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/configs/serverless_complete_tier.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/configs/serverless_complete_tier.config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { createTestConfig } from '../../../../../config/serverless/config.base';
+
+export default createTestConfig({
+  testFiles: [require.resolve('..')],
+  junit: {
+    reportName:
+      'Detection Engine - Alert Suppression Integration Tests - Serverless Env - Complete Tier',
+  },
+});

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('Detection Engine - Alert Suppression', function () {
+    loadTestFile(require.resolve('./bulk_edit_alert_suppression'));
+  });
+}

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/index.ts
@@ -12,7 +12,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./perform_bulk_action_dry_run'));
     loadTestFile(require.resolve('./perform_bulk_action_dry_run_ess'));
     loadTestFile(require.resolve('./perform_bulk_action'));
-    loadTestFile(require.resolve('./perform_bulk_action_suppression'));
     loadTestFile(require.resolve('./perform_bulk_action_ess'));
     loadTestFile(require.resolve('./perform_bulk_enable_disable.ts'));
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_dry_run.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_dry_run.ts
@@ -10,12 +10,7 @@ import {
   BulkActionEditTypeEnum,
 } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management';
 import moment from 'moment';
-import {
-  getCustomQueryRuleParams,
-  getSimpleMlRule,
-  getSimpleRule,
-  getThresholdRuleForAlertTesting,
-} from '../../../utils';
+import { getCustomQueryRuleParams, getSimpleMlRule, getSimpleRule } from '../../../utils';
 import {
   createRule,
   createAlertsIndex,
@@ -567,101 +562,6 @@ export default ({ getService }: FtrProviderContext): void => {
               name: createdRule1.name,
             },
           ],
-        });
-      });
-    });
-
-    // skips serverless MKI due to feature flag
-    describe('@skipInServerlessMKI alert suppression', () => {
-      it('should return error when attempting to apply set_alert_suppression bulk action to a threshold rule', async () => {
-        const createdRule = await createRule(
-          supertest,
-          log,
-          getThresholdRuleForAlertTesting(['*'], 'ruleId')
-        );
-
-        const { body } = await securitySolutionApi
-          .performRulesBulkAction({
-            query: { dry_run: true },
-            body: {
-              ids: [createdRule.id],
-              action: BulkActionTypeEnum.edit,
-              [BulkActionTypeEnum.edit]: [
-                {
-                  type: BulkActionEditTypeEnum.set_alert_suppression,
-                  value: { group_by: ['host.name'], duration: { value: 5, unit: 'm' as const } },
-                },
-              ],
-            },
-          })
-          .expect(500);
-
-        expect(body.attributes.summary).toEqual({
-          failed: 1,
-          skipped: 0,
-          succeeded: 0,
-          total: 1,
-        });
-
-        expect(body.attributes.errors).toHaveLength(1);
-        expect(body.attributes.errors[0]).toEqual({
-          err_code: 'THRESHOLD_RULE_TYPE_IN_SUPPRESSION',
-          message:
-            "Threshold rule doesn't support this action. Use 'set_alert_suppression_for_threshold' action instead",
-          rules: [
-            {
-              id: createdRule.id,
-              name: createdRule.name,
-            },
-          ],
-          status_code: 500,
-        });
-      });
-
-      it('should return error when attempting to apply set_alert_suppression_for_threshold bulk action to a non-threshold rule', async () => {
-        const createdRule = await createRule(
-          supertest,
-          log,
-          getCustomQueryRuleParams({
-            rule_id: 'rule-1',
-          })
-        );
-
-        const { body } = await securitySolutionApi
-          .performRulesBulkAction({
-            query: { dry_run: true },
-            body: {
-              ids: [createdRule.id],
-              action: BulkActionTypeEnum.edit,
-              [BulkActionTypeEnum.edit]: [
-                {
-                  type: BulkActionEditTypeEnum.set_alert_suppression_for_threshold,
-                  value: { duration: { value: 5, unit: 'm' as const } },
-                },
-              ],
-            },
-          })
-          .expect(500);
-
-        expect(body.attributes.summary).toEqual({
-          failed: 1,
-          skipped: 0,
-          succeeded: 0,
-          total: 1,
-        });
-
-        expect(body.attributes.errors).toHaveLength(1);
-        expect(body.attributes.errors[0]).toEqual({
-          err_code: 'UNSUPPORTED_RULE_IN_SUPPRESSION_FOR_THRESHOLD',
-          message:
-            "Rule type doesn't support this action. Use 'set_alert_suppression' action instead.",
-          rules: [
-            {
-              id: createdRule.id,
-              name: createdRule.name,
-            },
-          ],
-          status_code: 500,
         });
       });
     });


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/229688**

## Summary

This PR transfers some API Integration tests for Alert Suppression under the ownership of @elastic/security-detection-engine who own this area of features. Tests being transferred:

From:

- `x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_suppression.ts`
- `x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_dry_run.ts`

To:

- `x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alert_suppression/bulk_edit_alert_suppression.ts`

## Flaky test runs

1. [50x ESS + 50x Serverless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8974) 🟢 

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
