### PR TITLE
[9.1] [Discover][Unified Waterfall] Enable partial trace rendering with warnings (#230195)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/bar_details.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/bar_details.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
+  EuiIconTip,
   EuiText,
   useEuiTheme,
 } from '@elastic/eui';
@@ -18,16 +19,27 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { asDuration } from '../../../../common/utils/formatters';
-import type { TraceItem } from '../../../../common/waterfall/unified_trace_item';
 import { TruncateWithTooltip } from '../truncate_with_tooltip';
 import { useTraceWaterfallContext } from './trace_waterfall_context';
+import type { TraceWaterfallItem } from './use_trace_waterfall';
+
+const ORPHAN_TITLE = i18n.translate('xpack.apm.trace.barDetails.euiIconTip.orphanTitleLabel', {
+  defaultMessage: 'Orphan',
+});
+const ORPHAN_CONTENT = i18n.translate(
+  'xpack.apm.trace.barDetails.euiIconTip.orphanSpanContentLabel',
+  {
+    defaultMessage:
+      'This span is orphaned due to missing trace context and has been reparented to the root to restore the execution flow',
+  }
+);
 
 export function BarDetails({
   item,
   left,
   onErrorClick,
 }: {
-  item: TraceItem;
+  item: TraceWaterfallItem;
   left: number;
   onErrorClick?: (params: { traceId: string; docId: string }) => void;
 }) {
@@ -116,6 +128,21 @@ export function BarDetails({
             ) : (
               <EuiIcon type="errorFilled" color={theme.euiTheme.colors.danger} size="s" />
             )}
+          </EuiFlexItem>
+        ) : null}
+        {item.isOrphan ? (
+          <EuiFlexItem grow={false}>
+            <EuiIconTip
+              data-test-subj="apmBarDetailsOrphanTooltip"
+              iconProps={{
+                'data-test-subj': 'apmBarDetailsOrphanIcon',
+                'aria-label': ORPHAN_TITLE,
+              }}
+              color={theme.euiTheme.colors.danger}
+              type="unlink"
+              title={ORPHAN_TITLE}
+              content={ORPHAN_CONTENT}
+            />
           </EuiFlexItem>
         ) : null}
       </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithContext } from '../../../utils/test_helpers';
+import { TraceWaterfallContext, type TraceWaterfallContextProps } from './trace_waterfall_context';
+import { TraceWarning } from './trace_warning';
+import { TraceDataState } from './use_trace_waterfall';
+
+describe('TraceWarning', () => {
+  it("doesn't render a warning for a complete trace", () => {
+    renderWithContext(
+      <TraceWaterfallContext.Provider
+        value={{ traceState: TraceDataState.Full } as TraceWaterfallContextProps}
+      >
+        <TraceWarning>
+          <div>Trace</div>
+        </TraceWarning>
+      </TraceWaterfallContext.Provider>
+    );
+
+    const warning = screen.queryByTestId('traceWarning');
+    const trace = screen.queryByText('Trace');
+
+    expect(warning).not.toBeInTheDocument();
+    expect(trace).toBeInTheDocument();
+  });
+
+  it('renders a warning for a partial trace, and shows the trace', () => {
+    renderWithContext(
+      <TraceWaterfallContext.Provider
+        value={{ traceState: TraceDataState.Partial } as TraceWaterfallContextProps}
+      >
+        <TraceWarning>
+          <div>Trace</div>
+        </TraceWarning>
+      </TraceWaterfallContext.Provider>
+    );
+
+    const warning = screen.queryByTestId('traceWarning');
+    const trace = screen.queryByText('Trace');
+
+    expect(warning).toBeInTheDocument();
+    expect(trace).toBeInTheDocument();
+  });
+
+  it('renders a warning for an empty trace, and does not show the trace', () => {
+    renderWithContext(
+      <TraceWaterfallContext.Provider
+        value={{ traceState: TraceDataState.Empty } as TraceWaterfallContextProps}
+      >
+        <TraceWarning>
+          <div>Trace</div>
+        </TraceWarning>
+      </TraceWaterfallContext.Provider>
+    );
+
+    const warning = screen.queryByTestId('traceWarning');
+    const trace = screen.queryByText('Trace');
+
+    expect(warning).toBeInTheDocument();
+    expect(trace).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.tsx
@@ -7,8 +7,9 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiCallOut } from '@elastic/eui';
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useTraceWaterfallContext } from './trace_waterfall_context';
+import { TraceDataState } from './use_trace_waterfall';
 
 const FALLBACK_WARNING = i18n.translate(
   'xpack.apm.traceWaterfallContext.warningMessage.fallbackWarning',
@@ -19,7 +20,35 @@ const FALLBACK_WARNING = i18n.translate(
 );
 
 export function TraceWarning({ children }: { children: React.ReactNode }) {
-  const { rootItem } = useTraceWaterfallContext();
+  const { traceState } = useTraceWaterfallContext();
 
-  return !rootItem ? <EuiCallOut color="warning" size="s" title={FALLBACK_WARNING} /> : children;
+  switch (traceState) {
+    case TraceDataState.Partial:
+      return (
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <EuiCallOut
+              data-test-subj="traceWarning"
+              color="warning"
+              size="s"
+              title={FALLBACK_WARNING}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>{children}</EuiFlexItem>
+        </EuiFlexGroup>
+      );
+
+    case TraceDataState.Empty:
+      return (
+        <EuiCallOut
+          data-test-subj="traceWarning"
+          color="warning"
+          size="s"
+          title={FALLBACK_WARNING}
+        />
+      );
+
+    default:
+      return children;
+  }
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
@@ -9,12 +9,13 @@ import React, { createContext, useContext, useMemo } from 'react';
 import type { TraceItem } from '../../../../common/waterfall/unified_trace_item';
 import { TOGGLE_BUTTON_WIDTH } from './toggle_accordion_button';
 import { ACCORDION_PADDING_LEFT } from './trace_item_row';
-import type { TraceWaterfallItem } from './use_trace_waterfall';
+import { TraceDataState, type TraceWaterfallItem } from './use_trace_waterfall';
 import { useTraceWaterfall } from './use_trace_waterfall';
 import type { IWaterfallGetRelatedErrorsHref } from '../../app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
 
-interface TraceWaterfallContextProps {
+export interface TraceWaterfallContextProps {
   duration: number;
+  traceState: TraceDataState;
   traceWaterfall: TraceWaterfallItem[];
   rootItem?: TraceItem;
   margin: { left: number; right: number };
@@ -30,6 +31,7 @@ interface TraceWaterfallContextProps {
 
 export const TraceWaterfallContext = createContext<TraceWaterfallContextProps>({
   duration: 0,
+  traceState: TraceDataState.Empty,
   traceWaterfall: [],
   rootItem: undefined,
   margin: { left: 0, right: 0 },
@@ -62,7 +64,7 @@ export function TraceWaterfallContextProvider({
   getRelatedErrorsHref?: IWaterfallGetRelatedErrorsHref;
   isEmbeddable: boolean;
 }) {
-  const { duration, traceWaterfall, maxDepth, rootItem } = useTraceWaterfall({
+  const { duration, traceWaterfall, maxDepth, rootItem, traceState } = useTraceWaterfall({
     traceItems,
   });
 
@@ -74,6 +76,7 @@ export function TraceWaterfallContextProvider({
   return (
     <TraceWaterfallContext.Provider
       value={{
+        traceState,
         duration,
         rootItem,
         traceWaterfall,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Discover][Unified Waterfall] Enable partial trace rendering with warnings (#230195)](https://github.com/elastic/kibana/pull/230195)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-08-08T13:10:25Z","message":"[Discover][Unified Waterfall] Enable partial trace rendering with warnings (#230195)\n\n## Summary\n\nAllow the Unified Trace Waterfall embeddable to render partial traces,\nwhich might have missing root spans or orphan spans. By doing this, we\nbring the embeddable to have feature parity with the old APM Waterfall,\nallowing it to display even partial traces alongside warnings to let\nusers know they are viewing partial/incomplete data.\n\n|     | Screenshot |\n| -- | ------------ |\n| **Missing root span** | ![Missing Root\nSpan](https://github.com/user-attachments/assets/ca593409-8266-4468-808c-dbcbf30426b4)\n|\n| **Orphan Spans** | ![Orphan\nSpans](https://github.com/user-attachments/assets/66dde63c-c638-42be-84fc-439a92c854ee)\n|\n\n\nCloses #227480\n\n### How to test\n\n* Ensure space is set to Observability mode, navigate to Discover,\nswitch to ES|QL mode and target an index with processed OTEL traces. For\nexample with edge-oblt-ccs: remote_cluster:traces-generic.otel-default\n* Select the newest/freshest span/transaction and open the overview.\n* If the focused waterfall doesn't render, it should show a callout.\n* Go to the Full Trace Waterfall, and it should not only display a\ncallout as well, but should show a trace waterfall rendered with the\npartial data.\n* Any spans that are orphans should be annotated with an `unlink` icon\nwith a tooltip to explain its orphan status.\n* Refreshing the time range should load more data, and if the same span\nis selected, the callout should disappear as the full data is likely to\nbe present.\n\n### Todo\n\n- [x] Basic partial rendering for Full waterfall\n- [x] Warnings for Orphan Spans\n- [x] ~~Partial rendering for Focused waterfall~~ Descoping since this\nrequires a larger amount of changes","sha":"c96a8839e018feef4843603d3a2b4730e43d002b","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.1.1","v8.19.1"],"title":"[Discover][Unified Waterfall] Enable partial trace rendering with warnings","number":230195,"url":"https://github.com/elastic/kibana/pull/230195","mergeCommit":{"message":"[Discover][Unified Waterfall] Enable partial trace rendering with warnings (#230195)\n\n## Summary\n\nAllow the Unified Trace Waterfall embeddable to render partial traces,\nwhich might have missing root spans or orphan spans. By doing this, we\nbring the embeddable to have feature parity with the old APM Waterfall,\nallowing it to display even partial traces alongside warnings to let\nusers know they are viewing partial/incomplete data.\n\n|     | Screenshot |\n| -- | ------------ |\n| **Missing root span** | ![Missing Root\nSpan](https://github.com/user-attachments/assets/ca593409-8266-4468-808c-dbcbf30426b4)\n|\n| **Orphan Spans** | ![Orphan\nSpans](https://github.com/user-attachments/assets/66dde63c-c638-42be-84fc-439a92c854ee)\n|\n\n\nCloses #227480\n\n### How to test\n\n* Ensure space is set to Observability mode, navigate to Discover,\nswitch to ES|QL mode and target an index with processed OTEL traces. For\nexample with edge-oblt-ccs: remote_cluster:traces-generic.otel-default\n* Select the newest/freshest span/transaction and open the overview.\n* If the focused waterfall doesn't render, it should show a callout.\n* Go to the Full Trace Waterfall, and it should not only display a\ncallout as well, but should show a trace waterfall rendered with the\npartial data.\n* Any spans that are orphans should be annotated with an `unlink` icon\nwith a tooltip to explain its orphan status.\n* Refreshing the time range should load more data, and if the same span\nis selected, the callout should disappear as the full data is likely to\nbe present.\n\n### Todo\n\n- [x] Basic partial rendering for Full waterfall\n- [x] Warnings for Orphan Spans\n- [x] ~~Partial rendering for Focused waterfall~~ Descoping since this\nrequires a larger amount of changes","sha":"c96a8839e018feef4843603d3a2b4730e43d002b"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230195","number":230195,"mergeCommit":{"message":"[Discover][Unified Waterfall] Enable partial trace rendering with warnings (#230195)\n\n## Summary\n\nAllow the Unified Trace Waterfall embeddable to render partial traces,\nwhich might have missing root spans or orphan spans. By doing this, we\nbring the embeddable to have feature parity with the old APM Waterfall,\nallowing it to display even partial traces alongside warnings to let\nusers know they are viewing partial/incomplete data.\n\n|     | Screenshot |\n| -- | ------------ |\n| **Missing root span** | ![Missing Root\nSpan](https://github.com/user-attachments/assets/ca593409-8266-4468-808c-dbcbf30426b4)\n|\n| **Orphan Spans** | ![Orphan\nSpans](https://github.com/user-attachments/assets/66dde63c-c638-42be-84fc-439a92c854ee)\n|\n\n\nCloses #227480\n\n### How to test\n\n* Ensure space is set to Observability mode, navigate to Discover,\nswitch to ES|QL mode and target an index with processed OTEL traces. For\nexample with edge-oblt-ccs: remote_cluster:traces-generic.otel-default\n* Select the newest/freshest span/transaction and open the overview.\n* If the focused waterfall doesn't render, it should show a callout.\n* Go to the Full Trace Waterfall, and it should not only display a\ncallout as well, but should show a trace waterfall rendered with the\npartial data.\n* Any spans that are orphans should be annotated with an `unlink` icon\nwith a tooltip to explain its orphan status.\n* Refreshing the time range should load more data, and if the same span\nis selected, the callout should disappear as the full data is likely to\nbe present.\n\n### Todo\n\n- [x] Basic partial rendering for Full waterfall\n- [x] Warnings for Orphan Spans\n- [x] ~~Partial rendering for Focused waterfall~~ Descoping since this\nrequires a larger amount of changes","sha":"c96a8839e018feef4843603d3a2b4730e43d002b"}},{"branch":"9.1","label":"v9.1.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->