### PR TITLE
[9.0] [Security Solution] Add new EBT Kibana browser events for telemetry (#230387)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleUpgradeTelemetryEvent } from './types';
+import { RuleUpgradeEventTypes } from './types';
+
+export const flyoutButtonClickEvent: RuleUpgradeTelemetryEvent = {
+  eventType: RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick,
+  schema: {
+    type: {
+      type: 'keyword',
+      _meta: {
+        description: 'Click Rule Upgrade Flyout Button (update|dismiss)',
+        optional: false,
+      },
+    },
+    hasMissingBaseVersion: {
+      type: 'boolean',
+      _meta: {
+        description: 'Indicates if the rule has a missing base version',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const openFlyoutEvent: RuleUpgradeTelemetryEvent = {
+  eventType: RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen,
+  schema: {
+    hasMissingBaseVersion: {
+      type: 'boolean',
+      _meta: {
+        description: 'Indicates if the rule has a missing base version',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const ruleUpgradeTelemetryEvents = [flyoutButtonClickEvent, openFlyoutEvent];

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/rule_upgrade/types.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { RootSchema } from '@kbn/core/public';
+
+export enum RuleUpgradeEventTypes {
+  RuleUpgradeFlyoutButtonClick = 'Click Rule Upgrade Flyout Button',
+  RuleUpgradeFlyoutOpen = 'Open Rule Upgrade Flyout',
+}
+interface ReportRuleUpgradeFlyoutButtonClickParams {
+  type: 'update' | 'dismiss';
+  hasMissingBaseVersion: boolean;
+}
+
+interface ReportRuleUpgradeFlyoutOpenParams {
+  hasMissingBaseVersion: boolean;
+}
+
+export interface RuleUpgradeTelemetryEventsMap {
+  [RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick]: ReportRuleUpgradeFlyoutButtonClickParams;
+  [RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen]: ReportRuleUpgradeFlyoutOpenParams;
+}
+
+export interface RuleUpgradeTelemetryEvent {
+  eventType: RuleUpgradeEventTypes;
+  schema: RootSchema<RuleUpgradeTelemetryEventsMap[RuleUpgradeEventTypes]>;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/telemetry_events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/events/telemetry_events.ts
@@ -16,6 +16,7 @@ import { notesTelemetryEvents } from './notes';
 import { onboardingHubTelemetryEvents } from './onboarding';
 import { previewRuleTelemetryEvents } from './preview_rule';
 import { siemMigrationsTelemetryEvents } from './siem_migrations';
+import { ruleUpgradeTelemetryEvents } from './rule_upgrade';
 
 export const telemetryEvents = [
   ...assistantTelemetryEvents,
@@ -26,6 +27,7 @@ export const telemetryEvents = [
   ...documentTelemetryEvents,
   ...onboardingHubTelemetryEvents,
   ...manualRuleRunTelemetryEvents,
+  ...ruleUpgradeTelemetryEvents,
   ...eventLogTelemetryEvents,
   ...notesTelemetryEvents,
   ...appTelemetryEvents,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/telemetry/types.ts
@@ -42,6 +42,10 @@ import type {
   SiemMigrationsEventTypes,
   SiemMigrationsTelemetryEventsMap,
 } from './events/siem_migrations/types';
+import type {
+  RuleUpgradeEventTypes,
+  RuleUpgradeTelemetryEventsMap,
+} from './events/rule_upgrade/types';
 
 export * from './events/app/types';
 export * from './events/ai_assistant/types';
@@ -84,6 +88,8 @@ export type TelemetryEventTypeData<T extends TelemetryEventTypes> = T extends As
   ? AppTelemetryEventsMap[T]
   : T extends SiemMigrationsEventTypes
   ? SiemMigrationsTelemetryEventsMap[T]
+  : T extends RuleUpgradeEventTypes
+  ? RuleUpgradeTelemetryEventsMap[T]
   : never;
 
 export type TelemetryEventTypes =
@@ -98,4 +104,5 @@ export type TelemetryEventTypes =
   | EventLogEventTypes
   | NotesEventTypes
   | AppEventTypes
-  | SiemMigrationsEventTypes;
+  | SiemMigrationsEventTypes
+  | RuleUpgradeEventTypes;

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiToolTip } from '@elastic/eui';
+import { RuleUpgradeEventTypes } from '../../../common/lib/telemetry/events/rule_upgrade/types';
 import type { ReviewPrebuiltRuleUpgradeFilter } from '../../../../common/api/detection_engine/prebuilt_rules/common/review_prebuilt_rules_upgrade_filter';
 import { FieldUpgradeStateEnum, type RuleUpgradeState } from '../model/prebuilt_rule_upgrade';
 import { PerFieldRuleDiffTab } from '../components/rule_details/per_field_rule_diff_tab';
@@ -39,10 +40,12 @@ import { RuleUpgradeTab } from '../components/rule_details/three_way_diff';
 import { TabContentPadding } from '../../../siem_migrations/rules/components/rule_details_flyout';
 import { RuleTypeChangeCallout } from '../../rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/rule_type_change_callout';
 import { RuleDiffTab } from '../components/rule_details/rule_diff_tab';
+import type { RulePreviewFlyoutCloseReason } from '../../rule_management_ui/components/rules_table/use_rule_preview_flyout';
 import { useRulePreviewFlyout } from '../../rule_management_ui/components/rules_table/use_rule_preview_flyout';
 import type { UpgradePrebuiltRulesSortingOptions } from '../../rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context';
 import { RULES_TABLE_INITIAL_PAGE_SIZE } from '../../rule_management_ui/components/rules_table/constants';
 import type { RulesConflictStats } from '../../rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_with_conflicts_modal/conflicts_description';
+import { useKibana } from '../../../common/lib/kibana';
 
 const REVIEW_PREBUILT_RULES_UPGRADE_REFRESH_INTERVAL = 5 * 60 * 1000;
 
@@ -67,6 +70,7 @@ export function usePrebuiltRulesUpgrade({
   const { isRulesCustomizationEnabled } = usePrebuiltRulesCustomizationStatus();
   const isUpgradingSecurityPackages = useIsUpgradingSecurityPackages();
   const [loadingRules, setLoadingRules] = useState<RuleSignatureId[]>([]);
+  const { telemetry } = useKibana().services;
 
   const {
     data: upgradeReviewResponse,
@@ -347,7 +351,22 @@ export function usePrebuiltRulesUpgrade({
     },
     [rulesUpgradeState, isRulesCustomizationEnabled, setRuleFieldResolvedValue]
   );
-  const { rulePreviewFlyout, openRulePreview } = useRulePreviewFlyout({
+  const closeRulePreviewAction = (rule: RuleResponse, reason: RulePreviewFlyoutCloseReason) => {
+    const ruleUpgradeState = rulesUpgradeState[rule.rule_id];
+    const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
+    if (reason === 'dismiss') {
+      telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
+        type: 'dismiss',
+        hasMissingBaseVersion,
+      });
+    } else {
+      telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutButtonClick, {
+        type: 'update',
+        hasMissingBaseVersion,
+      });
+    }
+  };
+  const { rulePreviewFlyout, openRulePreview: openRulePreviewDefault } = useRulePreviewFlyout({
     rules: ruleUpgradeStates.map(({ target_rule: targetRule }) => targetRule),
     subHeaderFactory,
     ruleActionsFactory,
@@ -356,7 +375,20 @@ export function usePrebuiltRulesUpgrade({
       id: PREBUILT_RULE_UPDATE_FLYOUT_ANCHOR,
       dataTestSubj: PREBUILT_RULE_UPDATE_FLYOUT_ANCHOR,
     },
+    closeRulePreviewAction,
   });
+
+  const openRulePreview = useCallback(
+    (ruleId: string) => {
+      openRulePreviewDefault(ruleId);
+      const ruleUpgradeState = rulesUpgradeState[ruleId];
+      const hasMissingBaseVersion = ruleUpgradeState.has_base_version === false;
+      telemetry.reportEvent(RuleUpgradeEventTypes.RuleUpgradeFlyoutOpen, {
+        hasMissingBaseVersion,
+      });
+    },
+    [openRulePreviewDefault, rulesUpgradeState, telemetry]
+  );
 
   return {
     ruleUpgradeStates,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Add new EBT Kibana browser events for telemetry (#230387)](https://github.com/elastic/kibana/pull/230387)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jacek Kolezynski","email":"jacek.kolezynski@elastic.co"},"sourceCommit":{"committedDate":"2025-08-08T10:00:39Z","message":"[Security Solution] Add new EBT Kibana browser events for telemetry (#230387)\n\n**Partially addresses:** #140369\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the\nhttps://github.com/elastic/kibana/issues/140369 ticket.\n\nThe requirements covered in this PR are:\n\n- Events of opening the update flyout\n- Events for Applying update/ dismissing update\n\nI am adding new kind of EBT Kibana Browser events, RuleUpgradeFlyoutOpen\nand RuleUpgradeFlyoutButtonClick.\nBoth these events carry information if the rule that is supposed to be\nupgraded has missing base version.\nThe RuleUpgradeFlyoutButtonClick event also carries information about\nthe type of the button: whether it is the \"Update rule\" button or the\n\"Dismiss\" button.\n\nThe point of this change is to be able to prepare visualizations\ndescribed by @approksiu in this\n[document](https://docs.google.com/spreadsheets/d/1MX66Eymvem5LyWRlkuWm6FLkkrxy0la76vwseznB_Uk/edit?gid=0#gid=0).\n\nIn this\n[document](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0)\nI am summarizing the attempt in details, also taking into account the\nreq \"Events of Rule updates tab visits\"\n\nIn this [Staging\ndashboard](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/dashboards#/view/64a5cc65-7ded-4959-b84d-3486b7dc2b29?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now)))\nyou can observe the visualizations. When you start Kibana using code\nfrom this PR, when you open the Detection Rules and play with the rules,\nthe updates and the flyout, the events will be sent to Kibana Telemetry\nstaging backend and should start to be visible in this dashboard.\n\nTesting:\nOpen browser and inside it open the Developer Tools -> Network tab.\nInside, filter for 'kibana-browser' events. Click such event and copy it\nto some external editor for easier viewing. Make sure the new events\ncreated in this PR are sent in the appropriate situations and contain\ncorrect information about the rule. Use the abovementioned\n[doc](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0)\nas reference.\nTest the following scenarios:\n1. All possible ways of opening the Rule Updates Flyout (by clicking the\nname or by clicking \"Review update\" mini callout)\n2. Clicking the \"Dismiss\" and \"Update rule\" button in the Rule Update\nFlyout\n \n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"57ebec44069de61c6cf8c3108dcaefa84c4c8fa8","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Team:ML","Feature:Prebuilt Detection Rules","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.2.0"],"title":"[Security Solution] Add new EBT Kibana browser events for telemetry","number":230387,"url":"https://github.com/elastic/kibana/pull/230387","mergeCommit":{"message":"[Security Solution] Add new EBT Kibana browser events for telemetry (#230387)\n\n**Partially addresses:** #140369\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the\nhttps://github.com/elastic/kibana/issues/140369 ticket.\n\nThe requirements covered in this PR are:\n\n- Events of opening the update flyout\n- Events for Applying update/ dismissing update\n\nI am adding new kind of EBT Kibana Browser events, RuleUpgradeFlyoutOpen\nand RuleUpgradeFlyoutButtonClick.\nBoth these events carry information if the rule that is supposed to be\nupgraded has missing base version.\nThe RuleUpgradeFlyoutButtonClick event also carries information about\nthe type of the button: whether it is the \"Update rule\" button or the\n\"Dismiss\" button.\n\nThe point of this change is to be able to prepare visualizations\ndescribed by @approksiu in this\n[document](https://docs.google.com/spreadsheets/d/1MX66Eymvem5LyWRlkuWm6FLkkrxy0la76vwseznB_Uk/edit?gid=0#gid=0).\n\nIn this\n[document](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0)\nI am summarizing the attempt in details, also taking into account the\nreq \"Events of Rule updates tab visits\"\n\nIn this [Staging\ndashboard](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/dashboards#/view/64a5cc65-7ded-4959-b84d-3486b7dc2b29?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now)))\nyou can observe the visualizations. When you start Kibana using code\nfrom this PR, when you open the Detection Rules and play with the rules,\nthe updates and the flyout, the events will be sent to Kibana Telemetry\nstaging backend and should start to be visible in this dashboard.\n\nTesting:\nOpen browser and inside it open the Developer Tools -> Network tab.\nInside, filter for 'kibana-browser' events. Click such event and copy it\nto some external editor for easier viewing. Make sure the new events\ncreated in this PR are sent in the appropriate situations and contain\ncorrect information about the rule. Use the abovementioned\n[doc](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0)\nas reference.\nTest the following scenarios:\n1. All possible ways of opening the Rule Updates Flyout (by clicking the\nname or by clicking \"Review update\" mini callout)\n2. Clicking the \"Dismiss\" and \"Update rule\" button in the Rule Update\nFlyout\n \n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"57ebec44069de61c6cf8c3108dcaefa84c4c8fa8"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231083","number":231083,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231082","number":231082,"state":"OPEN"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230387","number":230387,"mergeCommit":{"message":"[Security Solution] Add new EBT Kibana browser events for telemetry (#230387)\n\n**Partially addresses:** #140369\n\n## Summary\n\nThis is another PR from of a series of PRs I am planning to create to\ncover the requirements in the\nhttps://github.com/elastic/kibana/issues/140369 ticket.\n\nThe requirements covered in this PR are:\n\n- Events of opening the update flyout\n- Events for Applying update/ dismissing update\n\nI am adding new kind of EBT Kibana Browser events, RuleUpgradeFlyoutOpen\nand RuleUpgradeFlyoutButtonClick.\nBoth these events carry information if the rule that is supposed to be\nupgraded has missing base version.\nThe RuleUpgradeFlyoutButtonClick event also carries information about\nthe type of the button: whether it is the \"Update rule\" button or the\n\"Dismiss\" button.\n\nThe point of this change is to be able to prepare visualizations\ndescribed by @approksiu in this\n[document](https://docs.google.com/spreadsheets/d/1MX66Eymvem5LyWRlkuWm6FLkkrxy0la76vwseznB_Uk/edit?gid=0#gid=0).\n\nIn this\n[document](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0)\nI am summarizing the attempt in details, also taking into account the\nreq \"Events of Rule updates tab visits\"\n\nIn this [Staging\ndashboard](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/dashboards#/view/64a5cc65-7ded-4959-b84d-3486b7dc2b29?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now)))\nyou can observe the visualizations. When you start Kibana using code\nfrom this PR, when you open the Detection Rules and play with the rules,\nthe updates and the flyout, the events will be sent to Kibana Telemetry\nstaging backend and should start to be visible in this dashboard.\n\nTesting:\nOpen browser and inside it open the Developer Tools -> Network tab.\nInside, filter for 'kibana-browser' events. Click such event and copy it\nto some external editor for easier viewing. Make sure the new events\ncreated in this PR are sent in the appropriate situations and contain\ncorrect information about the rule. Use the abovementioned\n[doc](https://docs.google.com/document/d/15dsKOqbRt3HDpPyCg0uzZ_m5bU92lN9M78gll_LCpJY/edit?tab=t.0)\nas reference.\nTest the following scenarios:\n1. All possible ways of opening the Rule Updates Flyout (by clicking the\nname or by clicking \"Review update\" mini callout)\n2. Clicking the \"Dismiss\" and \"Update rule\" button in the Rule Update\nFlyout\n \n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"57ebec44069de61c6cf8c3108dcaefa84c4c8fa8"}}]}] BACKPORT-->