### PR TITLE
[dashboard] fix duplicate panel action hangs when dashboard has collapsed section that are closed on page load

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
@@ -42,7 +42,7 @@ describe('layout manager', () => {
   };
 
   const section1 = {
-    title: 'Section open on page load',
+    title: 'Section one',
     collapsed: false,
     gridData: {
       y: 1,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
@@ -203,4 +203,102 @@ describe('layout manager', () => {
       expect(layoutManager.api.canRemovePanels()).toBe(false);
     });
   });
+
+  describe('getChildApi', () => {
+    const panelsWithSections = [
+      {
+        gridData: { x: 0, y: 0, w: 6, h: 6, i: 'panel1' },
+        panelConfig: { title: 'panel One' },
+        panelIndex: 'panel1',
+        type: 'testPanelType',
+      },
+      {
+        title: 'Section closed on page load',
+        collapsed: true,
+        gridData: {
+          y: 6,
+          i: 'section1',
+        },
+        panels: [
+          {
+            gridData: { x: 0, y: 0, w: 6, h: 6, i: 'panel2InClosedSection' },
+            panelConfig: { title: 'panel Three' },
+            panelIndex: 'panel2InClosedSection',
+            type: 'testPanelType',
+          },
+        ],
+      },
+      {
+        title: 'Section open on page load',
+        collapsed: false,
+        gridData: {
+          y: 7,
+          i: 'section2',
+        },
+        panels: [
+          {
+            gridData: { x: 0, y: 0, w: 6, h: 6, i: 'panel3InOpenSection' },
+            panelConfig: { title: 'panel Four' },
+            panelIndex: 'panel3InOpenSection',
+            type: 'testPanelType',
+          },
+        ],
+      },
+    ];
+
+    test('should return api when api is available', (done) => {
+      const layoutManager = initializeLayoutManager(
+        undefined,
+        panelsWithSections,
+        trackPanelMock,
+        () => []
+      );
+
+      layoutManager.api.getChildApi('panel1').then((api) => {
+        expect(api).toBeDefined();
+        done();
+      });
+
+      layoutManager.internalApi.registerChildApi({
+        ...childApi,
+        uuid: 'panel1',
+      });
+    });
+
+    test('should return api from panel in open section when api is available', (done) => {
+      const layoutManager = initializeLayoutManager(
+        undefined,
+        panelsWithSections,
+        trackPanelMock,
+        () => []
+      );
+
+      layoutManager.api.getChildApi('panel3InOpenSection').then((api) => {
+        expect(api).toBeDefined();
+        done();
+      });
+
+      layoutManager.internalApi.registerChildApi({
+        ...childApi,
+        uuid: 'panel3InOpenSection',
+      });
+    });
+
+    test('should return undefined from panel in closed section', (done) => {
+      const layoutManager = initializeLayoutManager(
+        undefined,
+        panelsWithSections,
+        trackPanelMock,
+        () => []
+      );
+
+      layoutManager.api.getChildApi('panel2InClosedSection').then((api) => {
+        expect(api).toBeUndefined();
+        done();
+      });
+
+      // do not call layoutManager.internalApi.registerChildApi
+      // because api will never become available
+    });
+  });
 });

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
@@ -41,6 +41,17 @@ describe('layout manager', () => {
     panelIndex: PANEL_ONE_ID,
   };
 
+  const titleManager = initializeTitleManager(panel1.panelConfig);
+  const panel1Api: DefaultEmbeddableApi = {
+    type: 'testPanelType',
+    uuid: PANEL_ONE_ID,
+    phase$: {} as unknown as PublishingSubject<PhaseEvent | undefined>,
+    ...titleManager.api,
+    serializeState: () => ({
+      rawState: titleManager.getLatestState(),
+    }),
+  };
+
   const section1 = {
     title: 'Section one',
     collapsed: false,
@@ -49,13 +60,6 @@ describe('layout manager', () => {
       i: 'section1',
     },
     panels: [panel1],
-  };
-
-  const panel1Api: DefaultEmbeddableApi = {
-    type: 'testPanelType',
-    uuid: PANEL_ONE_ID,
-    phase$: {} as unknown as PublishingSubject<PhaseEvent | undefined>,
-    serializeState: jest.fn(),
   };
 
   test('can register child APIs', () => {
@@ -105,18 +109,9 @@ describe('layout manager', () => {
   });
 
   describe('duplicatePanel', () => {
-    const titleManager = initializeTitleManager(panel1.panelConfig);
-    const childApiToDuplicate = {
-      ...panel1Api,
-      ...titleManager.api,
-      serializeState: () => ({
-        rawState: titleManager.getLatestState(),
-      }),
-    };
-
     test('should add duplicated panel to layout', async () => {
       const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
-      layoutManager.internalApi.registerChildApi(childApiToDuplicate);
+      layoutManager.internalApi.registerChildApi(panel1Api);
 
       await layoutManager.api.duplicatePanel('panelOne');
 
@@ -142,7 +137,7 @@ describe('layout manager', () => {
     test('should clone by reference embeddable as by value', async () => {
       const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
       layoutManager.internalApi.registerChildApi({
-        ...childApiToDuplicate,
+        ...panel1Api,
         checkForDuplicateTitle: jest.fn(),
         canLinkToLibrary: jest.fn(),
         canUnlinkFromLibrary: jest.fn(),
@@ -168,7 +163,7 @@ describe('layout manager', () => {
       const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
       const titleManagerOfClone = initializeTitleManager({ title: 'Panel One (copy)' });
       layoutManager.internalApi.registerChildApi({
-        ...childApiToDuplicate,
+        ...panel1Api,
         ...titleManagerOfClone.api,
         serializeState: () => ({
           rawState: titleManagerOfClone.getLatestState(),
@@ -217,7 +212,7 @@ describe('layout manager', () => {
       const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
 
       layoutManager.api.getChildApi(PANEL_ONE_ID).then((api) => {
-        expect(api).toBeDefined();
+        expect(api).toBe(panel1Api);
         done();
       });
 
@@ -238,7 +233,7 @@ describe('layout manager', () => {
       );
 
       layoutManager.api.getChildApi(PANEL_ONE_ID).then((api) => {
-        expect(api).toBeDefined();
+        expect(api).toBe(panel1Api);
         done();
       });
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -18,6 +18,7 @@ import {
   tap,
 } from 'rxjs';
 import { v4 } from 'uuid';
+
 import { METRIC_TYPE } from '@kbn/analytics';
 import type { Reference } from '@kbn/content-management-utils';
 import {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.ts
@@ -18,7 +18,6 @@ import {
   tap,
 } from 'rxjs';
 import { v4 } from 'uuid';
-
 import { METRIC_TYPE } from '@kbn/analytics';
 import type { Reference } from '@kbn/content-management-utils';
 import {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/230818

PR updates getChildApi with logic to return `undefined` if panel is in a collapsed section.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->