### PR TITLE
[Onechat] Fix support for conversations API when used with ApiKey 

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/client.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/client.ts
@@ -66,7 +66,7 @@ class ConversationClientImpl implements ConversationClient {
         bool: {
           must: [
             {
-              match: this.user.username
+              term: this.user.username
                 ? { user_name: this.user.username }
                 : { user_id: this.user.id },
             },

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/client.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/client.ts
@@ -65,7 +65,11 @@ class ConversationClientImpl implements ConversationClient {
       query: {
         bool: {
           must: [
-            { term: { user_id: this.user.id } },
+            {
+              match: this.user.username
+                ? { user_name: this.user.username }
+                : { user_id: this.user.id },
+            },
             ...(agentId ? [{ term: { agent_id: agentId } }] : []),
           ],
         },
@@ -135,5 +139,7 @@ const hasAccess = ({
   conversation: Pick<Document, '_source'>;
   user: UserIdAndName;
 }) => {
-  return conversation._source!.user_id === user.id;
+  return (
+    conversation._source!.user_id === user.id || conversation._source!.user_name === user.username
+  );
 };


### PR DESCRIPTION
- Modified the query logic to match user by username if available, otherwise fallback to user ID.
- Enhanced access check to include username comparison for conversation access validation.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


