### PR TITLE
[OTel Metrics] Allow configuring the temporalityPreference

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -204,6 +204,8 @@ kibana_vars=(
     telemetry.metrics.exporters # Allow specifying the array here or..
     telemetry.metrics.exporters.grpc.url # ... or a single exporter by specifying these 2.
     telemetry.metrics.exporters.grpc.headers
+    telemetry.metrics.exporters.grpc.exportIntervalMillis
+    telemetry.metrics.exporters.grpc.temporalityPreference
     tilemap.options.attribution
     tilemap.options.maxZoom
     tilemap.options.minZoom

--- a/src/platform/packages/private/opentelemetry/kbn-metrics-config/index.ts
+++ b/src/platform/packages/private/opentelemetry/kbn-metrics-config/index.ts
@@ -7,7 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { MetricsExporterConfig, MetricsConfig } from './src/types';
+export type {
+  MetricsExporterCommonConfig,
+  MetricsExporterConfig,
+  MetricsConfig,
+} from './src/types';
 export { metricsConfigSchema } from './src/metrics_schema';
 export {
   monitoringCollectionSchema,

--- a/src/platform/packages/private/opentelemetry/kbn-metrics-config/src/metrics_schema.ts
+++ b/src/platform/packages/private/opentelemetry/kbn-metrics-config/src/metrics_schema.ts
@@ -10,22 +10,27 @@
 import { schema, type Type } from '@kbn/config-schema';
 import type { MetricsExporterConfig, MetricsConfig } from './types';
 
+const metricsCommonExporterConfigSchema = schema.object({
+  exportIntervalMillis: schema.maybe(schema.duration()),
+  temporalityPreference: schema.oneOf([schema.literal('cumulative'), schema.literal('delta')], {
+    defaultValue: 'delta',
+  }),
+});
+
 export const metricsExporterConfigSchema: Type<MetricsExporterConfig> = schema.oneOf([
   // gRPC OTLP Exporter
   schema.object({
-    grpc: schema.object({
+    grpc: metricsCommonExporterConfigSchema.extends({
       url: schema.string(),
       headers: schema.maybe(schema.recordOf(schema.string(), schema.string())),
-      exportIntervalMillis: schema.maybe(schema.duration()),
     }),
   }),
 
   // HTTP OTLP Exporter
   schema.object({
-    http: schema.object({
+    http: metricsCommonExporterConfigSchema.extends({
       url: schema.string(),
       headers: schema.maybe(schema.recordOf(schema.string(), schema.string())),
-      exportIntervalMillis: schema.maybe(schema.duration()),
     }),
   }),
 ]);

--- a/src/platform/packages/private/opentelemetry/kbn-metrics-config/src/types.ts
+++ b/src/platform/packages/private/opentelemetry/kbn-metrics-config/src/types.ts
@@ -10,29 +10,35 @@
 import type { Duration } from 'moment';
 
 /**
+ * Common configuration for OTLP metrics exporters
+ */
+export interface MetricsExporterCommonConfig {
+  /** Frequency in which the exporter should collect the metrics */
+  exportIntervalMillis?: number | Duration;
+  /** The preferred temporality of the metrics. Defaults to `delta`, as it plays better with the ES backend. */
+  temporalityPreference: 'delta' | 'cumulative';
+}
+
+/**
  * Allowed configurations for OTLP metrics exporters
  */
 export type MetricsExporterConfig =
   | {
       /** GRPC OTLP Exporter */
-      grpc: {
+      grpc: MetricsExporterCommonConfig & {
         /** The URL of the OTLP gRPC endpoint */
         url: string;
         /** HTTP headers to send to the OTLP gRPC endpoint. Typically, the `Authorization` header is one of them */
         headers?: Record<string, string>;
-        /** Frequency in which the exporter should collect the metrics */
-        exportIntervalMillis?: number | Duration;
       };
     }
   | {
       /** HTTP OTLP Exporter */
-      http: {
+      http: MetricsExporterCommonConfig & {
         /** The URL of the OTLP HTTP endpoint */
         url: string;
         /** HTTP headers to send to the OTLP HTTP endpoint. Typically, the `Authorization` header is one of them */
         headers?: Record<string, string>;
-        /** Frequency in which the exporter should collect the metrics */
-        exportIntervalMillis?: number | Duration;
       };
     };
 

--- a/src/platform/packages/private/opentelemetry/kbn-metrics/src/init_metrics.test.ts
+++ b/src/platform/packages/private/opentelemetry/kbn-metrics/src/init_metrics.test.ts
@@ -30,6 +30,7 @@ jest.mock('@elastic/opentelemetry-node/sdk', () => {
 
 import { resources } from '@elastic/opentelemetry-node/sdk';
 import { PrometheusExporter, initMetrics } from '..';
+import type { MetricsExporterConfig } from '@kbn/metrics-config';
 
 describe('initMetrics', () => {
   const resource = resources.resourceFromAttributes({});
@@ -38,9 +39,21 @@ describe('initMetrics', () => {
 
   const { metrics } = jest.requireActual('@elastic/opentelemetry-node/sdk');
 
-  const exporters = [
-    { grpc: { url: 'http://remote', headers: { Authorization: '1234' } } },
-    { http: { url: 'http://remote-http', headers: { Authorization: '1234' } } },
+  const exporters: MetricsExporterConfig[] = [
+    {
+      grpc: {
+        url: 'http://remote',
+        headers: { Authorization: '1234' },
+        temporalityPreference: 'delta',
+      },
+    },
+    {
+      http: {
+        url: 'http://remote-http',
+        headers: { Authorization: '1234' },
+        temporalityPreference: 'cumulative',
+      },
+    },
   ];
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/230041 by adding a new config parameter to the exporters where users have the option to override the default `delta` option.

NOTE: The gRPC OTLP configured through the _legacy_ monitoringCollection settings, we default to CUMULATIVE (as it was the original case). It can be overridden via ENV vars if necessary.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



