### PR TITLE
[Index Management] Fix filter list button styling

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_selector/component_templates.scss
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_selector/component_templates.scss
@@ -30,9 +30,6 @@ $heightHeader: $euiSizeL * 2;
   }
 
   &__filterListButton {
-    border-bottom: $euiBorderThin;
-    border-top: $euiBorderThin;
-    border-left: $euiBorderThin;
     box-shadow: none;
     height: $euiSizeXXL; /* [2] */
 
@@ -40,6 +37,10 @@ $heightHeader: $euiSizeL * 2;
     & > :first-child .euiFilterButton { /* EUI specificity override */
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
+    }
+
+    &::after {
+      border: $euiBorderThin;
     }
   }
 


### PR DESCRIPTION
Addresses #220645

- Remove redundant border properties from `.componentTemplates__filterListButton`
- Align color in ::after element with main the rest of filterListButton and searchBox

-----------------------------------------

Before:

<img width="1257" height="933" alt="SCR-20250806-qvhp" src="https://github.com/user-attachments/assets/ad270a62-6696-42d9-be0c-895b22036baf" />


After:

<img width="1245" height="915" alt="SCR-20250806-qlsq" src="https://github.com/user-attachments/assets/5f03a750-41a1-425c-a2fa-9542b7535d89" />


<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->