### PR TITLE
[Content Management] Allow `v0` to `v1` transforms

### DIFF
--- a/src/platform/packages/shared/kbn-object-versioning/lib/object_transform.ts
+++ b/src/platform/packages/shared/kbn-object-versioning/lib/object_transform.ts
@@ -57,7 +57,7 @@ const getTransformFns = <I = unknown, O = unknown>(
   let fn: ObjectTransform<I, O> | undefined;
   if (to > from) {
     while (i <= to) {
-      fn = migrationDefinition[i].up;
+      fn = migrationDefinition[i]?.up;
       if (fn) {
         fns.push(fn);
       }
@@ -65,7 +65,7 @@ const getTransformFns = <I = unknown, O = unknown>(
     }
   } else if (to < from) {
     while (i >= to) {
-      fn = migrationDefinition[i].down;
+      fn = migrationDefinition[i]?.down;
       if (fn) {
         fns.push(fn);
       }
@@ -177,14 +177,15 @@ export const initTransform =
 
           const fromVersion = getVersion(from);
 
-          if (!migrationDefinition[fromVersion]) {
+          // Only allow missing from definition for initial versioning (i.e. v0 → v1)
+          if (!migrationDefinition[fromVersion] && fromVersion !== 0) {
             return {
               error: new Error(`Unvalid version to down transform from [${from}].`),
               value: null,
             };
           }
 
-          if (validate) {
+          if (validate && fromVersion !== 0) {
             const error = validateFn(obj, fromVersion);
             if (error) {
               return { error, value: null };


### PR DESCRIPTION
## Summary

Allows versioning for initial CM version `v0` in transforms.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios