### PR TITLE
fix(slo): use locator for add to case url

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/common/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/index.ts
@@ -78,6 +78,7 @@ export const alertsLocatorID = 'ALERTS_LOCATOR';
 export const ruleDetailsLocatorID = 'RULE_DETAILS_LOCATOR';
 export const rulesLocatorID = 'RULES_LOCATOR';
 export const sloDetailsLocatorID = 'SLO_DETAILS_LOCATOR';
+export const sloDetailsHistoryLocatorID = 'SLO_DETAILS_HISTORY_LOCATOR';
 export const sloEditLocatorID = 'SLO_EDIT_LOCATOR';
 export const sloListLocatorID = 'SLO_LIST_LOCATOR';
 

--- a/x-pack/solutions/observability/plugins/slo/common/locators/paths.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/locators/paths.ts
@@ -37,7 +37,6 @@ export const paths = {
     }
     return `${SLOS_BASE_PATH}/${encodeURIComponent(sloId)}?${qs.toString()}`;
   },
-
   sloDetailsHistory: ({
     id,
     instanceId,

--- a/x-pack/solutions/observability/plugins/slo/public/components/slo/add_to_case_action/add_to_case_action.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/slo/add_to_case_action/add_to_case_action.tsx
@@ -7,10 +7,10 @@
 
 import { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
 import { i18n } from '@kbn/i18n';
+import { sloDetailsHistoryLocatorID } from '@kbn/observability-plugin/common';
 import { encode } from '@kbn/rison';
 import { ALL_VALUE, SLODefinitionResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
 import React, { useEffect } from 'react';
-import { sloPaths } from '../../../../common';
 import { useKibana } from '../../../hooks/use_kibana';
 import { useUrlAppState } from '../../../pages/slo_details/components/history/hooks/use_url_app_state';
 
@@ -43,9 +43,15 @@ export function AddToCaseAction({ slo, onCancel, onConfirm }: Props) {
 
 function Content({ slo, onCancel, onConfirm }: Props) {
   const {
-    services: { cases },
+    services: {
+      cases,
+      share: {
+        url: { locators },
+      },
+    },
   } = useKibana();
   const { state } = useUrlAppState(slo);
+  const locator = locators.get(sloDetailsHistoryLocatorID);
 
   const useCasesAddToExistingCaseModal = cases?.hooks?.useCasesAddToExistingCaseModal!;
   const casesModal = useCasesAddToExistingCaseModal({
@@ -66,7 +72,7 @@ function Content({ slo, onCancel, onConfirm }: Props) {
             persistableStateAttachmentState: {
               type: 'slo_history',
               url: {
-                pathAndQuery: sloPaths.sloDetailsHistory({
+                pathAndQuery: locator?.getRedirectUrl({
                   id: slo.id,
                   instanceId: 'instanceId' in slo ? slo.instanceId : ALL_VALUE,
                   encodedAppState: encode(state),
@@ -86,7 +92,7 @@ function Content({ slo, onCancel, onConfirm }: Props) {
     });
 
     return () => casesModal.close();
-  }, [casesModal, slo, state]);
+  }, [casesModal, slo, state, locator]);
 
   return null;
 }

--- a/x-pack/solutions/observability/plugins/slo/public/locators/slo_details_history.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/locators/slo_details_history.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { encode } from '@kbn/rison';
+import { SloDetailsHistoryLocatorDefinition } from './slo_details_history';
+
+describe('SloDetailsHistoryLocator', () => {
+  const locator = new SloDetailsHistoryLocatorDefinition();
+
+  it('returns correct url when id is provided', async () => {
+    const location = await locator.getLocation({ id: 'some-id' });
+    expect(location.path).toEqual('/some-id/history');
+  });
+
+  it('returns correct url when id and instanceId are provided', async () => {
+    const location = await locator.getLocation({ id: 'some-id', instanceId: 'instance-1' });
+    expect(location.path).toEqual('/some-id/history?instanceId=instance-1');
+  });
+
+  it('returns correct url when id and state are provided', async () => {
+    const location = await locator.getLocation({
+      id: 'some-id',
+      encodedAppState: encode({
+        range: { from: '2025-01-01T15:23:45.000Z', to: '2025-01-07T15:23:45.000Z' },
+      }),
+    });
+    expect(location.path).toMatchInlineSnapshot(
+      `"/some-id/history?_a=%28range%3A%28from%3A%272025-01-01T15%3A23%3A45.000Z%27%2Cto%3A%272025-01-07T15%3A23%3A45.000Z%27%29%29"`
+    );
+  });
+
+  it('returns correct url when id, instanceId and state are provided', async () => {
+    const location = await locator.getLocation({
+      id: 'some-id',
+      instanceId: 'instance-1',
+      encodedAppState: encode({
+        range: { from: '2025-01-01T15:23:45.000Z', to: '2025-01-07T15:23:45.000Z' },
+      }),
+    });
+    expect(location.path).toMatchInlineSnapshot(
+      `"/some-id/history?instanceId=instance-1&_a=%28range%3A%28from%3A%272025-01-01T15%3A23%3A45.000Z%27%2Cto%3A%272025-01-07T15%3A23%3A45.000Z%27%29%29"`
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/locators/slo_details_history.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/locators/slo_details_history.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sloDetailsHistoryLocatorID } from '@kbn/observability-plugin/common';
+import type { LocatorDefinition } from '@kbn/share-plugin/public';
+import { ALL_VALUE } from '@kbn/slo-schema/src/schema/common';
+import type { SerializableRecord } from '@kbn/utility-types';
+
+export interface SloDetailsHistoryLocatorParams extends SerializableRecord {
+  id: string;
+  instanceId?: string;
+  encodedAppState?: string;
+}
+
+export class SloDetailsHistoryLocatorDefinition
+  implements LocatorDefinition<SloDetailsHistoryLocatorParams>
+{
+  public readonly id = sloDetailsHistoryLocatorID;
+
+  public readonly getLocation = async ({
+    id,
+    instanceId,
+    encodedAppState,
+  }: SloDetailsHistoryLocatorParams) => {
+    const qs = new URLSearchParams();
+    if (!!instanceId && instanceId !== ALL_VALUE) qs.append('instanceId', instanceId);
+    if (!!encodedAppState) qs.append('_a', encodedAppState);
+
+    return {
+      app: 'slo',
+      path: `/${encodeURIComponent(id)}/history${formatQueryParams(qs)}`,
+      state: {},
+    };
+  };
+}
+
+function formatQueryParams(qs: URLSearchParams): string {
+  if (qs.size === 0) {
+    return '';
+  }
+  return `?${qs.toString()}`;
+}

--- a/x-pack/solutions/observability/plugins/slo/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/plugin.ts
@@ -39,6 +39,7 @@ import type {
 } from './types';
 import { getLazyWithContextProviders } from './utils/get_lazy_with_context_providers';
 import { registerSloUiActions } from './ui_actions/register_ui_actions';
+import { SloDetailsHistoryLocatorDefinition } from './locators/slo_details_history';
 
 export class SLOPlugin
   implements Plugin<SLOPublicSetup, SLOPublicStart, SLOPublicPluginsSetup, SLOPublicPluginsStart>
@@ -62,6 +63,9 @@ export class SLOPlugin
     const sloClient = createRepositoryClient<SLORouteRepository, DefaultClientOptions>(core);
 
     const sloDetailsLocator = plugins.share.url.locators.create(new SloDetailsLocatorDefinition());
+    const sloDetailsHistoryLocator = plugins.share.url.locators.create(
+      new SloDetailsHistoryLocatorDefinition()
+    );
     const sloEditLocator = plugins.share.url.locators.create(new SloEditLocatorDefinition());
     const sloListLocator = plugins.share.url.locators.create(new SloListLocatorDefinition());
 
@@ -191,6 +195,7 @@ export class SLOPlugin
 
     return {
       sloDetailsLocator,
+      sloDetailsHistoryLocator,
       sloEditLocator,
       sloListLocator,
     };


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/231354

This PR fixes a bug when running kibana with a base path and attaching an SLO to a case. It uses a new locator for the history tab.



**Before:** 
<img width="1225" height="204" alt="image" src="https://github.com/user-attachments/assets/523b2c72-93de-4e37-99a5-b133bff59d11" />


**After:**
<img width="1221" height="130" alt="image" src="https://github.com/user-attachments/assets/cadb8726-e01d-4060-a23b-dde0f4d5d9e2" />

