### PR TITLE
Implement "Center graph" button in Controls

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -55,6 +55,7 @@ export const entitySchema = schema.object({
 });
 
 export const nodeDocumentDataSchema = schema.object({
+  _id: schema.string(),
   id: schema.string(),
   type: schema.oneOf([schema.literal(DOCUMENT_TYPE_EVENT), schema.literal(DOCUMENT_TYPE_ALERT)]),
   index: schema.maybe(schema.string()),

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -122,6 +122,7 @@ export const entityNodeDataSchema = schema.allOf([
     ips: schema.maybe(schema.arrayOf(schema.string())),
     countryCodes: schema.maybe(schema.arrayOf(schema.string())),
     documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
+    hasOriginEvents: schema.maybe(schema.boolean()),
   }),
 ]);
 
@@ -141,6 +142,7 @@ export const labelNodeDataSchema = schema.allOf([
     ips: schema.maybe(schema.arrayOf(schema.string())),
     countryCodes: schema.maybe(schema.arrayOf(schema.string())),
     documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
+    hasOriginEvents: schema.maybe(schema.boolean()),
   }),
 ]);
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -55,10 +55,14 @@ export const entitySchema = schema.object({
 });
 
 export const nodeDocumentDataSchema = schema.object({
-  _id: schema.string(),
   id: schema.string(),
   type: schema.oneOf([schema.literal(DOCUMENT_TYPE_EVENT), schema.literal(DOCUMENT_TYPE_ALERT)]),
   index: schema.maybe(schema.string()),
+  event: schema.maybe(
+    schema.object({
+      id: schema.string(),
+    })
+  ),
   alert: schema.maybe(
     schema.object({
       ruleName: schema.maybe(schema.string()),

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -122,7 +122,6 @@ export const entityNodeDataSchema = schema.allOf([
     ips: schema.maybe(schema.arrayOf(schema.string())),
     countryCodes: schema.maybe(schema.arrayOf(schema.string())),
     documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
-    hasOriginEvents: schema.maybe(schema.boolean()),
   }),
 ]);
 
@@ -142,7 +141,8 @@ export const labelNodeDataSchema = schema.allOf([
     ips: schema.maybe(schema.arrayOf(schema.string())),
     countryCodes: schema.maybe(schema.arrayOf(schema.string())),
     documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
-    hasOriginEvents: schema.maybe(schema.boolean()),
+    isOrigin: schema.maybe(schema.boolean()),
+    isOriginAlert: schema.maybe(schema.boolean()),
   }),
 ]);
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -141,8 +141,6 @@ export const labelNodeDataSchema = schema.allOf([
     ips: schema.maybe(schema.arrayOf(schema.string())),
     countryCodes: schema.maybe(schema.arrayOf(schema.string())),
     documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
-    isOrigin: schema.maybe(schema.boolean()),
-    isOriginAlert: schema.maybe(schema.boolean()),
   }),
 ]);
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.integration.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.integration.test.tsx
@@ -44,8 +44,8 @@ describe('Controls integration with Graph', () => {
     useStoreMock.mockReturnValue({ minZoomReached: false, maxZoomReached: false });
   });
 
-  describe('center graph to nodes with hasOriginEvents flag', () => {
-    it('should render center button when all nodes have hasOriginEvents set to true', async () => {
+  describe('center graph on nodes with isOrigin or isOriginAlert flags', () => {
+    it('should render center button when some nodes have isOrigin set to true', async () => {
       renderGraphPreview({
         nodes: [
           {
@@ -53,21 +53,19 @@ describe('Controls integration with Graph', () => {
             label: 'Node 1',
             color: 'primary',
             shape: 'hexagon',
-            hasOriginEvents: true,
           },
           {
             id: 'node2',
-            label: 'Node 2',
+            label: 'Label Node',
             color: 'primary',
-            shape: 'rectangle',
-            hasOriginEvents: true,
+            shape: 'label',
+            isOrigin: true,
           },
           {
             id: 'node3',
             label: 'Node 3',
             color: 'primary',
             shape: 'ellipse',
-            hasOriginEvents: true,
           },
         ],
         edges: [],
@@ -79,7 +77,7 @@ describe('Controls integration with Graph', () => {
       });
     });
 
-    it('should render center button when some nodes have hasOriginEvents set to true', async () => {
+    it('should render center button when some nodes have isOriginAlert set to true', async () => {
       renderGraphPreview({
         nodes: [
           {
@@ -87,21 +85,19 @@ describe('Controls integration with Graph', () => {
             label: 'Node 1',
             color: 'primary',
             shape: 'hexagon',
-            hasOriginEvents: true,
           },
           {
             id: 'node2',
-            label: 'Node 2',
-            color: 'primary',
-            shape: 'rectangle',
-            hasOriginEvents: false,
+            label: 'Label Node',
+            color: 'danger',
+            shape: 'label',
+            isOriginAlert: true,
           },
           {
             id: 'node3',
             label: 'Node 3',
             color: 'primary',
             shape: 'ellipse',
-            // hasOriginEvents undefined (should be treated as false)
           },
         ],
         edges: [],
@@ -113,7 +109,7 @@ describe('Controls integration with Graph', () => {
       });
     });
 
-    it('should not render center button when no nodes have hasOriginEvents set to true', async () => {
+    it('should not render center button when no nodes have isOrigin or isOriginAlert set to true', async () => {
       renderGraphPreview({
         nodes: [
           {
@@ -121,21 +117,19 @@ describe('Controls integration with Graph', () => {
             label: 'Node 1',
             color: 'primary',
             shape: 'hexagon',
-            hasOriginEvents: false,
           },
           {
             id: 'node2',
             label: 'Node 2',
-            color: 'primary',
-            shape: 'rectangle',
-            hasOriginEvents: false,
+            color: 'danger',
+            shape: 'label',
+            // undefined isOrigin and isOriginAlert should be treated as false
           },
           {
             id: 'node3',
             label: 'Node 3',
             color: 'primary',
             shape: 'ellipse',
-            // hasOriginEvents undefined (should be treated as false)
           },
         ],
         edges: [],
@@ -159,49 +153,58 @@ describe('Controls integration with Graph', () => {
       });
     });
 
-    it('should center graph to only nodes with hasOriginEvents=true regardless of edge connections when center button is clicked', async () => {
+    it('should center graph on only nodes with isOrigin=true or isOriginAlert=true regardless of edge connections when center button is clicked', async () => {
       renderGraphPreview({
         nodes: [
           {
-            id: 'origin1',
-            label: 'Origin Node 1',
+            id: 'actor',
+            label: 'Actor Node',
             color: 'primary',
             shape: 'hexagon',
-            hasOriginEvents: true,
           },
           {
-            id: 'regular1',
-            label: 'Regular Node 1',
+            id: 'originEvent',
+            label: 'Origin Event',
             color: 'primary',
-            shape: 'rectangle',
-            hasOriginEvents: false,
+            shape: 'label',
+            isOrigin: true,
           },
           {
-            id: 'origin2',
-            label: 'Origin Node 2',
+            id: 'originAlert',
+            label: 'Origin Alert',
+            color: 'danger',
+            shape: 'label',
+            isOriginAlert: true,
+          },
+          {
+            id: 'noOriginEvent',
+            label: 'No Origin Event',
+            color: 'primary',
+            shape: 'label',
+          },
+          {
+            id: 'noOriginAlert',
+            label: 'No Origin Alert',
+            color: 'danger',
+            shape: 'label',
+          },
+          {
+            id: 'target',
+            label: 'Target Node',
             color: 'primary',
             shape: 'ellipse',
-            hasOriginEvents: true,
-          },
-          {
-            id: 'regular2',
-            label: 'Regular Node 2',
-            color: 'primary',
-            shape: 'diamond',
-            // hasOriginEvents undefined
-          },
-          {
-            id: 'origin3-isolated',
-            label: 'Regular Node 2',
-            color: 'primary',
-            shape: 'diamond',
-            hasOriginEvents: true,
           },
         ],
         edges: [
-          { id: 'edge1', color: 'primary', source: 'origin1', target: 'regular1' },
-          { id: 'edge2', color: 'primary', source: 'origin1', target: 'origin2' },
-          { id: 'edge1', color: 'primary', source: 'regular1', target: 'regular2' },
+          { id: 'actorToLabel1', color: 'primary', source: 'actor', target: 'originEvent' },
+          { id: 'actorToLabel2', color: 'primary', source: 'actor', target: 'originAlert' },
+          { id: 'actorToLabel3', color: 'primary', source: 'actor', target: 'noOriginEvent' },
+          { id: 'actorToLabel4', color: 'primary', source: 'actor', target: 'noOriginAlert' },
+
+          { id: 'labelToTarget1', color: 'primary', source: 'originEvent', target: 'target' },
+          { id: 'labelToTarget2', color: 'primary', source: 'originAlert', target: 'target' },
+          { id: 'labelToTarget3', color: 'primary', source: 'noOriginEvent', target: 'target' },
+          { id: 'labelToTarget4', color: 'primary', source: 'noOriginAlert', target: 'target' },
         ],
         interactive: true,
       });
@@ -215,10 +218,9 @@ describe('Controls integration with Graph', () => {
       });
 
       await waitFor(() => {
-        // Should only center on nodes with hasOriginEvents=true
         expect(useReactFlowMock().fitView).toHaveBeenCalledWith({
           duration: 200,
-          nodes: [{ id: 'origin1' }, { id: 'origin2' }, { id: 'origin3-isolated' }],
+          nodes: [{ id: 'originEvent' }, { id: 'originAlert' }],
         });
       });
     });
@@ -228,10 +230,10 @@ describe('Controls integration with Graph', () => {
         nodes: [
           {
             id: 'node1',
-            label: 'Node 1',
+            label: 'Label Node 1',
             color: 'primary',
-            shape: 'hexagon',
-            hasOriginEvents: false,
+            shape: 'label',
+            isOrigin: false,
           },
         ],
         edges: [],
@@ -243,17 +245,16 @@ describe('Controls integration with Graph', () => {
         expect(screen.queryByTestId(GRAPH_CONTROLS_CENTER_ID)).not.toBeInTheDocument();
       });
 
-      // Update node to have hasOriginEvents=true
       rerender(
         <TestProviders>
           <Graph
             nodes={[
               {
                 id: 'node1',
-                label: 'Node 1',
+                label: 'Label Node 1',
                 color: 'primary',
-                shape: 'hexagon',
-                hasOriginEvents: true,
+                shape: 'label',
+                isOrigin: true,
               },
             ]}
             edges={[]}
@@ -275,10 +276,10 @@ describe('Controls integration with Graph', () => {
         nodes: [
           {
             id: 'node1',
-            label: 'Node 1',
+            label: 'Label Node 1',
             color: 'primary',
-            shape: 'hexagon',
-            hasOriginEvents: true,
+            shape: 'label',
+            isOrigin: true,
           },
         ],
         edges: [],
@@ -298,10 +299,10 @@ describe('Controls integration with Graph', () => {
         nodes: [
           {
             id: 'node1',
-            label: 'Node 1',
+            label: 'Label Node 1',
             color: 'primary',
-            shape: 'hexagon',
-            hasOriginEvents: true,
+            shape: 'label',
+            isOrigin: true,
           },
         ],
         edges: [],

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.integration.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.integration.test.tsx
@@ -1,0 +1,361 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { useReactFlow, useStore } from '@xyflow/react';
+import { Graph, type GraphProps } from '../graph/graph';
+import { TestProviders } from '../mock/test_providers';
+import {
+  GRAPH_CONTROLS_CENTER_ID,
+  GRAPH_CONTROLS_FIT_VIEW_ID,
+  GRAPH_CONTROLS_ZOOM_IN_ID,
+  GRAPH_CONTROLS_ZOOM_OUT_ID,
+} from '../test_ids';
+
+jest.mock('@xyflow/react', () => ({
+  ...jest.requireActual('@xyflow/react'),
+  useReactFlow: jest.fn(),
+  useStore: jest.fn(),
+}));
+
+const useReactFlowMock = useReactFlow as jest.Mock;
+const useStoreMock = useStore as jest.Mock;
+
+describe('Controls integration with Graph', () => {
+  const renderGraphPreview = (props: GraphProps) =>
+    render(
+      <TestProviders>
+        <Graph {...props} />
+      </TestProviders>
+    );
+
+  beforeEach(() => {
+    useReactFlowMock.mockReturnValue({
+      zoomIn: jest.fn(),
+      zoomOut: jest.fn(),
+      fitView: jest.fn(),
+    });
+
+    useStoreMock.mockReturnValue({ minZoomReached: false, maxZoomReached: false });
+  });
+
+  describe('center graph to nodes with hasOriginEvents flag', () => {
+    it('should render center button when all nodes have hasOriginEvents set to true', async () => {
+      renderGraphPreview({
+        nodes: [
+          {
+            id: 'node1',
+            label: 'Node 1',
+            color: 'primary',
+            shape: 'hexagon',
+            hasOriginEvents: true,
+          },
+          {
+            id: 'node2',
+            label: 'Node 2',
+            color: 'primary',
+            shape: 'rectangle',
+            hasOriginEvents: true,
+          },
+          {
+            id: 'node3',
+            label: 'Node 3',
+            color: 'primary',
+            shape: 'ellipse',
+            hasOriginEvents: true,
+          },
+        ],
+        edges: [],
+        interactive: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId(GRAPH_CONTROLS_CENTER_ID)).toBeInTheDocument();
+      });
+    });
+
+    it('should render center button when some nodes have hasOriginEvents set to true', async () => {
+      renderGraphPreview({
+        nodes: [
+          {
+            id: 'node1',
+            label: 'Node 1',
+            color: 'primary',
+            shape: 'hexagon',
+            hasOriginEvents: true,
+          },
+          {
+            id: 'node2',
+            label: 'Node 2',
+            color: 'primary',
+            shape: 'rectangle',
+            hasOriginEvents: false,
+          },
+          {
+            id: 'node3',
+            label: 'Node 3',
+            color: 'primary',
+            shape: 'ellipse',
+            // hasOriginEvents undefined (should be treated as false)
+          },
+        ],
+        edges: [],
+        interactive: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId(GRAPH_CONTROLS_CENTER_ID)).toBeInTheDocument();
+      });
+    });
+
+    it('should not render center button when no nodes have hasOriginEvents set to true', async () => {
+      renderGraphPreview({
+        nodes: [
+          {
+            id: 'node1',
+            label: 'Node 1',
+            color: 'primary',
+            shape: 'hexagon',
+            hasOriginEvents: false,
+          },
+          {
+            id: 'node2',
+            label: 'Node 2',
+            color: 'primary',
+            shape: 'rectangle',
+            hasOriginEvents: false,
+          },
+          {
+            id: 'node3',
+            label: 'Node 3',
+            color: 'primary',
+            shape: 'ellipse',
+            // hasOriginEvents undefined (should be treated as false)
+          },
+        ],
+        edges: [],
+        interactive: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(GRAPH_CONTROLS_CENTER_ID)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not render center button when nodes array is empty', async () => {
+      renderGraphPreview({
+        nodes: [],
+        edges: [],
+        interactive: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(GRAPH_CONTROLS_CENTER_ID)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should center graph to only nodes with hasOriginEvents=true regardless of edge connections when center button is clicked', async () => {
+      renderGraphPreview({
+        nodes: [
+          {
+            id: 'origin1',
+            label: 'Origin Node 1',
+            color: 'primary',
+            shape: 'hexagon',
+            hasOriginEvents: true,
+          },
+          {
+            id: 'regular1',
+            label: 'Regular Node 1',
+            color: 'primary',
+            shape: 'rectangle',
+            hasOriginEvents: false,
+          },
+          {
+            id: 'origin2',
+            label: 'Origin Node 2',
+            color: 'primary',
+            shape: 'ellipse',
+            hasOriginEvents: true,
+          },
+          {
+            id: 'regular2',
+            label: 'Regular Node 2',
+            color: 'primary',
+            shape: 'diamond',
+            // hasOriginEvents undefined
+          },
+          {
+            id: 'origin3-isolated',
+            label: 'Regular Node 2',
+            color: 'primary',
+            shape: 'diamond',
+            hasOriginEvents: true,
+          },
+        ],
+        edges: [
+          { id: 'edge1', color: 'primary', source: 'origin1', target: 'regular1' },
+          { id: 'edge2', color: 'primary', source: 'origin1', target: 'origin2' },
+          { id: 'edge1', color: 'primary', source: 'regular1', target: 'regular2' },
+        ],
+        interactive: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId(GRAPH_CONTROLS_CENTER_ID)).toBeInTheDocument();
+      });
+
+      await act(() => {
+        fireEvent.click(screen.getByTestId(GRAPH_CONTROLS_CENTER_ID));
+      });
+
+      await waitFor(() => {
+        // Should only center on nodes with hasOriginEvents=true
+        expect(useReactFlowMock().fitView).toHaveBeenCalledWith({
+          duration: 200,
+          nodes: [{ id: 'origin1' }, { id: 'origin2' }, { id: 'origin3-isolated' }],
+        });
+      });
+    });
+
+    it('should update center button visibility when nodes change dynamically', async () => {
+      const { rerender } = renderGraphPreview({
+        nodes: [
+          {
+            id: 'node1',
+            label: 'Node 1',
+            color: 'primary',
+            shape: 'hexagon',
+            hasOriginEvents: false,
+          },
+        ],
+        edges: [],
+        interactive: true,
+      });
+
+      await waitFor(() => {
+        // Initially no center button
+        expect(screen.queryByTestId(GRAPH_CONTROLS_CENTER_ID)).not.toBeInTheDocument();
+      });
+
+      // Update node to have hasOriginEvents=true
+      rerender(
+        <TestProviders>
+          <Graph
+            nodes={[
+              {
+                id: 'node1',
+                label: 'Node 1',
+                color: 'primary',
+                shape: 'hexagon',
+                hasOriginEvents: true,
+              },
+            ]}
+            edges={[]}
+            interactive={true}
+          />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        // Now center button should appear
+        expect(screen.getByTestId(GRAPH_CONTROLS_CENTER_ID)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Controls visibility', () => {
+    it('should not render controls when graph is non-interactive', async () => {
+      renderGraphPreview({
+        nodes: [
+          {
+            id: 'node1',
+            label: 'Node 1',
+            color: 'primary',
+            shape: 'hexagon',
+            hasOriginEvents: true,
+          },
+        ],
+        edges: [],
+        interactive: false,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(GRAPH_CONTROLS_ZOOM_IN_ID)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(GRAPH_CONTROLS_ZOOM_OUT_ID)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(GRAPH_CONTROLS_FIT_VIEW_ID)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(GRAPH_CONTROLS_CENTER_ID)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should render controls when graph is interactive but locked', async () => {
+      renderGraphPreview({
+        nodes: [
+          {
+            id: 'node1',
+            label: 'Node 1',
+            color: 'primary',
+            shape: 'hexagon',
+            hasOriginEvents: true,
+          },
+        ],
+        edges: [],
+        interactive: true,
+        isLocked: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(GRAPH_CONTROLS_ZOOM_IN_ID)).toBeInTheDocument();
+        expect(screen.queryByTestId(GRAPH_CONTROLS_ZOOM_OUT_ID)).toBeInTheDocument();
+        expect(screen.queryByTestId(GRAPH_CONTROLS_FIT_VIEW_ID)).toBeInTheDocument();
+        expect(screen.queryByTestId(GRAPH_CONTROLS_CENTER_ID)).toBeInTheDocument();
+      });
+
+      await act(() => {
+        // Zoom-in button should still work when locked
+        fireEvent.click(screen.getByTestId(GRAPH_CONTROLS_ZOOM_IN_ID));
+      });
+      await waitFor(() => {
+        expect(useReactFlowMock().zoomIn).toHaveBeenCalledWith({
+          duration: 200,
+        });
+      });
+
+      await act(() => {
+        // Zoom-out button should still work when locked
+        fireEvent.click(screen.getByTestId(GRAPH_CONTROLS_ZOOM_OUT_ID));
+      });
+      await waitFor(() => {
+        expect(useReactFlowMock().zoomOut).toHaveBeenCalledWith({
+          duration: 200,
+        });
+      });
+
+      await act(() => {
+        // Fit-view button should still work when locked
+        fireEvent.click(screen.getByTestId(GRAPH_CONTROLS_FIT_VIEW_ID));
+      });
+      await waitFor(() => {
+        expect(useReactFlowMock().fitView).toHaveBeenCalledWith({
+          duration: 200,
+        });
+      });
+
+      await act(() => {
+        // Center button should still work when locked
+        fireEvent.click(screen.getByTestId(GRAPH_CONTROLS_CENTER_ID));
+      });
+      await waitFor(() => {
+        expect(useReactFlowMock().fitView).toHaveBeenCalledWith({
+          duration: 200,
+          nodes: [{ id: 'node1' }],
+        });
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.stories.tsx
@@ -40,8 +40,10 @@ export default {
     showFitView: {
       control: { type: 'boolean' },
     },
-    showCenter: {
-      control: { type: 'boolean' },
+    nodeIdsToCenterOn: {
+      control: { type: 'object' },
+      description:
+        'Array of origin node IDs (nodes that have hasOriginEvents=true) the graph must center on',
     },
   },
   decorators: [GlobalStylesStorybookDecorator],
@@ -51,6 +53,7 @@ export const Controls: StoryObj<ControlsProps> = {
   args: {
     showZoom: true,
     showFitView: true,
-    showCenter: true,
+    nodeIdsToCenterOn: ['node1', 'node2'],
+    fitViewOptions: { duration: 200 },
   },
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.stories.tsx
@@ -43,7 +43,7 @@ export default {
     nodeIdsToCenterOn: {
       control: { type: 'object' },
       description:
-        'Array of origin node IDs (nodes that have hasOriginEvents=true) the graph must center on',
+        'Array of origin node IDs (nodes that have isOrigin=true or isOriginAlert=true) the graph must center on',
     },
   },
   decorators: [GlobalStylesStorybookDecorator],

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.test.tsx
@@ -7,15 +7,14 @@
 
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import type { ControlsProps } from './controls';
-import { Controls } from './controls';
-import { EuiThemeProvider } from '@elastic/eui';
+import userEvent from '@testing-library/user-event';
 import { useStore, useReactFlow } from '@xyflow/react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { Controls, type ControlsProps } from './controls';
 
 const defaultProps: ControlsProps = {
   showZoom: true,
   showFitView: true,
-  showCenter: true,
 };
 
 jest.mock('@xyflow/react', () => ({
@@ -45,76 +44,306 @@ describe('Controls', () => {
     useStoreMock.mockReturnValue({ minZoomReached: false, maxZoomReached: false });
   });
 
-  it('renders zoom in and zoom out buttons', () => {
-    const { getByLabelText } = renderWithProviders();
-    expect(getByLabelText('Zoom in')).toBeInTheDocument();
-    expect(getByLabelText('Zoom out')).toBeInTheDocument();
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('renders fit view button', () => {
-    const { getByLabelText } = renderWithProviders();
-    expect(getByLabelText('Fit view')).toBeInTheDocument();
+  describe('container', () => {
+    it('should render null when no control buttons are visible', () => {
+      const { container } = renderWithProviders({
+        showZoom: false,
+        showFitView: false,
+        nodeIdsToCenterOn: [],
+      });
+
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 
-  it('renders center button', () => {
-    const { getByLabelText } = renderWithProviders();
-    expect(getByLabelText('Center')).toBeInTheDocument();
+  describe('zoom', () => {
+    it('renders zoom in and zoom out buttons', () => {
+      const { getByLabelText } = renderWithProviders();
+      expect(getByLabelText('Zoom in')).toBeInTheDocument();
+      expect(getByLabelText('Zoom out')).toBeInTheDocument();
+    });
+
+    it('hides zoom in and zoom out buttons if showZoom is false', () => {
+      const { queryByLabelText } = renderWithProviders({ showZoom: false });
+      expect(queryByLabelText('Zoom in')).not.toBeInTheDocument();
+      expect(queryByLabelText('Zoom out')).not.toBeInTheDocument();
+    });
+
+    it('calls onZoomIn when zoom in button is clicked', () => {
+      const onZoomIn = jest.fn();
+      const { getByLabelText } = renderWithProviders({ ...defaultProps, onZoomIn });
+
+      fireEvent.click(getByLabelText('Zoom in'));
+
+      expect(useReactFlowMock().zoomIn).toHaveBeenCalled();
+      expect(onZoomIn).toHaveBeenCalled();
+    });
+
+    it('calls onZoomOut when zoom out button is clicked', () => {
+      const onZoomOut = jest.fn();
+      const { getByLabelText } = renderWithProviders({ ...defaultProps, onZoomOut });
+
+      fireEvent.click(getByLabelText('Zoom out'));
+
+      expect(useReactFlowMock().zoomOut).toHaveBeenCalled();
+      expect(onZoomOut).toHaveBeenCalled();
+    });
+
+    it('disables zoom in button when max zoom is reached', () => {
+      useStoreMock.mockReturnValue({ minZoomReached: false, maxZoomReached: true });
+
+      const { getByLabelText } = renderWithProviders();
+
+      const zoomInButton = getByLabelText('Zoom in');
+      expect(zoomInButton).toBeDisabled();
+    });
+
+    it('disables zoom out button when min zoom is reached', () => {
+      useStoreMock.mockReturnValue({ minZoomReached: true, maxZoomReached: false });
+
+      const { getByLabelText } = renderWithProviders();
+
+      const zoomOutButton = getByLabelText('Zoom out');
+      expect(zoomOutButton).toBeDisabled();
+    });
   });
 
-  it('calls onZoomIn when zoom in button is clicked', () => {
-    const onZoomIn = jest.fn();
-    const { getByLabelText } = renderWithProviders({ ...defaultProps, onZoomIn });
+  describe('fit view', () => {
+    it('renders fit view button', () => {
+      const { getByLabelText } = renderWithProviders();
+      expect(getByLabelText('Fit view')).toBeInTheDocument();
+    });
 
-    fireEvent.click(getByLabelText('Zoom in'));
+    it('hides fit view button', () => {
+      const { queryByLabelText } = renderWithProviders({ showFitView: false });
+      expect(queryByLabelText('Fit view')).not.toBeInTheDocument();
+    });
 
-    expect(useReactFlowMock().zoomIn).toHaveBeenCalled();
-    expect(onZoomIn).toHaveBeenCalled();
+    it('calls onFitView when fit view button is clicked', () => {
+      const onFitView = jest.fn();
+      const fitViewOptions = { duration: 200 };
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        onFitView,
+        fitViewOptions,
+      });
+
+      fireEvent.click(getByLabelText('Fit view'));
+
+      expect(useReactFlowMock().fitView).toHaveBeenCalledWith(fitViewOptions);
+      expect(onFitView).toHaveBeenCalled();
+    });
   });
 
-  it('calls onZoomOut when zoom out button is clicked', () => {
-    const onZoomOut = jest.fn();
-    const { getByLabelText } = renderWithProviders({ ...defaultProps, onZoomOut });
+  describe('center', () => {
+    it('hides center button by default', () => {
+      const { queryByLabelText } = renderWithProviders();
+      expect(queryByLabelText('Center')).not.toBeInTheDocument();
+    });
 
-    fireEvent.click(getByLabelText('Zoom out'));
+    it('hides center button when nodeIdsToCenterOn is null', () => {
+      const { queryByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: null as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      });
 
-    expect(useReactFlowMock().zoomOut).toHaveBeenCalled();
-    expect(onZoomOut).toHaveBeenCalled();
+      expect(queryByLabelText('Center')).not.toBeInTheDocument();
+    });
+
+    it('hides center button when nodeIdsToCenterOn is undefined', () => {
+      const { queryByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: undefined,
+      });
+
+      expect(queryByLabelText('Center')).not.toBeInTheDocument();
+    });
+
+    it('hides center button when nodeIdsToCenterOn is empty array', () => {
+      const { queryByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: [],
+      });
+
+      expect(queryByLabelText('Center')).not.toBeInTheDocument();
+    });
+
+    it('hides center button when nodeIdsToCenterOn contains only empty or whitespace strings', () => {
+      const { queryByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: ['', '   ', '\t', '\n', '  ', '\u00A0', '\u2000', '\u2028'],
+      });
+
+      expect(queryByLabelText('Center')).not.toBeInTheDocument();
+    });
+
+    it('renders center button when nodeIdsToCenterOn is populated', () => {
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: ['node1'], // Need at least one non-empty node ID for center button to render
+      });
+      expect(getByLabelText('Center')).toBeInTheDocument();
+    });
+
+    it('renders center button when nodeIdsToCenterOn contains mix of empty and non-empty IDs', () => {
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: ['', 'node1', '  ', 'node2', ''],
+      });
+
+      expect(getByLabelText('Center')).toBeInTheDocument();
+    });
+
+    it('calls onCenter and centers graph on selected node IDs when center button is clicked', () => {
+      const onCenter = jest.fn();
+      const fitViewOptions = { duration: 200 };
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        onCenter,
+        fitViewOptions,
+        nodeIdsToCenterOn: ['node1', 'node2'],
+      });
+
+      fireEvent.click(getByLabelText('Center'));
+
+      expect(useReactFlowMock().fitView).toHaveBeenCalledWith({
+        ...fitViewOptions,
+        nodes: [{ id: 'node1' }, { id: 'node2' }],
+      });
+      expect(onCenter).toHaveBeenCalled();
+    });
+
+    it('calls onCenter and centers graph on selected, non-empty node IDs when center button is clicked', () => {
+      const onCenter = jest.fn();
+      const fitViewOptions = { duration: 200 };
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        onCenter,
+        fitViewOptions,
+        nodeIdsToCenterOn: ['', 'node1', '  ', 'node2', ''],
+      });
+
+      fireEvent.click(getByLabelText('Center'));
+
+      expect(useReactFlowMock().fitView).toHaveBeenCalledWith({
+        ...fitViewOptions,
+        nodes: [{ id: 'node1' }, { id: 'node2' }],
+      });
+      expect(onCenter).toHaveBeenCalled();
+    });
+
+    it('should memoize node filtering correctly', () => {
+      const nodeIds = ['node1', 'node2', '', 'node3', '   '];
+
+      const { rerender, getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: nodeIds,
+      });
+
+      const centerButton = getByLabelText('Center');
+      fireEvent.click(centerButton);
+
+      const firstCall = useReactFlowMock().fitView.mock.calls[0][0];
+
+      // Re-render with same nodeIds reference
+      rerender(
+        <EuiThemeProvider>
+          <Controls {...defaultProps} nodeIdsToCenterOn={nodeIds} />
+        </EuiThemeProvider>
+      );
+
+      const newCenterButton = getByLabelText('Center');
+      fireEvent.click(newCenterButton);
+
+      const secondCall = useReactFlowMock().fitView.mock.calls[1][0];
+
+      // Should produce same array object (memoization working)
+      // That's why we use `toBe` vs `toEqual` here
+      expect(firstCall.nodes).toBe(secondCall.nodes);
+    });
   });
 
-  it('calls onFitView when fit view button is clicked', () => {
-    const onFitView = jest.fn();
-    const { getByLabelText } = renderWithProviders({ ...defaultProps, onFitView });
+  describe('fitViewOptions', () => {
+    it('handles undefined fitViewOptions', () => {
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        fitViewOptions: undefined,
+      });
 
-    fireEvent.click(getByLabelText('Fit view'));
+      fireEvent.click(getByLabelText('Fit view'));
 
-    expect(useReactFlowMock().fitView).toHaveBeenCalled();
-    expect(onFitView).toHaveBeenCalled();
+      expect(useReactFlowMock().fitView).toHaveBeenCalledWith(undefined);
+    });
+
+    it('handles empty fitViewOptions object', () => {
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        fitViewOptions: {},
+      });
+
+      fireEvent.click(getByLabelText('Fit view'));
+
+      expect(useReactFlowMock().fitView).toHaveBeenCalledWith({});
+    });
   });
 
-  it('calls onCenter when center button is clicked', () => {
-    const onCenter = jest.fn();
-    const { getByLabelText } = renderWithProviders({ ...defaultProps, onCenter });
+  describe('accessibility and user interaction edge cases', () => {
+    it('should handle keyboard navigation correctly', async () => {
+      const user = userEvent.setup();
 
-    fireEvent.click(getByLabelText('Center'));
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: ['node1'],
+      });
 
-    expect(onCenter).toHaveBeenCalled();
-  });
+      const zoomInButton = getByLabelText('Zoom in');
+      const zoomOutButton = getByLabelText('Zoom out');
+      const centerButton = getByLabelText('Center');
+      const fitViewButton = getByLabelText('Fit view');
 
-  it('disables zoom in button when max zoom is reached', () => {
-    useStoreMock.mockReturnValue({ minZoomReached: false, maxZoomReached: true });
+      // Test tab navigation and keyboard activation - zoom in
+      await user.tab();
+      expect(document.activeElement).toBe(zoomInButton);
+      // Test keyboard activation
+      await user.keyboard('{Enter}');
+      expect(useReactFlowMock().zoomIn).toHaveBeenCalled();
 
-    const { getByLabelText } = renderWithProviders();
+      // Test tab navigation and keyboard activation - zoom out
+      await user.tab();
+      expect(document.activeElement).toBe(zoomOutButton);
+      await user.keyboard('{Enter}');
+      expect(useReactFlowMock().zoomOut).toHaveBeenCalled();
 
-    const zoomInButton = getByLabelText('Zoom in');
-    expect(zoomInButton).toBeDisabled();
-  });
+      // Test tab navigation and keyboard activation - center
+      await user.tab();
+      expect(document.activeElement).toBe(centerButton);
+      await user.keyboard('{Enter}');
+      expect(useReactFlowMock().fitView).toHaveBeenCalled();
 
-  it('disables zoom out button when min zoom is reached', () => {
-    useStoreMock.mockReturnValue({ minZoomReached: true, maxZoomReached: false });
+      // Test tab navigation and keyboard activation - fit view
+      await user.tab();
+      expect(document.activeElement).toBe(fitViewButton);
+      await user.keyboard('{Enter}');
+      expect(useReactFlowMock().fitView).toHaveBeenCalled();
+    });
 
-    const { getByLabelText } = renderWithProviders();
+    it('should have proper accessible names', () => {
+      const { getByLabelText } = renderWithProviders({
+        ...defaultProps,
+        nodeIdsToCenterOn: ['node1'],
+      });
 
-    const zoomOutButton = getByLabelText('Zoom out');
-    expect(zoomOutButton).toBeDisabled();
+      const zoomInButton = getByLabelText('Zoom in');
+      const centerButton = getByLabelText('Center');
+      const fitViewButton = getByLabelText('Fit view');
+
+      expect(zoomInButton).toHaveAccessibleName('Zoom in');
+      expect(centerButton).toHaveAccessibleName('Center');
+      expect(fitViewButton).toHaveAccessibleName('Fit view');
+    });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.tsx
@@ -117,9 +117,9 @@ export const Graph = memo<GraphProps>(
     const [nodesState, setNodes, onNodesChange] = useNodesState<Node<NodeViewModel>>([]);
     const [edgesState, setEdges, onEdgesChange] = useEdgesState<Edge<EdgeViewModel>>([]);
 
-    // Filter the ids of those nodes that have origin events
-    const nodesWithOriginEvents = useMemo(
-      () => nodes.filter((node) => node.hasOriginEvents).map((node) => node.id),
+    // Filter the ids of those nodes that are origin events
+    const originNodeIds = useMemo(
+      () => nodes.filter((node) => node.isOrigin || node.isOriginAlert).map((node) => node.id),
       [nodes]
     );
 
@@ -189,7 +189,7 @@ export const Graph = memo<GraphProps>(
         >
           {interactive && (
             <Panel position="bottom-right">
-              <Controls fitViewOptions={fitViewOptions} nodeIdsToCenterOn={nodesWithOriginEvents} />
+              <Controls fitViewOptions={fitViewOptions} nodeIdsToCenterOn={originNodeIds} />
             </Panel>
           )}
           {children}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useCallback, useEffect, useRef, memo } from 'react';
+import React, { useState, useCallback, useEffect, useRef, memo, useMemo } from 'react';
 import { size, isEmpty, isEqual, xorWith } from 'lodash';
 import {
   Background,
@@ -117,6 +117,12 @@ export const Graph = memo<GraphProps>(
     const [nodesState, setNodes, onNodesChange] = useNodesState<Node<NodeViewModel>>([]);
     const [edgesState, setEdges, onEdgesChange] = useEdgesState<Edge<EdgeViewModel>>([]);
 
+    // Filter the ids of those nodes that have origin events
+    const nodesWithOriginEvents = useMemo(
+      () => nodes.filter((node) => node.hasOriginEvents).map((node) => node.id),
+      [nodes]
+    );
+
     useEffect(() => {
       // On nodes or edges changes reset the graph and re-layout
       if (
@@ -183,7 +189,7 @@ export const Graph = memo<GraphProps>(
         >
           {interactive && (
             <Panel position="bottom-right">
-              <Controls fitViewOptions={fitViewOptions} showCenter={false} />
+              <Controls fitViewOptions={fitViewOptions} nodeIdsToCenterOn={nodesWithOriginEvents} />
             </Panel>
           )}
           {children}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_centering.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_centering.stories.tsx
@@ -70,7 +70,6 @@ const meta: Meta<GraphCenteringStoryProps> = {
 export default meta;
 type Story = StoryObj<GraphCenteringStoryProps>;
 
-// Helper for regular entity nodes (never origin / origin alert)
 const createEntityNode = ({
   id,
   shape = 'ellipse',
@@ -85,7 +84,6 @@ const createEntityNode = ({
     label: `Entity ${id}`,
     color,
     shape,
-    // entity nodes should NOT have origin flags
     isOrigin: false,
     isOriginAlert: false,
     icon:
@@ -98,7 +96,6 @@ const createEntityNode = ({
         : 'globe',
   } as NodeViewModel);
 
-// Helper for label nodes that can be either origin or origin alert
 const createLabelNode = ({
   id,
   isOrigin = false,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_centering.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_centering.stories.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ThemeProvider, css } from '@emotion/react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiPanel } from '@elastic/eui';
+import { Graph } from './graph/graph';
+import type { NodeViewModel, EdgeViewModel } from './types';
+import { GlobalStylesStorybookDecorator } from '../../.storybook/decorators';
+
+type GraphCenteringStoryProps = React.ComponentProps<typeof Graph> & {
+  title?: string;
+  description?: string;
+};
+
+const meta: Meta<GraphCenteringStoryProps> = {
+  title: 'Components/Graph Components/Graph Centering',
+  render: ({ title, description, nodes, edges, interactive, isLocked, ...props }) => {
+    return (
+      <ThemeProvider theme={{ darkMode: false }}>
+        <EuiFlexGroup direction="column" gutterSize="m">
+          {(title || description) && (
+            <EuiFlexItem grow={false}>
+              <EuiPanel paddingSize="m">
+                {title && (
+                  <EuiText>
+                    <h3>{title}</h3>
+                  </EuiText>
+                )}
+                {description && (
+                  <EuiText size="s" color="subdued">
+                    <p>{description}</p>
+                  </EuiText>
+                )}
+              </EuiPanel>
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem>
+            <Graph
+              css={css`
+                height: 400px;
+                width: 100%;
+                border-radius: 6px;
+              `}
+              nodes={nodes ?? []}
+              edges={edges ?? []}
+              interactive={interactive ?? true}
+              isLocked={isLocked ?? false}
+              {...props}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </ThemeProvider>
+    );
+  },
+  argTypes: {
+    interactive: {
+      control: { type: 'boolean' },
+      description: 'Whether the graph is interactive (allows centering and panning)',
+    },
+    isLocked: {
+      control: { type: 'boolean' },
+      description: 'Whether the graph is locked (allows centering but prevents panning)',
+    },
+  },
+  args: {
+    interactive: true,
+    isLocked: false,
+  },
+  decorators: [GlobalStylesStorybookDecorator],
+};
+
+export default meta;
+type Story = StoryObj<GraphCenteringStoryProps>;
+
+const createNode = ({
+  id,
+  hasOriginEvents = false,
+  shape = 'ellipse',
+  color = 'primary',
+}: {
+  id: string;
+  hasOriginEvents?: boolean;
+  shape?: NodeViewModel['shape'];
+  color?: NodeViewModel['color'];
+}): NodeViewModel =>
+  ({
+    id,
+    label: hasOriginEvents ? `Origin ${id}` : `Regular ${id}`,
+    color: hasOriginEvents ? 'danger' : color,
+    shape,
+    hasOriginEvents,
+    icon: shape === 'ellipse' ? 'user' : shape === 'hexagon' ? 'storage' : 'globe',
+  } as NodeViewModel);
+
+const createEdge = ({
+  id,
+  source,
+  target,
+  color = 'primary',
+}: {
+  id: string;
+  source: string;
+  target: string;
+  color?: EdgeViewModel['color'];
+}): EdgeViewModel => ({
+  id,
+  source,
+  target,
+  color,
+});
+
+export const NoOriginNodes: Story = {
+  args: {
+    title: 'No Origin Nodes',
+    description:
+      'Graph with no origin nodes. The center button is hidden since there are no nodes to center on.',
+    nodes: [
+      createNode({ id: 'node1A', hasOriginEvents: false, shape: 'ellipse' }),
+      createNode({ id: 'node1B', hasOriginEvents: false, shape: 'ellipse' }),
+      createNode({ id: 'node2', hasOriginEvents: false, shape: 'hexagon' }),
+      createNode({ id: 'node3', hasOriginEvents: false, shape: 'diamond' }),
+      createNode({ id: 'node4', hasOriginEvents: false, shape: 'rectangle' }),
+    ],
+    edges: [
+      createEdge({ id: 'edge1A', source: 'node1A', target: 'node2' }),
+      createEdge({ id: 'edge1B', source: 'node1B', target: 'node2' }),
+      createEdge({ id: 'edge2', source: 'node2', target: 'node3' }),
+      createEdge({ id: 'edge3', source: 'node3', target: 'node4' }),
+    ],
+  },
+};
+
+export const SingleOriginNode: Story = {
+  args: {
+    title: 'Single Origin Node',
+    description:
+      'Graph with one origin node (red user) and several connected nodes. The center button should focus on the origin node.',
+    nodes: [
+      createNode({ id: 'node1A', hasOriginEvents: true, shape: 'ellipse' }),
+      createNode({ id: 'node1B', hasOriginEvents: false, shape: 'ellipse' }),
+      createNode({ id: 'node2', hasOriginEvents: false, shape: 'hexagon' }),
+      createNode({ id: 'node3', hasOriginEvents: false, shape: 'diamond' }),
+      createNode({ id: 'node4', hasOriginEvents: false, shape: 'rectangle' }),
+    ],
+    edges: [
+      createEdge({ id: 'edge1A', source: 'node1A', target: 'node2' }),
+      createEdge({ id: 'edge1B', source: 'node1B', target: 'node2' }),
+      createEdge({ id: 'edge2', source: 'node2', target: 'node3' }),
+      createEdge({ id: 'edge3', source: 'node3', target: 'node4' }),
+    ],
+  },
+};
+
+export const MultipleOriginNodes: Story = {
+  args: {
+    title: 'Multiple Origin Nodes',
+    description:
+      'Graph with multiple origin nodes (red nodes) scattered across the layout. The center button should focus on all origin nodes.',
+    nodes: [
+      createNode({ id: 'node1A', hasOriginEvents: true, shape: 'ellipse' }),
+      createNode({ id: 'node1B', hasOriginEvents: true, shape: 'ellipse' }),
+      createNode({ id: 'node2', hasOriginEvents: false, shape: 'hexagon' }),
+      createNode({ id: 'node3', hasOriginEvents: false, shape: 'diamond' }),
+      createNode({ id: 'node4', hasOriginEvents: false, shape: 'rectangle' }),
+    ],
+    edges: [
+      createEdge({ id: 'edge1A', source: 'node1A', target: 'node2' }),
+      createEdge({ id: 'edge1B', source: 'node1B', target: 'node2' }),
+      createEdge({ id: 'edge2', source: 'node2', target: 'node3' }),
+      createEdge({ id: 'edge3', source: 'node3', target: 'node4' }),
+    ],
+  },
+};
+
+export const NonInteractiveGraph: Story = {
+  args: {
+    title: 'Non-Interactive Graph',
+    description:
+      'Graph in non-interactive mode. Controls are hidden since user cannot interact with the graph.',
+    interactive: false,
+    nodes: [
+      createNode({ id: 'node1A', hasOriginEvents: false, shape: 'ellipse' }),
+      createNode({ id: 'node1B', hasOriginEvents: false, shape: 'ellipse' }),
+      createNode({ id: 'node2', hasOriginEvents: false, shape: 'hexagon' }),
+      createNode({ id: 'node3', hasOriginEvents: false, shape: 'diamond' }),
+      createNode({ id: 'node4', hasOriginEvents: false, shape: 'rectangle' }),
+    ],
+    edges: [
+      createEdge({ id: 'edge1A', source: 'node1A', target: 'node2' }),
+      createEdge({ id: 'edge1B', source: 'node1B', target: 'node2' }),
+      createEdge({ id: 'edge2', source: 'node2', target: 'node3' }),
+      createEdge({ id: 'edge3', source: 'node3', target: 'node4' }),
+    ],
+  },
+};
+
+export const LockedGraph: Story = {
+  args: {
+    title: 'Locked graph',
+    description:
+      'Graph in interactive mode but locked. Controls are visible and nodes are interactive but graph is not pannable',
+    interactive: true,
+    isLocked: true,
+    nodes: [
+      createNode({ id: 'node1A', hasOriginEvents: true, shape: 'ellipse' }),
+      createNode({ id: 'node1B', hasOriginEvents: true, shape: 'ellipse' }),
+      createNode({ id: 'node2', hasOriginEvents: false, shape: 'hexagon' }),
+      createNode({ id: 'node3', hasOriginEvents: false, shape: 'diamond' }),
+      createNode({ id: 'node4', hasOriginEvents: false, shape: 'rectangle' }),
+    ],
+    edges: [
+      createEdge({ id: 'edge1A', source: 'node1A', target: 'node2' }),
+      createEdge({ id: 'edge1B', source: 'node1B', target: 'node2' }),
+      createEdge({ id: 'edge2', source: 'node2', target: 'node3' }),
+      createEdge({ id: 'edge3', source: 'node3', target: 'node4' }),
+    ],
+  },
+};

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
@@ -279,26 +279,20 @@ export const GraphInvestigation = memo<GraphInvestigationProps>(
     const nodes = useMemo(() => {
       return (
         data?.nodes.map((node) => {
-          // Only label/entity nodes have documentsData. Narrow using in operator.
-          const documentsIds: string[] =
-            'documentsData' in node && Array.isArray(node.documentsData)
-              ? node.documentsData.map((d) => d.id)
-              : [];
-          const isOrigin = documentsIds.some((id) => originEventIdsSet.has(id));
-          const isOriginAlert = documentsIds.some((id) => originAlertIdsSet.has(id));
-
           if (isEntityNode(node)) {
             return {
               ...node,
-              isOrigin,
-              isOriginAlert,
               expandButtonClick: nodeExpandButtonClickHandler,
             };
           } else if (isLabelNode(node)) {
+            const docEventIds: string[] =
+              'documentsData' in node && Array.isArray(node.documentsData)
+                ? node.documentsData.flatMap((d) => (d.event ? d.event.id : []))
+                : [];
             return {
               ...node,
-              isOrigin,
-              isOriginAlert,
+              isOrigin: docEventIds.some((id) => originEventIdsSet.has(id)),
+              isOriginAlert: docEventIds.some((id) => originAlertIdsSet.has(id)),
               expandButtonClick: labelExpandButtonClickHandler,
             };
           }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
@@ -214,8 +214,8 @@ ${
 // but it flattens the data and we lose the structure
 | EVAL docType = CASE (isAlert, "${DOCUMENT_TYPE_ALERT}", "${DOCUMENT_TYPE_EVENT}")
 | EVAL docData = CONCAT("{",
-    "\\"_id\\":\\"", _id, "\\"",
-    ",\\"id\\":\\"", event.id, "\\"",
+    "\\"id\\":\\"", _id, "\\"",
+    CASE (event.id IS NOT NULL AND event.id != "", CONCAT(",\\"event\\":","{","\\"id\\":\\"", event.id, "\\"","}"), ""),
     ",\\"type\\":\\"", docType, "\\"",
     ",\\"index\\":\\"", _index, "\\"",
     ${

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
@@ -214,7 +214,8 @@ ${
 // but it flattens the data and we lose the structure
 | EVAL docType = CASE (isAlert, "${DOCUMENT_TYPE_ALERT}", "${DOCUMENT_TYPE_EVENT}")
 | EVAL docData = CONCAT("{",
-    "\\"id\\":\\"", _id, "\\"",
+    "\\"_id\\":\\"", _id, "\\"",
+    ",\\"id\\":\\"", event.id, "\\"",
     ",\\"type\\":\\"", docType, "\\"",
     ",\\"index\\":\\"", _index, "\\"",
     ${

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.ts
@@ -162,6 +162,8 @@ const createNodes = (records: GraphEdge[], context: Omit<ParseContext, 'edgesMap
           id: edgeId + `label(${action})oe(${isOrigin ? 1 : 0})oa(${isOriginAlert ? 1 : 0})`,
           label: action,
           color: isOriginAlert || isAlert ? 'danger' : 'primary',
+          isOrigin,
+          isOriginAlert,
           shape: 'label',
           documentsData: parseDocumentsData(docs),
         };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.ts
@@ -162,8 +162,6 @@ const createNodes = (records: GraphEdge[], context: Omit<ParseContext, 'edgesMap
           id: edgeId + `label(${action})oe(${isOrigin ? 1 : 0})oa(${isOriginAlert ? 1 : 0})`,
           label: action,
           color: isOriginAlert || isAlert ? 'danger' : 'primary',
-          isOrigin,
-          isOriginAlert,
           shape: 'label',
           documentsData: parseDocumentsData(docs),
         };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/205916.

### Changes

- In `<Controls>`, replace `showCenter` prop with new `nodeIdsToCenterOn`. It will expect an array of node ids to pass them to ReactFlow to center the graph on. If such sanitized array is empty, the 'center button' will be hidden
- From `<Graph>`, propagate to `<Controls>` the ids of those nodes that contain at least one origin event (boolean flag) 
- Extend `controls.test.tsx` to test the "center graph" button is shown or hidden based on the `nodeIdsToCenter` prop. 
- Create `controls.integration.test.tsx` to test the centering logic and the integration between `<Graph>` and `<Controls>`
- Add new `graph_centering.stories.tsx` file to show all use cases we support for the graph centering logic (no origin nodes, single origin, multiple origins, non-interactive graph and locked graph)

**Bonus**: 
- Extend `controls.test.tsx`:
  - Test the other buttons in `<Controls>` are hidden when their corresponding prop is false
  - Group tests by control button

### Video

Only first event has `isOrigin` and `isOriginAlert` set to true:

https://github.com/user-attachments/assets/9e04ec2d-6630-461a-9993-f1d5674d953f

### Stories

<img width="1061" height="540" alt="Screenshot 2025-09-08 at 16 22 01" src="https://github.com/user-attachments/assets/0c023fe3-8ba1-4663-ab3b-f8eaaeef1cc7" />

<img width="1058" height="547" alt="Screenshot 2025-09-08 at 16 22 11" src="https://github.com/user-attachments/assets/16d4e7c8-1919-423c-b4db-b3533d026233" />

<img width="1060" height="546" alt="Screenshot 2025-09-08 at 16 22 18" src="https://github.com/user-attachments/assets/dd6c1116-1b9c-4f53-b171-b5363f8b87f0" />

<img width="1059" height="546" alt="Screenshot 2025-09-08 at 16 22 26" src="https://github.com/user-attachments/assets/ab8c998e-3420-49a1-823a-c1803e4c9010" />

<img width="1059" height="499" alt="Screenshot 2025-09-08 at 16 22 32" src="https://github.com/user-attachments/assets/4ea1824d-221c-489c-b18f-7fbef6c1da38" />

<img width="1058" height="543" alt="Screenshot 2025-09-08 at 16 22 40" src="https://github.com/user-attachments/assets/d9fc1bb0-063b-48cf-b3f5-5da46d980bec" />

### How to test with fixtures

0. Enable feature flag adding this line to your `kibana.dev.yml` config:
    ```yml
    uiSettings.overrides.securitySolution:enableGraphVisualization: true
    ```
1. Run these 2 commands to load fixtures with ES Archiver
    ```bash
    node scripts/es_archiver load x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/logs_gcp_audit --es-url <ELASTICSEARCH_URL>:9200 --kibana-url <KIBANA_URL>:5601
    
    node scripts/es_archiver load x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/security_alerts_modified_mappings --es-url <ELASTICSEARCH_URL>:9200 --kibana-url <KIBANA_URL>:5601
    ```
2. Go to Alerts and open the flyout of one of the 3 alerts persent. Then in the flyout, expand the Graph Visualization panel

### How to test with ingested data

0. Enable feature flag adding this line to your `kibana.dev.yml` config:
    ```yml
    uiSettings.overrides.securitySolution:enableGraphVisualization: true
    ```
1. Install Cloud Asset Discovery (skip agent installation)
2. Re-index Asset Inventory data with this query
    ```
    POST _reindex?wait_for_completion=true
    {
      "conflicts": "proceed", 
      "source": {
        "remote": {
          "host": "${ES_REMOTE_HOST}", # <-- Set var in Config tab to https://keep-long-live-env-ess.es.us-west2.gcp.elastic-cloud.com:443
          "username": "${ES_REMOTE_USER}", # <-- Set var in Config tab to your user in https://keep-long-live-env-ess.kb.us-west2.gcp.elastic-cloud.com/app/management/security/users i.e. alberto
          "password": "${ES_REMOTE_PASS}" # <-- Set var in Config tab to your password in the same cloud env
        },
        "index": "logs-cloud_asset_inventory*",
        "query": {
          "bool": {
            "must": [
              {
                "range": {
                  "@timestamp": {
                    "gte": "now-1d"
                  }
                }
              }
            ]
          }
        }
      },
      "dest": {
        "op_type": "create",
        "index": "logs-cloud_asset_inventory.asset_inventory-default"
      }
    }
    ```
3. Reindex AWS Cloudtrail logs with this query
    ```
    POST _reindex?wait_for_completion=false
    {
      "conflicts": "proceed", 
      "source": {
        "remote": {
          "host": "${ES_REMOTE_HOST}",
          "username": "${ES_REMOTE_USER}",
          "password": "${ES_REMOTE_PASS}"
        },
        "index": "logs-aws.cloudtrail-*",
        "query": {
           "bool": {
             "must": [],
             "filter": [
               {
                 "range": {
                   "@timestamp": {
                     "gte": "now-3h",
                     "lte": "now"
                   }
                 }
               }
             ]
           }
         }
      },
      "dest": {
        "op_type": "create",
        "index": "logs-aws.cloudtrail-reindexed"
      }
    }
    ```
4. Create a new Data View that matches this index pattern `logs-aws.cloudtrail-*`. Give it the exact same name
5. Download and decompress this exported rule: [rules_export (2).ndjson.zip](https://github.com/user-attachments/files/22530457/rules_export.2.ndjson.zip). Go to Rules page and click on "Import rule"
6. Go to Alerts page. Set the date range from several days ago until now. You'll see a bunch of alerts.
7. Open one alert flyout and expand the Graph Visualization panel.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks.
