### PR TITLE
Increase ss prebuilt rules cypress timeout

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -124,7 +124,7 @@ steps:
       preemptible: true
     depends_on:
       - build
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80
     parallelism: 1
     retry:
       automatic:

--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -124,8 +124,8 @@ steps:
       preemptible: true
     depends_on:
       - build
-    timeout_in_minutes: 80
-    parallelism: 1
+    timeout_in_minutes: 60
+    parallelism: 2
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -140,8 +140,8 @@ steps:
           machineType: n2-standard-4
           preemptible: true
         depends_on: build
-        timeout_in_minutes: 80
-        parallelism: 1
+        timeout_in_minutes: 60
+        parallelism: 2
         retry:
           automatic:
             - exit_status: '-1'

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -140,7 +140,7 @@ steps:
           machineType: n2-standard-4
           preemptible: true
         depends_on: build
-        timeout_in_minutes: 60
+        timeout_in_minutes: 80
         parallelism: 1
         retry:
           automatic:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -246,8 +246,8 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
-    timeout_in_minutes: 80
-    parallelism: 1
+    timeout_in_minutes: 60
+    parallelism: 2
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -246,7 +246,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80
     parallelism: 1
     retry:
       automatic:

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -127,8 +127,8 @@ steps:
       preemptible: true
     depends_on:
       - build
-    timeout_in_minutes: 80
-    parallelism: 1
+    timeout_in_minutes: 60
+    parallelism: 2
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -127,7 +127,7 @@ steps:
       preemptible: true
     depends_on:
       - build
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80
     parallelism: 1
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -32,8 +32,8 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 80
-    parallelism: 1
+    timeout_in_minutes: 60
+    parallelism: 2
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -32,7 +32,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80
     parallelism: 1
     retry:
       automatic:


### PR DESCRIPTION
## Summary
These tests have been dancing around the 60m mark, now they're often timing out. (e.g.: https://buildkite.com/elastic/kibana-on-merge/builds/74840) - this PR raises parallelism to 2x to avoid timing out.

@elastic/security-detection-rule-management - can you take a look if the 60m timeout is reasonable? If so, please optimize the run time, if not, let's keep this new timeout.