### PR TITLE
[Synthetics] Honor an explicit namespace, support a custom monitor id, document max_attempts

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.test.ts
@@ -11,12 +11,12 @@ import { SyntheticsService } from '../../../synthetics_service/synthetics_servic
 import { syntheticsMonitorAttributes } from '../../../../common/types/saved_objects';
 
 describe('AddNewMonitorsPublicAPI', () => {
+  const syntheticsService = new SyntheticsService({
+    config: {
+      enabled: true,
+    },
+  } as any);
   it('should normalize schedule', async function () {
-    const syntheticsService = new SyntheticsService({
-      config: {
-        enabled: true,
-      },
-    } as any);
     const api = new AddEditMonitorAPI({
       syntheticsMonitorClient: new SyntheticsMonitorClient(syntheticsService, {} as any),
       request: {
@@ -52,10 +52,33 @@ describe('AddNewMonitorsPublicAPI', () => {
     expect(result.schedule).toEqual({ number: 3, unit: 'm' });
   });
 
-  describe('normalizeMonitor defaults', () => {
-    const syntheticsService = new SyntheticsService({
-      config: {},
+  it('should normalize namespace', async function () {
+    const api = new AddEditMonitorAPI({
+      syntheticsMonitorClient: new SyntheticsMonitorClient(syntheticsService, {} as any),
+      request: {
+        body: {},
+        query: {},
+      },
+      spaceId: 'default',
     } as any);
+    expect(api.getMonitorNamespace('testnamespace')).toEqual('testnamespace');
+  });
+
+  it('should normalize namespace in test space', async function () {
+    const api = new AddEditMonitorAPI({
+      syntheticsMonitorClient: new SyntheticsMonitorClient(syntheticsService, {} as any),
+      request: {
+        body: {},
+        query: {},
+      },
+      spaceId: 'test',
+    } as any);
+
+    expect(api.getMonitorNamespace('testnamespace')).toEqual('testnamespace');
+    expect(api.getMonitorNamespace('default')).toEqual('default');
+  });
+
+  describe('normalizeMonitor defaults', () => {
     const api = new AddEditMonitorAPI({
       syntheticsMonitorClient: new SyntheticsMonitorClient(syntheticsService, {} as any),
       request: {


### PR DESCRIPTION
## 📝 Summary

Reworks this stalled PR to close out all three asks from a customer request ([elastic/enhancements#23765](https://github.com/elastic/enhancements/issues/23765)) about the Synthetics **Add Monitor API**.

## 🐛 Fixed: `namespace` is now actually honored

`getMonitorNamespace` used to silently swap a literal `namespace: "default"` for the Kibana space id, even when a caller explicitly asked for `"default"` — with no documented way to opt out.

- Non-`internal` (external API) calls now honor the configured `namespace` literally, whatever it is.
- `internal` (UI-driven) calls keep the old space-derived behavior, so the Add/Edit Monitor form and alert-toggle actions are unaffected.
- Two UI create paths that didn't set `internal: true` (`fetchUpsertMonitor`'s POST branch, and the "Getting Started" flow) now do, so they keep deriving the namespace from the Kibana space instead of regressing to a literal `"default"`.

## ✨ New: a custom monitor `id` on create

- `id` can now be set directly in the create-monitor request **body** (previously only an undocumented `?id=` query param, kept for backwards compatibility).
- Reusing an existing monitor's `id` is now rejected with **409 Conflict** instead of silently overwriting it — `MonitorConfigRepository.create` always sets `overwrite: true`, so an unchecked colliding id would otherwise clobber the existing monitor.

## 📚 Docs: `id` and `max_attempts` are now documented

Both are added to `commonMonitorFields` in `docs/openapi/synthetic_apis.yaml`. `max_attempts` was a fully working field that had never made it into the public OpenAPI schema.

## ✅ Testing

- Unit tests for `getMonitorNamespace` (internal vs. external, `preserve_namespace`) in `add_monitor_api.test.ts`.
- Scout API coverage for namespace handling and custom-id create/collision behavior in `create_monitor.spec.ts`.
- `node scripts/check.js --scope branch` run locally before push.

## 🔗 Related issues

- Fixes #221335
- Fixes #291581
- Relates to [elastic/enhancements#23765](https://github.com/elastic/enhancements/issues/23765)