### PR TITLE
[Discover] Improve functional test checks for breakdown

### DIFF
--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -230,17 +230,11 @@ export class DiscoverPageObject extends FtrService {
     ).type(field);
 
     const optionValue = value ?? field;
-    let option;
 
-    await this.retry.try(async () => {
-      option = await this.find.byCssSelector(
-        `[data-test-subj="unifiedHistogramBreakdownSelectorSelectable"] .euiSelectableListItem[value="${optionValue}"]`
-      );
+    await this.find.clickDisplayedByCssSelector(
+      `[data-test-subj="unifiedHistogramBreakdownSelectorSelectable"] .euiSelectableListItem[value="${optionValue}"]`
+    );
 
-      return Boolean(option);
-    });
-
-    await option!.click();
     await this.retry.waitFor('the value to be selected', async () => {
       const breakdownButton = await this.testSubjects.find(
         'unifiedHistogramBreakdownSelectorButton'


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/229703

## Summary

Had to adjust it again since https://github.com/elastic/kibana/pull/230441 did not fully address this flaky test.

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->