### PR TITLE
[ES|QL] Moves the sources response result to the types package

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/types.ts
@@ -11,6 +11,7 @@ import type {
   IndexAutocompleteItem,
   InferenceEndpointAutocompleteItem,
   ESQLControlVariable,
+  ESQLSourceResult,
 } from '@kbn/esql-types';
 import { ESQLLicenseType } from '@kbn/esql-types';
 import type { PricingProduct } from '@kbn/core-pricing-common/src/types';
@@ -226,14 +227,6 @@ export enum Location {
    * In the COMPLETION command
    */
   COMPLETION = 'completion',
-}
-
-export interface ESQLSourceResult {
-  name: string;
-  hidden: boolean;
-  title?: string;
-  dataStreams?: Array<{ name: string; title?: string }>;
-  type?: string;
 }
 
 const commandOptionNameToLocation: Record<string, Location> = {

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/sources.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/sources.ts
@@ -6,10 +6,10 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { IndexAutocompleteItem } from '@kbn/esql-types';
+import type { IndexAutocompleteItem, ESQLSourceResult } from '@kbn/esql-types';
 import { i18n } from '@kbn/i18n';
 import type { ESQLCommand, ESQLSource } from '../../types';
-import type { ISuggestionItem, ESQLSourceResult } from '../../commands_registry/types';
+import type { ISuggestionItem } from '../../commands_registry/types';
 import { handleFragment } from './autocomplete/helpers';
 import { pipeCompleteItem, commaCompleteItem } from '../../commands_registry/complete_items';
 import { EDITOR_MARKER } from '../constants';

--- a/src/platform/packages/shared/kbn-esql-types/index.ts
+++ b/src/platform/packages/shared/kbn-esql-types/index.ts
@@ -23,6 +23,7 @@ export {
 export {
   type IndicesAutocompleteResult,
   type IndexAutocompleteItem,
+  type ESQLSourceResult,
 } from './src/sources_autocomplete_types';
 
 export {

--- a/src/platform/packages/shared/kbn-esql-types/src/sources_autocomplete_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/sources_autocomplete_types.ts
@@ -15,3 +15,11 @@ export interface IndexAutocompleteItem {
   mode: 'lookup' | 'time_series' | string;
   aliases: string[];
 }
+
+export interface ESQLSourceResult {
+  name: string;
+  hidden: boolean;
+  title?: string;
+  dataStreams?: Array<{ name: string; title?: string }>;
+  type?: string;
+}

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
@@ -6,11 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import {
-  Location,
-  ESQLSourceResult,
-  ESQLFieldWithMetadata,
-} from '@kbn/esql-ast/src/commands_registry/types';
+import { Location, ESQLFieldWithMetadata } from '@kbn/esql-ast/src/commands_registry/types';
 import { PricingProduct } from '@kbn/core-pricing-common/src/types';
 import type {
   ESQLControlVariable,
@@ -19,6 +15,7 @@ import type {
   RecommendedField,
   InferenceEndpointsAutocompleteResult,
   ESQLLicenseResult,
+  ESQLSourceResult,
 } from '@kbn/esql-types';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 /** @internal **/


### PR DESCRIPTION
## Summary

Having the resources are task https://github.com/elastic/kibana/pull/229304 but also because this type doesnt make sense to live in the autocomplete and fits better to the esql-types I moved it there




