### PR TITLE
fix: cutom esql tool runtime errors

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/esql/utils/to_tool_definition.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/esql/utils/to_tool_definition.ts
@@ -7,7 +7,8 @@
 
 import { EsqlToolConfig, ToolType } from '@kbn/onechat-common';
 import { z } from '@kbn/zod';
-import { ToolResult } from '@kbn/onechat-common/tools/tool_result';
+import { ToolResultType } from '@kbn/onechat-common/tools/tool_result';
+import { FieldValue } from '@elastic/elasticsearch/lib/api/types';
 import type { ToolPersistedDefinition } from '../../client';
 import { InternalToolDefinition } from '../../tool_provider';
 
@@ -26,17 +27,22 @@ export function toToolDefinition<TSchema extends z.ZodObject<any> = z.ZodObject<
       const client = esClient.asCurrentUser;
       const paramArray = Object.entries(params).map(([key, value]) => ({ [key]: value }));
 
-      const response = await client.transport.request({
-        method: 'POST',
-        path: '/_query',
-        body: {
-          query: configuration.query,
-          params: paramArray,
-        },
+      const response = await client.esql.query({
+        query: configuration.query,
+        // TODO: wait until client is fixed: https://github.com/elastic/elasticsearch-specification/issues/5083
+        params: paramArray as unknown as FieldValue[],
       });
 
       return {
-        results: response as ToolResult[],
+        results: [
+          {
+            type: ToolResultType.tabularData,
+            data: {
+              columns: response.columns,
+              values: response.values,
+            },
+          },
+        ],
       };
     },
   };


### PR DESCRIPTION
## Summary

- Make esql tools always return `ToolResultType.tabularData`
- Use es cli for building esql query 
  - Actually there is a bug with named params, reported here https://github.com/elastic/elasticsearch-specification/issues/5083

What I'm not doing?
- Figuring out how to wire ToolResultType everywhere ... the tool result type can still be `any`. This just fixes runtime errors as we are returning right `type` in the response

### Screenshot

Built in and custom esql tools work in agent runtime:


<img width="682" height="737" alt="Screenshot 2025-08-06 at 12 13 29" src="https://github.com/user-attachments/assets/9523d82f-58aa-4eab-b653-e8f97f15115e" />
