### PR TITLE
[ResponseOps][Reporting] reapply index mappings of reporting index at startup

### DIFF
--- a/src/platform/packages/private/kbn-reporting/server/constants.ts
+++ b/src/platform/packages/private/kbn-reporting/server/constants.ts
@@ -21,6 +21,8 @@ export const REPORTING_DATA_STREAM_WILDCARD = '.kibana-reporting*';
 export const REPORTING_LEGACY_INDICES = '.reporting-*';
 // Used to search for all reports and check for managing privileges
 export const REPORTING_DATA_STREAM_WILDCARD_WITH_LEGACY = '.reporting-*,.kibana-reporting*';
+// Name of index template
+export const REPORTING_DATA_STREAM_INDEX_TEMPLATE = '.kibana-reporting';
 // Name of component template which Kibana overrides for lifecycle settings
 export const REPORTING_DATA_STREAM_COMPONENT_TEMPLATE = 'kibana-reporting@custom';
 

--- a/x-pack/platform/plugins/private/reporting/server/lib/store/store.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/store/store.test.ts
@@ -497,6 +497,8 @@ describe('ReportingStore', () => {
         statefulSettings: { enabled: false },
       };
       mockCore = await createMockReportingCore(createMockConfigSchema(reportingConfig));
+      mockEsClient = (await mockCore.getEsClient()).asInternalUser as typeof mockEsClient;
+
       mockCallsForApplyingMapping(mockEsClient);
 
       const store = new TestReportingStore(mockCore, mockLogger);


### PR DESCRIPTION
resolves: https://github.com/elastic/kibana/issues/231200

This PR adds code run at startup to:

- read the `.kibana-reporting` index template to get the mappings
- apply those mappings directly to the write index of the `.kibana-reporting` data stream

This is needed for those times when the mappings change, for instance in this PR: https://github.com/elastic/elasticsearch/pull/129061.  The mappings do get updated, but are not applied to the data stream, so in fact the "new" fields (when updates happen) are not actually mapped in the existing data stream.

I was hoping to actually roll over the index, but it's not clear how we could determine if we need to, and we certainly don't want to do that on every restart.  Re-applying the mappings will ensure that any changes to the index template's mapping are made to the current index.

## Release note

Startup processing for reporting has changed to apply the current index template mappings to the kibana reporting index, if it exists.  This fixes a problem where a new field added to the index template, however it was not applied, so the field could not reliably used.  The field was `space_id`, which could cause reports in non-default spaces to not appear in the reports list.