### PR TITLE
[Controls] [A11y] Fix Timeslider focus ring visibility in Firefox

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/time_slider_popover_button.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/time_slider_popover_button.tsx
@@ -48,6 +48,10 @@ const timeSliderStyles = {
       text-decoration: line-through;
       color: ${euiTheme.colors.mediumShade};
     }
+
+    &:focus-visible {
+      outline-offset: -3px;
+    }
   `,
 };
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the timeslider's `:focus-visible` state was completely invisible in Firefox, and only kind of visible in Chrome:

| | Before | After
| --- | --- | --- |
Firefox | <img width="825" height="80" alt="Screenshot 2025-08-11 at 12 37 29 PM" src="https://github.com/user-attachments/assets/0a186f1d-619b-455c-8e38-6b9a66f44182" /> | <img width="814" height="72" alt="Screenshot 2025-08-11 at 12 38 35 PM" src="https://github.com/user-attachments/assets/170f7fde-e14f-4667-acea-333d08c5850e" />
Chrome |  <img width="814" height="75" alt="Screenshot 2025-08-11 at 12 37 08 PM" src="https://github.com/user-attachments/assets/08273000-eeb0-4f66-b2bb-f6f6348c9f7c" /> | <img width="817" height="92" alt="Screenshot 2025-08-11 at 12 39 45 PM" src="https://github.com/user-attachments/assets/32fde473-35bf-4b08-86cd-685d9bf7ff42" />

Note the black/blue appearance in Chrome happens on all button elements. Probably related to the visual inconsistencies being discussed in https://github.com/elastic/eui/issues/8953

Safari is not fixed by this PR, because it's not even focusable at all due to https://github.com/elastic/eui/issues/8961

The reason I'm opening this PR on its own instead of waiting for EUI to resolve https://github.com/elastic/eui/issues/8953 is because the Timeslider uniquely wraps a `<button>` in `overflow: hidden`. Therefore it will likely always need a different `outline-offset` style from the standard EUI theme.

## Testing

Use Tab to focus into a Timeslider control in Chrome and Firefox. Ensure the focus outline is at least 3px and visible.



<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->