### PR TITLE
[ES|QL] fix: completion column unknown validation

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.test.ts
@@ -169,13 +169,6 @@ describe('COMPLETION Validation', () => {
       });
 
       describe('a custom targetField is provided', () => {
-        it('targetField is not available before COMPLETION', () => {
-          completionExpectErrors(
-            `FROM index | KEEP customField | COMPLETION customField = "prompt" WITH inferenceId`,
-            ['Unknown column [customField]']
-          );
-        });
-
         it('targetField is available after COMPLETION', () => {
           completionExpectErrors(
             `FROM index | COMPLETION keywordField = "prompt" WITH inferenceId | KEEP keywordField`,

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/completion/validate.ts
@@ -43,8 +43,6 @@ export const validate = (
     });
   }
 
-  messages.push(...validateCommandArguments(command, ast, context, callbacks));
-
   const targetName = targetField?.name || 'completion';
 
   // Sets the target field so the column is recognized after the command is applied
@@ -55,6 +53,8 @@ export const validate = (
       type: 'keyword',
     },
   ]);
+
+  messages.push(...validateCommandArguments(command, ast, context, callbacks));
 
   return messages;
 };


### PR DESCRIPTION
## Summary
Problem: When the completion command was using a target column, the column was marked as unknown.

<img width="1636" height="454" alt="image" src="https://github.com/user-attachments/assets/f39bdf32-80df-4922-a63d-c2631cfcb82b" />
