### PR TITLE
[Security Solution] Add new EBT Kibana browser events for telemetry

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleUpgradeTelemetryEvent } from './types';
+import { RuleUpgradeEventTypes } from './types';
+
+export const flyoutButtonClickEvent: RuleUpgradeTelemetryEvent = {
+  eventType: RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick,
+  schema: {
+    type: {
+      type: 'keyword',
+      _meta: {
+        description: 'Click Rule Upgrade Flyout Button (update|dismiss)',
+        optional: false,
+      },
+    },
+    hasMissingBaseVersion: {
+      type: 'boolean',
+      _meta: {
+        description: 'Indicates if the rule has a missing base version',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const openFlyoutEvent: RuleUpgradeTelemetryEvent = {
+  eventType: RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen,
+  schema: {
+    hasMissingBaseVersion: {
+      type: 'boolean',
+      _meta: {
+        description: 'Indicates if the rule has a missing base version',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const ruleUpgradeTelemetryEvents = [flyoutButtonClickEvent, openFlyoutEvent];

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { RootSchema } from '@kbn/core/public';
+
+export enum RuleUpgradeEventTypes {
+  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button',
+  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout',
+}
+interface ReportRuleUpgradeFlyoutButtonClickParams {
+  type: 'update' | 'dismiss';
+  hasMissingBaseVersion: boolean;
+}
+
+interface ReportRuleUpgradeFlyoutOpenParams {
+  hasMissingBaseVersion: boolean;
+}
+
+export interface RuleUpgradeTelemetryEventsMap {
+  [RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick]: ReportRuleUpgradeFlyoutButtonClickParams;
+  [RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen]: ReportRuleUpgradeFlyoutOpenParams;
+}
+
+export interface RuleUpgradeTelemetryEvent {
+  eventType: RuleUpgradeEventTypes;
+  schema: RootSchema<RuleUpgradeTelemetryEventsMap[RuleUpgradeEventTypes]>;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/telemetry_events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/telemetry_events.ts
@@ -16,6 +16,7 @@ import { notesTelemetryEvents } from './notes';
 import { onboardingHubTelemetryEvents } from './onboarding';
 import { previewRuleTelemetryEvents } from './preview_rule';
 import { siemMigrationsTelemetryEvents } from './siem_migrations';
+import { ruleUpgradeTelemetryEvents } from './rule_upgrade';
 
 export const telemetryEvents = [
   ...alertsTelemetryEvents,
@@ -25,6 +26,7 @@ export const telemetryEvents = [
   ...documentTelemetryEvents,
   ...onboardingHubTelemetryEvents,
   ...manualRuleRunTelemetryEvents,
+  ...ruleUpgradeTelemetryEvents,
   ...bulkFillRuleGapsTelemetryEvents,
   ...eventLogTelemetryEvents,
   ...notesTelemetryEvents,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/types.ts
@@ -45,6 +45,10 @@ import type {
   SiemMigrationsEventTypes,
   SiemMigrationsTelemetryEventsMap,
 } from './events/siem_migrations/types';
+import type {
+  RuleUpgradeEventTypes,
+  RuleUpgradeTelemetryEventsMap,
+} from './events/rule_upgrade/types';
 
 export * from './events/app/types';
 export * from './events/alerts_grouping/types';
@@ -86,6 +90,8 @@ export type TelemetryEventTypeData<T extends TelemetryEventTypes> = T extends Al
   ? AppTelemetryEventsMap[T]
   : T extends SiemMigrationsEventTypes
   ? SiemMigrationsTelemetryEventsMap[T]
+  : T extends RuleUpgradeEventTypes
+  ? RuleUpgradeTelemetryEventsMap[T]
   : never;
 
 export type TelemetryEventTypes =
@@ -100,4 +106,5 @@ export type TelemetryEventTypes =
   | EventLogEventTypes
   | NotesEventTypes
   | AppEventTypes
-  | SiemMigrationsEventTypes;
+  | SiemMigrationsEventTypes
+  | RuleUpgradeEventTypes;

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -361,9 +361,23 @@ export function usePrebuiltRulesUpgrade({
     },
     [rulesUpgradeState, isRulesCustomizationEnabled, setRuleFieldResolvedValue]
   );
+  const closeRulePreviewAction = (rule: RuleResponse, reason: 'dismiss' | 'call_to_action') => {
+    const ruleUpgradeState = rulesUpgradeState[rule.rule_id];
+    const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
+    if (reason === 'dismiss') {
+      telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
+        type: 'dismiss',
+        hasMissingBaseVersion,
+      });
+    } else {
+      telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
+        type: 'update',
+        hasMissingBaseVersion,
+      });
+    }
+  };
   const { rulePreviewFlyout, openRulePreview: openRulePreviewDefault } = useRulePreviewFlyout({
     rules: ruleUpgradeStates.map(({ target_rule: targetRule }) => targetRule),
-    rulesUpgradeState,
     subHeaderFactory,
     ruleActionsFactory,
     extraTabsFactory,
@@ -371,6 +385,7 @@ export function usePrebuiltRulesUpgrade({
       id: PREBUILT_RULE_UPDATE_FLYOUT_ANCHOR,
       dataTestSubj: PREBUILT_RULE_UPDATE_FLYOUT_ANCHOR,
     },
+    closeRulePreviewAction,
   });
 
   const openRulePreview = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -40,6 +40,7 @@ import { RuleUpgradeTab } from '../components/rule_details/three_way_diff';
 import { TabContentPadding } from '../../../siem_migrations/rules/components/rule_details_flyout';
 import { RuleTypeChangeCallout } from '../../rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/rule_type_change_callout';
 import { RuleDiffTab } from '../components/rule_details/rule_diff_tab';
+import type { RulePreviewFlyoutCloseReason } from '../../rule_management_ui/components/rules_table/use_rule_preview_flyout';
 import { useRulePreviewFlyout } from '../../rule_management_ui/components/rules_table/use_rule_preview_flyout';
 import type { UpgradePrebuiltRulesSortingOptions } from '../../rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context';
 import { RULES_TABLE_INITIAL_PAGE_SIZE } from '../../rule_management_ui/components/rules_table/constants';
@@ -361,7 +362,7 @@ export function usePrebuiltRulesUpgrade({
     },
     [rulesUpgradeState, isRulesCustomizationEnabled, setRuleFieldResolvedValue]
   );
-  const closeRulePreviewAction = (rule: RuleResponse, reason: 'dismiss' | 'call_to_action') => {
+  const closeRulePreviewAction = (rule: RuleResponse, reason: RulePreviewFlyoutCloseReason) => {
     const ruleUpgradeState = rulesUpgradeState[rule.rule_id];
     const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
     if (reason === 'dismiss') {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_rule_preview_flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_rule_preview_flyout.tsx
@@ -27,9 +27,11 @@ interface UseRulePreviewFlyoutBaseParams {
   flyoutProps: RulePreviewFlyoutProps;
 }
 
+export type RulePreviewFlyoutCloseReason = 'dismiss' | 'call_to_action';
+
 interface UseRulePreviewFlyoutParams extends UseRulePreviewFlyoutBaseParams {
   rules: RuleResponse[];
-  closeRulePreviewAction?: (rule: RuleResponse, reason: 'dismiss' | 'call_to_action') => void;
+  closeRulePreviewAction?: (rule: RuleResponse, reason: RulePreviewFlyoutCloseReason) => void;
 }
 
 interface RulePreviewFlyoutProps {
@@ -43,7 +45,7 @@ interface RulePreviewFlyoutProps {
 interface UseRulePreviewFlyoutResult {
   rulePreviewFlyout: ReactNode;
   openRulePreview: (ruleId: RuleSignatureId) => void;
-  closeRulePreview: (reason: 'dismiss' | 'call_to_action') => void;
+  closeRulePreview: (reason: RulePreviewFlyoutCloseReason) => void;
 }
 
 export function useRulePreviewFlyout({
@@ -56,7 +58,7 @@ export function useRulePreviewFlyout({
 }: UseRulePreviewFlyoutParams): UseRulePreviewFlyoutResult {
   const [rule, setRuleForPreview] = useState<RuleResponse | undefined>();
   const closeRulePreview = useCallback(
-    (reason: 'dismiss' | 'call_to_action') => {
+    (reason: RulePreviewFlyoutCloseReason) => {
       if (closeRulePreviewAction && rule) {
         closeRulePreviewAction(rule, reason);
       }
@@ -102,7 +104,7 @@ const RulePreviewFlyoutInternal = memo(function RulePreviewFlyoutInternal({
   flyoutProps,
 }: UseRulePreviewFlyoutBaseParams & {
   rule: RuleResponse | undefined;
-  closeRulePreview: (reason: 'dismiss' | 'call_to_action') => void;
+  closeRulePreview: (reason: RulePreviewFlyoutCloseReason) => void;
 }) {
   const { isEditingRule } = useRulePreviewContext();
 


### PR DESCRIPTION
**Partially addresses:** #140369

## Summary

This is another PR from of a series of PRs I am planning to create to cover the requirements in the https://github.com/elastic/kibana/issues/140369 ticket.

The requirements covered in this PR are:

- Events of opening the update flyout
- Events for Applying update/ dismissing update

I am adding new kind of EBT Kibana Browser events, RuleUpgradeFlyoutOpen and RuleUpgradeFlyoutButtonClick.
Both these events carry information if the rule that is supposed to be upgraded has missing base version.
The RuleUpgradeFlyoutButtonClick event also carries information about the type of the button: whether it is the "Update rule" button or the "Dismiss" button.

The point of this change is to be able to prepare visualizations described by @approksiu in this [document](https://docs.google.com/spreadsheets/d/1MX66Eymvem5LyWRlkuWm6FLkkrxy0la76vwseznB_Uk/edit?gid=0#gid=0).

In this [document](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0) I am summarizing the attempt in details, also taking into account the req "Events of Rule updates tab visits"

In this [Staging dashboard](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/dashboards#/view/64a5cc65-7ded-4959-b84d-3486b7dc2b29?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now))) you can observe the visualizations. When you start Kibana using code from this PR, when you open the Detection Rules and play with the rules, the updates and the flyout, the events will be sent to Kibana Telemetry staging backend and should start to be visible in this dashboard.

Testing:
Open browser and inside it open the Developer Tools -> Network tab.
Inside, filter for 'kibana-browser' events. Click such event and copy it to some external editor for easier viewing. Make sure the new events created in this PR are sent in the appropriate situations and contain correct information about the rule. Use the abovementioned [doc](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0) as reference.
Test the following scenarios:
1. All possible ways of opening the Rule Updates Flyout (by clicking the name or by clicking "Review update" mini callout)
2. Clicking the "Dismiss" and "Update rule" button in the Rule Update Flyout
 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->