### PR TITLE
[8.19] [Inference] add inference timeout to anonymization settings (#230640)

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/types.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/types.ts
@@ -14,6 +14,7 @@ interface AnonymizationRuleBase {
 export interface NamedEntityRecognitionRule extends AnonymizationRuleBase {
   type: 'NER';
   modelId: string;
+  timeoutSeconds?: number;
   allowedEntityClasses?: Array<'PER' | 'ORG' | 'LOC' | 'MISC'>;
 }
 export interface RegexAnonymizationRule extends AnonymizationRuleBase {

--- a/x-pack/platform/plugins/shared/inference/common/ui_settings.ts
+++ b/x-pack/platform/plugins/shared/inference/common/ui_settings.ts
@@ -38,6 +38,7 @@ const nerRuleSchema = schema.allOf([
         ])
       )
     ),
+    timeoutSeconds: schema.maybe(schema.number({ min: 1 })),
   }),
 ]);
 
@@ -61,6 +62,7 @@ export const uiSettings: Record<string, UiSettingsParams> = {
             modelId: 'elastic__distilbert-base-uncased-finetuned-conll03-english',
             enabled: false,
             allowedEntityClasses: ['PER', 'ORG', 'LOC'],
+            timeoutSeconds: 30,
           },
         ],
       },
@@ -75,12 +77,14 @@ export const uiSettings: Record<string, UiSettingsParams> = {
             <li><strong>pattern:</strong> (regex type only) the regular-expression string to match</li>
             <li><strong>modelId:</strong> (ner type only) ID of the NER (Named Entity Recognition) model to use</li>
             <li><strong>enabled:</strong> boolean flag to turn the rule on or off</li>
+            <li><strong>timeoutSeconds:</strong> (ner type only) maximum seconds <em>per inference request</em> before timing out (multiple requests may be issued during a single chat interaction)</li>
           </ul>`,
       values: {
         em: (chunks) => `<em>${chunks}</em>`,
         ul: (chunks) => `<ul>${chunks}</ul>`,
         li: (chunks) => `<li>${chunks}</li>`,
         strong: (chunks) => `<strong>${chunks}</strong>`,
+        em: (chunks) => `<em>${chunks}</em>`,
       },
     }),
     schema: schema.object({

--- a/x-pack/platform/plugins/shared/inference/common/ui_settings.ts
+++ b/x-pack/platform/plugins/shared/inference/common/ui_settings.ts
@@ -84,7 +84,6 @@ export const uiSettings: Record<string, UiSettingsParams> = {
         ul: (chunks) => `<ul>${chunks}</ul>`,
         li: (chunks) => `<li>${chunks}</li>`,
         strong: (chunks) => `<strong>${chunks}</strong>`,
-        em: (chunks) => `<em>${chunks}</em>`,
       },
     }),
     schema: schema.object({

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
@@ -107,9 +107,12 @@ export async function executeNerRule({
               } catch (error) {
                 span?.recordException(error);
                 const errorMessage = error instanceof Error ? error.message : String(error);
-                throw new Error(`Inference failed for NER model '${rule.modelId}': ${errorMessage}`, {
-                  cause: error,
-                });
+                throw new Error(
+                  `Inference failed for NER model '${rule.modelId}': ${errorMessage}`,
+                  {
+                    cause: error,
+                  }
+                );
               }
             }
           )

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
@@ -94,12 +94,11 @@ export async function executeNerRule({
             async (span) => {
               try {
                 const docs = batch.map((text) => ({ text_field: text }));
-
                 span?.setAttribute('input.value', JSON.stringify(docs));
                 const response = await esClient.ml.inferTrainedModel({
                   model_id: rule.modelId,
                   docs,
-                  timeout: '30s',
+                  timeout: `${rule.timeoutSeconds ?? 30}s`,
                 });
 
                 span?.setAttribute('output.value', JSON.stringify(response.inference_results));
@@ -107,7 +106,8 @@ export async function executeNerRule({
                 return response.inference_results;
               } catch (error) {
                 span?.recordException(error);
-                throw new Error(`Inference failed for NER model '${rule.modelId}'`, {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                throw new Error(`Inference failed for NER model '${rule.modelId}': ${errorMessage}`, {
                   cause: error,
                 });
               }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Inference] add inference timeout to anonymization settings (#230640)](https://github.com/elastic/kibana/pull/230640)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sandra G","email":"neptunian@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-07T20:20:02Z","message":"[Inference] add inference timeout to anonymization settings (#230640)\n\nCloses https://github.com/elastic/kibana/issues/228497\n\nThe user can configure the timeout setting (default `30`) for the NER\ninference on an \"NER\" rule. eg.:\n\n```\n    {\n      \"type\": \"NER\",\n      \"modelId\": \"elastic__distilbert-base-uncased-finetuned-conll03-english\",\n      \"enabled\": true,\n      \"allowedEntityClasses\": [\n        \"PER\",\n        \"ORG\",\n        \"LOC\"\n      ],\n      \"timeoutSeconds\": 30\n    }\n```","sha":"2f012fa61fd0a871844bcf54ac98aa59e3f1039b","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Obs AI Assistant","backport:version","v9.2.0","v9.1.1","v8.19.1"],"title":"[Inference] add inference timeout to anonymization settings","number":230640,"url":"https://github.com/elastic/kibana/pull/230640","mergeCommit":{"message":"[Inference] add inference timeout to anonymization settings (#230640)\n\nCloses https://github.com/elastic/kibana/issues/228497\n\nThe user can configure the timeout setting (default `30`) for the NER\ninference on an \"NER\" rule. eg.:\n\n```\n    {\n      \"type\": \"NER\",\n      \"modelId\": \"elastic__distilbert-base-uncased-finetuned-conll03-english\",\n      \"enabled\": true,\n      \"allowedEntityClasses\": [\n        \"PER\",\n        \"ORG\",\n        \"LOC\"\n      ],\n      \"timeoutSeconds\": 30\n    }\n```","sha":"2f012fa61fd0a871844bcf54ac98aa59e3f1039b"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230640","number":230640,"mergeCommit":{"message":"[Inference] add inference timeout to anonymization settings (#230640)\n\nCloses https://github.com/elastic/kibana/issues/228497\n\nThe user can configure the timeout setting (default `30`) for the NER\ninference on an \"NER\" rule. eg.:\n\n```\n    {\n      \"type\": \"NER\",\n      \"modelId\": \"elastic__distilbert-base-uncased-finetuned-conll03-english\",\n      \"enabled\": true,\n      \"allowedEntityClasses\": [\n        \"PER\",\n        \"ORG\",\n        \"LOC\"\n      ],\n      \"timeoutSeconds\": 30\n    }\n```","sha":"2f012fa61fd0a871844bcf54ac98aa59e3f1039b"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->