### PR TITLE
fix: [ML] Anomaly Detection: Supplied configurations flyout missing title from announcement

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/supplied_configurations/supplied_configurations_flyout/flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/supplied_configurations/supplied_configurations_flyout/flyout.tsx
@@ -19,6 +19,7 @@ import {
   EuiTab,
   EuiTabs,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useEuiTheme } from '@elastic/eui';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
@@ -115,12 +116,14 @@ export const SuppliedConfigurationsFlyout: FC<Props> = ({ module, onClose }) => 
     [tabs, selectedTabId]
   );
 
+  const flyoutTitleId = useGeneratedHtmlId();
+
   return (
     <EuiFlyout
       size="l"
       ownFocus
       onClose={onClose}
-      aria-labelledby={'supplied-configurations-flyout'}
+      aria-labelledby={flyoutTitleId}
       data-test-subj={`mlSuppliedConfigurationsFlyout ${module.id}`}
     >
       <EuiFlyoutHeader hasBorder>
@@ -130,7 +133,7 @@ export const SuppliedConfigurationsFlyout: FC<Props> = ({ module, onClose }) => 
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiTitle size="m">
-              <h2 id={module.id}>{module.title}</h2>
+              <h2 id={flyoutTitleId}>{module.title}</h2>
             </EuiTitle>
           </EuiFlexItem>
         </EuiFlexGroup>


### PR DESCRIPTION
Closes: #217136

**Description**
Dialog modal, flyout, field visible title should be announced for the users, especially using assistive technology to know what dialog modal, flyout opened, what field is active and what is needed to enter in it.

**Changes made:**

1. Aria attributes were fixed for `Supplied configurations flyout`

**Screen:**

<img width="1356" height="657" alt="image" src="https://github.com/user-attachments/assets/f7fe5c30-5086-4538-ade0-c73a7d597cdd" />


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->