### PR TITLE
[CI] Fix Renovate helper bot trigger and out of sync labels

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -116,7 +116,7 @@
       "enabled": true,
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["elastic-vault-github-plugin-prod[bot]"],
+      "allowed_list": ["elastic-vault-github-plugin-prod[bot]", "elastic-renovate-prod[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "build_drafts": false,

--- a/.buildkite/scripts/steps/renovate/renovate_helper.sh
+++ b/.buildkite/scripts/steps/renovate/renovate_helper.sh
@@ -15,4 +15,11 @@ echo --- Additional helpers
 if [ "$GITHUB_PR_BRANCH" = "renovate/main-chainguard" ] && ! is_pr_with_label "ci:cloud-deploy"; then
   echo "Adding deploy label to main chainguard PR"
   gh api "repos/elastic/kibana/issues/${GITHUB_PR_NUMBER}/labels" --method POST -f "labels[]=ci:cloud-deploy" >/dev/null
+
+  # Sync GITHUB_PR_LABELS variable since we're passing it along to the PR pipeline
+  if [ -n "${GITHUB_PR_LABELS:-}" ]; then
+    export GITHUB_PR_LABELS="${GITHUB_PR_LABELS},ci:cloud-deploy"
+  else
+    export GITHUB_PR_LABELS="ci:cloud-deploy"
+  fi
 fi


### PR DESCRIPTION
## Summary

~~Note: I will backport this after backporting the original PR #228664. I was waiting to see the stability of the original PR.~~

Fixes two issues:
- The [pipeline](https://buildkite.com/elastic/kibana-renovate-helper) is not triggering for Renovate PRs, unless explicitly [commenting](https://github.com/elastic/kibana/pull/230882#issuecomment-3165286181) to run
- Since we're passing along `GITHUB_PR_*` env variables to the PR pipeline. Labels added in the helper pipeline to the PR itself were not in sync with the PR run. Example [this run](https://buildkite.com/elastic/kibana-pull-request/builds/327690#019885d3-196a-4950-896c-3bf7de6f735f) should have `ci:cloud-deploy` label.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->