### PR TITLE
[Search] Use Gemini 2.5 Pro as the default playground connector model

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/common/models.ts
+++ b/x-pack/solutions/search/plugins/search_playground/common/models.ts
@@ -46,15 +46,15 @@ export const MODELS: ModelProvider[] = [
     provider: LLMs.bedrock,
   },
   {
-    name: 'Google Gemini 1.5 Pro',
-    model: 'gemini-1.5-pro-002',
-    promptTokenLimit: 2097152,
+    name: 'Google Gemini 2.5 Pro',
+    model: 'gemini-2.5-pro',
+    promptTokenLimit: 1048576,
     provider: LLMs.gemini,
   },
   {
-    name: 'Google Gemini 1.5 Flash',
-    model: 'gemini-1.5-flash-002',
-    promptTokenLimit: 2097152,
+    name: 'Google Gemini 2.5 Flash',
+    model: 'gemini-2.5-flash',
+    promptTokenLimit: 1048576,
     provider: LLMs.gemini,
   },
   {

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
@@ -93,7 +93,7 @@ describe('getChatParams', () => {
     const result = await getChatParams(
       {
         connectorId: '1',
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         prompt: 'Hello, world!',
         citations: true,
       },
@@ -111,7 +111,7 @@ describe('getChatParams', () => {
       request,
       connectorId: '1',
       chatModelOptions: expect.objectContaining({
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         temperature: 0,
         maxRetries: 0,
       }),


### PR DESCRIPTION
## Summary
This PR bumps the default model for the Gemini Connector in Playground to Gemini 2.5 Pro.

**Before**

<img width="415" height="372" alt="Screenshot 2025-08-04 at 17 19 03" src="https://github.com/user-attachments/assets/5abf851f-72c9-4d1e-8d6a-e3f50bce5474" />

**After**

<img width="418" height="376" alt="Screenshot 2025-08-04 at 17 18 25" src="https://github.com/user-attachments/assets/00e94223-ae37-4108-b7b2-2a50bde04170" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note
Bumps default Gemini model for the Gemini Connector in Playground from Gemini 1.5 Pro to Gemini 2.5 Pro.


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->