### PR TITLE
[9.1] [ML] Anomaly Detection: Restore focus to row actions menu (#230170)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/flyout/rule_form_flyout.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/flyout/rule_form_flyout.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiFlyoutResizable, EuiLoadingElastic } from '@elastic/eui';
+import { EuiFlyoutResizable, EuiFlyoutResizableProps, EuiLoadingElastic } from '@elastic/eui';
 import React, { Suspense, lazy, useCallback } from 'react';
 import { css } from '@emotion/react';
 import type { RuleFormProps } from '../src/rule_form';
@@ -22,9 +22,15 @@ const RuleForm: React.LazyExoticComponent<React.FC<RuleFormProps<any>>> = lazy((
   import('../src/rule_form').then((module) => ({ default: module.RuleForm }))
 );
 
-const RuleFormFlyoutRenderer = <MetaData extends RuleTypeMetaData>(
-  props: RuleFormProps<MetaData>
-) => {
+interface RuleFormFlyoutRendererProps<MetaData extends RuleTypeMetaData> {
+  ruleFormProps: RuleFormProps<MetaData>;
+  focusTrapProps?: EuiFlyoutResizableProps['focusTrapProps'];
+}
+
+const RuleFormFlyoutRenderer = <MetaData extends RuleTypeMetaData>({
+  ruleFormProps,
+  focusTrapProps,
+}: RuleFormFlyoutRendererProps<MetaData>) => {
   const { onClickClose, hideCloseButton } = useRuleFlyoutUIContext();
 
   const inLineContainerCss = css`
@@ -41,9 +47,9 @@ const RuleFormFlyoutRenderer = <MetaData extends RuleTypeMetaData>(
     } else {
       // ONLY call props.onCancel directly from this level of the component hierarcht if onClickClose has not yet been initialized.
       // This will only occur if the user tries to close the flyout while the Suspense fallback is still visible
-      props.onCancel?.();
+      ruleFormProps.onCancel?.();
     }
-  }, [onClickClose, props]);
+  }, [onClickClose, ruleFormProps]);
   return (
     <EuiFlyoutResizable
       ownFocus
@@ -53,6 +59,7 @@ const RuleFormFlyoutRenderer = <MetaData extends RuleTypeMetaData>(
       size={620}
       minWidth={500}
       hideCloseButton={hideCloseButton}
+      focusTrapProps={focusTrapProps}
     >
       <Suspense
         fallback={
@@ -61,18 +68,23 @@ const RuleFormFlyoutRenderer = <MetaData extends RuleTypeMetaData>(
           </RuleFormErrorPromptWrapper>
         }
       >
-        <RuleForm {...props} isFlyout />
+        <RuleForm {...ruleFormProps} isFlyout />
       </Suspense>
     </EuiFlyoutResizable>
   );
 };
 
-export const RuleFormFlyout = <MetaData extends RuleTypeMetaData>(
-  props: RuleFormProps<MetaData>
-) => {
+interface RuleFormFlyoutProps<MetaData extends RuleTypeMetaData> extends RuleFormProps<MetaData> {
+  focusTrapProps?: EuiFlyoutResizableProps['focusTrapProps'];
+}
+
+export const RuleFormFlyout = <MetaData extends RuleTypeMetaData>({
+  focusTrapProps,
+  ...ruleFormProps
+}: RuleFormFlyoutProps<MetaData>) => {
   return (
     <RuleFlyoutUIContextProvider>
-      <RuleFormFlyoutRenderer {...props} />
+      <RuleFormFlyoutRenderer ruleFormProps={ruleFormProps} focusTrapProps={focusTrapProps} />
     </RuleFlyoutUIContextProvider>
   );
 };

--- a/x-pack/platform/plugins/shared/ml/public/alerting/ml_alerting_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/alerting/ml_alerting_flyout.tsx
@@ -9,19 +9,21 @@ import type { FC } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { RuleFormFlyout } from '@kbn/response-ops-rule-form/flyout';
-
 import type { Rule } from '@kbn/triggers-actions-ui-plugin/public';
 import type { JobId } from '../../common/types/anomaly_detection_jobs';
 import { useMlKibana } from '../application/contexts/kibana';
 import { ML_ALERT_TYPES } from '../../common/constants/alerts';
 import { PLUGIN_ID } from '../../common/constants/app';
 import type { MlAnomalyDetectionAlertRule } from '../../common/types/alerts';
+import type { FocusTrapProps } from '../application/util/create_focus_trap_props';
+import { createJobActionFocusTrapProps } from '../application/util/create_focus_trap_props';
 
 interface MlAnomalyAlertFlyoutProps {
   initialAlert?: MlAnomalyDetectionAlertRule & Rule;
   jobIds?: JobId[];
   onSave?: () => void;
   onCloseFlyout: () => void;
+  focusTrapProps?: FocusTrapProps;
 }
 
 /**
@@ -37,6 +39,7 @@ export const MlAnomalyAlertFlyout: FC<MlAnomalyAlertFlyoutProps> = ({
   jobIds,
   onCloseFlyout,
   onSave,
+  focusTrapProps,
 }) => {
   const {
     services: { triggersActionsUi, ...services },
@@ -77,6 +80,7 @@ export const MlAnomalyAlertFlyout: FC<MlAnomalyAlertFlyoutProps> = ({
             },
           },
         }}
+        focusTrapProps={focusTrapProps}
       />
     );
     // deps on id to avoid re-rendering on auto-refresh
@@ -127,6 +131,7 @@ export const JobListMlAnomalyAlertFlyout: FC<JobListMlAnomalyAlertFlyoutProps> =
         setIsVisible(false);
         onSave();
       }}
+      focusTrapProps={createJobActionFocusTrapProps(jobIds[0])}
     />
   ) : null;
 };

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/delete_job_modal/delete_job_modal.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/delete_job_modal/delete_job_modal.tsx
@@ -24,6 +24,7 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { createJobActionFocusRestoration } from '../../../../util/create_focus_restoration';
 import { useMlApi, useMlKibana } from '../../../../contexts/kibana';
 import { deleteJobs } from '../utils';
 import { BLOCKED_JOBS_REFRESH_INTERVAL_MS } from '../../../../../../common/constants/jobs_list';
@@ -88,7 +89,12 @@ export const DeleteJobModal: FC<Props> = ({ setShowFunction, unsetShowFunction, 
   const closeModal = useCallback(() => {
     setModalVisible(false);
     setCanDelete(false);
-  }, []);
+    // Manually return focus to the delete job action button
+    // This is a workaround to fix the issue where the focus is not returned to the action button when the modal is closed
+    if (jobIds.length === 1) {
+      createJobActionFocusRestoration(jobIds[0])();
+    }
+  }, [jobIds]);
 
   const deleteJob = useCallback(() => {
     setDeleting(true);

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/edit_job_flyout/edit_job_flyout.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/edit_job_flyout/edit_job_flyout.js
@@ -37,6 +37,8 @@ import { DATAFEED_STATE, JOB_STATE } from '../../../../../../common/constants/st
 import { CustomUrlsWrapper, isValidCustomUrls } from '../../../../components/custom_urls';
 import { isManagedJob } from '../../../jobs_utils';
 import { ManagedJobsWarningCallout } from '../confirm_modals/managed_jobs_warning_callout';
+import { createJobActionFocusTrapProps } from '../../../../util/create_focus_trap_props';
+import { createJobActionFocusRestoration } from '../../../../util/create_focus_restoration';
 
 const { collapseLiteralStrings } = XJson;
 
@@ -413,6 +415,10 @@ export class EditJobFlyoutUI extends Component {
           }}
           size="m"
           data-test-subj="mlJobEditFlyout"
+          aria-label={i18n.translate('xpack.ml.jobsList.editJobFlyout.ariaLabel', {
+            defaultMessage: 'Edit job flyout',
+          })}
+          focusTrapProps={createJobActionFocusTrapProps(job.job_id)}
         >
           <EuiFlyoutHeader>
             <EuiTitle>
@@ -480,6 +486,7 @@ export class EditJobFlyoutUI extends Component {
     }
 
     if (this.state.isConfirmationModalVisible) {
+      const returnFocus = createJobActionFocusRestoration(this.state.job.job_id);
       confirmationModal = (
         <EuiConfirmModal
           aria-labelledby={confirmModalTitleId}
@@ -487,8 +494,14 @@ export class EditJobFlyoutUI extends Component {
             defaultMessage: 'Save changes before leaving?',
           })}
           titleProps={{ id: confirmModalTitleId }}
-          onCancel={() => this.closeFlyout(true)}
-          onConfirm={() => this.save()}
+          onCancel={() => {
+            this.closeFlyout(true);
+            returnFocus();
+          }}
+          onConfirm={() => {
+            this.save();
+            returnFocus();
+          }}
           cancelButtonText={i18n.translate(
             'xpack.ml.jobsList.editJobFlyout.leaveAnywayButtonLabel',
             { defaultMessage: 'Leave anyway' }

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/reset_job_modal/reset_job_modal.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/reset_job_modal/reset_job_modal.tsx
@@ -23,6 +23,7 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { createJobActionFocusRestoration } from '../../../../util/create_focus_restoration';
 import { resetJobs } from '../utils';
 import type { MlSummaryJob } from '../../../../../../common/types/anomaly_detection_jobs';
 import { RESETTING_JOBS_REFRESH_INTERVAL_MS } from '../../../../../../common/constants/jobs_list';
@@ -79,7 +80,11 @@ export const ResetJobModal: FC<Props> = ({ setShowFunction, unsetShowFunction, r
 
   const closeModal = useCallback(() => {
     setModalVisible(false);
-  }, []);
+    // This is a workaround to fix the issue where the focus is not returned to the action button when the modal is closed
+    if (jobIds.length === 1) {
+      createJobActionFocusRestoration(jobIds[0])();
+    }
+  }, [jobIds]);
 
   const resetJob = useCallback(async () => {
     setResetting(true);

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/start_datafeed_modal/start_datafeed_modal.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/start_datafeed_modal/start_datafeed_modal.js
@@ -29,6 +29,8 @@ import { isManagedJob } from '../../../jobs_utils';
 import { forceStartDatafeeds } from '../utils';
 
 import { TimeRangeSelector } from './time_range_selector';
+import { i18n } from '@kbn/i18n';
+import { createJobActionFocusRestoration } from '../../../../util/create_focus_restoration';
 
 export class StartDatafeedModal extends Component {
   static contextType = context;
@@ -83,6 +85,12 @@ export class StartDatafeedModal extends Component {
 
   closeModal = () => {
     this.setState({ isModalVisible: false });
+
+    // Manually return focus to the start datafeed action button
+    // This is a workaround to fix the issue where the focus is not returned to the action button when the modal is closed
+    if (this.state.jobs.length === 1) {
+      createJobActionFocusRestoration(this.state.jobs[0].id)();
+    }
   };
 
   setTimeRangeValid = (timeRangeValid) => {
@@ -151,6 +159,9 @@ export class StartDatafeedModal extends Component {
           style={{ minWidth: '850px' }}
           maxWidth={false}
           data-test-subj="mlStartDatafeedModal"
+          aria-label={i18n.translate('xpack.ml.jobsList.startDatafeedModal.ariaLabel', {
+            defaultMessage: 'Start datafeed modal',
+          })}
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle>

--- a/x-pack/platform/plugins/shared/ml/public/application/util/create_focus_restoration.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/util/create_focus_restoration.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Creates a function that restores focus to a trigger element after a delay.
+ * Useful for modals that need time to close before focusing.
+ * @param triggerElement - The element to focus when the function is called
+ * @param delay - Delay in milliseconds before attempting to focus (default: 0)
+ * @returns A function that restores focus to the trigger element
+ */
+export const createFocusRestoration = (
+  triggerElement: HTMLElement | null | undefined,
+  delay = 0
+): (() => void) => {
+  return () => {
+    setTimeout(() => {
+      if (triggerElement) {
+        triggerElement.focus?.();
+      }
+    }, delay);
+  };
+};
+
+export const createJobActionFocusRestoration = (jobId: string) => {
+  const actionButton = document.getElementById(`${jobId}-actions`)?.querySelector('button');
+  return createFocusRestoration(actionButton);
+};

--- a/x-pack/platform/plugins/shared/ml/public/application/util/create_focus_trap_props.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/util/create_focus_trap_props.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiFlyoutProps } from '@elastic/eui';
+
+export type FocusTrapProps = EuiFlyoutProps['focusTrapProps'];
+
+/**
+ * Creates focusTrapProps for EuiFlyout components to restore focus to a trigger element.
+ * Useful when opening a flyout from a context menu.
+ */
+export const createFocusTrapProps = (
+  triggerElement: HTMLElement | null | undefined
+): FocusTrapProps => {
+  return {
+    returnFocus: () => {
+      if (triggerElement) {
+        triggerElement.focus?.();
+        return false; // Manual focus handled
+      }
+      return true; // Let EUI handle focus automatically
+    },
+  };
+};
+
+export const createJobActionFocusTrapProps = (jobId: string) => {
+  const actionButton = document.getElementById(`${jobId}-actions`)?.querySelector('button');
+  return createFocusTrapProps(actionButton);
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ML] Anomaly Detection: Restore focus to row actions menu (#230170)](https://github.com/elastic/kibana/pull/230170)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Jaszczurek","email":"92210485+rbrtj@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-05T10:55:36Z","message":"[ML] Anomaly Detection: Restore focus to row actions menu (#230170)\n\nFix for: https://github.com/elastic/kibana/issues/195017\nThis PR fixes an issue with focus restoration, where opening a Flyout or\nModal from the context action menu doesn't properly restore focus.\nUnfortunately, this isn't fixable on the Eui side at the moment, so to\naddress this, we need to manually restore focus to the action button. It\ncreates reusable helpers responsible for creating `focusTrapProps` for\nflyouts and manually restoring focus for Modals, as this issue occurs\nwhenever a Flyout or Modal is triggered from the context action menu.\nAfter fix:\n\n\n\n\n\n\nhttps://github.com/user-attachments/assets/19c259e0-1c8b-4304-bcdd-918d4e0d45cf","sha":"742ddef446a90668868a566b2eef5916552425e8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":[":ml","release_note:skip","Team:ML","backport:prev-minor","v9.2.0"],"title":"[ML] Anomaly Detection: Restore focus to row actions menu","number":230170,"url":"https://github.com/elastic/kibana/pull/230170","mergeCommit":{"message":"[ML] Anomaly Detection: Restore focus to row actions menu (#230170)\n\nFix for: https://github.com/elastic/kibana/issues/195017\nThis PR fixes an issue with focus restoration, where opening a Flyout or\nModal from the context action menu doesn't properly restore focus.\nUnfortunately, this isn't fixable on the Eui side at the moment, so to\naddress this, we need to manually restore focus to the action button. It\ncreates reusable helpers responsible for creating `focusTrapProps` for\nflyouts and manually restoring focus for Modals, as this issue occurs\nwhenever a Flyout or Modal is triggered from the context action menu.\nAfter fix:\n\n\n\n\n\n\nhttps://github.com/user-attachments/assets/19c259e0-1c8b-4304-bcdd-918d4e0d45cf","sha":"742ddef446a90668868a566b2eef5916552425e8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230170","number":230170,"mergeCommit":{"message":"[ML] Anomaly Detection: Restore focus to row actions menu (#230170)\n\nFix for: https://github.com/elastic/kibana/issues/195017\nThis PR fixes an issue with focus restoration, where opening a Flyout or\nModal from the context action menu doesn't properly restore focus.\nUnfortunately, this isn't fixable on the Eui side at the moment, so to\naddress this, we need to manually restore focus to the action button. It\ncreates reusable helpers responsible for creating `focusTrapProps` for\nflyouts and manually restoring focus for Modals, as this issue occurs\nwhenever a Flyout or Modal is triggered from the context action menu.\nAfter fix:\n\n\n\n\n\n\nhttps://github.com/user-attachments/assets/19c259e0-1c8b-4304-bcdd-918d4e0d45cf","sha":"742ddef446a90668868a566b2eef5916552425e8"}}]}] BACKPORT-->