### PR TITLE
[9.0] [APM] Configure fleet docker container for APM tests (#230398)

### DIFF
--- a/x-pack/test/apm_api_integration/common/config.ts
+++ b/x-pack/test/apm_api_integration/common/config.ts
@@ -15,7 +15,13 @@ import {
   createLogger,
   LogLevel,
 } from '@kbn/apm-synthtrace';
-import { FtrConfigProviderContext, kbnTestConfig } from '@kbn/test';
+import {
+  FtrConfigProviderContext,
+  defineDockerServersConfig,
+  fleetPackageRegistryDockerImage,
+  kbnTestConfig,
+} from '@kbn/test';
+import path from 'path';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import supertest from 'supertest';
 import { format, UrlObject } from 'url';
@@ -116,8 +122,24 @@ export function createTestConfig(
     const esServer = servers.elasticsearch as UrlObject;
     const synthtraceKibanaClient = getApmSynthtraceKibanaClient(kibanaServerUrl);
 
+    const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
+
+    const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
+    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+
     return {
       testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
+      dockerServers: defineDockerServersConfig({
+        registry: {
+          enabled: !!dockerRegistryPort,
+          image: fleetPackageRegistryDockerImage,
+          portInContainer: 8080,
+          port: dockerRegistryPort,
+          args: dockerArgs,
+          waitForLogLine: 'package manifests loaded',
+          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+        },
+      }),
       testFiles: [require.resolve('../tests')],
       servers,
       servicesRequiredForTestAnalysis: ['apmFtrConfig', 'registry'],

--- a/x-pack/test/apm_api_integration/common/fixtures/package_registry_config.yml
+++ b/x-pack/test/apm_api_integration/common/fixtures/package_registry_config.yml
@@ -1,0 +1,2 @@
+package_paths:
+  - /packages/package-storage


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[APM] Configure fleet docker container for APM tests (#230398)](https://github.com/elastic/kibana/pull/230398)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-05T11:12:35Z","message":"[APM] Configure fleet docker container for APM tests (#230398)\n\ncloses [228305](https://github.com/elastic/kibana/issues/228305)\ncloses [228130](https://github.com/elastic/kibana/issues/228130)\n\n## Summary\n\nThis PR follows this suggestion\nhttps://github.com/elastic/kibana/issues/228305#issuecomment-3103601583\nto use dockerized epm registry environment in CI","sha":"15456349ea853b8eebae28e23f4cfc1f48088375","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","ci:project-deploy-observability","Team:obs-ux-infra_services","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.2.0"],"title":"[APM] Configure fleet docker container for APM tests","number":230398,"url":"https://github.com/elastic/kibana/pull/230398","mergeCommit":{"message":"[APM] Configure fleet docker container for APM tests (#230398)\n\ncloses [228305](https://github.com/elastic/kibana/issues/228305)\ncloses [228130](https://github.com/elastic/kibana/issues/228130)\n\n## Summary\n\nThis PR follows this suggestion\nhttps://github.com/elastic/kibana/issues/228305#issuecomment-3103601583\nto use dockerized epm registry environment in CI","sha":"15456349ea853b8eebae28e23f4cfc1f48088375"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","9.1","8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230398","number":230398,"mergeCommit":{"message":"[APM] Configure fleet docker container for APM tests (#230398)\n\ncloses [228305](https://github.com/elastic/kibana/issues/228305)\ncloses [228130](https://github.com/elastic/kibana/issues/228130)\n\n## Summary\n\nThis PR follows this suggestion\nhttps://github.com/elastic/kibana/issues/228305#issuecomment-3103601583\nto use dockerized epm registry environment in CI","sha":"15456349ea853b8eebae28e23f4cfc1f48088375"}}]}] BACKPORT-->