### PR TITLE
[9.1] [Obs AI Assistant] knowledge base UI works offline (#229874)

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_create_knowledge_base_entry.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_create_knowledge_base_entry.ts
@@ -46,6 +46,7 @@ export function useCreateKnowledgeBaseEntry() {
       );
     },
     {
+      networkMode: 'always',
       onSuccess: (_data, { entry }) => {
         toasts.addSuccess(
           i18n.translate(

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_create_knowledge_base_user_instruction.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_create_knowledge_base_user_instruction.ts
@@ -41,6 +41,7 @@ export function useCreateKnowledgeBaseUserInstruction() {
       );
     },
     {
+      networkMode: 'always',
       onSuccess: (_data, { entry }) => {
         toasts.addSuccess(
           i18n.translate(

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_delete_knowledge_base_entry.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_delete_knowledge_base_entry.ts
@@ -38,6 +38,7 @@ export function useDeleteKnowledgeBaseEntry() {
       );
     },
     {
+      networkMode: 'always',
       onSuccess: (_data, { id, isUserInstruction }) => {
         if (isUserInstruction) {
           toasts.addSuccess(

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_knowledge_base_entries.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_knowledge_base_entries.ts
@@ -26,6 +26,7 @@ export function useGetKnowledgeBaseEntries({
   const observabilityAIAssistantApi = observabilityAIAssistant.service.callApi;
 
   const { isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery({
+    networkMode: 'always',
     queryKey: [REACT_QUERY_KEYS.GET_KB_ENTRIES, query, sortBy, sortDirection],
     queryFn: async ({ signal }) => {
       if (!signal) {

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_user_instructions.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_get_user_instructions.ts
@@ -14,6 +14,7 @@ export function useGetUserInstructions() {
   const observabilityAIAssistantApi = observabilityAIAssistant.service.callApi;
 
   const { isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery({
+    networkMode: 'always',
     queryKey: [REACT_QUERY_KEYS.GET_KB_USER_INSTRUCTIONS],
     queryFn: async ({ signal }) => {
       if (!signal) {

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_import_knowledge_base_entries.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_import_knowledge_base_entries.ts
@@ -46,6 +46,7 @@ export function useImportKnowledgeBaseEntries() {
       );
     },
     {
+      networkMode: 'always',
       onSuccess: (_data, { entries }) => {
         toasts.addSuccess(
           i18n.translate(

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_install_product_doc.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_install_product_doc.ts
@@ -26,6 +26,7 @@ export function useInstallProductDoc() {
       return productDocBase!.installation.install({ inferenceId });
     },
     {
+      networkMode: 'always',
       onSuccess: () => {
         toasts.addSuccess(
           i18n.translate(

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_uninstall_product_doc.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/hooks/use_uninstall_product_doc.ts
@@ -27,6 +27,7 @@ export function useUninstallProductDoc() {
       return productDocBase!.installation.uninstall({ inferenceId });
     },
     {
+      networkMode: 'always',
       onSuccess: () => {
         toasts.addSuccess(
           i18n.translate(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Obs AI Assistant] knowledge base UI works offline (#229874)](https://github.com/elastic/kibana/pull/229874)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sandra G","email":"neptunian@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-01T16:46:51Z","message":"[Obs AI Assistant] knowledge base UI works offline (#229874)\n\n## Summary\n\nWhen using kibana without an network connection, as is potentially the\ncase in airgapped environments, most requests in observability ai\nassistant management UI will not fire. This results in the inability to\nuse the knowledge base UI, though the api endpoints still work. By\ndefault, [TanStack Query (used by useQuery) disables all network\nrequests when the browser reports offline\nstatus](https://tanstack.com/query/latest/docs/framework/react/guides/network-mode).\nThis isn't necessary for kb endpoints that operate entirely against the\nlocal Elasticsearch cluster and do not require internet access.\n\nThis change updates all useQuery calls in the Observability AI Assistant\nManagement to use `networkMode: 'always'`. This ensures that queries are\nexecuted even when the browser is offline (`navigator.onLine ===\nfalse`).\n\nNot all air-gapped environments would be affected. In many real-world\ndeployments machines still have network interfaces configured, and\n`navigator.onLine` remains true. In those cases, the UI works as\nexpected.\nhttps://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine\n\nThis brings management in line with other kibana endpoints which do not\nuse `react-query` and do not have the issue, including\n`observability_ai_assistant/kb/status`\n\n### Test\n- Run es and kibana offline\n- Visit knowledge tab in settings and interact with the app \n- the network tab should have requests (they will fail unless you have\nelser running locally, but that is ok), eg New Entry should make the\nrequest to save when trying to save.","sha":"0b1864ae8b9a7fb6952d2579b206cd63619bff8d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","backport:all-open","Team:Obs AI Assistant","ci:project-deploy-observability","v9.2.0","v8.19.1"],"title":"[Obs AI Assistant] knowledge base UI works offline","number":229874,"url":"https://github.com/elastic/kibana/pull/229874","mergeCommit":{"message":"[Obs AI Assistant] knowledge base UI works offline (#229874)\n\n## Summary\n\nWhen using kibana without an network connection, as is potentially the\ncase in airgapped environments, most requests in observability ai\nassistant management UI will not fire. This results in the inability to\nuse the knowledge base UI, though the api endpoints still work. By\ndefault, [TanStack Query (used by useQuery) disables all network\nrequests when the browser reports offline\nstatus](https://tanstack.com/query/latest/docs/framework/react/guides/network-mode).\nThis isn't necessary for kb endpoints that operate entirely against the\nlocal Elasticsearch cluster and do not require internet access.\n\nThis change updates all useQuery calls in the Observability AI Assistant\nManagement to use `networkMode: 'always'`. This ensures that queries are\nexecuted even when the browser is offline (`navigator.onLine ===\nfalse`).\n\nNot all air-gapped environments would be affected. In many real-world\ndeployments machines still have network interfaces configured, and\n`navigator.onLine` remains true. In those cases, the UI works as\nexpected.\nhttps://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine\n\nThis brings management in line with other kibana endpoints which do not\nuse `react-query` and do not have the issue, including\n`observability_ai_assistant/kb/status`\n\n### Test\n- Run es and kibana offline\n- Visit knowledge tab in settings and interact with the app \n- the network tab should have requests (they will fail unless you have\nelser running locally, but that is ok), eg New Entry should make the\nrequest to save when trying to save.","sha":"0b1864ae8b9a7fb6952d2579b206cd63619bff8d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229874","number":229874,"mergeCommit":{"message":"[Obs AI Assistant] knowledge base UI works offline (#229874)\n\n## Summary\n\nWhen using kibana without an network connection, as is potentially the\ncase in airgapped environments, most requests in observability ai\nassistant management UI will not fire. This results in the inability to\nuse the knowledge base UI, though the api endpoints still work. By\ndefault, [TanStack Query (used by useQuery) disables all network\nrequests when the browser reports offline\nstatus](https://tanstack.com/query/latest/docs/framework/react/guides/network-mode).\nThis isn't necessary for kb endpoints that operate entirely against the\nlocal Elasticsearch cluster and do not require internet access.\n\nThis change updates all useQuery calls in the Observability AI Assistant\nManagement to use `networkMode: 'always'`. This ensures that queries are\nexecuted even when the browser is offline (`navigator.onLine ===\nfalse`).\n\nNot all air-gapped environments would be affected. In many real-world\ndeployments machines still have network interfaces configured, and\n`navigator.onLine` remains true. In those cases, the UI works as\nexpected.\nhttps://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine\n\nThis brings management in line with other kibana endpoints which do not\nuse `react-query` and do not have the issue, including\n`observability_ai_assistant/kb/status`\n\n### Test\n- Run es and kibana offline\n- Visit knowledge tab in settings and interact with the app \n- the network tab should have requests (they will fail unless you have\nelser running locally, but that is ok), eg New Entry should make the\nrequest to save when trying to save.","sha":"0b1864ae8b9a7fb6952d2579b206cd63619bff8d"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230280","number":230280,"state":"MERGED","mergeCommit":{"sha":"44ed100ae8190550af4382a7359626c50ab70173","message":"[8.19] [Obs AI Assistant] knowledge base UI works offline (#229874) (#230280)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Obs AI Assistant] knowledge base UI works offline\n(#229874)](https://github.com/elastic/kibana/pull/229874)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sandra G <neptunian@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/230281","number":230281,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->