### PR TITLE
[APM] Configure fleet docker container for APM tests

### DIFF
--- a/x-pack/solutions/observability/test/apm_api_integration/common/fixtures/package_registry_config.yml
+++ b/x-pack/solutions/observability/test/apm_api_integration/common/fixtures/package_registry_config.yml
@@ -1,0 +1,2 @@
+package_paths:
+  - /packages/package-storage


### PR DESCRIPTION
closes [228305](https://github.com/elastic/kibana/issues/228305)
closes [228130](https://github.com/elastic/kibana/issues/228130)

## Summary

This PR follows this suggestion https://github.com/elastic/kibana/issues/228305#issuecomment-3103601583 to use dockerized epm registry environment in CI



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->