### PR TITLE
Fix `scripts/kibana` with the `--allow-root` flag

### DIFF
--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -238,6 +238,7 @@ export default function (program) {
       pluginPathCollector,
       []
     )
+    .option('--allow-root', 'Required if Kibana is ran as root')
     .option('--optimize', 'Deprecated, running the optimizer is no longer required');
 
   if (!isKibanaDistributable()) {


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/231086 propagates `--allow-root` to further commands. This means we removed the part that carves this flag out after reading it. Because of this, the flag would show up in the `node scripts/kibana` CLI, causing it to fail with an unknown flag error.

This PR adds `--allow-root` as an explicit flag to kibana CLI, to avoid errors from starting kibana as root.