### PR TITLE
[Discover] New extension point for metrics PoC

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/get_sidebar_visibility.ts
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/get_sidebar_visibility.ts
@@ -11,7 +11,7 @@ import { BehaviorSubject } from 'rxjs';
 
 export interface SidebarVisibility {
   isCollapsed$: BehaviorSubject<boolean>;
-  toggle: (isCollapsed: boolean) => void;
+  toggle: (isCollapsed: boolean, shouldPersist?: boolean) => void;
   initialValue: boolean;
 }
 
@@ -40,9 +40,9 @@ export const getSidebarVisibility = ({
   return {
     initialValue,
     isCollapsed$,
-    toggle: (isCollapsed) => {
+    toggle: (isCollapsed, shouldPersist = true) => {
       isCollapsed$.next(isCollapsed);
-      if (localStorageKey) {
+      if (localStorageKey && shouldPersist) {
         setIsCollapsed(localStorageKey, isCollapsed);
       }
     },

--- a/src/platform/packages/shared/kbn-unified-histogram/index.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/index.ts
@@ -13,7 +13,11 @@ export type {
   UnifiedHistogramAdapters,
   UnifiedHistogramVisContext,
 } from './types';
-export { UnifiedHistogramFetchStatus, UnifiedHistogramExternalVisContextStatus } from './types';
+export {
+  UnifiedHistogramFetchStatus,
+  UnifiedHistogramExternalVisContextStatus,
+  UnifiedHistogramMode,
+} from './types';
 
 export {
   UnifiedBreakdownFieldSelector,

--- a/src/platform/packages/shared/kbn-unified-histogram/types.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/types.ts
@@ -177,3 +177,8 @@ export interface UnifiedHistogramVisContext {
   requestData: LensRequestData;
   suggestionType: UnifiedHistogramSuggestionType;
 }
+
+export enum UnifiedHistogramMode {
+  default = 'default',
+  metrics = 'metrics',
+}

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
@@ -7,19 +7,30 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
-import { type HtmlPortalNode, InPortal, createHtmlPortalNode } from 'react-reverse-portal';
-import { UnifiedHistogramChart, useUnifiedHistogram } from '@kbn/unified-histogram';
+import React, {
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createHtmlPortalNode, type HtmlPortalNode, InPortal } from 'react-reverse-portal';
+import {
+  UnifiedHistogramChart,
+  UnifiedHistogramMode,
+  useUnifiedHistogram,
+} from '@kbn/unified-histogram';
 import { DiscoverCustomizationProvider } from '../../../../customizations';
 import {
-  useInternalStateSelector,
-  type RuntimeStateManager,
-  selectTabRuntimeState,
-  selectRestorableTabRuntimeHistogramLayoutProps,
-  useRuntimeState,
   CurrentTabProvider,
+  type RuntimeStateManager,
   RuntimeStateProvider,
+  selectRestorableTabRuntimeHistogramLayoutProps,
+  selectTabRuntimeState,
   useCurrentTabSelector,
+  useInternalStateSelector,
+  useRuntimeState,
 } from '../../state_management/redux';
 import type { DiscoverMainContentProps } from '../layout/discover_main_content';
 import { DiscoverMainProvider } from '../../state_management/discover_state_provider';
@@ -27,6 +38,7 @@ import type { DiscoverStateContainer } from '../../state_management/discover_sta
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
 import { useDiscoverHistogram } from './use_discover_histogram';
 import { ScopedServicesProvider } from '../../../../components/scoped_services_provider';
+import { useProfileAccessor } from '../../../../context_awareness';
 
 export type ChartPortalNode = HtmlPortalNode;
 export type ChartPortalNodes = Record<string, ChartPortalNode>;
@@ -172,6 +184,13 @@ const UnifiedHistogramChartWrapper = ({
     [panelsToggle]
   );
 
+  const getChartConfigAccessor = useProfileAccessor('getChartConfig');
+  const chartConfig = useMemo(() => {
+    return getChartConfigAccessor(() => ({
+      mode: UnifiedHistogramMode.default,
+    }))();
+  }, [getChartConfigAccessor]);
+
   // Initialized when the first search has been requested or
   // when in ES|QL mode since search sessions are not supported
   if (!unifiedHistogram.isInitialized || (!unifiedHistogramProps.searchSessionId && !isEsqlMode)) {
@@ -181,6 +200,7 @@ const UnifiedHistogramChartWrapper = ({
   return (
     <UnifiedHistogramChart
       {...unifiedHistogram.chartProps}
+      mode={chartConfig.mode}
       renderCustomChartToggleActions={renderCustomChartToggleActions}
     />
   );

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -46,6 +46,7 @@ import {
   useDataViewsForPicker,
   useInternalStateDispatch,
 } from '../../state_management/redux';
+import { useAppStateSelector } from '../../state_management/discover_app_state_container';
 
 const EMPTY_FIELD_COUNTS = {};
 
@@ -400,6 +401,19 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
     },
     [dispatch, setFieldListUiState]
   );
+
+  const isSidebarHidden = useAppStateSelector((state) => state.hideSidebar);
+
+  useEffect(() => {
+    const currentState = sidebarToggleState$.getValue();
+    if (isSidebarHidden && currentState.isCollapsed === false) {
+      currentState.toggle?.(true, false);
+      return;
+    }
+    if (isSidebarHidden === undefined && currentState.isCollapsed === true) {
+      currentState.toggle?.(false, false);
+    }
+  }, [sidebarToggleState$, isSidebarHidden]);
 
   return (
     <EuiFlexGroup

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_app_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_app_state_container.ts
@@ -107,6 +107,10 @@ export interface DiscoverAppState {
    */
   hideChart?: boolean;
   /**
+   * Hide sidebar
+   */
+  hideSidebar?: boolean;
+  /**
    * The current data source
    */
   dataSource?: DiscoverDataSource;
@@ -284,6 +288,7 @@ export const getDiscoverAppStateContainer = ({
             rowHeight: rowHeight === undefined,
             breakdownField: breakdownField === undefined,
             hideChart: hideChart === undefined,
+            hideSidebar: true,
           },
         })
       );
@@ -388,6 +393,10 @@ export function getInitialState({
   // https://github.com/elastic/kibana/issues/122555
   if (typeof mergedState.hideChart !== 'boolean') {
     mergedState.hideChart = undefined;
+  }
+
+  if (typeof mergedState.hideSidebar !== 'boolean') {
+    mergedState.hideSidebar = undefined;
   }
 
   // Don't allow URL state to overwrite the data source if there's an ES|QL query

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -355,6 +355,7 @@ export function getDataStateContainer({
                     rowHeight: false,
                     breakdownField: false,
                     hideChart: false,
+                    hideSidebar: false,
                   },
                 })
               );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_saved_search_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_saved_search_container.ts
@@ -333,7 +333,7 @@ export function isEqualSavedSearch(savedSearchPrev: SavedSearch, savedSearchNext
   // at least one change in saved search attributes
   const hasChangesInSavedSearch = [...keys].some((key) => {
     if (
-      ['usesAdHocDataView', 'hideChart'].includes(key) &&
+      ['usesAdHocDataView', 'hideChart', 'hideSidebar'].includes(key) &&
       typeof prevSavedSearch[key] === 'undefined' &&
       nextSavedSearchWithoutSearchSource[key] === false
     ) {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -56,6 +56,7 @@ export const defaultTabState: Omit<TabState, keyof TabItem> = {
     rowHeight: false,
     breakdownField: false,
     hideChart: false,
+    hideSidebar: false,
   },
   documentsRequest: {
     loadingStatus: LoadingStatus.Uninitialized,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -74,6 +74,7 @@ export interface TabState extends TabItem {
     rowHeight: boolean;
     breakdownField: boolean;
     hideChart: boolean;
+    hideSidebar: boolean;
   };
   documentsRequest: DocumentsRequest;
   totalHitsRequest: TotalHitsRequest;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/build_esql_fetch_subscribe.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/build_esql_fetch_subscribe.ts
@@ -99,6 +99,7 @@ export const buildEsqlFetchSubscribe = ({
                 rowHeight: true,
                 breakdownField: true,
                 hideChart: true,
+                hideSidebar: true,
               },
             })
           );
@@ -160,6 +161,7 @@ export const buildEsqlFetchSubscribe = ({
             rowHeight: false,
             breakdownField: false,
             hideChart: false,
+            hideSidebar: false,
           },
         })
       );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/change_data_view.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/change_data_view.ts
@@ -83,6 +83,7 @@ export async function changeDataView({
           rowHeight: true,
           breakdownField: true,
           hideChart: true,
+          hideSidebar: true,
         },
       })
     );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_default_profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_default_profile_state.ts
@@ -48,6 +48,10 @@ export const getDefaultProfileState = ({
         stateUpdate.hideChart = defaultState.hideChart;
       }
 
+      if (resetDefaultProfileState.hideSidebar) {
+        stateUpdate.hideSidebar = defaultState.hideSidebar;
+      }
+
       return Object.keys(stateUpdate).length ? stateUpdate : undefined;
     },
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_state_defaults.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_state_defaults.ts
@@ -70,6 +70,7 @@ export function getStateDefaults({
     interval: 'auto',
     filters: cloneDeep(searchSource?.getOwnField('filter')) as DiscoverAppState['filters'],
     hideChart: chartHidden,
+    hideSidebar: undefined, // TODO: do we want to start saving it in Discover Session SO?
     viewMode: undefined,
     hideAggregatedPreview: undefined,
     savedQuery: undefined,
@@ -88,6 +89,9 @@ export function getStateDefaults({
   if (savedSearch?.hideChart !== undefined) {
     defaultState.hideChart = savedSearch.hideChart;
   }
+  // if (savedSearch?.hideSidebar !== undefined) {
+  //   defaultState.hideSidebar = savedSearch.hideSidebar;
+  // }
   if (savedSearch?.rowHeight !== undefined) {
     defaultState.rowHeight = savedSearch.rowHeight;
   }

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/update_saved_search.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/update_saved_search.ts
@@ -68,6 +68,7 @@ export function updateSavedSearch({
       savedSearch.grid = state.grid;
     }
     savedSearch.hideChart = state.hideChart;
+    // savedSearch.hideSidebar = state.hideSidebar;
     savedSearch.rowHeight = state.rowHeight;
     savedSearch.headerRowHeight = state.headerRowHeight;
     savedSearch.rowsPerPage = state.rowsPerPage;

--- a/src/platform/plugins/shared/discover/public/application/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/types.ts
@@ -29,5 +29,5 @@ export interface RecordsFetchResponse {
 
 export interface SidebarToggleState {
   isCollapsed: boolean;
-  toggle: undefined | ((isCollapsed: boolean) => void);
+  toggle: undefined | ((isCollapsed: boolean, shouldPersist?: boolean) => void);
 }

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/create_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/create_profile_providers.ts
@@ -18,11 +18,13 @@ import {
   createSystemLogsDataSourceProfileProvider,
   createWindowsLogsDataSourceProfileProvider,
 } from './sub_profiles';
+import { createMetricsDataSourceProfileProvider } from '../metrics_data_source_profile/profile';
 
 export const createObservabilityLogsDataSourceProfileProviders = (
   providerServices: ProfileProviderServices
 ) => {
   const logsDataSourceProfileProvider = createLogsDataSourceProfileProvider(providerServices);
+  const metricsDataSourceProfileProvider = createMetricsDataSourceProfileProvider(providerServices);
 
   return [
     createSystemLogsDataSourceProfileProvider(logsDataSourceProfileProvider),
@@ -33,5 +35,6 @@ export const createObservabilityLogsDataSourceProfileProviders = (
     createNginxAccessLogsDataSourceProfileProvider(logsDataSourceProfileProvider),
     createApacheErrorLogsDataSourceProfileProvider(logsDataSourceProfileProvider),
     logsDataSourceProfileProvider,
+    metricsDataSourceProfileProvider,
   ];
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.ts
@@ -20,6 +20,10 @@ export const createMetricsDataSourceProfileProvider = (
 ): MetricsDataSourceProfileProvider => ({
   profileId: 'metrics-data-source-profile',
   profile: {
+    getDefaultAppState: (prev) => (params) => ({
+      ...(prev ? prev(params) : {}),
+      hideSidebar: true,
+    }),
     getChartConfig: (prev) => () => ({
       ...(prev ? prev() : {}),
       mode: UnifiedHistogramMode.metrics,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { UnifiedHistogramMode } from '@kbn/unified-histogram';
+import { isOfAggregateQueryType } from '@kbn/es-query';
+import type { DataSourceProfileProvider } from '../../../profiles';
+import { DataSourceCategory } from '../../../profiles';
+import type { ProfileProviderServices } from '../../profile_provider_services';
+
+export type MetricsDataSourceProfileProvider = DataSourceProfileProvider<{}>;
+
+export const createMetricsDataSourceProfileProvider = (
+  services: ProfileProviderServices
+): MetricsDataSourceProfileProvider => ({
+  profileId: 'metrics-data-source-profile',
+  profile: {
+    getChartConfig: (prev) => () => ({
+      ...(prev ? prev() : {}),
+      mode: UnifiedHistogramMode.metrics,
+    }),
+  },
+  resolve: (params) => {
+    // if (params.rootContext.solutionType !== SolutionType.Observability) {
+    //   return { isMatch: false };
+    // }
+
+    // TODO: implement a more robust matching logic
+    if (
+      !isOfAggregateQueryType(params.query) ||
+      !params.query.esql.toLowerCase().includes('metrics')
+    ) {
+      return {
+        isMatch: false,
+      };
+    }
+
+    return {
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Logs,
+      },
+    };
+  },
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -24,6 +24,7 @@ import type { OmitIndexSignature } from 'type-fest';
 import type { Trigger } from '@kbn/ui-actions-plugin/public';
 import type { FunctionComponent, PropsWithChildren } from 'react';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
+import type { UnifiedHistogramMode } from '@kbn/unified-histogram/types';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
 import type { DiscoverDataSource } from '../../common/data_sources';
 import type { DiscoverAppState } from '../application/main/state_management/discover_app_state_container';
@@ -317,6 +318,13 @@ export interface AdditionalCellAction {
   execute: (context: AdditionalCellActionContext) => void | Promise<void>;
 }
 
+export interface ChartConfigExtension {
+  /**
+   * Supports customizing the chart (UnifiedHistogram) section in Discover
+   */
+  mode: UnifiedHistogramMode;
+}
+
 /**
  * The core profile interface for Discover context awareness.
  * Each of the available methods map to a specific extension point in the Discover application.
@@ -438,4 +446,10 @@ export interface Profile {
    * Example use case is to overwrite the column header display name or to add icons to the column headers.
    */
   getColumnsConfiguration: () => CustomGridColumnsConfiguration;
+
+  /**
+   * Gets configuration for the Discover chart (UnifiedHistogram) section
+   * @returns The custom configuration for the chart
+   */
+  getChartConfig: () => ChartConfigExtension;
 }

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -168,6 +168,10 @@ export interface DefaultAppStateExtension {
    * The state for chart visibility toggle
    */
   hideChart?: boolean;
+  /**
+   * The state for sidebar visibility toggle
+   */
+  hideSidebar?: boolean;
 }
 
 /**

--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -157,6 +157,7 @@ export const getSearchEmbeddableFactory = ({
             breakdownField: 'skip',
             hideAggregatedPreview: 'skip',
             hideChart: 'skip',
+            // hideSidebar: 'skip',
             isTextBasedQuery: 'skip',
             kibanaSavedObjectMeta: 'skip',
             nonPersistedDisplayOptions: 'skip',


### PR DESCRIPTION
## Summary

This PR is only for demo purposes to show one of the ways of extending Discover to show different view instead of the usual Discover histogram.

- [x] new extension point `getChartConfig` which allow to define mode for the chart section as `metrics` for example to replace the default histogram
- [x] new prop `hideSidebar` on `getDefaultAppState` extension

I defined a new profile under `src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.ts`. It showcases that if ES|QL query simply includes `metrics` (definitely needs a better matching logic!) then the profile will get enabled and will use these new settings.

![Aug-08-2025 15-12-57](https://github.com/user-attachments/assets/510343d9-a8e5-418d-b7c2-7695f8477aa1)

Hope it helps to get started!

