### PR TITLE
[8.16] [DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -89,7 +89,13 @@ include::upgrade-notes.asciidoc[]
 [[release-notes-8.16.6]]
 == {kib} 8.16.6
 
-The 8.16.6 release includes the following enhancements and fixes.
+The 8.16.6 release includes the following known issues, enhancements, and fixes.
+
+[float]
+[[known-issues-8.16.6]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[enhancement-v8.16.6]]
@@ -119,7 +125,13 @@ Management::
 [[release-notes-8.16.5]]
 == {kib} 8.16.5
 
-The 8.16.5 release includes the following enhancements and bug fixes.
+The 8.16.5 release includes the following known issues, enhancements, and bug fixes.
+
+[float]
+[[known-issues-8.16.5]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[enhancement-v8.16.5]]
@@ -155,7 +167,13 @@ Machine Learning::
 [[release-notes-8.16.4]]
 == {kib} 8.16.4
 
-The 8.16.4 release includes the following bug fixes.
+The 8.16.4 release includes the following known issues and bug fixes.
+
+[float]
+[[known-issues-8.16.4]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[fixes-v8.16.4]]
@@ -186,10 +204,23 @@ Kibana security::
 * Fixes breaks in YAML parsing by using single quotes in Structured log template ({kibana-pull}209736[#209736]).
 * Adds missing fields to input manifest templates ({kibana-pull}208768[#208768]).
 * Adds missing fields into AWS S3 manifest ({kibana-pull}208080[#208080]).
+
 [[release-notes-8.16.3]]
 
 == {kib} 8.16.3
+<<<<<<< HEAD
 The 8.16.3 release includes the following bug fixes.
+=======
+
+The 8.16.3 release includes the following known issues and bug fixes.
+
+[float]
+[[known-issues-8.16.3]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
+
+>>>>>>> 34557d33828 ([DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894))
 [float]
 [[fixes-v8.16.3]]
 === Bug fixes
@@ -213,7 +244,13 @@ Kibana security::
 [[release-notes-8.16.2]]
 == {kib} 8.16.2
 
-The 8.16.2 release includes the following enhancements and bug fixes.
+The 8.16.2 release includes the following known issues, enhancements, and bug fixes.
+
+[float]
+[[known-issues-8.16.2]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[enhancement-v8.16.2]]
@@ -259,14 +296,19 @@ Machine Learning::
 [[release-notes-8.16.1]]
 == {kib} 8.16.1
 
+<<<<<<< HEAD
 For information about the {kib} 8.16.1 release, review the following information.
 
 The 8.16.1 release includes the following known issues.
+=======
+The 8.16.1 release includes the following known issues and bug fixes.
+>>>>>>> 34557d33828 ([DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894))
 
 [float]
 [[known-issues-8.16.1]]
 === Known issues
 
+<<<<<<< HEAD
 [discrete]
 [[known-201115]]
 .Kibana `Dev Tools > Console` incorrectly splits a request string that contains concatenated JSON objects, resulting in errors when submitting the requests to Elasticsearch.
@@ -282,6 +324,9 @@ For more information, refer to {kibana-issue}200201[#200201] and {kibana-issue}2
 ====
 
 The 8.16.1 release includes the following bug fixes.
+=======
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
+>>>>>>> 34557d33828 ([DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894))
 
 [float]
 [[fixes-v8.16.1]]
@@ -313,6 +358,7 @@ The 8.16.0 release includes the following known issues.
 === Known issues
 
 include::CHANGELOG.asciidoc[tag=known-issue-187254]
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [discrete]
 [[known-199902]]
@@ -735,7 +781,13 @@ Management::
 [[release-notes-8.15.5]]
 == {kib} 8.15.5
 
-The 8.15.5 release includes the following bug fixes.
+The 8.15.5 release includes the following known issues and bug fixes.
+
+[float]
+[[known-issues-8.15.5]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[fixes-v8.15.5]]
@@ -756,7 +808,13 @@ Platform::
 [[release-notes-8.15.4]]
 == {kib} 8.15.4
 
-The 8.15.4 release includes the following bug fixes.
+The 8.15.4 release includes the following known issues and bug fixes.
+
+[float]
+[[known-issues-8.15.4]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[fixes-v8.15.4]]
@@ -784,7 +842,13 @@ Management::
 [[release-notes-8.15.3]]
 == {kib} 8.15.3
 
-The 8.15.3 release includes the following bug fixes.
+The 8.15.3 release includes the following known issues and bug fixes.
+
+[float]
+[[known-issues-8.15.3]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[fixes-v8.15.3]]
@@ -821,7 +885,13 @@ Machine Learning::
 [[release-notes-8.15.2]]
 == {kib} 8.15.2
 
-The 8.15.2 release includes the following enhancements and bug fixes.
+The 8.15.2 release includes the following known issues, enhancements, and bug fixes.
+
+[float]
+[[known-issues-8.15.2]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 [float]
 [[enhancement-v8.15.2]]
@@ -868,7 +938,13 @@ Machine Learning::
 [[release-notes-8.15.1]]
 == {kib} 8.15.1
 
-The 8.15.1 release includes the following bug fixes.
+The 8.15.1 release includes the following known issues and bug fixes.
+
+[float]
+[[known-issues-8.15.1]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
 // [float]
 // [[enhancement-v8.15.1]]
@@ -950,6 +1026,22 @@ If you used the *Incoming Webhook* app in Microsoft Teams to generate a webhook 
 Use the *Workflows* app in Microsoft Teams to create a new webhook URL, as described in <<configuring-teams>>.
 Update your Microsoft Teams connector to use the new URL before the end of December 2024.
 ====
+
+// tag::known-issue-1991[]
+.PDF and PNG reports time out and fail with an invalid header error if server.protocol is set to http2
+[%collapsible]
+====
+*Details* +
+If you've changed the <<settings,`server.protocol`>> value to `http2`, PDF and PNG reports will fail when you export them from the dashboard, visualization, or Canvas workpad that you're generating a report for.
+
+*Workaround* +
+To temporarily resolve the issue, set `server.protocol` to `http1`. 
+
+*Resolved* +
+This issue is resolved in 8.17.9, 8.18.4, 8.19.0 and later. 
+
+====
+// end::known-issue-1991[]
 
 [discrete]
 [[known-189283]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -299,7 +299,6 @@ For information about the {kib} 8.16.1 release, review the following information
 The 8.16.1 release includes the following known issues.
 =======
 The 8.16.1 release includes the following known issues and bug fixes.
->>>>>>> 34557d33828 ([DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894))
 
 [float]
 [[known-issues-8.16.1]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -321,7 +321,6 @@ For more information, refer to {kibana-issue}200201[#200201] and {kibana-issue}2
 The 8.16.1 release includes the following bug fixes.
 =======
 include::CHANGELOG.asciidoc[tag=known-issue-1991]
->>>>>>> 34557d33828 ([DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894))
 
 [float]
 [[fixes-v8.16.1]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -208,7 +208,6 @@ Kibana security::
 [[release-notes-8.16.3]]
 
 == {kib} 8.16.3
-<<<<<<< HEAD
 The 8.16.3 release includes the following bug fixes.
 =======
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -304,7 +304,6 @@ The 8.16.1 release includes the following known issues and bug fixes.
 [[known-issues-8.16.1]]
 === Known issues
 
-<<<<<<< HEAD
 [discrete]
 [[known-201115]]
 .Kibana `Dev Tools > Console` incorrectly splits a request string that contains concatenated JSON objects, resulting in errors when submitting the requests to Elasticsearch.

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -219,7 +219,6 @@ The 8.16.3 release includes the following known issues and bug fixes.
 
 include::CHANGELOG.asciidoc[tag=known-issue-1991]
 
->>>>>>> 34557d33828 ([DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894))
 [float]
 [[fixes-v8.16.3]]
 === Bug fixes

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -294,7 +294,6 @@ Machine Learning::
 [[release-notes-8.16.1]]
 == {kib} 8.16.1
 
-<<<<<<< HEAD
 For information about the {kib} 8.16.1 release, review the following information.
 
 The 8.16.1 release includes the following known issues.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.16`:
 - [[DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894)](https://github.com/elastic/kibana/pull/230894)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nastasha Solomon","email":"79124755+nastasha-solomon@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-07T19:24:12Z","message":"[DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894)\n\nContributes to https://github.com/elastic/docs-content/issues/1991. Adds\na known issue to the 8.15+ known issues about PDF and PNG reports\nfailing if users have set `server.protocol: http2` in their kibana.yml\nfile.\n\n**Corresponding 9.x updates**:\nhttps://github.com/elastic/kibana/pull/230887\n\n**Previews**\n\n8.15.x\n-\n[8.15.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.0.html)\n-\n[8.15.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.1.html)\n-\n[8.15.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.2.html)\n-\n[8.15.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.3.html)\n-\n[8.15.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.4.html)\n-\n[8.15.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.5.html)\n\n8.16.x\n-\n[8.16.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.0.html)\n-\n[8.16.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.1.html)\n-\n[8.16.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.2.html)\n-\n[8.16.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.3.html)\n-\n[8.16.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.4.html)\n-\n[8.16.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.5.html)\n-\n[8.16.6](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.6.html)\n\n8.17.x\n-\n[8.17.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.0.html)\n-\n[8.17.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.1.html)\n-\n[8.17.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.2.html)\n-\n[8.17.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.3.html)\n-\n[8.17.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.4.html)\n-\n[8.17.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.5.html)\n-\n[8.17.6](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.6.html)\n-\n[8.17.7](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.7.html)\n-\n[8.17.8](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.8.html)\n\n8.18.x\n-\n[8.18.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.0.html)\n-\n[8.18.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.1.html)\n-\n[8.18.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.2.html)\n-\n[8.18.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.3.html)","sha":"34557d33828668f7d941a5e35b90aa24ddf1c6b3","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v8.15.0","v8.16.0","backport:version","v8.17.0","v8.18.0","v8.19.0"],"title":"[DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2","number":230894,"url":"https://github.com/elastic/kibana/pull/230894","mergeCommit":{"message":"[DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894)\n\nContributes to https://github.com/elastic/docs-content/issues/1991. Adds\na known issue to the 8.15+ known issues about PDF and PNG reports\nfailing if users have set `server.protocol: http2` in their kibana.yml\nfile.\n\n**Corresponding 9.x updates**:\nhttps://github.com/elastic/kibana/pull/230887\n\n**Previews**\n\n8.15.x\n-\n[8.15.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.0.html)\n-\n[8.15.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.1.html)\n-\n[8.15.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.2.html)\n-\n[8.15.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.3.html)\n-\n[8.15.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.4.html)\n-\n[8.15.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.5.html)\n\n8.16.x\n-\n[8.16.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.0.html)\n-\n[8.16.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.1.html)\n-\n[8.16.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.2.html)\n-\n[8.16.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.3.html)\n-\n[8.16.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.4.html)\n-\n[8.16.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.5.html)\n-\n[8.16.6](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.6.html)\n\n8.17.x\n-\n[8.17.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.0.html)\n-\n[8.17.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.1.html)\n-\n[8.17.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.2.html)\n-\n[8.17.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.3.html)\n-\n[8.17.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.4.html)\n-\n[8.17.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.5.html)\n-\n[8.17.6](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.6.html)\n-\n[8.17.7](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.7.html)\n-\n[8.17.8](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.8.html)\n\n8.18.x\n-\n[8.18.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.0.html)\n-\n[8.18.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.1.html)\n-\n[8.18.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.2.html)\n-\n[8.18.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.3.html)","sha":"34557d33828668f7d941a5e35b90aa24ddf1c6b3"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.15","8.16","8.17"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","branchLabelMappingKey":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231035","number":231035,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230894","number":230894,"mergeCommit":{"message":"[DOCS][Known issue] Reporting failing in >= 8.15 when using server.protocol: http2 (#230894)\n\nContributes to https://github.com/elastic/docs-content/issues/1991. Adds\na known issue to the 8.15+ known issues about PDF and PNG reports\nfailing if users have set `server.protocol: http2` in their kibana.yml\nfile.\n\n**Corresponding 9.x updates**:\nhttps://github.com/elastic/kibana/pull/230887\n\n**Previews**\n\n8.15.x\n-\n[8.15.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.0.html)\n-\n[8.15.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.1.html)\n-\n[8.15.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.2.html)\n-\n[8.15.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.3.html)\n-\n[8.15.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.4.html)\n-\n[8.15.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.15.5.html)\n\n8.16.x\n-\n[8.16.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.0.html)\n-\n[8.16.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.1.html)\n-\n[8.16.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.2.html)\n-\n[8.16.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.3.html)\n-\n[8.16.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.4.html)\n-\n[8.16.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.5.html)\n-\n[8.16.6](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.16.6.html)\n\n8.17.x\n-\n[8.17.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.0.html)\n-\n[8.17.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.1.html)\n-\n[8.17.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.2.html)\n-\n[8.17.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.3.html)\n-\n[8.17.4](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.4.html)\n-\n[8.17.5](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.5.html)\n-\n[8.17.6](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.6.html)\n-\n[8.17.7](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.7.html)\n-\n[8.17.8](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.17.8.html)\n\n8.18.x\n-\n[8.18.0](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.0.html)\n-\n[8.18.1](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.1.html)\n-\n[8.18.2](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.2.html)\n-\n[8.18.3](https://kibana_bk_230894.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.18.3.html)","sha":"34557d33828668f7d941a5e35b90aa24ddf1c6b3"}}]}] BACKPORT-->