### PR TITLE
[8.19] [ResponseOps] [Reporting] Reports not showing up in the reporting list for spaces with a dash in them (#230876)

### DIFF
--- a/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.test.ts
@@ -65,6 +65,7 @@ describe('jobsQuery', () => {
                   bool: {
                     should: [
                       { term: { space_id: 'default' } },
+                      { term: { 'space_id.keyword': 'default' } },
                       // also show all reports created before space_id was added
                       { bool: { must_not: { exists: { field: 'space_id' } } } },
                     ],

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/jobs/jobs_query.ts
@@ -92,6 +92,7 @@ export function jobsQueryFactory(
                     bool: {
                       should: [
                         { term: { space_id: spaceId } },
+                        { term: { 'space_id.keyword': spaceId } },
                         // also show all reports created before space_id was added
                         { bool: { must_not: { exists: { field: 'space_id' } } } },
                       ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps] [Reporting] Reports not showing up in the reporting list for spaces with a dash in them (#230876)](https://github.com/elastic/kibana/pull/230876)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-08-11T18:01:09Z","message":"[ResponseOps] [Reporting] Reports not showing up in the reporting list for spaces with a dash in them (#230876)\n\nResolves https://github.com/elastic/kibana/issues/230867\n\n## Summary\n\nSometimes reports are showing up in the UI in spaces other than the\ndefault space. We noticed this bug for spaces with a dash in them, but\nit can happen in other spaces too. Thehe `space_id` is getting mapped as\na text field, so the `jobs/list` api is not filtering for them\ncorrectly. This PR updates the query to also search on\n`space_id.keyword`.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### To verify\n\n1. Checkout this branch, and create another space with spaces or dashes\nin the name, like test-internal.\n1. Generate PDF, PNG, and CSV reports in your new space and default\nspace. Go to Stack Management > Reporting to verify that your report\nshows up in the UI.\n\n**Test upgrading**\nUpgrade from 8.17.4 -> 8.18.4 -> 8.19.0 -> this branch\nRun Kibana with `yarn es snapshot --license trial -E path.data=../data`\n1. Checkout 8.17.4, and create another space with spaces or dashes in\nthe name, like test-internal.\n2. Generate PDF, PNG, and CSV reports in your new space and default\nspace.\n3. Upgrade to 8.18.4 and generate PDF, PNG, and CSV reports in your new\nspace and default space.\n4. Upgrade to 8.19.0 and generate PDF, PNG, and CSV reports in your new\nspace and default space. At this point, bc the bug is in the branch, you\nwont be able to see your reports in Stack Management > Reporting.\n5. Upgrade to this branch and generate PDF, PNG, and CSV reports in your\nnew space and default space. Go to Stack Management > Reporting to\nverify that your all report shows up in the UI for both spaces.","sha":"6702d2545c538b3c6e70729b612e4becebbe7355","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:version","v9.1.0","v8.19.0","v9.2.0"],"title":"[ResponseOps] [Reporting] Reports not showing up in the reporting list for spaces with a dash in them","number":230876,"url":"https://github.com/elastic/kibana/pull/230876","mergeCommit":{"message":"[ResponseOps] [Reporting] Reports not showing up in the reporting list for spaces with a dash in them (#230876)\n\nResolves https://github.com/elastic/kibana/issues/230867\n\n## Summary\n\nSometimes reports are showing up in the UI in spaces other than the\ndefault space. We noticed this bug for spaces with a dash in them, but\nit can happen in other spaces too. Thehe `space_id` is getting mapped as\na text field, so the `jobs/list` api is not filtering for them\ncorrectly. This PR updates the query to also search on\n`space_id.keyword`.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### To verify\n\n1. Checkout this branch, and create another space with spaces or dashes\nin the name, like test-internal.\n1. Generate PDF, PNG, and CSV reports in your new space and default\nspace. Go to Stack Management > Reporting to verify that your report\nshows up in the UI.\n\n**Test upgrading**\nUpgrade from 8.17.4 -> 8.18.4 -> 8.19.0 -> this branch\nRun Kibana with `yarn es snapshot --license trial -E path.data=../data`\n1. Checkout 8.17.4, and create another space with spaces or dashes in\nthe name, like test-internal.\n2. Generate PDF, PNG, and CSV reports in your new space and default\nspace.\n3. Upgrade to 8.18.4 and generate PDF, PNG, and CSV reports in your new\nspace and default space.\n4. Upgrade to 8.19.0 and generate PDF, PNG, and CSV reports in your new\nspace and default space. At this point, bc the bug is in the branch, you\nwont be able to see your reports in Stack Management > Reporting.\n5. Upgrade to this branch and generate PDF, PNG, and CSV reports in your\nnew space and default space. Go to Stack Management > Reporting to\nverify that your all report shows up in the UI for both spaces.","sha":"6702d2545c538b3c6e70729b612e4becebbe7355"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231345","number":231345,"state":"OPEN"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230876","number":230876,"mergeCommit":{"message":"[ResponseOps] [Reporting] Reports not showing up in the reporting list for spaces with a dash in them (#230876)\n\nResolves https://github.com/elastic/kibana/issues/230867\n\n## Summary\n\nSometimes reports are showing up in the UI in spaces other than the\ndefault space. We noticed this bug for spaces with a dash in them, but\nit can happen in other spaces too. Thehe `space_id` is getting mapped as\na text field, so the `jobs/list` api is not filtering for them\ncorrectly. This PR updates the query to also search on\n`space_id.keyword`.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### To verify\n\n1. Checkout this branch, and create another space with spaces or dashes\nin the name, like test-internal.\n1. Generate PDF, PNG, and CSV reports in your new space and default\nspace. Go to Stack Management > Reporting to verify that your report\nshows up in the UI.\n\n**Test upgrading**\nUpgrade from 8.17.4 -> 8.18.4 -> 8.19.0 -> this branch\nRun Kibana with `yarn es snapshot --license trial -E path.data=../data`\n1. Checkout 8.17.4, and create another space with spaces or dashes in\nthe name, like test-internal.\n2. Generate PDF, PNG, and CSV reports in your new space and default\nspace.\n3. Upgrade to 8.18.4 and generate PDF, PNG, and CSV reports in your new\nspace and default space.\n4. Upgrade to 8.19.0 and generate PDF, PNG, and CSV reports in your new\nspace and default space. At this point, bc the bug is in the branch, you\nwont be able to see your reports in Stack Management > Reporting.\n5. Upgrade to this branch and generate PDF, PNG, and CSV reports in your\nnew space and default space. Go to Stack Management > Reporting to\nverify that your all report shows up in the UI for both spaces.","sha":"6702d2545c538b3c6e70729b612e4becebbe7355"}}]}] BACKPORT-->