### PR TITLE
[ci] .gitignore Moon's caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ x-pack/solutions/security/test/security_solution_playwright/.auth/
 x-pack/solutions/security/test/security_solution_playwright/.env
 .codeql
 .dependency-graph-log.json
+
+.moon/cache


### PR DESCRIPTION
## Summary
prepare for moon: ignore .moon/cache to prevent not staged files when switching working branches

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->