### PR TITLE
[9.0] [DOCS][Known issue] Reporting failing in >= 9.0.0 when using `server.protocol: http2` (#230887)

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -22,6 +22,24 @@ To mitigate the issue, set `xpack.alerting.rules.run.alerts.max` to a value equa
 
 ::::
 
+::::{dropdown} PDF and PNG reports time out and fail with an invalid header error if server.protocol is set to http2
+
+Applies to: {{stack}} 9.0.0
+
+**Details**
+
+If you've changed the [`server.protocol`](/reference/configuration-reference/general-settings.md) value to `http2`, PDF and PNG reports will fail when you export them from the dashboard, visualization, or Canvas workpad that you're generating a report for.
+
+**Action**
+
+To temporarily resolve the issue, set `server.protocol` to `http1`. 
+
+**Resolved**
+
+This issue is resolved in {{stack}} 9.0.0, 9.0.4, 9.1.0.
+
+::::
+
 ::::{dropdown} Dashboard Copy link doesn't work when sharing from a space other than the default space
 
 Applies to: {{stack}} 9.0.3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS][Known issue] Reporting failing in >= 9.0.0 when using `server.protocol: http2` (#230887)](https://github.com/elastic/kibana/pull/230887)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nastasha Solomon","email":"79124755+nastasha-solomon@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-07T19:16:31Z","message":"[DOCS][Known issue] Reporting failing in >= 9.0.0 when using `server.protocol: http2` (#230887)\n\nContributes to https://github.com/elastic/docs-content/issues/1991. Adds\na known issue to the 9.x known issues page about PDF and PNG reports\nfailing if users have set `server.protocol: http2` in their kibana.yml\nfile.\n\n**Corresponding 8.x updates**:\nhttps://github.com/elastic/kibana/pull/230894\n\n\n[Preview](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/230887/release-notes/known-issues)","sha":"8ad439580c8efbf69ccac34db4b746ea9c194699","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport missing","v9.0.0","backport:version","v9.1.0","v9.2.0"],"title":"[DOCS][Known issue] Reporting failing in >= 9.0.0 when using `server.protocol: http2`","number":230887,"url":"https://github.com/elastic/kibana/pull/230887","mergeCommit":{"message":"[DOCS][Known issue] Reporting failing in >= 9.0.0 when using `server.protocol: http2` (#230887)\n\nContributes to https://github.com/elastic/docs-content/issues/1991. Adds\na known issue to the 9.x known issues page about PDF and PNG reports\nfailing if users have set `server.protocol: http2` in their kibana.yml\nfile.\n\n**Corresponding 8.x updates**:\nhttps://github.com/elastic/kibana/pull/230894\n\n\n[Preview](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/230887/release-notes/known-issues)","sha":"8ad439580c8efbf69ccac34db4b746ea9c194699"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230887","number":230887,"mergeCommit":{"message":"[DOCS][Known issue] Reporting failing in >= 9.0.0 when using `server.protocol: http2` (#230887)\n\nContributes to https://github.com/elastic/docs-content/issues/1991. Adds\na known issue to the 9.x known issues page about PDF and PNG reports\nfailing if users have set `server.protocol: http2` in their kibana.yml\nfile.\n\n**Corresponding 8.x updates**:\nhttps://github.com/elastic/kibana/pull/230894\n\n\n[Preview](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/230887/release-notes/known-issues)","sha":"8ad439580c8efbf69ccac34db4b746ea9c194699"}}]}] BACKPORT-->