### PR TITLE
[DOCS][9.1.0] [Known Issue] Rule issues occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -4,6 +4,42 @@ navigation_title: "Known issues"
 
 # Kibana known issues
 
+For Elastic {{observability}} known issues, refer to [Elastic Observability known issues](docs-content://release-notes/elastic-observability/known-issues.md).
+
+For Elastic Security known issues, refer to [Elastic Security known issues](docs-content://release-notes/elastic-security/known-issues.md).
+
+::::{dropdown} Issues with rules occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000
+
+Applies to: {{stack}} 9.0.3, 9.0.4, 9.1.0
+
+**Details**
+
+If you've set `xpack.alerting.rules.run.alerts.max` to a value greater than `5000`, you will encounter `Result window is too large` error messages when a maintenance window is active.
+
+**Action**
+
+To mitigate the issue, set `xpack.alerting.rules.run.alerts.max` to a value equal to or less than `5000`.
+
+::::
+
+::::{dropdown} Dashboard Copy link doesn't work when sharing from a space other than the default space
+
+Applies to: {{stack}} 9.0.3
+
+**Details**
+
+When attempting to share a dashboard from a space that isn't the default space, the **Copy link** action never completes.
+
+**Action**
+
+To avoid this error, don't upgrade {{kib}} to {{stack}} 9.0.3 or upgrade {{kib}} to {{stack}} 9.0.4 when available.
+
+**Resolved**
+
+This issue is resolved in {{stack}} 9.0.4.
+
+::::
+
 ::::{dropdown} Upgrading Kibana from 8.18.x to 9.0.2 fails due to a configuration conflict in the kibana.yml file
 
 Applies to: {{stack}} 9.0.2


### PR DESCRIPTION
Backports #230837

Adds the known issue about the `xpack.alerting.rules.run.alerts.max` setting to the 9.x Kibana known issues page and marked it as a known issue in 9.0.3, 9.0.4, and 9.1.0. Related issue:
https://github.com/elastic/kibana/issues/230275

**Corresponding 8.x PR**: https://github.com/elastic/kibana/pull/230835

Preview
