### PR TITLE
[9.1] [ska] relocate chat serverless api & functional tests (#230527)

### DIFF
--- a/.buildkite/ftr_chat_serverless_configs.yml
+++ b/.buildkite/ftr_chat_serverless_configs.yml
@@ -6,8 +6,8 @@ disabled:
   - x-pack/test_serverless/api_integration/test_suites/chat/config.ts
   - x-pack/test_serverless/api_integration/test_suites/chat/config.feature_flags.ts
   - x-pack/platform/test/serverless/api_integration/configs/chat/config.group1.ts
-  - x-pack/test_serverless/functional/test_suites/chat/config.ts
-  - x-pack/test_serverless/functional/test_suites/chat/config.feature_flags.ts
+  - x-pack/solutions/chat/test/serverless/functional/configs/config.ts
+  - x-pack/solutions/chat/test/serverless/functional/configs/config.feature_flags.ts
   - x-pack/platform/test/serverless/functional/configs/chat/config.config_compat_mode.ts
   - x-pack/platform/test/serverless/functional/configs/chat/config.group1.ts
 

--- a/.buildkite/ftr_chat_serverless_configs.yml
+++ b/.buildkite/ftr_chat_serverless_configs.yml
@@ -3,8 +3,8 @@ disabled:
   - x-pack/platform/test/serverless/functional/config.chat.base.ts
 
   # Serverless tests only run on main
-  - x-pack/test_serverless/api_integration/test_suites/chat/config.ts
-  - x-pack/test_serverless/api_integration/test_suites/chat/config.feature_flags.ts
+  - x-pack/solutions/chat/test/serverless/api_integration/configs/config.ts
+  - x-pack/solutions/chat/test/serverless/api_integration/configs/config.feature_flags.ts
   - x-pack/platform/test/serverless/api_integration/configs/chat/config.group1.ts
   - x-pack/solutions/chat/test/serverless/functional/configs/config.ts
   - x-pack/solutions/chat/test/serverless/functional/configs/config.feature_flags.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -783,6 +783,7 @@ module.exports = {
         'x-pack/solutions/*/test/**/tests/**/*',
         'x-pack/solutions/*/test/api_integration_deployment_agnostic/*configs/**/*',
         'x-pack/solutions/*/test/alerting_api_integration/**/*',
+        'x-pack/solutions/*/test/serverless/*/configs/**/*',
         'x-pack/test/*/{tests,test_suites,apis,apps}/**/*',
         'x-pack/test/*/*config.*ts',
         'x-pack/platform/test/saved_object_api_integration/*/apis/**/*',

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1029,6 +1029,7 @@ x-pack/solutions/chat/plugins/wci-index-source @elastic/search-kibana @elastic/w
 x-pack/solutions/chat/plugins/wci-salesforce @elastic/search-kibana @elastic/workchat-eng
 x-pack/solutions/chat/plugins/workchat-app @elastic/search-kibana @elastic/workchat-eng
 x-pack/solutions/chat/plugins/workchat-framework @elastic/search-kibana @elastic/workchat-eng
+x-pack/solutions/chat/test @elastic/workchat-eng
 x-pack/solutions/observability/packages/alert-details @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/alerting-test-data @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/obs-ux-management-team
@@ -2268,9 +2269,9 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 
 # workchat
 /x-pack/test_serverless/api_integration/test_suites/chat @elastic/search-kibana @elastic/workchat-eng
-/x-pack/test_serverless/api_integration/test_suites/chat/config.ts @elastic/search-kibana @elastic/appex-qa
+/x-pack/solutions/chat/test/serverless/api_integration/configs/config.ts @elastic/search-kibana @elastic/appex-qa
 /x-pack/test_serverless/functional/test_suites/chat/ @elastic/search-kibana
-/x-pack/test_serverless/functional/test_suites/chat/config.ts @elastic/search-kibana @elastic/appex-qa
+/x-pack/solutions/chat/test/serverless/functional/configs/config.ts @elastic/search-kibana @elastic/appex-qa
 
 # Management Experience - Deployment Management
 /src/platform/test/functional/fixtures/kbn_archiver/management.json @elastic/kibana-management @elastic/kibana-data-discovery # Assigned per 2 uses: test/functional/apps/management/_import_objects.ts && test/functional/apps/management/data_views/_scripted_fields_filter.ts

--- a/package.json
+++ b/package.json
@@ -1598,6 +1598,7 @@
     "@kbn/test-suites-serverless": "link:x-pack/test_serverless",
     "@kbn/test-suites-src": "link:src/platform/test",
     "@kbn/test-suites-xpack": "link:x-pack/test",
+    "@kbn/test-suites-xpack-chat": "link:x-pack/solutions/chat/test",
     "@kbn/test-suites-xpack-observability": "link:x-pack/solutions/observability/test",
     "@kbn/test-suites-xpack-performance": "link:x-pack/performance",
     "@kbn/test-suites-xpack-platform": "link:x-pack/platform/test",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2040,6 +2040,8 @@
       "@kbn/test-suites-src/*": ["src/platform/test/*"],
       "@kbn/test-suites-xpack": ["x-pack/test"],
       "@kbn/test-suites-xpack/*": ["x-pack/test/*"],
+      "@kbn/test-suites-xpack-chat": ["x-pack/solutions/chat/test"],
+      "@kbn/test-suites-xpack-chat/*": ["x-pack/solutions/chat/test/*"],
       "@kbn/test-suites-xpack-observability": ["x-pack/solutions/observability/test"],
       "@kbn/test-suites-xpack-observability/*": ["x-pack/solutions/observability/test/*"],
       "@kbn/test-suites-xpack-performance": ["x-pack/performance"],

--- a/x-pack/solutions/chat/test/.gitignore
+++ b/x-pack/solutions/chat/test/.gitignore
@@ -1,0 +1,2 @@
+/functional/failure_debug
+/functional/screenshots

--- a/x-pack/solutions/chat/test/kibana.jsonc
+++ b/x-pack/solutions/chat/test/kibana.jsonc
@@ -1,0 +1,8 @@
+{
+  "type": "test-helper",
+  "id": "@kbn/test-suites-xpack-chat",
+  "owner": ["@elastic/workchat-eng"],
+  "group": "chat",
+  "visibility": "private",
+  "devOnly": true
+}

--- a/x-pack/solutions/chat/test/serverless/api_integration/configs/config.feature_flags.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/configs/config.feature_flags.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../config.base';
+import { createTestConfig } from '@kbn/test-suites-xpack-platform/serverless/api_integration/config.base';
+import { services } from '../services';
 
 /**
  * Make sure to create a MKI deployment with custom Kibana image, that includes feature flags arguments
@@ -13,6 +14,7 @@ import { createTestConfig } from '../../config.base';
  */
 export default createTestConfig({
   serverlessProject: 'chat',
+  services,
   junit: {
     reportName: 'Serverless Chat Feature Flags API Integration Tests',
   },

--- a/x-pack/solutions/chat/test/serverless/api_integration/configs/config.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/configs/config.ts
@@ -5,19 +5,19 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../config.base';
+import { createTestConfig } from '@kbn/test-suites-xpack-platform/serverless/api_integration/config.base';
+import { services } from '../services';
 
 export default createTestConfig({
   serverlessProject: 'chat',
+  services,
   testFiles: [require.resolve('.')],
   junit: {
-    reportName: 'Serverless Chat Functional Tests',
+    reportName: 'Serverless Chat API Integration Tests',
   },
   suiteTags: { exclude: ['skipSvlChat'] },
 
   // include settings from project controller
   esServerArgs: [],
   kbnServerArgs: [],
-
-  apps: {},
 });

--- a/x-pack/solutions/chat/test/serverless/api_integration/configs/index.feature_flags.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/configs/index.feature_flags.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../ftr_provider_context';
+import { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Serverless chat API - feature flags', function () {

--- a/x-pack/solutions/chat/test/serverless/api_integration/configs/index.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/configs/index.ts
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../ftr_provider_context';
+import { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('serverless chat UI - feature flags', function () {
-    // add tests that require feature flags, defined in config.feature_flags.ts
-    // loadTestFile(require.resolve('./path/to/tests'));
+  describe('Serverless chat API', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../test_suites/platform_security'));
   });
 }

--- a/x-pack/solutions/chat/test/serverless/api_integration/ftr_provider_context.d.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/ftr_provider_context.d.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GenericFtrProviderContext } from '@kbn/test';
+
+import { services } from './services';
+
+export type FtrProviderContext = GenericFtrProviderContext<typeof services, {}>;

--- a/x-pack/solutions/chat/test/serverless/api_integration/services/index.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/services/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GenericFtrProviderContext } from '@kbn/test';
+import { services as svlPlatformServices } from '@kbn/test-suites-xpack-platform/serverless/api_integration/services';
+
+export const services = {
+  ...svlPlatformServices,
+
+  // Chat Solution serverless FTR services
+};
+
+export type InheritedFtrProviderContext = GenericFtrProviderContext<typeof services, {}>;
+
+export type InheritedServices = InheritedFtrProviderContext extends GenericFtrProviderContext<
+  infer TServices,
+  {}
+>
+  ? TServices
+  : {};
+
+export type { SupertestWithRoleScopeType } from '@kbn/test-suites-xpack-platform/serverless/shared/services';

--- a/x-pack/solutions/chat/test/serverless/api_integration/test_suites/platform_security/authorization.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/test_suites/platform_security/authorization.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const svlCommonApi = getService('svlCommonApi');

--- a/x-pack/solutions/chat/test/serverless/api_integration/test_suites/platform_security/index.ts
+++ b/x-pack/solutions/chat/test/serverless/api_integration/test_suites/platform_security/index.ts
@@ -8,9 +8,7 @@
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('Serverless chat API', function () {
-    this.tags(['esGate']);
-
-    loadTestFile(require.resolve('./platform_security'));
+  describe('Platform security APIs', function () {
+    loadTestFile(require.resolve('./authorization'));
   });
 }

--- a/x-pack/solutions/chat/test/serverless/functional/configs/config.feature_flags.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/configs/config.feature_flags.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../config.base';
+import { createTestConfig } from '@kbn/test-suites-xpack-platform/serverless/functional/config.base';
+import { services } from '../services';
 
 /**
  * Make sure to create a MKI deployment with custom Kibana image, that includes feature flags arguments
@@ -13,6 +14,7 @@ import { createTestConfig } from '../../config.base';
  */
 export default createTestConfig({
   serverlessProject: 'chat',
+  services,
   junit: {
     reportName: 'Serverless Chat Feature Flags Functional Tests',
   },

--- a/x-pack/solutions/chat/test/serverless/functional/configs/config.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/configs/config.ts
@@ -5,17 +5,21 @@
  * 2.0.
  */
 
-import { createTestConfig } from '../../config.base';
+import { createTestConfig } from '@kbn/test-suites-xpack-platform/serverless/functional/config.base';
+import { services } from '../services';
 
 export default createTestConfig({
   serverlessProject: 'chat',
+  services,
   testFiles: [require.resolve('.')],
   junit: {
-    reportName: 'Serverless Chat API Integration Tests',
+    reportName: 'Serverless Chat Functional Tests',
   },
   suiteTags: { exclude: ['skipSvlChat'] },
 
   // include settings from project controller
   esServerArgs: [],
   kbnServerArgs: [],
+
+  apps: {},
 });

--- a/x-pack/solutions/chat/test/serverless/functional/configs/index.feature_flags.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/configs/index.feature_flags.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('Platform security APIs', function () {
-    loadTestFile(require.resolve('./authorization'));
+  describe('serverless chat UI - feature flags', function () {
+    // add tests that require feature flags, defined in config.feature_flags.ts
+    // loadTestFile(require.resolve('./path/to/tests'));
   });
 }

--- a/x-pack/solutions/chat/test/serverless/functional/configs/index.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/configs/index.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../ftr_provider_context';
+import { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless chat UI', function () {
     this.tags(['esGate']);
 
-    loadTestFile(require.resolve('./navigation/navigation.ts'));
+    loadTestFile(require.resolve('../test_suites/navigation/navigation.ts'));
   });
 }

--- a/x-pack/solutions/chat/test/serverless/functional/ftr_provider_context.d.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/ftr_provider_context.d.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GenericFtrProviderContext } from '@kbn/test';
+
+import { services } from './services';
+import { pageObjects } from './page_objects';
+
+export type FtrProviderContext = GenericFtrProviderContext<typeof services, typeof pageObjects>;

--- a/x-pack/solutions/chat/test/serverless/functional/page_objects/index.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/page_objects/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { pageObjects as svlPlatformPageObjects } from '@kbn/test-suites-xpack-platform/serverless/functional/page_objects';
+
+export const services = {
+  ...svlPlatformPageObjects,
+  // Chat Solution serverless FTR page objects
+};

--- a/x-pack/solutions/chat/test/serverless/functional/services/index.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/services/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GenericFtrProviderContext } from '@kbn/test';
+import { services as svlPlatformServices } from '@kbn/test-suites-xpack-platform/serverless/functional/services';
+import { SvlChatNavigationServiceProvider } from './svl_chat_navigation';
+
+export const services = {
+  ...svlPlatformServices,
+  // Chat Solution serverless FTR services
+  svlChatNavigation: SvlChatNavigationServiceProvider,
+};
+
+export type InheritedFtrProviderContext = GenericFtrProviderContext<typeof services, {}>;
+
+export type InheritedServices = InheritedFtrProviderContext extends GenericFtrProviderContext<
+  infer TServices,
+  {}
+>
+  ? TServices
+  : {};
+
+export type { SupertestWithRoleScopeType } from '@kbn/test-suites-xpack-platform/serverless/shared/services';

--- a/x-pack/solutions/chat/test/serverless/functional/services/svl_chat_navigation.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/services/svl_chat_navigation.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export function SvlChatNavigationServiceProvider({
+  getService,
+  getPageObjects,
+}: FtrProviderContext) {
+  const retry = getService('retry');
+  const PageObjects = getPageObjects(['common']);
+  const testSubjects = getService('testSubjects');
+
+  return {
+    async navigateToLandingPage() {
+      await retry.tryForTime(60 * 1000, async () => {
+        await PageObjects.common.navigateToApp('landingPage');
+        await testSubjects.existOrFail('workChatHomePage', { timeout: 2000 });
+        await testSubjects.existOrFail('projectLayoutSideNav', { timeout: 2000 });
+      });
+    },
+  };
+}

--- a/x-pack/solutions/chat/test/serverless/functional/test_suites/navigation/navigation.ts
+++ b/x-pack/solutions/chat/test/serverless/functional/test_suites/navigation/navigation.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getPageObject, getService }: FtrProviderContext) {
   const svlChatNavigation = getService('svlChatNavigation');

--- a/x-pack/solutions/chat/test/tsconfig.json
+++ b/x-pack/solutions/chat/test/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "node",
+      "cheerio",
+      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
+      "@kbn/ambient-ftr-types"
+    ],
+    "resolveJsonModule": true,
+  },
+  "include": [
+    "**/*",
+    "../../../../typings/**/*",
+    "../../../../src/platform/packages/shared/kbn-test/types/ftr_globals/**/*",
+  ],
+  "exclude": ["target/**/*", "*/plugins/**/*", "plugins/**/*"],
+  "kbn_references": [
+    "@kbn/test",
+    "@kbn/test-suites-xpack-platform",
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7911,6 +7911,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/test-suites-xpack-chat@link:x-pack/solutions/chat/test":
+  version "0.0.0"
+  uid ""
+
 "@kbn/test-suites-xpack-observability@link:x-pack/solutions/observability/test":
   version "0.0.0"
   uid ""
@@ -30388,7 +30392,7 @@ string-replace-loader@^3.1.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -30405,15 +30409,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -30507,7 +30502,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -30520,13 +30515,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -33334,7 +33322,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -33355,15 +33343,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -33479,7 +33458,7 @@ xpath@^0.0.33:
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.33.tgz#5136b6094227c5df92002e7c3a13516a5074eb07"
   integrity sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==
 
-"xstate5@npm:xstate@^5.19.2":
+"xstate5@npm:xstate@^5.19.2", xstate@^5.19.2:
   version "5.19.2"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
   integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
@@ -33488,11 +33467,6 @@ xstate@^4.38.3:
   version "4.38.3"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.38.3.tgz#4e15e7ad3aa0ca1eea2010548a5379966d8f1075"
   integrity sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==
-
-xstate@^5.19.2:
-  version "5.19.2"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
-  integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ska] relocate chat serverless api & functional tests (#230527)](https://github.com/elastic/kibana/pull/230527)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-08-07T07:42:31Z","message":"[ska] relocate chat serverless api & functional tests (#230527)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR is mostly about moving chat FTR tests from\n`x-pack/test_serverless/` dir to `x-pack/solutions/chat/test`\n\nBefore\n```\nx-pack/test_serverless/\n  | - functional/test_suites/chat/\n  | - api_integration/test_suites/chat/\n```\n\nAfter: \n```\nx-pack/solutions/chat/test/serverless\n  | - functional/\n  |  |- test_suites/\n  |  |- configs/\n  | - api_integration/\n     |- test_suites/\n     |- configs/\n```\n\nAll the tests are run under the renamed FTR configs:\n\n<img width=\"1716\" height=\"200\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/56bf8459-4b5d-4504-81a0-6ea936140c09\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4fe1ea26032c8ba6e22d3775419aa64b05f1bc19","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.1.1","v8.19.1"],"title":"[ska] relocate chat serverless api & functional tests","number":230527,"url":"https://github.com/elastic/kibana/pull/230527","mergeCommit":{"message":"[ska] relocate chat serverless api & functional tests (#230527)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR is mostly about moving chat FTR tests from\n`x-pack/test_serverless/` dir to `x-pack/solutions/chat/test`\n\nBefore\n```\nx-pack/test_serverless/\n  | - functional/test_suites/chat/\n  | - api_integration/test_suites/chat/\n```\n\nAfter: \n```\nx-pack/solutions/chat/test/serverless\n  | - functional/\n  |  |- test_suites/\n  |  |- configs/\n  | - api_integration/\n     |- test_suites/\n     |- configs/\n```\n\nAll the tests are run under the renamed FTR configs:\n\n<img width=\"1716\" height=\"200\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/56bf8459-4b5d-4504-81a0-6ea936140c09\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4fe1ea26032c8ba6e22d3775419aa64b05f1bc19"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230527","number":230527,"mergeCommit":{"message":"[ska] relocate chat serverless api & functional tests (#230527)\n\n## Summary\n\nPart of https://github.com/elastic/kibana-team/issues/1503\n\nThis PR is mostly about moving chat FTR tests from\n`x-pack/test_serverless/` dir to `x-pack/solutions/chat/test`\n\nBefore\n```\nx-pack/test_serverless/\n  | - functional/test_suites/chat/\n  | - api_integration/test_suites/chat/\n```\n\nAfter: \n```\nx-pack/solutions/chat/test/serverless\n  | - functional/\n  |  |- test_suites/\n  |  |- configs/\n  | - api_integration/\n     |- test_suites/\n     |- configs/\n```\n\nAll the tests are run under the renamed FTR configs:\n\n<img width=\"1716\" height=\"200\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/56bf8459-4b5d-4504-81a0-6ea936140c09\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4fe1ea26032c8ba6e22d3775419aa64b05f1bc19"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->