### PR TITLE
[8.19] [TSVB] Fix missing unsaved changes on linked visualizations (#228685)

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.ts
+++ b/src/platform/packages/shared/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.ts
@@ -16,9 +16,9 @@ import {
 } from '@kbn/presentation-publishing';
 import { MaybePromise } from '@kbn/utility-types';
 import { Observable, combineLatestWith, debounceTime, map, of } from 'rxjs';
+import { isEqual, sortBy } from 'lodash';
 import { apiHasLastSavedChildState } from '../last_saved_child_state';
 import { PresentationContainer } from '../presentation_container';
-
 const UNSAVED_CHANGES_DEBOUNCE = 100;
 
 export const initializeUnsavedChanges = <StateType extends object = object>({
@@ -29,6 +29,7 @@ export const initializeUnsavedChanges = <StateType extends object = object>({
   defaultState,
   serializeState,
   anyStateChange$,
+  checkRefEquality,
 }: {
   uuid: string;
   parentApi: unknown;
@@ -37,6 +38,7 @@ export const initializeUnsavedChanges = <StateType extends object = object>({
   getComparators: () => StateComparators<StateType>;
   defaultState?: Partial<StateType>;
   onReset: (lastSavedPanelState?: SerializedPanelState<StateType>) => MaybePromise<void>;
+  checkRefEquality?: boolean;
 }): PublishesUnsavedChanges => {
   if (!apiHasLastSavedChildState<StateType>(parentApi)) {
     return {
@@ -46,16 +48,25 @@ export const initializeUnsavedChanges = <StateType extends object = object>({
   }
 
   const hasUnsavedChanges$ = anyStateChange$.pipe(
-    combineLatestWith(
-      parentApi.lastSavedStateForChild$(uuid).pipe(map((panelState) => panelState?.rawState))
-    ),
+    combineLatestWith(parentApi.lastSavedStateForChild$(uuid)),
     debounceTime(UNSAVED_CHANGES_DEBOUNCE),
     map(([, lastSavedState]) => {
-      const currentState = serializeState().rawState;
+      const currentState = serializeState();
+
+      // check ref equality
+      if (checkRefEquality) {
+        const lastSavedRefs = sortBy(lastSavedState?.references ?? [], 'id');
+        const currentRefs = sortBy(currentState?.references ?? [], 'id');
+        const equalRefs = isEqual(lastSavedRefs, currentRefs);
+
+        if (!equalRefs) return true;
+      }
+
+      // check state equality
       return !areComparatorsEqual(
         getComparators(),
-        lastSavedState,
-        currentState,
+        lastSavedState?.rawState,
+        currentState.rawState,
         defaultState,
         (key: string) => {
           const childApi = (parentApi as Partial<PresentationContainer>).children$?.getValue()[

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -177,6 +177,7 @@ export function getDashboardApi({
       }
 
       if (saveResult) {
+        references$.next(saveResult.references);
         unsavedChangesManager.internalApi.onSave(
           saveResult.savedState,
           saveResult.references ?? []
@@ -191,8 +192,6 @@ export function getDashboardApi({
           title: saveResult.savedState.title,
         });
         savedObjectId$.next(saveResult.id);
-
-        references$.next(saveResult.references);
       }
 
       return saveResult;
@@ -211,8 +210,8 @@ export function getDashboardApi({
       });
 
       if (saveResult?.error) return;
-      unsavedChangesManager.internalApi.onSave(dashboardState, searchSourceReferences);
       references$.next(saveResult.references);
+      unsavedChangesManager.internalApi.onSave(dashboardState, searchSourceReferences);
 
       return;
     },

--- a/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -176,6 +176,7 @@ export const getVisualizeEmbeddableFactory: (deps: {
       serializeState: () => {
         return serializeVisualizeEmbeddable(savedObjectId$.getValue(), linkedToLibrary);
       },
+      checkRefEquality: true,
       anyStateChange$: merge(
         ...(dynamicActionsManager ? [dynamicActionsManager.anyStateChange$] : []),
         savedObjectId$,

--- a/src/platform/test/functional/fixtures/kbn_archiver/dashboard/current/kibana.json
+++ b/src/platform/test/functional/fixtures/kbn_archiver/dashboard/current/kibana.json
@@ -3199,6 +3199,11 @@
       "id": "50643b60-3dd3-11e8-b2b9-5d5dc1715159"
     },
     {
+      "name":"ffc13252-56b4-4e3f-847e-61373fa0be86:kibanaSavedObjectMeta.searchSourceJSON.index",
+      "type":"index-pattern",
+      "id":"a0f483a0-3dc9-11e8-8660-4d65aa086b3c"
+    },
+    {
       "name": "controlGroup_41827e70-5285-4d44-8375-4c498449b9a7:optionsListControlDataView",
       "type": "index-pattern",
       "id": "a0f483a0-3dc9-11e8-8660-4d65aa086b3c"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[TSVB] Fix missing unsaved changes on linked visualizations (#228685)](https://github.com/elastic/kibana/pull/228685)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2025-08-05T17:20:39Z","message":"[TSVB] Fix missing unsaved changes on linked visualizations (#228685)\n\n## Summary\n\nThis PR tries to apply a patch to a logic that is not very clear about\nwhat a serialized state is and how this is used to evaluate if a\ndashboard has unsaved changes or not.\n\nThe current implementation leverage the type `SerializedPanelState` that\nhas a `rawState` property and a `references` array.\n\nhttps://github.com/elastic/kibana/blob/2eb9972ea52589fc2aab16f17bbc99cfedf76783/src/platform/packages/shared/presentation/presentation_publishing/interfaces/has_serializable_state.ts#L12-L19\n\n\nThis type is the result of the call to the passed method called\n`serializeState`, an as described in the type, the references are\nextracted. To my understanding, extracted refers to the fact that the\n`rawState` should only have a link/name to an external reference, and\nshould not contain any trace of the original referenced object id.\n\nIf this is the right way to understand that type definition, the\nassociated method and the operation of `reference extraction` then I'm\ninclined to say that the current implementation of\n`initializeUnsavedChanges` doesn't take in consideration the\n`references` array in the equality check, because the only property\npassed and used with the comparators is the `rawState` as seen here:\n\nhttps://github.com/elastic/kibana/blob/c9b441ec50dc8dc3c9180e1412019c695199909f/src/platform/packages/shared/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.ts#L48-L59\n\nThis can create unwanted situation where a change to the used references\ncan be undetected by the \"unsaved changes\" method. One example is coming\nfrom the linked [issue](https://github.com/elastic/kibana/issues/228203)\nwhere TSVB was extracting the references as requested, replacing, on the\nserializedState, the `index_pattern: {id: \"123abc\"}` with a\n`index_pattern_ref_name: \"metric_0_index_pattern\"` and moving the actual\nindex pattern references in the array outside the `rawState`. This\ngenerates the issue where switching an index pattern doesn't result in\nan unsaved change detected at the dashboard level because both the\ncurrent rawState and the latest saved rawState are in fact the same (but\nnot he references array).\n\nAn AggBased visualization, that uses the same embeddable as TSVB,\nsuffers from the same problem. If you the switch the data view the\nchange is not picked up.\n\nTSVB and AggBased issues are both regression coming from\nhttps://github.com/elastic/kibana/pull/215947 (I tested before and after\nthat PR)\n\n\nLens probably has the same issue, but due to a wrong implementation, the\n`rawState` also has it's own copy of the `references` array that is\nreplaced at the time of the references injection, but that is not\nremoved at the time of the reference extractions (yes it is saved in the\nSO as part of the attributes and could differ from the dashboard\nreference array if a reference id has been changed in the dashboard). (I\nhad also a discussion with @nickpeihl about this wrong behaviour).\nSo basically Lens, for a wrong implementation, doesn't suffer of this\nproblem, but if we are going to implement the reference extraction\ncorrectly will suffer of this issue.\n\nThe implementation is simple, but can be definitely improved.\n\n\nOne thing that is not clear now is the following: The dashboard is saved\nafter the first click to the `Save` button, but it will keep showing the\n`usaved changes` until:\n- you click save again\n- or you refresh the page\nSo basically the changes are correctly saved to ES but the\nlatestSavedState is not updated immediately. I believe this is an issue\nwith the current `Spaghetti Observable` used here.\n\nfix https://github.com/elastic/kibana/issues/228203\n\n## Release Note\n\nFixes a bug that prevented saving linked TSVB visualizations when change\ndata view.\n\n---------\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>\nCo-authored-by: Marco Liberati <dej611@users.noreply.github.com>","sha":"2747360e44b490319579155d23c7452575b3514c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.2.0","v9.0.5","v9.1.1","v8.17.10","v8.18.5","v8.19.1"],"title":"[TSVB] Fix missing unsaved changes on linked visualizations","number":228685,"url":"https://github.com/elastic/kibana/pull/228685","mergeCommit":{"message":"[TSVB] Fix missing unsaved changes on linked visualizations (#228685)\n\n## Summary\n\nThis PR tries to apply a patch to a logic that is not very clear about\nwhat a serialized state is and how this is used to evaluate if a\ndashboard has unsaved changes or not.\n\nThe current implementation leverage the type `SerializedPanelState` that\nhas a `rawState` property and a `references` array.\n\nhttps://github.com/elastic/kibana/blob/2eb9972ea52589fc2aab16f17bbc99cfedf76783/src/platform/packages/shared/presentation/presentation_publishing/interfaces/has_serializable_state.ts#L12-L19\n\n\nThis type is the result of the call to the passed method called\n`serializeState`, an as described in the type, the references are\nextracted. To my understanding, extracted refers to the fact that the\n`rawState` should only have a link/name to an external reference, and\nshould not contain any trace of the original referenced object id.\n\nIf this is the right way to understand that type definition, the\nassociated method and the operation of `reference extraction` then I'm\ninclined to say that the current implementation of\n`initializeUnsavedChanges` doesn't take in consideration the\n`references` array in the equality check, because the only property\npassed and used with the comparators is the `rawState` as seen here:\n\nhttps://github.com/elastic/kibana/blob/c9b441ec50dc8dc3c9180e1412019c695199909f/src/platform/packages/shared/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.ts#L48-L59\n\nThis can create unwanted situation where a change to the used references\ncan be undetected by the \"unsaved changes\" method. One example is coming\nfrom the linked [issue](https://github.com/elastic/kibana/issues/228203)\nwhere TSVB was extracting the references as requested, replacing, on the\nserializedState, the `index_pattern: {id: \"123abc\"}` with a\n`index_pattern_ref_name: \"metric_0_index_pattern\"` and moving the actual\nindex pattern references in the array outside the `rawState`. This\ngenerates the issue where switching an index pattern doesn't result in\nan unsaved change detected at the dashboard level because both the\ncurrent rawState and the latest saved rawState are in fact the same (but\nnot he references array).\n\nAn AggBased visualization, that uses the same embeddable as TSVB,\nsuffers from the same problem. If you the switch the data view the\nchange is not picked up.\n\nTSVB and AggBased issues are both regression coming from\nhttps://github.com/elastic/kibana/pull/215947 (I tested before and after\nthat PR)\n\n\nLens probably has the same issue, but due to a wrong implementation, the\n`rawState` also has it's own copy of the `references` array that is\nreplaced at the time of the references injection, but that is not\nremoved at the time of the reference extractions (yes it is saved in the\nSO as part of the attributes and could differ from the dashboard\nreference array if a reference id has been changed in the dashboard). (I\nhad also a discussion with @nickpeihl about this wrong behaviour).\nSo basically Lens, for a wrong implementation, doesn't suffer of this\nproblem, but if we are going to implement the reference extraction\ncorrectly will suffer of this issue.\n\nThe implementation is simple, but can be definitely improved.\n\n\nOne thing that is not clear now is the following: The dashboard is saved\nafter the first click to the `Save` button, but it will keep showing the\n`usaved changes` until:\n- you click save again\n- or you refresh the page\nSo basically the changes are correctly saved to ES but the\nlatestSavedState is not updated immediately. I believe this is an issue\nwith the current `Spaghetti Observable` used here.\n\nfix https://github.com/elastic/kibana/issues/228203\n\n## Release Note\n\nFixes a bug that prevented saving linked TSVB visualizations when change\ndata view.\n\n---------\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>\nCo-authored-by: Marco Liberati <dej611@users.noreply.github.com>","sha":"2747360e44b490319579155d23c7452575b3514c"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1","8.17","8.18","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/228685","number":228685,"mergeCommit":{"message":"[TSVB] Fix missing unsaved changes on linked visualizations (#228685)\n\n## Summary\n\nThis PR tries to apply a patch to a logic that is not very clear about\nwhat a serialized state is and how this is used to evaluate if a\ndashboard has unsaved changes or not.\n\nThe current implementation leverage the type `SerializedPanelState` that\nhas a `rawState` property and a `references` array.\n\nhttps://github.com/elastic/kibana/blob/2eb9972ea52589fc2aab16f17bbc99cfedf76783/src/platform/packages/shared/presentation/presentation_publishing/interfaces/has_serializable_state.ts#L12-L19\n\n\nThis type is the result of the call to the passed method called\n`serializeState`, an as described in the type, the references are\nextracted. To my understanding, extracted refers to the fact that the\n`rawState` should only have a link/name to an external reference, and\nshould not contain any trace of the original referenced object id.\n\nIf this is the right way to understand that type definition, the\nassociated method and the operation of `reference extraction` then I'm\ninclined to say that the current implementation of\n`initializeUnsavedChanges` doesn't take in consideration the\n`references` array in the equality check, because the only property\npassed and used with the comparators is the `rawState` as seen here:\n\nhttps://github.com/elastic/kibana/blob/c9b441ec50dc8dc3c9180e1412019c695199909f/src/platform/packages/shared/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.ts#L48-L59\n\nThis can create unwanted situation where a change to the used references\ncan be undetected by the \"unsaved changes\" method. One example is coming\nfrom the linked [issue](https://github.com/elastic/kibana/issues/228203)\nwhere TSVB was extracting the references as requested, replacing, on the\nserializedState, the `index_pattern: {id: \"123abc\"}` with a\n`index_pattern_ref_name: \"metric_0_index_pattern\"` and moving the actual\nindex pattern references in the array outside the `rawState`. This\ngenerates the issue where switching an index pattern doesn't result in\nan unsaved change detected at the dashboard level because both the\ncurrent rawState and the latest saved rawState are in fact the same (but\nnot he references array).\n\nAn AggBased visualization, that uses the same embeddable as TSVB,\nsuffers from the same problem. If you the switch the data view the\nchange is not picked up.\n\nTSVB and AggBased issues are both regression coming from\nhttps://github.com/elastic/kibana/pull/215947 (I tested before and after\nthat PR)\n\n\nLens probably has the same issue, but due to a wrong implementation, the\n`rawState` also has it's own copy of the `references` array that is\nreplaced at the time of the references injection, but that is not\nremoved at the time of the reference extractions (yes it is saved in the\nSO as part of the attributes and could differ from the dashboard\nreference array if a reference id has been changed in the dashboard). (I\nhad also a discussion with @nickpeihl about this wrong behaviour).\nSo basically Lens, for a wrong implementation, doesn't suffer of this\nproblem, but if we are going to implement the reference extraction\ncorrectly will suffer of this issue.\n\nThe implementation is simple, but can be definitely improved.\n\n\nOne thing that is not clear now is the following: The dashboard is saved\nafter the first click to the `Save` button, but it will keep showing the\n`usaved changes` until:\n- you click save again\n- or you refresh the page\nSo basically the changes are correctly saved to ES but the\nlatestSavedState is not updated immediately. I believe this is an issue\nwith the current `Spaghetti Observable` used here.\n\nfix https://github.com/elastic/kibana/issues/228203\n\n## Release Note\n\nFixes a bug that prevented saving linked TSVB visualizations when change\ndata view.\n\n---------\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>\nCo-authored-by: Marco Liberati <dej611@users.noreply.github.com>","sha":"2747360e44b490319579155d23c7452575b3514c"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->