### PR TITLE
[ES|QL] Construct list of quotable keywords from lexer definition, remove hard-coded list

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/constants.ts
@@ -14,61 +14,6 @@ export const HIDDEN_CHANNEL: number = +(Token as any).HIDDEN_CHANNEL;
 
 export const SOURCE_COMMANDS = new Set<string>(['FROM', 'ROW', 'SHOW', 'TS', 'EXPLAIN']);
 
-export const PROCESSING_COMMANDS = new Set<string>([
-  'EVAL',
-  'WHERE',
-  'KEEP',
-  'LIMIT',
-  'STATS',
-  'SORT',
-  'DROP',
-  'RENAME',
-  'DISSECT',
-  'GROK',
-  'ENRICH',
-  'MV_EXPAND',
-  'JOIN',
-  'CHANGE_POINT',
-  'COMPLETION',
-  'SAMPLE',
-  'FORK',
-  'INLINESTATS',
-  'LOOKUP',
-  'INSIST',
-  'RERANK',
-  'FUSE',
-]);
-
-export const COMMANDS = new Set<string>([...SOURCE_COMMANDS, ...PROCESSING_COMMANDS]);
-
-export const KEYWORDS = new Set<string>([
-  ...COMMANDS,
-  'AND',
-  'ASC',
-  'BY',
-  'DESC',
-  'FALSE',
-  'FIRST',
-  'FULL',
-  'IN',
-  'INFO',
-  'INNER',
-  'IS',
-  'LAST',
-  'LEFT',
-  'LIKE',
-  'METADATA',
-  'NOT',
-  'NULL',
-  'NULLS',
-  'ON',
-  'OR',
-  'OUTER',
-  'RIGHT',
-  'RLIKE',
-  'TRUE',
-  'WITH',
-]);
 // FROM https://github.com/elastic/elasticsearch/blob/a2dbb7b9174b109d89fa2da87645ecd4d4e8de14/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java#L174
 export const TIME_DURATION_UNITS = new Set([
   'millisecond',

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { KEYWORDS } from '../parser/constants';
+import { quotableKeywords } from './utils';
 import {
   ESQLAstComment,
   ESQLAstCommentMultiLine,
@@ -46,7 +46,7 @@ export const LeafPrinter = {
 
   identifier: (node: ESQLIdentifier) => {
     const name = node.name;
-    const isKeyword = KEYWORDS.has(name.toUpperCase());
+    const isKeyword = quotableKeywords().has(name.toUpperCase());
     const isQuotationNeeded = !regexUnquotedIdPattern.test(name);
 
     if (isKeyword || isQuotationNeeded) {

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/utils.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { default as esql_lexer } from '../antlr/esql_lexer';
+
+let _quotableKeywords: Set<string> | undefined;
+
+/**
+ * Lazily retrieves a set of keywords that should be quoted in ESQL.
+ *
+ * @returns Set of keywords that should be quoted in ESQL.
+ */
+export const quotableKeywords = (): Set<string> => {
+  if (_quotableKeywords) {
+    return _quotableKeywords;
+  }
+  _quotableKeywords = new Set<string>();
+
+  for (const literalName of esql_lexer.literalNames) {
+    // Remove null and empty strings
+    if (typeof literalName !== 'string') {
+      continue;
+    }
+
+    const lastChar = literalName.length - 1;
+
+    // ANTLR wraps literals with single quotes, so we check for that.
+    if (literalName[0] !== "'" || literalName[lastChar] !== "'") {
+      continue;
+    }
+
+    const keyword = literalName.slice(1, lastChar);
+
+    // Only add non-empty keywords that consist of alphanumeric characters or
+    // underscores. This prevents adding symbols like `::`, `,`, etc.
+    if (/^\w+$/.test(keyword)) {
+      _quotableKeywords.add(keyword.toUpperCase());
+    }
+  }
+
+  return _quotableKeywords;
+};


### PR DESCRIPTION
## Summary

Retrieves a list of keywords from the lexer instead of maintaining a hard-coded version.

I see some "dev mode" keywords are missing in the lexer list (such as `FUSE` command), I am thinking it is because those are behind the "dev mode" flag, and will appear once released. Or, we can append more keywords to the new list, if needed.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
