### PR TITLE
[Fleet] fix content package task interval config

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -21521,6 +21521,21 @@
                           "discovery": {
                             "additionalProperties": true,
                             "properties": {
+                              "datasets": {
+                                "items": {
+                                  "additionalProperties": true,
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
                               "fields": {
                                 "items": {
                                   "additionalProperties": true,
@@ -23654,6 +23669,21 @@
                         "discovery": {
                           "additionalProperties": true,
                           "properties": {
+                            "datasets": {
+                              "items": {
+                                "additionalProperties": true,
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
                             "fields": {
                               "items": {
                                 "additionalProperties": true,
@@ -24587,6 +24617,21 @@
                         "discovery": {
                           "additionalProperties": true,
                           "properties": {
+                            "datasets": {
+                              "items": {
+                                "additionalProperties": true,
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
                             "fields": {
                               "items": {
                                 "additionalProperties": true,

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -21521,6 +21521,21 @@
                           "discovery": {
                             "additionalProperties": true,
                             "properties": {
+                              "datasets": {
+                                "items": {
+                                  "additionalProperties": true,
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
                               "fields": {
                                 "items": {
                                   "additionalProperties": true,
@@ -23654,6 +23669,21 @@
                         "discovery": {
                           "additionalProperties": true,
                           "properties": {
+                            "datasets": {
+                              "items": {
+                                "additionalProperties": true,
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
                             "fields": {
                               "items": {
                                 "additionalProperties": true,
@@ -24587,6 +24617,21 @@
                         "discovery": {
                           "additionalProperties": true,
                           "properties": {
+                            "datasets": {
+                              "items": {
+                                "additionalProperties": true,
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
                             "fields": {
                               "items": {
                                 "additionalProperties": true,

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -24013,6 +24013,16 @@ paths:
                           additionalProperties: true
                           type: object
                           properties:
+                            datasets:
+                              items:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                              type: array
                             fields:
                               items:
                                 additionalProperties: true
@@ -25182,6 +25192,16 @@ paths:
                         additionalProperties: true
                         type: object
                         properties:
+                          datasets:
+                            items:
+                              additionalProperties: true
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                                - name
+                            type: array
                           fields:
                             items:
                               additionalProperties: true
@@ -25813,6 +25833,16 @@ paths:
                         additionalProperties: true
                         type: object
                         properties:
+                          datasets:
+                            items:
+                              additionalProperties: true
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                                - name
+                            type: array
                           fields:
                             items:
                               additionalProperties: true

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -26255,6 +26255,16 @@ paths:
                           additionalProperties: true
                           type: object
                           properties:
+                            datasets:
+                              items:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                              type: array
                             fields:
                               items:
                                 additionalProperties: true
@@ -27424,6 +27434,16 @@ paths:
                         additionalProperties: true
                         type: object
                         properties:
+                          datasets:
+                            items:
+                              additionalProperties: true
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                                - name
+                            type: array
                           fields:
                             items:
                               additionalProperties: true
@@ -28055,6 +28075,16 @@ paths:
                         additionalProperties: true
                         type: object
                         properties:
+                          datasets:
+                            items:
+                              additionalProperties: true
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                                - name
+                            type: array
                           fields:
                             items:
                               additionalProperties: true

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
@@ -37,6 +37,9 @@ export interface PackageSpecManifest {
   };
   asset_tags?: PackageSpecTags[];
   discovery?: {
+    fields?: Array<{
+      name: string;
+    }>;
     datasets?: DiscoveryDataset[];
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -333,6 +333,11 @@ export const config: PluginConfigDescriptor = {
           taskInterval: schema.maybe(schema.string()),
         })
       ),
+      autoInstallContentPackages: schema.maybe(
+        schema.object({
+          taskInterval: schema.maybe(schema.string()),
+        })
+      ),
       integrationsHomeOverride: schema.maybe(schema.string()),
       prereleaseEnabledByDefault: schema.boolean({ defaultValue: false }),
       hideDashboards: schema.boolean({ defaultValue: false }),

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
@@ -34,6 +34,9 @@ jest.mock('../services/epm/registry');
 jest.mock('../services/epm/packages', () => ({
   getInstalledPackages: jest.fn(),
 }));
+jest.mock('../services/epm/packages/get_prerelease_setting', () => ({
+  getPrereleaseFromSettings: jest.fn().mockReturnValue(false),
+}));
 
 const MockRegistry = jest.mocked(Registry);
 

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
@@ -173,8 +173,10 @@ describe('AutoInstallContentPackagesTask', () => {
       });
       expect(packageClientMock.installPackage).toHaveBeenCalledTimes(2);
       expect(esClient.esql.query).toHaveBeenCalledWith({
-        query:
-          'FROM logs-*,metrics-*,traces-* | KEEP @timestamp, data_stream.dataset | WHERE @timestamp > NOW() - 10 minutes | STATS COUNT(*) BY data_stream.dataset | LIMIT 100 ',
+        query: `FROM logs-*,metrics-*,traces-* 
+      | KEEP @timestamp, data_stream.dataset 
+      | WHERE @timestamp > NOW() - 10 minutes 
+      | STATS COUNT(*) BY data_stream.dataset `,
       });
     });
 
@@ -198,8 +200,10 @@ describe('AutoInstallContentPackagesTask', () => {
       });
       expect(packageClientMock.installPackage).toHaveBeenCalledTimes(1);
       expect(esClient.esql.query).toHaveBeenCalledWith({
-        query:
-          'FROM logs-*,metrics-*,traces-* | KEEP @timestamp, data_stream.dataset | WHERE @timestamp > NOW() - 10 minutes | STATS COUNT(*) BY data_stream.dataset | LIMIT 100 | WHERE data_stream.dataset NOT IN ("system.test")',
+        query: `FROM logs-*,metrics-*,traces-* 
+      | KEEP @timestamp, data_stream.dataset 
+      | WHERE @timestamp > NOW() - 10 minutes 
+      | STATS COUNT(*) BY data_stream.dataset | WHERE data_stream.dataset NOT IN ("system.test")`,
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -200,6 +200,7 @@ export const PackageInfoSchema = schema
     discovery: schema.maybe(
       schema.object({
         fields: schema.maybe(schema.arrayOf(schema.object({ name: schema.string() }))),
+        datasets: schema.maybe(schema.arrayOf(schema.object({ name: schema.string() }))),
       })
     ),
   })


### PR DESCRIPTION
## Summary

Follow up for https://github.com/elastic/ingest-dev/issues/5685

Fix fleet config to change auto install content packages task interval:
```
# enable feature flag
xpack.fleet.enableExperimental: ['enableAutoInstallContentPackages']

# change interval
xpack.fleet.autoInstallContentPackages.taskInterval: 15s
```

Also use prerelease flag from settings to be able to test auto install prerelease content package like system_otel:

<img width="875" height="1006" alt="image" src="https://github.com/user-attachments/assets/7d22bbc8-5b32-4af5-97ec-fb4dca644f42" />

Added `discovery.datasets` field to `system_otel` package to test with, but for some reason the datasets values are not showing up in the EPR response ([PR](https://github.com/elastic/integrations/pull/14770))
Tested with the package built locally and starting a local registry:
[system_otel-0.2.0.zip](https://github.com/user-attachments/files/21574295/system_otel-0.2.0.zip)

Update: this now works, had to pull the latest registry docker image

```
# start local registry
docker run -v /Users/juliabardi/kibana/x-pack/platform/test/fleet_api_integration/apis/fixtures/package_registry_config.yml:/package-registry/config.yml -v /Users/juliabardi/kibana/x-pack/platform/test/fleet_api_integration/apis/fixtures/test_packages:/packages/test-packages -v /Users/juliabardi/kibana/x-pack/platform/test/fleet_api_integration/apis/fixtures/package_verification/packages/zips:/packages/signed-test-packages -p 12345:8080 docker.elastic.co/package-registry/distribution:lite

# use local registry in kibana config
xpack.fleet.registryUrl: http://localhost:12345

http://localhost:12345/search?prerelease=true&type=content&spec.min=2.3&spec.max=3.4&discovery=datasets:hostmetricsreceiver.otel

[
{
name: "system_otel",
title: "System OpenTelemetry Assets",
version: "0.2.0",
release: "beta",
description: "Dashboards for the OpenTelemetry data collected with the `hostmetrics` receiver.",
type: "content",
...
discovery: {
datasets: [
{
name: "hostmetricsreceiver.otel"
}
]
}
}
]
```

Generated some otel data by following the instructions in OpenTelemetry integration in a multipass VM:

```
arch=$(if ([[ $(arch) == "arm" || $(arch) == "aarch64" ]]); then echo "arm64"; else echo $(arch); fi)
curl --output elastic-distro-9.1.0-linux-$arch.tar.gz --url https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.1.0-linux-$arch.tar.gz --proto '=https' --tlsv1.2 -fL && mkdir -p elastic-distro-9.1.0-linux-$arch && tar -xvf elastic-distro-9.1.0-linux-$arch.tar.gz -C "elastic-distro-9.1.0-linux-$arch" --strip-components=1 && cd elastic-distro-9.1.0-linux-$arch
rm ./otel.yml && cp ./otel_samples/platformlogs_hostmetrics.yml ./otel.yml && mkdir -p ./data/otelcol && sed -i 's#\${env:STORAGE_DIR}#'"$PWD"/data/otelcol'#g' ./otel.yml && sed -i 's#\${env:ELASTIC_ENDPOINT}#http://192.168.64.1:9200#g' ./otel.yml && sed -i 's/\${env:ELASTIC_API_KEY}/NEdfc2RKZ0JobV8xTXQxMjk0cUY6XzliVWIzSDRYZVBFSU9Ea05FTFdJdw==/g' ./otel.yml
```

And updating pipelines:
```
vim otel.yml 

service:
  extensions: [file_storage]
  pipelines:
    metrics/hostmetrics:
receivers: [hostmetrics/system]
processors: [resourcedetection, attributes/dataset, resource/process]
exporters: [elasticsearch/otel]

# start collector
 sudo ./otelcol --config otel.yml
```

For some reason the ES|QL query in the task doesn't return the `hostmetricsreceiver.otel` dataset, but is returned when running the same query in dev tools. Might be a permission issue.
```
FROM logs-*,metrics-*,traces-*
| KEEP @timestamp, data_stream.dataset | WHERE @timestamp > NOW() - 15 minutes 
| STATS COUNT(*) BY data_stream.dataset 

{
  "took": 6,
  "is_partial": false,
  "documents_found": 5752,
  "values_loaded": 5752,
      "columns": [
    {
      "name": "COUNT(*)",
      "type": "long"
    },
    {
      "name": "data_stream.dataset",
      "type": "keyword"
    }
  ],
  "values": [
    [
      115,
      "elastic_agent"
    ],
    [
      27,
      "elastic_agent.filebeat"
    ],
    [
      3,
      "elastic_agent.status_change"
    ],
    [
      1696,
      "elastic_agent.metricbeat"
    ],
    [
      3336,
      "elastic_agent.fleet_server"
    ],
    [
      271,
      "fleet_server.agent_versions"
    ],
    [
      271,
      "fleet_server.agent_status"
    ]
  ]
}
```

<img width="2511" height="1101" alt="image" src="https://github.com/user-attachments/assets/03721494-6ad0-4d69-8c79-a23d82ac1c84" />

Update: Yes, it seems `kibana_system` didn't have privileges to read the integration data streams.
Tested locally by adding read access, and now the query returns the expected results and installs the otel content package.
I'll create a pr to the elasticsearch repo. Here it is: https://github.com/elastic/elasticsearch/pull/132400

```
# checkout ES pr, start es from source
yarn es source --license trial -E xpack.security.authc.api_key.enabled=true -E xpack.security.authc.token.enabled=true  --source-path=/Users/juliabardi/elasticsearch  -E path.data=/tmp/es-data -E xpack.ml.enabled=false -E http.host=0.0.0.0

# kibana logs that run the task
[2025-08-04T15:51:43.748+02:00][DEBUG][plugins.fleet.fleet:auto-install-content-packages-task:1.0.1] [AutoInstallContentPackagesTask] Found datasets with data: hostmetricsreceiver.otel, elastic_agent, fleet_server.agent_status, system.process.summary, system.socket_summary, elastic_agent.filebeat_input, elastic_agent.metricbeat, elastic_agent.filebeat, system.memory, elastic_agent.elastic_agent, generic.otel, elastic_agent.status_change, hostmetricsreceiver, elastic_agent.fleet_server, system.uptime, system.cpu, system.process, system.filesystem, system.fsstat, system.load, fleet_server.agent_versions, system.network, system.diskio
[2025-08-04T15:51:43.748+02:00][DEBUG][plugins.fleet.fleet:auto-install-content-packages-task:1.0.1] [AutoInstallContentPackagesTask] Content packages to install: system_otel@0.2.0
[2025-08-04T15:51:43.748+02:00][DEBUG][plugins.fleet] Kicking off install of system_otel-0.2.0 from registry
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



