### PR TITLE
[Docs] [8.19] Add defaultSolution setting to config reference

### DIFF
--- a/docs/settings/spaces-settings.asciidoc
+++ b/docs/settings/spaces-settings.asciidoc
@@ -12,3 +12,6 @@ The maximum number of spaces that you can use with the {kib} instance. Some {kib
 return all spaces using a single `_search` from {es}, so you must
 configure this setting lower than the `index.max_result_window` in {es}.
 The default is `1000`.
+
+`xpack.spaces.defaultSolution`::
+Sets the solution view for your default space.


### PR DESCRIPTION
This PR copies a change added in the [9.1 docs](https://github.com/elastic/kibana/pull/229650).
Rel: https://github.com/elastic/docs-content/issues/1676
