### PR TITLE
[DOCS][8.18.3 & 8.18.4] [Known Issue] Rule issues occur when `xpack.alerting.rules.run.alerts.max` is set to a value greater than 5000 - small space typo

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -160,9 +160,12 @@ include::CHANGELOG.asciidoc[tag=known-issue-2088]
 [%collapsible]
 ====
 *Details* +
+
 If you've set `xpack.alerting.rules.run.alerts.max` to a value greater than `5000`, you will encounter `Result window is too large` error messages when a maintenance window is active.
+
 *Workaround* +
 To mitigate the issue, set `xpack.alerting.rules.run.alerts.max` to a value equal to or less than `5000`.
+
 ====
 // end::known-issue-230275[]
 


### PR DESCRIPTION
Adds missing space to the summary for the known issue about the `xpack.alerting.rules.run.alerts.max` value. 