### PR TITLE
[Security Solution] Fix flaky query related Jest frontend integration tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/test_utils/assert_field_validation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/test_utils/assert_field_validation.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { waitFor } from '@testing-library/react';
 import {
   ThreeWayDiffConflict,
   ThreeWayDiffOutcome,
@@ -61,9 +62,9 @@ export function assertFieldValidation({
       switchToFieldEdit(fieldUpgradeWrapper);
       await inputFieldValue(fieldUpgradeWrapper, { fieldName, value: invalidValue });
 
-      const saveButton = getSaveFieldValueButton(fieldUpgradeWrapper);
-
-      expect(saveButton).toBeDisabled();
+      await waitFor(() => expect(getSaveFieldValueButton(fieldUpgradeWrapper)).toBeDisabled(), {
+        timeout: 1000,
+      });
     });
   });
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/test_utils/assert_field_validation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/test_utils/assert_field_validation.ts
@@ -62,6 +62,11 @@ export function assertFieldValidation({
       switchToFieldEdit(fieldUpgradeWrapper);
       await inputFieldValue(fieldUpgradeWrapper, { fieldName, value: invalidValue });
 
+      // Some fields have async validation and/or debounced validation.
+      // It all makes it possible the validator function is scheduled with a delay
+      // or it may be picked up by the event loop later than expected.
+      // Waiting for the "Save" button to be disabled with a reasonable timeout makes sure the validation
+      // has enough time to run.
       await waitFor(() => expect(getSaveFieldValueButton(fieldUpgradeWrapper)).toBeDisabled(), {
         timeout: 1000,
       });


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/230123**
**Resolves: https://github.com/elastic/kibana/issues/230461**

## Summary

This PR fixes KQL/EQL/Threat query related Jest Frontend Integration tests asserting field validation.

## Details

KQL/EQL/Threat query inputs have async validation. On top of that EQL field has async validation debounced for `300ms`. It all makes it possible that the async validator may be scheduled with a delay or the validator function may be picked up by the event loop later than expected or it may take more than expected.

The fix adds `waitFor` to wait for Save button to be disabled with `1s` timeout which is more than enough for any async and debounced validation to pass.

## How to test the fix

The problem is mostly noticeable on previous stack version, for example on `8.19`. Follow the following steps to verify the fix

- Switch to `8.19` branch and bootstrap Kibana
- Add `.only` to the test `blocks saving field value when value is invalid` as the rest tests aren't relevant
- Wrap the test in `for (let i = 0; i < 10; ++i) { ... }` to repeat it `10` times
- Run `yarn test:jest_integration x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/upgrade_rule_after_preview/type_specific_fields/threat_query.test.ts` and make sure the one or more failures. (In case there are no failures re-run the command. There is a high chance the flakiness reveals itself in the first two runs).
- Apply the `waitFor` fix from the PR diff
- Run again `yarn test:jest_integration x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/__integration_tests__/rules_upgrade/upgrade_rule_after_preview/type_specific_fields/threat_query.test.ts` and make sure there are no failures
- Repeat the previous step 5 times

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->