### PR TITLE
[8.19] Use Gemini 2.5 Pro as the default playground connector model (#230457)

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/common/models.ts
+++ b/x-pack/solutions/search/plugins/search_playground/common/models.ts
@@ -40,15 +40,15 @@ export const MODELS: ModelProvider[] = [
     provider: LLMs.bedrock,
   },
   {
-    name: 'Google Gemini 1.5 Pro',
-    model: 'gemini-1.5-pro-002',
-    promptTokenLimit: 2097152,
+    name: 'Google Gemini 2.5 Pro',
+    model: 'gemini-2.5-pro',
+    promptTokenLimit: 1048576,
     provider: LLMs.gemini,
   },
   {
-    name: 'Google Gemini 1.5 Flash',
-    model: 'gemini-1.5-flash-002',
-    promptTokenLimit: 2097152,
+    name: 'Google Gemini 2.5 Flash',
+    model: 'gemini-2.5-flash',
+    promptTokenLimit: 1048576,
     provider: LLMs.gemini,
   },
   {

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
@@ -93,7 +93,7 @@ describe('getChatParams', () => {
     const result = await getChatParams(
       {
         connectorId: '1',
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         prompt: 'Hello, world!',
         citations: true,
       },
@@ -111,7 +111,7 @@ describe('getChatParams', () => {
       request,
       connectorId: '1',
       chatModelOptions: expect.objectContaining({
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         temperature: 0,
         maxRetries: 0,
       }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Use Gemini 2.5 Pro as the default playground connector model (#230457)](https://github.com/elastic/kibana/pull/230457)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2025-08-06T08:04:07Z","message":"Use Gemini 2.5 Pro as the default playground connector model (#230457)\n\n## Summary\nThis PR bumps the default model for the Gemini Connector in Playground\nto Gemini 2.5 Pro.\n\n**Before**\n\n<img width=\"415\" height=\"372\" alt=\"Screenshot 2025-08-04 at 17 19 03\"\nsrc=\"https://github.com/user-attachments/assets/5abf851f-72c9-4d1e-8d6a-e3f50bce5474\"\n/>\n\n**After**\n\n<img width=\"418\" height=\"376\" alt=\"Screenshot 2025-08-04 at 17 18 25\"\nsrc=\"https://github.com/user-attachments/assets/00e94223-ae37-4108-b7b2-2a50bde04170\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nBumps default Gemini model for the Gemini Connector in Playground from\nGemini 1.5 Pro to Gemini 2.5 Pro.","sha":"9a59b3591b3dcc60419db8f873d8e67a9198db46","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Search","backport:version","v9.2.0","v9.1.1","v8.19.1"],"title":"[Search] Use Gemini 2.5 Pro as the default playground connector model","number":230457,"url":"https://github.com/elastic/kibana/pull/230457","mergeCommit":{"message":"Use Gemini 2.5 Pro as the default playground connector model (#230457)\n\n## Summary\nThis PR bumps the default model for the Gemini Connector in Playground\nto Gemini 2.5 Pro.\n\n**Before**\n\n<img width=\"415\" height=\"372\" alt=\"Screenshot 2025-08-04 at 17 19 03\"\nsrc=\"https://github.com/user-attachments/assets/5abf851f-72c9-4d1e-8d6a-e3f50bce5474\"\n/>\n\n**After**\n\n<img width=\"418\" height=\"376\" alt=\"Screenshot 2025-08-04 at 17 18 25\"\nsrc=\"https://github.com/user-attachments/assets/00e94223-ae37-4108-b7b2-2a50bde04170\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nBumps default Gemini model for the Gemini Connector in Playground from\nGemini 1.5 Pro to Gemini 2.5 Pro.","sha":"9a59b3591b3dcc60419db8f873d8e67a9198db46"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230457","number":230457,"mergeCommit":{"message":"Use Gemini 2.5 Pro as the default playground connector model (#230457)\n\n## Summary\nThis PR bumps the default model for the Gemini Connector in Playground\nto Gemini 2.5 Pro.\n\n**Before**\n\n<img width=\"415\" height=\"372\" alt=\"Screenshot 2025-08-04 at 17 19 03\"\nsrc=\"https://github.com/user-attachments/assets/5abf851f-72c9-4d1e-8d6a-e3f50bce5474\"\n/>\n\n**After**\n\n<img width=\"418\" height=\"376\" alt=\"Screenshot 2025-08-04 at 17 18 25\"\nsrc=\"https://github.com/user-attachments/assets/00e94223-ae37-4108-b7b2-2a50bde04170\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nBumps default Gemini model for the Gemini Connector in Playground from\nGemini 1.5 Pro to Gemini 2.5 Pro.","sha":"9a59b3591b3dcc60419db8f873d8e67a9198db46"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230717","number":230717,"state":"MERGED","mergeCommit":{"sha":"523d726a9441626bb8d374e8c5aac88e9700b6a4","message":"[9.1] [Search] Use Gemini 2.5 Pro as the default playground connector model (#230457) (#230717)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [Use Gemini 2.5 Pro as the default playground connector model\n(#230457)](https://github.com/elastic/kibana/pull/230457)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Brittany <seialkali@gmail.com>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->