### PR TITLE
[8.17] [CI] Fix Renovate helper bot trigger and out of sync labels (#231031)

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -134,13 +134,8 @@
       "skip_ci_labels": [],
       "enabled": true,
       "allow_org_users": true,
-      "allowed_repo_permissions": [
-        "admin",
-        "write"
-      ],
-      "allowed_list": [
-        "elastic-vault-github-plugin-prod[bot]"
-      ],
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["elastic-vault-github-plugin-prod[bot]", "elastic-renovate-prod[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "build_drafts": false,

--- a/.buildkite/scripts/steps/renovate/renovate_helper.sh
+++ b/.buildkite/scripts/steps/renovate/renovate_helper.sh
@@ -15,4 +15,11 @@ echo --- Additional helpers
 if [ "$GITHUB_PR_BRANCH" = "renovate/main-chainguard" ] && ! is_pr_with_label "ci:cloud-deploy"; then
   echo "Adding deploy label to main chainguard PR"
   gh api "repos/elastic/kibana/issues/${GITHUB_PR_NUMBER}/labels" --method POST -f "labels[]=ci:cloud-deploy" >/dev/null
+
+  # Sync GITHUB_PR_LABELS variable since we're passing it along to the PR pipeline
+  if [ -n "${GITHUB_PR_LABELS:-}" ]; then
+    export GITHUB_PR_LABELS="${GITHUB_PR_LABELS},ci:cloud-deploy"
+  else
+    export GITHUB_PR_LABELS="ci:cloud-deploy"
+  fi
 fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[CI] Fix Renovate helper bot trigger and out of sync labels (#231031)](https://github.com/elastic/kibana/pull/231031)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-08T17:00:42Z","message":"[CI] Fix Renovate helper bot trigger and out of sync labels (#231031)\n\n## Summary\n\nNote: I will backport this after backporting the original PR #228664. I\nwas waiting to see the stability of the original PR.\n\nFixes two issues:\n- The [pipeline](https://buildkite.com/elastic/kibana-renovate-helper)\nis not triggering for Renovate PRs, unless explicitly\n[commenting](https://github.com/elastic/kibana/pull/230882#issuecomment-3165286181)\nto run\n- Since we're passing along `GITHUB_PR_*` env variables to the PR\npipeline. Labels added in the helper pipeline to the PR itself were not\nin sync with the PR run. Example [this\nrun](https://buildkite.com/elastic/kibana-pull-request/builds/327690#019885d3-196a-4950-896c-3bf7de6f735f)\nshould have `ci:cloud-deploy` label.","sha":"f61e1a2bb618c2f0f7586acb61721c76b0102674","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:prev-major","backport:current-major","v9.2.0"],"title":"[CI] Fix Renovate helper bot trigger and out of sync labels","number":231031,"url":"https://github.com/elastic/kibana/pull/231031","mergeCommit":{"message":"[CI] Fix Renovate helper bot trigger and out of sync labels (#231031)\n\n## Summary\n\nNote: I will backport this after backporting the original PR #228664. I\nwas waiting to see the stability of the original PR.\n\nFixes two issues:\n- The [pipeline](https://buildkite.com/elastic/kibana-renovate-helper)\nis not triggering for Renovate PRs, unless explicitly\n[commenting](https://github.com/elastic/kibana/pull/230882#issuecomment-3165286181)\nto run\n- Since we're passing along `GITHUB_PR_*` env variables to the PR\npipeline. Labels added in the helper pipeline to the PR itself were not\nin sync with the PR run. Example [this\nrun](https://buildkite.com/elastic/kibana-pull-request/builds/327690#019885d3-196a-4950-896c-3bf7de6f735f)\nshould have `ci:cloud-deploy` label.","sha":"f61e1a2bb618c2f0f7586acb61721c76b0102674"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231031","number":231031,"mergeCommit":{"message":"[CI] Fix Renovate helper bot trigger and out of sync labels (#231031)\n\n## Summary\n\nNote: I will backport this after backporting the original PR #228664. I\nwas waiting to see the stability of the original PR.\n\nFixes two issues:\n- The [pipeline](https://buildkite.com/elastic/kibana-renovate-helper)\nis not triggering for Renovate PRs, unless explicitly\n[commenting](https://github.com/elastic/kibana/pull/230882#issuecomment-3165286181)\nto run\n- Since we're passing along `GITHUB_PR_*` env variables to the PR\npipeline. Labels added in the helper pipeline to the PR itself were not\nin sync with the PR run. Example [this\nrun](https://buildkite.com/elastic/kibana-pull-request/builds/327690#019885d3-196a-4950-896c-3bf7de6f735f)\nshould have `ci:cloud-deploy` label.","sha":"f61e1a2bb618c2f0f7586acb61721c76b0102674"}},{"url":"https://github.com/elastic/kibana/pull/231216","number":231216,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->