### PR TITLE
[8.19] [watcher] Allow disabling watcher in any environment (#230905)

### DIFF
--- a/x-pack/platform/plugins/private/watcher/server/index.ts
+++ b/x-pack/platform/plugins/private/watcher/server/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { PluginInitializerContext } from '@kbn/core/server';
-import { offeringBasedSchema, schema } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
 
 export const plugin = async (ctx: PluginInitializerContext) => {
   const { WatcherServerPlugin } = await import('./plugin');
@@ -15,10 +15,8 @@ export const plugin = async (ctx: PluginInitializerContext) => {
 
 export const config = {
   schema: schema.object({
-    enabled: offeringBasedSchema({
-      // Watcher is disabled in serverless; refer to the serverless.yml file as the source of truth
-      // We take this approach in order to have a central place (serverless.yml) to view disabled plugins across Kibana
-      serverless: schema.boolean({ defaultValue: true }),
-    }),
+    // Watcher is disabled in serverless; refer to the serverless.yml file as the source of truth
+    // We take this approach in order to have a central place (serverless.yml) to view disabled plugins across Kibana
+    enabled: schema.boolean({ defaultValue: true }),
   }),
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[watcher] Allow disabling watcher in any environment (#230905)](https://github.com/elastic/kibana/pull/230905)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Matthew Kime","email":"matt@mattki.me"},"sourceCommit":{"committedDate":"2025-08-07T10:18:08Z","message":"[watcher] Allow disabling watcher in any environment (#230905)\n\n## Summary\n\nPreviously disabling watcher was only allowed for serverless but some\nclients consider it a potential security risk so its useful to be able\nto disable it in any environment.\n\nTo test: \n\nAdd `xpack.watcher.enabled: false` to your kibana.dev.yml file. \nGo look for watcher in management, it should be missing.\nChange `xpack.watcher.enabled:` to true.\nGo look for watcher, it should be back!\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c22a8fa73a9c1f4221e2177913de85db7131e74e","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Watcher","Feature:Kibana Management","release_note:skip","backport:current-major","v9.2.0"],"title":"[watcher] Allow disabling watcher in any environment","number":230905,"url":"https://github.com/elastic/kibana/pull/230905","mergeCommit":{"message":"[watcher] Allow disabling watcher in any environment (#230905)\n\n## Summary\n\nPreviously disabling watcher was only allowed for serverless but some\nclients consider it a potential security risk so its useful to be able\nto disable it in any environment.\n\nTo test: \n\nAdd `xpack.watcher.enabled: false` to your kibana.dev.yml file. \nGo look for watcher in management, it should be missing.\nChange `xpack.watcher.enabled:` to true.\nGo look for watcher, it should be back!\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c22a8fa73a9c1f4221e2177913de85db7131e74e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230905","number":230905,"mergeCommit":{"message":"[watcher] Allow disabling watcher in any environment (#230905)\n\n## Summary\n\nPreviously disabling watcher was only allowed for serverless but some\nclients consider it a potential security risk so its useful to be able\nto disable it in any environment.\n\nTo test: \n\nAdd `xpack.watcher.enabled: false` to your kibana.dev.yml file. \nGo look for watcher in management, it should be missing.\nChange `xpack.watcher.enabled:` to true.\nGo look for watcher, it should be back!\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c22a8fa73a9c1f4221e2177913de85db7131e74e"}}]}] BACKPORT-->