### PR TITLE
[ES|QL] Escape keywords in identifier priting

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/constants.ts
@@ -12,4 +12,69 @@ import { Token } from 'antlr4';
 export const DEFAULT_CHANNEL: number = +(Token as any).DEFAULT_CHANNEL;
 export const HIDDEN_CHANNEL: number = +(Token as any).HIDDEN_CHANNEL;
 
-export const SOURCE_COMMANDS = new Set<string>(['FROM', 'ROW', 'SHOW', 'TS', 'EXPLAIN']);
+export const SOURCE_COMMANDS = new Set<string>([
+  'FROM',
+  'ROW',
+  'SHOW',
+  'TS',
+  'EXPLAIN',
+]);
+
+export const PROCESSING_COMMANDS = new Set<string>([
+  'EVAL',
+  'WHERE',
+  'KEEP',
+  'LIMIT',
+  'STATS',
+  'SORT',
+  'DROP',
+  'RENAME',
+  'DISSECT',
+  'GROK',
+  'ENRICH',
+  'MV_EXPAND',
+  'JOIN',
+  'CHANGE_POINT',
+  'COMPLETION',
+  'SAMPLE',
+  'FORK',
+  'INLINESTATS',
+  'LOOKUP',
+  'INSIST',
+  'RERANK',
+  'FUSE',
+]);
+
+export const COMMANDS = new Set<string>([
+  ...SOURCE_COMMANDS,
+  ...PROCESSING_COMMANDS,
+]);
+
+export const KEYWORDS = new Set<string>([
+  ...COMMANDS,
+  'AND',
+  'ASC',
+  'BY',
+  'DESC',
+  'FALSE',
+  'FIRST',
+  'FULL',
+  'IN',
+  'INFO',
+  'INNER',
+  'IS',
+  'LAST',
+  'LEFT',
+  'LIKE',
+  'METADATA',
+  'NOT',
+  'NULL',
+  'NULLS',
+  'ON',
+  'OR',
+  'OUTER',
+  'RIGHT',
+  'RLIKE',
+  'TRUE',
+  'WITH',
+]);

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/constants.ts
@@ -12,13 +12,7 @@ import { Token } from 'antlr4';
 export const DEFAULT_CHANNEL: number = +(Token as any).DEFAULT_CHANNEL;
 export const HIDDEN_CHANNEL: number = +(Token as any).HIDDEN_CHANNEL;
 
-export const SOURCE_COMMANDS = new Set<string>([
-  'FROM',
-  'ROW',
-  'SHOW',
-  'TS',
-  'EXPLAIN',
-]);
+export const SOURCE_COMMANDS = new Set<string>(['FROM', 'ROW', 'SHOW', 'TS', 'EXPLAIN']);
 
 export const PROCESSING_COMMANDS = new Set<string>([
   'EVAL',
@@ -45,10 +39,7 @@ export const PROCESSING_COMMANDS = new Set<string>([
   'FUSE',
 ]);
 
-export const COMMANDS = new Set<string>([
-  ...SOURCE_COMMANDS,
-  ...PROCESSING_COMMANDS,
-]);
+export const COMMANDS = new Set<string>([...SOURCE_COMMANDS, ...PROCESSING_COMMANDS]);
 
 export const KEYWORDS = new Set<string>([
   ...COMMANDS,

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -75,6 +75,14 @@ describe('single line query', () => {
       });
     });
 
+    describe('WHERE', () => {
+      test('escapes field parts which match keywords (FIRST)', () => {
+        const { text } = reprint('FROM a | WHERE `first`.name == "Beatrice" AND `and` == "one"');
+
+        expect(text).toBe('FROM a | WHERE `first`.name == "Beatrice" AND `and` == "one"');
+      });
+    });
+
     describe('EXPLAIN', () => {
       /** @todo Enable once query expressions are supported.  */
       test.skip('a nested query', () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { KEYWORDS } from '../parser/constants';
 import {
   ESQLAstComment,
   ESQLAstCommentMultiLine,
@@ -44,13 +45,16 @@ export const LeafPrinter = {
 
   identifier: (node: ESQLIdentifier) => {
     const name = node.name;
+    const isKeyword = KEYWORDS.has(name.toUpperCase());
+    const isQuotationNeeded = !regexUnquotedIdPattern.test(name);
 
-    if (regexUnquotedIdPattern.test(name)) {
-      return name;
-    } else {
+    if (isKeyword || isQuotationNeeded) {
       // Escape backticks "`" with double backticks "``".
       const escaped = name.replace(/`/g, '``');
+      
       return '`' + escaped + '`';
+    } else {
+      return name;
     }
   },
 

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
@@ -51,7 +51,7 @@ export const LeafPrinter = {
     if (isKeyword || isQuotationNeeded) {
       // Escape backticks "`" with double backticks "``".
       const escaped = name.replace(/`/g, '``');
-      
+
       return '`' + escaped + '`';
     } else {
       return name;


### PR DESCRIPTION
## Summary

The `LeafPrinter` escapes identifiers only when needed, for example, when they contain special characters. However, it must also escape ES|QL **keywords**, which it did not. Fixes a bug where the `LeafPrinter` would not escape identifiers which match ES|QL keywords.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->