### PR TITLE
[AI Assistant] The last system prompt was deleted successfully but remained in the list until page refreshed

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/common/components/assistant_settings_management/badges/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/common/components/assistant_settings_management/badges/index.tsx
@@ -17,7 +17,13 @@ export const BadgesColumn: React.FC<{
   items && items.length > 0 ? (
     <div>
       {items.map((title, idx) => (
-        <EuiBadge key={`${prefix}-${idx}`} color={color} css={css`max-width: 400px;`}>
+        <EuiBadge
+          key={`${prefix}-${idx}`}
+          color={color}
+          css={css`
+            max-width: 400px;
+          `}
+        >
           {title}
         </EuiBadge>
       ))}

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/common/components/assistant_settings_management/badges/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/common/components/assistant_settings_management/badges/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import { EuiBadge } from '@elastic/eui';
+import { css } from '@emotion/react';
 import React from 'react';
 
 export const BadgesColumn: React.FC<{
@@ -16,7 +17,7 @@ export const BadgesColumn: React.FC<{
   items && items.length > 0 ? (
     <div>
       {items.map((title, idx) => (
-        <EuiBadge key={`${prefix}-${idx}`} color={color}>
+        <EuiBadge key={`${prefix}-${idx}`} color={color} css={css`max-width: 400px;`}>
           {title}
         </EuiBadge>
       ))}

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
@@ -53,7 +53,7 @@ const SystemPromptSettingsManagementComponent = ({ connectors, defaultConnector 
     toasts,
   } = useAssistantContext();
 
-  const { data: allPrompts, refetch: refetchPrompts, isFetched: promptsLoaded, isLoading: promptsLoading } = useFetchPrompts();
+  const { data: allPrompts, refetch: refetchPrompts, isFetched: promptsLoaded } = useFetchPrompts();
 
   const {
     data: conversations,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
@@ -53,7 +53,12 @@ const SystemPromptSettingsManagementComponent = ({ connectors, defaultConnector 
     toasts,
   } = useAssistantContext();
 
-  const { data: allPrompts, refetch: refetchPrompts, isFetched: promptsLoaded, isLoading: promptsLoading } = useFetchPrompts();
+  const {
+    data: allPrompts,
+    refetch: refetchPrompts,
+    isFetched: promptsLoaded,
+    isLoading: promptsLoading,
+  } = useFetchPrompts();
 
   const {
     data: conversations,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
@@ -53,7 +53,7 @@ const SystemPromptSettingsManagementComponent = ({ connectors, defaultConnector 
     toasts,
   } = useAssistantContext();
 
-  const { data: allPrompts, refetch: refetchPrompts, isFetched: promptsLoaded } = useFetchPrompts();
+  const { data: allPrompts, refetch: refetchPrompts, isFetched: promptsLoaded, isLoading: promptsLoading } = useFetchPrompts();
 
   const {
     data: conversations,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/use_system_prompt_table.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/use_system_prompt_table.tsx
@@ -55,6 +55,7 @@ export const useSystemPromptTable = () => {
         render: ({ conversations, id }: SystemPromptSettings) => (
           <BadgesColumn items={conversations.map(({ title }) => title)} prefix={id} />
         ),
+        width: '50%',
       },
       {
         align: 'left',

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_system_prompt_updater.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_system_prompt_updater.ts
@@ -76,7 +76,9 @@ export const useSystemPromptUpdater = ({
   toasts,
 }: Params): SystemPromptUpdater => {
   // server equivalent
-  const [systemPromptSettings, setSystemPromptSettings] = useState<SystemPromptSettings[]>(DEFAULT_SYSTEM_PROMPT_SETTINGS);
+  const [systemPromptSettings, setSystemPromptSettings] = useState<SystemPromptSettings[]>(
+    DEFAULT_SYSTEM_PROMPT_SETTINGS
+  );
   // local updates
   const [systemPromptSettingsUpdates, setSystemPromptSettingsUpdates] = useState<
     SystemPromptSettings[]
@@ -110,7 +112,6 @@ export const useSystemPromptUpdater = ({
     filter,
   });
   useEffect(() => {
-
     const updateSystemPromptSettings = (prev: SystemPromptSettings[]) => {
       const updatedSettings = systemPrompts.map((p) => {
         const conversations = Object.values(data).filter(
@@ -126,11 +127,9 @@ export const useSystemPromptUpdater = ({
       return prev;
     };
 
-    setSystemPromptSettings(prev => updateSystemPromptSettings(prev));
-    setSystemPromptSettingsUpdates(prev => updateSystemPromptSettings(prev));
+    setSystemPromptSettings((prev) => updateSystemPromptSettings(prev));
+    setSystemPromptSettingsUpdates((prev) => updateSystemPromptSettings(prev));
   }, [data, systemPrompts]);
-
-
 
   const onSystemPromptSelect = useCallback(
     (systemPrompt?: SystemPromptSettings | string) => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_system_prompt_updater.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_system_prompt_updater.ts
@@ -59,6 +59,11 @@ interface SystemPromptUpdater {
   selectedSystemPrompt?: SystemPromptSettings;
   systemPromptSettings: SystemPromptSettings[];
 }
+
+const DEFAULT_SYSTEM_PROMPT_SETTINGS: SystemPromptSettings[] = [];
+const DEFAULT_SYSTEM_PROMPT_SETTINGS_UPDATES: SystemPromptSettings[] = [];
+const DEFAULT_PROMPTS_BULK_ACTIONS: PromptsPerformBulkActionRequestBody = {};
+
 export const useSystemPromptUpdater = ({
   allPrompts,
   connectors,
@@ -71,13 +76,13 @@ export const useSystemPromptUpdater = ({
   toasts,
 }: Params): SystemPromptUpdater => {
   // server equivalent
-  const [systemPromptSettings, setSystemPromptSettings] = useState<SystemPromptSettings[]>([]);
+  const [systemPromptSettings, setSystemPromptSettings] = useState<SystemPromptSettings[]>(DEFAULT_SYSTEM_PROMPT_SETTINGS);
   // local updates
   const [systemPromptSettingsUpdates, setSystemPromptSettingsUpdates] = useState<
     SystemPromptSettings[]
-  >([]);
+  >(DEFAULT_SYSTEM_PROMPT_SETTINGS_UPDATES);
   const [promptsBulkActions, setPromptsBulkActions] = useState<PromptsPerformBulkActionRequestBody>(
-    {}
+    DEFAULT_PROMPTS_BULK_ACTIONS
   );
   // System Prompt Selection State
   const [selectedSystemPrompt, setSelectedSystemPrompt] = useState<
@@ -105,7 +110,7 @@ export const useSystemPromptUpdater = ({
     filter,
   });
   useEffect(() => {
-    if (!Object.keys(data).length && !systemPrompts.length) return;
+
     const updateSystemPromptSettings = (prev: SystemPromptSettings[]) => {
       const updatedSettings = systemPrompts.map((p) => {
         const conversations = Object.values(data).filter(
@@ -121,14 +126,11 @@ export const useSystemPromptUpdater = ({
       return prev;
     };
 
-    setSystemPromptSettings(updateSystemPromptSettings);
+    setSystemPromptSettings(prev => updateSystemPromptSettings(prev));
+    setSystemPromptSettingsUpdates(prev => updateSystemPromptSettings(prev));
   }, [data, systemPrompts]);
 
-  useEffect(() => {
-    if (systemPromptSettings.length) {
-      setSystemPromptSettingsUpdates(systemPromptSettings);
-    }
-  }, [systemPromptSettings]);
+
 
   const onSystemPromptSelect = useCallback(
     (systemPrompt?: SystemPromptSettings | string) => {


### PR DESCRIPTION
## Summary


1. The last system prompt was deleted successfully but remained in the list until page refreshed:
https://github.com/elastic/kibana/issues/230376

Steps to verify item 1:

- Create some system prompts and delete them:
```
POST kbn:/api/security_ai_assistant/prompts/_bulk_action
{
  "create": [
    {
      "id": "",
      "content": "xxx0",
      "name": "xxxx0",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx1",
      "name": "xxxx1",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx2",
      "name": "xxxx2",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx3",
      "name": "xxxx3",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx4",
      "name": "xxxx4",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx5",
      "name": "xxxx5",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx6",
      "name": "xxxx6",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx7",
      "name": "xxxx7",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx8",
      "name": "xxxx8",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx9",
      "name": "xxxx9",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx10",
      "name": "xxxx10",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },
    {
      "id": "",
      "content": "xxx11",
      "name": "xxxx11",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    },  
    {
      "id": "",
      "content": "xxx12",
      "name": "xxxx12",
      "promptType": "system",
      "consumer": "management",
      "conversations": []
    }
  ]
}
```

2. Conversation title overflow in settings:
<img width="2557" height="810" alt="Screenshot 2025-08-04 at 15 59 53" src="https://github.com/user-attachments/assets/5648cafe-a9e7-4043-a5ab-207133d86f7b" />
<img width="1511" height="768" alt="Screenshot 2025-08-04 at 16 56 32" src="https://github.com/user-attachments/assets/502925de-9018-4b16-a33f-03c8d5715494" />









<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->