### PR TITLE
remove sparse_checkout usage for scripts/eis.js

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_service_configuration.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_service_configuration.ts
@@ -25,9 +25,6 @@ async function getFiles(files: string[]): Promise<string[]> {
   await git.init();
   await git.raw(['config', 'core.sparseCheckout', 'true']);
 
-  const sparseCheckoutPath = Path.join(tmpDir, '.git', 'info', 'sparse-checkout');
-  await Fs.writeFile(sparseCheckoutPath, files.join('\n'), 'utf-8');
-
   async function pull() {
     return await git.pull('origin', 'main', { '--depth': '1' });
   }


### PR DESCRIPTION
the sparse-checkout path is not guaranteed to exist, and _will not_ exist if you have `~/.git-templates` that do not include the `info` directory. 

I've been just commenting out these lines so that I can use this locally, and have observed no ill effects, so I think this is probably safe to remove.

