### PR TITLE
[9.0] [DOCS][9.0.3, 9.0.4, 9.1.0] [Known Issue] Rule issues occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000 (#230837)

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -4,6 +4,42 @@ navigation_title: "Known issues"
 
 # Kibana known issues
 
+For Elastic {{observability}} known issues, refer to [Elastic Observability known issues](docs-content://release-notes/elastic-observability/known-issues.md).
+
+For Elastic Security known issues, refer to [Elastic Security known issues](docs-content://release-notes/elastic-security/known-issues.md).
+
+::::{dropdown} Issues with rules occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000
+
+Applies to: {{stack}} 9.0.3, 9.0.4, 9.1.0
+
+**Details**
+
+If you've set `xpack.alerting.rules.run.alerts.max` to a value greater than `5000`, you will encounter `Result window is too large` error messages when a maintenance window is active.
+
+**Action**
+
+To mitigate the issue, set `xpack.alerting.rules.run.alerts.max` to a value equal to or less than `5000`.
+
+::::
+
+::::{dropdown} Dashboard Copy link doesn't work when sharing from a space other than the default space
+
+Applies to: {{stack}} 9.0.3
+
+**Details**
+
+When attempting to share a dashboard from a space that isn't the default space, the **Copy link** action never completes.
+
+**Action**
+
+To avoid this error, don't upgrade {{kib}} to {{stack}} 9.0.3 or upgrade {{kib}} to {{stack}} 9.0.4 when available.
+
+**Resolved**
+
+This issue is resolved in {{stack}} 9.0.4.
+
+::::
+
 ::::{dropdown} Upgrading Kibana from 8.18.x to 9.0.2 fails due to a configuration conflict in the kibana.yml file
 
 Applies to: {{stack}} 9.0.2


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS][9.0.3, 9.0.4, 9.1.0] [Known Issue] Rule issues occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000 (#230837)](https://github.com/elastic/kibana/pull/230837)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nastasha Solomon","email":"79124755+nastasha-solomon@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-06T20:54:26Z","message":"[DOCS][9.0.3, 9.0.4, 9.1.0] [Known Issue] Rule issues occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000 (#230837)\n\nAdds the known issue about the `xpack.alerting.rules.run.alerts.max`\nsetting to the Kibana known issues page and marked it as a known issue\nin 9.0.3, 9.0.4, and 9.1.0. Related issue:\nhttps://github.com/elastic/kibana/issues/230275\n\n**Corresponding 8.x PR**: https://github.com/elastic/kibana/pull/230835\n\n\n[Preview](https://github.com/elastic/kibana/pull/230837#issuecomment-3160795376)","sha":"5a367223bc13f87bb913e31b229a1be688ca1e5e","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","v9.0.0","backport:version","v9.1.0","v9.0.3","v9.2.0"],"title":"[DOCS][9.0.3, 9.0.4, 9.1.0] [Known Issue] Rule issues occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000","number":230837,"url":"https://github.com/elastic/kibana/pull/230837","mergeCommit":{"message":"[DOCS][9.0.3, 9.0.4, 9.1.0] [Known Issue] Rule issues occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000 (#230837)\n\nAdds the known issue about the `xpack.alerting.rules.run.alerts.max`\nsetting to the Kibana known issues page and marked it as a known issue\nin 9.0.3, 9.0.4, and 9.1.0. Related issue:\nhttps://github.com/elastic/kibana/issues/230275\n\n**Corresponding 8.x PR**: https://github.com/elastic/kibana/pull/230835\n\n\n[Preview](https://github.com/elastic/kibana/pull/230837#issuecomment-3160795376)","sha":"5a367223bc13f87bb913e31b229a1be688ca1e5e"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231032","number":231032,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230837","number":230837,"mergeCommit":{"message":"[DOCS][9.0.3, 9.0.4, 9.1.0] [Known Issue] Rule issues occur when xpack.alerting.rules.run.alerts.max is set to a value greater than 5000 (#230837)\n\nAdds the known issue about the `xpack.alerting.rules.run.alerts.max`\nsetting to the Kibana known issues page and marked it as a known issue\nin 9.0.3, 9.0.4, and 9.1.0. Related issue:\nhttps://github.com/elastic/kibana/issues/230275\n\n**Corresponding 8.x PR**: https://github.com/elastic/kibana/pull/230835\n\n\n[Preview](https://github.com/elastic/kibana/pull/230837#issuecomment-3160795376)","sha":"5a367223bc13f87bb913e31b229a1be688ca1e5e"}}]}] BACKPORT-->