### PR TITLE
[9.1] [Entity Analytics][Privmon] Adding privmon e2e smoke test (#229626)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/onboarding_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring_onboarding/onboarding_panel.tsx
@@ -33,7 +33,7 @@ export const PrivilegedUserMonitoringOnboardingPanel = ({
   const { docLinks } = useKibana().services;
 
   return (
-    <EuiPanel paddingSize="none">
+    <EuiPanel paddingSize="none" data-test-subj="privilegedUserMonitoringOnboardingPanel">
       <EuiPanel paddingSize="xl" color="subdued" hasShadow={false} hasBorder={false}>
         <EuiFlexGroup
           direction="row"

--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/privileged_user_monitoring_page.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/privileged_user_monitoring_page.cy.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { enablePrivilegedUserMonitoring } from '../../tasks/entity_analytics/enable_privmon';
+import { login } from '../../tasks/login';
+import { visit } from '../../tasks/navigation';
+import { ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_URL } from '../../urls/navigation';
+
+describe(
+  'Privileged User Monitoring Page',
+  {
+    tags: ['@ess'],
+  },
+  () => {
+    before(() => {
+      cy.task('esArchiverLoad', { archiveName: 'all_users' });
+    });
+
+    beforeEach(() => {
+      login();
+
+      enablePrivilegedUserMonitoring();
+    });
+
+    after(() => {
+      cy.task('esArchiverUnload', { archiveName: 'all_users' });
+    });
+
+    it('renders page as expected', () => {
+      visit(ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_URL);
+      cy.get('[data-test-subj="privilegedUserMonitoringOnboardingPanel"]').should(
+        'contain.text',
+        'Privileged user monitoring'
+      );
+    });
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/tasks/entity_analytics/enable_privmon.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/entity_analytics/enable_privmon.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { visit } from '../navigation';
+import { ADVANCED_SETTINGS_URL } from '../../urls/navigation';
+
+export const enablePrivilegedUserMonitoring = () => {
+  visit(`${ADVANCED_SETTINGS_URL}?query=privilege+user`);
+  cy.get(
+    '[data-test-subj="management-settings-editField-securitySolution:enablePrivilegedUserMonitoring"]'
+  ).click();
+  cy.get('[data-test-subj="settings-save-button"]').click();
+  cy.get('[data-test-subj="pageReloadButton"]').should('be.visible');
+};

--- a/x-pack/test/security_solution_cypress/cypress/urls/navigation.ts
+++ b/x-pack/test/security_solution_cypress/cypress/urls/navigation.ts
@@ -95,9 +95,12 @@ export const VISUALIZE_URL = '/app/visualize';
 export const MAPS_URL = '/app/maps';
 export const LENS_URL = '/app/lens';
 export const APP_DASHBOARDS_URL = '/app/dashboards';
+export const ADVANCED_SETTINGS_URL = '/app/management/kibana/settings';
 
 // Entity Analytics
 export const ENTITY_ANALYTICS_DASHBOARD_URL = '/app/security/entity_analytics';
+export const ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_URL =
+  '/app/security/entity_analytics_privileged_user_monitoring';
 
 // Asset Inventory
 export const ASSET_INVENTORY_URL = '/app/security/asset_inventory';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Entity Analytics][Privmon] Adding privmon e2e smoke test (#229626)](https://github.com/elastic/kibana/pull/229626)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Vila Verde","email":"tiago.vilaverde@elastic.co"},"sourceCommit":{"committedDate":"2025-08-05T14:41:31Z","message":"[Entity Analytics][Privmon] Adding privmon e2e smoke test (#229626)\n\n## Summary\n\nThis PR adds a cypress smoke test that ensures the privileged user\nmonitoring page is available if the Kibana advanced setting is enabled.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cc9148e4f4ed18c730522653befff321fe1bbf7e","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Theme: entity_analytics","Team:Entity Analytics","backport:version","v9.1.0","v9.2.0"],"title":"[Entity Analytics][Privmon] Adding privmon e2e smoke test","number":229626,"url":"https://github.com/elastic/kibana/pull/229626","mergeCommit":{"message":"[Entity Analytics][Privmon] Adding privmon e2e smoke test (#229626)\n\n## Summary\n\nThis PR adds a cypress smoke test that ensures the privileged user\nmonitoring page is available if the Kibana advanced setting is enabled.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cc9148e4f4ed18c730522653befff321fe1bbf7e"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229626","number":229626,"mergeCommit":{"message":"[Entity Analytics][Privmon] Adding privmon e2e smoke test (#229626)\n\n## Summary\n\nThis PR adds a cypress smoke test that ensures the privileged user\nmonitoring page is available if the Kibana advanced setting is enabled.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cc9148e4f4ed18c730522653befff321fe1bbf7e"}}]}] BACKPORT-->