### PR TITLE
[DOCS][8.18.3, 8.18.4, 8.19.0] [Known Issue] Rule issues occur when `xpack.alerting.rules.run.alerts.max` is set to a value greater than 5000

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -548,7 +548,7 @@ include::CHANGELOG.asciidoc[tag=known-issue-1508]
 include::CHANGELOG.asciidoc[tag=known-issue-2088]
 
 // tag::known-issue-230275[]
-.Issues with rules occur when `xpack.alerting.rules.run.alerts.max` is set to a value greater than 5000.
+.Issues with rules occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000.
 [%collapsible]
 ====
 *Details* +

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -495,7 +495,12 @@ Search::
 [[release-notes-8.18.4]]
 == {kib} 8.18.4
 
-The 8.18.4 release includes the following fixes.
+The 8.18.4 release includes the following known issues and fixes.
+
+[float]
+[[known-issues-8.18.4]]
+=== Known issues
+include::CHANGELOG.asciidoc[tag::known-issue-230275]
 
 [float]
 [[fixes-v8.18.4]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -549,7 +549,7 @@ include::CHANGELOG.asciidoc[tag=known-issue-2088]
 
 *Details* +
 
-If you've set `xpack.alerting.rules.run.alerts.max` to a value greater than `5000`, you will encounter `Result window is too large` error messages similar when a maintenance window is active.
+If you've set `xpack.alerting.rules.run.alerts.max` to a value greater than `5000`, you will encounter `Result window is too large` error messages when a maintenance window is active.
 
 *Workaround* +
 To mitigate the issue, set `xpack.alerting.rules.run.alerts.max` to a value equal to or less than `5000`.

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -110,6 +110,11 @@ coming::[8.19.0]
 Review the following information about the {kib} 8.19.0 release.
 
 [float]
+[[known-issues-8.19.0]]
+=== Known issues
+include::CHANGELOG.asciidoc[tag::known-issue-230275]
+
+[float]
 [[breaking-changes-8.19.0]]
 === Breaking changes
 
@@ -526,7 +531,7 @@ Search::
 [[release-notes-8.18.3]]
 == {kib} 8.18.3
 
-The 8.18.3 release includes the following fixes.
+The 8.18.3 release includes the following known issues and fixes.
 
 IMPORTANT: The 8.18.3 release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory for more details].
 
@@ -536,6 +541,21 @@ IMPORTANT: The 8.18.3 release contains fixes for potential security vulnerabilit
 include::CHANGELOG.asciidoc[tag=known-issue-227976]
 include::CHANGELOG.asciidoc[tag=known-issue-1508]
 include::CHANGELOG.asciidoc[tag=known-issue-2088]
+
+// tag::known-issue-230275[]
+.Issues with rules occur when `xpack.alerting.rules.run.alerts.max` is set to a value greater than 5000.
+[%collapsible]
+====
+
+*Details* +
+
+If you've set `xpack.alerting.rules.run.alerts.max` to a value greater than `5000`, you will encounter `Result window is too large` error messages similar when a maintenance window is active.
+
+*Workaround* +
+To mitigate the issue, set `xpack.alerting.rules.run.alerts.max` to a value equal to or less than `5000`.
+
+====
+// end::known-issue-230275[]
 
 [float]
 [[enhancement-v8.18.3]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -112,7 +112,7 @@ Review the following information about the {kib} 8.19.0 release.
 [float]
 [[known-issues-8.19.0]]
 === Known issues
-include::CHANGELOG.asciidoc[tag::known-issue-230275]
+include::CHANGELOG.asciidoc[tag=known-issue-230275]
 
 [float]
 [[breaking-changes-8.19.0]]
@@ -500,7 +500,7 @@ The 8.18.4 release includes the following known issues and fixes.
 [float]
 [[known-issues-8.18.4]]
 === Known issues
-include::CHANGELOG.asciidoc[tag::known-issue-230275]
+include::CHANGELOG.asciidoc[tag=known-issue-230275]
 
 [float]
 [[fixes-v8.18.4]]
@@ -551,7 +551,6 @@ include::CHANGELOG.asciidoc[tag=known-issue-2088]
 .Issues with rules occur when `xpack.alerting.rules.run.alerts.max` is set to a value greater than 5000.
 [%collapsible]
 ====
-
 *Details* +
 
 If you've set `xpack.alerting.rules.run.alerts.max` to a value greater than `5000`, you will encounter `Result window is too large` error messages when a maintenance window is active.


### PR DESCRIPTION
## Summary

Adds the known issue about the `xpack.alerting.rules.run.alerts.max` setting to the 8.18.3, 8.18.4, and 8.19.0 release notes. Related issue: https://github.com/elastic/kibana/issues/230275

**Corresponding 9.x PR**: https://github.com/elastic/kibana/pull/230837

### Previews

- [8.18.3 known issues](https://kibana_bk_230835.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.3.html)
- [8.18.4 known issues](https://kibana_bk_230835.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.4.html)
- [8.19.0 known issues](https://kibana_bk_230835.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.19.0.html)