### PR TITLE
fix: [Observability:Overview page]Modal dialogs, flyouts missing title from announcement

### DIFF
--- a/src/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector_modal.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector_modal.tsx
@@ -20,6 +20,7 @@ import {
   EuiModalFooter,
   EuiSpacer,
   EuiTabbedContent,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import numeral from '@elastic/numeral';
 import { isEmpty } from 'lodash';
@@ -75,6 +76,7 @@ const AlertsQueryInspectorModalComponent = ({
   const parsedResponse: Response = parse(response[0]);
   const formattedRequest = stringify(parsedRequest);
   const formattedResponse = stringify(parsedResponse);
+  const modalTitleId = useGeneratedHtmlId();
 
   const statistics: Array<{
     title: NonNullable<ReactNode | string>;
@@ -193,9 +195,10 @@ const AlertsQueryInspectorModalComponent = ({
           max-width: 718px;
         }
       `}
+      aria-labelledby={modalTitleId}
     >
       <EuiModalHeader>
-        <EuiModalHeaderTitle>
+        <EuiModalHeaderTitle id={modalTitleId}>
           {i18n.INSPECT} {title}
         </EuiModalHeaderTitle>
       </EuiModalHeader>


### PR DESCRIPTION
Closes: #209997

**Description**
Dialog modal, flyout visible title should be announced for the users, especially using assistive technology to know what dialog modal, flyout opened.


**Changes made:**
1. added required aria attributes


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->