### PR TITLE
[9.0] [Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade_without_preview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade_without_preview.cy.ts
@@ -7,6 +7,8 @@
 
 import { getPrebuiltRuleMockOfType } from '@kbn/security-solution-plugin/server/lib/detection_engine/prebuilt_rules/mocks';
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
+import { IS_SERVERLESS } from '../../../../env_var_names_constants';
+import { waitForPageTitleToBeShown } from '../../../../tasks/alert_assignments';
 import { createRuleAssetSavedObject } from '../../../../helpers/rules';
 import {
   getReviewSingleRuleButtonByRuleId,
@@ -48,8 +50,7 @@ import {
   visitRulesUpgradeTable,
 } from '../../../../tasks/rules_management';
 
-// Failing: See https://github.com/elastic/kibana/issues/230105
-describe.skip(
+describe(
   'Detection rules, Prebuilt Rules Upgrade Without Preview',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
@@ -565,8 +566,10 @@ describe.skip(
           rulePatches: [],
           newRuleAssets: [NEW_PREBUILT_RULE_ASSET],
         });
-        login(ROLES.reader);
+        const isServerless = Cypress.env(IS_SERVERLESS);
+        login(isServerless ? ROLES.t1_analyst : ROLES.reader);
         visitRulesUpgradeTable();
+        waitForPageTitleToBeShown();
 
         cy.get(RULES_UPDATES_TAB).should('not.exist');
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557)](https://github.com/elastic/kibana/pull/230557)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-08-06T23:17:02Z","message":"[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557)\n\n**Resolves: https://github.com/elastic/kibana/issues/230105**\n\n## Summary\n\nThis PR fixes a failed Cypress test. The fix makes using the correct roles in Serverless.\n\n## Details\n\nUsing `reader` user role isn't reliable in Serverless. This PR switched to using `t1_analyst` in Serverless.\n\n## Flaky test runner\n\n- ✅  [Serverless 100 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9026)","sha":"538ad4c70f05725d838b71cd22d32649aafe8ca7","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v9.2.0","v9.0.5","v9.1.1","v8.18.5","v8.19.1"],"title":"[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test","number":230557,"url":"https://github.com/elastic/kibana/pull/230557","mergeCommit":{"message":"[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557)\n\n**Resolves: https://github.com/elastic/kibana/issues/230105**\n\n## Summary\n\nThis PR fixes a failed Cypress test. The fix makes using the correct roles in Serverless.\n\n## Details\n\nUsing `reader` user role isn't reliable in Serverless. This PR switched to using `t1_analyst` in Serverless.\n\n## Flaky test runner\n\n- ✅  [Serverless 100 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9026)","sha":"538ad4c70f05725d838b71cd22d32649aafe8ca7"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230557","number":230557,"mergeCommit":{"message":"[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557)\n\n**Resolves: https://github.com/elastic/kibana/issues/230105**\n\n## Summary\n\nThis PR fixes a failed Cypress test. The fix makes using the correct roles in Serverless.\n\n## Details\n\nUsing `reader` user role isn't reliable in Serverless. This PR switched to using `t1_analyst` in Serverless.\n\n## Flaky test runner\n\n- ✅  [Serverless 100 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9026)","sha":"538ad4c70f05725d838b71cd22d32649aafe8ca7"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230899","number":230899,"state":"MERGED","mergeCommit":{"sha":"bc23ce2b36caae6ad9418b8bb49c1f38713e30bc","message":"[9.1] [Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557) (#230899)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test\n(#230557)](https://github.com/elastic/kibana/pull/230557)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"8.18","label":"v8.18.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230897","number":230897,"state":"MERGED","mergeCommit":{"sha":"0f53f2e3ef0c3d203cce8a2e7a1da45593a37871","message":"[8.18] [Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557) (#230897)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test\n(#230557)](https://github.com/elastic/kibana/pull/230557)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/230898","number":230898,"state":"MERGED","mergeCommit":{"sha":"4b52d4a92b4d2a67989e5c433c626b8fbfabefe5","message":"[8.19] [Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test (#230557) (#230898)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution] Fix a failed e2e prebuilt rules upgrade RBAC test\n(#230557)](https://github.com/elastic/kibana/pull/230557)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>"}}]}] BACKPORT-->