### PR TITLE
[8.19] Remove @paralleldrive/cuid2 (#230293)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1086,7 +1086,6 @@
     "@opentelemetry/instrumentation-undici": "^0.13.2",
     "@opentelemetry/otlp-exporter-base": "^0.202.0",
     "@opentelemetry/semantic-conventions": "^1.34.0",
-    "@paralleldrive/cuid2": "^2.2.2",
     "@reduxjs/toolkit": "1.9.7",
     "@slack/webhook": "^7.0.1",
     "@smithy/eventstream-codec": "^4.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -751,7 +751,6 @@
       "groupName": "@elastic/fleet dependencies",
       "matchDepNames": [
         "exponential-backoff",
-        "@paralleldrive/cuid2",
         "isbinaryfile",
         "js-search",
         "openpgp",

--- a/src/platform/plugins/shared/custom_integrations/public/components/fleet_integration/sample/sample_client_readme.tsx
+++ b/src/platform/plugins/shared/custom_integrations/public/components/fleet_integration/sample/sample_client_readme.tsx
@@ -10,7 +10,7 @@
 import React, { useState } from 'react';
 
 import styled from 'styled-components';
-import { createId } from '@paralleldrive/cuid2';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   EuiButton,
@@ -145,7 +145,7 @@ export const SampleClientReadme = () => {
 
                 <EuiFlexGroup alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiButton onClick={() => setApiKey(createId())} disabled={!!apiKey}>
+                    <EuiButton onClick={() => setApiKey(uuidv4())} disabled={!!apiKey}>
                       Generate API key
                     </EuiButton>
                   </EuiFlexItem>

--- a/src/platform/plugins/shared/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/src/platform/plugins/shared/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createId } from '@paralleldrive/cuid2';
+import { randomUUID } from 'crypto';
 import { encode, decode } from '@kbn/cbor';
 import { errors as esErrors } from '@elastic/elasticsearch';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
@@ -226,7 +226,7 @@ export class ContentStream extends Duplex {
 
   private getId(): string {
     if (!this.id) {
-      this.id = createId();
+      this.id = randomUUID();
     }
     return this.id;
   }

--- a/src/platform/plugins/shared/files/server/file_client/file_client.ts
+++ b/src/platform/plugins/shared/files/server/file_client/file_client.ts
@@ -10,7 +10,7 @@
 import moment from 'moment';
 import { Readable } from 'stream';
 import mimeType from 'mime';
-import { createId } from '@paralleldrive/cuid2';
+import { randomUUID } from 'crypto';
 import { type Logger, SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { AuditLogger } from '@kbn/security-plugin/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
@@ -130,7 +130,7 @@ export class FileClientImpl implements FileClient {
   public async create<M = unknown>({ id, metadata }: CreateArgs): Promise<File<M>> {
     const serializedMetadata = serializeJSON({ ...metadata, mimeType: metadata.mime });
     const result = await this.metadataClient.create({
-      id: id || createId(),
+      id: id || randomUUID(),
       metadata: {
         ...createDefaultFileAttributes(),
         ...serializedMetadata,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Remove @paralleldrive/cuid2 (#230293)](https://github.com/elastic/kibana/pull/230293)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2025-08-11T16:54:51Z","message":"Remove @paralleldrive/cuid2 (#230293)\n\n## Attention Code Owners!\n\nPlease test these changes before approving. Your know your domains much\nbetter than I do, and I need your help to ensure I did not cause any\nregressions. Thank you!\n\n-------\n\nThis pull request removes the dependency on `@paralleldrive/cuid2` and\nreplaces it with alternatives (`uuid` and `crypto`) for generating\nunique IDs. The changes primarily focus on dependency management and\nupdating the code to use the new ID generation methods.\n\n### Dependency Management:\n* Removed `@paralleldrive/cuid2` from `package.json` and `renovate.json`\nto eliminate its usage in the project.\n[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1147)\n[[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L761)\n\n### Code Updates:\n* Replaced `createId` from `@paralleldrive/cuid2` with `uuidv4` from the\n`uuid` package in `sample_client_readme.tsx`. This change affects the\n`Generate API key` functionality.\n[[1]](diffhunk://#diff-19ec5ab675709969feeeaaa0b0549d8926f49e3115166426a17370bc6a98d673L13-R13)\n[[2]](diffhunk://#diff-19ec5ab675709969feeeaaa0b0549d8926f49e3115166426a17370bc6a98d673L148-R148)\n* Updated `content_stream.ts` to use `randomUUID` from the `crypto`\nmodule instead of `createId` for generating IDs in the `ContentStream`\nclass.\n[[1]](diffhunk://#diff-a7545f2aab64e1136452bd37f3388ae269f64761b19c80cc007be7e7c97f511dL10-R10)\n[[2]](diffhunk://#diff-a7545f2aab64e1136452bd37f3388ae269f64761b19c80cc007be7e7c97f511dL227-R227)\n* Updated `file_client.ts` to use `randomUUID` from the `crypto` module\ninstead of `createId` for generating IDs in the `FileClientImpl` class.\n[[1]](diffhunk://#diff-ffbfbe730b81183661bb18b6b78bbb3903496b5716598f4284531fe31390358aL13-R13)\n[[2]](diffhunk://#diff-ffbfbe730b81183661bb18b6b78bbb3903496b5716598f4284531fe31390358aL133-R133)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"35f311d6c61aa8998baba8f7499bbf744d212a2f","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:prev-minor","backport:prev-major","v9.2.0","dependency-reduction"],"title":"Remove @paralleldrive/cuid2","number":230293,"url":"https://github.com/elastic/kibana/pull/230293","mergeCommit":{"message":"Remove @paralleldrive/cuid2 (#230293)\n\n## Attention Code Owners!\n\nPlease test these changes before approving. Your know your domains much\nbetter than I do, and I need your help to ensure I did not cause any\nregressions. Thank you!\n\n-------\n\nThis pull request removes the dependency on `@paralleldrive/cuid2` and\nreplaces it with alternatives (`uuid` and `crypto`) for generating\nunique IDs. The changes primarily focus on dependency management and\nupdating the code to use the new ID generation methods.\n\n### Dependency Management:\n* Removed `@paralleldrive/cuid2` from `package.json` and `renovate.json`\nto eliminate its usage in the project.\n[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1147)\n[[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L761)\n\n### Code Updates:\n* Replaced `createId` from `@paralleldrive/cuid2` with `uuidv4` from the\n`uuid` package in `sample_client_readme.tsx`. This change affects the\n`Generate API key` functionality.\n[[1]](diffhunk://#diff-19ec5ab675709969feeeaaa0b0549d8926f49e3115166426a17370bc6a98d673L13-R13)\n[[2]](diffhunk://#diff-19ec5ab675709969feeeaaa0b0549d8926f49e3115166426a17370bc6a98d673L148-R148)\n* Updated `content_stream.ts` to use `randomUUID` from the `crypto`\nmodule instead of `createId` for generating IDs in the `ContentStream`\nclass.\n[[1]](diffhunk://#diff-a7545f2aab64e1136452bd37f3388ae269f64761b19c80cc007be7e7c97f511dL10-R10)\n[[2]](diffhunk://#diff-a7545f2aab64e1136452bd37f3388ae269f64761b19c80cc007be7e7c97f511dL227-R227)\n* Updated `file_client.ts` to use `randomUUID` from the `crypto` module\ninstead of `createId` for generating IDs in the `FileClientImpl` class.\n[[1]](diffhunk://#diff-ffbfbe730b81183661bb18b6b78bbb3903496b5716598f4284531fe31390358aL13-R13)\n[[2]](diffhunk://#diff-ffbfbe730b81183661bb18b6b78bbb3903496b5716598f4284531fe31390358aL133-R133)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"35f311d6c61aa8998baba8f7499bbf744d212a2f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230293","number":230293,"mergeCommit":{"message":"Remove @paralleldrive/cuid2 (#230293)\n\n## Attention Code Owners!\n\nPlease test these changes before approving. Your know your domains much\nbetter than I do, and I need your help to ensure I did not cause any\nregressions. Thank you!\n\n-------\n\nThis pull request removes the dependency on `@paralleldrive/cuid2` and\nreplaces it with alternatives (`uuid` and `crypto`) for generating\nunique IDs. The changes primarily focus on dependency management and\nupdating the code to use the new ID generation methods.\n\n### Dependency Management:\n* Removed `@paralleldrive/cuid2` from `package.json` and `renovate.json`\nto eliminate its usage in the project.\n[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1147)\n[[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L761)\n\n### Code Updates:\n* Replaced `createId` from `@paralleldrive/cuid2` with `uuidv4` from the\n`uuid` package in `sample_client_readme.tsx`. This change affects the\n`Generate API key` functionality.\n[[1]](diffhunk://#diff-19ec5ab675709969feeeaaa0b0549d8926f49e3115166426a17370bc6a98d673L13-R13)\n[[2]](diffhunk://#diff-19ec5ab675709969feeeaaa0b0549d8926f49e3115166426a17370bc6a98d673L148-R148)\n* Updated `content_stream.ts` to use `randomUUID` from the `crypto`\nmodule instead of `createId` for generating IDs in the `ContentStream`\nclass.\n[[1]](diffhunk://#diff-a7545f2aab64e1136452bd37f3388ae269f64761b19c80cc007be7e7c97f511dL10-R10)\n[[2]](diffhunk://#diff-a7545f2aab64e1136452bd37f3388ae269f64761b19c80cc007be7e7c97f511dL227-R227)\n* Updated `file_client.ts` to use `randomUUID` from the `crypto` module\ninstead of `createId` for generating IDs in the `FileClientImpl` class.\n[[1]](diffhunk://#diff-ffbfbe730b81183661bb18b6b78bbb3903496b5716598f4284531fe31390358aL13-R13)\n[[2]](diffhunk://#diff-ffbfbe730b81183661bb18b6b78bbb3903496b5716598f4284531fe31390358aL133-R133)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"35f311d6c61aa8998baba8f7499bbf744d212a2f"}}]}] BACKPORT-->