### PR TITLE
[APM] Unskip APM tests

### DIFF
--- a/x-pack/solutions/observability/test/apm_api_integration/tests/index.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/tests/index.ts
@@ -29,9 +29,7 @@ export default function apmApiIntegrationTests({ getService, loadTestFile }: Ftr
   // DO NOT SKIP
   // Skipping here will skip the entire apm api test suite
   // Instead skip (flaky) tests individually
-  // Failing: See https://github.com/elastic/kibana/issues/228130
-  // Failing: See https://github.com/elastic/kibana/issues/228131
-  describe.skip('APM API tests', function () {
+  describe('APM API tests', function () {
     const filePattern = getGlobPattern();
     const tests = globby.sync(filePattern, { cwd });
 


### PR DESCRIPTION
## Summary

All APM tests have been skipped, this PR reverts it.




<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->