### PR TITLE
[DOCS][Known issue] Reporting failing in >= 9.0.0 when using `server.protocol: http2`

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -28,7 +28,7 @@ Applies to: {{stack}} 9.0.0
 
 **Details**
 
-In {{stack}} 9.0.0, {{kib}} uses HTTP/2 protocol by default to communicate with {{es}}. If you've set [`server.protocol`](/reference/configuration-reference/general-settings.md) to `http2`, PDF and PNG reports will fail when you export them from the dashboard, visualization, or Canvas workpad that you're generating a report for.
+If you've changed the [`server.protocol`](/reference/configuration-reference/general-settings.md) value to `http2`, PDF and PNG reports will fail when you export them from the dashboard, visualization, or Canvas workpad that you're generating a report for.
 
 **Action**
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -22,6 +22,24 @@ To mitigate the issue, set `xpack.alerting.rules.run.alerts.max` to a value equa
 
 ::::
 
+::::{dropdown} PDF and PNG reports time out and fail with an invalid header error if server.protocol is set to http2
+
+Applies to: {{stack}} 9.0.0
+
+**Details**
+
+In {{stack}} 9.0.0, {{kib}} uses HTTP/2 protocol by default to communicate with {{es}}. If you've set [`server.protocol`](/reference/configuration-reference/general-settings.md) to `http2`, PDF and PNG reports will fail when you export them from the dashboard, visualization, or Canvas workpad that you're generating a report for.
+
+**Action**
+
+To temporarily resolve the issue, set `server.protocol` to `http1`. 
+
+**Resolved**
+
+This issue is resolved in {{stack}} 9.0.0, 9.0.4, 9.1.0.
+
+::::
+
 ::::{dropdown} Dashboard Copy link doesn't work when sharing from a space other than the default space
 
 Applies to: {{stack}} 9.0.3


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1991. Adds a known issue to the 9.x known issues page about PDF and PNG reports failing if users have set `server.protocol: http2` in their kibana.yml file.

**Corresponding 8.x updates**: https://github.com/elastic/kibana/pull/230894

[Preview](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/230887/release-notes/known-issues)



<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->