### PR TITLE
[AI4DSOC] [Attack discovery] Improves test coverage for Attack discovery alerts

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/data_clients.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/data_clients.mock.ts
@@ -6,6 +6,9 @@
  */
 
 import type { PublicMethodsOf } from '@kbn/utility-types';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+
 import { AIAssistantConversationsDataClient } from '../ai_assistant_data_clients/conversations';
 import { AIAssistantKnowledgeBaseDataClient } from '../ai_assistant_data_clients/knowledge_base';
 import { AIAssistantDataClient } from '../ai_assistant_data_clients';
@@ -14,7 +17,16 @@ import { AttackDiscoveryScheduleDataClient } from '../lib/attack_discovery/sched
 
 type ConversationsDataClientContract = PublicMethodsOf<AIAssistantConversationsDataClient>;
 export type ConversationsDataClientMock = jest.Mocked<ConversationsDataClientContract>;
-type AttackDiscoveryDataClientContract = PublicMethodsOf<AttackDiscoveryDataClient>;
+type AttackDiscoveryDataClientContract = PublicMethodsOf<AttackDiscoveryDataClient> & {
+  spaceId: AttackDiscoveryDataClient['spaceId'];
+  indexTemplateAndPattern: AttackDiscoveryDataClient['indexTemplateAndPattern'];
+  options: AttackDiscoveryDataClient['options'];
+  // additional properties that are accessed at runtime:
+  adhocAttackDiscoveryDataClient: unknown;
+  currentUser: unknown;
+  writerCache: unknown;
+  initializeWriter: unknown;
+};
 export type AttackDiscoveryDataClientMock = jest.Mocked<AttackDiscoveryDataClientContract>;
 type AttackDiscoveryScheduleDataClientContract = PublicMethodsOf<AttackDiscoveryScheduleDataClient>;
 export type AttackDiscoveryScheduleDataClientMock =
@@ -45,25 +57,54 @@ export const conversationsDataClientMock: {
   create: createConversationsDataClientMock,
 };
 
-const createAttackDiscoveryDataClientMock = (): AttackDiscoveryDataClientMock => ({
-  bulkUpdateAttackDiscoveryAlerts: jest.fn(),
-  createAttackDiscovery: jest.fn(),
-  getAdHocAlertsIndexPattern: jest.fn(),
-  getScheduledAndAdHocIndexPattern: jest.fn(),
-  createAttackDiscoveryAlerts: jest.fn(),
-  findAllAttackDiscoveries: jest.fn(),
-  getAlertConnectorNames: jest.fn(),
-  getAttackDiscovery: jest.fn(),
-  findAttackDiscoveryAlerts: jest.fn(),
-  findDocuments: jest.fn(),
-  findAttackDiscoveryByConnectorId: jest.fn(),
-  getAttackDiscoveryGenerations: jest.fn(),
-  getAttackDiscoveryGenerationById: jest.fn(),
-  getReader: jest.fn(),
-  getWriter: jest.fn().mockResolvedValue({ bulk: jest.fn() }),
-  refreshEventLogIndex: jest.fn(),
-  updateAttackDiscovery: jest.fn(),
-});
+const createAttackDiscoveryDataClientMock = (): AttackDiscoveryDataClientMock => {
+  const mockDataClient = {
+    bulkUpdateAttackDiscoveryAlerts: jest.fn(),
+    createAttackDiscovery: jest.fn(),
+    getAdHocAlertsIndexPattern: jest.fn(),
+    getScheduledAndAdHocIndexPattern: jest.fn(),
+    createAttackDiscoveryAlerts: jest.fn(),
+    findAllAttackDiscoveries: jest.fn(),
+    getAlertConnectorNames: jest.fn(),
+    getAttackDiscovery: jest.fn(),
+    findAttackDiscoveryAlerts: jest.fn(),
+    findDocuments: jest.fn(),
+    findAttackDiscoveryByConnectorId: jest.fn(),
+    getAttackDiscoveryGenerations: jest.fn(),
+    getAttackDiscoveryGenerationById: jest.fn(),
+    getReader: jest.fn(),
+    getWriter: jest.fn().mockResolvedValue({ bulk: jest.fn() }),
+    refreshEventLogIndex: jest.fn(),
+    updateAttackDiscovery: jest.fn(),
+    // Properties from AIAssistantDataClient
+    spaceId: 'default',
+    indexTemplateAndPattern: {
+      alias: '.ds-.kibana-elastic-ai-assistant-attack-discovery-default',
+      pattern: '.ds-.kibana-elastic-ai-assistant-attack-discovery-default*',
+      basePattern: '.kibana-elastic-ai-assistant-attack-discovery',
+      name: '.ds-.kibana-elastic-ai-assistant-attack-discovery-default-000001',
+      validPrefixes: ['.ds-.kibana-elastic-ai-assistant-attack-discovery-default'],
+    },
+    options: {
+      elasticsearchClientPromise: Promise.resolve(
+        elasticsearchServiceMock.createElasticsearchClient()
+      ),
+      kibanaVersion: '8.0.0',
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+      indexPatternsResourceName: 'attackDiscovery',
+      currentUser: null,
+      adhocAttackDiscoveryDataClient: undefined,
+    },
+    // Additional properties that are accessed at runtime
+    adhocAttackDiscoveryDataClient: undefined,
+    currentUser: null,
+    writerCache: new Map(),
+    initializeWriter: jest.fn(),
+  } as AttackDiscoveryDataClientMock;
+
+  return mockDataClient;
+};
 
 export const attackDiscoveryDataClientMock: {
   create: () => AttackDiscoveryDataClientMock;
@@ -110,6 +151,7 @@ const createKnowledgeBaseDataClientMock = () => {
     getLoadedSecurityLabsDocsCount: jest.fn(),
     getProductDocumentationStatus: jest.fn(),
   };
+
   return mocked;
 };
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/get_successful_generations_search_result.mock.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/get_successful_generations_search_result.mock.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// This mock matches the GetSuccessfulGenerationsSearchResult schema
+export const getMockSuccessfulGenerationsSearchResult = () => ({
+  aggregations: {
+    successfull_generations_by_connector_id: {
+      buckets: [
+        {
+          key: 'connector-1',
+          doc_count: 5,
+          event_actions: {
+            buckets: [
+              { key: 'generation-succeeded', doc_count: 3 },
+              { key: 'generation-failed', doc_count: 2 },
+            ],
+          },
+          successful_generations: { value: 3 },
+          avg_event_duration_nanoseconds: { value: 1000000 },
+          latest_successfull_generation: {
+            value: 1620000000,
+            value_as_string: '2021-05-03T00:00:00Z',
+          },
+        },
+      ],
+    },
+  },
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/create_event_logger/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/create_event_logger/index.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IEventLogService } from '@kbn/event-log-plugin/server';
+import { eventLogServiceMock } from '@kbn/event-log-plugin/server/mocks';
+
+import { createEventLogger } from '.';
+import { ATTACK_DISCOVERY_EVENT_PROVIDER } from '../../common/constants';
+
+describe('createEventLogger', () => {
+  let mockEventLogService: jest.Mocked<IEventLogService>;
+
+  beforeEach(() => {
+    mockEventLogService = eventLogServiceMock.create();
+  });
+
+  it('calls eventLog.getLogger with the correct parameters', () => {
+    createEventLogger(mockEventLogService);
+
+    expect(mockEventLogService.getLogger).toHaveBeenCalledWith({
+      event: { provider: ATTACK_DISCOVERY_EVENT_PROVIDER },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/combine_find_attack_discovery_filters/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/combine_find_attack_discovery_filters/index.test.ts
@@ -1,0 +1,261 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
+import {
+  ALERT_ATTACK_DISCOVERY_ALERT_IDS,
+  ALERT_ATTACK_DISCOVERY_API_CONFIG_NAME,
+  ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS,
+  ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS,
+  ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS,
+  ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS,
+} from '../../schedules/fields';
+import { combineFindAttackDiscoveryFilters } from '.';
+
+describe('combineFindAttackDiscoveryFilters', () => {
+  describe('when no filters are provided', () => {
+    it('returns an empty string when all parameters are undefined', () => {
+      const result = combineFindAttackDiscoveryFilters({});
+
+      expect(result).toBe('');
+    });
+
+    it('returns an empty string when all arrays are empty', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        alertIds: [],
+        connectorNames: [],
+        ids: [],
+        status: [],
+      });
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('when a search filter is provided', () => {
+    it('returns the expected search filter for single search term', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        search: 'malware',
+      });
+
+      const expectedSearchFilter = `(${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}: "*malware*" OR ${ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*malware*" OR ${ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*malware*" OR ${ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS}: "*malware*")`;
+
+      expect(result).toBe(expectedSearchFilter);
+    });
+
+    it('returns a search filter with a trimmed search term', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        search: '  suspicious activity  ',
+      });
+
+      const expectedSearchFilter = `(${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}: "*suspicious activity*" OR ${ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*suspicious activity*" OR ${ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*suspicious activity*" OR ${ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS}: "*suspicious activity*")`;
+
+      expect(result).toBe(expectedSearchFilter);
+    });
+
+    it('returns an empty string when search is empty string', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        search: '',
+      });
+
+      expect(result).toBe('');
+    });
+
+    it('returns an empty string when search is only whitespace', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        search: '   ',
+      });
+
+      expect(result).toBe('');
+    });
+
+    it('returns a search filter with escaped special characters', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        search: 'test+search-term=value&other|more>less<!(){}[]^"~*?:\\/',
+      });
+
+      const expectedSearchFilter = `(${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}: "*test\\+search\\-term\\=value\\&other\\|more\\>less\\<\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\\\/*" OR ${ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*test\\+search\\-term\\=value\\&other\\|more\\>less\\<\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\\\/*" OR ${ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*test\\+search\\-term\\=value\\&other\\|more\\>less\\<\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\\\/*" OR ${ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS}: "*test\\+search\\-term\\=value\\&other\\|more\\>less\\<\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\\\/*")`;
+
+      expect(result).toBe(expectedSearchFilter);
+    });
+  });
+
+  describe('when an ids filter is provided', () => {
+    it('returns ids filter for single id', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        ids: ['id1'],
+      });
+
+      expect(result).toBe('(_id: "id1")');
+    });
+
+    it('returns ids filter for multiple ids', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        ids: ['id1', 'id2', 'id3'],
+      });
+
+      expect(result).toBe('(_id: "id1" OR _id: "id2" OR _id: "id3")');
+    });
+
+    it('returns an empty string when ids is empty array', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        ids: [],
+      });
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('when status filter is provided', () => {
+    it('returns a status filter for single status', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        status: ['open'],
+      });
+
+      expect(result).toBe(`(${ALERT_WORKFLOW_STATUS}: "open")`);
+    });
+
+    it('returns a status filter for multiple statuses', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        status: ['open', 'closed', 'acknowledged'],
+      });
+
+      expect(result).toBe(
+        `(${ALERT_WORKFLOW_STATUS}: "open" OR ${ALERT_WORKFLOW_STATUS}: "closed" OR ${ALERT_WORKFLOW_STATUS}: "acknowledged")`
+      );
+    });
+
+    it('returns an empty string when status is empty array', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        status: [],
+      });
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('when a connectorNames filter is provided', () => {
+    it('returns a connectorNames filter for single connector', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        connectorNames: ['GPT-4'],
+      });
+
+      expect(result).toBe(`(${ALERT_ATTACK_DISCOVERY_API_CONFIG_NAME}: "GPT-4")`);
+    });
+
+    it('returns a connectorNames filter for multiple connectors', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        connectorNames: ['GPT-4', 'Claude', 'Bedrock'],
+      });
+
+      expect(result).toBe(
+        `(${ALERT_ATTACK_DISCOVERY_API_CONFIG_NAME}: "GPT-4" OR ${ALERT_ATTACK_DISCOVERY_API_CONFIG_NAME}: "Claude" OR ${ALERT_ATTACK_DISCOVERY_API_CONFIG_NAME}: "Bedrock")`
+      );
+    });
+
+    it('returns an empty string when connectorNames is empty array', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        connectorNames: [],
+      });
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('when an alertIds filter is provided', () => {
+    it('returns an alertIds filter for single alert ID', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        alertIds: ['alert123'],
+      });
+
+      expect(result).toBe(`(${ALERT_ATTACK_DISCOVERY_ALERT_IDS}: "alert123")`);
+    });
+
+    it('returns an alertIds filter for multiple alert IDs', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        alertIds: ['alert123', 'alert456', 'alert789'],
+      });
+
+      expect(result).toBe(
+        `(${ALERT_ATTACK_DISCOVERY_ALERT_IDS}: "alert123" OR ${ALERT_ATTACK_DISCOVERY_ALERT_IDS}: "alert456" OR ${ALERT_ATTACK_DISCOVERY_ALERT_IDS}: "alert789")`
+      );
+    });
+
+    it('returns an empty string when alertIds is empty array', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        alertIds: [],
+      });
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('when a date range filters are provided', () => {
+    it('returns a start date filter when start is provided', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        start: '2024-01-01T00:00:00.000Z',
+      });
+
+      expect(result).toBe('@timestamp >= "2024-01-01T00:00:00.000Z"');
+    });
+
+    it('returns an end date filter when end is provided', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        end: '2024-12-31T23:59:59.999Z',
+      });
+
+      expect(result).toBe('@timestamp <= "2024-12-31T23:59:59.999Z"');
+    });
+
+    it('returns both date filters when start and end are provided', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        start: '2024-01-01T00:00:00.000Z',
+        end: '2024-12-31T23:59:59.999Z',
+      });
+
+      expect(result).toBe(
+        '@timestamp >= "2024-01-01T00:00:00.000Z" AND @timestamp <= "2024-12-31T23:59:59.999Z"'
+      );
+    });
+  });
+
+  describe('when multiple filters are provided', () => {
+    it('returns combined filters with AND operator', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        search: 'malware',
+        ids: ['id1', 'id2'],
+        status: ['open'],
+        connectorNames: ['GPT-4'],
+        alertIds: ['alert123'],
+        start: '2024-01-01T00:00:00.000Z',
+        end: '2024-12-31T23:59:59.999Z',
+      });
+
+      const expectedSearchFilter = `${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}: "*malware*" OR ${ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*malware*" OR ${ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*malware*" OR ${ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS}: "*malware*"`;
+      const expectedResult = `(${expectedSearchFilter}) AND (_id: "id1" OR _id: "id2") AND (${ALERT_WORKFLOW_STATUS}: "open") AND (${ALERT_ATTACK_DISCOVERY_API_CONFIG_NAME}: "GPT-4") AND (${ALERT_ATTACK_DISCOVERY_ALERT_IDS}: "alert123") AND @timestamp >= "2024-01-01T00:00:00.000Z" AND @timestamp <= "2024-12-31T23:59:59.999Z"`;
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('returns combined filters excluding empty arrays and undefined values', () => {
+      const result = combineFindAttackDiscoveryFilters({
+        search: 'test',
+        ids: [],
+        status: ['open'],
+        connectorNames: undefined,
+        alertIds: ['alert123'],
+        start: undefined,
+        end: '2024-12-31T23:59:59.999Z',
+      });
+
+      const expectedSearchFilter = `${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}: "*test*" OR ${ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*test*" OR ${ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS}: "*test*" OR ${ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS}: "*test*"`;
+      const expectedResult = `(${expectedSearchFilter}) AND (${ALERT_WORKFLOW_STATUS}: "open") AND (${ALERT_ATTACK_DISCOVERY_ALERT_IDS}: "alert123") AND @timestamp <= "2024-12-31T23:59:59.999Z"`;
+
+      expect(result).toBe(expectedResult);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/combine_generations_with_success_metadata/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/combine_generations_with_success_metadata/index.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { combineGenerationsWithSuccessMetadata } from '.';
+import { getMockAttackDiscoveryGenerationsResponse } from '../../../../__mocks__/attack_discovery_generations_response';
+
+describe('combineGenerationsWithSuccessMetadata', () => {
+  let successfulGenerationsMetadata: Record<
+    string,
+    {
+      averageSuccessfulDurationNanoseconds?: number;
+      successfulGenerations?: number;
+    }
+  >;
+  let transformedGenerations: ReturnType<typeof getMockAttackDiscoveryGenerationsResponse>;
+
+  beforeEach(() => {
+    successfulGenerationsMetadata = {
+      claudeV3Haiku: {
+        averageSuccessfulDurationNanoseconds: 987654321,
+        successfulGenerations: 3,
+      },
+      gpt41Azure: {
+        averageSuccessfulDurationNanoseconds: 123456789,
+        successfulGenerations: 2,
+      },
+    };
+
+    transformedGenerations = getMockAttackDiscoveryGenerationsResponse();
+  });
+
+  it('returns generations with connector_stats when metadata exists', () => {
+    const result = combineGenerationsWithSuccessMetadata({
+      successfulGenerationsMetadata,
+      transformedGenerations,
+    });
+
+    expect(
+      result.generations.find((g) => g.connector_id === 'gpt41Azure')?.connector_stats
+    ).toEqual({
+      average_successful_duration_nanoseconds: 123456789,
+      successful_generations: 2,
+    });
+  });
+
+  it('returns generations without connector_stats when metadata does not exist', () => {
+    const result = combineGenerationsWithSuccessMetadata({
+      successfulGenerationsMetadata: {},
+      transformedGenerations,
+    });
+
+    expect(
+      result.generations.find((g) => g.connector_id === 'claudeSonnet_40')?.connector_stats
+    ).toBeUndefined();
+  });
+
+  it('returns the expected generations', () => {
+    const result = combineGenerationsWithSuccessMetadata({
+      successfulGenerationsMetadata,
+      transformedGenerations,
+    });
+
+    expect(result.generations).toEqual([
+      {
+        connector_id: 'claudeV3Haiku',
+        discoveries: 0,
+        end: '2025-06-26T21:23:04.604Z',
+        loading_message:
+          'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.',
+        execution_uuid: 'f29f3d04-14da-4660-8ac1-a6c95f618a7e',
+        reason:
+          'Maximum hallucination failures (5) reached. Try sending fewer alerts to this model.\n',
+        start: '2025-06-26T21:19:06.317Z',
+        status: 'failed',
+        connector_stats: {
+          average_successful_duration_nanoseconds: 987654321,
+          successful_generations: 3,
+        },
+      },
+      {
+        alerts_context_count: 75,
+        connector_id: 'gpt41Azure',
+        discoveries: 2,
+        end: '2025-06-26T21:20:01.248Z',
+        loading_message:
+          'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.',
+        execution_uuid: 'a8e12578-d1a0-4d78-8d56-9bb7802223be',
+        start: '2025-06-26T21:18:54.254Z',
+        status: 'succeeded',
+        connector_stats: {
+          average_successful_duration_nanoseconds: 123456789,
+          successful_generations: 2,
+        },
+      },
+      {
+        connector_id: 'claudeSonnet_40',
+        discoveries: 0,
+        loading_message:
+          'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.',
+        execution_uuid: 'dd96c116-e8d0-4a1f-91e5-486c9fc3e455',
+        start: '2025-06-26T21:18:45.182Z',
+        status: 'started',
+      },
+    ]);
+  });
+
+  it('returns empty array when generations is empty', () => {
+    const result = combineGenerationsWithSuccessMetadata({
+      successfulGenerationsMetadata,
+      transformedGenerations: { generations: [] },
+    });
+
+    expect(result.generations).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_attack_discovery_alerts/get_ids_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_attack_discovery_alerts/get_ids_query/index.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getIdsQuery } from '.';
+
+describe('getIdsQuery', () => {
+  it('returns the expected query for an empty array', () => {
+    const result = getIdsQuery([]);
+
+    expect(result).toEqual({
+      query: {
+        ids: {
+          values: [],
+        },
+      },
+    });
+  });
+
+  it('returns the expected query for a single document ID', () => {
+    const result = getIdsQuery(['testId']);
+
+    expect(result).toEqual({
+      query: {
+        ids: {
+          values: ['testId'],
+        },
+      },
+    });
+  });
+
+  it('returns the expected query for multiple document IDs', () => {
+    const ids = ['id1', 'id2', 'id3'];
+    const result = getIdsQuery(ids);
+
+    expect(result).toEqual({
+      query: {
+        ids: {
+          values: ids,
+        },
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_attack_discovery_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_attack_discovery_alerts/index.test.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { estypes } from '@elastic/elasticsearch';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import type { IRuleDataReader } from '@kbn/rule-registry-plugin/server';
+
+import { getCreatedAttackDiscoveryAlerts } from '.';
+import { getResponseMock } from '../../../../../__mocks__/attack_discovery_alert_document_response';
+
+describe('getCreatedAttackDiscoveryAlerts', () => {
+  const attackDiscoveryAlertsIndex = 'test-index';
+  const createdDocumentIds = ['id-1', 'id-2'];
+
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let readDataClient: jest.Mocked<Pick<IRuleDataReader, 'search'>>;
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    readDataClient = { search: jest.fn() };
+  });
+
+  it('returns alerts when given valid ids', async () => {
+    const mockResponse = getResponseMock();
+    readDataClient.search.mockResolvedValueOnce(
+      mockResponse as unknown as estypes.SearchResponse<unknown>
+    );
+
+    const result = await getCreatedAttackDiscoveryAlerts({
+      attackDiscoveryAlertsIndex,
+      createdDocumentIds,
+      logger,
+      readDataClient: readDataClient as unknown as IRuleDataReader,
+    });
+
+    expect(result).toEqual([
+      {
+        alertIds: [
+          'ee183cf525d7e9d0f47d1b2bb928d760a0f53756ffa61edcf0672f71c986ac21',
+          '46ebac989ca72439b14b57d32102543c17d5f33e0f6532d8a5c148949d8ff7b5',
+          '857f6434220ff27f807bef6829f32d1ad1c337026db016bc54e302eecf95cf93',
+          'e892d2e28a1e10822385cd0bff1399d63d1014961e020d9b3251dd24764914e6',
+          '492c647e3c671a9d62567d100cdad1a503c749755db3b67ba3c08335acc79e18',
+          '9004764b04239eed88a61a6779c5b1dc82ec3ff6f05ab1dcd6892df75322958d',
+          '4f27dc19eee50707adfb1fc9710292bc2264d176fea671a26bb90b904d565547',
+          '5cbe0d15df86b6b080ace4139338eb2a8b3e9696dd28f8c7f586747a88652a38',
+          'f9aea50da1ae3e4c157802f64eb090bbfa65fc95d1c1d39c4c16d9dc52338a67',
+          '713a8950584268a0c48fa85f60b71a4aa200043587f9136aa3b2e5269a01377b',
+          '624a2d4db0705ad13bceb19655dc23c89db1fcb3dfb1162f579495e291692528',
+          'f3108492aabb7b342bf6880cff39060092f0465dd16e4413ae4da3d03ab9ce27',
+          '3f3e3169d8c4270ad33eb4b5943d6d52023a410b7f6e9ce9569ea85d6aa67dc4',
+          '7934c23154502cb585332d9540072f6678d18296aa4ce63ff46b5645114c1ece',
+          '3496beb26016dd31fb3bcaff1363d694f10819a0965447c5a13a2c5ef7e69e76',
+          'f6c88010fa0ac0022c6c4270deeeea4dcf54d2cce9ca3a19e307726a703cbf97',
+          '4aa5b853e0284a1d3a7f5c55b9cc2dd3ff832cdfa617c8cb78159872c0524db4',
+          '4833ff1e37aa3f63b60cb360c89864210fa63224ff1eecdc8084d081795e0cf7',
+          'a34a21fcb0a4b3ba10fc15575346b8f8122b14664f06a41929ca19fc6f07fd33',
+          '09ab33140c37cbadc84f75e833ca0f7846951938dbe75bbe6144b83083c0cc56',
+          'cdf0665f5fb126bd53d17979ca8ecfc06b62325ad31e8784a0d171d31b12de7f',
+          '35ddcc81c91ef0a6db1b4243bfbb39d90a40123222a3d7ab8379ab9a83420c46',
+          '01566232ff1a19c907dd99bcfb5dca1525b8b1038f5ef35896b6419db55dc585',
+          '3bf858728a763b6c95846eb75393f2c61081390cf42043e41929a0762b272cd0',
+          '3efcb54f2f75e1b1386284db7a050fb5d002dd604a3078090e3164174377a7ee',
+          '7ee01f9f3928491be0184aea39ba21ee38864c54858d2d33de52b3316b8600dc',
+          'b26078a6de3d1e023a78902dc966dc433c9125bb9b12db1c1b1d0c8512ef2853',
+          '859e93ffbafba637fe3bf36ff2288b7461c9b559656e13129ea878fca5f2486a',
+          'c0e618e366e374f6a60ab32dc006356680904a618c7e0ee31a574a248aaf83cf',
+          '57f1eb796cd46413992f214bf89db53fc549b4fc6e8d3d8769c2c1a8dd8a3078',
+          '1021ef6fd529c9f45d3e2ac791f0a7de332514dd9dcc7640f839db617649cd75',
+          '7bb4d2d5168cc13d4e8a7558eb68d2d189833cddedaf03e7959e9a256038c9fe',
+          'a14446fdfcb3559556ff08f1d9fc97d72435a8741ede1a59302211d4a2b1a7bd',
+          'c8008b0d2af8987698f8b10d925c1e088c8b72571d32a74120ba8b7416c8b818',
+          'b767e145aaa84bf01d80eed08c9135bc3f7c9c638593fd82e1ea8155a41317d3',
+          '2f18e88a345a3d183b2093cb15bd8d68fb37e7485e55a9938ec385386114a710',
+          'aa9fa70573cbc8136171543179244abc563ca839890ec0f19c32aaee7d91d5ee',
+          'd4a609ca641075862e9e94f6ca70b699c734279f424a39ae54498e74d57a9edf',
+          '1ca972204a9667f163f29c6d732ac6cafdf1a0793e029c8b2df9e84254619486',
+          '4a52df99422830601a2daa35f574e08214a4ec23ad82578c6a33a4bc24614177',
+          'c720d533a8086db64aa19dc289ba7d8dba931c0c1e81c31b3a2381108bd54f80',
+          '1d0b42cc9bab440d30ae6ccf0b586fac1a3416e2470e84b0e7fe2fe336b3ecdb',
+          '152c39218c74e1f1efea9f6a592e85c9b3715ac4c9b36f2a67c3b66f7cda476a',
+          '41e37269498d007217b82e0e5e0bd2bc11cfb8472d22f2bf5d57bf559518bc90',
+          '96a013fe5840fa4ebf9e8b413ad9ba5c6b9da0406225e0bd6ad4d1a7110045c0',
+          '67bad3f1ee713789aa58a8f712e31e55816df15a08e4fef17f0a77f0dcea2a16',
+          'bfc18b3ee2c15d34d80fc3781902b7e90f689f7298f368712c3dd5b8640e6f06',
+          '756e21cf69f49031f99fb60e05bbd5cf3b6101528cb84ea5f8cb6c328c727f68',
+          '1d1a2fc0aa17f818c49dcd1effbe3f0d3b937ceb2852f0614f272141a432683b',
+          'efd78eda82be49976cba570675624475838d97462795fa427582c09a08914e24',
+          'a5774ec28dceccdd88b4cedced5c09004023005c47438ceb538edf906a3a4976',
+          '0c19dd81b6abe18b3a3e72aa471c8ab9c08f0c76acf80441b1556f6520e63607',
+          '5f05a2d80b8b0b78c3b978b8b4143b863832d99f8f02c793aed23419d80889ae',
+          'b189d3e05a0dd24cd5326150fdf95460be60914bf919da3cdad707827e360444',
+          'ca88c363dae68e62a690e63e90728538431b30d35b3686adb32d7a973350a456',
+          '2612f23d1dc0c3fdc3679c2cf05b66e150fdef006b02d59fd317d70c76018d8c',
+          '168d23918d7561c7494a2d5b75a12a515ec6054c78801f26512a757b40e81e08',
+          'ad590fd49fa67224d9a562ad33d4b7d8f8bca6f63ff5d8c1859127d43b49fb15',
+          '9be5996df1622222a96b4b3d6359f06922866cb4560c0cd8a806be8b828e7531',
+          '644e2c3a505baa9cdc047972ecff9e7ede214fa964b392efc2dcda4a80c9c60e',
+          '05a26a422f52e03b318e763ecd53d027b39bbf1920b53babc33fba9db0f10fc4',
+          'fbf23653042416c886f12df972a885d847fe5681f466aff64a611aa01f9a5011',
+          'b0c92ae7ecaa07702798fbb161ce189a80da259390876c14daace753d73896f9',
+        ],
+        alertRuleUuid: 'attack_discovery_ad_hoc_rule_id',
+        alertStart: '2025-06-23T14:25:24.104Z',
+        alertUpdatedAt: '2025-06-23T15:16:52.984Z',
+        alertUpdatedByUserId: 'u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0',
+        alertUpdatedByUserName: 'elastic',
+        alertWorkflowStatus: 'acknowledged',
+        alertWorkflowStatusUpdatedAt: '2025-06-23T15:16:52.984Z',
+        connectorId: 'gemini_2_5_pro',
+        connectorName: 'Gemini 2.5 Pro',
+        detailsMarkdown:
+          'A widespread attack campaign was executed across multiple Windows hosts, unified by the use of a single compromised user account, {{ user.name 6f53c297-f5cb-48c3-8aff-2e2d7a390169 }}. The attacker leveraged this access to deploy a variety of malware families using different initial access and execution techniques, culminating in a ransomware attack.\n* **Qakbot Infection:** On host {{ host.name 0d7534c9-79f5-46ed-9df9-3dfcff57e5ed }}, the attack began with a malicious OneNote file. This led to {{ process.name mshta.exe }} executing a script, which used {{ process.name curl.exe }} to download a payload from {{ source.ip 77.75.230.128 }}. The payload was executed via {{ process.name rundll32.exe }} and injected into {{ process.name AtBroker.exe }}, identified as the {{ rule.name Windows.Trojan.Qbot }} trojan.\n* **Emotet Infection:** On host {{ host.name deb5784c-55d3-4422-9d7c-06f1f71c04b3 }}, a malicious Excel document spawned {{ process.name regsvr32.exe }} to load a malicious DLL, ultimately leading to the execution of the {{ rule.name Windows.Trojan.Emotet }} trojan and the establishment of persistence via registry run keys.\n* **Bumblebee Trojan:** On host {{ host.name 4d9943f7-cbef-462b-a882-e39db5da7abd }}, the attacker used {{ process.parent.name msiexec.exe }} to proxy the execution of a malicious PowerShell script, which injected the {{ rule.name Windows.Trojan.Bumblebee }} trojan into its own memory and established C2 communication.\n* **Generic Droppers:** On other hosts, similar initial access vectors were used. On host {{ host.name 9a98cc1d-a7a3-4924-b939-b17b2ec5dbdd }}, a Word document dropped and executed a VBScript, which then used PowerShell and created a scheduled task for persistence. On host {{ host.name 7c9a79a0-c029-4acb-b61c-d5831b409943 }}, an Excel file used {{ process.name certutil.exe }} to decode and execute a payload.\n* **Ransomware Deployment:** The campaign culminated on host {{ host.name 6aece05f-675e-4dc0-b8fa-ba0f1a43d691 }} with the deployment of Sodinokibi (REvil) ransomware. A malicious executable used DLL side-loading to compromise the legitimate Microsoft Defender process, {{ process.name MsMpEng.exe }}, which then executed the ransomware and began encrypting files.',
+        entitySummaryMarkdown:
+          'A widespread malware campaign using the compromised account of user {{ user.name 6f53c297-f5cb-48c3-8aff-2e2d7a390169 }} impacted multiple Windows hosts, including {{ host.name 6aece05f-675e-4dc0-b8fa-ba0f1a43d691 }} and {{ host.name 0d7534c9-79f5-46ed-9df9-3dfcff57e5ed }}.',
+        generationUuid: 'c10c51a5-10d2-481d-853a-e7fd5f393b23',
+        id: '29ceb1fa1482f02a2eb6073991078544e529edfc633a5621b20a93eefbb63083',
+        mitreAttackTactics: [
+          'Initial Access',
+          'Execution',
+          'Persistence',
+          'Defense Evasion',
+          'Command and Control',
+          'Impact',
+        ],
+        replacements: {
+          'e56f5c52-ebb0-4ec8-aad5-2659df2e0206': 'root',
+          '99612aef-0a5a-41da-9da4-b5b5ece226a4': 'SRVMAC08',
+          '02de873c-51e3-4c01-8a22-0986225775f3': 'james',
+          '9a98cc1d-a7a3-4924-b939-b17b2ec5dbdd': 'SRVWIN07',
+          '6f53c297-f5cb-48c3-8aff-2e2d7a390169': 'Administrator',
+          '4d9943f7-cbef-462b-a882-e39db5da7abd': 'SRVWIN06',
+          'aa5e02c8-f542-4db9-8ade-87fd1283ddac': 'SRVNIX05',
+          '0d7534c9-79f5-46ed-9df9-3dfcff57e5ed': 'SRVWIN04',
+          'deb5784c-55d3-4422-9d7c-06f1f71c04b3': 'SRVWIN03',
+          '6aece05f-675e-4dc0-b8fa-ba0f1a43d691': 'SRVWIN02',
+          '7c9a79a0-c029-4acb-b61c-d5831b409943': 'SRVWIN01',
+        },
+        riskScore: 6237,
+        summaryMarkdown:
+          'A widespread campaign was conducted using the compromised account of user {{ user.name 6f53c297-f5cb-48c3-8aff-2e2d7a390169 }}, deploying various malware including Sodinokibi, Emotet, Qakbot, and Bumblebee across multiple Windows hosts.',
+        timestamp: '2025-06-23T14:25:24.104Z',
+        title: 'Widespread Malware Campaign via Compromised Account',
+        userId: 'u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0',
+        userName: 'elastic',
+        users: [
+          {
+            name: 'elastic',
+            id: 'u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('returns an empty array when ids are empty', async () => {
+    const emptyIds: string[] = [];
+
+    const result = await getCreatedAttackDiscoveryAlerts({
+      attackDiscoveryAlertsIndex,
+      createdDocumentIds: emptyIds,
+      logger,
+      readDataClient: readDataClient as unknown as IRuleDataReader,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('throws an error when search fails', async () => {
+    readDataClient.search.mockRejectedValueOnce(new Error('search failed'));
+
+    await expect(
+      getCreatedAttackDiscoveryAlerts({
+        attackDiscoveryAlertsIndex,
+        createdDocumentIds,
+        logger,
+        readDataClient: readDataClient as unknown as IRuleDataReader,
+      })
+    ).rejects.toThrow('search failed');
+  });
+
+  it('logs debug when no ids are provided', async () => {
+    const emptyIds: string[] = [];
+
+    await getCreatedAttackDiscoveryAlerts({
+      attackDiscoveryAlertsIndex,
+      createdDocumentIds: emptyIds,
+      logger,
+      readDataClient: readDataClient as unknown as IRuleDataReader,
+    });
+
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('logs error when search throws', async () => {
+    readDataClient.search.mockRejectedValueOnce(new Error('fail'));
+
+    try {
+      await getCreatedAttackDiscoveryAlerts({
+        attackDiscoveryAlertsIndex,
+        createdDocumentIds,
+        logger,
+        readDataClient: readDataClient as unknown as IRuleDataReader,
+      });
+    } catch {
+      // ignore, assert is for the logger
+    }
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error getting created Attack discovery alerts')
+    );
+  });
+
+  it('calls search with the expected size', async () => {
+    const mockResponse = getResponseMock();
+    readDataClient.search.mockResolvedValueOnce(
+      mockResponse as unknown as estypes.SearchResponse<unknown>
+    );
+
+    await getCreatedAttackDiscoveryAlerts({
+      attackDiscoveryAlertsIndex,
+      createdDocumentIds,
+      logger,
+      readDataClient: readDataClient as unknown as IRuleDataReader,
+    });
+
+    expect(readDataClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({ size: createdDocumentIds.length })
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_document_ids/index.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/get_created_document_ids/index.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BulkResponse } from '@elastic/elasticsearch/lib/api/types';
+
+import { getCreatedDocumentIds } from '.';
+
+const mockBulkResponse: BulkResponse = {
+  errors: false,
+  took: 0,
+  items: [
+    {
+      create: {
+        _index: '.ds-.alerts-security.attack.discovery.alerts-ad-hoc-default-2025.04.21-000001',
+        _id: '0771fe50-3524-4f93-b658-fc509550375c',
+        _version: 1,
+        result: 'created',
+        forced_refresh: true,
+        _shards: {
+          total: 1,
+          successful: 1,
+          failed: 0,
+        },
+        _seq_no: 302,
+        _primary_term: 23,
+        status: 201,
+      },
+    },
+    {
+      create: {
+        _index: '.ds-.alerts-security.attack.discovery.alerts-ad-hoc-default-2025.04.21-000001',
+        _id: 'cc4e25d9-2eb2-4e6a-8047-ecd19dd9b3d6',
+        _version: 1,
+        result: 'created',
+        forced_refresh: true,
+        _shards: {
+          total: 1,
+          successful: 1,
+          failed: 0,
+        },
+        _seq_no: 303,
+        _primary_term: 23,
+        status: 201,
+      },
+    },
+    {
+      create: {
+        _index: '.ds-.alerts-security.attack.discovery.alerts-ad-hoc-default-2025.04.21-000001',
+        _id: '05bb4562-6931-40bd-a110-ca2fe4eeb430',
+        _version: 1,
+        result: 'created',
+        forced_refresh: true,
+        _shards: {
+          total: 1,
+          successful: 1,
+          failed: 0,
+        },
+        _seq_no: 304,
+        _primary_term: 23,
+        status: 201,
+      },
+    },
+  ],
+};
+
+describe('getCreatedDocumentIds', () => {
+  it('returns all created document ids from a successful bulk response', () => {
+    const ids = getCreatedDocumentIds(mockBulkResponse);
+
+    expect(ids).toEqual([
+      '0771fe50-3524-4f93-b658-fc509550375c',
+      'cc4e25d9-2eb2-4e6a-8047-ecd19dd9b3d6',
+      '05bb4562-6931-40bd-a110-ca2fe4eeb430',
+    ]);
+  });
+
+  it('returns an empty array if no items are present', () => {
+    const ids = getCreatedDocumentIds({ ...mockBulkResponse, items: [] });
+
+    expect(ids).toEqual([]);
+  });
+
+  it('returns only ids where result is "created"', () => {
+    const response = {
+      ...mockBulkResponse,
+      items: [
+        { create: { ...mockBulkResponse.items[0].create, result: 'created' } },
+        { create: { ...mockBulkResponse.items[1].create, result: 'noop' } },
+        { create: { ...mockBulkResponse.items[2].create, result: 'created' } },
+      ],
+    } as BulkResponse;
+
+    const ids = getCreatedDocumentIds(response);
+
+    expect(ids).toEqual([
+      '0771fe50-3524-4f93-b658-fc509550375c',
+      '05bb4562-6931-40bd-a110-ca2fe4eeb430',
+    ]);
+  });
+
+  it('returns an empty array if no items have result "created"', () => {
+    const response = {
+      ...mockBulkResponse,
+      items: mockBulkResponse.items.map((item) => ({
+        create: { ...item.create, result: 'noop' },
+      })),
+    } as BulkResponse;
+
+    const ids = getCreatedDocumentIds(response);
+
+    expect(ids).toEqual([]);
+  });
+
+  it('handles missing _id', () => {
+    const response = {
+      ...mockBulkResponse,
+      items: [
+        {
+          create: {
+            ...mockBulkResponse.items[0].create,
+            _id: undefined, // <-- missing _id
+            _index: mockBulkResponse.items[0].create?._index,
+            result: 'created',
+          },
+        },
+      ],
+    } as BulkResponse;
+
+    const ids = getCreatedDocumentIds(response);
+
+    expect(ids).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/create_attack_discovery_alerts/index.test.ts
@@ -108,4 +108,19 @@ describe('createAttackDiscoveryAlerts', () => {
       expect.stringContaining('Error getting created Attack discovery alerts')
     );
   });
+
+  it('returns an empty array if bulk response is undefined', async () => {
+    bulkMock.mockResolvedValue({ body: undefined });
+    (ruleDataClientMock.getWriter as jest.Mock).mockResolvedValue({ bulk: bulkMock });
+
+    const result = await createAttackDiscoveryAlerts({
+      adhocAttackDiscoveryDataClient: ruleDataClientMock,
+      authenticatedUser: mockAuthenticatedUser,
+      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+      logger: mockLogger,
+      spaceId,
+    });
+
+    expect(result).toEqual([]);
+  });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/find_all_attack_discoveries/find_all_attack_discoveries.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/find_all_attack_discoveries/find_all_attack_discoveries.test.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { findAllAttackDiscoveries } from './find_all_attack_discoveries';
+import { mockAuthenticatedUser } from '../../../../__mocks__/mock_authenticated_user';
+import type { estypes } from '@elastic/elasticsearch';
+import { ElasticsearchClient, Logger } from '@kbn/core/server';
+
+describe('findAllAttackDiscoveries', () => {
+  let esClient: jest.Mocked<ElasticsearchClient>;
+  let logger: jest.Mocked<Logger>;
+  const attackDiscoveryIndex = 'test-index';
+  const user = mockAuthenticatedUser;
+
+  beforeEach(() => {
+    esClient = {
+      search: jest.fn(),
+    } as unknown as jest.Mocked<ElasticsearchClient>;
+    logger = {
+      error: jest.fn(),
+    } as unknown as jest.Mocked<Logger>;
+  });
+
+  it('returns an empty array when the ES search returns no hits', async () => {
+    const mockEsResponse: estypes.SearchResponse<unknown> = {
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: {
+        total: { value: 0, relation: 'eq' },
+        max_score: null,
+        hits: [],
+      },
+    };
+    esClient.search.mockResolvedValue(mockEsResponse);
+
+    const result = await findAllAttackDiscoveries({
+      esClient,
+      logger,
+      attackDiscoveryIndex,
+      user,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns the expected transformed attack discoveries when the ES search returns hits', async () => {
+    const mockHit = {
+      _id: 'test-id',
+      _index: 'test-index',
+      _source: {
+        '@timestamp': '2023-01-01T00:00:00Z',
+        alerts_context_count: 1,
+        api_config: {
+          action_type_id: 'aid',
+          connector_id: 'cid',
+          default_system_prompt_id: 'pid',
+          model: 'model',
+          provider: 'provider',
+        },
+        attack_discoveries: [
+          {
+            alert_ids: ['alert-1'],
+            details_markdown: 'Details',
+            entity_summary_markdown: 'Entity',
+            id: 'ad-1',
+            mitre_attack_tactics: ['Execution'],
+            summary_markdown: 'Summary',
+            timestamp: '2023-01-01T00:00:00Z',
+            title: 'Attack Discovery 1',
+          },
+        ],
+        created_at: '2023-01-01T00:00:00Z',
+        last_viewed_at: '2023-01-01T00:00:00Z',
+        namespace: 'default',
+        status: 'active',
+        updated_at: '2023-01-01T00:00:00Z',
+        users: [
+          {
+            id: 'u1',
+            name: 'user1',
+          },
+        ],
+      },
+    };
+    const mockEsResponse: estypes.SearchResponse<unknown> = {
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: {
+        total: { value: 1, relation: 'eq' },
+        max_score: 1,
+        hits: [mockHit],
+      },
+    };
+    esClient.search.mockResolvedValue(mockEsResponse);
+
+    const result = await findAllAttackDiscoveries({
+      esClient,
+      logger,
+      attackDiscoveryIndex,
+      user,
+    });
+
+    expect(result).toEqual([
+      {
+        alertsContextCount: 1,
+        apiConfig: {
+          actionTypeId: 'aid',
+          connectorId: 'cid',
+          defaultSystemPromptId: 'pid',
+          model: 'model',
+          provider: 'provider',
+        },
+        attackDiscoveries: [
+          {
+            alertIds: ['alert-1'],
+            detailsMarkdown: 'Details',
+            entitySummaryMarkdown: 'Entity',
+            id: 'ad-1',
+            mitreAttackTactics: ['Execution'],
+            summaryMarkdown: 'Summary',
+            timestamp: '2023-01-01T00:00:00Z',
+            title: 'Attack Discovery 1',
+          },
+        ],
+        averageIntervalMs: 0,
+        backingIndex: 'test-index',
+        createdAt: '2023-01-01T00:00:00Z',
+        generationIntervals: [],
+        id: 'test-id',
+        lastViewedAt: '2023-01-01T00:00:00Z',
+        namespace: 'default',
+        status: 'active',
+        timestamp: '2023-01-01T00:00:00Z',
+        updatedAt: '2023-01-01T00:00:00Z',
+        users: [
+          {
+            id: 'u1',
+            name: 'user1',
+          },
+        ],
+      },
+    ]);
+  });
+
+  describe('when ES search fails', () => {
+    const error = new Error('ES error');
+
+    beforeEach(() => {
+      esClient.search.mockRejectedValue(error);
+    });
+
+    it('throws the error', async () => {
+      await expect(
+        findAllAttackDiscoveries({
+          esClient,
+          logger,
+          attackDiscoveryIndex,
+          user,
+        })
+      ).rejects.toThrow('ES error');
+    });
+
+    it('logs the error', async () => {
+      try {
+        await findAllAttackDiscoveries({
+          esClient,
+          logger,
+          attackDiscoveryIndex,
+          user,
+        });
+      } catch (e) {
+        // error expected
+      }
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error fetching attack discoveries:')
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generation_by_id_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generation_by_id_query/index.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAttackDiscoveryGenerationByIdQuery } from '.';
+import { mockAuthenticatedUser } from '../../../../__mocks__/mock_authenticated_user';
+
+describe('getAttackDiscoveryGenerationByIdQuery', () => {
+  const defaultProps = {
+    authenticatedUser: mockAuthenticatedUser,
+    eventLogIndex: 'test-event-log-index',
+    executionUuid: 'test-execution-uuid',
+    spaceId: 'test-space-id',
+  };
+
+  let query: ReturnType<typeof getAttackDiscoveryGenerationByIdQuery>;
+
+  beforeEach(() => {
+    query = getAttackDiscoveryGenerationByIdQuery(defaultProps);
+  });
+
+  it('returns a query with the correct index', () => {
+    expect(query.index).toEqual(['test-event-log-index']);
+  });
+
+  it('returns a query with allow_no_indices true', () => {
+    expect(query.allow_no_indices).toBe(true);
+  });
+
+  it('returns a query with ignore_unavailable true', () => {
+    expect(query.ignore_unavailable).toBe(true);
+  });
+
+  it('returns a query with _source false', () => {
+    expect(query._source).toBe(false);
+  });
+
+  it('returns a query with size 0', () => {
+    expect(query.size).toBe(0);
+  });
+
+  it('returns a query with the expected aggs', () => {
+    expect(query.aggs).toEqual({
+      generations: {
+        terms: {
+          field: 'kibana.alert.rule.execution.uuid',
+          size: 1,
+          order: {
+            generation_start_time: 'desc',
+          },
+        },
+        aggs: {
+          alerts_context_count: {
+            max: {
+              field: 'kibana.alert.rule.execution.metrics.alert_counts.active',
+            },
+          },
+          connector_id: {
+            terms: {
+              field: 'event.dataset',
+            },
+          },
+          discoveries: {
+            max: {
+              field: 'kibana.alert.rule.execution.metrics.alert_counts.new',
+            },
+          },
+          loading_message: {
+            terms: {
+              field: 'kibana.alert.rule.execution.status',
+            },
+          },
+          event_actions: {
+            terms: {
+              field: 'event.action',
+            },
+          },
+          event_reason: {
+            terms: {
+              field: 'event.reason',
+            },
+          },
+          generation_end_time: {
+            max: {
+              field: 'event.end',
+              format: 'strict_date_optional_time',
+            },
+          },
+          generation_start_time: {
+            min: {
+              field: 'event.start',
+              format: 'strict_date_optional_time',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("returns the expected query for the user's generations", () => {
+    expect(query.query).toEqual({
+      bool: {
+        must: [
+          {
+            term: {
+              'event.provider': 'securitySolution.attackDiscovery',
+            },
+          },
+          {
+            term: {
+              'user.name': 'test_user',
+            },
+          },
+          {
+            term: {
+              'kibana.space_ids': 'test-space-id',
+            },
+          },
+          {
+            term: {
+              'kibana.alert.rule.execution.uuid': 'test-execution-uuid',
+            },
+          },
+          {
+            exists: {
+              field: 'event.dataset',
+            },
+          },
+          {
+            exists: {
+              field: 'event.action',
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations/index.test.ts
@@ -1,0 +1,377 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAttackDiscoveryGenerations } from '.';
+
+import { authenticatedUser } from '../../../../__mocks__/user';
+
+describe('getAttackDiscoveryGenerations', () => {
+  const esClient = { msearch: jest.fn() } as { msearch: jest.Mock };
+  interface Logger {
+    debug: jest.Mock;
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+  }
+  const logger: Logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  const eventLogIndex = 'test-index';
+  const spaceId = 'default';
+  // use imported authenticatedUser
+  const generationsQuery = {
+    allow_no_indices: true,
+    index: eventLogIndex,
+    ignore_unavailable: true,
+    aggs: {},
+    query: {},
+    size: 10,
+  };
+  const getAttackDiscoveryGenerationsParams = { size: 10 };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('returns the expected response', () => {
+    let result: ReturnType<typeof getAttackDiscoveryGenerations> extends Promise<infer R>
+      ? R
+      : never;
+    beforeEach(async () => {
+      esClient.msearch.mockResolvedValue({
+        responses: [
+          {
+            aggregations: {
+              generations: {
+                buckets: [
+                  {
+                    key: 'f29f3d04-14da-4660-8ac1-a6c95f618a7e',
+                    doc_count: 1,
+                    alerts_context_count: { value: 2 },
+                    connector_id: { buckets: [{ key: 'claudeV3Haiku', doc_count: 1 }] },
+                    discoveries: { value: 0 },
+                    event_actions: {
+                      buckets: [
+                        { key: 'generation-started', doc_count: 1 },
+                        { key: 'generation-failed', doc_count: 1 },
+                      ],
+                    },
+                    event_reason: {
+                      buckets: [
+                        {
+                          key: 'Maximum hallucination failures (5) reached. Try sending fewer alerts to this model.\n',
+                          doc_count: 1,
+                        },
+                      ],
+                    },
+                    loading_message: {
+                      buckets: [
+                        {
+                          key: 'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.',
+                          doc_count: 1,
+                        },
+                      ],
+                    },
+                    generation_end_time: { value_as_string: '2025-06-26T21:23:04.604Z' },
+                    generation_start_time: { value_as_string: '2025-06-26T21:19:06.317Z' },
+                  },
+                ],
+              },
+            },
+          },
+          {
+            aggregations: {
+              successfull_generations_by_connector_id: {
+                buckets: [
+                  {
+                    key: 'claudeV3Haiku',
+                    doc_count: 1,
+                    event_actions: { buckets: [{ key: 'generation-succeeded', doc_count: 1 }] },
+                    successful_generations: { value: 1 },
+                    avg_event_duration_nanoseconds: { value: null },
+                    latest_successfull_generation: { value: null, value_as_string: null },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+      result = await getAttackDiscoveryGenerations({
+        authenticatedUser,
+        esClient: esClient as unknown as import('@kbn/core/server').ElasticsearchClient,
+        eventLogIndex,
+        generationsQuery,
+        getAttackDiscoveryGenerationsParams,
+        logger: logger as unknown as import('@kbn/core/server').Logger,
+        spaceId,
+      });
+    });
+
+    it('returns the one generation', () => {
+      expect(result.generations.length).toBe(1);
+    });
+
+    it('returns the correct connector_id', () => {
+      expect(result.generations[0].connector_id).toBe('claudeV3Haiku');
+    });
+
+    it('returns the correct discoveries', () => {
+      expect(result.generations[0].discoveries).toBe(0);
+    });
+
+    it('returns the correct loading_message', () => {
+      expect(result.generations[0].loading_message).toBe(
+        'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.'
+      );
+    });
+
+    it('returns the correct end', () => {
+      expect(result.generations[0].end).toBe('2025-06-26T21:23:04.604Z');
+    });
+
+    it('returns the correct start', () => {
+      expect(result.generations[0].start).toBe('2025-06-26T21:19:06.317Z');
+    });
+
+    it('returns the correct reason', () => {
+      expect(result.generations[0].reason).toBe(
+        'Maximum hallucination failures (5) reached. Try sending fewer alerts to this model.\n'
+      );
+    });
+  });
+
+  describe('handles multiple generations and connectors', () => {
+    let result: ReturnType<typeof getAttackDiscoveryGenerations> extends Promise<infer R>
+      ? R
+      : never;
+    beforeEach(async () => {
+      esClient.msearch.mockResolvedValue({
+        responses: [
+          {
+            aggregations: {
+              generations: {
+                buckets: [
+                  {
+                    key: 'uuid-1',
+                    doc_count: 2,
+                    alerts_context_count: { value: 5 },
+                    connector_id: { buckets: [{ key: 'connA', doc_count: 2 }] },
+                    discoveries: { value: 3 },
+                    event_actions: {
+                      buckets: [
+                        { key: 'generation-started', doc_count: 1 },
+                        { key: 'generation-succeeded', doc_count: 2 },
+                      ],
+                    },
+                    event_reason: { buckets: [{ key: 'All good', doc_count: 2 }] },
+                    loading_message: { buckets: [{ key: 'Done', doc_count: 2 }] },
+                    generation_end_time: { value_as_string: '2025-07-25T10:00:00.000Z' },
+                    generation_start_time: { value_as_string: '2025-07-25T09:00:00.000Z' },
+                  },
+                  {
+                    key: 'uuid-2',
+                    doc_count: 1,
+                    alerts_context_count: { value: 1 },
+                    connector_id: { buckets: [{ key: 'connB', doc_count: 1 }] },
+                    discoveries: { value: 0 },
+                    event_actions: {
+                      buckets: [
+                        { key: 'generation-started', doc_count: 1 },
+                        { key: 'generation-failed', doc_count: 1 },
+                      ],
+                    },
+                    event_reason: { buckets: [{ key: 'Timeout', doc_count: 1 }] },
+                    loading_message: { buckets: [{ key: 'Processing', doc_count: 1 }] },
+                    generation_end_time: { value_as_string: '2025-07-25T11:00:00.000Z' },
+                    generation_start_time: { value_as_string: '2025-07-25T10:30:00.000Z' },
+                  },
+                ],
+              },
+            },
+          },
+          {
+            aggregations: {
+              successfull_generations_by_connector_id: {
+                buckets: [
+                  {
+                    key: 'connA',
+                    doc_count: 2,
+                    event_actions: { buckets: [{ key: 'generation-succeeded', doc_count: 2 }] },
+                    successful_generations: { value: 2 },
+                    avg_event_duration_nanoseconds: { value: 1000000 },
+                    latest_successfull_generation: {
+                      value: 1721901600000,
+                      value_as_string: '2025-07-25T10:00:00.000Z',
+                    },
+                  },
+                  {
+                    key: 'connB',
+                    doc_count: 1,
+                    event_actions: { buckets: [{ key: 'generation-succeeded', doc_count: 1 }] },
+                    successful_generations: { value: 1 },
+                    avg_event_duration_nanoseconds: { value: 2000000 },
+                    latest_successfull_generation: {
+                      value: 1721905200000,
+                      value_as_string: '2025-07-25T11:00:00.000Z',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+      result = await getAttackDiscoveryGenerations({
+        authenticatedUser,
+        esClient: esClient as unknown as import('@kbn/core/server').ElasticsearchClient,
+        eventLogIndex,
+        generationsQuery,
+        getAttackDiscoveryGenerationsParams,
+        logger: logger as unknown as import('@kbn/core/server').Logger,
+        spaceId,
+      });
+    });
+
+    it('returns the correct connector_id for the first generation', () => {
+      expect(result.generations[0].connector_id).toBe('connA');
+    });
+
+    it('returns the correct connector_id for the second generation', () => {
+      expect(result.generations[1].connector_id).toBe('connB');
+    });
+
+    it('returns the correct status for the first generation', () => {
+      expect(result.generations[0].status).toBe('succeeded');
+    });
+
+    it('returns the correct status for the second generation', () => {
+      expect(result.generations[1].status).toBe('failed');
+    });
+  });
+
+  it('handles the empty buckets (no generations)', async () => {
+    esClient.msearch.mockResolvedValue({
+      responses: [
+        {
+          aggregations: {
+            generations: {
+              buckets: [],
+            },
+          },
+        },
+        {
+          aggregations: {
+            successfull_generations_by_connector_id: {
+              buckets: [],
+            },
+          },
+        },
+      ],
+    });
+
+    const result = await getAttackDiscoveryGenerations({
+      authenticatedUser,
+      esClient: esClient as unknown as import('@kbn/core/server').ElasticsearchClient,
+      eventLogIndex,
+      generationsQuery,
+      getAttackDiscoveryGenerationsParams,
+      logger: logger as unknown as import('@kbn/core/server').Logger,
+      spaceId,
+    });
+
+    expect(result.generations).toEqual([]);
+  });
+
+  describe('handles missing optional fields gracefully', () => {
+    let result: ReturnType<typeof getAttackDiscoveryGenerations> extends Promise<infer R>
+      ? R
+      : never;
+    beforeEach(async () => {
+      esClient.msearch.mockResolvedValue({
+        responses: [
+          {
+            aggregations: {
+              generations: {
+                buckets: [
+                  {
+                    key: 'uuid-3',
+                    doc_count: 1,
+                    alerts_context_count: { value: null },
+                    connector_id: { buckets: [{ key: 'connC', doc_count: 1 }] },
+                    discoveries: { value: null },
+                    event_actions: {
+                      buckets: [
+                        { key: 'generation-started', doc_count: 1 },
+                        { key: 'generation-succeeded', doc_count: 1 },
+                      ],
+                    },
+                    event_reason: { buckets: [] },
+                    loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+                    generation_end_time: { value_as_string: null },
+                    generation_start_time: { value_as_string: '2025-07-25T12:00:00.000Z' },
+                  },
+                ],
+              },
+            },
+          },
+          {
+            aggregations: {
+              successfull_generations_by_connector_id: {
+                buckets: [
+                  {
+                    key: 'connC',
+                    doc_count: 1,
+                    event_actions: { buckets: [{ key: 'generation-succeeded', doc_count: 1 }] },
+                    successful_generations: { value: 1 },
+                    avg_event_duration_nanoseconds: { value: null },
+                    latest_successfull_generation: { value: null, value_as_string: null },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+      result = await getAttackDiscoveryGenerations({
+        authenticatedUser,
+        esClient: esClient as unknown as import('@kbn/core/server').ElasticsearchClient,
+        eventLogIndex,
+        generationsQuery,
+        getAttackDiscoveryGenerationsParams,
+        logger: logger as unknown as import('@kbn/core/server').Logger,
+        spaceId,
+      });
+    });
+
+    it('returns the correct connector_id', () => {
+      expect(result.generations[0].connector_id).toBe('connC');
+    });
+
+    it('returns the undefined alerts_context_count', () => {
+      expect(result.generations[0].alerts_context_count).toBeUndefined();
+    });
+
+    it('returns the discoveries as 0', () => {
+      expect(result.generations[0].discoveries).toBe(0);
+    });
+
+    it('returns the undefined reason', () => {
+      expect(result.generations[0].reason).toBeUndefined();
+    });
+
+    it('returns the loading_message as "Loading..."', () => {
+      expect(result.generations[0].loading_message).toBe('Loading...');
+    });
+
+    it('returns the undefined end', () => {
+      expect(result.generations[0].end).toBeUndefined();
+    });
+
+    it('returns the correct start', () => {
+      expect(result.generations[0].start).toBe('2025-07-25T12:00:00.000Z');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations_aggs/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations_aggs/index.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAttackDiscoveryGenerationsAggs } from '.';
+
+describe('getAttackDiscoveryGenerationsAggs', () => {
+  const size = 5;
+  let result: ReturnType<typeof getAttackDiscoveryGenerationsAggs>;
+
+  beforeEach(() => {
+    result = getAttackDiscoveryGenerationsAggs(size);
+  });
+
+  it('returns an aggregation query with the correct size', () => {
+    expect(result.aggs?.generations?.terms?.size).toBe(size);
+  });
+
+  it('returns the expected static aggregation structure', () => {
+    expect(result.aggs?.generations).toMatchObject({
+      terms: {
+        field: 'kibana.alert.rule.execution.uuid',
+        order: { generation_start_time: 'desc' },
+      },
+      aggs: {
+        alerts_context_count: {
+          max: { field: 'kibana.alert.rule.execution.metrics.alert_counts.active' },
+        },
+        connector_id: {
+          terms: { field: 'event.dataset' },
+        },
+        discoveries: {
+          max: { field: 'kibana.alert.rule.execution.metrics.alert_counts.new' },
+        },
+        loading_message: {
+          terms: { field: 'kibana.alert.rule.execution.status' },
+        },
+        event_actions: {
+          terms: { field: 'event.action' },
+        },
+        event_reason: {
+          terms: { field: 'event.reason' },
+        },
+        generation_end_time: {
+          max: { field: 'event.end', format: 'strict_date_optional_time' },
+        },
+        generation_start_time: {
+          min: { field: 'event.start', format: 'strict_date_optional_time' },
+        },
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations_query/index.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAttackDiscoveryGenerationsQuery, DEFAULT_START, DEFAULT_END } from '.';
+import { ATTACK_DISCOVERY_EVENT_PROVIDER } from '../../../../../common/constants';
+import { mockAuthenticatedUser } from '../../../../__mocks__/mock_authenticated_user';
+
+describe('getAttackDiscoveryGenerationsQuery', () => {
+  const defaultProps = {
+    authenticatedUser: mockAuthenticatedUser,
+    end: DEFAULT_END,
+    eventLogIndex: 'mock-index',
+    size: 10,
+    start: DEFAULT_START,
+    spaceId: 'default',
+  };
+
+  it('returns the expected index', () => {
+    const query = getAttackDiscoveryGenerationsQuery(defaultProps);
+
+    expect(query.index).toEqual(['mock-index']);
+  });
+
+  it('returns a query with a size of zero', () => {
+    const query = getAttackDiscoveryGenerationsQuery(defaultProps);
+
+    expect(query.size).toBe(0);
+  });
+
+  it('does not include source documents', () => {
+    const query = getAttackDiscoveryGenerationsQuery(defaultProps);
+
+    expect(query._source).toBe(false);
+  });
+
+  it("ensures the query does not error if the indices don't exist", () => {
+    const query = getAttackDiscoveryGenerationsQuery(defaultProps);
+
+    expect(query.allow_no_indices).toBe(true);
+  });
+
+  it('ignores unavailable indicies', () => {
+    const query = getAttackDiscoveryGenerationsQuery(defaultProps);
+
+    expect(query.ignore_unavailable).toBe(true);
+  });
+
+  it('returns the expected query', () => {
+    const query = getAttackDiscoveryGenerationsQuery(defaultProps);
+    const expectedQuery = {
+      bool: {
+        must: [
+          { term: { 'event.provider': ATTACK_DISCOVERY_EVENT_PROVIDER } },
+          { term: { 'user.name': defaultProps.authenticatedUser.username } },
+          { term: { 'kibana.space_ids': defaultProps.spaceId } },
+          {
+            range: {
+              '@timestamp': {
+                gte: DEFAULT_START,
+                lte: DEFAULT_END,
+                format: 'strict_date_optional_time',
+              },
+            },
+          },
+          { exists: { field: 'kibana.alert.rule.execution.uuid' } },
+          { exists: { field: 'event.dataset' } },
+          { exists: { field: 'event.action' } },
+        ],
+      },
+    };
+    expect(query.query).toEqual(expectedQuery);
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations_search_result/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_attack_discovery_generations_search_result/index.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GetAttackDiscoveryGenerationsSearchResult } from '.';
+
+const mockRawResponse = {
+  aggregations: {
+    generations: {
+      buckets: [
+        {
+          alerts_context_count: { value: 5 },
+          connector_id: {
+            buckets: [{ key: 'connector-1', doc_count: 10 }],
+          },
+          discoveries: { value: 2 },
+          doc_count: 10,
+          event_actions: {
+            buckets: [{ key: 'action-1', doc_count: 3 }],
+          },
+          event_reason: {
+            buckets: [{ key: 'reason-1', doc_count: 1 }],
+          },
+          generation_end_time: { value_as_string: '2025-07-28T00:00:00.000Z' },
+          generation_start_time: { value_as_string: '2025-07-27T00:00:00.000Z' },
+          key: 'uuid-123',
+          loading_message: {
+            buckets: [{ key: 'Loading...', doc_count: 1 }],
+          },
+        },
+      ],
+    },
+  },
+};
+
+describe('GetAttackDiscoveryGenerationsSearchResult schema', () => {
+  it('returns a parsed result for a valid response', () => {
+    const result = GetAttackDiscoveryGenerationsSearchResult.parse(mockRawResponse);
+
+    expect(result.aggregations.generations.buckets[0].key).toBe('uuid-123');
+  });
+
+  describe('GetAttackDiscoveryGenerationsSearchResult schema edge cases', () => {
+    const baseBucket = {
+      alerts_context_count: { value: 5 },
+      connector_id: { buckets: [{ key: 'connector-1', doc_count: 10 }] },
+      discoveries: { value: 2 },
+      doc_count: 10,
+      event_actions: { buckets: [{ key: 'action-1', doc_count: 3 }] },
+      event_reason: { buckets: [{ key: 'reason-1', doc_count: 1 }] },
+      generation_end_time: { value_as_string: '2025-07-28T00:00:00.000Z' },
+      generation_start_time: { value_as_string: '2025-07-27T00:00:00.000Z' },
+      key: 'uuid-123',
+      loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+    };
+
+    it('returns a parsed result when alerts_context_count.value is null', () => {
+      const response = {
+        aggregations: {
+          generations: {
+            buckets: [{ ...baseBucket, alerts_context_count: { value: null } }],
+          },
+        },
+      };
+      const result = GetAttackDiscoveryGenerationsSearchResult.parse(response);
+
+      expect(result.aggregations.generations.buckets[0].alerts_context_count.value).toBeNull();
+    });
+
+    it('returns a parsed result when discoveries.value is missing', () => {
+      const bucket = { ...baseBucket, discoveries: {} };
+      const response = {
+        aggregations: { generations: { buckets: [bucket] } },
+      };
+      const result = GetAttackDiscoveryGenerationsSearchResult.parse(response);
+
+      expect(result.aggregations.generations.buckets[0].discoveries.value).toBeUndefined();
+    });
+
+    it('returns a parsed result when generation_end_time.value_as_string is null', () => {
+      const bucket = { ...baseBucket, generation_end_time: { value_as_string: null } };
+      const response = {
+        aggregations: { generations: { buckets: [bucket] } },
+      };
+      const result = GetAttackDiscoveryGenerationsSearchResult.parse(response);
+
+      expect(
+        result.aggregations.generations.buckets[0].generation_end_time.value_as_string
+      ).toBeNull();
+    });
+
+    it('returns an error when generation_start_time is missing', () => {
+      // Omit generation_start_time by destructuring
+      const { generation_start_time: _generationStartTime, ...bucketWithoutStartTime } = baseBucket;
+      const response = {
+        aggregations: { generations: { buckets: [bucketWithoutStartTime] } },
+      };
+
+      expect(() => GetAttackDiscoveryGenerationsSearchResult.parse(response)).toThrow();
+    });
+
+    it('returns a parsed result for empty buckets array', () => {
+      const response = {
+        aggregations: { generations: { buckets: [] } },
+      };
+      const result = GetAttackDiscoveryGenerationsSearchResult.parse(response);
+
+      expect(result.aggregations.generations.buckets).toEqual([]);
+    });
+
+    it('returns an error for missing aggregations', () => {
+      const response = {};
+
+      expect(() => GetAttackDiscoveryGenerationsSearchResult.parse(response)).toThrow();
+    });
+
+    it('returns an error for missing generations', () => {
+      const response = { aggregations: {} };
+
+      expect(() => GetAttackDiscoveryGenerationsSearchResult.parse(response)).toThrow();
+    });
+
+    it('returns an error for missing buckets', () => {
+      const response = { aggregations: { generations: {} } };
+
+      expect(() => GetAttackDiscoveryGenerationsSearchResult.parse(response)).toThrow();
+    });
+
+    it('returns a parsed result for multiple buckets', () => {
+      const bucket1 = { ...baseBucket, key: 'uuid-1' };
+      const bucket2 = { ...baseBucket, key: 'uuid-2' };
+      const response = {
+        aggregations: { generations: { buckets: [bucket1, bucket2] } },
+      };
+      const result = GetAttackDiscoveryGenerationsSearchResult.parse(response);
+
+      expect(result.aggregations.generations.buckets.length).toBe(2);
+    });
+  });
+
+  it('throws an error for an invalid response', () => {
+    const invalidResponse = { aggregations: {} };
+
+    expect(() => GetAttackDiscoveryGenerationsSearchResult.parse(invalidResponse)).toThrow();
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_combined_filter/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_combined_filter/index.test.ts
@@ -119,11 +119,13 @@ describe('getCombinedFilter', () => {
   describe('getAdditionalFilter', () => {
     it('returns the additional filter joined with an AND when filter is defined', () => {
       const result = getAdditionalFilter('foo: "bar"');
+
       expect(result).toBe(' AND foo: "bar"');
     });
 
     it('returns an empty string when filter is undefined', () => {
       const result = getAdditionalFilter(undefined);
+
       expect(result).toBe('');
     });
   });
@@ -243,6 +245,58 @@ describe('getCombinedFilter', () => {
           `(${EMPTY_ALERT_ATTACK_DISCOVERY_USERS_KQL} OR ${ALERT_ATTACK_DISCOVERY_USERS_NOT_EXISTS_KQL}) AND foo: "bar"`
         );
       });
+    });
+
+    it('returns id when username is undefined', () => {
+      const authenticatedUser = {
+        username: undefined,
+        profile_uid: 'abc',
+      } as unknown as AuthenticatedUser;
+
+      const result = getUserNameOrId(authenticatedUser);
+
+      expect(result).toBe('id: "abc"');
+    });
+
+    it('returns empty string for getUserFilter when authenticatedUser is missing profile_uid and username', () => {
+      const authenticatedUser = {} as unknown as AuthenticatedUser;
+      const result = getUserFilter({ authenticatedUser, shared: true });
+
+      expect(result).toBe('');
+    });
+
+    it('returns the correct filter when filter is empty string', () => {
+      const authenticatedUser = {
+        username: 'test_user',
+        profile_uid: '123',
+      } as AuthenticatedUser;
+      const filter = '';
+      const result = getCombinedFilter({ authenticatedUser, filter, shared: false });
+
+      expect(result).toBe(`(${ALERT_ATTACK_DISCOVERY_USERS}: { name: "test_user" }) AND `);
+    });
+
+    it('returns correct filter when filter is whitespace', () => {
+      const authenticatedUser = {
+        username: 'test_user',
+        profile_uid: '123',
+      } as AuthenticatedUser;
+      const filter = ' ';
+      const result = getCombinedFilter({ authenticatedUser, filter, shared: false });
+
+      expect(result).toBe(`(${ALERT_ATTACK_DISCOVERY_USERS}: { name: "test_user" }) AND  `);
+    });
+
+    it('returns correct filter when shared is null', () => {
+      const authenticatedUser = {
+        username: 'test_user',
+        profile_uid: '123',
+      } as AuthenticatedUser;
+      const filter = undefined;
+      const shared = null as unknown as boolean;
+      const result = getCombinedFilter({ authenticatedUser, filter, shared });
+
+      expect(result).toBe(`(${ALERT_ATTACK_DISCOVERY_USERS}: { name: "test_user" })`);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_successfull_generations_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_successfull_generations_query/index.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getSuccessfulGenerationsQuery, DEFAULT_START, DEFAULT_END } from '.';
+
+import {
+  ATTACK_DISCOVERY_EVENT_PROVIDER,
+  ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_SUCCEEDED,
+} from '../../../../../common/constants';
+
+import { mockAuthenticatedUser } from '../../../../__mocks__/mock_authenticated_user';
+
+describe('getSuccessfulGenerationsQuery', () => {
+  const defaultProps = {
+    authenticatedUser: mockAuthenticatedUser,
+    end: DEFAULT_END,
+    eventLogIndex: 'mock-index',
+    size: 10,
+    spaceId: 'default',
+    start: DEFAULT_START,
+  };
+
+  const getMustClauses = (query: ReturnType<typeof getSuccessfulGenerationsQuery>): unknown[] => {
+    if (!query.query || !query.query.bool) return [];
+    return Array.isArray(query.query.bool.must) ? query.query.bool.must : [];
+  };
+
+  const findTerm = (mustClauses: unknown[], field: string) =>
+    mustClauses.find(
+      (clause: unknown) =>
+        typeof clause === 'object' &&
+        clause !== null &&
+        'term' in clause &&
+        typeof (clause as Record<string, unknown>).term === 'object' &&
+        (clause as { term: Record<string, unknown> }).term !== null &&
+        field in (clause as { term: Record<string, unknown> }).term
+    ) as { term: Record<string, unknown> } | undefined;
+
+  const findRange = (mustClauses: unknown[], field: string) =>
+    mustClauses.find(
+      (clause: unknown) =>
+        typeof clause === 'object' &&
+        clause !== null &&
+        'range' in clause &&
+        typeof (clause as Record<string, unknown>).range === 'object' &&
+        (clause as { range: Record<string, unknown> }).range !== null &&
+        field in (clause as { range: Record<string, unknown> }).range
+    ) as { range: Record<string, unknown> } | undefined;
+
+  it('returns a query with the expected index', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+
+    expect(query.index).toEqual(['mock-index']);
+  });
+
+  it('returns a query with size zero', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+
+    expect(query.size).toEqual(0);
+  });
+
+  it('returns a query with the expected aggs size', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+
+    expect(query.aggs?.successfull_generations_by_connector_id?.terms?.size).toEqual(10);
+  });
+
+  it('returns a query with the expected user.name filter', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+    const userTerm = findTerm(getMustClauses(query), 'user.name');
+
+    expect(userTerm?.term['user.name']).toEqual(mockAuthenticatedUser.username);
+  });
+
+  it('returns a query with the expected spaceId filter', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+    const spaceTerm = findTerm(getMustClauses(query), 'kibana.space_ids');
+
+    expect(spaceTerm?.term['kibana.space_ids']).toEqual('default');
+  });
+
+  it('returns a query with the expected event.provider filter', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+    const providerTerm = findTerm(getMustClauses(query), 'event.provider');
+
+    expect(providerTerm?.term['event.provider']).toEqual(ATTACK_DISCOVERY_EVENT_PROVIDER);
+  });
+
+  it('returns a query with the expected event.action filter', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+    const actionTerm = findTerm(getMustClauses(query), 'event.action');
+
+    expect(actionTerm?.term['event.action']).toEqual(
+      ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_SUCCEEDED
+    );
+  });
+
+  it('returns a query with the expected timestamp range', () => {
+    const query = getSuccessfulGenerationsQuery({ ...defaultProps });
+    const rangeTerm = findRange(getMustClauses(query), '@timestamp');
+
+    expect(rangeTerm?.range['@timestamp']).toEqual({
+      gte: DEFAULT_START,
+      lte: DEFAULT_END,
+      format: 'strict_date_optional_time',
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_successfull_generations_search_result/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_successfull_generations_search_result/index.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GetSuccessfulGenerationsSearchResult } from '.';
+import { getMockSuccessfulGenerationsSearchResult } from '../../../../__mocks__/get_successful_generations_search_result.mock';
+
+describe('GetSuccessfulGenerationsSearchResult schema', () => {
+  it('successfully parses a valid raw response', () => {
+    const parsed = GetSuccessfulGenerationsSearchResult.safeParse(
+      getMockSuccessfulGenerationsSearchResult()
+    );
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it('returns parsed = false for a missing aggregations field', () => {
+    const invalidResponse = {};
+    const parsed = GetSuccessfulGenerationsSearchResult.safeParse(invalidResponse);
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('returns invalid for wrong bucket key type', () => {
+    const invalidResponse = {
+      aggregations: {
+        successfull_generations_by_connector_id: {
+          buckets: [
+            {
+              key: 123, // should be string
+              doc_count: 5,
+              event_actions: { buckets: [] },
+              successful_generations: { value: 3 },
+              avg_event_duration_nanoseconds: { value: 1000000 },
+              latest_successfull_generation: { value: null, value_as_string: null },
+            },
+          ],
+        },
+      },
+    };
+
+    const parsed = GetSuccessfulGenerationsSearchResult.safeParse(invalidResponse);
+
+    expect(parsed.success).toBe(false);
+  });
+
+  describe('table-driven edge cases', () => {
+    const cases = [
+      {
+        name: 'returns valid for nullable avg_event_duration_nanoseconds',
+        input: {
+          aggregations: {
+            successfull_generations_by_connector_id: {
+              buckets: [
+                {
+                  key: 'connector-2',
+                  doc_count: 1,
+                  event_actions: { buckets: [] },
+                  successful_generations: { value: 1 },
+                  avg_event_duration_nanoseconds: { value: null },
+                  latest_successfull_generation: { value: null, value_as_string: null },
+                },
+              ],
+            },
+          },
+        },
+        expected: true,
+      },
+      {
+        name: 'returns valid for empty buckets',
+        input: {
+          aggregations: {
+            successfull_generations_by_connector_id: {
+              buckets: [],
+            },
+          },
+        },
+        expected: true,
+      },
+      {
+        name: 'returns invalid for missing buckets',
+        input: {
+          aggregations: {
+            successfull_generations_by_connector_id: {},
+          },
+        },
+        expected: false,
+      },
+      {
+        name: 'returns valid for multiple connectors',
+        input: {
+          aggregations: {
+            successfull_generations_by_connector_id: {
+              buckets: [
+                {
+                  key: 'connector-1',
+                  doc_count: 2,
+                  event_actions: { buckets: [] },
+                  successful_generations: { value: 1 },
+                  avg_event_duration_nanoseconds: { value: 1000 },
+                  latest_successfull_generation: {
+                    value: 123,
+                    value_as_string: '2021-01-01T00:00:00Z',
+                  },
+                },
+                {
+                  key: 'connector-2',
+                  doc_count: 3,
+                  event_actions: { buckets: [] },
+                  successful_generations: { value: 2 },
+                  avg_event_duration_nanoseconds: { value: null },
+                  latest_successfull_generation: { value: null, value_as_string: null },
+                },
+              ],
+            },
+          },
+        },
+        expected: true,
+      },
+    ];
+
+    cases.forEach(({ name, input, expected }) => {
+      it(name, () => {
+        const parsed = GetSuccessfulGenerationsSearchResult.safeParse(input);
+        expect(parsed.success).toBe(expected);
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_get_attack_discovery_generations_search_result/get_generation_status_or_throw/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_get_attack_discovery_generations_search_result/get_generation_status_or_throw/index.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getGenerationStatusOrThrow } from '.';
+import {
+  ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_STARTED,
+  ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_DISMISSED,
+  ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_FAILED,
+  ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_SUCCEEDED,
+  ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_CANCELED,
+} from '../../../../../../../common/constants';
+
+describe('getGenerationStatusOrThrow', () => {
+  const executionUuid = 'test-uuid';
+  const baseActions = [ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_STARTED];
+
+  it('returns "started" when only a started event is present', () => {
+    const result = getGenerationStatusOrThrow({
+      executionUuid,
+      eventActions: [...baseActions],
+    });
+
+    expect(result).toBe('started');
+  });
+
+  it('returns "dismissed" when a dismissed event is present', () => {
+    const result = getGenerationStatusOrThrow({
+      executionUuid,
+      eventActions: [...baseActions, ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_DISMISSED],
+    });
+
+    expect(result).toBe('dismissed');
+  });
+
+  it('returns "failed" when a failed event is present', () => {
+    const result = getGenerationStatusOrThrow({
+      executionUuid,
+      eventActions: [...baseActions, ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_FAILED],
+    });
+
+    expect(result).toBe('failed');
+  });
+
+  it('returns "succeeded" when a succeeded event is present', () => {
+    const result = getGenerationStatusOrThrow({
+      executionUuid,
+      eventActions: [...baseActions, ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_SUCCEEDED],
+    });
+
+    expect(result).toBe('succeeded');
+  });
+
+  it('returns "canceled" when a canceled event is present', () => {
+    const result = getGenerationStatusOrThrow({
+      executionUuid,
+      eventActions: [...baseActions, ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_CANCELED],
+    });
+
+    expect(result).toBe('canceled');
+  });
+
+  it('throws when a started event is missing', () => {
+    expect(() =>
+      getGenerationStatusOrThrow({
+        executionUuid,
+        eventActions: [],
+      })
+    ).toThrow(
+      `Generation ${executionUuid} is missing ${ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_STARTED} event.action`
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_get_attack_discovery_generations_search_result/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_get_attack_discovery_generations_search_result/index.test.ts
@@ -1,0 +1,498 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+
+import { transformGetAttackDiscoveryGenerationsSearchResult } from '.';
+
+describe('transformGetAttackDiscoveryGenerationsSearchResult', () => {
+  const logger = loggingSystemMock.createLogger();
+
+  const validRawResponse = {
+    aggregations: {
+      generations: {
+        buckets: [
+          {
+            key: 'exec-uuid-1',
+            doc_count: 1,
+            alerts_context_count: { value: 1 },
+            connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+            discoveries: { value: 2 },
+            event_actions: {
+              buckets: [
+                { key: 'generation-started', doc_count: 1 },
+                { key: 'generation-succeeded', doc_count: 1 },
+              ],
+            },
+            event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+            loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+            generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+            generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+          },
+        ],
+      },
+    },
+  };
+
+  it('returns the expected transformed result', () => {
+    const result = transformGetAttackDiscoveryGenerationsSearchResult({
+      rawResponse: validRawResponse,
+      logger,
+    });
+
+    expect(result.generations).toEqual([
+      {
+        alerts_context_count: 1,
+        connector_id: 'test-connector',
+        discoveries: 2,
+        end: '2025-07-30T00:00:00Z',
+        execution_uuid: 'exec-uuid-1',
+        generation_start_time: '2025-07-29T00:00:00Z',
+        loading_message: 'Loading...',
+        reason: 'test-reason',
+        start: '2025-07-29T00:00:00Z',
+        status: 'succeeded',
+      },
+    ]);
+  });
+
+  it('returns an empty array when buckets is empty', () => {
+    const rawResponse = {
+      aggregations: {
+        generations: {
+          buckets: [],
+        },
+      },
+    };
+
+    const result = transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger });
+
+    expect(result.generations).toEqual([]);
+  });
+
+  it('skips a bucket with a missing connector_id', () => {
+    const rawResponse = {
+      aggregations: {
+        generations: {
+          buckets: [
+            {
+              key: 'exec-uuid-2',
+              doc_count: 1,
+              alerts_context_count: { value: 1 },
+              connector_id: { buckets: [] },
+              discoveries: { value: 2 },
+              event_actions: {
+                buckets: [
+                  { key: 'generation-started', doc_count: 1 },
+                  { key: 'generation-succeeded', doc_count: 1 },
+                ],
+              },
+              event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+              loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+              generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+              generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+            },
+          ],
+        },
+      },
+    };
+
+    const result = transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger });
+
+    expect(result.generations.length).toBe(0);
+  });
+
+  it('throws when aggregations is missing', () => {
+    // Pass the required shape but with aggregations as undefined
+    const rawResponse = { aggregations: undefined };
+
+    expect(() =>
+      transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger })
+    ).toThrow();
+  });
+
+  it('throws when a bucket is missing generation_start_time', () => {
+    const rawResponse = {
+      aggregations: {
+        generations: {
+          buckets: [
+            {
+              key: 'exec-uuid-3',
+              doc_count: 1,
+              alerts_context_count: { value: 1 },
+              connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+              discoveries: { value: 2 },
+              event_actions: { buckets: [{ key: 'generation-succeeded', doc_count: 1 }] },
+              event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+              generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+              // generation_start_time missing
+              loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+            },
+          ],
+        },
+      },
+    };
+
+    expect(() =>
+      transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger })
+    ).toThrow();
+  });
+
+  it('returns the expected generations given two valid buckets', () => {
+    const rawResponse = {
+      aggregations: {
+        generations: {
+          buckets: [
+            {
+              key: 'exec-uuid-1',
+              doc_count: 1,
+              alerts_context_count: { value: 1 },
+              connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+              discoveries: { value: 2 },
+              event_actions: {
+                buckets: [
+                  { key: 'generation-started', doc_count: 1 },
+                  { key: 'generation-succeeded', doc_count: 1 },
+                ],
+              },
+              event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+              loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+              generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+              generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+            },
+            {
+              key: 'exec-uuid-2',
+              doc_count: 1,
+              alerts_context_count: { value: 2 },
+              connector_id: { buckets: [{ key: 'test-connector-2', doc_count: 1 }] },
+              discoveries: { value: 3 },
+              event_actions: {
+                buckets: [
+                  { key: 'generation-started', doc_count: 1 },
+                  { key: 'generation-succeeded', doc_count: 1 },
+                ],
+              },
+              event_reason: { buckets: [{ key: 'test-reason-2', doc_count: 1 }] },
+              loading_message: { buckets: [{ key: 'Loading2...', doc_count: 1 }] },
+              generation_end_time: { value_as_string: '2025-07-31T00:00:00Z' },
+              generation_start_time: { value_as_string: '2025-07-30T00:00:00Z' },
+            },
+          ],
+        },
+      },
+    };
+
+    const result = transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger });
+
+    expect(result.generations).toEqual([
+      {
+        alerts_context_count: 1,
+        connector_id: 'test-connector',
+        discoveries: 2,
+        end: '2025-07-30T00:00:00Z',
+        execution_uuid: 'exec-uuid-1',
+        generation_start_time: '2025-07-29T00:00:00Z',
+        loading_message: 'Loading...',
+        reason: 'test-reason',
+        start: '2025-07-29T00:00:00Z',
+        status: 'succeeded',
+      },
+      {
+        alerts_context_count: 2,
+        connector_id: 'test-connector-2',
+        discoveries: 3,
+        end: '2025-07-31T00:00:00Z',
+        execution_uuid: 'exec-uuid-2',
+        generation_start_time: '2025-07-30T00:00:00Z',
+        loading_message: 'Loading2...',
+        reason: 'test-reason-2',
+        start: '2025-07-30T00:00:00Z',
+        status: 'succeeded',
+      },
+    ]);
+  });
+
+  it('skips a bucket with a missing loading_message', () => {
+    const rawResponse = {
+      aggregations: {
+        generations: {
+          buckets: [
+            {
+              key: 'exec-uuid-4',
+              doc_count: 1,
+              alerts_context_count: { value: 1 },
+              connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+              discoveries: { value: 2 },
+              event_actions: {
+                buckets: [
+                  { key: 'generation-started', doc_count: 1 },
+                  { key: 'generation-succeeded', doc_count: 1 },
+                ],
+              },
+              event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+              loading_message: { buckets: [] }, // empty buckets means no loading message
+              generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+              generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+            },
+          ],
+        },
+      },
+    };
+
+    const result = transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger });
+
+    expect(result.generations.length).toBe(0);
+  });
+
+  it('skips a bucket with a null executionUuid key', () => {
+    // Since zod schema requires key to be string, this test should expect an error during parsing
+    const rawResponse = {
+      aggregations: {
+        generations: {
+          buckets: [
+            {
+              key: null,
+              doc_count: 1,
+              alerts_context_count: { value: 1 },
+              connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+              discoveries: { value: 2 },
+              event_actions: {
+                buckets: [
+                  { key: 'generation-started', doc_count: 1 },
+                  { key: 'generation-succeeded', doc_count: 1 },
+                ],
+              },
+              event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+              loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+              generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+              generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+            },
+          ],
+        },
+      },
+    };
+
+    expect(() =>
+      transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger })
+    ).toThrow('Failed to parse search results');
+  });
+
+  describe('when buckets have undefined optional fields', () => {
+    let result: ReturnType<typeof transformGetAttackDiscoveryGenerationsSearchResult>;
+    beforeEach(() => {
+      const rawResponse = {
+        aggregations: {
+          generations: {
+            buckets: [
+              {
+                key: 'exec-uuid-5',
+                doc_count: 1,
+                alerts_context_count: { value: null }, // null value
+                connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+                discoveries: { value: 0 }, // zero discoveries
+                event_actions: {
+                  buckets: [
+                    { key: 'generation-started', doc_count: 1 },
+                    { key: 'generation-succeeded', doc_count: 1 },
+                  ],
+                },
+                event_reason: { buckets: [] }, // no event reason
+                loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+                generation_end_time: { value_as_string: null }, // null instead of missing
+                generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+              },
+            ],
+          },
+        },
+      };
+      result = transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger });
+    });
+
+    it('returns one generation', () => {
+      expect(result.generations.length).toBe(1);
+    });
+
+    it('has an undefined alerts_context_count', () => {
+      expect(result.generations[0].alerts_context_count).toBeUndefined();
+    });
+
+    it('has zero discoveries', () => {
+      expect(result.generations[0].discoveries).toBe(0);
+    });
+
+    it('has an undefined reason', () => {
+      expect(result.generations[0].reason).toBeUndefined();
+    });
+
+    it('has an undefined end', () => {
+      expect(result.generations[0].end).toBeUndefined();
+    });
+  });
+
+  describe('handles mixed valid and invalid buckets', () => {
+    let result: ReturnType<typeof transformGetAttackDiscoveryGenerationsSearchResult>;
+    beforeEach(() => {
+      const rawResponse = {
+        aggregations: {
+          generations: {
+            buckets: [
+              // Valid bucket
+              {
+                key: 'exec-uuid-valid',
+                doc_count: 1,
+                alerts_context_count: { value: 1 },
+                connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+                discoveries: { value: 2 },
+                event_actions: {
+                  buckets: [
+                    { key: 'generation-started', doc_count: 1 },
+                    { key: 'generation-succeeded', doc_count: 1 },
+                  ],
+                },
+                event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+                loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+                generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+                generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+              },
+              // Invalid bucket: missing connector_id
+              {
+                key: 'exec-uuid-invalid',
+                doc_count: 1,
+                alerts_context_count: { value: 1 },
+                connector_id: { buckets: [] },
+                discoveries: { value: 2 },
+                event_actions: {
+                  buckets: [
+                    { key: 'generation-started', doc_count: 1 },
+                    { key: 'generation-succeeded', doc_count: 1 },
+                  ],
+                },
+                event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+                loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+                generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+                generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+              },
+            ],
+          },
+        },
+      };
+      result = transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger });
+    });
+
+    it('returns only one generation', () => {
+      expect(result.generations.length).toBe(1);
+    });
+
+    it('has execution_uuid of exec-uuid-valid', () => {
+      expect(result.generations[0].execution_uuid).toBe('exec-uuid-valid');
+    });
+  });
+
+  it('verifies that debug logs are called for skipped buckets', () => {
+    const mockLogger = loggingSystemMock.createLogger();
+    const rawResponse = {
+      aggregations: {
+        generations: {
+          buckets: [
+            {
+              key: 'exec-uuid-debug-test',
+              doc_count: 1,
+              alerts_context_count: { value: 1 },
+              connector_id: { buckets: [] }, // missing connector_id will cause skip
+              discoveries: { value: 2 },
+              event_actions: {
+                buckets: [
+                  { key: 'generation-started', doc_count: 1 },
+                  { key: 'generation-succeeded', doc_count: 1 },
+                ],
+              },
+              event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+              loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+              generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+              generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+            },
+          ],
+        },
+      },
+    };
+
+    transformGetAttackDiscoveryGenerationsSearchResult({
+      rawResponse,
+      logger: mockLogger,
+    });
+
+    expect(mockLogger.debug).toHaveBeenCalled();
+  });
+
+  describe('handles different generation statuses based on event actions', () => {
+    let result: ReturnType<typeof transformGetAttackDiscoveryGenerationsSearchResult>;
+    beforeEach(() => {
+      const rawResponse = {
+        aggregations: {
+          generations: {
+            buckets: [
+              // Test "started" status (only generation-started action)
+              {
+                key: 'exec-uuid-running',
+                doc_count: 1,
+                alerts_context_count: { value: 1 },
+                connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+                discoveries: { value: 0 },
+                event_actions: {
+                  buckets: [{ key: 'generation-started', doc_count: 1 }], // only started, not completed
+                },
+                event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+                loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+                generation_end_time: { value_as_string: null },
+                generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+              },
+              // Test "canceled" status
+              {
+                key: 'exec-uuid-canceled',
+                doc_count: 1,
+                alerts_context_count: { value: 1 },
+                connector_id: { buckets: [{ key: 'test-connector', doc_count: 1 }] },
+                discoveries: { value: 0 },
+                event_actions: {
+                  buckets: [
+                    { key: 'generation-started', doc_count: 1 },
+                    { key: 'generation-canceled', doc_count: 1 },
+                  ],
+                },
+                event_reason: { buckets: [{ key: 'test-reason', doc_count: 1 }] },
+                loading_message: { buckets: [{ key: 'Loading...', doc_count: 1 }] },
+                generation_end_time: { value_as_string: '2025-07-30T00:00:00Z' },
+                generation_start_time: { value_as_string: '2025-07-29T00:00:00Z' },
+              },
+            ],
+          },
+        },
+      };
+      result = transformGetAttackDiscoveryGenerationsSearchResult({ rawResponse, logger });
+    });
+
+    it('returns two generations', () => {
+      expect(result.generations.length).toBe(2);
+    });
+
+    it('has status "started" for exec-uuid-running', () => {
+      const runningGeneration = result.generations.find(
+        (g) => g.execution_uuid === 'exec-uuid-running'
+      );
+
+      expect(runningGeneration?.status).toBe('started');
+    });
+
+    it('has status "canceled" for exec-uuid-canceled', () => {
+      const canceledGeneration = result.generations.find(
+        (g) => g.execution_uuid === 'exec-uuid-canceled'
+      );
+
+      expect(canceledGeneration?.status).toBe('canceled');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_search_response_to_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_search_response_to_alerts/index.test.ts
@@ -5,52 +5,274 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
 import {
   ALERT_RULE_EXECUTION_UUID,
   ALERT_START,
   ALERT_UPDATED_AT,
-  ALERT_UPDATED_BY_USER_ID,
-  ALERT_UPDATED_BY_USER_NAME,
   ALERT_WORKFLOW_STATUS_UPDATED_AT,
 } from '@kbn/rule-data-utils';
-import type { Logger } from '@kbn/core/server';
 
 import { transformSearchResponseToAlerts } from '.';
 import { getResponseMock } from '../../../../../__mocks__/attack_discovery_alert_document_response';
 import { ALERT_ATTACK_DISCOVERY_REPLACEMENTS } from '../../../schedules/fields/field_names';
 
-// Manual logger mock implementing all Logger methods
 const createLoggerMock = (): Logger =>
   ({
-    warn: jest.fn(),
-    info: jest.fn(),
     debug: jest.fn(),
-    trace: jest.fn(),
     error: jest.fn(),
     fatal: jest.fn(),
     get: jest.fn(() => createLoggerMock()),
+    info: jest.fn(),
     isLevelEnabled: jest.fn(() => true),
+    trace: jest.fn(),
+    warn: jest.fn(),
   } as unknown as Logger);
 
 describe('transformSearchResponseToAlerts', () => {
   let logger: Logger;
+
   beforeEach(() => {
     logger = createLoggerMock();
   });
 
-  it('returns alerts from a valid search response', () => {
+  it('returns the expected alerts from a valid search response', () => {
     const response = getResponseMock();
+
     const result = transformSearchResponseToAlerts({ logger, response });
 
-    expect(result.data.length).toBeGreaterThan(0);
+    expect(result.data).toEqual([
+      {
+        alertIds: [
+          'ee183cf525d7e9d0f47d1b2bb928d760a0f53756ffa61edcf0672f71c986ac21',
+          '46ebac989ca72439b14b57d32102543c17d5f33e0f6532d8a5c148949d8ff7b5',
+          '857f6434220ff27f807bef6829f32d1ad1c337026db016bc54e302eecf95cf93',
+          'e892d2e28a1e10822385cd0bff1399d63d1014961e020d9b3251dd24764914e6',
+          '492c647e3c671a9d62567d100cdad1a503c749755db3b67ba3c08335acc79e18',
+          '9004764b04239eed88a61a6779c5b1dc82ec3ff6f05ab1dcd6892df75322958d',
+          '4f27dc19eee50707adfb1fc9710292bc2264d176fea671a26bb90b904d565547',
+          '5cbe0d15df86b6b080ace4139338eb2a8b3e9696dd28f8c7f586747a88652a38',
+          'f9aea50da1ae3e4c157802f64eb090bbfa65fc95d1c1d39c4c16d9dc52338a67',
+          '713a8950584268a0c48fa85f60b71a4aa200043587f9136aa3b2e5269a01377b',
+          '624a2d4db0705ad13bceb19655dc23c89db1fcb3dfb1162f579495e291692528',
+          'f3108492aabb7b342bf6880cff39060092f0465dd16e4413ae4da3d03ab9ce27',
+          '3f3e3169d8c4270ad33eb4b5943d6d52023a410b7f6e9ce9569ea85d6aa67dc4',
+          '7934c23154502cb585332d9540072f6678d18296aa4ce63ff46b5645114c1ece',
+          '3496beb26016dd31fb3bcaff1363d694f10819a0965447c5a13a2c5ef7e69e76',
+          'f6c88010fa0ac0022c6c4270deeeea4dcf54d2cce9ca3a19e307726a703cbf97',
+          '4aa5b853e0284a1d3a7f5c55b9cc2dd3ff832cdfa617c8cb78159872c0524db4',
+          '4833ff1e37aa3f63b60cb360c89864210fa63224ff1eecdc8084d081795e0cf7',
+          'a34a21fcb0a4b3ba10fc15575346b8f8122b14664f06a41929ca19fc6f07fd33',
+          '09ab33140c37cbadc84f75e833ca0f7846951938dbe75bbe6144b83083c0cc56',
+          'cdf0665f5fb126bd53d17979ca8ecfc06b62325ad31e8784a0d171d31b12de7f',
+          '35ddcc81c91ef0a6db1b4243bfbb39d90a40123222a3d7ab8379ab9a83420c46',
+          '01566232ff1a19c907dd99bcfb5dca1525b8b1038f5ef35896b6419db55dc585',
+          '3bf858728a763b6c95846eb75393f2c61081390cf42043e41929a0762b272cd0',
+          '3efcb54f2f75e1b1386284db7a050fb5d002dd604a3078090e3164174377a7ee',
+          '7ee01f9f3928491be0184aea39ba21ee38864c54858d2d33de52b3316b8600dc',
+          'b26078a6de3d1e023a78902dc966dc433c9125bb9b12db1c1b1d0c8512ef2853',
+          '859e93ffbafba637fe3bf36ff2288b7461c9b559656e13129ea878fca5f2486a',
+          'c0e618e366e374f6a60ab32dc006356680904a618c7e0ee31a574a248aaf83cf',
+          '57f1eb796cd46413992f214bf89db53fc549b4fc6e8d3d8769c2c1a8dd8a3078',
+          '1021ef6fd529c9f45d3e2ac791f0a7de332514dd9dcc7640f839db617649cd75',
+          '7bb4d2d5168cc13d4e8a7558eb68d2d189833cddedaf03e7959e9a256038c9fe',
+          'a14446fdfcb3559556ff08f1d9fc97d72435a8741ede1a59302211d4a2b1a7bd',
+          'c8008b0d2af8987698f8b10d925c1e088c8b72571d32a74120ba8b7416c8b818',
+          'b767e145aaa84bf01d80eed08c9135bc3f7c9c638593fd82e1ea8155a41317d3',
+          '2f18e88a345a3d183b2093cb15bd8d68fb37e7485e55a9938ec385386114a710',
+          'aa9fa70573cbc8136171543179244abc563ca839890ec0f19c32aaee7d91d5ee',
+          'd4a609ca641075862e9e94f6ca70b699c734279f424a39ae54498e74d57a9edf',
+          '1ca972204a9667f163f29c6d732ac6cafdf1a0793e029c8b2df9e84254619486',
+          '4a52df99422830601a2daa35f574e08214a4ec23ad82578c6a33a4bc24614177',
+          'c720d533a8086db64aa19dc289ba7d8dba931c0c1e81c31b3a2381108bd54f80',
+          '1d0b42cc9bab440d30ae6ccf0b586fac1a3416e2470e84b0e7fe2fe336b3ecdb',
+          '152c39218c74e1f1efea9f6a592e85c9b3715ac4c9b36f2a67c3b66f7cda476a',
+          '41e37269498d007217b82e0e5e0bd2bc11cfb8472d22f2bf5d57bf559518bc90',
+          '96a013fe5840fa4ebf9e8b413ad9ba5c6b9da0406225e0bd6ad4d1a7110045c0',
+          '67bad3f1ee713789aa58a8f712e31e55816df15a08e4fef17f0a77f0dcea2a16',
+          'bfc18b3ee2c15d34d80fc3781902b7e90f689f7298f368712c3dd5b8640e6f06',
+          '756e21cf69f49031f99fb60e05bbd5cf3b6101528cb84ea5f8cb6c328c727f68',
+          '1d1a2fc0aa17f818c49dcd1effbe3f0d3b937ceb2852f0614f272141a432683b',
+          'efd78eda82be49976cba570675624475838d97462795fa427582c09a08914e24',
+          'a5774ec28dceccdd88b4cedced5c09004023005c47438ceb538edf906a3a4976',
+          '0c19dd81b6abe18b3a3e72aa471c8ab9c08f0c76acf80441b1556f6520e63607',
+          '5f05a2d80b8b0b78c3b978b8b4143b863832d99f8f02c793aed23419d80889ae',
+          'b189d3e05a0dd24cd5326150fdf95460be60914bf919da3cdad707827e360444',
+          'ca88c363dae68e62a690e63e90728538431b30d35b3686adb32d7a973350a456',
+          '2612f23d1dc0c3fdc3679c2cf05b66e150fdef006b02d59fd317d70c76018d8c',
+          '168d23918d7561c7494a2d5b75a12a515ec6054c78801f26512a757b40e81e08',
+          'ad590fd49fa67224d9a562ad33d4b7d8f8bca6f63ff5d8c1859127d43b49fb15',
+          '9be5996df1622222a96b4b3d6359f06922866cb4560c0cd8a806be8b828e7531',
+          '644e2c3a505baa9cdc047972ecff9e7ede214fa964b392efc2dcda4a80c9c60e',
+          '05a26a422f52e03b318e763ecd53d027b39bbf1920b53babc33fba9db0f10fc4',
+          'fbf23653042416c886f12df972a885d847fe5681f466aff64a611aa01f9a5011',
+          'b0c92ae7ecaa07702798fbb161ce189a80da259390876c14daace753d73896f9',
+        ],
+        alertRuleUuid: 'attack_discovery_ad_hoc_rule_id',
+        alertStart: '2025-06-23T14:25:24.104Z',
+        alertUpdatedAt: '2025-06-23T15:16:52.984Z',
+        alertUpdatedByUserId: 'u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0',
+        alertUpdatedByUserName: 'elastic',
+        alertWorkflowStatus: 'acknowledged',
+        alertWorkflowStatusUpdatedAt: '2025-06-23T15:16:52.984Z',
+        connectorId: 'gemini_2_5_pro',
+        connectorName: 'Gemini 2.5 Pro',
+        detailsMarkdown:
+          'A widespread attack campaign was executed across multiple Windows hosts, unified by the use of a single compromised user account, {{ user.name 6f53c297-f5cb-48c3-8aff-2e2d7a390169 }}. The attacker leveraged this access to deploy a variety of malware families using different initial access and execution techniques, culminating in a ransomware attack.\n* **Qakbot Infection:** On host {{ host.name 0d7534c9-79f5-46ed-9df9-3dfcff57e5ed }}, the attack began with a malicious OneNote file. This led to {{ process.name mshta.exe }} executing a script, which used {{ process.name curl.exe }} to download a payload from {{ source.ip 77.75.230.128 }}. The payload was executed via {{ process.name rundll32.exe }} and injected into {{ process.name AtBroker.exe }}, identified as the {{ rule.name Windows.Trojan.Qbot }} trojan.\n* **Emotet Infection:** On host {{ host.name deb5784c-55d3-4422-9d7c-06f1f71c04b3 }}, a malicious Excel document spawned {{ process.name regsvr32.exe }} to load a malicious DLL, ultimately leading to the execution of the {{ rule.name Windows.Trojan.Emotet }} trojan and the establishment of persistence via registry run keys.\n* **Bumblebee Trojan:** On host {{ host.name 4d9943f7-cbef-462b-a882-e39db5da7abd }}, the attacker used {{ process.parent.name msiexec.exe }} to proxy the execution of a malicious PowerShell script, which injected the {{ rule.name Windows.Trojan.Bumblebee }} trojan into its own memory and established C2 communication.\n* **Generic Droppers:** On other hosts, similar initial access vectors were used. On host {{ host.name 9a98cc1d-a7a3-4924-b939-b17b2ec5dbdd }}, a Word document dropped and executed a VBScript, which then used PowerShell and created a scheduled task for persistence. On host {{ host.name 7c9a79a0-c029-4acb-b61c-d5831b409943 }}, an Excel file used {{ process.name certutil.exe }} to decode and execute a payload.\n* **Ransomware Deployment:** The campaign culminated on host {{ host.name 6aece05f-675e-4dc0-b8fa-ba0f1a43d691 }} with the deployment of Sodinokibi (REvil) ransomware. A malicious executable used DLL side-loading to compromise the legitimate Microsoft Defender process, {{ process.name MsMpEng.exe }}, which then executed the ransomware and began encrypting files.',
+        entitySummaryMarkdown:
+          'A widespread malware campaign using the compromised account of user {{ user.name 6f53c297-f5cb-48c3-8aff-2e2d7a390169 }} impacted multiple Windows hosts, including {{ host.name 6aece05f-675e-4dc0-b8fa-ba0f1a43d691 }} and {{ host.name 0d7534c9-79f5-46ed-9df9-3dfcff57e5ed }}.',
+        generationUuid: 'c10c51a5-10d2-481d-853a-e7fd5f393b23',
+        id: '29ceb1fa1482f02a2eb6073991078544e529edfc633a5621b20a93eefbb63083',
+        mitreAttackTactics: [
+          'Initial Access',
+          'Execution',
+          'Persistence',
+          'Defense Evasion',
+          'Command and Control',
+          'Impact',
+        ],
+        replacements: {
+          'e56f5c52-ebb0-4ec8-aad5-2659df2e0206': 'root',
+          '99612aef-0a5a-41da-9da4-b5b5ece226a4': 'SRVMAC08',
+          '02de873c-51e3-4c01-8a22-0986225775f3': 'james',
+          '9a98cc1d-a7a3-4924-b939-b17b2ec5dbdd': 'SRVWIN07',
+          '6f53c297-f5cb-48c3-8aff-2e2d7a390169': 'Administrator',
+          '4d9943f7-cbef-462b-a882-e39db5da7abd': 'SRVWIN06',
+          'aa5e02c8-f542-4db9-8ade-87fd1283ddac': 'SRVNIX05',
+          '0d7534c9-79f5-46ed-9df9-3dfcff57e5ed': 'SRVWIN04',
+          'deb5784c-55d3-4422-9d7c-06f1f71c04b3': 'SRVWIN03',
+          '6aece05f-675e-4dc0-b8fa-ba0f1a43d691': 'SRVWIN02',
+          '7c9a79a0-c029-4acb-b61c-d5831b409943': 'SRVWIN01',
+        },
+        riskScore: 6237,
+        summaryMarkdown:
+          'A widespread campaign was conducted using the compromised account of user {{ user.name 6f53c297-f5cb-48c3-8aff-2e2d7a390169 }}, deploying various malware including Sodinokibi, Emotet, Qakbot, and Bumblebee across multiple Windows hosts.',
+        timestamp: '2025-06-23T14:25:24.104Z',
+        title: 'Widespread Malware Campaign via Compromised Account',
+        userId: 'u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0',
+        userName: 'elastic',
+        users: [
+          {
+            name: 'elastic',
+            id: 'u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0',
+          },
+        ],
+      },
+    ]);
   });
 
-  it('skips hits with missing required fields and calls logger.warn', () => {
+  it('calls logger.warn when the response is missing required fields', () => {
     const response = getResponseMock();
     response.hits.hits[0]._source = undefined;
+
     transformSearchResponseToAlerts({ logger, response });
 
     expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('returns empty data if all hits are missing required fields', () => {
+    const response = getResponseMock();
+    response.hits.hits = [
+      {
+        _id: '1',
+        _index: 'foo',
+        _source: undefined,
+      },
+      {
+        _id: '2',
+        _index: 'foo',
+        _source: undefined,
+      },
+    ];
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data).toEqual([]);
+  });
+
+  it('correctly transforms the ALERT_START field', () => {
+    const response = getResponseMock();
+    const testDate = '2024-01-01T12:00:00.000Z';
+    if (response.hits.hits[0]._source) {
+      response.hits.hits[0]._source[ALERT_START] = testDate;
+    }
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data[0].alertStart).toBe(testDate);
+  });
+
+  it('correctly transforms the ALERT_UPDATED_AT field', () => {
+    const response = getResponseMock();
+    const testDate = '2024-02-02T15:30:00.000Z';
+    if (response.hits.hits[0]._source) {
+      response.hits.hits[0]._source[ALERT_UPDATED_AT] = testDate;
+    }
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data[0].alertUpdatedAt).toBe(testDate);
+  });
+
+  it('correctly transforms the ALERT_WORKFLOW_STATUS_UPDATED_AT field', () => {
+    const response = getResponseMock();
+    const testDate = '2024-03-03T10:20:30.000Z';
+    if (response.hits.hits[0]._source) {
+      response.hits.hits[0]._source[ALERT_WORKFLOW_STATUS_UPDATED_AT] = testDate;
+    }
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data[0].alertWorkflowStatusUpdatedAt).toBe(testDate);
+  });
+
+  it("returns undefined for mitreAttackTactics when it's not an array", () => {
+    const response = getResponseMock();
+    if (response.hits.hits[0]._source) {
+      const src = response.hits.hits[0]._source as unknown as Record<string, unknown>; // purposely assign the wrong type for test
+      src['kibana.alert.attack_discovery.mitre_attack_tactics'] = 123;
+    }
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data[0].mitreAttackTactics).toBeUndefined();
+  });
+
+  it("returns undefined for replacements when it's not an array", () => {
+    const response = getResponseMock();
+    if (response.hits.hits[0]._source) {
+      const src = response.hits.hits[0]._source as unknown as Record<string, unknown>; // purposely assign the wrong type for test
+      src[ALERT_ATTACK_DISCOVERY_REPLACEMENTS] = 123;
+    }
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data[0].replacements).toBeUndefined();
+  });
+
+  it('returns empty data if ALERT_ATTACK_DISCOVERY_API_CONFIG is missing', () => {
+    const response = getResponseMock();
+    if (response.hits.hits[0]._source) {
+      const src = response.hits.hits[0]._source as unknown as Record<string, unknown>; // purposely delete required field for test
+      delete src['kibana.alert.attack_discovery.api_config'];
+    }
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data).toEqual([]);
+  });
+
+  it('returns empty data if both _id and ALERT_RULE_EXECUTION_UUID are missing', () => {
+    const response = getResponseMock();
+    (response.hits.hits[0] as unknown as Record<string, unknown>)._id = undefined; // purposely assign undefined to _id for test
+    if (response.hits.hits[0]._source) {
+      const src = response.hits.hits[0]._source as unknown as Record<string, unknown>;
+      delete src[ALERT_RULE_EXECUTION_UUID]; // purposely delete ALERT_RULE_EXECUTION_UUID for test
+    }
+
+    const result = transformSearchResponseToAlerts({ logger, response });
+
+    expect(result.data).toEqual([]);
   });
 
   it('returns uniqueAlertIdsCount from aggregation if present', () => {
@@ -89,33 +311,16 @@ describe('transformSearchResponseToAlerts', () => {
   it('returns empty connectorNames if aggregation is missing', () => {
     const response = getResponseMock();
     response.aggregations = undefined;
+
     const result = transformSearchResponseToAlerts({ logger, response });
 
     expect(result.connectorNames).toEqual([]);
   });
 
-  it('returns empty data if all hits are missing required fields', () => {
-    const response = getResponseMock();
-    response.hits.hits = [
-      {
-        _id: '1',
-        _index: 'foo',
-        _source: undefined,
-      },
-      {
-        _id: '2',
-        _index: 'foo',
-        _source: undefined,
-      },
-    ];
-    const result = transformSearchResponseToAlerts({ logger, response });
-
-    expect(result.data).toEqual([]);
-  });
-
   it('returns empty data if hits is empty', () => {
     const response = getResponseMock();
     response.hits.hits = [];
+
     const result = transformSearchResponseToAlerts({ logger, response });
 
     expect(result.data).toEqual([]);
@@ -128,7 +333,9 @@ describe('transformSearchResponseToAlerts', () => {
       response.hits.hits[0]._source['@timestamp'] = 'not-a-date';
       response.hits.hits[0]._source[ALERT_START] = 'not-a-date';
     }
+
     const result = transformSearchResponseToAlerts({ logger, response });
+
     expect(new Date(result.data[0].timestamp).toString()).not.toBe('Invalid Date');
     expect(result.data[0].alertStart).toBeUndefined();
   });
@@ -142,7 +349,9 @@ describe('transformSearchResponseToAlerts', () => {
         // skip invalid entries, only valid ones allowed by type
       ];
     }
+
     const result = transformSearchResponseToAlerts({ logger, response });
+
     expect(result.data[0].replacements).toEqual({ a: 'A' });
   });
 
@@ -159,57 +368,9 @@ describe('transformSearchResponseToAlerts', () => {
     // Simulate fallback: create a new hit with _id set to generationUuid and check
     const fallbackHit = { ...hit, _id: 'gen-uuid' };
     response.hits.hits = [fallbackHit];
+
     result = transformSearchResponseToAlerts({ logger, response });
+
     expect(result.data[0].id).toBe('gen-uuid');
-  });
-
-  it('correctly transforms ALERT_START field', () => {
-    const response = getResponseMock();
-    const testDate = '2024-01-01T12:00:00.000Z';
-    if (response.hits.hits[0]._source) {
-      response.hits.hits[0]._source[ALERT_START] = testDate;
-    }
-    const result = transformSearchResponseToAlerts({ logger, response });
-    expect(result.data[0].alertStart).toBe(testDate);
-  });
-
-  it('correctly transforms ALERT_UPDATED_AT field', () => {
-    const response = getResponseMock();
-    const testDate = '2024-02-02T15:30:00.000Z';
-    if (response.hits.hits[0]._source) {
-      response.hits.hits[0]._source[ALERT_UPDATED_AT] = testDate;
-    }
-    const result = transformSearchResponseToAlerts({ logger, response });
-    expect(result.data[0].alertUpdatedAt).toBe(testDate);
-  });
-
-  it('correctly transforms ALERT_UPDATED_BY_USER_ID field', () => {
-    const response = getResponseMock();
-    const testId = 'user-123';
-    if (response.hits.hits[0]._source) {
-      response.hits.hits[0]._source[ALERT_UPDATED_BY_USER_ID] = testId;
-    }
-    const result = transformSearchResponseToAlerts({ logger, response });
-    expect(result.data[0].alertUpdatedByUserId).toBe(testId);
-  });
-
-  it('correctly transforms ALERT_UPDATED_BY_USER_NAME field', () => {
-    const response = getResponseMock();
-    const testName = 'testuser';
-    if (response.hits.hits[0]._source) {
-      response.hits.hits[0]._source[ALERT_UPDATED_BY_USER_NAME] = testName;
-    }
-    const result = transformSearchResponseToAlerts({ logger, response });
-    expect(result.data[0].alertUpdatedByUserName).toBe(testName);
-  });
-
-  it('correctly transforms ALERT_WORKFLOW_STATUS_UPDATED_AT field', () => {
-    const response = getResponseMock();
-    const testDate = '2024-03-03T10:20:30.000Z';
-    if (response.hits.hits[0]._source) {
-      response.hits.hits[0]._source[ALERT_WORKFLOW_STATUS_UPDATED_AT] = testDate;
-    }
-    const result = transformSearchResponseToAlerts({ logger, response });
-    expect(result.data[0].alertWorkflowStatusUpdatedAt).toBe(testDate);
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_search_response_to_alerts/is_missing_required_fields/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_search_response_to_alerts/is_missing_required_fields/index.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALERT_RULE_EXECUTION_UUID } from '@kbn/rule-data-utils';
+import { omit } from 'lodash/fp';
+
+import { isMissingRequiredFields } from '.';
+import { getResponseMock } from '../../../../../../__mocks__/attack_discovery_alert_document_response';
+import {
+  ALERT_ATTACK_DISCOVERY_ALERT_IDS,
+  ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT,
+  ALERT_ATTACK_DISCOVERY_API_CONFIG,
+  ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN,
+  ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN,
+  ALERT_ATTACK_DISCOVERY_TITLE,
+} from '../../../../schedules/fields/field_names';
+
+describe('isMissingRequiredFields', () => {
+  const getHit = () => {
+    const mock = getResponseMock();
+
+    const hit = mock.hits.hits[0];
+    return {
+      ...hit,
+      _source: hit._source ? { ...hit._source } : hit._source,
+    };
+  };
+
+  it('returns false for a valid document', () => {
+    const hit = getHit();
+
+    expect(isMissingRequiredFields(hit)).toBe(false);
+  });
+
+  it('returns true if _source is null', () => {
+    const hit = getHit();
+    // Simulate _source being undefined while keeping the rest of the shape
+    const hitWithUndefinedSource = { ...hit };
+    delete hitWithUndefinedSource._source;
+
+    expect(isMissingRequiredFields(hitWithUndefinedSource)).toBe(true);
+  });
+
+  it('returns true if @timestamp is missing', () => {
+    let hit = getHit();
+    if (hit._source) {
+      hit = {
+        ...hit,
+        _source: omit(['@timestamp'], hit._source) as typeof hit._source,
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_ALERT_IDS is not an array', () => {
+    const hit = getHit();
+    if (hit._source) {
+      // @ts-expect-error: testing invalid type
+      hit._source[ALERT_ATTACK_DISCOVERY_ALERT_IDS] = undefined;
+    }
+
+    expect(isMissingRequiredFields(hit as typeof hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_ALERT_IDS is not an array (string)', () => {
+    const hit = getHit();
+    if (hit._source) {
+      // @ts-expect-error: testing invalid type
+      hit._source[ALERT_ATTACK_DISCOVERY_ALERT_IDS] = 'not-an-array';
+    }
+
+    expect(isMissingRequiredFields(hit as typeof hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT is missing', () => {
+    let hit = getHit();
+    if (hit._source) {
+      hit = {
+        ...hit,
+        _source: omit(
+          [ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT],
+          hit._source
+        ) as typeof hit._source,
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_API_CONFIG is missing', () => {
+    let hit = getHit();
+    if (hit._source) {
+      hit = {
+        ...hit,
+        _source: omit([ALERT_ATTACK_DISCOVERY_API_CONFIG], hit._source) as typeof hit._source,
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_API_CONFIG.action_type_id is missing', () => {
+    let hit = getHit();
+    if (hit._source && hit._source[ALERT_ATTACK_DISCOVERY_API_CONFIG]) {
+      hit = {
+        ...hit,
+        _source: {
+          ...hit._source,
+          [ALERT_ATTACK_DISCOVERY_API_CONFIG]: omit(
+            ['action_type_id'],
+            hit._source[ALERT_ATTACK_DISCOVERY_API_CONFIG]
+          ) as (typeof hit._source)[typeof ALERT_ATTACK_DISCOVERY_API_CONFIG],
+        },
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_API_CONFIG.connector_id is missing', () => {
+    let hit = getHit();
+    if (hit._source && hit._source[ALERT_ATTACK_DISCOVERY_API_CONFIG]) {
+      hit = {
+        ...hit,
+        _source: {
+          ...hit._source,
+          [ALERT_ATTACK_DISCOVERY_API_CONFIG]: omit(
+            ['connector_id'],
+            hit._source[ALERT_ATTACK_DISCOVERY_API_CONFIG]
+          ) as (typeof hit._source)[typeof ALERT_ATTACK_DISCOVERY_API_CONFIG],
+        },
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_API_CONFIG.name is missing', () => {
+    let hit = getHit();
+    if (hit._source && hit._source[ALERT_ATTACK_DISCOVERY_API_CONFIG]) {
+      hit = {
+        ...hit,
+        _source: {
+          ...hit._source,
+          [ALERT_ATTACK_DISCOVERY_API_CONFIG]: omit(
+            ['name'],
+            hit._source[ALERT_ATTACK_DISCOVERY_API_CONFIG]
+          ) as (typeof hit._source)[typeof ALERT_ATTACK_DISCOVERY_API_CONFIG],
+        },
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN is missing', () => {
+    let hit = getHit();
+    if (hit._source) {
+      hit = {
+        ...hit,
+        _source: omit([ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN], hit._source) as typeof hit._source,
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_RULE_EXECUTION_UUID is missing', () => {
+    let hit = getHit();
+    if (hit._source) {
+      hit = {
+        ...hit,
+        _source: omit([ALERT_RULE_EXECUTION_UUID], hit._source) as typeof hit._source,
+      };
+    }
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if _id is missing', () => {
+    let hit = getHit();
+    hit = omit(['_id'], hit) as typeof hit;
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN is missing', () => {
+    let hit = getHit();
+    if (hit._source) {
+      hit = {
+        ...hit,
+        _source: omit([ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN], hit._source) as typeof hit._source,
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+
+  it('returns true if ALERT_ATTACK_DISCOVERY_TITLE is missing', () => {
+    let hit = getHit();
+    if (hit._source) {
+      hit = {
+        ...hit,
+        _source: omit([ALERT_ATTACK_DISCOVERY_TITLE], hit._source) as typeof hit._source,
+      };
+    }
+
+    expect(isMissingRequiredFields(hit)).toBe(true);
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_successful_generations_search_result/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_successful_generations_search_result/index.test.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AggregationsAggregate } from '@elastic/elasticsearch/lib/api/types';
+import { loggerMock } from '@kbn/logging-mocks';
+
+import { transformSuccessfulGenerationsSearchResult } from '.';
+
+interface RawResponse {
+  aggregations: AggregationsAggregate | undefined;
+}
+
+const mockRawResponse: RawResponse = {
+  aggregations: {
+    successfull_generations_by_connector_id: {
+      buckets: [
+        {
+          key: 'gpt41Azure',
+          doc_count: 2,
+          event_actions: {
+            buckets: [
+              {
+                key: 'generation-succeeded',
+                doc_count: 2,
+              },
+            ],
+          },
+          successful_generations: {
+            value: 2,
+          },
+          avg_event_duration_nanoseconds: {
+            value: 36714000000,
+          },
+          latest_successfull_generation: {
+            value: 1751061769473,
+            value_as_string: '2025-06-27T22:02:49.473Z',
+          },
+        },
+      ],
+    },
+  },
+};
+
+describe('transformSuccessfulGenerationsSearchResult', () => {
+  const mockLogger = loggerMock.create();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns transformed successful generations metadata when the raw response is valid', () => {
+    const result = transformSuccessfulGenerationsSearchResult({
+      logger: mockLogger,
+      rawResponse: mockRawResponse,
+    });
+
+    expect(result).toEqual({
+      gpt41Azure: {
+        averageSuccessfulDurationNanoseconds: 36714000000,
+        successfulGenerations: 2,
+      },
+    });
+  });
+
+  it('returns transformed metadata with multiple connectors', () => {
+    const multiConnectorResponse: RawResponse = {
+      aggregations: {
+        successfull_generations_by_connector_id: {
+          buckets: [
+            {
+              key: 'gpt41Azure',
+              doc_count: 2,
+              event_actions: {
+                buckets: [
+                  {
+                    key: 'generation-succeeded',
+                    doc_count: 2,
+                  },
+                ],
+              },
+              successful_generations: {
+                value: 2,
+              },
+              avg_event_duration_nanoseconds: {
+                value: 36714000000,
+              },
+              latest_successfull_generation: {
+                value: 1751061769473,
+                value_as_string: '2025-06-27T22:02:49.473Z',
+              },
+            },
+            {
+              key: 'claude3',
+              doc_count: 5,
+              event_actions: {
+                buckets: [
+                  {
+                    key: 'generation-succeeded',
+                    doc_count: 5,
+                  },
+                ],
+              },
+              successful_generations: {
+                value: 5,
+              },
+              avg_event_duration_nanoseconds: {
+                value: 25000000000,
+              },
+              latest_successfull_generation: {
+                value: 1751061869473,
+                value_as_string: '2025-06-27T22:04:29.473Z',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const result = transformSuccessfulGenerationsSearchResult({
+      logger: mockLogger,
+      rawResponse: multiConnectorResponse,
+    });
+
+    expect(result).toEqual({
+      gpt41Azure: {
+        averageSuccessfulDurationNanoseconds: 36714000000,
+        successfulGenerations: 2,
+      },
+      claude3: {
+        averageSuccessfulDurationNanoseconds: 25000000000,
+        successfulGenerations: 5,
+      },
+    });
+  });
+
+  it('returns transformed metadata when average duration is null', () => {
+    const responseWithNullDuration: RawResponse = {
+      aggregations: {
+        successfull_generations_by_connector_id: {
+          buckets: [
+            {
+              key: 'gpt41Azure',
+              doc_count: 2,
+              event_actions: {
+                buckets: [
+                  {
+                    key: 'generation-succeeded',
+                    doc_count: 2,
+                  },
+                ],
+              },
+              successful_generations: {
+                value: 2,
+              },
+              avg_event_duration_nanoseconds: {
+                value: null,
+              },
+              latest_successfull_generation: {
+                value: 1751061769473,
+                value_as_string: '2025-06-27T22:02:49.473Z',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const result = transformSuccessfulGenerationsSearchResult({
+      logger: mockLogger,
+      rawResponse: responseWithNullDuration,
+    });
+
+    expect(result).toEqual({
+      gpt41Azure: {
+        averageSuccessfulDurationNanoseconds: undefined,
+        successfulGenerations: 2,
+      },
+    });
+  });
+
+  it('returns an empty object when the buckets array is empty', () => {
+    const responseWithEmptyBuckets: RawResponse = {
+      aggregations: {
+        successfull_generations_by_connector_id: {
+          buckets: [],
+        },
+      },
+    };
+
+    const result = transformSuccessfulGenerationsSearchResult({
+      logger: mockLogger,
+      rawResponse: responseWithEmptyBuckets,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  describe('when raw response validation fails', () => {
+    let invalidResponse: unknown;
+
+    beforeEach(() => {
+      invalidResponse = {
+        aggregations: {
+          wrong_field_name: {
+            buckets: [],
+          },
+        },
+      };
+    });
+
+    it('throws an error', () => {
+      expect(() => {
+        transformSuccessfulGenerationsSearchResult({
+          logger: mockLogger,
+          rawResponse: invalidResponse as { aggregations: AggregationsAggregate | undefined },
+        });
+      }).toThrow('Failed to parse search results in transformSuccessfulGenerationsSearchResult');
+    });
+
+    it('logs an error', () => {
+      try {
+        transformSuccessfulGenerationsSearchResult({
+          logger: mockLogger,
+          rawResponse: invalidResponse as { aggregations: AggregationsAggregate | undefined },
+        });
+      } catch (e) {
+        // error expected
+      }
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Failed to parse search results in transformSuccessfulGenerationsSearchResult'
+        )
+      );
+    });
+  });
+
+  it('throws error and logs when aggregations is undefined', () => {
+    const responseWithUndefinedAggregations: RawResponse = {
+      aggregations: undefined,
+    };
+
+    expect(() => {
+      transformSuccessfulGenerationsSearchResult({
+        logger: mockLogger,
+        rawResponse: responseWithUndefinedAggregations,
+      });
+    }).toThrow('Failed to parse search results in transformSuccessfulGenerationsSearchResult');
+  });
+
+  it('throws when the bucket structure is invalid', () => {
+    const responseWithInvalidBucket = {
+      aggregations: {
+        successfull_generations_by_connector_id: {
+          buckets: [
+            {
+              key: 'gpt41Azure',
+              doc_count: 2,
+              // Missing required fields
+            },
+          ],
+        },
+      },
+    };
+
+    expect(() => {
+      transformSuccessfulGenerationsSearchResult({
+        logger: mockLogger,
+        rawResponse: responseWithInvalidBucket,
+      });
+    }).toThrow('Failed to parse search results in transformSuccessfulGenerationsSearchResult');
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/get_alert_risk_score/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/get_alert_risk_score/index.test.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Document } from '@langchain/core/documents';
+
+import { getAlertRiskScore } from '.';
+
+describe('getAlertRiskScore', () => {
+  // Test data with minimal examples covering different scenarios
+  const createAlertDocument = (alertId: string, riskScore?: number): Document => ({
+    pageContent: `@timestamp,2024-10-16T02:40:08.837Z
+_id,${alertId}
+${riskScore !== undefined ? `kibana.alert.risk_score,${riskScore}` : ''}
+host.name,test-host
+event.category,malware
+message,Test alert`,
+    metadata: {},
+  });
+
+  const alertIdWithRiskScore = '87c42d26897490ee02ba42ec4e872910b29f3c69bda357b8faf197b533b8528a';
+  const alertIdWithoutRiskScore =
+    'be6d293f9a71ba209adbcacc3ba04adfd8e9456260f6af342b7cb0478a7a144a';
+  const nonExistentAlertId = 'f9c0dc4953531a9fc757e8ae88bf70a70e20dfc665de92241f162cff9191fa4e';
+
+  let anonymizedAlerts: Document[];
+
+  beforeEach(() => {
+    anonymizedAlerts = [
+      createAlertDocument(alertIdWithRiskScore, 99),
+      createAlertDocument(alertIdWithoutRiskScore), // No risk score
+    ];
+  });
+
+  describe('when provided valid alert IDs with risk scores', () => {
+    it('returns the sum of risk scores for matching alerts', () => {
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBe(99);
+    });
+
+    it('returns the sum when multiple alerts with risk scores match', () => {
+      const secondAlertId = 'second-alert-id';
+      anonymizedAlerts.push(createAlertDocument(secondAlertId, 75));
+
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore, secondAlertId],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBe(174);
+    });
+  });
+
+  describe('when provided alert IDs without risk scores', () => {
+    it('returns undefined when alert exists but has no risk score', () => {
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithoutRiskScore],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when provided non-existent alert IDs', () => {
+    it('returns undefined when alert ID does not exist in documents', () => {
+      const result = getAlertRiskScore({
+        alertIds: [nonExistentAlertId],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when provided empty inputs', () => {
+    it('returns undefined when alert IDs array is empty', () => {
+      const result = getAlertRiskScore({
+        alertIds: [],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when anonymized alerts array is empty', () => {
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore],
+        anonymizedAlerts: [],
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when provided mixed scenarios', () => {
+    it('returns sum of only the alerts with risk scores', () => {
+      const alertWithRisk = 'alert-with-risk';
+      anonymizedAlerts.push(createAlertDocument(alertWithRisk, 50));
+
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore, alertIdWithoutRiskScore, alertWithRisk],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBe(149); // 99 + 50
+    });
+
+    it('returns undefined when some alert IDs exist but none have risk scores', () => {
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithoutRiskScore, nonExistentAlertId],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when document pageContent format is malformed', () => {
+    it('returns undefined when pageContent does not contain the _id field', () => {
+      const malformedDoc: Document = {
+        pageContent: 'kibana.alert.risk_score,99\nhost.name,test-host',
+        metadata: {},
+      };
+
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore],
+        anonymizedAlerts: [malformedDoc],
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the risk score field has an invalid format', () => {
+      const invalidRiskScoreDoc: Document = {
+        pageContent: `_id,${alertIdWithRiskScore}\nkibana.alert.risk_score,invalid\nhost.name,test-host`,
+        metadata: {},
+      };
+
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore],
+        anonymizedAlerts: [invalidRiskScoreDoc],
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns undefined when risk score is zero', () => {
+      anonymizedAlerts = [createAlertDocument(alertIdWithRiskScore, 0)];
+
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns risk score when only one alert has a positive risk score', () => {
+      const zeroRiskAlertId = 'zero-risk-alert';
+      anonymizedAlerts.push(createAlertDocument(zeroRiskAlertId, 0));
+
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore, zeroRiskAlertId],
+        anonymizedAlerts,
+      });
+
+      expect(result).toBe(99);
+    });
+
+    it('returns undefined when risk score is NaN', () => {
+      const nanRiskScoreDoc: Document = {
+        pageContent: `_id,${alertIdWithRiskScore}\nkibana.alert.risk_score,NaN\nhost.name,test-host`,
+        metadata: {},
+      };
+
+      const result = getAlertRiskScore({
+        alertIds: [alertIdWithRiskScore],
+        anonymizedAlerts: [nanRiskScoreDoc],
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the extracted ID is null', () => {
+      const nullIdDoc: Document = {
+        pageContent: '_id,\nkibana.alert.risk_score,99\nhost.name,test-host',
+        metadata: {},
+      };
+
+      const result = getAlertRiskScore({
+        alertIds: [''],
+        anonymizedAlerts: [nullIdDoc],
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.test.ts
@@ -233,6 +233,48 @@ describe('Transform attack discoveries to alert documents', () => {
 
       expect(result[0][ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toBeUndefined();
     });
+
+    it('returns undefined for replacements when replacements is undefined', () => {
+      const params = {
+        ...mockCreateAttackDiscoveryAlertsParams,
+        replacements: undefined,
+      };
+
+      const result = transformToAlertDocuments({
+        ...defaultProps,
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: params,
+        now: mockNow,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toBeUndefined();
+    });
+
+    it('returns undefined for entitySummaryMarkdown_with_replacements when entitySummaryMarkdown is an empty string', () => {
+      const params = {
+        ...mockCreateAttackDiscoveryAlertsParams,
+        attackDiscoveries: [
+          {
+            ...mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0],
+            entitySummaryMarkdown: '',
+          },
+        ],
+      };
+
+      const result = transformToAlertDocuments({
+        ...defaultProps,
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: params,
+        now: mockNow,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]).toEqual(
+        replaceAnonymizedValuesWithOriginalValues({
+          messageContent: '',
+          replacements: params.replacements ?? {},
+        })
+      );
+    });
   });
 
   describe('transformToBaseAlertDocument', () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/register_event_log_provider/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/register_event_log_provider/index.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IEventLogService } from '@kbn/event-log-plugin/server';
+
+import { registerEventLogProvider } from '.';
+import {
+  ATTACK_DISCOVERY_EVENT_ACTIONS,
+  ATTACK_DISCOVERY_EVENT_PROVIDER,
+} from '../../common/constants';
+
+describe('registerEventLogProvider', () => {
+  let eventLog: IEventLogService;
+
+  beforeEach(() => {
+    eventLog = {
+      getProviderActionId: jest.fn().mockReturnValue(''),
+      getProviderActionName: jest.fn().mockReturnValue(''),
+      getProviderActions: jest.fn().mockReturnValue([]),
+      getProviderActionsForProvider: jest.fn().mockReturnValue([]),
+      isIndexingEntries: jest.fn().mockReturnValue(true),
+      isLoggingEntries: jest.fn().mockReturnValue(true),
+      isProviderActionRegistered: jest.fn().mockReturnValue(false),
+      registerProviderActions: jest.fn(),
+    } as unknown as IEventLogService;
+  });
+
+  it('calls registerProviderActions with correct provider and actions', () => {
+    registerEventLogProvider(eventLog);
+
+    expect(eventLog.registerProviderActions).toHaveBeenCalledWith(
+      ATTACK_DISCOVERY_EVENT_PROVIDER,
+      ATTACK_DISCOVERY_EVENT_ACTIONS
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/get/find_attack_discoveries.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/get/find_attack_discoveries.test.ts
@@ -11,10 +11,10 @@ import { httpServiceMock, httpServerMock } from '@kbn/core-http-server-mocks';
 import { findAttackDiscoveriesRoute } from './find_attack_discoveries';
 import * as helpers from '../../helpers';
 import { hasReadAttackDiscoveryAlertsPrivileges } from '../helpers/index_privileges';
+import { AttackDiscoveryDataClient } from '../../../lib/attack_discovery/persistence';
 import { getMockAttackDiscoveryFindResponse } from '../../../__mocks__/attack_discovery_find_response';
 import { mockAuthenticatedUser } from '../../../__mocks__/mock_authenticated_user';
 import { requestContextMock } from '../../../__mocks__/request_context';
-import { AttackDiscoveryDataClient } from '../../../lib/attack_discovery/persistence';
 
 const mockAttackDiscoveryFindResponse = getMockAttackDiscoveryFindResponse();
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/get_duration_nanoseconds/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/get_duration_nanoseconds/index.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getDurationNanoseconds } from '.';
+
+describe('getDurationNanoseconds', () => {
+  const defaultStart = new Date('2023-01-01T00:00:00.000Z');
+  const defaultEnd = new Date('2023-01-01T00:00:01.000Z');
+
+  it('returns 1_000_000_000 nanoseconds for a 1 second difference', () => {
+    const result = getDurationNanoseconds({ start: defaultStart, end: defaultEnd });
+
+    expect(result).toBe(1_000_000_000);
+  });
+
+  it('returns 0 nanoseconds for identical start and end', () => {
+    const result = getDurationNanoseconds({ start: defaultStart, end: defaultStart });
+
+    expect(result).toBe(0);
+  });
+
+  it('returns negative nanoseconds for end before start', () => {
+    const result = getDurationNanoseconds({ start: defaultEnd, end: defaultStart });
+
+    expect(result).toBe(-1_000_000_000);
+  });
+
+  it('returns correct nanoseconds for a millisecond difference', () => {
+    const start = new Date('2023-01-01T00:00:00.123Z');
+    const end = new Date('2023-01-01T00:00:00.456Z');
+    const result = getDurationNanoseconds({ start, end });
+
+    expect(result).toBe(333_000_000);
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/helpers/write_attack_discovery_event/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/helpers/write_attack_discovery_event/index.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IEventLogger } from '@kbn/event-log-plugin/server';
+
+import { writeAttackDiscoveryEvent } from '.';
+import type { AttackDiscoveryDataClient } from '../../../../../lib/attack_discovery/persistence';
+import { mockAuthenticatedUser } from '../../../../../__mocks__/mock_authenticated_user';
+import { attackDiscoveryDataClientMock } from '../../../../../__mocks__/data_clients.mock';
+
+describe('writeAttackDiscoveryEvent', () => {
+  const mockEventLogger = {
+    logEvent: jest.fn(),
+  } as {
+    logEvent: jest.Mock;
+  } as unknown as IEventLogger;
+  const mockDataClient =
+    attackDiscoveryDataClientMock.create() as unknown as AttackDiscoveryDataClient;
+  const defaultProps: Parameters<typeof writeAttackDiscoveryEvent>[0] = {
+    action: 'generation-started',
+    alertsContextCount: 2,
+    attackDiscoveryAlertsEnabled: true,
+    authenticatedUser: mockAuthenticatedUser,
+    connectorId: 'test-connector',
+    dataClient: mockDataClient,
+    duration: 12345,
+    end: new Date('2024-01-01T00:00:00Z'),
+    eventLogger: mockEventLogger,
+    eventLogIndex: 'event-log-index',
+    executionUuid: 'uuid-123',
+    loadingMessage: 'loading',
+    message: 'test message',
+    newAlerts: 1,
+    outcome: 'success',
+    reason: 'test reason',
+    spaceId: 'default',
+    start: new Date('2024-01-01T00:00:00Z'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs the attack discovery event', async () => {
+    await writeAttackDiscoveryEvent({ ...defaultProps });
+
+    expect(mockEventLogger.logEvent).toHaveBeenCalled();
+  });
+
+  it('refreshes the index', async () => {
+    await writeAttackDiscoveryEvent({ ...defaultProps });
+
+    expect(mockDataClient.refreshEventLogIndex).toHaveBeenCalledWith('event-log-index');
+  });
+
+  it('trims reason to 1024 chars', async () => {
+    const longReason = 'a'.repeat(2000);
+
+    await writeAttackDiscoveryEvent({ ...defaultProps, reason: longReason });
+    const eventArg = (mockEventLogger.logEvent as jest.Mock).mock.calls[0][0];
+
+    expect(eventArg.event.reason.length).toBe(1024);
+  });
+
+  it('omits alert_counts if alertsContextCount and newAlerts are undefined', async () => {
+    await writeAttackDiscoveryEvent({
+      ...defaultProps,
+      alertsContextCount: undefined,
+      newAlerts: undefined,
+    });
+    const eventArg = (mockEventLogger.logEvent as jest.Mock).mock.calls[0][0];
+
+    expect(eventArg.kibana.alert.rule.execution.metrics).toBeUndefined();
+  });
+
+  it('logs event with event outcome success', async () => {
+    await writeAttackDiscoveryEvent({ ...defaultProps, outcome: 'success', reason: undefined });
+    const eventArg = (mockEventLogger.logEvent as jest.Mock).mock.calls[0][0];
+
+    expect(eventArg.event.outcome).toBe('success');
+  });
+
+  it('logs event with event.outcome failure', async () => {
+    await writeAttackDiscoveryEvent({ ...defaultProps, outcome: 'failure', reason: 'fail reason' });
+    const eventArg = (mockEventLogger.logEvent as jest.Mock).mock.calls[0][0];
+
+    expect(eventArg.event.outcome).toBe('failure');
+  });
+
+  it('logs event with the reason for the failure', async () => {
+    await writeAttackDiscoveryEvent({ ...defaultProps, outcome: 'failure', reason: 'fail reason' });
+    const eventArg = (mockEventLogger.logEvent as jest.Mock).mock.calls[0][0];
+
+    expect(eventArg.event.reason).toBe('fail reason');
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery.test.ts
@@ -5,39 +5,56 @@
  * 2.0.
  */
 
-import { AuthenticatedUser } from '@kbn/core-security-common';
-import { postAttackDiscoveryRoute } from './post_attack_discovery';
-import { serverMock } from '../../../__mocks__/server';
-import { requestContextMock } from '../../../__mocks__/request_context';
-import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { actionsMock } from '@kbn/actions-plugin/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { AttackDiscoveryPostRequestBody } from '@kbn/elastic-assistant-common';
+import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
+
+import { performChecks } from '../../helpers';
+import { updateAttackDiscoveryStatusToRunning } from '../helpers/helpers';
+import { hasReadWriteAttackDiscoveryAlertsPrivileges } from '../helpers/index_privileges';
+import { requestIsValid } from './helpers/request_is_valid';
 import { AttackDiscoveryDataClient } from '../../../lib/attack_discovery/persistence';
 import { transformESSearchToAttackDiscovery } from '../../../lib/attack_discovery/persistence/transforms/transforms';
 import { getAttackDiscoverySearchEsMock } from '../../../__mocks__/attack_discovery_schema.mock';
-import { postAttackDiscoveryRequest } from '../../../__mocks__/request';
-import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
-import { AttackDiscoveryPostRequestBody } from '@kbn/elastic-assistant-common';
+import { serverMock } from '../../../__mocks__/server';
+import { requestContextMock } from '../../../__mocks__/request_context';
+import { postAttackDiscoveryRoute } from './post_attack_discovery';
 
-import { updateAttackDiscoveryStatusToRunning } from '../helpers/helpers';
-import { hasReadWriteAttackDiscoveryAlertsPrivileges } from '../helpers/index_privileges';
+const mockCurrentAd = transformESSearchToAttackDiscovery(getAttackDiscoverySearchEsMock())[0];
+const runningAd = {
+  ...mockCurrentAd,
+  status: 'running',
+};
+import { postAttackDiscoveryRequest } from '../../../__mocks__/request';
 
 jest.mock('../helpers/helpers', () => {
-  const original = jest.requireActual('../helpers/helpers');
-
+  const helpersOriginal = jest.requireActual('../helpers/helpers');
   return {
-    ...original,
+    ...helpersOriginal,
     updateAttackDiscoveryStatusToRunning: jest.fn(),
   };
 });
 
 jest.mock('../helpers/index_privileges', () => {
-  const original = jest.requireActual('../helpers/index_privileges');
-
+  const privilegesOriginal = jest.requireActual('../helpers/index_privileges');
   return {
-    ...original,
+    ...privilegesOriginal,
     hasReadWriteAttackDiscoveryAlertsPrivileges: jest.fn(),
   };
 });
+
+jest.mock('../../helpers', () => {
+  const helpersModuleOriginal = jest.requireActual('../../helpers');
+  return {
+    ...helpersModuleOriginal,
+    performChecks: jest.fn(),
+  };
+});
+
+jest.mock('./helpers/request_is_valid', () => ({
+  requestIsValid: jest.fn(),
+}));
 
 const { clients, context } = requestContextMock.createTools();
 const server: ReturnType<typeof serverMock.create> = serverMock.create();
@@ -49,7 +66,26 @@ const mockUser = {
     type: 'my_realm_type',
     name: 'my_realm_name',
   },
-} as AuthenticatedUser;
+  lookup_realm: {
+    type: 'my_lookup_type',
+    name: 'my_lookup_name',
+  },
+  authentication_provider: { type: 'basic', name: 'basic1' },
+  authentication_type: 'realm',
+  elastic_cloud_user: false,
+  enabled: true,
+  roles: ['superuser'],
+  full_name: 'Test User',
+  email: 'test@example.com',
+};
+
+const mockApiConfig = {
+  connectorId: 'connector-id',
+  actionTypeId: '.bedrock',
+  model: 'model',
+  provider: OpenAiProviderType.OpenAi,
+};
+
 const findAttackDiscoveryByConnectorId = jest.fn();
 const mockDataClient = {
   findAttackDiscoveryByConnectorId,
@@ -58,12 +94,7 @@ const mockDataClient = {
   getAttackDiscovery: jest.fn(),
   refreshEventLogIndex: jest.fn(),
 } as unknown as AttackDiscoveryDataClient;
-const mockApiConfig = {
-  connectorId: 'connector-id',
-  actionTypeId: '.bedrock',
-  model: 'model',
-  provider: OpenAiProviderType.OpenAi,
-};
+
 const mockRequestBody: AttackDiscoveryPostRequestBody = {
   subAction: 'invokeAI',
   apiConfig: mockApiConfig,
@@ -75,26 +106,137 @@ const mockRequestBody: AttackDiscoveryPostRequestBody = {
   langSmithProject: 'langSmithProject',
   langSmithApiKey: 'langSmithApiKey',
 };
-const mockCurrentAd = transformESSearchToAttackDiscovery(getAttackDiscoverySearchEsMock())[0];
-const runningAd = {
-  ...mockCurrentAd,
-  status: 'running',
-};
 describe('postAttackDiscoveryRoute', () => {
+  it('returns 403 when privilege check returns forbidden', async () => {
+    context.core.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(true);
+    (hasReadWriteAttackDiscoveryAlertsPrivileges as jest.Mock).mockImplementation(
+      ({ response }) => {
+        return Promise.resolve({
+          isSuccess: false,
+          response: response.forbidden({ body: { message: 'forbidden' } }),
+        });
+      }
+    );
+    const response = await server.inject(
+      postAttackDiscoveryRequest(mockRequestBody),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(response.status).toEqual(403);
+  });
+});
+
+it('returns 400 when request body is missing required fields', async () => {
+  (requestIsValid as jest.Mock).mockReturnValue(false);
+  const invalidBody: AttackDiscoveryPostRequestBody = {
+    ...mockRequestBody,
+    alertsIndexPattern: '',
+  };
+
+  const response = await server.inject(
+    postAttackDiscoveryRequest(invalidBody),
+    requestContextMock.convertContext(context)
+  );
+
+  expect(response.status).toEqual(400);
+});
+
+it('returns 500 when feature flag check throws', async () => {
+  context.core.featureFlags.getBooleanValue = jest.fn().mockImplementation(() => {
+    throw new Error('Feature flag error');
+  });
+
+  const response = await server.inject(
+    postAttackDiscoveryRequest(mockRequestBody),
+    requestContextMock.convertContext(context)
+  );
+
+  expect(response.body).toEqual({
+    message: {
+      error: 'Feature flag error',
+      success: false,
+    },
+    status_code: 500,
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  context.elasticAssistant.getCurrentUser.mockResolvedValue(mockUser);
+  context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValue(mockDataClient);
+  context.elasticAssistant.actions = actionsMock.createStart();
+  context.core.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(false);
+  postAttackDiscoveryRoute(server.router);
+  findAttackDiscoveryByConnectorId.mockResolvedValue(mockCurrentAd);
+
+  // Mock successful defaults
+  (performChecks as jest.Mock).mockResolvedValue({ isSuccess: true });
+  (requestIsValid as jest.Mock).mockReturnValue(true);
+  (updateAttackDiscoveryStatusToRunning as jest.Mock).mockResolvedValue({
+    currentAd: runningAd,
+    attackDiscoveryId: mockCurrentAd.id,
+  });
+  (hasReadWriteAttackDiscoveryAlertsPrivileges as jest.Mock).mockResolvedValue({
+    isSuccess: true,
+  });
+});
+
+it('should handle successful request', async () => {
+  const response = await server.inject(
+    postAttackDiscoveryRequest(mockRequestBody),
+    requestContextMock.convertContext(context)
+  );
+  expect(response.status).toEqual(200);
+  expect(response.body).toEqual(runningAd);
+});
+
+it('should handle missing authenticated user', async () => {
+  context.elasticAssistant.getCurrentUser.mockResolvedValueOnce(null);
+  const response = await server.inject(
+    postAttackDiscoveryRequest(mockRequestBody),
+    requestContextMock.convertContext(context)
+  );
+
+  expect(response.status).toEqual(401);
+  expect(response.body).toEqual({
+    message: 'Authenticated user not found',
+    status_code: 401,
+  });
+});
+
+it('should handle missing data client', async () => {
+  context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValue(null);
+  const response = await server.inject(
+    postAttackDiscoveryRequest(mockRequestBody),
+    requestContextMock.convertContext(context)
+  );
+
+  expect(response.status).toEqual(500);
+  expect(response.body).toEqual({
+    message: 'Attack discovery data client not initialized',
+    status_code: 500,
+  });
+});
+
+it('should handle updateAttackDiscoveryStatusToRunning error', async () => {
+  (updateAttackDiscoveryStatusToRunning as jest.Mock).mockRejectedValue(new Error('Oh no!'));
+  const response = await server.inject(
+    postAttackDiscoveryRequest(mockRequestBody),
+    requestContextMock.convertContext(context)
+  );
+  expect(response.status).toEqual(500);
+  expect(response.body).toEqual({
+    message: {
+      error: 'Oh no!',
+      success: false,
+    },
+    status_code: 500,
+  });
+});
+
+describe('Enabled `attackDiscoveryAlertsEnabled` feature flag', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    context.elasticAssistant.getCurrentUser.mockResolvedValue(mockUser);
-    context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValue(mockDataClient);
-    context.elasticAssistant.actions = actionsMock.createStart();
-    postAttackDiscoveryRoute(server.router);
-    findAttackDiscoveryByConnectorId.mockResolvedValue(mockCurrentAd);
-    (updateAttackDiscoveryStatusToRunning as jest.Mock).mockResolvedValue({
-      currentAd: runningAd,
-      attackDiscoveryId: mockCurrentAd.id,
-    });
-    (hasReadWriteAttackDiscoveryAlertsPrivileges as jest.Mock).mockResolvedValue({
-      isSuccess: true,
-    });
+    clients.core.featureFlags.getBooleanValue.mockResolvedValue(true);
   });
 
   it('should handle successful request', async () => {
@@ -106,80 +248,21 @@ describe('postAttackDiscoveryRoute', () => {
     expect(response.body).toEqual(runningAd);
   });
 
-  it('should handle missing authenticated user', async () => {
-    context.elasticAssistant.getCurrentUser.mockResolvedValueOnce(null);
+  it('should handle missing privileges', async () => {
+    (hasReadWriteAttackDiscoveryAlertsPrivileges as jest.Mock).mockImplementation(
+      ({ response }) => {
+        return Promise.resolve({
+          isSuccess: false,
+          response: response.forbidden({ body: { message: 'no privileges' } }),
+        });
+      }
+    );
+
     const response = await server.inject(
       postAttackDiscoveryRequest(mockRequestBody),
       requestContextMock.convertContext(context)
     );
-
-    expect(response.status).toEqual(401);
-    expect(response.body).toEqual({
-      message: 'Authenticated user not found',
-      status_code: 401,
-    });
-  });
-
-  it('should handle missing data client', async () => {
-    context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValue(null);
-    const response = await server.inject(
-      postAttackDiscoveryRequest(mockRequestBody),
-      requestContextMock.convertContext(context)
-    );
-
-    expect(response.status).toEqual(500);
-    expect(response.body).toEqual({
-      message: 'Attack discovery data client not initialized',
-      status_code: 500,
-    });
-  });
-
-  it('should handle updateAttackDiscoveryStatusToRunning error', async () => {
-    (updateAttackDiscoveryStatusToRunning as jest.Mock).mockRejectedValue(new Error('Oh no!'));
-    const response = await server.inject(
-      postAttackDiscoveryRequest(mockRequestBody),
-      requestContextMock.convertContext(context)
-    );
-    expect(response.status).toEqual(500);
-    expect(response.body).toEqual({
-      message: {
-        error: 'Oh no!',
-        success: false,
-      },
-      status_code: 500,
-    });
-  });
-
-  describe('Enabled `attackDiscoveryAlertsEnabled` feature flag', () => {
-    beforeEach(() => {
-      clients.core.featureFlags.getBooleanValue.mockResolvedValue(true);
-    });
-
-    it('should handle successful request', async () => {
-      const response = await server.inject(
-        postAttackDiscoveryRequest(mockRequestBody),
-        requestContextMock.convertContext(context)
-      );
-      expect(response.status).toEqual(200);
-      expect(response.body).toEqual(runningAd);
-    });
-
-    it('should handle missing privileges', async () => {
-      (hasReadWriteAttackDiscoveryAlertsPrivileges as jest.Mock).mockImplementation(
-        ({ response }) => {
-          return Promise.resolve({
-            isSuccess: false,
-            response: response.forbidden({ body: { message: 'no privileges' } }),
-          });
-        }
-      );
-
-      const response = await server.inject(
-        postAttackDiscoveryRequest(mockRequestBody),
-        requestContextMock.convertContext(context)
-      );
-      expect(response.status).toEqual(403);
-      expect(response.body).toEqual({ message: 'no privileges' });
-    });
+    expect(response.status).toEqual(403);
+    expect(response.body).toEqual({ message: 'no privileges' });
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery_generations_dismiss.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery_generations_dismiss.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AuthenticatedUser } from '@kbn/core-security-common';
+
+import { AttackDiscoveryDataClient } from '../../../lib/attack_discovery/persistence';
+import { postAttackDiscoveryGenerationsDismissRoute } from './post_attack_discovery_generations_dismiss';
+import { attackDiscoveryDataClientMock } from '../../../__mocks__/data_clients.mock';
+import { requestMock } from '../../../__mocks__/request';
+import { requestContextMock } from '../../../__mocks__/request_context';
+import { serverMock } from '../../../__mocks__/server';
+
+const { context } = requestContextMock.createTools();
+const server = serverMock.create();
+
+describe('postAttackDiscoveryGenerationsDismissRoute', () => {
+  const mockUser = {
+    authentication_realm: {
+      name: 'my_realm_name',
+      type: 'my_realm_type',
+    },
+    username: 'my_username',
+  } as AuthenticatedUser;
+
+  const mockDataClient = attackDiscoveryDataClientMock.create();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValue(
+      mockDataClient as unknown as AttackDiscoveryDataClient
+    );
+    context.elasticAssistant.getCurrentUser.mockResolvedValue(mockUser);
+    context.elasticAssistant.logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      fatal: jest.fn(),
+      get: jest.fn().mockReturnThis(),
+      info: jest.fn(),
+      isLevelEnabled: jest.fn().mockReturnValue(true),
+      log: jest.fn(),
+      trace: jest.fn(),
+      warn: jest.fn(),
+    };
+    context.elasticAssistant.eventLogIndex = 'event-log-index';
+    context.elasticAssistant.eventLogger = {
+      logEvent: jest.fn().mockResolvedValue(undefined),
+      startTiming: jest.fn(),
+      stopTiming: jest.fn(),
+      updateEvents: jest.fn(),
+    };
+    context.elasticAssistant.getSpaceId = jest.fn().mockReturnValue('default');
+    context.core.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(true);
+
+    const mockGeneration = {
+      alerts_context_count: 10,
+      connector_id: 'cid',
+      connector_stats: {
+        average_successful_duration_nanoseconds: 1500000000,
+        successful_generations: 5,
+      },
+      discoveries: 3,
+      end: '2024-06-07T21:19:08.090Z',
+      execution_uuid: 'uuid-1',
+      loading_message: 'Generating attack discovery',
+      reason: undefined,
+      start: '2024-06-07T18:56:17.357Z',
+      status: 'succeeded' as const,
+    };
+
+    mockDataClient.getAttackDiscoveryGenerationById.mockResolvedValue(mockGeneration);
+    postAttackDiscoveryGenerationsDismissRoute(server.router);
+  });
+
+  it('returns 401 if an authenticated user is not found', async () => {
+    context.elasticAssistant.getCurrentUser.mockResolvedValueOnce(null);
+    const request = requestMock.create({
+      method: 'post',
+      params: { execution_uuid: 'uuid-1' },
+      path: '/internal/elastic_assistant/attack_discovery/generations/uuid-1/dismiss',
+    });
+
+    const response = await server.inject(request, requestContextMock.convertContext(context));
+
+    expect(response.status).toEqual(401);
+  });
+
+  it('returns 500 if the data client is not initialized', async () => {
+    context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValueOnce(null);
+    const request = requestMock.create({
+      method: 'post',
+      params: { execution_uuid: 'uuid-1' },
+      path: '/internal/elastic_assistant/attack_discovery/generations/uuid-1/dismiss',
+    });
+
+    const response = await server.inject(request, requestContextMock.convertContext(context));
+
+    expect(response.status).toEqual(500);
+  });
+
+  it('returns 500 if an error is thrown', async () => {
+    mockDataClient.getAttackDiscoveryGenerationById.mockRejectedValueOnce(new Error('Oh no!'));
+    const request = requestMock.create({
+      method: 'post',
+      params: { execution_uuid: 'uuid-1' },
+      path: '/internal/elastic_assistant/attack_discovery/generations/uuid-1/dismiss',
+    });
+
+    const response = await server.inject(request, requestContextMock.convertContext(context));
+
+    expect(response.status).toEqual(500);
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/register_routes.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/register_routes.test.ts
@@ -14,6 +14,9 @@ import { findAlertSummaryRoute } from './alert_summary/find_route';
 import { cancelAttackDiscoveryRoute } from './attack_discovery/post/cancel/cancel_attack_discovery';
 import { getAttackDiscoveryRoute } from './attack_discovery/get/get_attack_discovery';
 import { postAttackDiscoveryRoute } from './attack_discovery/post/post_attack_discovery';
+import { findAttackDiscoveriesRoute } from './attack_discovery/get/find_attack_discoveries';
+import { getAttackDiscoveryGenerationsRoute } from './attack_discovery/get/get_attack_discovery_generations';
+import { postAttackDiscoveryGenerationsDismissRoute } from './attack_discovery/post/post_attack_discovery_generations_dismiss';
 import { createConversationRoute } from './user_conversations/create_route';
 import { deleteConversationRoute } from './user_conversations/delete_route';
 import { readConversationRoute } from './user_conversations/read_route';
@@ -62,6 +65,13 @@ jest.mock('./attack_discovery/get/get_attack_discovery');
 const getAttackDiscoveryRouteMock = getAttackDiscoveryRoute as jest.Mock;
 jest.mock('./attack_discovery/post/post_attack_discovery');
 const postAttackDiscoveryRouteMock = postAttackDiscoveryRoute as jest.Mock;
+jest.mock('./attack_discovery/get/find_attack_discoveries');
+const findAttackDiscoveriesRouteMock = findAttackDiscoveriesRoute as jest.Mock;
+jest.mock('./attack_discovery/get/get_attack_discovery_generations');
+const getAttackDiscoveryGenerationsRouteMock = getAttackDiscoveryGenerationsRoute as jest.Mock;
+jest.mock('./attack_discovery/post/post_attack_discovery_generations_dismiss');
+const postAttackDiscoveryGenerationsDismissRouteMock =
+  postAttackDiscoveryGenerationsDismissRoute as jest.Mock;
 jest.mock('./user_conversations/create_route');
 const createConversationRouteMock = createConversationRoute as jest.Mock;
 jest.mock('./user_conversations/delete_route');
@@ -147,6 +157,18 @@ describe('registerRoutes', () => {
 
   it('should call `cancelAttackDiscoveryRouteMock`', () => {
     expect(cancelAttackDiscoveryRouteMock).toHaveBeenCalledWith(server.router);
+  });
+
+  it('should call `findAttackDiscoveriesRouteMock`', () => {
+    expect(findAttackDiscoveriesRouteMock).toHaveBeenCalledWith(server.router);
+  });
+
+  it('should call `getAttackDiscoveryGenerationsRouteMock`', () => {
+    expect(getAttackDiscoveryGenerationsRouteMock).toHaveBeenCalledWith(server.router);
+  });
+
+  it('should call `postAttackDiscoveryGenerationsDismissRouteMock`', () => {
+    expect(postAttackDiscoveryGenerationsDismissRouteMock).toHaveBeenCalledWith(server.router);
   });
 
   it('should call `getAttackDiscoveryRouteMock`', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
@@ -98,4 +98,18 @@ describe('Countdown', () => {
 
     expect(screen.getByRole('button', { name: INFORMATION })).toBeInTheDocument();
   });
+
+  it('returns null when approximateFutureTime is null', () => {
+    (useKibanaFeatureFlags as jest.Mock).mockReturnValue({
+      attackDiscoveryAlertsEnabled: true,
+    });
+
+    const { container } = render(
+      <TestProviders>
+        <Countdown approximateFutureTime={null} connectorIntervals={connectorIntervals} />
+      </TestProviders>
+    );
+
+    expect(container.innerHTML).toEqual('');
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/last_times_popover/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/last_times_popover/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { GenerationInterval } from '@kbn/elastic-assistant-common';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import React from 'react';
 
 import { LastTimesPopover } from '.';
@@ -42,6 +42,7 @@ describe('LastTimesPopover', () => {
       </TestProviders>
     );
   });
+  afterEach(cleanup);
 
   it('renders average time calculated message', () => {
     const averageTimeIsCalculated = screen.getByTestId('averageTimeIsCalculated');
@@ -62,5 +63,45 @@ describe('LastTimesPopover', () => {
     ];
 
     generationTimings.forEach((timing, i) => expect(timing).toHaveTextContent(expectedDates[i]));
+  });
+
+  it('renders the average time calculated message with successfulGenerations', () => {
+    (useKibanaFeatureFlags as jest.Mock).mockReturnValue({
+      attackDiscoveryAlertsEnabled: true,
+    });
+    render(
+      <TestProviders>
+        <LastTimesPopover connectorIntervals={connectorIntervals} successfulGenerations={5} />
+      </TestProviders>
+    );
+    const averageTimeIsCalculated = screen.getAllByTestId('averageTimeIsCalculated');
+
+    expect(
+      averageTimeIsCalculated.some(
+        (el) =>
+          el.textContent ===
+          'Remaining time is based on the average speed of the last 5 times the same connector generated results.'
+      )
+    ).toBe(true);
+  });
+
+  it('renders the average time calculated message with zero when successfulGenerations is undefined', () => {
+    (useKibanaFeatureFlags as jest.Mock).mockReturnValue({
+      attackDiscoveryAlertsEnabled: true,
+    });
+    render(
+      <TestProviders>
+        <LastTimesPopover connectorIntervals={connectorIntervals} />
+      </TestProviders>
+    );
+    const averageTimeIsCalculated = screen.getAllByTestId('averageTimeIsCalculated');
+
+    expect(
+      averageTimeIsCalculated.some(
+        (el) =>
+          el.textContent ===
+          'Remaining time is based on the average speed of the last 0 times the same connector generated results.'
+      )
+    ).toBe(true);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/get_is_terminal_state/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/get_is_terminal_state/index.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getIsTerminalState } from '.';
+
+describe('getIsTerminalState', () => {
+  it.each<['started' | 'succeeded' | 'failed' | 'canceled' | 'dismissed' | undefined, boolean]>([
+    ['succeeded', true],
+    ['failed', true],
+    ['canceled', true],
+    ['started', false],
+    ['dismissed', false],
+    [undefined, false],
+  ])('returns %s as %s', (status, expected) => {
+    expect(getIsTerminalState(status)).toBe(expected);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.test.tsx
@@ -8,9 +8,23 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { LoadingCallout } from '.';
 import type { GenerationInterval } from '@kbn/elastic-assistant-common';
 import { TestProviders } from '../../../common/mock';
+import { LoadingCallout } from '.';
+
+jest.mock('@kbn/react-kibana-context-theme', () => ({
+  useKibanaIsDarkMode: jest.fn(() => false),
+}));
+
+jest.mock('../use_kibana_feature_flags', () => ({
+  useKibanaFeatureFlags: jest.fn(() => ({ attackDiscoveryAlertsEnabled: true })),
+}));
+
+jest.mock('../use_dismiss_attack_discovery_generations', () => ({
+  useDismissAttackDiscoveryGeneration: jest.fn(() => ({
+    mutateAsync: jest.fn(),
+  })),
+}));
 
 describe('LoadingCallout', () => {
   const connectorIntervals: GenerationInterval[] = [
@@ -70,5 +84,31 @@ describe('LoadingCallout', () => {
     const countdown = screen.getByTestId('countdown');
 
     expect(countdown).toBeInTheDocument();
+  });
+
+  it('renders a terminal state icon for succeeded', () => {
+    render(
+      <TestProviders>
+        <LoadingCallout {...defaultProps} status="succeeded" executionUuid="uuid-123" />
+      </TestProviders>
+    );
+    const icon = screen
+      .getByTestId('loadingCallout')
+      .querySelector('[data-euiicon-type="logoElastic"]');
+
+    expect(icon).not.toBeNull();
+  });
+
+  it('renders terminal state icon for failed', () => {
+    render(
+      <TestProviders>
+        <LoadingCallout {...defaultProps} status="failed" executionUuid="uuid-123" />
+      </TestProviders>
+    );
+    const icon = screen
+      .getByTestId('loadingCallout')
+      .querySelector('[data-euiicon-type="logoElastic"]');
+
+    expect(icon).not.toBeNull();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
@@ -233,6 +233,7 @@ const LoadingCalloutComponent: React.FC<Props> = ({
                     disabled={isDismissing}
                     iconType="cross"
                     onClick={dismissGeneration}
+                    data-test-subj="dismissButton"
                   />
                 )}
               </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/info_popover_body/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/info_popover_body/index.test.tsx
@@ -5,36 +5,28 @@
  * 2.0.
  */
 
-import type { GenerationInterval } from '@kbn/elastic-assistant-common';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { InfoPopoverBody } from '.';
 import { TestProviders } from '../../../../common/mock';
 import { AVERAGE_TIME } from '../countdown/translations';
+import { getMockAttackDiscoveryAlerts } from '../../mock/mock_attack_discovery_alerts';
 import { useKibanaFeatureFlags } from '../../use_kibana_feature_flags';
 
 jest.mock('../../use_kibana_feature_flags');
 
-describe('InfoPopoverBody', () => {
-  const connectorIntervals: GenerationInterval[] = [
-    {
-      date: '2024-05-16T14:13:09.838Z',
-      durationMs: 173648,
-    },
-    {
-      date: '2024-05-16T13:59:49.620Z',
-      durationMs: 146605,
-    },
-    {
-      date: '2024-05-16T13:47:00.629Z',
-      durationMs: 255163,
-    },
-  ];
+const defaultProps = {
+  connectorIntervals: [
+    { date: '2024-05-16T14:13:09.838Z', durationMs: 173648 },
+    { date: '2024-05-16T13:59:49.620Z', durationMs: 146605 },
+    { date: '2024-05-16T13:47:00.629Z', durationMs: 255163 },
+  ],
+};
 
+describe('InfoPopoverBody', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
     (useKibanaFeatureFlags as jest.Mock).mockReturnValue({
       attackDiscoveryAlertsEnabled: false,
     });
@@ -43,24 +35,78 @@ describe('InfoPopoverBody', () => {
   it('renders the expected average time', () => {
     render(
       <TestProviders>
-        <InfoPopoverBody connectorIntervals={connectorIntervals} />
+        <InfoPopoverBody {...defaultProps} />
       </TestProviders>
     );
 
-    const averageTimeBadge = screen.getByTestId('averageTimeBadge');
-
-    expect(averageTimeBadge).toHaveTextContent('191s');
+    expect(screen.getByTestId('averageTimeBadge')).toHaveTextContent('191s');
   });
 
   it('renders the expected explanation', () => {
     render(
       <TestProviders>
-        <InfoPopoverBody connectorIntervals={connectorIntervals} />
+        <InfoPopoverBody {...defaultProps} />
       </TestProviders>
     );
 
-    const averageTimeIsCalculated = screen.getAllByTestId('averageTimeIsCalculated');
+    expect(screen.getAllByTestId('averageTimeIsCalculated')[0]).toHaveTextContent(AVERAGE_TIME);
+  });
 
-    expect(averageTimeIsCalculated[0]).toHaveTextContent(AVERAGE_TIME);
+  it('renders 0s when connectorIntervals is empty', () => {
+    render(
+      <TestProviders>
+        <InfoPopoverBody connectorIntervals={[]} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('averageTimeBadge')).toHaveTextContent('0s');
+  });
+
+  it('renders the correct average when attackDiscoveryAlertsEnabled is true and nanoseconds is provided', () => {
+    (useKibanaFeatureFlags as jest.Mock).mockReturnValue({ attackDiscoveryAlertsEnabled: true });
+    render(
+      <TestProviders>
+        <InfoPopoverBody {...defaultProps} averageSuccessfulDurationNanoseconds={8_500_000_000} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('averageTimeBadge')).toHaveTextContent('9s');
+  });
+
+  it('renders 0s when attackDiscoveryAlertsEnabled is true and nanoseconds is undefined', () => {
+    (useKibanaFeatureFlags as jest.Mock).mockReturnValue({ attackDiscoveryAlertsEnabled: true });
+    render(
+      <TestProviders>
+        <InfoPopoverBody {...defaultProps} averageSuccessfulDurationNanoseconds={undefined} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('averageTimeBadge')).toHaveTextContent('0s');
+  });
+
+  it('renders the LastTimesPopover with successfulGenerations', () => {
+    render(
+      <TestProviders>
+        <InfoPopoverBody {...defaultProps} successfulGenerations={5} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('lastTimesPopover')).toBeInTheDocument();
+  });
+
+  it('renders with attack discovery alert intervals', () => {
+    const alerts = getMockAttackDiscoveryAlerts();
+    const intervals = alerts.map((a, i) => ({
+      date: `2024-05-16T14:13:0${i}.000Z`,
+      durationMs: 1000 * (i + 1),
+    }));
+
+    render(
+      <TestProviders>
+        <InfoPopoverBody connectorIntervals={intervals} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('averageTimeBadge')).toHaveTextContent('1s');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/failure_accordion/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/failure_accordion/index.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { FailureAccordion } from '.';
+import { TestProviders } from '../../../../../common/mock/test_providers';
+
+describe('FailureAccordion', () => {
+  describe('when there is only one line', () => {
+    const defaultProps = { failureReason: 'Error: what a failure' };
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <FailureAccordion {...defaultProps} />
+        </TestProviders>
+      );
+    });
+
+    it('renders a <p> with the failure reason', () => {
+      expect(screen.getByText('Error: what a failure')).toBeInTheDocument();
+    });
+
+    it('does not render an accordion', () => {
+      expect(screen.queryByTestId('failuresAccordion')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders an accordion when there are multiple lines', () => {
+    const multiLineProps = {
+      failureReason: 'First line\nSecond line\nThird line',
+    };
+
+    render(
+      <TestProviders>
+        <FailureAccordion {...multiLineProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('failuresAccordion')).toBeInTheDocument();
+  });
+
+  it('renders all additional lines inside a code block', () => {
+    const multiLineProps = {
+      failureReason: 'First line\nSecond line\nThird line',
+    };
+
+    render(
+      <TestProviders>
+        <FailureAccordion {...multiLineProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Second line')).toBeInTheDocument();
+  });
+
+  describe('when failureReason is null', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <FailureAccordion failureReason={null} />
+        </TestProviders>
+      );
+    });
+
+    it('does not render the failure reason text', () => {
+      expect(screen.queryByText('Error: what a failure')).not.toBeInTheDocument();
+    });
+
+    it('does not render an accordion', () => {
+      expect(screen.queryByTestId('failuresAccordion')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_canceled_result_message/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_canceled_result_message/index.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getCanceledResultMessage } from '.';
+import { getFormattedDate } from '../get_formatted_time';
+import * as i18n from '../../translations';
+
+jest.mock('../get_formatted_time', () => ({
+  getFormattedDate: jest.fn(),
+}));
+
+jest.mock('../../translations', () => ({
+  CANCELED_VIA: jest.fn(),
+}));
+
+describe('getCanceledResultMessage', () => {
+  const mockConnectorName = 'Test Connector';
+  const mockDateFormat = 'MMM D, YYYY @ HH:mm:ss.SSS';
+  const mockGenerationEndTime = '2025-05-02T17:46:43.486Z';
+  const mockFormattedDate = 'May 2, 2025 @ 17:46:43.486';
+  const mockMessage = 'Canceled via Test Connector at May 2, 2025 @ 17:46:43.486';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getFormattedDate as jest.Mock).mockReturnValue(mockFormattedDate);
+    (i18n.CANCELED_VIA as jest.Mock).mockReturnValue(mockMessage);
+  });
+
+  it('invokes CANCELED_VIA with the connector name and formatted generation end time', () => {
+    getCanceledResultMessage({
+      connectorName: mockConnectorName,
+      dateFormat: mockDateFormat,
+      generationEndTime: mockGenerationEndTime,
+    });
+
+    expect(i18n.CANCELED_VIA).toHaveBeenCalledWith({
+      connectorName: mockConnectorName,
+      formattedGenerationEndTime: mockFormattedDate,
+    });
+  });
+
+  it('returns the canceled message string', () => {
+    const result = getCanceledResultMessage({
+      connectorName: mockConnectorName,
+      dateFormat: mockDateFormat,
+      generationEndTime: mockGenerationEndTime,
+    });
+
+    expect(result).toBe(mockMessage);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_failure_result_message/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_failure_result_message/index.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as i18n from '../../translations';
+import { getFailureResultMessage } from '.';
+import { getFormattedDate } from '../get_formatted_time';
+
+jest.mock('../get_formatted_time', () => ({
+  getFormattedDate: jest.fn(),
+}));
+
+jest.mock('../../translations', () => ({
+  FAILED_VIA: jest.fn(),
+}));
+
+describe('getFailureResultMessage', () => {
+  const mockConnectorName = 'Test Connector';
+  const mockDateFormat = 'MMM D, YYYY @ HH:mm:ss.SSS';
+  const mockGenerationEndTime = '2025-05-02T17:46:43.486Z';
+  const mockFormattedDate = 'May 2, 2025 @ 17:46:43.486';
+  const mockMessage = 'Failed via Test Connector at May 2, 2025 @ 17:46:43.486';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getFormattedDate as jest.Mock).mockReturnValue(mockFormattedDate);
+    (i18n.FAILED_VIA as jest.Mock).mockReturnValue(mockMessage);
+  });
+
+  it('invokes FAILED_VIA with the connector name and formatted generation end time', () => {
+    getFailureResultMessage({
+      connectorName: mockConnectorName,
+      dateFormat: mockDateFormat,
+      generationEndTime: mockGenerationEndTime,
+    });
+
+    expect(i18n.FAILED_VIA).toHaveBeenCalledWith({
+      connectorName: mockConnectorName,
+      formattedGenerationEndTime: mockFormattedDate,
+    });
+  });
+
+  it('returns the failure message string', () => {
+    const result = getFailureResultMessage({
+      connectorName: mockConnectorName,
+      dateFormat: mockDateFormat,
+      generationEndTime: mockGenerationEndTime,
+    });
+
+    expect(result).toBe(mockMessage);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_success_result_message/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_success_result_message/index.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getSuccessResultMessage } from '.';
+
+jest.mock('../get_formatted_time', () => ({
+  getFormattedDate: jest.fn(() => 'mocked-date'),
+}));
+
+jest.mock('../../translations', () => ({
+  NO_MATCHING_ALERTS_VIA: jest.fn(() => 'no-matching-alerts'),
+  RAN_SUCCESSFULLY_VIA_WITH_DISCOVERIES_COUNT: jest.fn(() => 'with-discoveries'),
+  RAN_SUCCESSFULLY_VIA_NO_DISCOVERIES_COUNT: jest.fn(() => 'no-discoveries'),
+}));
+
+const defaultProps = {
+  alertsContextCount: 1,
+  connectorName: 'Test Connector',
+  dateFormat: 'YYYY-MM-DD',
+  discoveries: undefined,
+  generationEndTime: '2025-05-30T12:00:00Z',
+};
+
+describe('getSuccessResultMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns no-matching-alerts when alertsContextCount is 0', () => {
+    const result = getSuccessResultMessage({ ...defaultProps, alertsContextCount: 0 });
+
+    expect(result).toBe('no-matching-alerts');
+  });
+
+  it('returns with-discoveries when discoveries is not null', () => {
+    const result = getSuccessResultMessage({ ...defaultProps, discoveries: 5 });
+
+    expect(result).toBe('with-discoveries');
+  });
+
+  it('returns no-discoveries by default', () => {
+    const result = getSuccessResultMessage(defaultProps);
+
+    expect(result).toBe('no-discoveries');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/index.test.tsx
@@ -85,4 +85,92 @@ describe('LoadingMessages', () => {
       'AI is analyzing up to 30 alerts in the last 24 hours to generate discoveries.'
     );
   });
+
+  describe('terminal states', () => {
+    const defaultProps = {
+      alertsContextCount: 10,
+      localStorageAttackDiscoveryMaxAlerts: '15',
+      start: 'now-24h',
+      end: 'now',
+    };
+
+    it('renders the success result message when status is succeeded', () => {
+      render(
+        <TestProviders>
+          <LoadingMessages
+            {...defaultProps}
+            status="succeeded"
+            discoveries={2}
+            generationEndTime="2025-05-23T08:00:00.000Z"
+          />
+        </TestProviders>
+      );
+      const aiCurrentlyAnalyzing = screen.getByTestId('aisCurrentlyAnalyzing');
+
+      expect(aiCurrentlyAnalyzing.textContent).toMatch(/ran successfully/);
+    });
+
+    it('renders the failure result message and FailureAccordion when status is failed and reason is provided', () => {
+      render(
+        <TestProviders>
+          <LoadingMessages {...defaultProps} status="failed" reason="Some error occurred" />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId('aisCurrentlyAnalyzing').textContent).toMatch(/failed/);
+      expect(screen.getByText('Some error occurred')).toBeInTheDocument();
+    });
+
+    it('renders the canceled result message when status is canceled', () => {
+      render(
+        <TestProviders>
+          <LoadingMessages {...defaultProps} status="canceled" />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId('aisCurrentlyAnalyzing').textContent).toMatch(/canceled/);
+    });
+
+    it('renders the progress message when status is started', () => {
+      render(
+        <TestProviders>
+          <LoadingMessages {...defaultProps} status="started" />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId('attackDiscoveryGenerationInProgress')).toBeInTheDocument();
+    });
+
+    it('renders with connectorName', () => {
+      render(
+        <TestProviders>
+          <LoadingMessages {...defaultProps} connectorName="Test Connector" />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId('attackDiscoveryGenerationInProgress').textContent).toMatch(
+        /Test Connector/
+      );
+    });
+
+    it('does not render FailureAccordion when status is failed but reason is empty', () => {
+      render(
+        <TestProviders>
+          <LoadingMessages {...defaultProps} status="failed" reason="" />
+        </TestProviders>
+      );
+
+      expect(screen.queryByTestId('failuresAccordion')).not.toBeInTheDocument();
+    });
+
+    it('does not render FailureAccordion when status is failed but reason is undefined', () => {
+      render(
+        <TestProviders>
+          <LoadingMessages {...defaultProps} status="failed" />
+        </TestProviders>
+      );
+
+      expect(screen.queryByTestId('failuresAccordion')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/mock/mock_generations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/mock/mock_generations.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GetAttackDiscoveryGenerationsResponse } from '@kbn/elastic-assistant-common';
+
+export const getMockGenerations = (): GetAttackDiscoveryGenerationsResponse => ({
+  generations: [
+    {
+      alerts_context_count: 75,
+      connector_id: 'gpt41Azure',
+      discoveries: 8,
+      end: '2025-05-19T22:16:23.315Z',
+      loading_message:
+        'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.',
+      execution_uuid: '96aaee15-47c1-4150-91cd-18541b85e7cf',
+      start: '2025-05-19T22:15:10.759Z',
+      status: 'succeeded',
+      connector_stats: {
+        average_successful_duration_nanoseconds: 75516500000,
+        successful_generations: 2,
+      },
+    },
+    {
+      connector_id: 'gemini_2_5_pro',
+      discoveries: 0,
+      end: '2025-05-19T17:34:32.191Z',
+      loading_message:
+        'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.',
+      execution_uuid: 'bb2f5e6e-6dcd-4335-a3d2-a69ba090561d',
+      reason:
+        'Maximum generation attempts (10) reached. Try sending fewer alerts to this model.\ngenerate node is unable to parse (gemini) response from attempt 0; (this may be an incomplete response from the model): Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined]): ActionsClientLlm: action result status is error: an error occurred while running the action - Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined]),\ngenerate node is unable to parse (gemini) response from attempt 1; (this may be an incomplete response from the model): Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined]): ActionsClientLlm: action result status is error: an error occurred while running the action - Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined]),\ngenera',
+      start: '2025-05-19T17:21:51.620Z',
+      status: 'dismissed',
+    },
+    {
+      alerts_context_count: 75,
+      connector_id: 'pmeClaudeV37SonnetUsEast1',
+      discoveries: 8,
+      end: '2025-05-19T17:44:07.117Z',
+      loading_message:
+        'AI is analyzing up to 100 alerts in the last 24 hours to generate discoveries.',
+      execution_uuid: '22660874-7149-487a-8da5-51d876820401',
+      start: '2025-05-19T17:21:40.569Z',
+      status: 'dismissed',
+      connector_stats: {
+        average_successful_duration_nanoseconds: 1346548000000,
+        successful_generations: 1,
+      },
+    },
+  ],
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/index.tsx
@@ -45,7 +45,7 @@ const AttackDiscoveryPanelComponent: React.FC<Props> = ({
 
   return (
     <>
-      <EuiPanel data-test-subj="attackDiscovery" hasBorder={true}>
+      <EuiPanel data-test-subj={`attackDiscoveryPanel-${attackDiscovery.id}`} hasBorder={true}>
         <EuiSpacer size="xs" />
 
         <PanelHeader

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/index.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { PanelHeader } from '.';
+import { TestProviders } from '../../../../../common/mock/test_providers';
+import { getMockAttackDiscoveryAlerts } from '../../../mock/mock_attack_discovery_alerts';
+
+const mockSetIsOpen = jest.fn();
+const mockSetSelectedAttackDiscoveries = jest.fn();
+const mockSetIsSelected = jest.fn();
+const mockOnToggle = jest.fn();
+
+const mockAttackDiscovery = getMockAttackDiscoveryAlerts()[0];
+
+const defaultProps = {
+  attackDiscovery: mockAttackDiscovery,
+  isOpen: 'open' as const,
+  isSelected: false,
+  setIsSelected: mockSetIsSelected,
+  onToggle: mockOnToggle,
+  replacements: mockAttackDiscovery.replacements,
+  setIsOpen: mockSetIsOpen,
+  setSelectedAttackDiscoveries: mockSetSelectedAttackDiscoveries,
+  showAnonymized: false,
+};
+
+describe('PanelHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the PrimaryInteractions', () => {
+    render(
+      <TestProviders>
+        <PanelHeader {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('primaryInteractions')).toBeInTheDocument();
+  });
+
+  it('renders the SummaryActions', () => {
+    render(
+      <TestProviders>
+        <PanelHeader {...defaultProps} />
+      </TestProviders>
+    );
+    expect(screen.getByTestId('summaryActions')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/index.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Badges } from '.';
+import { TestProviders } from '../../../../../../../common/mock/test_providers';
+import { getMockAttackDiscoveryAlerts } from '../../../../../mock/mock_attack_discovery_alerts';
+
+// Mock child badge components to isolate Badges
+jest.mock('./workflow_badge', () => ({
+  WorkflowBadge: () => <div data-test-subj="workflowBadge" />,
+}));
+jest.mock('./shared_badge', () => ({
+  SharedBadge: () => <div data-test-subj="sharedBadge" />,
+}));
+
+const mockAttackDiscoveryAlert = getMockAttackDiscoveryAlerts()[0];
+const defaultProps = { attackDiscovery: mockAttackDiscoveryAlert };
+
+describe('Badges', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders badges for an AttackDiscoveryAlert', () => {
+    render(
+      <TestProviders>
+        <Badges {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('badges')).toBeInTheDocument();
+  });
+
+  it('renders the WorkflowBadge', () => {
+    render(
+      <TestProviders>
+        <Badges {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('workflowBadge')).toBeInTheDocument();
+  });
+
+  it('renders the SharedBadge', () => {
+    render(
+      <TestProviders>
+        <Badges {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('sharedBadge')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/workflow_badge/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/workflow_badge/index.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { WorkflowBadge } from '.';
+import { getMockAttackDiscoveryAlerts } from '../../../../../../mock/mock_attack_discovery_alerts';
+import { isAttackDiscoveryAlert } from '../../../../../../utils/is_attack_discovery_alert';
+
+jest.mock('../../../../../../utils/is_attack_discovery_alert', () => ({
+  isAttackDiscoveryAlert: jest.fn(),
+}));
+
+describe('WorkflowBadge', () => {
+  const defaultProps = {
+    attackDiscovery: getMockAttackDiscoveryAlerts()[0],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the badge when attackDiscovery is an alert with a workflow status', () => {
+    (isAttackDiscoveryAlert as unknown as jest.Mock).mockReturnValue(true);
+
+    const { getByText } = render(<WorkflowBadge {...defaultProps} />);
+
+    expect(getByText(defaultProps.attackDiscovery.alertWorkflowStatus ?? '')).toBeInTheDocument();
+  });
+
+  it('does NOT render the badge when attackDiscovery is NOT an alert', () => {
+    (isAttackDiscoveryAlert as unknown as jest.Mock).mockReturnValue(false);
+
+    const { queryByTestId } = render(<WorkflowBadge {...defaultProps} />);
+
+    expect(queryByTestId('workflowBadge')).toBeNull();
+  });
+
+  it('does NOT render the badge when alertWorkflowStatus is null', () => {
+    (isAttackDiscoveryAlert as unknown as jest.Mock).mockReturnValue(true);
+    const props = {
+      ...defaultProps,
+      attackDiscovery: { ...defaultProps.attackDiscovery, alertWorkflowStatus: null },
+    };
+
+    const { queryByTestId } = render(<WorkflowBadge {...props} />);
+
+    expect(queryByTestId('workflowBadge')).toBeNull();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/index.test.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { PrimaryInteractions } from '.';
+import { getMockAttackDiscoveryAlerts } from '../../../../mock/mock_attack_discovery_alerts';
+import { TestProviders } from '../../../../../../common/mock/test_providers';
+
+jest.mock('../../../../../../common/lib/kibana', () => ({
+  useDateFormat: jest.fn(() => 'MMM D, YYYY @ HH:mm:ss.SSS'),
+  useKibana: jest.fn(() => ({
+    services: {
+      application: { navigateToUrl: jest.fn() },
+      featureFlags: {
+        getBooleanValue: jest.fn().mockReturnValue(true),
+      },
+    },
+  })),
+  useToasts: jest.fn(() => ({
+    addError: jest.fn(),
+    addSuccess: jest.fn(),
+    addWarning: jest.fn(),
+    addInfo: jest.fn(),
+    remove: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../../use_attack_discovery_bulk', () => ({
+  useAttackDiscoveryBulk: jest.fn(() => ({
+    mutate: jest.fn(),
+    isLoading: false,
+  })),
+}));
+
+jest.mock('../../../../use_find_attack_discoveries', () => ({
+  useInvalidateFindAttackDiscoveries: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../../../use_kibana_feature_flags', () => ({
+  useKibanaFeatureFlags: jest.fn(() => ({
+    attackDiscoveryAlertsEnabled: true,
+  })),
+}));
+
+const defaultProps = {
+  attackDiscovery: getMockAttackDiscoveryAlerts()[0],
+  isOpen: 'closed' as const,
+  isSelected: false,
+  setIsOpen: jest.fn(),
+  onToggle: jest.fn(),
+};
+
+describe('PrimaryInteractions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls setIsOpen when toggled', () => {
+    const setIsOpenMock = jest.fn();
+
+    render(
+      <TestProviders>
+        <PrimaryInteractions {...defaultProps} setIsOpen={setIsOpenMock} isOpen={'closed'} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('titleText'));
+
+    expect(setIsOpenMock).toHaveBeenCalledWith('open');
+  });
+
+  it('renders with isOpen set to open', () => {
+    render(
+      <TestProviders>
+        <PrimaryInteractions {...defaultProps} isOpen="open" />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('primaryInteractions')).toBeInTheDocument();
+  });
+
+  it('calls onToggle when provided', () => {
+    const onToggleMock = jest.fn();
+
+    render(
+      <TestProviders>
+        <PrimaryInteractions {...defaultProps} onToggle={onToggleMock} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('titleText'));
+
+    expect(onToggleMock).toHaveBeenCalledWith('open');
+  });
+
+  describe('title and subtitle', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <PrimaryInteractions {...defaultProps} />
+        </TestProviders>
+      );
+    });
+
+    it('renders the title', () => {
+      expect(screen.getByTestId('titleText')).toBeInTheDocument();
+    });
+
+    it('renders the subtitle', () => {
+      expect(screen.getByTestId('subtitle')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/subtitle/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/subtitle/index.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Subtitle } from '.';
+import { TestProviders } from '../../../../../../../common/mock/test_providers';
+import { getMockAttackDiscoveryAlerts } from '../../../../../mock/mock_attack_discovery_alerts';
+
+jest.mock('../../../../../../../common/lib/kibana', () => ({
+  useDateFormat: jest.fn(() => 'MMM D, YYYY @ HH:mm:ss.SSS'),
+  useKibana: jest.fn(() => ({ services: { upselling: {} } })),
+}));
+
+jest.mock('../../../../../utils/is_attack_discovery_alert', () => ({
+  isAttackDiscoveryAlert: jest.fn((obj) => 'generationUuid' in obj),
+}));
+
+jest.mock('../../../../../loading_callout/loading_messages/get_formatted_time', () => ({
+  getFormattedDate: jest.fn(({ date }) => `formatted-${date}`),
+}));
+
+jest.mock('./translations', () => ({
+  CREATED_BY_USER: (user: string) => `Created by: ${user}`,
+}));
+
+const mockAlert = getMockAttackDiscoveryAlerts()[0];
+const defaultProps = { attackDiscovery: mockAlert };
+
+describe('Subtitle', () => {
+  it('renders the expected formatted timestamp', () => {
+    render(
+      <TestProviders>
+        <Subtitle {...defaultProps} />
+      </TestProviders>
+    );
+    expect(screen.getByTestId('timestamp')).toHaveTextContent('formatted-2025-05-05T17:36:50.533Z');
+  });
+
+  it('renders the expected createdBy text', () => {
+    render(
+      <TestProviders>
+        <Subtitle {...defaultProps} />
+      </TestProviders>
+    );
+    expect(screen.getByTestId('createdBy')).toHaveTextContent('Created by: elastic');
+  });
+
+  it('renders createdBy with userId if userName is missing', () => {
+    const alert = { ...defaultProps.attackDiscovery, userName: undefined, userId: 'user-id-123' };
+    render(
+      <TestProviders>
+        <Subtitle attackDiscovery={alert} />
+      </TestProviders>
+    );
+    expect(screen.getByTestId('createdBy')).toHaveTextContent('Created by: user-id-123');
+  });
+
+  it('renders createdBy as empty if both userName and userId are missing', () => {
+    const alert = { ...defaultProps.attackDiscovery, userName: undefined, userId: undefined };
+    render(
+      <TestProviders>
+        <Subtitle attackDiscovery={alert} />
+      </TestProviders>
+    );
+    expect(screen.getByTestId('createdBy')).toBeEmptyDOMElement();
+  });
+
+  it('returns null if it is NOT an AttackDiscoveryAlert', () => {
+    const notAlert = { foo: 'bar' } as unknown as typeof mockAlert;
+    render(
+      <TestProviders>
+        <Subtitle attackDiscovery={notAlert} />
+      </TestProviders>
+    );
+    expect(screen.queryByTestId('subtitle')).toBeNull();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/title/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/title/index.test.tsx
@@ -1,0 +1,314 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { Title } from '.';
+import { TestProviders } from '../../../../../../../common/mock';
+import { useKibanaFeatureFlags } from '../../../../../use_kibana_feature_flags';
+
+jest.mock('../../../../../use_kibana_feature_flags', () => ({
+  useKibanaFeatureFlags: jest.fn(),
+}));
+
+jest.mock('@kbn/elastic-assistant-common', () => ({
+  ATTACK_DISCOVERY_AD_HOC_RULE_ID: 'ad-hoc-rule-id',
+  API_VERSIONS: {
+    public: {
+      v1: '2023-10-31',
+    },
+    internal: {
+      v1: '1',
+    },
+  },
+  replaceAnonymizedValuesWithOriginalValues: jest.fn((params) => params.messageContent),
+}));
+
+jest.mock('../../../../../settings_flyout/schedule/details_flyout', () => ({
+  DetailsFlyout: ({ scheduleId, onClose }: { scheduleId: string; onClose: () => void }) => (
+    <div data-test-subj="detailsFlyout">
+      {scheduleId}
+      <button type="button" onClick={onClose} data-test-subj="closeFlyout">
+        {'Close'}
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('../../../../../utils/is_attack_discovery_alert', () => ({
+  isAttackDiscoveryAlert: jest.fn((discovery) => !!discovery.alertRuleUuid),
+}));
+
+const mockUseKibanaFeatureFlags = useKibanaFeatureFlags as jest.MockedFunction<
+  typeof useKibanaFeatureFlags
+>;
+
+// Test wrapper with QueryClient and TestProviders
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return (
+    <TestProviders>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </TestProviders>
+  );
+};
+
+// Complete mockRawResponse matching AttackDiscovery shape
+const mockRawResponse = {
+  id: 'test-id',
+  title: 'Test Attack Discovery',
+  alertIds: ['alert-1'],
+  detailsMarkdown: 'Details',
+  summaryMarkdown: 'Summary',
+  timestamp: '2023-01-01T00:00:00Z',
+  connectorId: 'connector-id',
+  connectorName: 'Connector Name',
+  generationUuid: 'generation-uuid',
+  entitySummaryMarkdown: 'Entity summary',
+  mitreAttackTactics: ['TA0001'],
+  users: [],
+};
+
+const defaultProps = {
+  attackDiscovery: mockRawResponse,
+  isOpen: 'closed' as const,
+  isSelected: false,
+  onToggle: jest.fn(),
+  setIsOpen: jest.fn(),
+  setIsSelected: jest.fn(),
+  showAnonymized: false,
+};
+
+describe('Title', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKibanaFeatureFlags.mockReturnValue({
+      attackDiscoveryAlertsEnabled: true,
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders the title component', () => {
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('titleText')).toBeInTheDocument();
+    });
+
+    it('renders the checkbox when attackDiscoveryAlertsEnabled is true', () => {
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('attackDiscoveryCheckbox')).toBeInTheDocument();
+    });
+
+    it('renders the accordion', () => {
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('attackDiscoveryAccordion')).toBeInTheDocument();
+    });
+  });
+
+  describe('feature flag variations', () => {
+    describe('when attackDiscoveryAlertsEnabled is false', () => {
+      beforeEach(() => {
+        mockUseKibanaFeatureFlags.mockReturnValue({
+          attackDiscoveryAlertsEnabled: false,
+        });
+      });
+
+      it('does not render the checkbox', () => {
+        render(
+          <TestWrapper>
+            <Title {...defaultProps} />
+          </TestWrapper>
+        );
+
+        expect(screen.queryByTestId('attackDiscoveryCheckbox')).not.toBeInTheDocument();
+      });
+
+      it('still renders other components', () => {
+        render(
+          <TestWrapper>
+            <Title {...defaultProps} />
+          </TestWrapper>
+        );
+
+        expect(screen.getByTestId('attackDiscoveryAccordion')).toBeInTheDocument();
+      });
+    });
+
+    describe('when attackDiscoveryAlertsEnabled is true', () => {
+      beforeEach(() => {
+        mockUseKibanaFeatureFlags.mockReturnValue({
+          attackDiscoveryAlertsEnabled: true,
+        });
+      });
+
+      it('renders the checkbox', () => {
+        render(
+          <TestWrapper>
+            <Title {...defaultProps} />
+          </TestWrapper>
+        );
+
+        expect(screen.getByTestId('attackDiscoveryCheckbox')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('user interactions', () => {
+    it('calls setIsSelected when checkbox is clicked', async () => {
+      const setIsSelected = jest.fn();
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} setIsSelected={setIsSelected} />
+        </TestWrapper>
+      );
+
+      await userEvent.click(screen.getByTestId('attackDiscoveryCheckbox'));
+
+      expect(setIsSelected).toHaveBeenCalledWith({
+        id: 'test-id',
+        selected: true,
+      });
+    });
+
+    describe('when the accordion button is clicked', () => {
+      let setIsOpen: jest.Mock;
+      let onToggle: jest.Mock;
+
+      beforeEach(async () => {
+        setIsOpen = jest.fn();
+        onToggle = jest.fn();
+        render(
+          <TestWrapper>
+            <Title {...defaultProps} setIsOpen={setIsOpen} onToggle={onToggle} />
+          </TestWrapper>
+        );
+
+        const accordion = screen.getByTestId('attackDiscoveryAccordion');
+        const button = accordion.querySelector('button.euiAccordion__button');
+        if (button != null) {
+          await userEvent.click(button);
+        }
+      });
+
+      it('calls setIsOpen with "open"', () => {
+        expect(setIsOpen).toHaveBeenCalledWith('open');
+      });
+
+      it('calls onToggle with "open"', () => {
+        expect(onToggle).toHaveBeenCalledWith('open');
+      });
+    });
+  });
+
+  describe('schedule detection', () => {
+    it('renders DetailsFlyout when attack discovery has alertRuleUuid that is not ad-hoc', async () => {
+      const discoveryWithSchedule = {
+        ...mockRawResponse,
+        alertRuleUuid: 'scheduled-rule-id',
+      };
+
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} attackDiscovery={discoveryWithSchedule} />
+        </TestWrapper>
+      );
+
+      // Click the schedule button to open the flyout
+      await userEvent.click(screen.getByTestId('scheduleButton'));
+
+      expect(screen.getByTestId('detailsFlyout')).toHaveTextContent('scheduled-rule-id');
+    });
+
+    it('does NOT render the schedule button when attack discovery has no alertRuleUuid', () => {
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} />
+        </TestWrapper>
+      );
+
+      expect(screen.queryByTestId('scheduleButton')).not.toBeInTheDocument();
+    });
+
+    it('handles an attack discovery without an id when a checkbox is clicked', async () => {
+      const setIsSelected = jest.fn();
+      const discoveryWithoutId = { ...mockRawResponse, id: undefined };
+      render(
+        <TestWrapper>
+          <Title
+            {...defaultProps}
+            attackDiscovery={discoveryWithoutId}
+            setIsSelected={setIsSelected}
+          />
+        </TestWrapper>
+      );
+
+      await userEvent.click(screen.getByTestId('attackDiscoveryCheckbox'));
+
+      expect(setIsSelected).not.toHaveBeenCalled();
+    });
+
+    it('renders the schedule button for a scheduled attack discovery', () => {
+      const discoveryWithAlertRule = {
+        ...mockRawResponse,
+        alertRuleUuid: 'some-scheduled-rule-id',
+      };
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} attackDiscovery={discoveryWithAlertRule} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('scheduleButton')).toBeInTheDocument();
+    });
+
+    it('handles the isSelected prop correctly', () => {
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} isSelected={true} />
+        </TestWrapper>
+      );
+
+      const checkbox = screen.getByTestId('attackDiscoveryCheckbox');
+
+      expect(checkbox).toBeChecked();
+    });
+
+    it('handles the isOpen prop correctly', () => {
+      render(
+        <TestWrapper>
+          <Title {...defaultProps} isOpen="open" />
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('attackDiscoveryAccordion')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant/use_view_in_ai_assistant.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant/use_view_in_ai_assistant.test.ts
@@ -86,6 +86,66 @@ describe('useViewInAiAssistant', () => {
     expect(result.current.disabled).toBe(true);
   });
 
+  it('returns disabled: true when attackDiscovery is undefined', () => {
+    const { result } = renderHook(() =>
+      useViewInAiAssistant({
+        attackDiscovery: undefined,
+      })
+    );
+
+    expect(result.current.disabled).toBe(true);
+  });
+
+  it('returns disabled: true when attackDiscovery is null', () => {
+    const { result } = renderHook(() =>
+      useViewInAiAssistant({
+        attackDiscovery: null as unknown as typeof mockAttackDiscovery,
+      })
+    );
+
+    expect(result.current.disabled).toBe(true);
+  });
+
+  it('calls showOverlay(true) when showAssistantOverlay is called', () => {
+    const showOverlayMock = jest.fn();
+    mockUseAssistantOverlay.mockReturnValue({
+      promptContextId: 'prompt-context-id',
+      showAssistantOverlay: showOverlayMock,
+    });
+
+    const { result } = renderHook(() =>
+      useViewInAiAssistant({
+        attackDiscovery: mockAttackDiscovery,
+      })
+    );
+
+    result.current.showAssistantOverlay();
+
+    expect(showOverlayMock).toHaveBeenCalledWith(true);
+  });
+
+  it('passes replacements to useAssistantOverlay when provided', () => {
+    const replacements = { foo: 'bar' };
+    renderHook(() =>
+      useViewInAiAssistant({
+        attackDiscovery: mockAttackDiscovery,
+        replacements,
+      })
+    );
+
+    expect(mockUseAssistantOverlay.mock.calls[0][8]).toEqual(replacements);
+  });
+
+  it('passes null to useAssistantOverlay for replacements when not provided', () => {
+    renderHook(() =>
+      useViewInAiAssistant({
+        attackDiscovery: mockAttackDiscovery,
+      })
+    );
+
+    expect(mockUseAssistantOverlay.mock.calls[0][8]).toBeNull();
+  });
+
   it('uses the title + last 5 of the attack discovery id as the conversation title', () => {
     renderHook(() =>
       useViewInAiAssistant({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/current/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/current/index.test.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { Current } from '.';
+import { TestProviders } from '../../../../common/mock/test_providers';
+import * as showEmptyStatesModule from '../empty_states/helpers/show_empty_states';
+import * as helpersModule from '../../helpers';
+import { getMockAttackDiscoveryAlerts } from '../../mock/mock_attack_discovery_alerts';
+
+// Helper to convert AttackDiscoveryAlert[] to AttackDiscovery[] (they are structurally compatible for test purposes)
+const getMockAttackDiscoveries = () => {
+  const alerts = getMockAttackDiscoveryAlerts();
+  return alerts.map(
+    ({
+      alertIds,
+      detailsMarkdown,
+      summaryMarkdown,
+      title,
+      id,
+      entitySummaryMarkdown,
+      mitreAttackTactics,
+      timestamp,
+    }) => ({
+      alertIds,
+      detailsMarkdown,
+      summaryMarkdown,
+      title,
+      id,
+      entitySummaryMarkdown,
+      mitreAttackTactics,
+      timestamp,
+    })
+  );
+};
+
+const defaultProps = {
+  aiConnectorsCount: 1,
+  alertsContextCount: 1,
+  alertsCount: 2,
+  approximateFutureTime: null,
+  attackDiscoveriesCount: 2,
+  connectorId: 'test-connector',
+  connectorIntervals: [],
+  end: null,
+  failureReason: null,
+  isLoading: false,
+  isLoadingPost: false,
+  loadingConnectorId: null,
+  localStorageAttackDiscoveryMaxAlerts: undefined,
+  onGenerate: jest.fn(),
+  onToggleShowAnonymized: jest.fn(),
+  selectedConnectorAttackDiscoveries: getMockAttackDiscoveries(),
+  selectedConnectorLastUpdated: null,
+  selectedConnectorReplacements: {},
+  showAnonymized: false,
+  start: null,
+  stats: null,
+};
+
+describe('Current', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(showEmptyStatesModule, 'showEmptyStates').mockReturnValue(false);
+    jest.spyOn(helpersModule, 'showLoading').mockReturnValue(false);
+  });
+
+  it('renders the summary', async () => {
+    await act(async () => {
+      render(
+        <TestProviders>
+          <Current {...defaultProps} />
+        </TestProviders>
+      );
+    });
+
+    expect(screen.getByTestId('summary')).toBeInTheDocument();
+  });
+
+  it('renders attack discovery panels for each alert', () => {
+    render(
+      <TestProviders>
+        <Current {...defaultProps} />
+      </TestProviders>
+    );
+    const alerts = defaultProps.selectedConnectorAttackDiscoveries;
+
+    alerts.forEach((alert) => {
+      expect(screen.getByTestId(`attackDiscoveryPanel-${alert.id}`)).toBeInTheDocument();
+    });
+  });
+
+  it('renders empty states when showEmptyStates returns true', () => {
+    jest.spyOn(showEmptyStatesModule, 'showEmptyStates').mockReturnValue(true);
+    render(
+      <TestProviders>
+        <Current
+          {...defaultProps}
+          attackDiscoveriesCount={0}
+          selectedConnectorAttackDiscoveries={[]}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('emptyStates')).toBeInTheDocument();
+  });
+
+  it('renders the loading callout when showLoading returns true', () => {
+    jest.spyOn(helpersModule, 'showLoading').mockReturnValue(true);
+    render(
+      <TestProviders>
+        <Current {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('loadingCallout')).toBeInTheDocument();
+  });
+
+  it('does not render the summary when attackDiscoveriesCount is 0', () => {
+    render(
+      <TestProviders>
+        <Current {...defaultProps} attackDiscoveriesCount={0} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('summary')).not.toBeInTheDocument();
+  });
+
+  it('renders empty states when connectorId is undefined', () => {
+    jest.spyOn(showEmptyStatesModule, 'showEmptyStates').mockReturnValue(true);
+    render(
+      <TestProviders>
+        <Current
+          {...defaultProps}
+          connectorId={undefined}
+          attackDiscoveriesCount={0}
+          selectedConnectorAttackDiscoveries={[]}
+          alertsContextCount={0}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('emptyStates')).toBeInTheDocument();
+  });
+
+  it('renders the failure when failureReason is set', () => {
+    jest.spyOn(showEmptyStatesModule, 'showEmptyStates').mockReturnValue(true);
+    render(
+      <TestProviders>
+        <Current
+          {...defaultProps}
+          failureReason={'Some error'}
+          connectorId={'test-connector'}
+          attackDiscoveriesCount={0}
+          selectedConnectorAttackDiscoveries={[]}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('failure')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.test.tsx
@@ -191,4 +191,43 @@ describe('EmptyPrompt', () => {
       expect(generateButton).toBeDisabled();
     });
   });
+
+  describe('when attackDiscoveryAlertsEnabled is true', () => {
+    const defaultProps = {
+      alertsCount: 20,
+      aiConnectorsCount: 2,
+      attackDiscoveriesCount: 0,
+      isLoading: false,
+      isDisabled: false,
+      onGenerate: jest.fn(),
+    };
+
+    beforeEach(() => {
+      (useKibanaFeatureFlags as jest.Mock).mockReturnValue({
+        attackDiscoveryAlertsEnabled: true,
+      });
+      (useAssistantAvailability as jest.Mock).mockReturnValue({
+        hasAssistantPrivilege: true,
+        isAssistantEnabled: true,
+      });
+      jest.clearAllMocks();
+      render(
+        <TestProviders>
+          <EmptyPrompt {...defaultProps} />
+        </TestProviders>
+      );
+    });
+
+    it('renders the history title', () => {
+      const historyTitle = screen.getByTestId('historyTitle');
+
+      expect(historyTitle).toBeInTheDocument();
+    });
+
+    it('renders the history body', () => {
+      const historyBody = screen.getByTestId('historyBody');
+
+      expect(historyBody).toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/generations/get_approximate_future_time/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/generations/get_approximate_future_time/index.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+let mockShouldThrow = false;
+jest.mock('moment', () => {
+  const actualMoment = jest.requireActual('moment');
+  return (...args: unknown[]) => {
+    if (mockShouldThrow) {
+      throw new Error('forced error');
+    }
+
+    return actualMoment(...args);
+  };
+});
+
+import { getApproximateFutureTime } from '.';
+
+describe('getApproximateFutureTime', () => {
+  const baseTime = '2024-01-01T00:00:00.000Z';
+
+  afterEach(() => {
+    mockShouldThrow = false;
+    jest.resetAllMocks();
+  });
+
+  it('returns null if averageSuccessfulDurationNanoseconds is undefined', () => {
+    const result = getApproximateFutureTime({
+      averageSuccessfulDurationNanoseconds: undefined,
+      generationStartTime: baseTime,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns a Date offset by the rounded-up seconds', () => {
+    const result = getApproximateFutureTime({
+      averageSuccessfulDurationNanoseconds: 1_500_000_000, // 1.5s => 2s
+      generationStartTime: baseTime,
+    });
+
+    expect(result?.toISOString()).toBe('2024-01-01T00:00:02.000Z');
+  });
+
+  it('returns a Date offset by 0 seconds if duration is 0', () => {
+    const result = getApproximateFutureTime({
+      averageSuccessfulDurationNanoseconds: 0,
+      generationStartTime: baseTime,
+    });
+
+    expect(result?.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('returns a Date offset by 1 second if duration is less than 1s', () => {
+    const result = getApproximateFutureTime({
+      averageSuccessfulDurationNanoseconds: 999_999_999, // just under 1s
+      generationStartTime: baseTime,
+    });
+
+    expect(result?.toISOString()).toBe('2024-01-01T00:00:01.000Z');
+  });
+
+  it('returns an invalid Date if generationStartTime is not a valid date', () => {
+    const result = getApproximateFutureTime({
+      averageSuccessfulDurationNanoseconds: 1_000_000_000,
+      generationStartTime: 'not-a-date',
+    });
+
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
+  it('returns null when an error is thrown', () => {
+    mockShouldThrow = true;
+    const result = getApproximateFutureTime({
+      averageSuccessfulDurationNanoseconds: 1_000_000_000,
+      generationStartTime: baseTime,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/generations/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/generations/index.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { Generations } from '.';
+import { TestProviders } from '../../../../../common/mock';
+import { getMockConnectors } from '../../../mock/mock_connectors';
+import { getMockGenerations } from '../../../mock/mock_generations';
+
+const mockFutureTime = '2025-05-19T23:20:15.933Z';
+
+jest.mock('./get_approximate_future_time', () => ({
+  getApproximateFutureTime: jest.fn(() => new Date(mockFutureTime)),
+}));
+jest.mock('../../../utils/get_connector_name_from_id', () => ({
+  getConnectorNameFromId: jest.fn(() => 'Mock Connector Name'),
+}));
+
+const defaultProps = {
+  aiConnectors: getMockConnectors(),
+  localStorageAttackDiscoveryMaxAlerts: undefined,
+  refetchGenerations: jest.fn(),
+};
+
+describe('Generations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a callout for every NON-dismissed generation', () => {
+    render(
+      <TestProviders>
+        <Generations {...defaultProps} data={{ generations: getMockGenerations().generations }} />
+      </TestProviders>
+    );
+
+    expect(screen.getAllByTestId('generations').length).toBe(1); // only 1/3 of the generations are non-dismissed
+  });
+
+  it(`renders at most 5 latest non-dismissed generations`, () => {
+    const length = 8;
+    const baseGen = getMockGenerations().generations[0];
+    const manyGenerations = Array.from({ length }, (_, i) => ({
+      ...baseGen,
+      execution_uuid: `uuid-${i}`,
+      status: 'succeeded' as const,
+    }));
+
+    render(
+      <TestProviders>
+        <Generations {...defaultProps} data={{ generations: manyGenerations }} />
+      </TestProviders>
+    );
+
+    expect(screen.getAllByTestId('generations').length).toBe(5);
+  });
+
+  it('does NOT render callouts when data is undefined', () => {
+    render(
+      <TestProviders>
+        <Generations {...defaultProps} data={undefined} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('generations')).toBeNull();
+  });
+
+  it('does not render callouts when generations is empty', () => {
+    render(
+      <TestProviders>
+        <Generations {...defaultProps} data={{ generations: [] }} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('generations')).toBeNull();
+  });
+
+  it('filters out dismissed generations', () => {
+    render(
+      <TestProviders>
+        <Generations {...defaultProps} data={getMockGenerations()} />
+      </TestProviders>
+    );
+
+    const nonDismissedGenerations = getMockGenerations().generations.filter(
+      (x) => x.status !== 'dismissed'
+    ).length;
+
+    expect(screen.getAllByTestId('generations').length).toBe(nonDismissedGenerations);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/get_initial_selection/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/get_initial_selection/index.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getInitialSelection } from '.';
+import { getMockAttackDiscoveryAlerts } from '../../../mock/mock_attack_discovery_alerts';
+
+describe('getInitialSelection', () => {
+  it('returns an empty object given an empty array', () => {
+    const result = getInitialSelection([]);
+    expect(result).toEqual({});
+  });
+
+  it('returns an object with all alert ids set to false for multiple alerts', () => {
+    const alerts = getMockAttackDiscoveryAlerts();
+    const result = getInitialSelection(alerts);
+
+    expect(result).toEqual({
+      '0b8cf9c7-5ba1-49ce-b53d-3cfb06918b60': false,
+      'b8a1be79-54af-4c1e-a71e-291a7b93b769': false,
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.test.tsx
@@ -1,0 +1,529 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockCasesContext } from '@kbn/cases-plugin/public/mocks/mock_cases_context';
+import { Router } from '@kbn/shared-ux-router';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { History } from '.';
+import { ATTACK_DISCOVERY_PATH } from '../../../../../common/constants';
+import { TestProviders } from '../../../../common/mock';
+import { mockHistory } from '../../../../common/utils/route/mocks';
+import { getMockAttackDiscoveryAlerts } from '../../mock/mock_attack_discovery_alerts';
+import { useFindAttackDiscoveries } from '../../use_find_attack_discoveries';
+import { useGetAttackDiscoveryGenerations } from '../../use_get_attack_discovery_generations';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  matchPath: jest.fn(),
+  useLocation: jest.fn().mockReturnValue({
+    search: '',
+  }),
+  withRouter: jest.fn(),
+}));
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useSearchParams: jest.fn(() => [{ get: jest.fn() }]),
+}));
+
+jest.mock('../../../../common/lib/kibana', () => ({
+  useDateFormat: jest.fn(),
+  useKibana: jest.fn(() => ({
+    services: {
+      application: {
+        capabilities: {
+          siemV2: { crud_alerts: true, read_alerts: true },
+          siemV3: { configurations: true },
+        },
+        navigateToUrl: jest.fn(),
+      },
+      cases: {
+        helpers: {
+          canUseCases: jest.fn().mockReturnValue({
+            all: true,
+            connectors: true,
+            create: true,
+            delete: true,
+            push: true,
+            read: true,
+            settings: true,
+            update: true,
+          }),
+        },
+        hooks: {
+          useCasesAddToExistingCase: jest.fn(),
+          useCasesAddToExistingCaseModal: jest.fn().mockReturnValue({ open: jest.fn() }),
+          useCasesAddToNewCaseFlyout: jest.fn(),
+        },
+        ui: { getCasesContext: mockCasesContext },
+      },
+      featureFlags: {
+        getBooleanValue: jest.fn().mockReturnValue(true),
+      },
+      theme: {
+        getTheme: jest.fn().mockReturnValue({ darkMode: false }),
+      },
+    },
+  })),
+  useToasts: jest.fn(() => ({
+    addError: jest.fn(),
+    addSuccess: jest.fn(),
+    addWarning: jest.fn(),
+    addInfo: jest.fn(),
+    remove: jest.fn(),
+  })),
+}));
+
+jest.mock('../../use_dismiss_attack_discovery_generations', () => ({
+  useDismissAttackDiscoveryGeneration: jest.fn().mockReturnValue({
+    dismiss: jest.fn(),
+    mutateAsync: jest.fn(),
+  }),
+}));
+
+jest.mock('../../use_find_attack_discoveries', () => ({
+  useFindAttackDiscoveries: jest.fn().mockReturnValue({
+    cancelRequest: jest.fn(),
+    data: { data: [], total: 0 },
+    isLoading: false,
+    refetch: jest.fn(),
+  }),
+  useInvalidateFindAttackDiscoveries: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock('../../use_get_attack_discovery_generations', () => ({
+  useGetAttackDiscoveryGenerations: jest.fn().mockReturnValue({
+    cancelRequest: jest.fn(),
+    data: {
+      generations: [
+        {
+          alerts_context_count: 84,
+          connector_id: 'claudeV3Haiku',
+          discoveries: 1,
+          end: '2025-05-02T17:46:43.486Z',
+          loading_message:
+            'AI is analyzing up to 100 alerts from now-30d to now to generate discoveries.',
+          execution_uuid: '27384b25-5fc0-4d11-a04f-42b2707092fa',
+          generation_start_time: '2025-05-02T17:45:25.426Z',
+          start: '2025-05-02T17:45:25.426Z',
+          status: 'succeeded',
+          connector_stats: {
+            average_successful_duration_nanoseconds: 78060000000,
+            successful_generations: 1,
+          },
+        },
+      ],
+    },
+    isLoading: false,
+    refetch: jest.fn(),
+  }),
+  useInvalidateGetAttackDiscoveryGenerations: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock('./use_ids_from_url', () => ({
+  useIdsFromUrl: jest.fn().mockReturnValue({
+    ids: ['alert-1'],
+    setIdsUrl: jest.fn(),
+  }),
+}));
+
+const historyMock = {
+  ...mockHistory,
+  location: {
+    hash: '',
+    pathname: ATTACK_DISCOVERY_PATH,
+    search: '',
+    state: '',
+  },
+};
+
+const defaultProps = {
+  aiConnectors: [],
+  localStorageAttackDiscoveryMaxAlerts: undefined,
+  onGenerate: jest.fn(),
+  onToggleShowAnonymized: jest.fn(),
+  showAnonymized: false,
+};
+
+describe('History', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset mocks to their default state
+    (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+      cancelRequest: jest.fn(),
+      data: { data: [], total: 0 },
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    (useGetAttackDiscoveryGenerations as jest.Mock).mockReturnValue({
+      cancelRequest: jest.fn(),
+      data: {
+        generations: [
+          {
+            alerts_context_count: 84,
+            connector_id: 'claudeV3Haiku',
+            discoveries: 1,
+            end: '2025-05-02T17:46:43.486Z',
+            loading_message:
+              'AI is analyzing up to 100 alerts from now-30d to now to generate discoveries.',
+            execution_uuid: '27384b25-5fc0-4d11-a04f-42b2707092fa',
+            generation_start_time: '2025-05-02T17:45:25.426Z',
+            start: '2025-05-02T17:45:25.426Z',
+            status: 'succeeded',
+            connector_stats: {
+              average_successful_duration_nanoseconds: 78060000000,
+              successful_generations: 1,
+            },
+          },
+        ],
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+  });
+
+  describe('rendering', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <History {...defaultProps} />
+          </Router>
+        </TestProviders>
+      );
+    });
+
+    it('renders the SearchAndFilter', () => {
+      expect(screen.getByTestId('searchAndFilterQueryQuery')).toBeInTheDocument();
+    });
+
+    it('renders the Summary', () => {
+      expect(screen.getByTestId('summary')).toBeInTheDocument();
+    });
+
+    it('renders the Generations', () => {
+      expect(screen.getByTestId('generations')).toBeInTheDocument();
+    });
+  });
+
+  it('calls refetchFindAttackDiscoveries on refresh', async () => {
+    const refetchMock = jest.fn();
+    (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+      cancelRequest: jest.fn(),
+      data: { data: [], total: 0 },
+      isLoading: false,
+      refetch: refetchMock,
+    });
+
+    render(
+      <TestProviders>
+        <Router history={historyMock}>
+          <History {...defaultProps} />
+        </Router>
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('superDatePickerApplyTimeButton'));
+
+    await waitFor(() => {
+      expect(refetchMock).toHaveBeenCalled();
+    });
+  });
+
+  it('renders an empty prompt when data is empty', () => {
+    (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+      cancelRequest: jest.fn(),
+      data: { data: [], total: 0 },
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <TestProviders>
+        <Router history={historyMock}>
+          <History {...defaultProps} />
+        </Router>
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('emptyPrompt')).toBeInTheDocument();
+  });
+
+  describe('refetching generations', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it('sets up interval to refetch generations every 10 seconds', () => {
+      const refetchGenerationsMock = jest.fn();
+      (useGetAttackDiscoveryGenerations as jest.Mock).mockReturnValue({
+        cancelRequest: jest.fn(),
+        data: { generations: [] },
+        isLoading: false,
+        refetch: refetchGenerationsMock,
+      });
+
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <History {...defaultProps} />
+          </Router>
+        </TestProviders>
+      );
+
+      expect(refetchGenerationsMock).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(10000);
+
+      expect(refetchGenerationsMock).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(10000);
+
+      expect(refetchGenerationsMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the interval and cancels requests on unmount', () => {
+      const cancelFindAttackDiscoveriesRequestMock = jest.fn();
+      const cancelGetAttackDiscoveryGenerationsMock = jest.fn();
+
+      (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+        cancelRequest: cancelFindAttackDiscoveriesRequestMock,
+        data: { data: [], total: 0 },
+        isLoading: false,
+        refetch: jest.fn(),
+      });
+
+      (useGetAttackDiscoveryGenerations as jest.Mock).mockReturnValue({
+        cancelRequest: cancelGetAttackDiscoveryGenerationsMock,
+        data: { generations: [] },
+        isLoading: false,
+        refetch: jest.fn(),
+      });
+
+      const { unmount } = render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <History {...defaultProps} />
+          </Router>
+        </TestProviders>
+      );
+
+      unmount();
+
+      expect(cancelFindAttackDiscoveriesRequestMock).toHaveBeenCalled();
+      expect(cancelGetAttackDiscoveryGenerationsMock).toHaveBeenCalled();
+    });
+  });
+
+  it('calls onToggleShowAnonymized when clicked', () => {
+    const onToggleMock = jest.fn();
+
+    render(
+      <TestProviders>
+        <Router history={historyMock}>
+          <History {...defaultProps} onToggleShowAnonymized={onToggleMock} />
+        </Router>
+      </TestProviders>
+    );
+
+    const anonymizedToggleButton = screen.getByTestId('toggleAnonymized');
+    fireEvent.click(anonymizedToggleButton);
+
+    expect(onToggleMock).toHaveBeenCalled();
+  });
+
+  describe('handles multiple pages of data', () => {
+    let multiPageData;
+
+    beforeEach(() => {
+      const data = getMockAttackDiscoveryAlerts();
+      // Create enough data for multiple pages
+      multiPageData = [
+        ...data,
+        ...Array.from({ length: 50 }).map((_, index) => ({
+          ...data[0],
+          id: `custom-id-${index + 1}`,
+        })),
+      ];
+
+      (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+        cancelRequest: jest.fn(),
+        data: {
+          data: multiPageData.slice(0, 25), // First page
+          total: multiPageData.length,
+        },
+        isLoading: false,
+        refetch: jest.fn(),
+      });
+
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <History {...defaultProps} />
+          </Router>
+        </TestProviders>
+      );
+    });
+
+    it('shows page 1 as selected', () => {
+      expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('enables the next page button', () => {
+      const nextPageButton = screen.getByTestId('pagination-button-next');
+      expect(nextPageButton).not.toBeDisabled();
+    });
+  });
+
+  it('updates the current page when the next button is clicked', () => {
+    const data = getMockAttackDiscoveryAlerts();
+
+    // Create multiple pages
+    const multiPageData = [
+      ...data,
+      ...Array.from({ length: 20 }).map((_, index) => ({
+        ...data[0],
+        id: `custom-id-${index + 1}`,
+        title: `Custom Attack Discovery ${index + 1}`,
+      })),
+    ];
+
+    (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+      cancelRequest: jest.fn(),
+      data: {
+        data: multiPageData,
+        total: multiPageData.length,
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <TestProviders>
+        <Router history={historyMock}>
+          <History {...defaultProps} />
+        </Router>
+      </TestProviders>
+    );
+
+    // Go to next page - this should reset selected attack discoveries
+    const nextPageButton = screen.getByTestId('pagination-button-next');
+
+    fireEvent.click(nextPageButton);
+
+    expect(screen.getByTestId('pagination-button-1')).toHaveAttribute('aria-current', 'page');
+  });
+
+  describe('resets page and selected attack discoveries when changing items per page', () => {
+    let multiPageData;
+
+    beforeEach(() => {
+      const data = getMockAttackDiscoveryAlerts();
+      // Create 20 items to have multiple pages
+      multiPageData = [
+        ...data,
+        ...Array.from({ length: 15 }).map((_, index) => ({
+          ...data[0],
+          id: `custom-id-${index + 1}`,
+          title: `Custom Attack Discovery ${index + 1}`,
+        })),
+      ];
+
+      (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+        cancelRequest: jest.fn(),
+        data: {
+          data: multiPageData,
+          total: multiPageData.length,
+        },
+        isLoading: false,
+        refetch: jest.fn(),
+      });
+
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <History {...defaultProps} />
+          </Router>
+        </TestProviders>
+      );
+    });
+
+    it('navigates to page 2 when next is clicked', () => {
+      const nextPageButton = screen.getByTestId('pagination-button-next');
+      fireEvent.click(nextPageButton);
+
+      expect(screen.getByTestId('pagination-button-1')).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('resets to the first page when items per page is changed', () => {
+      // Go to page 2 first
+      const nextPageButton = screen.getByTestId('pagination-button-next');
+      fireEvent.click(nextPageButton);
+
+      expect(screen.getByTestId('pagination-button-1')).toHaveAttribute('aria-current', 'page');
+
+      // Open the items per page popover
+      const tablePaginationPopoverButton = screen.getByTestId('tablePaginationPopoverButton');
+      fireEvent.click(tablePaginationPopoverButton);
+
+      // Select 20 rows per page
+      const tablePagination20Rows = screen.getByTestId('tablePagination-20-rows');
+      fireEvent.click(tablePagination20Rows);
+
+      // Should reset to first page
+      expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
+    });
+  });
+
+  it('renders with filter by alert IDs when provided', () => {
+    render(
+      <TestProviders>
+        <Router history={historyMock}>
+          <History {...defaultProps} />
+        </Router>
+      </TestProviders>
+    );
+
+    expect(screen.getByText('_id: alert-1')).toBeInTheDocument();
+  });
+
+  it('renders Attack discoveries', () => {
+    const data = getMockAttackDiscoveryAlerts();
+
+    (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+      cancelRequest: jest.fn(),
+      data: {
+        data,
+        total: data.length,
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <TestProviders>
+        <Router history={historyMock}>
+          <History
+            aiConnectors={[]}
+            localStorageAttackDiscoveryMaxAlerts={undefined}
+            onGenerate={jest.fn()}
+            onToggleShowAnonymized={jest.fn()}
+            showAnonymized={false}
+          />
+        </Router>
+      </TestProviders>
+    );
+
+    expect(screen.getAllByTestId(/^attackDiscoveryPanel-/).length).toEqual(data.length);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/connector_filter/get_description/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/connector_filter/get_description/index.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getDescription } from '.';
+
+jest.mock('../translations', () => ({
+  AMAZON_BEDROCK: 'Amazon Bedrock',
+  GOOGLE_GEMINI: 'Google Gemini',
+  OPENAI: 'OpenAI',
+}));
+
+describe('getDescription', () => {
+  it("returns the expected description for '.bedrock'", () => {
+    expect(getDescription('.bedrock')).toBe('Amazon Bedrock');
+  });
+
+  it("returns the expected description for '.gemini'", () => {
+    expect(getDescription('.gemini')).toBe('Google Gemini');
+  });
+
+  it("returns the expected description for '.gen-ai'", () => {
+    expect(getDescription('.gen-ai')).toBe('OpenAI');
+  });
+
+  it('returns undefined for an unknown actionTypeId', () => {
+    expect(getDescription('unknown')).toBeUndefined();
+  });
+
+  it('returns undefined for an undefined actionTypeId', () => {
+    expect(getDescription(undefined)).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/index.test.tsx
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiSelectableOption } from '@elastic/eui';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SearchAndFilter } from '.';
+import { TestProviders } from '../../../../../common/mock';
+
+jest.mock('../../../use_get_attack_discovery_generations', () => ({
+  useInvalidateGetAttackDiscoveryGenerations: jest.fn().mockReturnValue(jest.fn()),
+}));
+jest.mock('../../../use_find_attack_discoveries', () => ({
+  useInvalidateFindAttackDiscoveries: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+const mockSetQuery = jest.fn();
+const mockSetStart = jest.fn();
+const mockSetEnd = jest.fn();
+const mockSetFilterByAlertIds = jest.fn();
+const mockSetSelectedAttackDiscoveries = jest.fn();
+const mockOnRefresh = jest.fn();
+const mockSetSelectedConnectorNames = jest.fn();
+const mockSetShared = jest.fn();
+const mockSetStatusItems = jest.fn();
+
+const defaultProps = {
+  aiConnectors: [],
+  connectorNames: [],
+  end: undefined,
+  filterByAlertIds: [],
+  isLoading: false,
+  onRefresh: mockOnRefresh,
+  query: '',
+  selectedConnectorNames: [],
+  setEnd: mockSetEnd,
+  setFilterByAlertIds: mockSetFilterByAlertIds,
+  setQuery: mockSetQuery,
+  setSelectedAttackDiscoveries: mockSetSelectedAttackDiscoveries,
+  setSelectedConnectorNames: mockSetSelectedConnectorNames,
+  setShared: mockSetShared,
+  setStart: mockSetStart,
+  setStatusItems: mockSetStatusItems,
+  shared: undefined,
+  start: undefined,
+  statusItems: [],
+};
+
+describe('SearchAndFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the search bar', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    const input = screen
+      .getByTestId('searchAndFilterQueryQuery')
+      .querySelector('input[type="search"]');
+
+    expect(input).toBeInTheDocument();
+  });
+
+  it('renders the Visibility filter', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Visibility')).toBeInTheDocument();
+  });
+
+  it('renders the Status filter', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  it('renders the Connector filter', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Connector')).toBeInTheDocument();
+  });
+
+  it('renders the date picker', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('alertSelectionDatePicker')).toBeInTheDocument();
+  });
+
+  describe('when the date picker changes', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <SearchAndFilter {...defaultProps} />
+        </TestProviders>
+      );
+
+      fireEvent.click(screen.getByTestId('superDatePickerToggleQuickMenuButton'));
+      fireEvent.click(screen.getByTestId('superDatePickerCommonlyUsed_Last_7 days'));
+    });
+
+    it('calls setStart when the date picker changes', () => {
+      expect(mockSetStart).toHaveBeenCalledWith('now-7d');
+    });
+
+    it('calls setEnd when the date picker changes', () => {
+      expect(mockSetEnd).toHaveBeenCalledWith('now');
+    });
+  });
+
+  it('calls onRefresh when the refresh button is clicked', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('superDatePickerApplyTimeButton'));
+
+    expect(mockOnRefresh).toHaveBeenCalled();
+  });
+
+  it('updates the query when the search input changes and the Enter key is pressed', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    const input = screen
+      .getByTestId('searchAndFilterQueryQuery')
+      .querySelector('input[type="search"]');
+    if (input) {
+      fireEvent.change(input, { target: { value: 'test query' } });
+      fireEvent.keyDown(screen.getByTestId('searchAndFilterQueryQuery'), { key: 'Enter' });
+    }
+
+    expect(mockSetQuery).toHaveBeenCalledWith('test query');
+  });
+
+  it('onKeyDown does not refresh for a non-Enter key press', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.keyDown(screen.getByTestId('searchAndFilterQueryQuery'), { key: 'a' });
+
+    expect(mockOnRefresh).not.toHaveBeenCalled();
+  });
+
+  it('renders alert ID badges when filterByAlertIds is provided', () => {
+    const alertIds = ['alert-id-1'];
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} filterByAlertIds={alertIds} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('_id: alert-id-1')).toBeInTheDocument();
+  });
+
+  it('calls mockSetFilterByAlertIds when the badge cross icon is clicked', () => {
+    const alertIds = ['alert-id-1'];
+
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} filterByAlertIds={alertIds} />
+      </TestProviders>
+    );
+
+    const clearButton = screen.getByRole('button', { name: 'Clear filter _id:alert-id-1' });
+    fireEvent.click(clearButton);
+
+    expect(mockSetFilterByAlertIds).toHaveBeenCalledWith([]);
+  });
+
+  it('disables the date picker when isLoading is true', () => {
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} isLoading={true} />
+      </TestProviders>
+    );
+
+    const datePicker = screen.getByTestId('alertSelectionDatePicker');
+    const button = datePicker.querySelector('button');
+
+    expect(button).toBeDisabled();
+  });
+
+  it('returns statusItems updated when Status filter changes', () => {
+    const statusOptions: EuiSelectableOption[] = [
+      { label: 'Open', checked: undefined },
+      { label: 'Closed', checked: undefined },
+    ];
+
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} statusItems={statusOptions} />
+      </TestProviders>
+    );
+
+    // Simulate clicking the Status filter and selecting 'Open'
+    fireEvent.click(screen.getByText('Status'));
+    fireEvent.click(screen.getByText('Open'));
+
+    expect(mockSetStatusItems).toHaveBeenCalledWith([
+      { label: 'Open', checked: 'on' },
+      { label: 'Closed', checked: undefined },
+    ]);
+  });
+
+  it('returns selectedConnectorNames updated when Connector filter changes', () => {
+    const connectorNames = ['GPT-4', 'Claude', 'Gemini'];
+    render(
+      <TestProviders>
+        <SearchAndFilter {...defaultProps} connectorNames={connectorNames} />
+      </TestProviders>
+    );
+
+    defaultProps.setSelectedConnectorNames(['GPT-4']);
+
+    expect(mockSetSelectedConnectorNames).toHaveBeenCalledWith(['GPT-4']);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/status_filter/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/status_filter/index.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiSelectableOption } from '@elastic/eui';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { StatusFilter } from '.';
+import { TestProviders } from '../../../../../../common/mock/test_providers';
+import * as useFindAttackDiscoveriesModule from '../../../../use_find_attack_discoveries';
+
+jest.mock('../../../../use_find_attack_discoveries', () => {
+  const actual = jest.requireActual('../../../../use_find_attack_discoveries');
+  return {
+    ...actual,
+    useInvalidateFindAttackDiscoveries: jest.fn(() => jest.fn()),
+  };
+});
+
+const defaultStatusItems: EuiSelectableOption[] = [
+  { checked: 'on' as const, 'data-test-subj': 'open', label: 'Open' },
+  { checked: 'on' as const, 'data-test-subj': 'acknowledged', label: 'Acknowledged' },
+  { checked: undefined, 'data-test-subj': 'closed', label: 'Closed' },
+];
+
+const defaultProps = {
+  statusItems: defaultStatusItems,
+  setStatusItems: jest.fn(),
+};
+
+describe('StatusFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the expected number of options', () => {
+    render(
+      <TestProviders>
+        <StatusFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('statusFilterButton'));
+
+    expect(screen.getAllByRole('option').length).toBe(defaultStatusItems.length);
+  });
+
+  it('returns the correct checked state for open and acknowledged', () => {
+    render(
+      <TestProviders>
+        <StatusFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('statusFilterButton'));
+    const checkedOptions = screen
+      .getAllByRole('option')
+      .filter((el) => el.getAttribute('aria-checked') === 'true');
+
+    expect(checkedOptions.length).toBe(2);
+  });
+
+  it('returns the correct checked state for closed', () => {
+    render(
+      <TestProviders>
+        <StatusFilter {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('statusFilterButton'));
+    const checkedOptions = screen
+      .getAllByRole('option')
+      .filter((el) => el.getAttribute('aria-checked') === 'false');
+
+    expect(checkedOptions.length).toBe(1);
+  });
+
+  it('disables the filter button when loading', () => {
+    render(
+      <TestProviders>
+        <StatusFilter {...defaultProps} isLoading={true} />
+      </TestProviders>
+    );
+
+    const button = screen.getByTestId('statusFilterButton');
+
+    expect(button).toBeDisabled();
+  });
+
+  describe('when an option is changed', () => {
+    let setStatusItems: jest.Mock;
+    let invalidateFindAttackDiscoveries: jest.Mock;
+
+    beforeEach(() => {
+      setStatusItems = jest.fn();
+      invalidateFindAttackDiscoveries = jest.fn();
+      (
+        useFindAttackDiscoveriesModule.useInvalidateFindAttackDiscoveries as jest.Mock
+      ).mockImplementation(() => invalidateFindAttackDiscoveries);
+
+      render(
+        <TestProviders>
+          <StatusFilter {...defaultProps} setStatusItems={setStatusItems} />
+        </TestProviders>
+      );
+
+      fireEvent.click(screen.getByTestId('statusFilterButton'));
+      const options = screen.getAllByRole('option');
+      fireEvent.click(options[0]);
+    });
+
+    it('calls setStatusItems', () => {
+      expect(setStatusItems).toHaveBeenCalled();
+    });
+
+    it('calls invalidateFindAttackDiscoveries', () => {
+      expect(invalidateFindAttackDiscoveries).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/visibility_filter/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/visibility_filter/index.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useInvalidateFindAttackDiscoveries } from '../../../../use_find_attack_discoveries';
+import React from 'react';
+
+import { VisibilityFilter } from '.';
+import { TestProviders } from '../../../../../../common/mock/test_providers';
+
+jest.mock('../../../../use_find_attack_discoveries', () => ({
+  useInvalidateFindAttackDiscoveries: jest.fn(() => jest.fn()),
+}));
+
+const defaultProps = {
+  setShared: jest.fn(),
+};
+
+describe('VisibilityFilter', () => {
+  let setShared: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setShared = jest.fn();
+  });
+
+  describe('expected options', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <VisibilityFilter {...defaultProps} setShared={setShared} />
+        </TestProviders>
+      );
+      fireEvent.click(screen.getByText('Visibility'));
+    });
+
+    it('shows the Not shared option', () => {
+      expect(screen.getByText('Not shared')).toBeInTheDocument();
+    });
+
+    it('shows the Shared option', () => {
+      expect(screen.getByText('Shared')).toBeInTheDocument();
+    });
+  });
+
+  it('selects both options by default', () => {
+    render(
+      <TestProviders>
+        <VisibilityFilter {...defaultProps} setShared={setShared} />
+      </TestProviders>
+    );
+    fireEvent.click(screen.getByText('Visibility'));
+    const checkedOptions = screen
+      .getAllByRole('option')
+      .filter((el) => el.getAttribute('aria-checked') === 'true');
+
+    expect(checkedOptions.length).toBe(2);
+  });
+
+  it('disables the filter button when loading', () => {
+    render(
+      <TestProviders>
+        <VisibilityFilter {...defaultProps} setShared={setShared} isLoading={true} />
+      </TestProviders>
+    );
+
+    const button = screen.getByRole('button', { name: /visibility/i });
+
+    expect(button).toBeDisabled();
+  });
+
+  it('calls setShared with true when only Shared is selected', () => {
+    render(
+      <TestProviders>
+        <VisibilityFilter {...defaultProps} setShared={setShared} />
+      </TestProviders>
+    );
+    fireEvent.click(screen.getByText('Visibility'));
+    // Deselect Not shared first (since both are selected by default)
+    const notSharedOption = screen.getByText('Not shared').closest('[role="option"]');
+    fireEvent.click(notSharedOption!);
+
+    expect(setShared).toHaveBeenCalledWith(true);
+  });
+
+  it('returns setShared called with undefined when only Not shared is selected', () => {
+    render(
+      <TestProviders>
+        <VisibilityFilter {...defaultProps} setShared={setShared} shared={true} />
+      </TestProviders>
+    );
+    fireEvent.click(screen.getByText('Visibility'));
+    // Deselect Shared first (since both are selected by default if shared=true)
+    const sharedOption = screen.getByText('Shared').closest('[role="option"]');
+    fireEvent.click(sharedOption!);
+
+    expect(setShared).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls invalidateFindAttackDiscoveries on change', () => {
+    const invalidateFindAttackDiscoveries = jest.fn();
+    (useInvalidateFindAttackDiscoveries as jest.Mock).mockImplementation(
+      () => invalidateFindAttackDiscoveries
+    );
+
+    render(
+      <TestProviders>
+        <VisibilityFilter {...defaultProps} setShared={setShared} />
+      </TestProviders>
+    );
+    fireEvent.click(screen.getByText('Visibility'));
+    // Deselect Not shared to trigger a change
+    const notSharedOption = screen.getByText('Not shared').closest('[role="option"]');
+    fireEvent.click(notSharedOption!);
+
+    expect(invalidateFindAttackDiscoveries).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/use_ids_from_url/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/use_ids_from_url/index.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useIdsFromUrl } from '.';
+
+const mockSetSearchParams = jest.fn();
+let mockSearchParams: URLSearchParams;
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useSearchParams: jest.fn(() => [mockSearchParams, mockSetSearchParams]),
+}));
+
+describe('useIdsFromUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetSearchParams.mockClear();
+
+    mockSearchParams = new URLSearchParams('');
+  });
+
+  it('returns an empty array if no id param is present', () => {
+    mockSearchParams = new URLSearchParams('');
+    const { result } = renderHook(() => useIdsFromUrl());
+
+    expect(result.current.ids).toEqual([]);
+  });
+
+  it('returns a single id if one id param is present', () => {
+    mockSearchParams = new URLSearchParams('id=foo');
+    const { result } = renderHook(() => useIdsFromUrl());
+
+    expect(result.current.ids).toEqual(['foo']);
+  });
+
+  it('returns multiple ids if id param is comma-separated', () => {
+    mockSearchParams = new URLSearchParams('id=foo,bar,baz');
+    const { result } = renderHook(() => useIdsFromUrl());
+
+    expect(result.current.ids).toEqual(['foo', 'bar', 'baz']);
+  });
+
+  it('returns multiple ids if multiple id params are present', () => {
+    mockSearchParams = new URLSearchParams('id=foo&id=bar');
+    mockSearchParams.append('id', 'baz');
+    const { result } = renderHook(() => useIdsFromUrl());
+
+    expect(result.current.ids).toEqual(['foo', 'bar', 'baz']);
+  });
+
+  it('decodes ids', () => {
+    mockSearchParams = new URLSearchParams('id=foo%20bar,baz%2Cqux');
+    const { result } = renderHook(() => useIdsFromUrl());
+
+    expect(result.current.ids).toEqual(['foo bar', 'baz', 'qux']);
+  });
+
+  it('returns an empty array if ids param is malformed', () => {
+    mockSearchParams = new URLSearchParams('id=');
+    const { result } = renderHook(() => useIdsFromUrl());
+
+    expect(result.current.ids).toEqual(['']);
+  });
+
+  describe('setIdsUrl', () => {
+    let result: ReturnType<typeof renderHook>['result'];
+    type UseIdsFromUrlReturn = ReturnType<typeof useIdsFromUrl>;
+
+    describe('when given ids', () => {
+      beforeEach(() => {
+        mockSearchParams = new URLSearchParams('');
+        result = renderHook(() => useIdsFromUrl()).result;
+        act(() => {
+          (result.current as UseIdsFromUrlReturn).setIdsUrl(['foo', 'bar']);
+        });
+      });
+
+      it('calls setSearchParams with updated params', () => {
+        expect(mockSetSearchParams).toHaveBeenCalledWith(mockSearchParams);
+      });
+
+      it('sets the id param correctly', () => {
+        expect(mockSearchParams.get('id')).toEqual('foo,bar');
+      });
+    });
+
+    describe('when setIdsUrl is given an empty array', () => {
+      beforeEach(() => {
+        mockSearchParams = new URLSearchParams('id=foo');
+        result = renderHook(() => useIdsFromUrl()).result;
+        act(() => {
+          (result.current as UseIdsFromUrlReturn).setIdsUrl([]);
+        });
+      });
+
+      it('calls setSearchParams with updated params', () => {
+        expect(mockSetSearchParams).toHaveBeenCalledWith(mockSearchParams);
+      });
+
+      it('deletes the id param', () => {
+        expect(mockSearchParams.get('id')).toBeNull();
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/index.test.tsx
@@ -21,6 +21,9 @@ import { Results } from '.';
 import { SECURITY_FEATURE_ID } from '../../../../common/constants';
 
 jest.mock('../../../common/lib/kibana');
+jest.mock('./history', () => ({
+  History: () => <div data-test-subj="history" />,
+}));
 
 const mockFilterManager = createFilterManagerMock();
 
@@ -97,7 +100,6 @@ describe('Results', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
     mockUseKibana.mockReturnValue({
       services: {
         application: {
@@ -144,13 +146,26 @@ describe('Results', () => {
     } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
   });
 
-  it('renders the Summary when showSummary returns true', () => {
-    render(
-      <TestProviders>
-        <Results {...defaultProps} />
-      </TestProviders>
-    );
-    expect(screen.getByTestId('summary')).toBeInTheDocument();
+  describe('when isLoading is true', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <Results {...defaultProps} isLoading={true} />
+        </TestProviders>
+      );
+    });
+
+    it('does not render the welcome empty state', () => {
+      expect(screen.queryByTestId('welcome')).not.toBeInTheDocument();
+    });
+
+    it('does not render the failure empty state', () => {
+      expect(screen.queryByTestId('failure')).not.toBeInTheDocument();
+    });
+
+    it('does not render the noAlerts empty state', () => {
+      expect(screen.queryByTestId('noAlerts')).not.toBeInTheDocument();
+    });
   });
 
   it('calls onToggleShowAnonymized when the show anonymized toggle is clicked', () => {
@@ -165,15 +180,96 @@ describe('Results', () => {
     expect(defaultProps.onToggleShowAnonymized).toHaveBeenCalled();
   });
 
-  it('renders a AttackDiscoveryPanel for the attack discovery', () => {
+  it('renders the failure EmptyStates when failureReason is present and not loading', () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        ...mockUseKibana().services,
+        featureFlags: {
+          getBooleanValue: jest.fn().mockReturnValue(false),
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    render(
+      <TestProviders>
+        <Results
+          {...defaultProps}
+          failureReason="some error"
+          isLoading={false}
+          attackDiscoveriesCount={0}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('failure')).toBeInTheDocument();
+  });
+
+  it('renders the welcome empty state when there are no connectors', () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        ...mockUseKibana().services,
+        featureFlags: {
+          getBooleanValue: jest.fn().mockReturnValue(false),
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    render(
+      <TestProviders>
+        <Results {...defaultProps} aiConnectors={[]} attackDiscoveriesCount={0} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('welcome')).toBeInTheDocument();
+  });
+
+  it('renders the noAlerts empty state when alertsContextCount is 0', () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        ...mockUseKibana().services,
+        featureFlags: {
+          getBooleanValue: jest.fn().mockReturnValue(false),
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    render(
+      <TestProviders>
+        <Results {...defaultProps} alertsContextCount={0} attackDiscoveriesCount={0} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('noAlerts')).toBeInTheDocument();
+  });
+
+  it('renders a AttackDiscoveryPanel for each attack discovery', () => {
     render(
       <TestProviders>
         <Results {...defaultProps} />
       </TestProviders>
     );
 
-    expect(screen.getAllByTestId('attackDiscovery')).toHaveLength(
-      defaultProps.selectedConnectorAttackDiscoveries.length
+    // The panel uses data-test-subj="attackDiscoveryPanel-<id>"
+    const panels = screen.getAllByTestId(/^attackDiscoveryPanel-/);
+    expect(panels).toHaveLength(defaultProps.selectedConnectorAttackDiscoveries.length);
+  });
+
+  it('renders the History component when attackDiscoveryAlertsEnabled is true', () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        ...mockUseKibana().services,
+        featureFlags: {
+          getBooleanValue: jest.fn().mockReturnValue(true),
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    render(
+      <TestProviders>
+        <Results {...defaultProps} />
+      </TestProviders>
     );
+
+    expect(screen.getByTestId('history')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/selected_actions/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/selected_actions/index.test.tsx
@@ -1,0 +1,267 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import '@testing-library/jest-dom';
+import { SelectedActions } from '.';
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+
+import { TestProviders } from '../../../../../common/mock';
+import { getMockAttackDiscoveryAlerts } from '../../../mock/mock_attack_discovery_alerts';
+import * as i18n from './translations';
+
+jest.mock('../../../../../assistant/use_assistant_availability', () => ({
+  useAssistantAvailability: () => ({
+    hasSearchAILakeConfigurations: true, // This ensures direct call to onConfirm
+  }),
+}));
+
+jest.mock('../../../use_attack_discovery_bulk', () => ({
+  useAttackDiscoveryBulk: () => ({
+    mutateAsync: jest.fn().mockResolvedValue({}),
+  }),
+}));
+
+jest.mock('../../take_action/use_update_alerts_status', () => ({
+  useUpdateAlertsStatus: () => ({
+    mutateAsync: jest.fn().mockResolvedValue({}),
+  }),
+}));
+
+jest.mock('../../take_action/use_add_to_case', () => ({
+  useAddToNewCase: () => ({
+    disabled: false,
+    onAddToNewCase: jest.fn(),
+  }),
+}));
+
+jest.mock('../../take_action/use_add_to_existing_case', () => ({
+  useAddToExistingCase: () => ({
+    onAddToExistingCase: jest.fn(),
+  }),
+}));
+
+jest.mock('../../attack_discovery_panel/view_in_ai_assistant/use_view_in_ai_assistant', () => ({
+  useViewInAiAssistant: () => ({
+    showAssistantOverlay: jest.fn(),
+    disabled: false,
+  }),
+}));
+
+jest.mock('../../../use_kibana_feature_flags', () => ({
+  useKibanaFeatureFlags: () => ({
+    attackDiscoveryAlertsEnabled: true,
+  }),
+}));
+
+describe('SelectedActions', () => {
+  const defaultProps = {
+    refetchFindAttackDiscoveries: jest.fn(),
+    selectedAttackDiscoveries: { '0b8cf9c7-5ba1-49ce-b53d-3cfb06918b60': true },
+    selectedConnectorAttackDiscoveries: getMockAttackDiscoveryAlerts(),
+    setSelectedAttackDiscoveries: jest.fn(),
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the expected selected discoveries count', () => {
+    render(
+      <TestProviders>
+        <SelectedActions {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText(i18n.SELECTED_DISCOVERIES(1))).toBeInTheDocument();
+  });
+
+  it('does NOT render when no discoveries are selected', () => {
+    render(
+      <TestProviders>
+        <SelectedActions {...defaultProps} selectedAttackDiscoveries={{}} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('summary')).toBeNull();
+  });
+
+  it('calls setSelectedAttackDiscoveries when Mark as Closed is clicked', async () => {
+    render(
+      <TestProviders>
+        <SelectedActions {...defaultProps} />
+      </TestProviders>
+    );
+
+    await act(async () => {
+      screen.getByTestId('takeActionPopoverButton').click();
+    });
+
+    const markAsClosed = await screen.findByTestId('markAsClosed');
+    await act(async () => {
+      markAsClosed.click();
+    });
+    await screen.findByTestId('takeActionPopoverButton');
+
+    expect(defaultProps.setSelectedAttackDiscoveries).toHaveBeenCalledWith({});
+  });
+
+  it('renders the expected count when multiple discoveries are selected', () => {
+    const multiSelected = {
+      ...defaultProps,
+      selectedAttackDiscoveries: {
+        '0b8cf9c7-5ba1-49ce-b53d-3cfb06918b60': true,
+        'another-id': true,
+      },
+      selectedConnectorAttackDiscoveries: [
+        ...getMockAttackDiscoveryAlerts(),
+        { ...getMockAttackDiscoveryAlerts()[0], id: 'another-id' },
+      ],
+    };
+
+    render(
+      <TestProviders>
+        <SelectedActions {...multiSelected} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText(i18n.SELECTED_DISCOVERIES(2))).toBeInTheDocument();
+  });
+
+  it('renders correctly when selectedAttackDiscoveries has multiple entries but only one is true', () => {
+    const props = {
+      ...defaultProps,
+      selectedAttackDiscoveries: {
+        id1: true,
+        id2: false,
+        id3: false,
+      },
+    };
+
+    render(
+      <TestProviders>
+        <SelectedActions {...props} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText(i18n.SELECTED_DISCOVERIES(1))).toBeInTheDocument();
+  });
+
+  it('does not render when the selectedConnectorAttackDiscoveries array is empty', () => {
+    const props = {
+      ...defaultProps,
+      selectedConnectorAttackDiscoveries: [],
+    };
+
+    render(
+      <TestProviders>
+        <SelectedActions {...props} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('summary')).toBeInTheDocument();
+  });
+
+  it('handles mismatched IDs between selectedAttackDiscoveries and selectedConnectorAttackDiscoveries', () => {
+    const props = {
+      ...defaultProps,
+      selectedAttackDiscoveries: { 'non-existent-id': true },
+      selectedConnectorAttackDiscoveries: getMockAttackDiscoveryAlerts(),
+    };
+
+    render(
+      <TestProviders>
+        <SelectedActions {...props} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText(i18n.SELECTED_DISCOVERIES(1))).toBeInTheDocument();
+  });
+
+  describe('action buttons', () => {
+    describe('case buttons', () => {
+      beforeEach(async () => {
+        render(
+          <TestProviders>
+            <SelectedActions {...defaultProps} />
+          </TestProviders>
+        );
+        await act(async () => {
+          screen.getByTestId('takeActionPopoverButton').click();
+        });
+      });
+
+      it('renders the add to case button', () => {
+        expect(screen.getByTestId('addToCase')).toBeInTheDocument();
+      });
+
+      it('renders the add to existing case button', () => {
+        expect(screen.getByTestId('addToExistingCase')).toBeInTheDocument();
+      });
+    });
+
+    it('renders view in AI assistant button when only one discovery is selected', async () => {
+      render(
+        <TestProviders>
+          <SelectedActions {...defaultProps} />
+        </TestProviders>
+      );
+
+      await act(async () => {
+        screen.getByTestId('takeActionPopoverButton').click();
+      });
+
+      expect(screen.getByTestId('viewInAiAssistant')).toBeInTheDocument();
+    });
+
+    it('does NOT render view in AI assistant button when multiple discoveries are selected', async () => {
+      const multiSelected = {
+        ...defaultProps,
+        selectedAttackDiscoveries: {
+          '0b8cf9c7-5ba1-49ce-b53d-3cfb06918b60': true,
+          'another-id': true,
+        },
+        selectedConnectorAttackDiscoveries: [
+          ...getMockAttackDiscoveryAlerts(),
+          { ...getMockAttackDiscoveryAlerts()[0], id: 'another-id' },
+        ],
+      };
+
+      render(
+        <TestProviders>
+          <SelectedActions {...multiSelected} />
+        </TestProviders>
+      );
+
+      await act(async () => {
+        screen.getByTestId('takeActionPopoverButton').click();
+      });
+
+      expect(screen.queryByTestId('viewInAiAssistant')).toBeNull();
+    });
+
+    describe('status buttons', () => {
+      beforeEach(async () => {
+        render(
+          <TestProviders>
+            <SelectedActions {...defaultProps} />
+          </TestProviders>
+        );
+        await act(async () => {
+          screen.getByTestId('takeActionPopoverButton').click();
+        });
+      });
+
+      it('renders mark as acknowledged button', () => {
+        // Note: markAsOpen is not shown because mock alerts have status 'open'
+        expect(screen.getByTestId('markAsAcknowledged')).toBeInTheDocument();
+      });
+
+      it('renders mark as closed button', () => {
+        expect(screen.getByTestId('markAsClosed')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/index.test.tsx
@@ -135,4 +135,14 @@ describe('AlertSelection', () => {
 
     expect(secondTab).toHaveAttribute('aria-selected', 'true');
   });
+
+  it('does not render the connector selector or customize text when showConnectorSelector is false', () => {
+    render(
+      <TestProviders>
+        <AlertSelection {...defaultProps} showConnectorSelector={false} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('customizeAlerts')).toBeNull();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery_history_timerange/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery_history_timerange/index.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import * as ReactUse from 'react-use/lib/useLocalStorage';
+import { useAttackDiscoveryHistoryTimerange } from '.';
+
+describe('useAttackDiscoveryHistoryTimerange', () => {
+  const defaultStart = 'now-24h';
+  const defaultEnd = 'now';
+  const customStart = '2024-01-01T00:00:00Z';
+  const customEnd = '2024-01-02T00:00:00Z';
+
+  describe('when localStorage is empty', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest
+        .spyOn(ReactUse, 'default')
+        .mockReturnValueOnce([undefined, jest.fn(), jest.fn()])
+        .mockReturnValueOnce([undefined, jest.fn(), jest.fn()]);
+    });
+
+    it('returns the default historyStart value', () => {
+      const { result } = renderHook(() => useAttackDiscoveryHistoryTimerange());
+
+      expect(result.current.historyStart).toBe(defaultStart);
+    });
+
+    it('returns the default historyEnd value', () => {
+      const { result } = renderHook(() => useAttackDiscoveryHistoryTimerange());
+
+      expect(result.current.historyEnd).toBe(defaultEnd);
+    });
+  });
+
+  it('returns a custom start value from localStorage', () => {
+    jest
+      .spyOn(ReactUse, 'default')
+      .mockReturnValueOnce([customStart, jest.fn(), jest.fn()])
+      .mockReturnValueOnce([undefined, jest.fn(), jest.fn()]);
+
+    const { result } = renderHook(() => useAttackDiscoveryHistoryTimerange());
+
+    expect(result.current.historyStart).toBe(customStart);
+  });
+
+  it('returns custom end value from localStorage', () => {
+    jest
+      .spyOn(ReactUse, 'default')
+      .mockReturnValueOnce([undefined, jest.fn(), jest.fn()])
+      .mockReturnValueOnce([customEnd, jest.fn(), jest.fn()]);
+
+    const { result } = renderHook(() => useAttackDiscoveryHistoryTimerange());
+
+    expect(result.current.historyEnd).toBe(customEnd);
+  });
+
+  it('setHistoryStart updates the value', () => {
+    const setHistoryStart = jest.fn();
+    jest
+      .spyOn(ReactUse, 'default')
+      .mockReturnValueOnce([customStart, setHistoryStart, jest.fn()])
+      .mockReturnValueOnce([customEnd, jest.fn(), jest.fn()]);
+
+    const { result } = renderHook(() => useAttackDiscoveryHistoryTimerange());
+
+    act(() => {
+      result.current.setHistoryStart('new-start');
+    });
+
+    expect(setHistoryStart).toHaveBeenCalledWith('new-start');
+  });
+
+  it('setHistoryEnd updates the value', () => {
+    const setHistoryEnd = jest.fn();
+    jest
+      .spyOn(ReactUse, 'default')
+      .mockReturnValueOnce([customStart, jest.fn(), jest.fn()])
+      .mockReturnValueOnce([customEnd, setHistoryEnd, jest.fn()]);
+
+    const { result } = renderHook(() => useAttackDiscoveryHistoryTimerange());
+
+    act(() => {
+      result.current.setHistoryEnd('new-end');
+    });
+
+    expect(setHistoryEnd).toHaveBeenCalledWith('new-end');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_dismiss_attack_discovery_generations/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_dismiss_attack_discovery_generations/index.test.ts
@@ -1,0 +1,314 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type PostAttackDiscoveryGenerationsDismissResponse } from '@kbn/elastic-assistant-common';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { useDismissAttackDiscoveryGeneration } from '.';
+import { TestProviders } from '../../../common/mock/test_providers';
+
+const mockHttpFetch = jest.fn();
+const mockAddSuccessToast = jest.fn();
+const mockAddError = jest.fn();
+const mockInvalidateGenerations = jest.fn();
+const mockUseKibanaFeatureFlags = jest.fn();
+
+jest.mock('@kbn/i18n', () => ({
+  i18n: {
+    translate: jest.fn((key, { defaultMessage }) => defaultMessage),
+    getIsInitialized: jest.fn(() => true),
+    getTranslation: jest.fn(() => ({
+      messages: {},
+      formats: {},
+      locale: 'en',
+      defaultLocale: 'en',
+      defaultFormats: {},
+    })),
+  },
+}));
+
+interface MockHttp {
+  post: (...args: unknown[]) => unknown;
+  fetch: (...args: unknown[]) => unknown;
+}
+
+interface MockKibanaServices {
+  get: jest.Mock<
+    {
+      http: MockHttp;
+    },
+    []
+  >;
+}
+
+interface MockUseKibanaReturn {
+  services: {
+    http: MockHttp;
+    upselling: Record<string, unknown>;
+  };
+}
+
+jest.mock(
+  '../../../common/lib/kibana',
+  (): {
+    KibanaServices: MockKibanaServices;
+    useKibana: jest.Mock<MockUseKibanaReturn, []>;
+  } => ({
+    KibanaServices: {
+      get: jest.fn().mockReturnValue({
+        http: {
+          post: (...args: unknown[]) => mockHttpFetch(...args),
+          fetch: (...args: unknown[]) => mockHttpFetch(...args),
+        },
+      }),
+    },
+    useKibana: jest.fn().mockReturnValue({
+      services: {
+        http: {
+          post: (...args: unknown[]) => mockHttpFetch(...args),
+          fetch: (...args: unknown[]) => mockHttpFetch(...args),
+        },
+        upselling: {}, // Add any other required services here
+      },
+    }),
+  })
+);
+
+interface MockUseAppToasts {
+  addSuccessToast: (...args: unknown[]) => unknown;
+  addError: (...args: unknown[]) => unknown;
+}
+
+jest.mock('../../../common/hooks/use_app_toasts', () => ({
+  useAppToasts: (): MockUseAppToasts => ({
+    addSuccessToast: (...args: unknown[]) => mockAddSuccessToast(...args),
+    addError: (...args: unknown[]) => mockAddError(...args),
+  }),
+}));
+
+jest.mock('../use_get_attack_discovery_generations', () => ({
+  useInvalidateGetAttackDiscoveryGenerations: () => mockInvalidateGenerations,
+}));
+
+jest.mock('../use_kibana_feature_flags', () => ({
+  useKibanaFeatureFlags: () => mockUseKibanaFeatureFlags(),
+}));
+
+describe('useDismissAttackDiscoveryGeneration', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockHttpFetch.mockReset();
+    mockAddSuccessToast.mockReset();
+    mockAddError.mockReset();
+    mockInvalidateGenerations.mockReset();
+    mockUseKibanaFeatureFlags.mockReset();
+
+    // Default mock implementations
+    mockUseKibanaFeatureFlags.mockReturnValue({
+      attackDiscoveryAlertsEnabled: true, // Default to true
+    });
+    // Default successful response for http.fetch
+    mockHttpFetch.mockResolvedValue({} as PostAttackDiscoveryGenerationsDismissResponse);
+  });
+
+  describe('when attackDiscoveryAlertsEnabled is false', () => {
+    beforeEach(() => {
+      mockUseKibanaFeatureFlags.mockReturnValue({
+        attackDiscoveryAlertsEnabled: false,
+      });
+    });
+
+    it('returns isLoading as false', () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('returns isSuccess as false', () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+      expect(result.current.isSuccess).toBe(false);
+    });
+
+    it('returns isError as false', () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+      expect(result.current.isError).toBe(false);
+    });
+
+    it('returns error as null', () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('when mutate is called and feature flag is true and mutation succeeds', () => {
+    beforeEach(() => {
+      mockUseKibanaFeatureFlags.mockReturnValue({
+        attackDiscoveryAlertsEnabled: true,
+      });
+    });
+
+    it('sets isSuccess to true', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    it('calls the API', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(mockHttpFetch).toHaveBeenCalled());
+    });
+
+    it('calls invalidateGenerations', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(mockInvalidateGenerations).toHaveBeenCalled());
+    });
+
+    it('does not call addError', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(mockAddError).not.toHaveBeenCalled());
+    });
+
+    it('sets isLoading to false after success', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+    });
+
+    it('sets isError to false after success', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(false));
+    });
+
+    it('sets error to null after success', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.error).toBeNull());
+    });
+  });
+
+  describe('when mutate is called and feature flag is true and mutation fails', () => {
+    const error = new Error('Mutation failed');
+    beforeEach(() => {
+      mockUseKibanaFeatureFlags.mockReturnValue({
+        attackDiscoveryAlertsEnabled: true,
+      });
+      mockHttpFetch.mockRejectedValue(error);
+    });
+
+    it('returns isError as true after failure', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+
+    it('calls addError after failure', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(mockAddError).toHaveBeenCalled());
+    });
+
+    it('returns isLoading as false after failure', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+    });
+
+    it('returns isSuccess as false after failure', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(false));
+    });
+    it('returns error as the thrown error after failure', async () => {
+      const { result } = renderHook(() => useDismissAttackDiscoveryGeneration(), {
+        wrapper: TestProviders,
+      });
+
+      act(() => {
+        result.current.mutate({ executionUuid: 'gen1', attackDiscoveryAlertsEnabled: true });
+      });
+
+      await waitFor(() => expect(result.current.error).toBe(error));
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_kibana_feature_flags/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_kibana_feature_flags/index.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ATTACK_DISCOVERY_ALERTS_ENABLED_FEATURE_FLAG } from '@kbn/elastic-assistant-common';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { TestProviders } from '../../../common/mock/test_providers';
+import { useKibanaFeatureFlags } from '.';
+
+const mockGetBooleanValueFn = jest.fn();
+
+jest.mock('../../../common/lib/kibana', () => {
+  const originalModule = jest.requireActual('../../../common/lib/kibana');
+  return {
+    ...originalModule,
+    useKibana: jest.fn(() => ({
+      services: {
+        featureFlags: {
+          getBooleanValue: mockGetBooleanValueFn,
+        },
+      },
+    })),
+  };
+});
+
+jest.mock('@kbn/core/public', () => ({
+  HttpFetchError: class HttpFetchError extends Error {
+    public statusCode: number;
+    public body: unknown;
+    constructor(message: string, statusCode: number, body: unknown) {
+      super(message);
+      this.statusCode = statusCode;
+      this.body = body;
+    }
+  },
+  uiSettings: {
+    get: jest.fn((key, defaultValue) => defaultValue ?? null), // Simplified uiSettings
+  },
+}));
+
+describe('useKibanaFeatureFlags', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetBooleanValueFn.mockReturnValue(false);
+  });
+
+  it('returns false when the attack discovery alerts feature flag is disabled', async () => {
+    mockGetBooleanValueFn.mockReturnValue(false);
+
+    const { result } = renderHook(() => useKibanaFeatureFlags(), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    await waitFor(() => {
+      expect(result.current.attackDiscoveryAlertsEnabled).toBe(false);
+    });
+  });
+
+  it('returns true when the attack discovery alerts feature flag is enabled', async () => {
+    mockGetBooleanValueFn.mockReturnValue(true);
+
+    const { result } = renderHook(() => useKibanaFeatureFlags(), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    await waitFor(() => {
+      expect(result.current.attackDiscoveryAlertsEnabled).toBe(true);
+    });
+  });
+
+  it('calls getBooleanValue with the expected default value (true)', async () => {
+    mockGetBooleanValueFn.mockReturnValue(false);
+
+    renderHook(() => useKibanaFeatureFlags(), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    await waitFor(() => {
+      expect(mockGetBooleanValueFn).toHaveBeenCalledWith(
+        ATTACK_DISCOVERY_ALERTS_ENABLED_FEATURE_FLAG,
+        true // <-- expected default when the feature flag is not configured
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/utils/get_connector_name_from_id/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/utils/get_connector_name_from_id/index.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getConnectorNameFromId } from '.';
+import { getMockConnectors } from '../../mock/mock_connectors';
+
+describe('getConnectorNameFromId', () => {
+  const mockAIConnectors = getMockConnectors();
+  const mockConnectorId = mockAIConnectors[0].id; // Use an ID from the mock connectors
+  const mockConnectorName = mockAIConnectors[0].name; // Corresponding name
+
+  it('returns the name of the connector when found', () => {
+    const result = getConnectorNameFromId({
+      aiConnectors: mockAIConnectors,
+      connectorId: mockConnectorId,
+    });
+
+    expect(result).toBe(mockConnectorName);
+  });
+
+  it('returns undefined when aiConnectors is undefined', () => {
+    const result = getConnectorNameFromId({
+      aiConnectors: undefined,
+      connectorId: mockConnectorId,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when connectorId is undefined', () => {
+    const result = getConnectorNameFromId({
+      aiConnectors: mockAIConnectors,
+      connectorId: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the connector is not found', () => {
+    const result = getConnectorNameFromId({
+      aiConnectors: mockAIConnectors,
+      connectorId: 'non-existent-id',
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/utils/is_attack_discovery_alert/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/utils/is_attack_discovery_alert/index.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttackDiscovery, AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
+
+import { getMockAttackDiscoveryAlerts } from '../../mock/mock_attack_discovery_alerts';
+import { isAttackDiscoveryAlert } from '.';
+
+describe('isAttackDiscoveryAlert', () => {
+  it('returns true for an AttackDiscoveryAlert object', () => {
+    const alert = getMockAttackDiscoveryAlerts()[0]; // Use imported mock
+
+    expect(isAttackDiscoveryAlert(alert)).toBe(true);
+  });
+
+  it('returns false for an AttackDiscovery object', () => {
+    const discovery: AttackDiscovery = {
+      id: 'discovery-1',
+      timestamp: '2023-10-01T00:00:00Z',
+      alertIds: [],
+      detailsMarkdown: 'Some details',
+      summaryMarkdown: 'Some summary',
+      title: 'Discovery Title',
+    };
+
+    expect(isAttackDiscoveryAlert(discovery)).toBe(false);
+  });
+
+  it('returns false for an object without the generationUuid property', () => {
+    const obj = {
+      id: 'obj-1',
+      name: 'Test Object',
+      timestamp: '2023-10-01T00:00:00Z',
+    };
+
+    expect(isAttackDiscoveryAlert(obj as unknown as AttackDiscovery | AttackDiscoveryAlert)).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## [AI4DSOC] [Attack discovery] Improves test coverage for _Attack discovery alerts_

This PR improves unit test coverage for the [[AI4DSOC] [Attack discovery] Attack discovery alerts](https://github.com/elastic/kibana/pull/218906) feature.

![attack_discovery_alerts](https://github.com/user-attachments/assets/7c69ceff-2a90-4d60-8792-51cdb87e62a2)

_Above: The Attack discovery alerts feature_


<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->