### PR TITLE
[8.17] [Observability Nav] [Serverless Nav] remove apm link from application nav section (#230152)

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/navigation_tree.ts
+++ b/x-pack/plugins/observability_solution/observability/public/navigation_tree.ts
@@ -88,13 +88,15 @@ export function createNavTree(pluginsStart: ObservabilityPublicPluginsStart) {
             spaceBefore: 'm',
           },
           {
-            id: 'apm',
+            id: 'applications',
             title: i18n.translate('xpack.observability.obltNav.applications', {
               defaultMessage: 'Applications',
             }),
             renderAs: 'panelOpener',
             children: [
               {
+                id: 'apm',
+                link: 'apm:services',
                 children: [
                   {
                     link: 'apm:services',

--- a/x-pack/test/functional_solution_sidenav/tests/observability_sidenav.ts
+++ b/x-pack/test/functional_solution_sidenav/tests/observability_sidenav.ts
@@ -49,16 +49,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           deepLinkId: 'observabilityOnboarding',
         });
 
-        // open apm (Application) panel using the link button (not the button icon)
-        await solutionNavigation.sidenav.openPanel('apm', { button: 'link' });
+        // open application panel
+        await solutionNavigation.sidenav.openPanel('applications');
         {
-          const isOpen = await solutionNavigation.sidenav.isPanelOpen('apm');
+          const isOpen = await solutionNavigation.sidenav.isPanelOpen('applications');
           expect(isOpen).to.be(true);
         }
 
-        await solutionNavigation.sidenav.closePanel('apm', { button: 'link' });
+        await solutionNavigation.sidenav.closePanel('applications');
         {
-          const isOpen = await solutionNavigation.sidenav.isPanelOpen('apm');
+          const isOpen = await solutionNavigation.sidenav.isPanelOpen('applications');
           expect(isOpen).to.be(false);
         }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Observability Nav] [Serverless Nav] remove apm link from application nav section (#230152)](https://github.com/elastic/kibana/pull/230152)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-08-02T00:07:44Z","message":"[Observability Nav] [Serverless Nav] remove apm link from application nav section (#230152)","sha":"066e673bad504351006a45e069b802f42dbcdd73","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","Team:obs-ux-management","backport:version","author:obs-ux-management","v9.2.0","v9.0.5","v9.1.1","v8.17.10","v8.18.5","v8.19.1"],"title":"[Observability Nav] [Serverless Nav] remove apm link from application nav section","number":230152,"url":"https://github.com/elastic/kibana/pull/230152","mergeCommit":{"message":"[Observability Nav] [Serverless Nav] remove apm link from application nav section (#230152)","sha":"066e673bad504351006a45e069b802f42dbcdd73"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.17","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230152","number":230152,"mergeCommit":{"message":"[Observability Nav] [Serverless Nav] remove apm link from application nav section (#230152)","sha":"066e673bad504351006a45e069b802f42dbcdd73"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230330","number":230330,"state":"MERGED","mergeCommit":{"sha":"80300c27560c1b19261f5253c2c073a3c0cce462","message":"[9.1] [Observability Nav] [Serverless Nav] remove apm link from application nav section (#230152) (#230330)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Observability Nav] [Serverless Nav] remove apm link from application\nnav section (#230152)](https://github.com/elastic/kibana/pull/230152)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Bailey Cash <bailey.cash@elastic.co>"}},{"branch":"8.17","label":"v8.17.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230329","number":230329,"state":"OPEN"}]}] BACKPORT-->