### PR TITLE
[Infra]  Run fleet registry in container

### DIFF
--- a/src/platform/packages/private/kbn-journeys/fixtures/package_registry_config.yml
+++ b/src/platform/packages/private/kbn-journeys/fixtures/package_registry_config.yml
@@ -1,0 +1,2 @@
+package_paths:
+  - /packages/package-storage

--- a/src/platform/packages/private/kbn-journeys/journey/journey_ftr_config.ts
+++ b/src/platform/packages/private/kbn-journeys/journey/journey_ftr_config.ts
@@ -11,9 +11,14 @@ import Path from 'path';
 
 import { v4 as uuidV4 } from 'uuid';
 import { REPO_ROOT } from '@kbn/repo-info';
-import type { FtrConfigProviderContext, FtrConfigProvider } from '@kbn/test';
+import {
+  type FtrConfigProviderContext,
+  type FtrConfigProvider,
+  defineDockerServersConfig,
+  fleetPackageRegistryDockerImage,
+} from '@kbn/test';
+import path from 'path';
 import { services } from '../services';
-
 import { AnyStep } from './journey';
 import { JourneyConfig } from './journey_config';
 import { JOURNEY_APM_CONFIG } from './journey_apm_config';
@@ -59,8 +64,31 @@ export function makeFtrConfigProvider(
       journeyName: config.getName(),
     };
 
+    /**
+     * This is used by CI to set the docker registry port
+     * you can also define this environment variable locally when running tests which
+     * will spin up a local docker package registry locally for you
+     * if this is defined it takes precedence over the `packageRegistryOverride` variable
+     */
+    const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
+
+    const packageRegistryConfig = path.join(__dirname, '../fixtures/package_registry_config.yml');
+    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+
     return {
       ...baseConfig,
+
+      dockerServers: defineDockerServersConfig({
+        registry: {
+          enabled: !!dockerRegistryPort,
+          image: fleetPackageRegistryDockerImage,
+          portInContainer: 8080,
+          port: dockerRegistryPort,
+          args: dockerArgs,
+          waitForLogLine: 'package manifests loaded',
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+        },
+      }),
 
       mochaOpts: {
         ...baseConfig.mochaOpts,


### PR DESCRIPTION
closes [#194357](https://github.com/elastic/kibana/issues/194357)

## Summary

This PR follows this suggestion https://github.com/elastic/kibana/issues/228305#issuecomment-3103601583 to use dockerized epm registry environment in CI



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->