### PR TITLE
[Security Solution] Wait for Fleet plugin setup completion in Rule Management integration tests

### DIFF
--- a/x-pack/test/security_solution_api_integration/config/serverless/config.base.essentials.ts
+++ b/x-pack/test/security_solution_api_integration/config/serverless/config.base.essentials.ts
@@ -15,6 +15,12 @@ export interface CreateTestConfigOptions {
   junit: { reportName: string };
   kbnTestServerArgs?: string[];
   kbnTestServerEnv?: Record<string, string>;
+  /**
+   * Log message to wait for before initiating tests, defaults to waiting for Kibana status to be `available`.
+   * Note that this log message must not be filtered out by the current logging config, for example by the
+   * log level. If needed, you can adjust the logging level via `kbnTestServer.serverArgs`.
+   */
+  kbnTestServerWait?: RegExp;
 }
 
 export function createTestConfig(options: CreateTestConfigOptions) {
@@ -42,6 +48,10 @@ export function createTestConfig(options: CreateTestConfigOptions) {
         env: {
           ...svlSharedConfig.get('kbnTestServer.env'),
           ...options.kbnTestServerEnv,
+        },
+        runOptions: {
+          ...svlSharedConfig.get('kbnTestServer.runOptions'),
+          wait: options.kbnTestServerWait,
         },
       },
       testFiles: options.testFiles,

--- a/x-pack/test/security_solution_api_integration/config/serverless/config.base.ts
+++ b/x-pack/test/security_solution_api_integration/config/serverless/config.base.ts
@@ -18,6 +18,12 @@ export interface CreateTestConfigOptions {
   junit: { reportName: string };
   kbnTestServerArgs?: string[];
   kbnTestServerEnv?: Record<string, string>;
+  /**
+   * Log message to wait for before initiating tests, defaults to waiting for Kibana status to be `available`.
+   * Note that this log message must not be filtered out by the current logging config, for example by the
+   * log level. If needed, you can adjust the logging level via `kbnTestServer.serverArgs`.
+   */
+  kbnTestServerWait?: RegExp;
   suiteTags?: { include?: string[]; exclude?: string[] };
 }
 
@@ -51,6 +57,10 @@ export function createTestConfig(options: CreateTestConfigOptions) {
         env: {
           ...svlSharedConfig.get('kbnTestServer.env'),
           ...options.kbnTestServerEnv,
+        },
+        runOptions: {
+          ...svlSharedConfig.get('kbnTestServer.runOptions'),
+          wait: options.kbnTestServerWait,
         },
       },
       testFiles: options.testFiles,

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/constants.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/constants.ts
@@ -15,3 +15,12 @@ export const LOGGING_CONFIG = [
     level: 'debug',
   },
 ];
+
+/**
+ * A log message indicating that Fleet plugin has completed any necessary setup logic
+ * to make sure test suites can run without race conditions with Fleet plugin initialization.
+ *
+ * The message must not be filtered out by the logging configuration. Subsequently higher log level is better.
+ * "Fleet setup completed" has the same "info" level as "Kibana server is ready" log message.
+ */
+export const FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP = /Fleet setup completed/;

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.basic.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.basic.config.ts
@@ -6,7 +6,7 @@
  */
 
 import { FtrConfigProviderContext } from '@kbn/test';
-import { LOGGING_CONFIG } from '../constants';
+import { LOGGING_CONFIG, FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP } from '../constants';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
@@ -21,6 +21,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...functionalConfig.get('kbnTestServer.serverArgs'),
         `--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`,
       ],
+      runOptions: {
+        wait: FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP,
+      },
     },
   };
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.trial.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.trial.config.ts
@@ -6,7 +6,7 @@
  */
 
 import { FtrConfigProviderContext } from '@kbn/test';
-import { LOGGING_CONFIG } from '../constants';
+import { LOGGING_CONFIG, FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP } from '../constants';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
@@ -21,6 +21,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...functionalConfig.get('kbnTestServer.serverArgs'),
         `--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`,
       ],
+      runOptions: {
+        wait: FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP,
+      },
     },
   };
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.complete.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.complete.config.ts
@@ -7,11 +7,12 @@
 
 import type { CreateTestConfigOptions } from '../../../../../config/serverless/config.base';
 import { createTestConfig } from '../../../../../config/serverless/config.base';
-import { LOGGING_CONFIG } from '../constants';
+import { LOGGING_CONFIG, FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP } from '../constants';
 
 export function createCompleteTierTestConfig(options: CreateTestConfigOptions) {
   return createTestConfig({
     kbnTestServerArgs: [`--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`],
+    kbnTestServerWait: FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP,
     ...options,
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.essentials.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/serverless/rules_management.essentials.config.ts
@@ -7,11 +7,12 @@
 
 import type { CreateTestConfigOptions } from '../../../../../config/serverless/config.base.essentials';
 import { createTestConfig } from '../../../../../config/serverless/config.base.essentials';
-import { LOGGING_CONFIG } from '../constants';
+import { LOGGING_CONFIG, FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP } from '../constants';
 
 export function createEssentialsTierTestConfig(options: CreateTestConfigOptions) {
   return createTestConfig({
     kbnTestServerArgs: [`--logging.loggers=${JSON.stringify(LOGGING_CONFIG)}`],
+    kbnTestServerWait: FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP,
     ...options,
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/import_export/import_with_installing_package.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/import_export/import_with_installing_package.ts
@@ -68,8 +68,7 @@ export default ({ getService }: FtrProviderContext): void => {
     },
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/228844
-  describe.skip('@ess @serverless @skipInServerlessMKI Import prebuilt rules when the package is not installed', () => {
+  describe('@ess @serverless @skipInServerlessMKI Import prebuilt rules when the package is not installed', () => {
     beforeEach(async () => {
       await deletePrebuiltRulesFleetPackage({ supertest, es, log, retryService });
       await deleteAllRules(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/prebuilt_rules_package/air_gapped/bootstrap_prebuilt_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/prebuilt_rules_package/air_gapped/bootstrap_prebuilt_rules.ts
@@ -20,8 +20,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const retryService = getService('retry');
   const securitySolutionApi = getService('securitySolutionApi');
 
-  // Failing: See https://github.com/elastic/kibana/issues/229297
-  describe.skip('@ess @serverless @skipInServerlessMKI Bootstrap Prebuilt Rules', () => {
+  describe('@ess @serverless @skipInServerlessMKI Bootstrap Prebuilt Rules', () => {
     beforeEach(async () => {
       await deletePrebuiltRulesFleetPackage({ supertest, es, log, retryService });
       await deleteEndpointFleetPackage({ supertest, es, log, retryService });


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/228844**
**Resolves: https://github.com/elastic/kibana/issues/229297**
**Resolves: https://github.com/elastic/kibana/issues/229490**
**Relates to: https://github.com/elastic/kibana/issues/230363**

## Summary

This PR fixes integration tests flakiness caused by a race condition with the Fleet setup logic.

## Details

Investigation of the related flaky integration tests has revealed that Fleet's setup logic (usually executed upon Kibana startup) performs installed packages re-installation. However, Fleet allows to make API calls like install a package. Subsequently some package (for example `security_detection_engine`) might be installed before Fleet's setup logic completed. In particular a package installation API call leads to creation of package installation SO which is read by Fleet's setup logic. So Fleet "thinks" the package was installed some time ago and required re-installation.

There is a Fleet bug ticket describing this issue.

This fix in this PR just wait for Fleet plugin to finish setup before running integration tests for Rule Management area.

## Flaky test runner

- ✅ [200 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8999)


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->