### PR TITLE
[9.1] [ML][AI Connector] Ensure form fields persist when validation fails (#230321)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/additional_options_fields.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/additional_options_fields.tsx
@@ -38,6 +38,15 @@ import { DEFAULT_TASK_TYPE } from '../constants';
 import { Config, ConfigEntryView } from '../types/types';
 import { TaskTypeOption } from '../utils/helpers';
 
+const taskTypeConfig = {
+  validations: [
+    {
+      validator: fieldValidators.emptyField(LABELS.getRequiredMessage('Task type')),
+      isBlocking: true,
+    },
+  ],
+};
+
 // Custom trigger button CSS
 const buttonCss = css`
   &:hover {
@@ -92,17 +101,7 @@ export const AdditionalOptionsFields: React.FC<AdditionalOptionsFieldsProps> = (
             />
           </EuiText>
           <EuiSpacer size="m" />
-          <UseField
-            path="config.taskType"
-            config={{
-              validations: [
-                {
-                  validator: fieldValidators.emptyField(LABELS.getRequiredMessage('Task type')),
-                  isBlocking: true,
-                },
-              ],
-            }}
-          >
+          <UseField path="config.taskType" config={taskTypeConfig}>
             {(field) => {
               const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
 

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/hidden_fields/provider_config_hidden_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/hidden_fields/provider_config_hidden_field.tsx
@@ -12,13 +12,13 @@ import { ConfigEntryView } from '../../types/types';
 import { getNonEmptyValidator } from '../../utils/helpers';
 
 interface ProviderConfigHiddenFieldProps {
-  providerSchema: ConfigEntryView[];
+  requiredProviderFormFields: ConfigEntryView[];
   setRequiredProviderFormFields: React.Dispatch<React.SetStateAction<ConfigEntryView[]>>;
   isSubmitting: boolean;
 }
 
 export const ProviderConfigHiddenField: React.FC<ProviderConfigHiddenFieldProps> = ({
-  providerSchema,
+  requiredProviderFormFields,
   setRequiredProviderFormFields,
   isSubmitting,
 }) => (
@@ -29,7 +29,7 @@ export const ProviderConfigHiddenField: React.FC<ProviderConfigHiddenFieldProps>
       validations: [
         {
           validator: getNonEmptyValidator(
-            providerSchema,
+            requiredProviderFormFields,
             setRequiredProviderFormFields,
             isSubmitting
           ),

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/hidden_fields/provider_secret_hidden_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/hidden_fields/provider_secret_hidden_field.tsx
@@ -12,13 +12,13 @@ import { ConfigEntryView } from '../../types/types';
 import { getNonEmptyValidator } from '../../utils/helpers';
 
 interface ProviderSecretHiddenFieldProps {
-  providerSchema: ConfigEntryView[];
+  requiredProviderFormFields: ConfigEntryView[];
   setRequiredProviderFormFields: React.Dispatch<React.SetStateAction<ConfigEntryView[]>>;
   isSubmitting: boolean;
 }
 
 export const ProviderSecretHiddenField: React.FC<ProviderSecretHiddenFieldProps> = ({
-  providerSchema,
+  requiredProviderFormFields,
   setRequiredProviderFormFields,
   isSubmitting,
 }) => (
@@ -29,7 +29,7 @@ export const ProviderSecretHiddenField: React.FC<ProviderSecretHiddenFieldProps>
       validations: [
         {
           validator: getNonEmptyValidator(
-            providerSchema,
+            requiredProviderFormFields,
             setRequiredProviderFormFields,
             isSubmitting,
             true

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
@@ -48,6 +48,15 @@ import { ProviderSecretHiddenField } from './hidden_fields/provider_secret_hidde
 import { ProviderConfigHiddenField } from './hidden_fields/provider_config_hidden_field';
 import { useProviders } from '../hooks/use_providers';
 
+const providerConfigConfig = {
+  validations: [
+    {
+      validator: fieldValidators.emptyField(LABELS.PROVIDER_REQUIRED),
+      isBlocking: true,
+    },
+  ],
+};
+
 interface InferenceServicesProps {
   http: HttpSetup;
   toasts: IToasts;
@@ -363,17 +372,7 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
 
   return !isLoading ? (
     <>
-      <UseField
-        path="config.provider"
-        config={{
-          validations: [
-            {
-              validator: fieldValidators.emptyField(LABELS.PROVIDER_REQUIRED),
-              isBlocking: true,
-            },
-          ],
-        }}
-      >
+      <UseField path="config.provider" config={providerConfigConfig}>
         {(field) => {
           const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
           const selectInput = providerSuperSelect(isInvalid);
@@ -434,12 +433,12 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
           <EuiSpacer size="m" />
           <EuiHorizontalRule margin="xs" />
           <ProviderSecretHiddenField
-            providerSchema={providerSchema}
+            requiredProviderFormFields={requiredProviderFormFields}
             setRequiredProviderFormFields={setRequiredProviderFormFields}
             isSubmitting={isSubmitting}
           />
           <ProviderConfigHiddenField
-            providerSchema={providerSchema}
+            requiredProviderFormFields={requiredProviderFormFields}
             setRequiredProviderFormFields={setRequiredProviderFormFields}
             isSubmitting={isSubmitting}
           />

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/utils/helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/utils/helpers.ts
@@ -32,7 +32,7 @@ export const generateInferenceEndpointId = (config: Config) => {
 };
 
 export const getNonEmptyValidator = (
-  schema: ConfigEntryView[],
+  requiredFieldsSchema: ConfigEntryView[],
   validationEventHandler: (fieldsWithErrors: ConfigEntryView[]) => void,
   isSubmitting: boolean = false,
   isSecrets: boolean = false
@@ -43,8 +43,8 @@ export const getNonEmptyValidator = (
 
     const configData = (value ?? {}) as Record<string, unknown>;
     let hasErrors = false;
-    if (schema) {
-      schema.map((field: ConfigEntryView) => {
+    if (requiredFieldsSchema) {
+      requiredFieldsSchema.map((field: ConfigEntryView) => {
         // validate if submitting or on field edit - value is not default to null
         if (field.required && (configData[field.key] !== null || isSubmitting)) {
           // validate secrets fields separately from regular


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ML][AI Connector] Ensure form fields persist when validation fails (#230321)](https://github.com/elastic/kibana/pull/230321)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Melissa Alvarez","email":"melissa.alvarez@elastic.co"},"sourceCommit":{"committedDate":"2025-08-08T16:21:40Z","message":"[ML][AI Connector] Ensure form fields persist when validation fails (#230321)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/218809\nThis is also an issue in 8.18, 8.19, 9.0, and 9.1.\nNeeds to be backported for \n- [ ] 8.18.6 (after Aug 12) \n- [ ] 8.19.2 (after Aug 7)\n- [ ] 9.0.6 (after Aug 12)\n- [ ] 9.1.2 (after Aug 7)\n\nThis PR ensures that the validation of the required provider fields does\nnot alter the list of required fields, thus causing duplication of\nfields in the form.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/26d2b14d-abb8-40a4-8791-981d2e289ce6\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/bca4260d-11a2-452e-954f-dd559a5f52c6\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6f8e44d5fdfb2cfcfcbe79e0afa02fbe15263d9c","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","Feature:Inference UI","v9.2.0","v9.1.2","v8.19.2"],"title":"[ML][AI Connector] Ensure form fields persist when validation fails","number":230321,"url":"https://github.com/elastic/kibana/pull/230321","mergeCommit":{"message":"[ML][AI Connector] Ensure form fields persist when validation fails (#230321)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/218809\nThis is also an issue in 8.18, 8.19, 9.0, and 9.1.\nNeeds to be backported for \n- [ ] 8.18.6 (after Aug 12) \n- [ ] 8.19.2 (after Aug 7)\n- [ ] 9.0.6 (after Aug 12)\n- [ ] 9.1.2 (after Aug 7)\n\nThis PR ensures that the validation of the required provider fields does\nnot alter the list of required fields, thus causing duplication of\nfields in the form.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/26d2b14d-abb8-40a4-8791-981d2e289ce6\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/bca4260d-11a2-452e-954f-dd559a5f52c6\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6f8e44d5fdfb2cfcfcbe79e0afa02fbe15263d9c"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230321","number":230321,"mergeCommit":{"message":"[ML][AI Connector] Ensure form fields persist when validation fails (#230321)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/218809\nThis is also an issue in 8.18, 8.19, 9.0, and 9.1.\nNeeds to be backported for \n- [ ] 8.18.6 (after Aug 12) \n- [ ] 8.19.2 (after Aug 7)\n- [ ] 9.0.6 (after Aug 12)\n- [ ] 9.1.2 (after Aug 7)\n\nThis PR ensures that the validation of the required provider fields does\nnot alter the list of required fields, thus causing duplication of\nfields in the form.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/26d2b14d-abb8-40a4-8791-981d2e289ce6\n\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/bca4260d-11a2-452e-954f-dd559a5f52c6\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"6f8e44d5fdfb2cfcfcbe79e0afa02fbe15263d9c"}},{"branch":"9.1","label":"v9.1.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->