### PR TITLE
[8.17] [Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698)

### DIFF
--- a/src/plugins/es_ui_shared/__packages_do_not_import__/authorization/types.ts
+++ b/src/plugins/es_ui_shared/__packages_do_not_import__/authorization/types.ts
@@ -20,4 +20,10 @@ export interface Error {
   error: string;
   cause?: string[];
   message?: string;
+  statusCode?: number;
+  attributes?: {
+    error?: {
+      type?: string;
+    };
+  };
 }

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/http_requests.ts
@@ -14,6 +14,11 @@ type HttpResponse = Record<string, any> | any[];
 export interface ResponseError {
   statusCode: number;
   message: string | Error;
+  attributes?: {
+    error?: {
+      type?: string;
+    };
+  };
 }
 
 // Register helpers to mock HTTP Requests

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/home.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/home.test.ts
@@ -7,7 +7,10 @@
 
 import { act } from 'react-dom/test-utils';
 import * as fixtures from '../../test/fixtures';
-import { SNAPSHOT_STATE } from '../../public/application/constants';
+import {
+  SNAPSHOT_REPOSITORY_EXCEPTION_ERROR,
+  SNAPSHOT_STATE,
+} from '../../public/application/constants';
 import { API_BASE_PATH } from '../../common';
 import { setupEnvironment, pageHelpers, getRandomString, findTestSubject } from './helpers';
 import { HomeTestBed } from './helpers/home.helpers';
@@ -418,7 +421,8 @@ describe('<SnapshotRestoreHome />', () => {
   describe('snapshots', () => {
     describe('when there are no snapshots nor repositories', () => {
       beforeAll(() => {
-        httpRequestsMockHelpers.setLoadSnapshotsResponse({ snapshots: [], repositories: [] });
+        httpRequestsMockHelpers.setLoadSnapshotsResponse({ snapshots: [] });
+        httpRequestsMockHelpers.setLoadRepositoriesResponse({ repositories: [] });
       });
 
       beforeEach(async () => {
@@ -448,8 +452,10 @@ describe('<SnapshotRestoreHome />', () => {
       beforeEach(async () => {
         httpRequestsMockHelpers.setLoadSnapshotsResponse({
           snapshots: [],
-          repositories: ['my-repo'],
           total: 0,
+        });
+        httpRequestsMockHelpers.setLoadRepositoriesResponse({
+          repositories: [{ name: 'my-repo' }],
         });
 
         testBed = await setup(httpSetup);
@@ -489,8 +495,10 @@ describe('<SnapshotRestoreHome />', () => {
       beforeEach(async () => {
         httpRequestsMockHelpers.setLoadSnapshotsResponse({
           snapshots,
-          repositories: [REPOSITORY_NAME],
           total: 2,
+        });
+        httpRequestsMockHelpers.setLoadRepositoriesResponse({
+          repositories: [{ name: REPOSITORY_NAME }],
         });
 
         testBed = await setup(httpSetup);
@@ -527,7 +535,6 @@ describe('<SnapshotRestoreHome />', () => {
         httpRequestsMockHelpers.setLoadSnapshotsResponse({
           snapshots,
           total: 2,
-          repositories: [REPOSITORY_NAME],
           errors: {
             repository_with_errors: {
               type: 'repository_exception',
@@ -535,6 +542,9 @@ describe('<SnapshotRestoreHome />', () => {
                 '[repository_with_errors] Could not read repository data because the contents of the repository do not match its expected state.',
             },
           },
+        });
+        httpRequestsMockHelpers.setLoadRepositoriesResponse({
+          repositories: [{ name: REPOSITORY_NAME }],
         });
 
         testBed = await setup(httpSetup);
@@ -550,32 +560,6 @@ describe('<SnapshotRestoreHome />', () => {
         expect(find('repositoryErrorsWarning').text()).toContain(
           'Some repositories contain errors'
         );
-      });
-
-      test('should show a prompt if a repository contains errors and there are no other repositories', async () => {
-        httpRequestsMockHelpers.setLoadSnapshotsResponse({
-          snapshots,
-          repositories: [],
-          errors: {
-            repository_with_errors: {
-              type: 'repository_exception',
-              reason:
-                '[repository_with_errors] Could not read repository data because the contents of the repository do not match its expected state.',
-            },
-          },
-        });
-
-        testBed = await setup(httpSetup);
-
-        await act(async () => {
-          testBed.actions.selectTab('snapshots');
-        });
-
-        testBed.component.update();
-
-        const { find, exists } = testBed;
-        expect(exists('repositoryErrorsPrompt')).toBe(true);
-        expect(find('repositoryErrorsPrompt').text()).toContain('Some repositories contain errors');
       });
 
       test('each row should have a link to the repository', async () => {
@@ -883,6 +867,69 @@ describe('<SnapshotRestoreHome />', () => {
           expect(shardText).toBe(`Shard ${mockedFailure.shard_id}`);
           expect(reasonText).toBe(`${mockedFailure.status}: ${mockedFailure.reason}`);
         });
+      });
+    });
+
+    describe('when there is an error while fetching the snapshots', () => {
+      beforeEach(async () => {
+        httpRequestsMockHelpers.setLoadSnapshotsResponse(undefined, {
+          statusCode: 500,
+          message: '[repository_with_errors] cannot retrieve snapshots list from this repository',
+        });
+        httpRequestsMockHelpers.setLoadRepositoriesResponse({
+          repositories: [{ name: REPOSITORY_NAME }, { name: 'repository_with_errors' }],
+        });
+
+        testBed = await setup(httpSetup);
+
+        await act(async () => {
+          testBed.actions.selectTab('snapshots');
+        });
+
+        testBed.component.update();
+      });
+
+      test('should show a generic error prompt if snapshots request fails while still showing the search bar', async () => {
+        const { find, exists } = testBed;
+
+        // Check that the search bar is still present
+        expect(exists('snapshotListSearch')).toBe(true);
+
+        // Check that the error message is displayed
+        expect(exists('snapshotsLoadingError')).toBe(true);
+        expect(find('snapshotsLoadingError').text()).toContain('Error loading snapshots');
+      });
+
+      test('should show a repository error prompt if snapshots request fails due to repository exception while still showing the search bar', async () => {
+        httpRequestsMockHelpers.setLoadSnapshotsResponse(undefined, {
+          statusCode: 500,
+          message: '[repository_with_errors] cannot retrieve snapshots list from this repository',
+          attributes: {
+            error: {
+              type: SNAPSHOT_REPOSITORY_EXCEPTION_ERROR,
+            },
+          },
+        });
+        httpRequestsMockHelpers.setLoadRepositoriesResponse({
+          repositories: [{ name: REPOSITORY_NAME }, { name: 'repository_with_errors' }],
+        });
+
+        testBed = await setup(httpSetup);
+
+        await act(async () => {
+          testBed.actions.selectTab('snapshots');
+        });
+
+        testBed.component.update();
+
+        const { find, exists } = testBed;
+
+        // Check that the search bar is still present
+        expect(exists('snapshotListSearch')).toBe(true);
+
+        // Check that the error message is displayed
+        expect(exists('repositoryErrorsPrompt')).toBe(true);
+        expect(find('repositoryErrorsPrompt').text()).toContain('Some repositories contain errors');
       });
     });
   });

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/snapshot_list.test.tsx
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/snapshot_list.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { EuiSearchBoxProps } from '@elastic/eui/src/components/search_bar/search_box';
 
-import { useLoadSnapshots } from '../../public/application/services/http';
+import { useLoadRepositories, useLoadSnapshots } from '../../public/application/services/http';
 import { DEFAULT_SNAPSHOT_LIST_PARAMS } from '../../public/application/lib';
 
 import * as fixtures from '../../test/fixtures';
@@ -26,6 +26,7 @@ import { pageHelpers, getRandomString } from './helpers';
  */
 jest.mock('../../public/application/services/http', () => ({
   useLoadSnapshots: jest.fn(),
+  useLoadRepositories: jest.fn(),
   setUiMetricServiceSnapshot: () => {},
   setUiMetricService: () => {},
 }));
@@ -67,12 +68,23 @@ describe('<SnapshotList />', () => {
       isLoading: false,
       data: {
         snapshots,
-        repositories: [REPOSITORY_NAME],
         policies: [],
         errors: {},
         total: snapshots.length,
       },
       resendRequest: () => {},
+    });
+    (useLoadRepositories as jest.Mock).mockReturnValue({
+      error: null,
+      isInitialRequest: false,
+      isLoading: false,
+      data: {
+        repositories: [
+          {
+            name: REPOSITORY_NAME,
+          },
+        ],
+      },
     });
   });
 

--- a/x-pack/plugins/snapshot_restore/public/application/constants/index.ts
+++ b/x-pack/plugins/snapshot_restore/public/application/constants/index.ts
@@ -20,6 +20,8 @@ export enum SNAPSHOT_STATE {
   INCOMPATIBLE = 'INCOMPATIBLE',
 }
 
+export const SNAPSHOT_REPOSITORY_EXCEPTION_ERROR = 'repository_exception';
+
 const INDEX_SETTING_SUGGESTIONS: string[] = [
   'index.number_of_shards',
   'index.shard.check_on_startup',

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/repository_error.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/repository_error.tsx
@@ -8,11 +8,15 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiLink, EuiPageTemplate } from '@elastic/eui';
+import { EuiLink, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
 import { reactRouterNavigate } from '../../../../../shared_imports';
 import { linkToRepositories } from '../../../../services/navigation';
 
-export const RepositoryError: React.FunctionComponent = () => {
+interface RepositoryErrorProps {
+  errorMessage?: string;
+}
+
+export const RepositoryError = ({ errorMessage }: RepositoryErrorProps) => {
   const history = useHistory();
   return (
     <EuiPageTemplate.EmptyPrompt
@@ -29,9 +33,11 @@ export const RepositoryError: React.FunctionComponent = () => {
       }
       body={
         <p>
+          {errorMessage}
+          <EuiSpacer size="xs" />
           <FormattedMessage
             id="xpack.snapshotRestore.snapshotList.emptyPrompt.repositoryWarningDescription"
-            defaultMessage="Go to {repositoryLink} to fix the errors."
+            defaultMessage="Go to {repositoryLink} to fix the errors or select another repository."
             values={{
               repositoryLink: (
                 <EuiLink {...reactRouterNavigate(history, linkToRepositories())}>

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_table.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_table.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiTableSortingType } from '@elastic/eui/src/components/basic_table/table_types';
 
@@ -54,6 +54,7 @@ interface Props {
   setListParams: (listParams: SnapshotListParams) => void;
   totalItemCount: number;
   isLoading: boolean;
+  error?: ReactNode;
 }
 
 export const SnapshotTable: React.FunctionComponent<Props> = (props: Props) => {
@@ -66,6 +67,7 @@ export const SnapshotTable: React.FunctionComponent<Props> = (props: Props) => {
     setListParams,
     totalItemCount,
     isLoading,
+    error,
   } = props;
   const { i18n, uiMetricService, history } = useServices();
   const [selectedItems, setSelectedItems] = useState<SnapshotDetails[]>([]);
@@ -313,33 +315,37 @@ export const SnapshotTable: React.FunctionComponent<Props> = (props: Props) => {
         onSnapshotDeleted={onSnapshotDeleted}
         repositories={repositories}
       />
-      <EuiBasicTable
-        items={snapshots}
-        itemId="uuid"
-        columns={columns}
-        sorting={sorting}
-        onChange={(criteria: Criteria<SnapshotDetails>) => {
-          const { page: { index, size } = {}, sort: { field, direction } = {} } = criteria;
+      {error ? (
+        error
+      ) : (
+        <EuiBasicTable
+          items={snapshots}
+          itemId="uuid"
+          columns={columns}
+          sorting={sorting}
+          onChange={(criteria: Criteria<SnapshotDetails>) => {
+            const { page: { index, size } = {}, sort: { field, direction } = {} } = criteria;
 
-          setListParams({
-            ...listParams,
-            sortField: (field as SortField) ?? listParams.sortField,
-            sortDirection: (direction as SortDirection) ?? listParams.sortDirection,
-            pageIndex: index ?? listParams.pageIndex,
-            pageSize: size ?? listParams.pageSize,
-          });
-        }}
-        loading={isLoading}
-        selection={selection}
-        pagination={pagination}
-        rowProps={() => ({
-          'data-test-subj': 'row',
-        })}
-        cellProps={() => ({
-          'data-test-subj': 'cell',
-        })}
-        data-test-subj="snapshotTable"
-      />
+            setListParams({
+              ...listParams,
+              sortField: (field as SortField) ?? listParams.sortField,
+              sortDirection: (direction as SortDirection) ?? listParams.sortDirection,
+              pageIndex: index ?? listParams.pageIndex,
+              pageSize: size ?? listParams.pageSize,
+            });
+          }}
+          loading={isLoading}
+          selection={selection}
+          pagination={pagination}
+          rowProps={() => ({
+            'data-test-subj': 'row',
+          })}
+          cellProps={() => ({
+            'data-test-subj': 'cell',
+          })}
+          data-test-subj="snapshotTable"
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698)](https://github.com/elastic/kibana/pull/229698)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-01T14:57:09Z","message":"[Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698)\n\nCloses #225935\n\n## Summary\n\nThis PR fixes an issue where after request to load snapshots fails, e.g.\ndue to one of repositories misconfiguration, user was not able to use\nsearch bar to change query to access snapshots from different\nrepositories.","sha":"3d9c2bfb5bb95098c882e57cdd315a86846ab5d3","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","Feature:Snapshot and Restore","backport:all-open","v9.2.0","v9.0.5","v9.1.1","v8.19.1"],"title":"[Snapshot and restore] Display snapshot searchbar even if snapshots request fails","number":229698,"url":"https://github.com/elastic/kibana/pull/229698","mergeCommit":{"message":"[Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698)\n\nCloses #225935\n\n## Summary\n\nThis PR fixes an issue where after request to load snapshots fails, e.g.\ndue to one of repositories misconfiguration, user was not able to use\nsearch bar to change query to access snapshots from different\nrepositories.","sha":"3d9c2bfb5bb95098c882e57cdd315a86846ab5d3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229698","number":229698,"mergeCommit":{"message":"[Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698)\n\nCloses #225935\n\n## Summary\n\nThis PR fixes an issue where after request to load snapshots fails, e.g.\ndue to one of repositories misconfiguration, user was not able to use\nsearch bar to change query to access snapshots from different\nrepositories.","sha":"3d9c2bfb5bb95098c882e57cdd315a86846ab5d3"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230260","number":230260,"state":"MERGED","mergeCommit":{"sha":"8118409719a4261ce6bb6b6664a582e78eea1204","message":"[9.0] [Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698) (#230260)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Snapshot and restore] Display snapshot searchbar even if snapshots\nrequest fails (#229698)](https://github.com/elastic/kibana/pull/229698)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230261","number":230261,"state":"MERGED","mergeCommit":{"sha":"bc148fb9cfc7fb747dabc6dc3753b323b851b663","message":"[9.1] [Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698) (#230261)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Snapshot and restore] Display snapshot searchbar even if snapshots\nrequest fails (#229698)](https://github.com/elastic/kibana/pull/229698)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230259","number":230259,"state":"MERGED","mergeCommit":{"sha":"234d29f36442871aba53f4d3d2a8184677a7a684","message":"[8.19] [Snapshot and restore] Display snapshot searchbar even if snapshots request fails (#229698) (#230259)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Snapshot and restore] Display snapshot searchbar even if snapshots\nrequest fails (#229698)](https://github.com/elastic/kibana/pull/229698)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}}]}] BACKPORT-->