### PR TITLE
[8.19] Lock manager: Fix setup bug (#230519)

### DIFF
--- a/packages/kbn-lock-manager/src/lock_manager_client.ts
+++ b/packages/kbn-lock-manager/src/lock_manager_client.ts
@@ -12,7 +12,6 @@ import { errors } from '@elastic/elasticsearch';
 import { Logger } from '@kbn/logging';
 import { v4 as uuid } from 'uuid';
 import prettyMilliseconds from 'pretty-ms';
-import { once } from 'lodash';
 import { duration } from 'moment';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { LOCKS_CONCRETE_INDEX_NAME, setupLockManagerIndex } from './setup_lock_manager_index';
@@ -39,10 +38,21 @@ export interface AcquireOptions {
 }
 
 // The index assets should only be set up once
+let runLockManagerSetupSuccessfully = false;
+export const runSetupIndexAssetOnce = async (
+  esClient: ElasticsearchClient,
+  logger: Logger
+): Promise<void> => {
+  if (runLockManagerSetupSuccessfully) {
+    return;
+  }
+  await setupLockManagerIndex(esClient, logger);
+  runLockManagerSetupSuccessfully = true;
+};
+
 // For testing purposes, we need to be able to set it up every time
-let runSetupIndexAssetOnce = once(setupLockManagerIndex);
-export function runSetupIndexAssetEveryTime() {
-  runSetupIndexAssetOnce = setupLockManagerIndex;
+export function rerunSetupIndexAsset() {
+  runLockManagerSetupSuccessfully = false;
 }
 
 export class LockManager {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/distributed_lock_manager/distributed_lock_manager.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/distributed_lock_manager/distributed_lock_manager.spec.ts
@@ -18,7 +18,7 @@ import {
   LockManager,
   LockDocument,
   withLock,
-  runSetupIndexAssetEveryTime,
+  rerunSetupIndexAsset,
 } from '@kbn/lock-manager/src/lock_manager_client';
 import {
   LOCKS_COMPONENT_TEMPLATE_NAME,
@@ -42,9 +42,11 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     before(async () => {
       // delete existing index mappings to ensure we start from a clean state
       await deleteLockIndexAssets(es, log);
+    });
 
+    beforeEach(async () => {
       // ensure that the index and templates are created
-      runSetupIndexAssetEveryTime();
+      rerunSetupIndexAsset();
     });
 
     after(async () => {
@@ -785,6 +787,38 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           const indexExists = await es.indices.exists({ index: LOCKS_CONCRETE_INDEX_NAME });
           expect(indexExists).to.be(true);
         });
+      });
+    });
+
+    describe('setup robustness', () => {
+      it('should retry if setup fails the first time', async () => {
+        const brokenEsClient = {
+          ...es,
+          cluster: {
+            ...es.cluster,
+            putComponentTemplate: () => {
+              throw new Error('Simulated failure on first attempt');
+            },
+          },
+        } as unknown as Client;
+        const brokenLockManager = new LockManager('test', brokenEsClient, logger);
+        const workingLockManager = new LockManager('test', es, logger);
+        let error;
+        try {
+          await brokenLockManager.acquire();
+        } catch (e) {
+          error = e;
+        }
+        expect(error).to.be.an(Error);
+
+        // if the the second attempt succeeds, it means it didn't get stuck on the first failure
+        error = undefined;
+        try {
+          await workingLockManager.acquire();
+        } catch (e) {
+          error = e;
+        }
+        expect(error).to.be(undefined);
       });
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Lock manager: Fix setup bug (#230519)](https://github.com/elastic/kibana/pull/230519)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2025-08-05T11:41:28Z","message":"Lock manager: Fix setup bug (#230519)\n\nFixes https://github.com/elastic/kibana/issues/230499\n\nThe lock manager runs `setupLockManagerIndex` via lodash `once`, so it's\nnot happening on every call. However, if the first call to\n`setupLockManagerIndex` errors out (e.g. because Elasticsearch isn't\nready yet), then every subsequent call will return the cached rejected\npromise and fail as well, rendering all lock managers in that node\ninstance broken (since `once` keeps its state on module scope)\n\nThis leads to issues like this (timeout exception thrown from streams,\nbut the call stack originates from the slo plugin setup routine since\nit's the cached rejected promise):\n```\n[2025-08-01T18:36:25.080+00:00][ERROR][plugins.streams] TimeoutError: Request timed out\n    at KibanaTransport._request (/usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:564:50)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runNextTicks (node:internal/process/task_queues:69:3)\n    at listOnTimeout (node:internal/timers:549:9)\n    at processTimers (node:internal/timers:523:7)\n    at /usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:631:32\n    at KibanaTransport.request (/usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:627:20)\n    at KibanaTransport.request (/usr/share/kibana/node_modules/@kbn/core-elasticsearch-client-server-internal/src/create_transport.js:60:16)\n    at Cluster.putComponentTemplate (/usr/share/kibana/node_modules/@elastic/elasticsearch/lib/api/api/cluster.js:600:16)\n    at ensureTemplatesAndIndexCreated (/usr/share/kibana/node_modules/@kbn/lock-manager/src/setup_lock_manager_index.js:56:3)\n    at setupLockManagerIndex (/usr/share/kibana/node_modules/@kbn/lock-manager/src/setup_lock_manager_index.js:110:3)\n    at LockManager.acquire (/usr/share/kibana/node_modules/@kbn/lock-manager/src/lock_manager_client.js:53:5)\n    at withLock (/usr/share/kibana/node_modules/@kbn/lock-manager/src/lock_manager_client.js:242:20)\n    at /usr/share/kibana/node_modules/@kbn/slo-plugin/server/plugin.js:176:7\n```\n\n\nThis PR fixes the problem by not using once but instead keeping the\nstate manually only if the promise succeeds, passing errors through.","sha":"b4f8488f6c8d3758797e2b0efde3c67510b9707d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-knowledge","backport:version","v9.2.0","v9.1.1","v8.19.1"],"title":"Lock manager: Fix setup bug","number":230519,"url":"https://github.com/elastic/kibana/pull/230519","mergeCommit":{"message":"Lock manager: Fix setup bug (#230519)\n\nFixes https://github.com/elastic/kibana/issues/230499\n\nThe lock manager runs `setupLockManagerIndex` via lodash `once`, so it's\nnot happening on every call. However, if the first call to\n`setupLockManagerIndex` errors out (e.g. because Elasticsearch isn't\nready yet), then every subsequent call will return the cached rejected\npromise and fail as well, rendering all lock managers in that node\ninstance broken (since `once` keeps its state on module scope)\n\nThis leads to issues like this (timeout exception thrown from streams,\nbut the call stack originates from the slo plugin setup routine since\nit's the cached rejected promise):\n```\n[2025-08-01T18:36:25.080+00:00][ERROR][plugins.streams] TimeoutError: Request timed out\n    at KibanaTransport._request (/usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:564:50)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runNextTicks (node:internal/process/task_queues:69:3)\n    at listOnTimeout (node:internal/timers:549:9)\n    at processTimers (node:internal/timers:523:7)\n    at /usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:631:32\n    at KibanaTransport.request (/usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:627:20)\n    at KibanaTransport.request (/usr/share/kibana/node_modules/@kbn/core-elasticsearch-client-server-internal/src/create_transport.js:60:16)\n    at Cluster.putComponentTemplate (/usr/share/kibana/node_modules/@elastic/elasticsearch/lib/api/api/cluster.js:600:16)\n    at ensureTemplatesAndIndexCreated (/usr/share/kibana/node_modules/@kbn/lock-manager/src/setup_lock_manager_index.js:56:3)\n    at setupLockManagerIndex (/usr/share/kibana/node_modules/@kbn/lock-manager/src/setup_lock_manager_index.js:110:3)\n    at LockManager.acquire (/usr/share/kibana/node_modules/@kbn/lock-manager/src/lock_manager_client.js:53:5)\n    at withLock (/usr/share/kibana/node_modules/@kbn/lock-manager/src/lock_manager_client.js:242:20)\n    at /usr/share/kibana/node_modules/@kbn/slo-plugin/server/plugin.js:176:7\n```\n\n\nThis PR fixes the problem by not using once but instead keeping the\nstate manually only if the promise succeeds, passing errors through.","sha":"b4f8488f6c8d3758797e2b0efde3c67510b9707d"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230519","number":230519,"mergeCommit":{"message":"Lock manager: Fix setup bug (#230519)\n\nFixes https://github.com/elastic/kibana/issues/230499\n\nThe lock manager runs `setupLockManagerIndex` via lodash `once`, so it's\nnot happening on every call. However, if the first call to\n`setupLockManagerIndex` errors out (e.g. because Elasticsearch isn't\nready yet), then every subsequent call will return the cached rejected\npromise and fail as well, rendering all lock managers in that node\ninstance broken (since `once` keeps its state on module scope)\n\nThis leads to issues like this (timeout exception thrown from streams,\nbut the call stack originates from the slo plugin setup routine since\nit's the cached rejected promise):\n```\n[2025-08-01T18:36:25.080+00:00][ERROR][plugins.streams] TimeoutError: Request timed out\n    at KibanaTransport._request (/usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:564:50)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runNextTicks (node:internal/process/task_queues:69:3)\n    at listOnTimeout (node:internal/timers:549:9)\n    at processTimers (node:internal/timers:523:7)\n    at /usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:631:32\n    at KibanaTransport.request (/usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:627:20)\n    at KibanaTransport.request (/usr/share/kibana/node_modules/@kbn/core-elasticsearch-client-server-internal/src/create_transport.js:60:16)\n    at Cluster.putComponentTemplate (/usr/share/kibana/node_modules/@elastic/elasticsearch/lib/api/api/cluster.js:600:16)\n    at ensureTemplatesAndIndexCreated (/usr/share/kibana/node_modules/@kbn/lock-manager/src/setup_lock_manager_index.js:56:3)\n    at setupLockManagerIndex (/usr/share/kibana/node_modules/@kbn/lock-manager/src/setup_lock_manager_index.js:110:3)\n    at LockManager.acquire (/usr/share/kibana/node_modules/@kbn/lock-manager/src/lock_manager_client.js:53:5)\n    at withLock (/usr/share/kibana/node_modules/@kbn/lock-manager/src/lock_manager_client.js:242:20)\n    at /usr/share/kibana/node_modules/@kbn/slo-plugin/server/plugin.js:176:7\n```\n\n\nThis PR fixes the problem by not using once but instead keeping the\nstate manually only if the promise succeeds, passing errors through.","sha":"b4f8488f6c8d3758797e2b0efde3c67510b9707d"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230549","number":230549,"state":"MERGED","mergeCommit":{"sha":"bca9737ad0d48d378716b23a0d1c84ca866e164b","message":"[9.1] Lock manager: Fix setup bug (#230519) (#230549)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [Lock manager: Fix setup bug\n(#230519)](https://github.com/elastic/kibana/pull/230519)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->