### PR TITLE
[Fleet] Make O11y assistant aware of `integration_knowledge*` indices for context

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/common/ui_settings.ts
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/common/ui_settings.ts
@@ -67,7 +67,7 @@ export const uiSettings: Record<string, UiSettingsParams> = {
       'xpack.observabilityAiAssistantManagement.settingsTab.h3.searchConnectorIndexPatternLabel',
       { defaultMessage: 'Search connector index pattern' }
     ),
-    value: '',
+    value: '.integration_knowledge*',
     description: i18n.translate(
       'xpack.observabilityAiAssistantManagement.settingsPage.searchConnectorIndexPatternDescription',
       {


### PR DESCRIPTION
## Summary

Will close https://github.com/elastic/ingest-dev/issues/5680

- Sets the default search connector pattern to match the new system indices of `integration_knowledge*`. As we support comma separated values for this setting, the user will be able to extend functionality as they see fit. 

## Open Questions

- If this approach is the correct one, should we consider making it so that this default value of `.integration_knowledge*` cant be removed by the user if they add other patterns?

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A



