### PR TITLE
[Alerting] Fix alerting table pagination

### DIFF
--- a/src/platform/packages/shared/response-ops/alerts-table/components/alerts_table.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/components/alerts_table.tsx
@@ -40,7 +40,7 @@ import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { useSearchAlertsQuery } from '@kbn/alerts-ui-shared/src/common/hooks/use_search_alerts_query';
 import { DEFAULT_ALERTS_PAGE_SIZE } from '@kbn/alerts-ui-shared/src/common/constants';
 import { AlertsQueryContext } from '@kbn/alerts-ui-shared/src/common/contexts/alerts_query_context';
-import deepEqual from 'fast-deep-equal';
+import { isEqual } from 'lodash';
 import { Alert } from '@kbn/alerting-types';
 import { useGetMutedAlertsQuery } from '@kbn/response-ops-alerts-apis/hooks/use_get_muted_alerts_query';
 import { queryKeys as alertsQueryKeys } from '@kbn/response-ops-alerts-apis/query_keys';
@@ -298,13 +298,14 @@ const AlertsTableContent = typedForwardRef(
         minScore,
         trackScores,
         // Go back to the first page if the query changes
-        pageIndex: !deepEqual(prevQueryParams, {
+        pageIndex: !isEqual(prevQueryParams, {
           ruleTypeIds,
           consumers,
           fields,
           query,
           sort,
           runtimeMappings,
+          trackScores,
         })
           ? 0
           : oldPageIndex,


### PR DESCRIPTION
## Summary

Closes #231339

https://github.com/user-attachments/assets/42a6968f-2981-487b-9b21-b8515dc36cb5

fast-deep-equal was returning false despite two objects being equal. Switched to lodash.


