### PR TITLE
fix: (Accessibility) Filter language popover needs to identify KQL or Lucene as selected to screen readers

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/language_switcher.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/language_switcher.tsx
@@ -15,6 +15,7 @@ import {
   toSentenceCase,
   EuiHorizontalRule,
   EuiButtonIcon,
+  EuiSelectable,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState } from 'react';
@@ -25,6 +26,14 @@ export const strings = {
   getSwitchLanguageButtonText: () =>
     i18n.translate('unifiedSearch.switchLanguage.buttonText', {
       defaultMessage: 'Switch language button.',
+    }),
+  getFilterLanguageLabel: () =>
+    i18n.translate('unifiedSearch.switchLanguage.filterLanguageLabel', {
+      defaultMessage: 'Filter language',
+    }),
+  documentationLabel: () =>
+    i18n.translate('unifiedSearch.switchLanguage.documentationLabel', {
+      defaultMessage: 'Documentation',
     }),
 };
 
@@ -64,28 +73,38 @@ export const QueryLanguageSwitcher = React.memo(function QueryLanguageSwitcher({
     />
   );
 
+  const isKqlSelected = language === 'kuery';
+
   const languageMenuItem = (
-    <div>
-      <EuiContextMenuItem
-        key="KQL"
-        icon={language === 'kuery' ? 'check' : 'empty'}
-        data-test-subj="kqlLanguageMenuItem"
-        onClick={() => {
-          onSelectLanguage('kuery');
+    <>
+      <EuiSelectable
+        aria-label={strings.getFilterLanguageLabel()}
+        options={[
+          {
+            key: 'kuery',
+            label: 'KQL',
+            'data-test-subj': 'kqlLanguageMenuItem',
+            checked: isKqlSelected ? 'on' : undefined,
+          },
+          {
+            key: nonKqlMode,
+            label: toSentenceCase(nonKqlMode),
+            'data-test-subj': 'luceneLanguageMenuItem',
+            checked: !isKqlSelected ? 'on' : undefined,
+          },
+        ]}
+        onChange={(newOptions) => {
+          const selectedOptions = newOptions.find((option) => option.checked === 'on');
+
+          if (selectedOptions) {
+            onSelectLanguage(selectedOptions.key);
+          }
         }}
+        singleSelection={true}
+        listProps={{ bordered: false }}
       >
-        KQL
-      </EuiContextMenuItem>
-      <EuiContextMenuItem
-        key={nonKqlMode}
-        icon={language === 'kuery' ? 'empty' : 'check'}
-        data-test-subj="luceneLanguageMenuItem"
-        onClick={() => {
-          onSelectLanguage(nonKqlMode);
-        }}
-      >
-        {toSentenceCase(nonKqlMode)}
-      </EuiContextMenuItem>
+        {(list) => list}
+      </EuiSelectable>
       <EuiHorizontalRule margin="none" />
       <EuiContextMenuItem
         key={'documentation'}
@@ -93,9 +112,9 @@ export const QueryLanguageSwitcher = React.memo(function QueryLanguageSwitcher({
         href={kueryQuerySyntaxDocs}
         target="_blank"
       >
-        Documentation
+        {strings.documentationLabel()}
       </EuiContextMenuItem>
-    </div>
+    </>
   );
 
   const languageQueryStringComponent = (


### PR DESCRIPTION
Closes: #151506

**Description:**
Screen reader announces a more descriptive label like "Kay Queue Ele, selected, button" OR "Kay Queue Ele, selected query language, button". Screen reader should pronounce it as abbreviations or just "selected"

**Changes made:**
`Filter Languages` related buttons were refactored to use `EuiSelectable` component.

**Screen:**

<img width="913" height="444" alt="image" src="https://github.com/user-attachments/assets/768a07c1-0227-4778-8e1b-e9dd47bfe5b1" />



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->