### PR TITLE
[ci] Fix ubuntu24 schedules

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
@@ -27,56 +27,56 @@ spec:
       provider_settings:
         trigger_mode: none
       schedules:
-        daily kibana base image build [ubuntu20.04]:
+        "[ubuntu20.04] daily kibana base image build":
           branch: main
           cronline: '0 0 * * *'
           env:
             IMAGES_CONFIG: kibana/base_image.yml
-          message: Builds Kibana VM base image daily
-        daily kibana cache layer build [ubuntu20.04]:
+          message: Builds Kibana VM base image daily (20.04)
+        "[ubuntu20.04] daily kibana cache layer build":
           branch: main
           cronline: '0 1 * * *' # make sure this runs after the daily kibana base image build
           env:
             IMAGES_CONFIG: kibana/image_cache.yml
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml'
-          message: Builds Kibana VM cache warmup daily
-        daily kibana fips image build [ubuntu20.04]:
+          message: Builds Kibana VM cache warmup daily (20.04)
+        "[ubuntu20.04] daily kibana fips image build":
           branch: main
           cronline: '0 4 * * *' # make sure this runs after the daily kibana cache image build
           env:
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml,kibana/image_cache.yml'
             IMAGES_CONFIG: kibana/fips.yml
-          message: Builds Kibana FIPS VM image daily
-        weekly kibana base image build [ubuntu24.04]:
+          message: Builds Kibana FIPS VM image daily (20.04)
+        "[ubuntu24.04] weekly kibana base image build":
           branch: kibana-upgrade-ubuntu
           cronline: '0 0 * * 0' # Sunday at midnight
           env:
             IMAGES_CONFIG: kibana/base_image.yml
-          message: Builds Kibana VM base image daily
-        weekly kibana packages layer build [ubuntu24.04]:
+          message: Builds Kibana VM base image daily (24.04)
+        "[ubuntu24.04] weekly kibana packages layer build":
           branch: kibana-upgrade-ubuntu
           cronline: '0 1 * * 0' # make sure this runs after the weekly kibana base image build
           env:
             IMAGES_CONFIG: kibana/packages_layer.yml
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml'
             KIBANA_BRANCH: 'adopt-moon-clean'
-          message: Builds Kibana Packages Layer Weekly
-        daily kibana cache image build [ubuntu24.04]:
+          message: Builds Kibana Packages Layer Weekly (24.04)
+        "[ubuntu24.04] daily kibana cache image build":
           branch: kibana-upgrade-ubuntu
           cronline: '0 2 * * *' # Daily at 2AM UTC
           env:
             IMAGES_CONFIG: kibana/image_cache.tpl.yml
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml,kibana/packages_layer.yml'
             KIBANA_BRANCH: 'adopt-moon-clean'
-          message: Builds Kibana VM base image daily
-        daily kibana fips image build [ubuntu24.04]:
+          message: Builds Kibana VM base image daily (24.04)
+        "[ubuntu24.04] daily kibana fips image build":
           branch: kibana-upgrade-ubuntu
           cronline: '0 4 * * *'
           env:
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml,kibana/packages_layer.yml,kibana/image_cache.tpl.yml'
             IMAGES_CONFIG: kibana/fips.yml
             KIBANA_BRANCH: 'adopt-moon-clean'
-          message: Builds Kibana FIPS VM image daily
+          message: Builds Kibana FIPS VM image daily (24.04)
       teams:
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
@@ -52,6 +52,7 @@ spec:
           cronline: '0 0 * * 0' # Sunday at midnight
           env:
             IMAGES_CONFIG: kibana/base_image.yml
+            FORCE_PROMOTE: true
           message: Builds Kibana VM base image daily (24.04)
         "[ubuntu24.04] weekly kibana packages layer build":
           branch: kibana-upgrade-ubuntu
@@ -60,6 +61,7 @@ spec:
             IMAGES_CONFIG: kibana/packages_layer.yml
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml'
             KIBANA_BRANCH: 'adopt-moon-clean'
+            FORCE_PROMOTE: true
           message: Builds Kibana Packages Layer Weekly (24.04)
         "[ubuntu24.04] daily kibana cache image build":
           branch: kibana-upgrade-ubuntu
@@ -68,6 +70,7 @@ spec:
             IMAGES_CONFIG: kibana/image_cache.tpl.yml
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml,kibana/packages_layer.yml'
             KIBANA_BRANCH: 'adopt-moon-clean'
+            FORCE_PROMOTE: true
           message: Builds Kibana VM base image daily (24.04)
         "[ubuntu24.04] daily kibana fips image build":
           branch: kibana-upgrade-ubuntu
@@ -76,6 +79,7 @@ spec:
             BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml,kibana/packages_layer.yml,kibana/image_cache.tpl.yml'
             IMAGES_CONFIG: kibana/fips.yml
             KIBANA_BRANCH: 'adopt-moon-clean'
+            FORCE_PROMOTE: true
           message: Builds Kibana FIPS VM image daily (24.04)
       teams:
         kibana-operations:


### PR DESCRIPTION
## Summary
- updates build messages to reflect built versions
- updates schedule names to reflect built versions
- adds `FORCE_PROMOTE="true"` to push to `elastic-images-prod`

Required for https://github.com/elastic/kibana/pull/227026 so we can stay on `elastic-images-prod`