### PR TITLE
[OneChat] Auto Resize Conversation Input

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -5,38 +5,24 @@
  * 2.0.
  */
 
-import { EuiResizableContainer, useEuiScrollBar } from '@elastic/eui';
+import { useEuiScrollBar } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useHasActiveConversation } from '../../hooks/use_conversation';
+import { useConversationId } from '../../hooks/use_conversation_id';
 import { useStickToBottom } from '../../hooks/use_stick_to_bottom';
 import { ConversationInputForm } from './conversation_input/conversation_input_form';
+import { ConversationResizableContainer } from './conversation_resizable_container';
 import { ConversationRounds } from './conversation_rounds/conversation_rounds';
 import { NewConversationPrompt } from './new_conversation_prompt';
-import { useConversationId } from '../../hooks/use_conversation_id';
 
 const fullHeightStyles = css`
   height: 100%;
 `;
-const fullSizeStyles = css`
-  ${fullHeightStyles}
-  width: 100%;
-`;
-const INITIAL_INPUT_PANEL_PERCENTAGE = 15;
-const MIN_INPUT_PANEL_HEIGHT = 130;
-const MAX_INPUT_PANEL_PERCENTAGE = 45;
-const panelIds = {
-  INPUT: 'input-panel',
-  CONTENT: 'content-panel',
-} as const;
 
 export const Conversation: React.FC<{}> = () => {
   const conversationId = useConversationId();
   const hasActiveConversation = useHasActiveConversation();
-  const [inputPanelPercentage, setInputPanelPercentage] = useState(INITIAL_INPUT_PANEL_PERCENTAGE);
-  const contentPanelPercentage = 100 - inputPanelPercentage;
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const initialInputPanelHeightRef = useRef<number>();
 
   const scrollContainerStyles = css`
     overflow-y: auto;
@@ -53,107 +39,29 @@ export const Conversation: React.FC<{}> = () => {
     setStickToBottom(true);
   }, [conversationId, setStickToBottom]);
 
-  // Ensure the input panel is at least the minimum size
-  // Necessary until this bug is closed https://github.com/elastic/eui/issues/4453
-  useEffect(() => {
-    if (initialInputPanelHeightRef.current !== undefined) {
-      return;
-    }
-    const containerHeight = containerRef.current?.getBoundingClientRect().height;
-    if (!containerHeight) {
-      return;
-    }
-    const inputPanelHeight = containerHeight * (inputPanelPercentage / 100);
-    if (inputPanelHeight < MIN_INPUT_PANEL_HEIGHT) {
-      initialInputPanelHeightRef.current = MIN_INPUT_PANEL_HEIGHT;
-      const minInputPanelPercentage = Math.ceil((MIN_INPUT_PANEL_HEIGHT / containerHeight) * 100);
-      setInputPanelPercentage(minInputPanelPercentage);
-    } else {
-      initialInputPanelHeightRef.current = inputPanelHeight;
-    }
-  }, [inputPanelPercentage]);
-  const hasUserResizedRef = useRef(false);
-
   return (
-    <div ref={containerRef} css={fullSizeStyles}>
-      <EuiResizableContainer
-        css={fullSizeStyles}
-        direction="vertical"
-        onPanelWidthChange={(nextPanelSizes) => {
-          const nextInputPanelSize = nextPanelSizes[panelIds.INPUT];
-          if (nextInputPanelSize !== undefined) {
-            setInputPanelPercentage(nextInputPanelSize);
-          }
-        }}
-        onResizeStart={() => {
-          hasUserResizedRef.current = true;
-        }}
-      >
-        {(EuiResizablePanel, EuiResizableButton) => {
-          return (
-            <>
-              {hasActiveConversation ? (
-                <EuiResizablePanel id={panelIds.CONTENT} size={contentPanelPercentage}>
-                  <div css={scrollContainerStyles}>
-                    <div ref={scrollContainerRef}>
-                      <ConversationRounds />
-                    </div>
-                  </div>
-                </EuiResizablePanel>
-              ) : (
-                <EuiResizablePanel id={panelIds.CONTENT} size={contentPanelPercentage}>
-                  <div css={fullHeightStyles}>
-                    <NewConversationPrompt />
-                  </div>
-                </EuiResizablePanel>
-              )}
-              <EuiResizableButton />
-              <EuiResizablePanel
-                id={panelIds.INPUT}
-                size={inputPanelPercentage}
-                minSize={`${MIN_INPUT_PANEL_HEIGHT}px`}
-                scrollable={false}
-              >
-                <ConversationInputForm
-                  onSubmit={() => {
-                    setStickToBottom(true);
-                  }}
-                  onTextAreaHeightChange={(heightDiff) => {
-                    if (hasUserResizedRef.current) {
-                      // If the user has manually resized, we don't want to override their changes
-                      return;
-                    }
-                    if (!containerRef.current) {
-                      throw new Error('Container ref is not set');
-                    }
-                    if (initialInputPanelHeightRef.current === undefined) {
-                      throw new Error('Initial input panel height is not set');
-                    }
-                    const containerHeight = containerRef.current.getBoundingClientRect().height;
-                    if (containerHeight === 0) {
-                      return;
-                    }
-                    const neededHeight = initialInputPanelHeightRef.current + heightDiff;
-                    const neededPercentage = (neededHeight / containerHeight) * 100;
-                    const minPercentage = (MIN_INPUT_PANEL_HEIGHT / containerHeight) * 100;
-                    const targetPercentage = Math.max(neededPercentage, minPercentage);
-
-                    // Don't grow beyond max percentage and never automatically shrink
-                    if (
-                      targetPercentage > MAX_INPUT_PANEL_PERCENTAGE ||
-                      targetPercentage < inputPanelPercentage
-                    ) {
-                      return;
-                    }
-
-                    setInputPanelPercentage(targetPercentage);
-                  }}
-                />
-              </EuiResizablePanel>
-            </>
-          );
-        }}
-      </EuiResizableContainer>
-    </div>
+    <ConversationResizableContainer
+      content={
+        hasActiveConversation ? (
+          <div css={scrollContainerStyles}>
+            <div ref={scrollContainerRef}>
+              <ConversationRounds />
+            </div>
+          </div>
+        ) : (
+          <div css={fullHeightStyles}>
+            <NewConversationPrompt />
+          </div>
+        )
+      }
+      input={(onInputHeightChange) => (
+        <ConversationInputForm
+          onSubmit={() => {
+            setStickToBottom(true);
+          }}
+          onTextAreaHeightChange={onInputHeightChange}
+        />
+      )}
+    />
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
@@ -17,13 +17,17 @@ import { ConversationInputTextArea } from './conversation_input_text_area';
 
 interface ConversationInputFormProps {
   onSubmit: () => void;
+  onTextAreaHeightChange: (heightDiff: number) => void;
 }
 
 const fullHeightStyles = css`
   height: 100%;
 `;
 
-export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ onSubmit }) => {
+export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({
+  onSubmit,
+  onTextAreaHeightChange,
+}) => {
   const isSendingMessage = useIsSendingMessage();
   const { input, setInput, sendMessage } = useMessages();
   const { euiTheme } = useEuiTheme();
@@ -71,6 +75,7 @@ export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ on
           message={input}
           setMessage={setInput}
           handleSubmit={handleSubmit}
+          onHeightChange={onTextAreaHeightChange}
         />
         <ConversationInputActions handleSubmit={handleSubmit} submitDisabled={disabled} />
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_text_area.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_text_area.tsx
@@ -5,18 +5,28 @@
  * 2.0.
  */
 
-import { EuiFlexItem, EuiTextArea, keys } from '@elastic/eui';
+import {
+  EuiFlexItem,
+  EuiResizeObserver,
+  EuiTextArea,
+  keys,
+  useEuiFontSize,
+  useEuiTheme,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useRef } from 'react';
 import { useConversationId } from '../../../hooks/use_conversation_id';
 
+const fullHeightStyles = css`
+  height: 100%;
+`;
 const inputContainerStyles = css`
   display: flex;
   flex-direction: column;
   .euiFormControlLayout--euiTextArea,
   .euiFormControlLayout__childrenWrapper {
-    height: 100%;
+    ${fullHeightStyles}
   }
   /* Using ID for high specificity selector */
   #conversationInput {
@@ -26,58 +36,111 @@ const inputContainerStyles = css`
     background-image: none;
   }
 `;
-const textareaStyles = css`
-  height: 100%;
-  padding: 0;
+const textareaContainerStyles = css`
+  width: 100%;
+  ${fullHeightStyles}
 `;
+
+const INITIAL_TEXTAREA_HEIGHT = 20;
 
 interface ConversationInputTextAreaProps {
   message: string;
   setMessage: (message: string) => void;
   handleSubmit: () => void;
+  onHeightChange: (heightDiff: number) => void;
 }
 
 export const ConversationInputTextArea: React.FC<ConversationInputTextAreaProps> = ({
   message,
   setMessage,
   handleSubmit,
+  onHeightChange,
 }) => {
   const conversationId = useConversationId();
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const { euiTheme } = useEuiTheme();
+  const textareaStyles = css`
+    ${fullHeightStyles}
+    padding: 0;
+    ${useEuiFontSize('s')}
+  `;
+  const heightMeasuringProxyStyles = css`
+    position: absolute;
+    /*
+      Position outside the viewport
+      There is technically a point where the proxy will overflow the container,
+      but that amount of content is so large that the API does not support it anyways.
+    */
+    top: -999999px;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: auto;
+    min-height: auto;
+    visibility: hidden;
+    pointer-events: none;
+    user-select: none;
+    z-index: -1;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    font-family: ${euiTheme.font.family};
+    ${useEuiFontSize('s')}
+    padding: 0;
+    margin: 0;
+    border: 0;
+  `;
 
+  // Focus on mount
   useEffect(() => {
     // Auto focus the text area when the user switches conversations
     setTimeout(() => {
       textAreaRef.current?.focus();
     }, 200);
   }, [conversationId]);
+
   return (
     <EuiFlexItem css={inputContainerStyles}>
-      <EuiTextArea
-        id="conversationInput"
-        name={i18n.translate('xpack.onechat.conversationInputForm.textArea.name', {
-          defaultMessage: 'Conversation input',
-        })}
-        css={textareaStyles}
-        data-test-subj="onechatAppConversationInputFormTextArea"
-        value={message}
-        onChange={(event) => {
-          setMessage(event.currentTarget.value);
-        }}
-        onKeyDown={(event) => {
-          if (!event.shiftKey && event.key === keys.ENTER) {
-            event.preventDefault();
-            handleSubmit();
-          }
-        }}
-        placeholder={i18n.translate('xpack.onechat.conversationInputForm.placeholder', {
-          defaultMessage: 'Ask anything',
-        })}
-        rows={1}
-        inputRef={textAreaRef}
-        fullWidth
-        resize="none"
-      />
+      <div css={textareaContainerStyles}>
+        <EuiTextArea
+          id="conversationInput"
+          name={i18n.translate('xpack.onechat.conversationInputForm.textArea.name', {
+            defaultMessage: 'Conversation input',
+          })}
+          css={textareaStyles}
+          data-test-subj="onechatAppConversationInputFormTextArea"
+          value={message}
+          onChange={(event) => {
+            setMessage(event.currentTarget.value);
+          }}
+          onKeyDown={(event) => {
+            if (!event.shiftKey && event.key === keys.ENTER) {
+              event.preventDefault();
+              handleSubmit();
+            }
+          }}
+          placeholder={i18n.translate('xpack.onechat.conversationInputForm.placeholder', {
+            defaultMessage: 'Ask anything',
+          })}
+          rows={1}
+          inputRef={textAreaRef}
+          fullWidth
+          resize="none"
+        />
+        {/* Absolutely positioned height measuring proxy */}
+        <EuiResizeObserver
+          onResize={({ height }) => {
+            const heightDiff = height - INITIAL_TEXTAREA_HEIGHT;
+            onHeightChange(heightDiff);
+          }}
+        >
+          {(resizeRef) => (
+            <div ref={resizeRef} css={heightMeasuringProxyStyles} aria-hidden="true">
+              {message}
+            </div>
+          )}
+        </EuiResizeObserver>
+      </div>
     </EuiFlexItem>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_resizable_container.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_resizable_container.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiResizableContainer } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useEffect, useRef, useState } from 'react';
+
+const fullHeightStyles = css`
+  height: 100%;
+`;
+const fullSizeStyles = css`
+  ${fullHeightStyles}
+  width: 100%;
+`;
+const INITIAL_INPUT_PANEL_PERCENTAGE = 15;
+const MIN_INPUT_PANEL_HEIGHT = 130;
+const MAX_INPUT_PANEL_PERCENTAGE = 45;
+const panelIds = {
+  INPUT: 'input-panel',
+  CONTENT: 'content-panel',
+} as const;
+
+interface ConversationResizableContainerProps {
+  content: React.ReactNode;
+  input: (onInputHeightChange: (heightDiff: number) => void) => React.ReactNode;
+}
+export const ConversationResizableContainer: React.FC<ConversationResizableContainerProps> = ({
+  content,
+  input,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [inputPanelPercentage, setInputPanelPercentage] = useState(INITIAL_INPUT_PANEL_PERCENTAGE);
+  const contentPanelPercentage = 100 - inputPanelPercentage;
+  const hasUserResizedRef = useRef(false);
+  const initialInputPanelHeightRef = useRef<number>();
+  // Ensure the input panel is at least the minimum size
+  // Necessary until this bug is closed https://github.com/elastic/eui/issues/4453
+  useEffect(() => {
+    if (initialInputPanelHeightRef.current !== undefined) {
+      return;
+    }
+    const containerHeight = containerRef.current?.getBoundingClientRect().height;
+    if (!containerHeight) {
+      return;
+    }
+    const inputPanelHeight = containerHeight * (inputPanelPercentage / 100);
+    if (inputPanelHeight < MIN_INPUT_PANEL_HEIGHT) {
+      initialInputPanelHeightRef.current = MIN_INPUT_PANEL_HEIGHT;
+      const minInputPanelPercentage = Math.ceil((MIN_INPUT_PANEL_HEIGHT / containerHeight) * 100);
+      setInputPanelPercentage(minInputPanelPercentage);
+    } else {
+      initialInputPanelHeightRef.current = inputPanelHeight;
+    }
+  }, [inputPanelPercentage]);
+  const onInputHeightChange = (heightDiff: number) => {
+    if (hasUserResizedRef.current) {
+      // If the user has manually resized, we don't want to override their changes
+      return;
+    }
+    if (!containerRef.current) {
+      throw new Error('Container ref is not set');
+    }
+    if (initialInputPanelHeightRef.current === undefined) {
+      throw new Error('Initial input panel height is not set');
+    }
+    const containerHeight = containerRef.current.getBoundingClientRect().height;
+    if (containerHeight === 0) {
+      return;
+    }
+    const neededHeight = initialInputPanelHeightRef.current + heightDiff;
+    const neededPercentage = (neededHeight / containerHeight) * 100;
+    const minPercentage = (MIN_INPUT_PANEL_HEIGHT / containerHeight) * 100;
+    const targetPercentage = Math.max(neededPercentage, minPercentage);
+
+    // Don't grow beyond max percentage and never automatically shrink
+    if (targetPercentage > MAX_INPUT_PANEL_PERCENTAGE || targetPercentage < inputPanelPercentage) {
+      return;
+    }
+
+    setInputPanelPercentage(targetPercentage);
+  };
+  return (
+    <div ref={containerRef} css={fullSizeStyles}>
+      <EuiResizableContainer
+        css={fullSizeStyles}
+        direction="vertical"
+        onPanelWidthChange={(nextPanelSizes) => {
+          const nextInputPanelSize = nextPanelSizes[panelIds.INPUT];
+          if (nextInputPanelSize !== undefined) {
+            setInputPanelPercentage(nextInputPanelSize);
+          }
+        }}
+        onResizeStart={() => {
+          hasUserResizedRef.current = true;
+        }}
+      >
+        {(EuiResizablePanel, EuiResizableButton) => {
+          return (
+            <>
+              <EuiResizablePanel id={panelIds.CONTENT} size={contentPanelPercentage}>
+                {content}
+              </EuiResizablePanel>
+              <EuiResizableButton />
+              <EuiResizablePanel
+                id={panelIds.INPUT}
+                size={inputPanelPercentage}
+                minSize={`${MIN_INPUT_PANEL_HEIGHT}px`}
+                scrollable={false}
+              >
+                {input(onInputHeightChange)}
+              </EuiResizablePanel>
+            </>
+          );
+        }}
+      </EuiResizableContainer>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Who knew making a textarea fit to its content and syncing that height with a resizable panel would be so hard? Well now I know.

If the user manually changes the input panel's height, then we won't auto expand the height anymore, so we don't override their set height.


https://github.com/user-attachments/assets/511d4ece-bf47-4e3d-9762-579c7148d984

The warning that is produced when the user manually changes the panel size is present even in [the demo](https://eui.elastic.co/docs/components/containers/resizable-container/#horizontal-resizing-with-controlled-widths); it appears to be a bug in EUI. It appears to only happen the very first time the panel sizes are manually changed.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



