### PR TITLE
[Security Solution] Wait for Fleet setup completion in Cypress before running tests

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/config.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/config.ts
@@ -61,6 +61,18 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--csp.strict=false',
         '--csp.warnLegacyBrowsers=false',
       ],
+      runOptions: {
+        wait: FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP,
+      },
     },
   };
 }
+
+/**
+ * A log message indicating that Fleet plugin has completed any necessary setup logic
+ * to make sure test suites can run without race conditions with Fleet plugin initialization.
+ *
+ * The message must not be filtered out by the logging configuration. Subsequently higher log level is better.
+ * "Fleet setup completed" has the same "info" level as "Kibana server is ready" log message.
+ */
+const FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP = /Fleet setup completed/;

--- a/x-pack/solutions/security/test/security_solution_cypress/serverless_config.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/serverless_config.ts
@@ -42,7 +42,19 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--csp.warnLegacyBrowsers=false',
         '--xpack.fleet.agentless.enabled=true',
       ],
+      runOptions: {
+        wait: FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP,
+      },
     },
     testRunner: SecuritySolutionConfigurableCypressTestRunner,
   };
 }
+
+/**
+ * A log message indicating that Fleet plugin has completed any necessary setup logic
+ * to make sure test suites can run without race conditions with Fleet plugin initialization.
+ *
+ * The message must not be filtered out by the logging configuration. Subsequently higher log level is better.
+ * "Fleet setup completed" has the same "info" level as "Kibana server is ready" log message.
+ */
+const FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP = /Fleet setup completed/;


### PR DESCRIPTION
**Relates to: https://github.com/elastic/kibana/issues/230363**
**Relates to: https://github.com/elastic/kibana/pull/230338**

## Summary

This PR makes sure Cypress e2e test run after Fleet setup is finished. This approach is similar to https://github.com/elastic/kibana/pull/230338 used in our integration tests.

Fleet setup running concurrently to the tests may cause tests flakiness. This behavior is described in https://github.com/elastic/kibana/issues/230363.




<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1"]} ONMERGE-->