### PR TITLE
[Dataset quality] moving failure store options out of settings

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/logs/custom_logsdb_index_templates.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/logs/custom_logsdb_index_templates.ts
@@ -67,10 +67,11 @@ export const indexTemplates: {
     template: {
       settings: {
         default_pipeline: 'logs@default-pipeline',
-        data_stream_options: {
-          failure_store: {
-            enabled: false,
-          },
+      },
+      // @ts-expect-error
+      data_stream_options: {
+        failure_store: {
+          enabled: false,
         },
       },
     },


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/230154

According to [this](https://github.com/elastic/kibana/blob/d5be33397344ec453b798fb5a3dcbefabbe71fcf/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/lib.ts#L88) `data_stream_options` is now placed accordingly.

There is an open issue to update js client https://github.com/elastic/kibana/issues/220614 and get rid of 
```
// @ts-expect-error
```

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->