### PR TITLE
[9.1] Fix violations of the @elastic/eui/require-aria-label-for-modals ESLint rule (Step 3) (#229616)

### DIFF
--- a/src/platform/plugins/private/interactive_setup/public/cluster_configuration_form.tsx
+++ b/src/platform/plugins/private/interactive_setup/public/cluster_configuration_form.tsx
@@ -32,6 +32,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { FunctionComponent } from 'react';
 import React, { useState } from 'react';
@@ -414,6 +415,7 @@ export interface CertificateChainProps {
 }
 const CertificateChain: FunctionComponent<CertificateChainProps> = ({ certificateChain }) => {
   const [showModal, setShowModal] = useState(false);
+  const modalTitleId = useGeneratedHtmlId();
 
   return (
     <>
@@ -423,9 +425,13 @@ const CertificateChain: FunctionComponent<CertificateChainProps> = ({ certificat
         compressed
       />
       {showModal && (
-        <EuiModal onClose={() => setShowModal(false)} maxWidth={euiThemeVars.euiBreakpoints.s}>
+        <EuiModal
+          aria-labelledby={modalTitleId}
+          onClose={() => setShowModal(false)}
+          maxWidth={euiThemeVars.euiBreakpoints.s}
+        >
           <EuiModalHeader>
-            <EuiModalHeaderTitle>
+            <EuiModalHeaderTitle id={modalTitleId}>
               <FormattedMessage
                 id="interactiveSetup.certificateChain.title"
                 defaultMessage="Certificate chain"

--- a/src/platform/plugins/shared/vis_types/timeseries/public/application/components/lib/external_url_error_modal.tsx
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/application/components/lib/external_url_error_modal.tsx
@@ -17,6 +17,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiTextColor,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 interface ExternalUrlErrorModalProps {
@@ -24,38 +25,42 @@ interface ExternalUrlErrorModalProps {
   handleClose: () => void;
 }
 
-export const ExternalUrlErrorModal = ({ url, handleClose }: ExternalUrlErrorModalProps) => (
-  <EuiModal onClose={handleClose}>
-    <EuiModalHeader>
-      <EuiModalHeaderTitle>
+export const ExternalUrlErrorModal = ({ url, handleClose }: ExternalUrlErrorModalProps) => {
+  const externalUrlErrorModalTitleId = useGeneratedHtmlId();
+
+  return (
+    <EuiModal onClose={handleClose} aria-labelledby={externalUrlErrorModalTitleId}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={externalUrlErrorModalTitleId}>
+          <FormattedMessage
+            id="visTypeTimeseries.externalUrlErrorModal.headerTitle"
+            defaultMessage="Access to this external URL is not yet enabled"
+          />
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
         <FormattedMessage
-          id="visTypeTimeseries.externalUrlErrorModal.headerTitle"
-          defaultMessage="Access to this external URL is not yet enabled"
+          id="visTypeTimeseries.externalUrlErrorModal.bodyMessage"
+          defaultMessage="Configure {externalUrlPolicy} in your {kibanaConfigFileName} to allow access to {url}."
+          values={{
+            url: (
+              <EuiTextColor color="warning" component="span">
+                {url}
+              </EuiTextColor>
+            ),
+            externalUrlPolicy: 'externalUrl.policy',
+            kibanaConfigFileName: 'kibana.yml',
+          }}
         />
-      </EuiModalHeaderTitle>
-    </EuiModalHeader>
-    <EuiModalBody>
-      <FormattedMessage
-        id="visTypeTimeseries.externalUrlErrorModal.bodyMessage"
-        defaultMessage="Configure {externalUrlPolicy} in your {kibanaConfigFileName} to allow access to {url}."
-        values={{
-          url: (
-            <EuiTextColor color="warning" component="span">
-              {url}
-            </EuiTextColor>
-          ),
-          externalUrlPolicy: 'externalUrl.policy',
-          kibanaConfigFileName: 'kibana.yml',
-        }}
-      />
-    </EuiModalBody>
-    <EuiModalFooter>
-      <EuiButton onClick={handleClose} fill>
-        <FormattedMessage
-          id="visTypeTimeseries.externalUrlErrorModal.closeButtonLabel"
-          defaultMessage="Close"
-        />
-      </EuiButton>
-    </EuiModalFooter>
-  </EuiModal>
-);
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton onClick={handleClose} fill>
+          <FormattedMessage
+            id="visTypeTimeseries.externalUrlErrorModal.closeButtonLabel"
+            defaultMessage="Close"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_with_embeddable_example/drilldowns_with_embeddable_example.tsx
+++ b/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_with_embeddable_example/drilldowns_with_embeddable_example.tsx
@@ -107,7 +107,7 @@ export const DrilldownsWithEmbeddableExample: React.FC = () => {
       </EuiFlexGroup>
 
       {showManager && (
-        <EuiFlyout onClose={() => setShowManager(false)} aria-labelledby="Drilldown Manager">
+        <EuiFlyout onClose={() => setShowManager(false)} aria-label="Drilldown Manager">
           <plugins.uiActionsEnhanced.DrilldownManager
             key={viewRef.current}
             initialRoute={viewRef.current}

--- a/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_without_embeddable_example/drilldowns_without_embeddable_example.tsx
+++ b/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_without_embeddable_example/drilldowns_without_embeddable_example.tsx
@@ -115,7 +115,7 @@ export const DrilldownsWithoutEmbeddableExample: React.FC = () => {
       </EuiFlexGroup>
 
       {showManager && (
-        <EuiFlyout onClose={() => setShowManager(false)} aria-labelledby="Drilldown Manager">
+        <EuiFlyout onClose={() => setShowManager(false)} aria-label="Drilldown Manager">
           <plugins.uiActionsEnhanced.DrilldownManager
             key={viewRef.current}
             initialRoute={viewRef.current}

--- a/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_without_embeddable_single_button_example/drilldowns_without_embeddable_single_button_example.tsx
+++ b/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_without_embeddable_single_button_example/drilldowns_without_embeddable_single_button_example.tsx
@@ -48,7 +48,7 @@ export const DrilldownsWithoutEmbeddableSingleButtonExample: React.FC = () => {
       </EuiFlexGroup>
 
       {showManager && (
-        <EuiFlyout onClose={() => setShowManager(false)} aria-labelledby="Drilldown Manager">
+        <EuiFlyout onClose={() => setShowManager(false)} aria-label="Drilldown Manager">
           <plugins.uiActionsEnhanced.DrilldownManager
             initialRoute={'/create'}
             dynamicActionManager={managerWithoutEmbeddableSingleButton}

--- a/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_preview/datasource_preview.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_preview/datasource_preview.js
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { i18n } from '@kbn/i18n';
@@ -17,6 +16,7 @@ import {
   EuiText,
   EuiEmptyPrompt,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { withSuspense } from '@kbn/presentation-util-plugin/public';
@@ -48,48 +48,57 @@ const strings = {
     }),
 };
 
-export const DatasourcePreview = ({ done, datatable }) => (
-  <EuiModal onClose={done} maxWidth="1000px" className="canvasModal--fixedSize">
-    <EuiModalHeader>
-      <EuiModalHeaderTitle>{strings.getModalTitle()}</EuiModalHeaderTitle>
-    </EuiModalHeader>
-    <EuiModalBody className="canvasDatasourcePreview">
-      <EuiText size="s">
-        <p>
-          <FormattedMessage
-            id="xpack.canvas.datasourceDatasourcePreview.modalDescription"
-            defaultMessage="The following data will be available to the selected element upon clicking {saveLabel} in the sidebar."
-            values={{
-              saveLabel: <strong>{strings.getSaveButtonLabel()}</strong>,
-            }}
-          />
-        </p>
-      </EuiText>
-      <EuiSpacer />
-      {datatable.type === 'error' ? (
-        <Error payload={datatable} />
-      ) : (
-        <EuiPanel className="canvasDatasourcePreview__panel" paddingSize="none">
-          {datatable.rows.length > 0 ? (
-            <Datatable datatable={datatable} showHeader paginate />
-          ) : (
-            <EuiEmptyPrompt
-              title={<h2>{strings.getEmptyTitle()}</h2>}
-              titleSize="s"
-              body={
-                <p>
-                  {strings.getEmptyFirstLineDescription()}
-                  <br />
-                  {strings.getEmptySecondLineDescription()}
-                </p>
-              }
+export const DatasourcePreview = ({ done, datatable }) => {
+  const modalTitleId = useGeneratedHtmlId();
+
+  return (
+    <EuiModal
+      aria-labelledby={modalTitleId}
+      onClose={done}
+      maxWidth="1000px"
+      className="canvasModal--fixedSize"
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>{strings.getModalTitle()}</EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody className="canvasDatasourcePreview">
+        <EuiText size="s">
+          <p>
+            <FormattedMessage
+              id="xpack.canvas.datasourceDatasourcePreview.modalDescription"
+              defaultMessage="The following data will be available to the selected element upon clicking {saveLabel} in the sidebar."
+              values={{
+                saveLabel: <strong>{strings.getSaveButtonLabel()}</strong>,
+              }}
             />
-          )}
-        </EuiPanel>
-      )}
-    </EuiModalBody>
-  </EuiModal>
-);
+          </p>
+        </EuiText>
+        <EuiSpacer />
+        {datatable.type === 'error' ? (
+          <Error payload={datatable} />
+        ) : (
+          <EuiPanel className="canvasDatasourcePreview__panel" paddingSize="none">
+            {datatable.rows.length > 0 ? (
+              <Datatable datatable={datatable} showHeader paginate />
+            ) : (
+              <EuiEmptyPrompt
+                title={<h2>{strings.getEmptyTitle()}</h2>}
+                titleSize="s"
+                body={
+                  <p>
+                    {strings.getEmptyFirstLineDescription()}
+                    <br />
+                    {strings.getEmptySecondLineDescription()}
+                  </p>
+                }
+              />
+            )}
+          </EuiPanel>
+        )}
+      </EuiModalBody>
+    </EuiModal>
+  );
+};
 
 DatasourcePreview.propTypes = {
   datatable: PropTypes.object,

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/auto_follow_pattern_request_flyout.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/auto_follow_pattern_request_flyout.js
@@ -19,6 +19,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  htmlIdGenerator,
 } from '@elastic/eui';
 
 import { serializeAutoFollowPattern } from '../../../common/services/auto_follow_pattern_serialization';
@@ -36,12 +37,13 @@ export class AutoFollowPatternRequestFlyout extends PureComponent {
     const endpoint = `PUT /_ccr/auto_follow/${name ? name : '<autoFollowPatternName>'}`;
     const payload = JSON.stringify(serializeAutoFollowPattern(autoFollowPattern), null, 2);
     const request = `${endpoint}\n${payload}`;
+    const modalTitleId = htmlIdGenerator()('autoFollowPatternRequestFlyoutTitle');
 
     return (
-      <EuiFlyout maxWidth={480} onClose={close}>
+      <EuiFlyout maxWidth={480} onClose={close} aria-labelledby={modalTitleId}>
         <EuiFlyoutHeader>
           <EuiTitle>
-            <h2>
+            <h2 id={modalTitleId}>
               {name ? (
                 <FormattedMessage
                   id="xpack.crossClusterReplication.autoFollowPatternForm.requestFlyout.namedTitle"

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/follower_index_form/follower_index_request_flyout.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/follower_index_form/follower_index_request_flyout.js
@@ -19,6 +19,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  htmlIdGenerator,
 } from '@elastic/eui';
 
 import { serializeFollowerIndex } from '../../../../common/services/follower_index_serialization';
@@ -35,12 +36,13 @@ export class FollowerIndexRequestFlyout extends PureComponent {
     const endpoint = `PUT /${name ? name : '<followerIndexName>'}/_ccr/follow`;
     const payload = JSON.stringify(serializeFollowerIndex(followerIndex), null, 2);
     const request = `${endpoint}\n${payload}`;
+    const flyoutTitleId = htmlIdGenerator()('flyoutTitle');
 
     return (
-      <EuiFlyout maxWidth={480} onClose={close}>
+      <EuiFlyout maxWidth={480} onClose={close} aria-labelledby={flyoutTitleId}>
         <EuiFlyoutHeader>
           <EuiTitle>
-            <h2>
+            <h2 id={flyoutTitleId}>
               <FormattedMessage
                 id="xpack.crossClusterReplication.followerIndexForm.requestFlyout.title"
                 defaultMessage="Request"

--- a/x-pack/platform/plugins/private/monitoring/public/components/logstash/pipeline_viewer/views/__snapshots__/detail_drawer.test.js.snap
+++ b/x-pack/platform/plugins/private/monitoring/public/components/logstash/pipeline_viewer/views/__snapshots__/detail_drawer.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`DetailDrawer component If vertices shows basic info and no stats for if 1`] = `
 <EuiFlyout
+  aria-labelledby="generated-id"
   onClose={[MockFunction]}
   size="s"
 >
@@ -17,7 +18,9 @@ exports[`DetailDrawer component If vertices shows basic info and no stats for if
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTitle>
-          <h2>
+          <h2
+            id="generated-id"
+          >
             if
           </h2>
         </EuiTitle>
@@ -53,6 +56,7 @@ exports[`DetailDrawer component If vertices shows basic info and no stats for if
 
 exports[`DetailDrawer component Plugin vertices Plugin does not have explicit ID shows basic info and stats for plugin, suggesting that user set explicit ID 1`] = `
 <EuiFlyout
+  aria-labelledby="generated-id"
   onClose={[MockFunction]}
   size="s"
 >
@@ -68,7 +72,9 @@ exports[`DetailDrawer component Plugin vertices Plugin does not have explicit ID
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTitle>
-          <h2>
+          <h2
+            id="generated-id"
+          >
             grok filter
           </h2>
         </EuiTitle>
@@ -300,6 +306,7 @@ exports[`DetailDrawer component Plugin vertices Plugin does not have explicit ID
 
 exports[`DetailDrawer component Plugin vertices Plugin has explicit ID shows basic info and stats for plugin, including explicit ID 1`] = `
 <EuiFlyout
+  aria-labelledby="generated-id"
   onClose={[MockFunction]}
   size="s"
 >
@@ -315,7 +322,9 @@ exports[`DetailDrawer component Plugin vertices Plugin has explicit ID shows bas
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTitle>
-          <h2>
+          <h2
+            id="generated-id"
+          >
             grok filter
           </h2>
         </EuiTitle>
@@ -541,6 +550,7 @@ exports[`DetailDrawer component Plugin vertices Plugin has explicit ID shows bas
 
 exports[`DetailDrawer component Queue vertices shows basic info and no stats for queue 1`] = `
 <EuiFlyout
+  aria-labelledby="generated-id"
   onClose={[MockFunction]}
   size="s"
 >
@@ -556,7 +566,9 @@ exports[`DetailDrawer component Queue vertices shows basic info and no stats for
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTitle>
-          <h2>
+          <h2
+            id="generated-id"
+          >
             queue
           </h2>
         </EuiTitle>
@@ -584,6 +596,7 @@ exports[`DetailDrawer component Queue vertices shows basic info and no stats for
 
 exports[`DetailDrawer component shows vertex title 1`] = `
 <EuiFlyout
+  aria-labelledby="generated-id"
   onClose={[MockFunction]}
   size="s"
 >
@@ -599,7 +612,9 @@ exports[`DetailDrawer component shows vertex title 1`] = `
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTitle>
-          <h2 />
+          <h2
+            id="generated-id"
+          />
         </EuiTitle>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/platform/plugins/private/monitoring/public/components/logstash/pipeline_viewer/views/detail_drawer.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/logstash/pipeline_viewer/views/detail_drawer.js
@@ -24,6 +24,7 @@ import {
   EuiTableRowCell,
   EuiText,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -301,14 +302,16 @@ function renderTitle(vertex) {
 }
 
 export function DetailDrawer({ vertex, onHide, timeseriesTooltipXValueFormatter }) {
+  const detailDrawerTitleId = useGeneratedHtmlId();
+
   return (
-    <EuiFlyout size="s" onClose={onHide}>
+    <EuiFlyout size="s" onClose={onHide} aria-labelledby={detailDrawerTitleId}>
       <EuiFlyoutHeader>
         <EuiFlexGroup alignItems="baseline" gutterSize="s">
           <EuiFlexItem grow={false}>{renderIcon(vertex)}</EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle>
-              <h2>{renderTitle(vertex)}</h2>
+              <h2 id={detailDrawerTitleId}>{renderTitle(vertex)}</h2>
             </EuiTitle>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_manual_entry_flyout.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_manual_entry_flyout.tsx
@@ -24,6 +24,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import moment from 'moment';
 import { KnowledgeBaseEntryRole } from '@kbn/observability-ai-assistant-plugin/public';
@@ -74,11 +75,13 @@ export function KnowledgeBaseEditManualEntryFlyout({
     onClose();
   };
 
+  const flyoutTitleId = useGeneratedHtmlId();
+
   return (
-    <EuiFlyout onClose={onClose}>
+    <EuiFlyout onClose={onClose} aria-labelledby={flyoutTitleId}>
       <EuiFlyoutHeader hasBorder data-test-subj="knowledgeBaseManualEntryFlyout">
         <EuiTitle>
-          <h2>
+          <h2 id={flyoutTitleId}>
             {!entry
               ? i18n.translate(
                   'xpack.observabilityAiAssistantManagement.knowledgeBaseNewEntryFlyout.h2.newEntryLabel',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_yaml_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_yaml_flyout.tsx
@@ -22,6 +22,7 @@ import {
   EuiButton,
   EuiCallOut,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { MAX_FLYOUT_WIDTH } from '../../../constants';
@@ -38,6 +39,8 @@ const FlyoutBody = styled(EuiFlyoutBody)`
 
 export const AgentPolicyYamlFlyout = memo<{ policyId: string; onClose: () => void }>(
   ({ policyId, onClose }) => {
+    const flyoutTitleId = useGeneratedHtmlId();
+
     const core = useStartServices();
     const { isLoading: isLoadingYaml, data: yamlData, error } = useGetOneAgentPolicyFull(policyId);
     const { data: agentPolicyData } = useGetOneAgentPolicy(policyId);
@@ -72,10 +75,10 @@ export const AgentPolicyYamlFlyout = memo<{ policyId: string; onClose: () => voi
       `?apiVersion=${API_VERSIONS.public.v1}`;
 
     return (
-      <EuiFlyout onClose={onClose} maxWidth={MAX_FLYOUT_WIDTH}>
-        <EuiFlyoutHeader hasBorder aria-labelledby="IngestManagerAgentPolicyYamlFlyoutTitle">
+      <EuiFlyout onClose={onClose} maxWidth={MAX_FLYOUT_WIDTH} aria-labelledby={flyoutTitleId}>
+        <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="IngestManagerAgentPolicyYamlFlyoutTitle">
+            <h2 id={flyoutTitleId}>
               {agentPolicyData?.item ? (
                 <FormattedMessage
                   id="xpack.fleet.policyDetails.yamlflyoutTitleWithName"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
@@ -15,6 +15,7 @@ import {
   EuiModalHeaderTitle,
   EuiButton,
   EuiSkeletonText,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -32,11 +33,17 @@ export const ChangelogModal: React.FunctionComponent<Props> = ({
   onClose,
 }) => {
   const changelogText = formatChangelog(changelog);
+  const changelogModalTitleId = useGeneratedHtmlId();
 
   return (
-    <EuiModal maxWidth={true} onClose={onClose} data-test-subj="integrations.changelogModal">
+    <EuiModal
+      maxWidth={true}
+      onClose={onClose}
+      data-test-subj="integrations.changelogModal"
+      aria-labelledby={changelogModalTitleId}
+    >
       <EuiModalHeader>
-        <EuiModalHeaderTitle>{'Changelog'}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle id={changelogModalTitleId}>{'Changelog'}</EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
         <EuiSkeletonText

--- a/x-pack/platform/plugins/shared/ml/public/application/components/validate_job/validate_job_view.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/validate_job/validate_job_view.js
@@ -22,6 +22,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -79,21 +80,27 @@ const LoadingSpinner = () => (
   </EuiFlexGroup>
 );
 
-const Modal = ({ close, title, children }) => (
-  <EuiModal onClose={close} style={{ width: '800px' }}>
-    <EuiModalHeader>
-      <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
-    </EuiModalHeader>
+const Modal = ({ close, title, children }) => {
+  const modalTitleId = useGeneratedHtmlId();
+  return (
+    <EuiModal onClose={close} style={{ width: '800px' }} aria-labelledby={modalTitleId}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>{title}</EuiModalHeaderTitle>
+      </EuiModalHeader>
 
-    <EuiModalBody>{children}</EuiModalBody>
+      <EuiModalBody>{children}</EuiModalBody>
 
-    <EuiModalFooter>
-      <EuiButton onClick={close} size="s" fill>
-        <FormattedMessage id="xpack.ml.validateJob.modal.closeButtonLabel" defaultMessage="Close" />
-      </EuiButton>
-    </EuiModalFooter>
-  </EuiModal>
-);
+      <EuiModalFooter>
+        <EuiButton onClick={close} size="s" fill>
+          <FormattedMessage
+            id="xpack.ml.validateJob.modal.closeButtonLabel"
+            defaultMessage="Close"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};
 Modal.propType = {
   close: PropTypes.func.isRequired,
   title: PropTypes.string,

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/test_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/test_flyout.tsx
@@ -8,7 +8,14 @@
 import type { FC } from 'react';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiSpacer, EuiTitle } from '@elastic/eui';
+import {
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiSpacer,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import type { TrainedModelItem } from '../../../../common/types/trained_models';
 import { TestTrainedModelContent } from './test_trained_model_content';
 
@@ -16,24 +23,33 @@ interface Props {
   model: TrainedModelItem;
   onClose: () => void;
 }
-export const TestTrainedModelFlyout: FC<Props> = ({ model, onClose }) => (
-  <EuiFlyout maxWidth={600} onClose={onClose} data-test-subj="mlTestModelsFlyout">
-    <EuiFlyoutHeader hasBorder>
-      <EuiTitle size="m">
-        <h2>
-          <FormattedMessage
-            id="xpack.ml.trainedModels.testModelsFlyout.headerLabel"
-            defaultMessage="Test trained model"
-          />
-        </h2>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiTitle size="xs">
-        <h4>{model.model_id}</h4>
-      </EuiTitle>
-    </EuiFlyoutHeader>
-    <EuiFlyoutBody>
-      <TestTrainedModelContent model={model} />
-    </EuiFlyoutBody>
-  </EuiFlyout>
-);
+export const TestTrainedModelFlyout: FC<Props> = ({ model, onClose }) => {
+  const flyoutTitleId = useGeneratedHtmlId();
+
+  return (
+    <EuiFlyout
+      aria-labelledby={flyoutTitleId}
+      maxWidth={600}
+      onClose={onClose}
+      data-test-subj="mlTestModelsFlyout"
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id={flyoutTitleId}>
+            <FormattedMessage
+              id="xpack.ml.trainedModels.testModelsFlyout.headerLabel"
+              defaultMessage="Test trained model"
+            />
+          </h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiTitle size="xs">
+          <h4>{model.model_id}</h4>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <TestTrainedModelContent model={model} />
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/ml/public/application/settings/calendars/edit/import_modal/import_modal.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/settings/calendars/edit/import_modal/import_modal.js
@@ -19,6 +19,7 @@ import {
   EuiModalFooter,
   EuiFlexGroup,
   EuiFlexItem,
+  htmlIdGenerator,
 } from '@elastic/eui';
 
 import { ImportedEvents } from '../imported_events';
@@ -127,6 +128,8 @@ export class ImportModal extends Component {
       includePastEvents,
     } = this.state;
 
+    const modalTitleId = htmlIdGenerator()('importModalTitle');
+
     let showRecurringWarning = false;
     let importedEvents;
 
@@ -142,11 +145,11 @@ export class ImportModal extends Component {
 
     return (
       <Fragment>
-        <EuiModal onClose={closeImportModal} maxWidth={true}>
+        <EuiModal onClose={closeImportModal} maxWidth={true} aria-labelledby={modalTitleId}>
           <EuiModalHeader>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem grow={false}>
-                <EuiModalHeaderTitle>
+                <EuiModalHeaderTitle id={modalTitleId}>
                   <FormattedMessage
                     id="xpack.ml.calendarsEdit.eventsTable.importEventsTitle"
                     defaultMessage="Import events"

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/forecasting_modal/modal.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/forecasting_modal/modal.js
@@ -20,6 +20,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { MessageCallOut } from '../../../components/message_call_out';
@@ -31,6 +32,8 @@ import { RunControls } from './run_controls';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 export function Modal(props) {
+  const modalTitleId = useGeneratedHtmlId();
+
   const [mlNodesAvailable, setMlNodesAvailable] = useState(false);
   const {
     services: {
@@ -50,9 +53,14 @@ export function Modal(props) {
   );
 
   return (
-    <EuiModal onClose={props.close} maxWidth={860} data-test-subj="mlModalForecast">
+    <EuiModal
+      aria-labelledby={modalTitleId}
+      onClose={props.close}
+      maxWidth={860}
+      data-test-subj="mlModalForecast"
+    >
       <EuiModalHeader>
-        <EuiModalHeaderTitle>
+        <EuiModalHeaderTitle id={modalTitleId}>
           <FormattedMessage
             id="xpack.ml.timeSeriesExplorer.forecastingModal.forecastingTitle"
             defaultMessage="Forecasting"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_dashboards_view/import_content_pack_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_dashboards_view/import_content_pack_flyout.tsx
@@ -20,6 +20,7 @@ import {
   EuiFlyoutHeader,
   EuiSpacer,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '../../hooks/use_kibana';
@@ -41,6 +42,8 @@ export function ImportContentPackFlyout({
     core: { http, notifications },
   } = useKibana();
 
+  const modalTitleId = useGeneratedHtmlId();
+
   const [isLoading, setIsLoading] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [contentPackObjects, setContentPackObjects] = useState<ContentPackEntry[]>([]);
@@ -50,10 +53,10 @@ export function ImportContentPackFlyout({
   const [manifest, setManifest] = useState<ContentPackManifest | undefined>();
 
   return (
-    <EuiFlyout onClose={onClose}>
+    <EuiFlyout onClose={onClose} aria-labelledby={modalTitleId}>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle>
-          <h2>
+          <h2 id={modalTitleId}>
             {i18n.translate('xpack.streams.streamDetailDashboard.importContent', {
               defaultMessage: 'Import content pack',
             })}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/bulk_snooze_schedule_modal.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/bulk_snooze_schedule_modal.tsx
@@ -125,13 +125,14 @@ export const BulkSnoozeScheduleModal = (props: BulkSnoozeScheduleModalProps) => 
     return deleteConfirmPlural(numberOfSelectedRules);
   }, [rules, filter, numberOfSelectedRules]);
 
-  const modalTitleId = useGeneratedHtmlId();
+  const confirmModalTitleId = useGeneratedHtmlId();
+  const modalHeaderTitleId = useGeneratedHtmlId();
 
   if (bulkEditAction === 'unschedule' && (rules.length || filter)) {
     return (
       <EuiConfirmModal
-        aria-labelledby={modalTitleId}
-        titleProps={{ id: modalTitleId }}
+        aria-labelledby={confirmModalTitleId}
+        titleProps={{ id: confirmModalTitleId }}
         title={confirmationTitle}
         onCancel={onClose}
         onConfirm={onRemoveSnoozeSchedule}
@@ -156,9 +157,9 @@ export const BulkSnoozeScheduleModal = (props: BulkSnoozeScheduleModalProps) => 
 
   if (bulkEditAction === 'schedule' && (rules.length || filter)) {
     return (
-      <EuiModal onClose={onClose}>
+      <EuiModal aria-labelledby={modalHeaderTitleId} onClose={onClose}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
+          <EuiModalHeaderTitle id={modalHeaderTitleId}>
             <FormattedMessage
               id="xpack.triggersActionsUI.sections.rulesList.bulkSnoozeScheduleModal.modalTitle"
               defaultMessage="Add snooze schedule"

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -20,6 +20,7 @@ import {
   EuiButtonEmpty,
   EuiCallOut,
   useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useEffect, useState } from 'react';
@@ -118,6 +119,8 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
 
   const { AdditionalChargesMessage } = useContractComponents();
 
+  const modalTitleId = useGeneratedHtmlId();
+
   if (!visible) {
     return null;
   }
@@ -133,9 +136,13 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
     </EuiCallOut>
   );
   return (
-    <EuiModal onClose={() => toggle(false)} data-test-subj="entityStoreEnablementModal">
+    <EuiModal
+      onClose={() => toggle(false)}
+      aria-labelledby={modalTitleId}
+      data-test-subj="entityStoreEnablementModal"
+    >
       <EuiModalHeader>
-        <EuiModalHeaderTitle>
+        <EuiModalHeaderTitle id={modalTitleId}>
           <FormattedMessage
             id="xpack.securitySolution.entityAnalytics.enablements.modal.title"
             defaultMessage="Entity Analytics Enablement"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix violations of the @elastic/eui/require-aria-label-for-modals ESLint rule (Step 3) (#229616)](https://github.com/elastic/kibana/pull/229616)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2025-08-04T12:18:33Z","message":"Fix violations of the @elastic/eui/require-aria-label-for-modals ESLint rule (Step 3) (#229616)\n\n## Summary\n\nThis PR manually fixes some remaining violations of the following rule\nthat, for some reason, were not addressed in the previous PR:\nhttps://github.com/elastic/kibana/pull/227821\n\nIt applies the auto-fix for the newly introduced\n`@elastic/eui/require-aria-label-for-modals` rule. This rule ensures\nthat `EUI` modal components (`EuiModal` and `EuiFlyout`) include either\nan aria-label or `aria-labelledby` prop to support screen reader\naccessibility. These attributes help users understand the purpose and\ncontent of modal dialogs.\n\n## Changes Made\n\n1. **Identified the modal title/header element** used within `EuiModal`\nor `EuiFlyout`.\nCommon elements include: `EuiFlyoutTitle`, `EuiModalTitle`, `EuiTitle`,\n`<h2>`, `<h3>`, or other heading tags.\n\n2. **Ensured the title element has an `id`:**\nIf the header element lacked an `id`, one was programmatically\ngenerated:\n\n   * **For function components:**\n\n* Imported `useGeneratedHtmlId` from `@elastic/eui` if not already\npresent:\n\n       ```ts\n       import { useGeneratedHtmlId } from '@elastic/eui';\n       ```\n     * Defined a unique ID before the `return` statement:\n\n       ```ts\n       const modalTitleId = useGeneratedHtmlId();\n       ```\n     * Applied the ID to the title element:\n\n       ```tsx\n       <EuiModalTitle id={modalTitleId}>Title</EuiModalTitle>\n       ```\n\n   * **For class components:**\n\n* Imported `htmlIdGenerator` from `@elastic/eui` if not already present:\n\n       ```ts\n       import { htmlIdGenerator } from '@elastic/eui';\n       ```\n     * Defined a unique ID within the `render()` method:\n\n       ```ts\n       const modalTitleId = htmlIdGenerator()('modalTitle');\n       ```\n     * Applied the ID to the title element:\n\n       ```tsx\n       <EuiModalTitle id={modalTitleId}>Title</EuiModalTitle>\n       ```\n\n3. **Updated the `EuiModal` or `EuiFlyout` component** to include the\n`aria-labelledby` attribute referencing the generated title ID:\n\n   ```tsx\n   <EuiModal aria-labelledby={modalTitleId} />\n   ```\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ef05e61a64ff49080636578a37d6502492f9c947","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","Team:Fleet","backport:prev-minor","ci:project-deploy-observability","v9.2.0"],"title":"Fix violations of the @elastic/eui/require-aria-label-for-modals ESLint rule (Step 3)","number":229616,"url":"https://github.com/elastic/kibana/pull/229616","mergeCommit":{"message":"Fix violations of the @elastic/eui/require-aria-label-for-modals ESLint rule (Step 3) (#229616)\n\n## Summary\n\nThis PR manually fixes some remaining violations of the following rule\nthat, for some reason, were not addressed in the previous PR:\nhttps://github.com/elastic/kibana/pull/227821\n\nIt applies the auto-fix for the newly introduced\n`@elastic/eui/require-aria-label-for-modals` rule. This rule ensures\nthat `EUI` modal components (`EuiModal` and `EuiFlyout`) include either\nan aria-label or `aria-labelledby` prop to support screen reader\naccessibility. These attributes help users understand the purpose and\ncontent of modal dialogs.\n\n## Changes Made\n\n1. **Identified the modal title/header element** used within `EuiModal`\nor `EuiFlyout`.\nCommon elements include: `EuiFlyoutTitle`, `EuiModalTitle`, `EuiTitle`,\n`<h2>`, `<h3>`, or other heading tags.\n\n2. **Ensured the title element has an `id`:**\nIf the header element lacked an `id`, one was programmatically\ngenerated:\n\n   * **For function components:**\n\n* Imported `useGeneratedHtmlId` from `@elastic/eui` if not already\npresent:\n\n       ```ts\n       import { useGeneratedHtmlId } from '@elastic/eui';\n       ```\n     * Defined a unique ID before the `return` statement:\n\n       ```ts\n       const modalTitleId = useGeneratedHtmlId();\n       ```\n     * Applied the ID to the title element:\n\n       ```tsx\n       <EuiModalTitle id={modalTitleId}>Title</EuiModalTitle>\n       ```\n\n   * **For class components:**\n\n* Imported `htmlIdGenerator` from `@elastic/eui` if not already present:\n\n       ```ts\n       import { htmlIdGenerator } from '@elastic/eui';\n       ```\n     * Defined a unique ID within the `render()` method:\n\n       ```ts\n       const modalTitleId = htmlIdGenerator()('modalTitle');\n       ```\n     * Applied the ID to the title element:\n\n       ```tsx\n       <EuiModalTitle id={modalTitleId}>Title</EuiModalTitle>\n       ```\n\n3. **Updated the `EuiModal` or `EuiFlyout` component** to include the\n`aria-labelledby` attribute referencing the generated title ID:\n\n   ```tsx\n   <EuiModal aria-labelledby={modalTitleId} />\n   ```\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ef05e61a64ff49080636578a37d6502492f9c947"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229616","number":229616,"mergeCommit":{"message":"Fix violations of the @elastic/eui/require-aria-label-for-modals ESLint rule (Step 3) (#229616)\n\n## Summary\n\nThis PR manually fixes some remaining violations of the following rule\nthat, for some reason, were not addressed in the previous PR:\nhttps://github.com/elastic/kibana/pull/227821\n\nIt applies the auto-fix for the newly introduced\n`@elastic/eui/require-aria-label-for-modals` rule. This rule ensures\nthat `EUI` modal components (`EuiModal` and `EuiFlyout`) include either\nan aria-label or `aria-labelledby` prop to support screen reader\naccessibility. These attributes help users understand the purpose and\ncontent of modal dialogs.\n\n## Changes Made\n\n1. **Identified the modal title/header element** used within `EuiModal`\nor `EuiFlyout`.\nCommon elements include: `EuiFlyoutTitle`, `EuiModalTitle`, `EuiTitle`,\n`<h2>`, `<h3>`, or other heading tags.\n\n2. **Ensured the title element has an `id`:**\nIf the header element lacked an `id`, one was programmatically\ngenerated:\n\n   * **For function components:**\n\n* Imported `useGeneratedHtmlId` from `@elastic/eui` if not already\npresent:\n\n       ```ts\n       import { useGeneratedHtmlId } from '@elastic/eui';\n       ```\n     * Defined a unique ID before the `return` statement:\n\n       ```ts\n       const modalTitleId = useGeneratedHtmlId();\n       ```\n     * Applied the ID to the title element:\n\n       ```tsx\n       <EuiModalTitle id={modalTitleId}>Title</EuiModalTitle>\n       ```\n\n   * **For class components:**\n\n* Imported `htmlIdGenerator` from `@elastic/eui` if not already present:\n\n       ```ts\n       import { htmlIdGenerator } from '@elastic/eui';\n       ```\n     * Defined a unique ID within the `render()` method:\n\n       ```ts\n       const modalTitleId = htmlIdGenerator()('modalTitle');\n       ```\n     * Applied the ID to the title element:\n\n       ```tsx\n       <EuiModalTitle id={modalTitleId}>Title</EuiModalTitle>\n       ```\n\n3. **Updated the `EuiModal` or `EuiFlyout` component** to include the\n`aria-labelledby` attribute referencing the generated title ID:\n\n   ```tsx\n   <EuiModal aria-labelledby={modalTitleId} />\n   ```\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ef05e61a64ff49080636578a37d6502492f9c947"}}]}] BACKPORT-->