### PR TITLE
[ResponseOps]Categorize Webhook connector 404 errors as user errors.

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
@@ -760,7 +760,7 @@ describe('execute()', () => {
     expect(params.body).toBe(`{"x": "double-quote:\\"; line-break->\\n"}`);
   });
 
-  test('404 response is returns user error', async () => {
+  test('404 response returns user error', async () => {
     const config: ConnectorTypeConfigType = {
       url: 'https://abc.def/my-webhook',
       method: WebhookMethods.POST,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
@@ -759,4 +759,43 @@ describe('execute()', () => {
     expect(paramsObject.x).toBe(rogue);
     expect(params.body).toBe(`{"x": "double-quote:\\"; line-break->\\n"}`);
   });
+
+  test('404 response is returns user error', async () => {
+    const config: ConnectorTypeConfigType = {
+      url: 'https://abc.def/my-webhook',
+      method: WebhookMethods.POST,
+      headers: {
+        aheader: 'a value',
+      },
+      authType: AuthType.Basic,
+      hasAuth: true,
+    };
+
+    requestMock.mockRejectedValueOnce({
+      tag: 'err',
+      response: {
+        status: 404,
+        statusText: 'Not Found',
+        data: {
+          message:
+            'The requested webhook "b946082a-a623-4353-bd99-ed35e5fa4fce" is not registered.',
+        },
+      },
+    });
+    const result = await connectorType.executor({
+      actionId: 'some-id',
+      services,
+      config,
+      secrets: { user: 'abc', password: '123', key: null, crt: null, pfx: null },
+      params: { body: 'some data' },
+      configurationUtilities,
+      logger: mockedLogger,
+      connectorUsageCollector,
+    });
+
+    expect(result.errorSource).toBe('user');
+    expect(result.serviceMessage).toBe(
+      '[404] Not Found: The requested webhook "b946082a-a623-4353-bd99-ed35e5fa4fce" is not registered.'
+    );
+  });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.ts
@@ -41,6 +41,7 @@ import { isOk, promiseResult } from '../lib/result_type';
 import { ConfigSchema, ParamsSchema } from './schema';
 import { buildConnectorAuth } from '../../../common/auth/utils';
 import { SecretConfigurationSchema } from '../../../common/auth/schema';
+import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 
 export const ConnectorTypeId = '.webhook';
 
@@ -220,6 +221,11 @@ export async function executor(
           getOrElse(() => retryResult(actionId, message))
         );
       }
+
+      if (status === 404) {
+        return errorResultInvalid(actionId, message, TaskErrorSource.USER);
+      }
+
       return errorResultInvalid(actionId, message);
     } else if (error.code) {
       const message = `[${error.code}] ${error.message}`;
@@ -243,7 +249,8 @@ function successResult(actionId: string, data: unknown): ConnectorTypeExecutorRe
 
 function errorResultInvalid(
   actionId: string,
-  serviceMessage: string
+  serviceMessage: string,
+  errorSource?: TaskErrorSource
 ): ConnectorTypeExecutorResult<void> {
   const errMessage = i18n.translate('xpack.stackConnectors.webhook.invalidResponseErrorMessage', {
     defaultMessage: 'error calling webhook, invalid response',
@@ -253,6 +260,7 @@ function errorResultInvalid(
     message: errMessage,
     actionId,
     serviceMessage,
+    errorSource,
   };
 }
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.ts
@@ -26,6 +26,7 @@ import {
 import { renderMustacheString } from '@kbn/actions-plugin/server/lib/mustache_renderer';
 import { combineHeadersWithBasicAuthHeader } from '@kbn/actions-plugin/server/lib';
 
+import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { SSLCertType } from '../../../common/auth/constants';
 import type {
   WebhookConnectorType,
@@ -41,7 +42,6 @@ import { isOk, promiseResult } from '../lib/result_type';
 import { ConfigSchema, ParamsSchema } from './schema';
 import { buildConnectorAuth } from '../../../common/auth/utils';
 import { SecretConfigurationSchema } from '../../../common/auth/schema';
-import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 
 export const ConnectorTypeId = '.webhook';
 


### PR DESCRIPTION
Closes https://github.com/elastic/response-ops-team/issues/403

## Summary

A customer with a misconfigured external connector recently triggered an alert for the connector execution SLO.

We decided to tag these errors as `user` errors to reduce noise.


