### PR TITLE
[Entity Store] Fix Enrich Policy execution in multiple namespaces

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/auth/api_key.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/auth/api_key.ts
@@ -80,7 +80,8 @@ export const getApiKeyManager = ({
       return (
         await encryptedSavedObjectsClient.getDecryptedAsInternalUser<EntityDiscoveryAPIKey>(
           EntityDiscoveryApiKeyType.name,
-          getSpaceAwareEntityDiscoverySavedObjectId(namespace)
+          getSpaceAwareEntityDiscoverySavedObjectId(namespace),
+          { namespace }
         )
       ).attributes;
     } catch (err) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/field_retention_enrichment/field_retention_enrichment_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/field_retention_enrichment/field_retention_enrichment_task.ts
@@ -18,10 +18,8 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import { SECURITY_SOLUTION_ENABLE_ASSET_INVENTORY_SETTING } from '@kbn/management-settings-ids';
 import { getEnabledEntityTypes } from '../../../../../../common/entity_analytics/utils';
-import {
-  EngineComponentResourceEnum,
-  EntityType,
-} from '../../../../../../common/api/entity_analytics/entity_store';
+import type { EntityType } from '../../../../../../common/api/entity_analytics/entity_store';
+import { EngineComponentResourceEnum } from '../../../../../../common/api/entity_analytics/entity_store';
 import {
   defaultState,
   stateSchemaByVersion,
@@ -110,7 +108,7 @@ export const registerEntityStoreFieldRetentionEnrichTask = ({
       logger.info(
         `[Entity Store] No API key found, returning all entity types as enabled in ${namespace} namespace`
       );
-      return Object.values(EntityType);
+      return getEnabledEntityTypes(true);
     }
 
     const { soClient } = await apiKeyManager.getClientFromApiKey(apiKey);


### PR DESCRIPTION
## Summary

Solves two bugs:

- The API key was not being found once multiple spaces were created, and **no enrich policy** should be working before this PR in a kibana with multiple spaces. We were missing the `option` `namespace` to get `getDecryptedAsInternalUser` (doesn't feel that like that much of an option). The call chain:
  - [`getDecryptedAsInternalUser` calls `internalRepository.get` passing options down](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/encrypted_saved_objects/server/saved_objects/index.ts#L77)
  - [A `performGet` is done passing options down](https://github.com/elastic/kibana/blob/main/src/core/packages/saved-objects/api-server-internal/src/lib/repository.ts#L377)
  - [`options.namespace` is normalized (and remais undefined)](https://github.com/elastic/kibana/blob/main/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.ts#L34)
  - [We check if document exists in the namespace, passing the undefined namespace](https://github.com/elastic/kibana/blob/main/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.ts#L56)
  - [On verifying that the namespace saved in the SavedObject is the same as the passed down](https://github.com/elastic/kibana/blob/main/src/core/packages/saved-objects/api-server-internal/src/lib/apis/utils/internal_utils.ts#L178), we [normalize the namespace to `default`](https://github.com/elastic/kibana/blob/main/src/core/packages/saved-objects/utils-server/src/saved_objects_utils.ts#L39), which is then preset in the list stored in the saved object.
- If no API key found for namespace, return all entity types. Before it was being returned an object. Decided to just use method `getEnabledEntityTypes` passing the feature flag as enabled (there is also a log).

Relates to https://github.com/elastic/kibana/issues/230723

#### Logs Before PR
<img width="1671" height="735" alt="image" src="https://github.com/user-attachments/assets/0fc538b9-ecf3-4f9b-9209-198d514b44c7" />

#### Logs with PR

<img width="1574" height="141" alt="image" src="https://github.com/user-attachments/assets/1574531f-57e7-4848-8e8b-0aeff033f1c9" />


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->