### PR TITLE
[9.1] Fixes agentless integration data fields being overwritten by package metadata (#230479)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_policy_helper.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { AGENTLESS_DISABLED_INPUTS } from '../constants';
+import {
+  AGENTLESS_DISABLED_INPUTS,
+  AGENTLESS_GLOBAL_TAG_NAME_DIVISION,
+  AGENTLESS_GLOBAL_TAG_NAME_TEAM,
+  AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION,
+} from '../constants';
 import { PackagePolicyValidationError } from '../errors';
 import type { NewPackagePolicyInput, PackageInfo, RegistryPolicyTemplate } from '../types';
 
@@ -99,3 +104,44 @@ function throwIfInputNotAllowed(
     );
   }
 }
+
+/**
+ * Derive global data tags for agentless agent policies from package agentless info.
+ */
+export const getAgentlessGlobalDataTags = (packageInfo?: PackageInfo) => {
+  if (
+    !packageInfo?.policy_templates &&
+    !packageInfo?.policy_templates?.some((policy) => policy.deployment_modes)
+  ) {
+    return undefined;
+  }
+  const agentlessPolicyTemplate = packageInfo.policy_templates.find(
+    (policy) => policy.deployment_modes
+  );
+
+  // assumes that all the policy templates agentless deployments modes indentify have the same organization, division and team
+  const agentlessInfo = agentlessPolicyTemplate?.deployment_modes?.agentless;
+  if (
+    agentlessInfo === undefined ||
+    !agentlessInfo.organization ||
+    !agentlessInfo.division ||
+    !agentlessInfo.team
+  ) {
+    return undefined;
+  }
+
+  return [
+    {
+      name: AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION,
+      value: agentlessInfo.organization,
+    },
+    {
+      name: AGENTLESS_GLOBAL_TAG_NAME_DIVISION,
+      value: agentlessInfo.division,
+    },
+    {
+      name: AGENTLESS_GLOBAL_TAG_NAME_TEAM,
+      value: agentlessInfo.team,
+    },
+  ];
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -19,9 +19,6 @@ import { SetupTechnology } from '../../../../../types';
 import { useStartServices } from '../../../../../hooks';
 import { SelectedPolicyTab } from '../../components';
 import {
-  AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION,
-  AGENTLESS_GLOBAL_TAG_NAME_DIVISION,
-  AGENTLESS_GLOBAL_TAG_NAME_TEAM,
   AGENTLESS_AGENT_POLICY_INACTIVITY_TIMEOUT,
   AGENTLESS_AGENT_POLICY_MONITORING,
   SERVERLESS_DEFAULT_OUTPUT_ID,
@@ -33,6 +30,7 @@ import {
   isAgentlessIntegration as isAgentlessIntegrationFn,
   getAgentlessAgentPolicyNameFromPackagePolicyName,
   isOnlyAgentlessIntegration,
+  getAgentlessGlobalDataTags,
 } from '../../../../../../../../common/services/agentless_policy_helper';
 
 export const useAgentless = () => {
@@ -214,7 +212,7 @@ export function useSetupTechnology({
           : {}),
       }),
       name: agentlessPolicyName,
-      global_data_tags: getGlobaDataTags(packageInfo),
+      global_data_tags: getAgentlessGlobalDataTags(packageInfo),
     };
 
     const agentlessPolicy = getAgentlessPolicy(packageInfo);
@@ -288,44 +286,6 @@ export const isAgentlessSetupDefault = (
   }
 
   return false;
-};
-
-const getGlobaDataTags = (packageInfo?: PackageInfo) => {
-  if (
-    !packageInfo?.policy_templates &&
-    !packageInfo?.policy_templates?.some((policy) => policy.deployment_modes)
-  ) {
-    return undefined;
-  }
-  const agentlessPolicyTemplate = packageInfo.policy_templates.find(
-    (policy) => policy.deployment_modes
-  );
-
-  // assumes that all the policy templates agentless deployments modes indentify have the same organization, division and team
-  const agentlessInfo = agentlessPolicyTemplate?.deployment_modes?.agentless;
-  if (
-    agentlessInfo === undefined ||
-    !agentlessInfo.organization ||
-    !agentlessInfo.division ||
-    !agentlessInfo.team
-  ) {
-    return undefined;
-  }
-
-  return [
-    {
-      name: AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION,
-      value: agentlessInfo.organization,
-    },
-    {
-      name: AGENTLESS_GLOBAL_TAG_NAME_DIVISION,
-      value: agentlessInfo.division,
-    },
-    {
-      name: AGENTLESS_GLOBAL_TAG_NAME_TEAM,
-      value: agentlessInfo.team,
-    },
-  ];
 };
 
 const getAgentlessPolicy = (packageInfo?: PackageInfo) => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.test.ts
@@ -30,6 +30,22 @@ packageInfoCache.set('limited_package-0.0.0', {
     },
   ],
 });
+packageInfoCache.set('mock_package_agentless-0.0.0', {
+  name: 'mock_package_agentless',
+  version: '0.0.0',
+  policy_templates: [
+    {
+      multiple: true,
+      deployment_modes: {
+        agentless: {
+          organization: 'elastic',
+          division: 'engineering',
+          team: 'security-service-integrations',
+        },
+      },
+    },
+  ],
+});
 
 describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
   const mockPackagePolicy: PackagePolicy = {
@@ -924,6 +940,110 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
           },
         },
         inputVar: 'input-value',
+      },
+    ]);
+  });
+
+  it('returns agent inputs with add fields process from global data tags excluding agentless defaults', async () => {
+    expect(
+      await storedPackagePoliciesToAgentInputs(
+        [
+          {
+            ...mockPackagePolicy,
+            name: 'mock_package_agentless-policy',
+            package: {
+              name: 'mock_package_agentless',
+              title: 'Mock package agentless',
+              version: '0.0.0',
+            },
+            inputs: [
+              {
+                ...mockInput,
+                compiled_input: {
+                  inputVar: 'input-value',
+                },
+                streams: [],
+              },
+              {
+                ...mockInput2,
+                compiled_input: {
+                  inputVar: 'input-value',
+                },
+                streams: [],
+              },
+            ],
+          },
+        ],
+        packageInfoCache,
+        undefined,
+        undefined,
+        [
+          { name: 'testName', value: 'testValue' },
+          { name: 'testName2', value: 'testValue2' },
+          { name: 'organization', value: 'elastic' },
+          { name: 'division', value: 'engineering' },
+          { name: 'team', value: 'security-service-integrations' },
+          { name: 'organization', value: 'foo' },
+        ]
+      )
+    ).toEqual([
+      {
+        id: 'test-logs-some-uuid',
+        name: 'mock_package_agentless-policy',
+        package_policy_id: 'some-uuid',
+        processors: [
+          {
+            add_fields: {
+              fields: {
+                testName: 'testValue',
+                testName2: 'testValue2',
+                organization: 'foo',
+              },
+              target: '',
+            },
+          },
+        ],
+        revision: 1,
+        type: 'test-logs',
+        data_stream: { namespace: 'default' },
+        use_output: 'default',
+        meta: {
+          package: {
+            name: 'mock_package_agentless',
+            version: '0.0.0',
+          },
+        },
+        inputVar: 'input-value',
+      },
+      {
+        id: 'test-metrics-some-template-some-uuid',
+        data_stream: {
+          namespace: 'default',
+        },
+        inputVar: 'input-value',
+        meta: {
+          package: {
+            name: 'mock_package_agentless',
+            version: '0.0.0',
+          },
+        },
+        name: 'mock_package_agentless-policy',
+        package_policy_id: 'some-uuid',
+        processors: [
+          {
+            add_fields: {
+              target: '',
+              fields: {
+                testName: 'testValue',
+                testName2: 'testValue2',
+                organization: 'foo',
+              },
+            },
+          },
+        ],
+        revision: 1,
+        type: 'test-metrics',
+        use_output: 'default',
       },
     ]);
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.ts
@@ -8,6 +8,7 @@ import { merge } from 'lodash';
 import deepMerge from 'deepmerge';
 
 import type { FullAgentPolicyAddFields, GlobalDataTag } from '../../../common/types';
+import { getAgentlessGlobalDataTags } from '../../../common/services/agentless_policy_helper';
 import { isPackageLimited } from '../../../common/services';
 import type {
   PackagePolicy,
@@ -155,11 +156,6 @@ export const storedPackagePoliciesToAgentInputs = async (
 ): Promise<FullAgentPolicyInput[]> => {
   const fullInputs: FullAgentPolicyInput[] = [];
 
-  const addFields =
-    globalDataTags && globalDataTags.length > 0
-      ? globalDataTagsToAddFields(globalDataTags)
-      : undefined;
-
   for (const packagePolicy of packagePolicies) {
     if (!isPolicyEnabled(packagePolicy)) {
       continue;
@@ -168,6 +164,12 @@ export const storedPackagePoliciesToAgentInputs = async (
     const packageInfo = packagePolicy.package
       ? packageInfoCache.get(pkgToPkgKey(packagePolicy.package))
       : undefined;
+
+    const filteredGlobalDataTags = filterGlobalDataTags(globalDataTags, packageInfo);
+    const addFields =
+      filteredGlobalDataTags && filteredGlobalDataTags.length > 0
+        ? globalDataTagsToAddFields(filteredGlobalDataTags)
+        : undefined;
 
     fullInputs.push(
       ...storedPackagePolicyToAgentInputs(
@@ -196,4 +198,25 @@ const globalDataTagsToAddFields = (tags: GlobalDataTag[]): FullAgentPolicyAddFie
       fields,
     },
   };
+};
+
+const filterGlobalDataTags = (
+  globalDataTags: GlobalDataTag[] | undefined,
+  packageInfo: PackageInfo | undefined
+): GlobalDataTag[] | undefined => {
+  if (!globalDataTags) {
+    return globalDataTags;
+  }
+
+  const agentlessGlobalDataTags = getAgentlessGlobalDataTags(packageInfo);
+
+  if (!agentlessGlobalDataTags) {
+    return globalDataTags;
+  }
+
+  return globalDataTags.filter((globalDataTag) => {
+    return !agentlessGlobalDataTags.some(
+      ({ name, value }) => name === globalDataTag.name && value === globalDataTag.value
+    );
+  });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fixes agentless integration data fields being overwritten by package metadata (#230479)](https://github.com/elastic/kibana/pull/230479)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2025-08-05T17:32:21Z","message":"Fixes agentless integration data fields being overwritten by package metadata (#230479)\n\n## Summary\n\nResolves: https://github.com/elastic/kibana/issues/221312\n\nExcludes the agentless package metadata ('organization', 'division',\n'team') from an `add_fields` global processor for agent policy inputs.\nThis is to avoid collision with data field usage of the same names by\nintegrations.\n\n## Release Note\n\nFixes agentless integrations using 'organization', 'division', or 'team'\ndata fields being overwritten by package agentless metadata on the agent\npolicy.","sha":"35f52e9778641e94489345d9836449e9230ce559","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-major","v9.2.0","v8.18.5","v8.19.1"],"title":"Fixes agentless integration data fields being overwritten by package metadata","number":230479,"url":"https://github.com/elastic/kibana/pull/230479","mergeCommit":{"message":"Fixes agentless integration data fields being overwritten by package metadata (#230479)\n\n## Summary\n\nResolves: https://github.com/elastic/kibana/issues/221312\n\nExcludes the agentless package metadata ('organization', 'division',\n'team') from an `add_fields` global processor for agent policy inputs.\nThis is to avoid collision with data field usage of the same names by\nintegrations.\n\n## Release Note\n\nFixes agentless integrations using 'organization', 'division', or 'team'\ndata fields being overwritten by package agentless metadata on the agent\npolicy.","sha":"35f52e9778641e94489345d9836449e9230ce559"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230479","number":230479,"mergeCommit":{"message":"Fixes agentless integration data fields being overwritten by package metadata (#230479)\n\n## Summary\n\nResolves: https://github.com/elastic/kibana/issues/221312\n\nExcludes the agentless package metadata ('organization', 'division',\n'team') from an `add_fields` global processor for agent policy inputs.\nThis is to avoid collision with data field usage of the same names by\nintegrations.\n\n## Release Note\n\nFixes agentless integrations using 'organization', 'division', or 'team'\ndata fields being overwritten by package agentless metadata on the agent\npolicy.","sha":"35f52e9778641e94489345d9836449e9230ce559"}},{"branch":"8.18","label":"v8.18.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230649","number":230649,"state":"MERGED","mergeCommit":{"sha":"570bfc04c04e970ac9e972f310967fb64a72ed74","message":"[8.18] Fixes agentless integration data fields being overwritten by package metadata (#230479) (#230649)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [Fixes agentless integration data fields being overwritten by package\nmetadata (#230479)](https://github.com/elastic/kibana/pull/230479)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Michel Losier <michel.losier@elastic.co>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230650","number":230650,"state":"MERGED","mergeCommit":{"sha":"01de655281c53bde129028e8d0d53a004d7edd16","message":"[8.19] Fixes agentless integration data fields being overwritten by package metadata (#230479) (#230650)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [Fixes agentless integration data fields being overwritten by package\nmetadata (#230479)](https://github.com/elastic/kibana/pull/230479)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Michel Losier <michel.losier@elastic.co>"}}]}] BACKPORT-->