### PR TITLE
[9.1] [dashboard] fix duplicate panel action hangs when dashboard has collapsed section that are closed on page load (#230842)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/layout_manager/layout_manager.test.ts
@@ -16,6 +16,7 @@ import {
   PublishingSubject,
   initializeTitleManager,
 } from '@kbn/presentation-publishing';
+import { BehaviorSubject } from 'rxjs';
 
 jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('54321'),
@@ -33,26 +34,38 @@ describe('layout manager', () => {
 
   const PANEL_ONE_ID = 'panelOne';
 
-  const panels = [
-    {
-      gridData: { w: 1, h: 1, x: 0, y: 0, i: PANEL_ONE_ID },
-      type: 'testPanelType',
-      panelConfig: { title: 'Panel One' },
-      panelIndex: PANEL_ONE_ID,
-    },
-  ];
+  const panel1 = {
+    gridData: { w: 1, h: 1, x: 0, y: 0, i: PANEL_ONE_ID },
+    type: 'testPanelType',
+    panelConfig: { title: 'Panel One' },
+    panelIndex: PANEL_ONE_ID,
+  };
 
-  const childApi: DefaultEmbeddableApi = {
+  const titleManager = initializeTitleManager(panel1.panelConfig);
+  const panel1Api: DefaultEmbeddableApi = {
     type: 'testPanelType',
     uuid: PANEL_ONE_ID,
     phase$: {} as unknown as PublishingSubject<PhaseEvent | undefined>,
-    serializeState: jest.fn(),
+    ...titleManager.api,
+    serializeState: () => ({
+      rawState: titleManager.getLatestState(),
+    }),
+  };
+
+  const section1 = {
+    title: 'Section one',
+    collapsed: false,
+    gridData: {
+      y: 1,
+      i: 'section1',
+    },
+    panels: [panel1],
   };
 
   test('can register child APIs', () => {
-    const layoutManager = initializeLayoutManager(undefined, panels, trackPanelMock, () => []);
-    layoutManager.internalApi.registerChildApi(childApi);
-    expect(layoutManager.api.children$.getValue()[PANEL_ONE_ID]).toBe(childApi);
+    const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
+    layoutManager.internalApi.registerChildApi(panel1Api);
+    expect(layoutManager.api.children$.getValue()[PANEL_ONE_ID]).toBe(panel1Api);
   });
 
   test('should append incoming embeddable to existing panels', () => {
@@ -71,13 +84,13 @@ describe('layout manager', () => {
     };
     const layoutManager = initializeLayoutManager(
       incomingEmbeddable,
-      panels,
+      [panel1],
       trackPanelMock,
       () => []
     );
 
     const layout = layoutManager.internalApi.layout$.value;
-    expect(Object.keys(layout.panels).length).toBe(Object.keys(panels).length + 1);
+    expect(Object.keys(layout.panels).length).toBe(2);
     expect(layout.panels.panelTwo).toEqual({
       gridData: {
         h: 1,
@@ -96,23 +109,14 @@ describe('layout manager', () => {
   });
 
   describe('duplicatePanel', () => {
-    const titleManager = initializeTitleManager(panels[0].panelConfig);
-    const childApiToDuplicate = {
-      ...childApi,
-      ...titleManager.api,
-      serializeState: () => ({
-        rawState: titleManager.getLatestState(),
-      }),
-    };
-
     test('should add duplicated panel to layout', async () => {
-      const layoutManager = initializeLayoutManager(undefined, panels, trackPanelMock, () => []);
-      layoutManager.internalApi.registerChildApi(childApiToDuplicate);
+      const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
+      layoutManager.internalApi.registerChildApi(panel1Api);
 
       await layoutManager.api.duplicatePanel('panelOne');
 
       const layout = layoutManager.internalApi.layout$.value;
-      expect(Object.keys(layout.panels).length).toBe(Object.keys(panels).length + 1);
+      expect(Object.keys(layout.panels).length).toBe(2);
       expect(layout.panels['54321']).toEqual({
         gridData: {
           h: 1,
@@ -131,9 +135,9 @@ describe('layout manager', () => {
     });
 
     test('should clone by reference embeddable as by value', async () => {
-      const layoutManager = initializeLayoutManager(undefined, panels, trackPanelMock, () => []);
+      const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
       layoutManager.internalApi.registerChildApi({
-        ...childApiToDuplicate,
+        ...panel1Api,
         checkForDuplicateTitle: jest.fn(),
         canLinkToLibrary: jest.fn(),
         canUnlinkFromLibrary: jest.fn(),
@@ -156,10 +160,10 @@ describe('layout manager', () => {
     });
 
     test('should give a correct title to the clone of a clone', async () => {
-      const layoutManager = initializeLayoutManager(undefined, panels, trackPanelMock, () => []);
+      const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
       const titleManagerOfClone = initializeTitleManager({ title: 'Panel One (copy)' });
       layoutManager.internalApi.registerChildApi({
-        ...childApiToDuplicate,
+        ...panel1Api,
         ...titleManagerOfClone.api,
         serializeState: () => ({
           rawState: titleManagerOfClone.getLatestState(),
@@ -172,6 +176,90 @@ describe('layout manager', () => {
       expect(duplicatedPanelState.rawState).toEqual({
         title: 'Panel One (copy 1)',
       });
+    });
+  });
+
+  describe('canRemovePanels', () => {
+    test('allows removing panels when there is no expanded panel', () => {
+      const layoutManager = initializeLayoutManager(
+        undefined,
+        [panel1],
+        {
+          ...trackPanelMock,
+          expandedPanelId$: new BehaviorSubject<string | undefined>(undefined),
+        },
+        () => []
+      );
+      expect(layoutManager.api.canRemovePanels()).toBe(true);
+    });
+
+    test('does not allow removing panels when there is an expanded panel', () => {
+      const layoutManager = initializeLayoutManager(
+        undefined,
+        [panel1],
+        {
+          ...trackPanelMock,
+          expandedPanelId$: new BehaviorSubject<string | undefined>('1'),
+        },
+        () => []
+      );
+      expect(layoutManager.api.canRemovePanels()).toBe(false);
+    });
+  });
+
+  describe('getChildApi', () => {
+    test('should return api when api is available', (done) => {
+      const layoutManager = initializeLayoutManager(undefined, [panel1], trackPanelMock, () => []);
+
+      layoutManager.api.getChildApi(PANEL_ONE_ID).then((api) => {
+        expect(api).toBe(panel1Api);
+        done();
+      });
+
+      layoutManager.internalApi.registerChildApi(panel1Api);
+    });
+
+    test('should return api from panel in open section when api is available', (done) => {
+      const layoutManager = initializeLayoutManager(
+        undefined,
+        [
+          {
+            ...section1,
+            collapsed: false,
+          },
+        ],
+        trackPanelMock,
+        () => []
+      );
+
+      layoutManager.api.getChildApi(PANEL_ONE_ID).then((api) => {
+        expect(api).toBe(panel1Api);
+        done();
+      });
+
+      layoutManager.internalApi.registerChildApi(panel1Api);
+    });
+
+    test('should return undefined from panel in closed section', (done) => {
+      const layoutManager = initializeLayoutManager(
+        undefined,
+        [
+          {
+            ...section1,
+            collapsed: true,
+          },
+        ],
+        trackPanelMock,
+        () => []
+      );
+
+      layoutManager.api.getChildApi(PANEL_ONE_ID).then((api) => {
+        expect(api).toBeUndefined();
+        done();
+      });
+
+      // do not call layoutManager.internalApi.registerChildApi
+      // because api will never become available
     });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[dashboard] fix duplicate panel action hangs when dashboard has collapsed section that are closed on page load (#230842)](https://github.com/elastic/kibana/pull/230842)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-08-06T21:05:19Z","message":"[dashboard] fix duplicate panel action hangs when dashboard has collapsed section that are closed on page load (#230842)\n\nCloses https://github.com/elastic/kibana/issues/230818\n\nPR updates getChildApi with logic to return `undefined` if panel is in a\ncollapsed section.","sha":"3095cebf0680288689a5fe9d9bd1a3f99146be98","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport:version","v9.2.0","v9.1.1","v8.19.1"],"title":"[dashboard] fix duplicate panel action hangs when dashboard has collapsed section that are closed on page load","number":230842,"url":"https://github.com/elastic/kibana/pull/230842","mergeCommit":{"message":"[dashboard] fix duplicate panel action hangs when dashboard has collapsed section that are closed on page load (#230842)\n\nCloses https://github.com/elastic/kibana/issues/230818\n\nPR updates getChildApi with logic to return `undefined` if panel is in a\ncollapsed section.","sha":"3095cebf0680288689a5fe9d9bd1a3f99146be98"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230842","number":230842,"mergeCommit":{"message":"[dashboard] fix duplicate panel action hangs when dashboard has collapsed section that are closed on page load (#230842)\n\nCloses https://github.com/elastic/kibana/issues/230818\n\nPR updates getChildApi with logic to return `undefined` if panel is in a\ncollapsed section.","sha":"3095cebf0680288689a5fe9d9bd1a3f99146be98"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->