### PR TITLE
[CI] Align action/checkout SHA with rest of repo

### DIFF
--- a/.github/workflows/evaluate-dependency-health.yml
+++ b/.github/workflows/evaluate-dependency-health.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.pull_request.draft == false
     steps:
       - name: Checkout kibana-operations
-        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'elastic/kibana-operations'
           ref: main


### PR DESCRIPTION
## Summary

This SHA isn't aligned with the rest of the repo's usage of `action/checkout` and is being updated out of band (see #229151)

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->