### PR TITLE
[8.19][UII] Put back agent log level selection and test for 8.19

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.test.tsx
@@ -191,4 +191,35 @@ describe('AgentLogsUI', () => {
     const result = renderComponent();
     expect(result.queryByTestId('viewInLogsBtn')).not.toBeInTheDocument();
   });
+
+  it('should show log level dropdown with correct value', () => {
+    mockStartServices();
+    const result = renderComponent();
+    const logLevelDropdown = result.getByTestId('selectAgentLogLevel');
+    expect(logLevelDropdown.getElementsByTagName('option').length).toBe(4);
+    expect(logLevelDropdown).toHaveDisplayValue('debug');
+  });
+
+  it('should always show apply log level changes button', () => {
+    mockStartServices();
+    const result = renderComponent();
+    const applyLogLevelBtn = result.getByTestId('applyLogLevelBtn');
+    expect(applyLogLevelBtn).toBeInTheDocument();
+    expect(applyLogLevelBtn).not.toHaveAttribute('disabled');
+  });
+
+  it('should hide reset log level button for agents version < 8.15.0', () => {
+    mockStartServices();
+    const result = renderComponent();
+    const resetLogLevelBtn = result.queryByTestId('resetLogLevelBtn');
+    expect(resetLogLevelBtn).not.toBeInTheDocument();
+  });
+
+  it('should show reset log level button for agents version >= 8.15.0', () => {
+    mockStartServices();
+    const result = renderComponent({ agentVersion: '8.15.0' });
+    const resetLogLevelBtn = result.getByTestId('resetLogLevelBtn');
+    expect(resetLogLevelBtn).toBeInTheDocument();
+    expect(resetLogLevelBtn).not.toHaveAttribute('disabled');
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -34,6 +34,7 @@ import { LogLevelFilter } from './filter_log_level';
 import { LogQueryBar } from './query_bar';
 import { buildQuery } from './build_query';
 import { ViewLogsButton, getFormattedRange } from './view_logs_button';
+import { SelectLogLevel } from './select_log_level';
 
 const WrapperFlexGroup = styled(EuiFlexGroup)`
   height: 100%;
@@ -327,6 +328,12 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(
               />
             ) : null}
           </EuiPanel>
+        <EuiFlexItem grow={false}>
+          <SelectLogLevel
+            agent={agent}
+            agentPolicyLogLevel={agentPolicy?.advanced_settings?.agent_logging_level}
+          />
+        </EuiFlexItem>
         </EuiFlexItem>
       </WrapperFlexGroup>
     );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -328,12 +328,12 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(
               />
             ) : null}
           </EuiPanel>
-        <EuiFlexItem grow={false}>
-          <SelectLogLevel
-            agent={agent}
-            agentPolicyLogLevel={agentPolicy?.advanced_settings?.agent_logging_level}
-          />
-        </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <SelectLogLevel
+              agent={agent}
+              agentPolicyLogLevel={agentPolicy?.advanced_settings?.agent_logging_level}
+            />
+          </EuiFlexItem>
         </EuiFlexItem>
       </WrapperFlexGroup>
     );


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/230980. This PR puts back agent log level selection that was accidentally removed in 8.19 branch only.
