### PR TITLE
[Security Solution] Change alerts page data view and add help text

### DIFF
--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor.tsx
@@ -25,7 +25,7 @@ export const DataViewEditor = ({
   requireTimestampField = false,
   editData,
   allowAdHocDataView,
-  indexHelpText,
+  getDataViewHelpText,
 }: DataViewEditorPropsWithServices) => {
   const { Provider: KibanaReactContextProvider } =
     createKibanaReactContext<DataViewEditorContext>(services);
@@ -45,7 +45,7 @@ export const DataViewEditor = ({
           requireTimestampField={requireTimestampField}
           editData={editData}
           allowAdHocDataView={allowAdHocDataView}
-          indexHelpText={indexHelpText}
+          getDataViewHelpText={getDataViewHelpText}
         />
       </EuiFlyout>
     </KibanaReactContextProvider>

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor.tsx
@@ -25,6 +25,7 @@ export const DataViewEditor = ({
   requireTimestampField = false,
   editData,
   allowAdHocDataView,
+  indexHelpText,
 }: DataViewEditorPropsWithServices) => {
   const { Provider: KibanaReactContextProvider } =
     createKibanaReactContext<DataViewEditorContext>(services);
@@ -44,6 +45,7 @@ export const DataViewEditor = ({
           requireTimestampField={requireTimestampField}
           editData={editData}
           allowAdHocDataView={allowAdHocDataView}
+          indexHelpText={indexHelpText}
         />
       </EuiFlyout>
     </KibanaReactContextProvider>

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiTitle,
@@ -70,7 +70,7 @@ export interface Props {
   showManagementLink?: boolean;
   allowAdHoc: boolean;
   dataViewEditorService: DataViewEditorService;
-  indexHelpText?: string;
+  getDataViewHelpText?: (dataView: DataView) => string | undefined;
 }
 
 const editorTitle = i18n.translate('indexPatternEditor.title', {
@@ -88,7 +88,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
   editData,
   allowAdHoc,
   showManagementLink,
-  indexHelpText,
+  getDataViewHelpText,
   dataViewEditorService,
 }: Props) => {
   const styles = useMemoCss(componentStyles);
@@ -197,6 +197,10 @@ const IndexPatternEditorFlyoutContentComponent = ({
   }, [dataViewEditorService, type]);
 
   const getRollupIndices = (rollupCapsRes: RollupIndicesCapsResponse) => Object.keys(rollupCapsRes);
+  const titleHelpText = useMemo(
+    () => editData && getDataViewHelpText && getDataViewHelpText(editData),
+    [editData, getDataViewHelpText]
+  );
 
   const onTypeChange = useCallback(
     (newType: INDEX_PATTERN_TYPE) => {
@@ -300,7 +304,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
                   indexPatternValidationProvider={
                     dataViewEditorService.indexPatternValidationProvider
                   }
-                  indexHelpText={indexHelpText}
+                  titleHelpText={titleHelpText}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useCallback, useMemo } from 'react';
+import React, { useEffect, useCallback, useMemo, ReactNode } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiTitle,
@@ -70,7 +70,7 @@ export interface Props {
   showManagementLink?: boolean;
   allowAdHoc: boolean;
   dataViewEditorService: DataViewEditorService;
-  getDataViewHelpText?: (dataView: DataView) => string | undefined;
+  getDataViewHelpText?: (dataView: DataView) => ReactNode | string | undefined;
 }
 
 const editorTitle = i18n.translate('indexPatternEditor.title', {

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -70,6 +70,7 @@ export interface Props {
   showManagementLink?: boolean;
   allowAdHoc: boolean;
   dataViewEditorService: DataViewEditorService;
+  indexHelpText?: string;
 }
 
 const editorTitle = i18n.translate('indexPatternEditor.title', {
@@ -87,6 +88,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
   editData,
   allowAdHoc,
   showManagementLink,
+  indexHelpText,
   dataViewEditorService,
 }: Props) => {
   const styles = useMemoCss(componentStyles);
@@ -298,6 +300,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
                   indexPatternValidationProvider={
                     dataViewEditorService.indexPatternValidationProvider
                   }
+                  indexHelpText={indexHelpText}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useCallback, useMemo, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { useEffect, useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiTitle,

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_flyout_content_container.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_flyout_content_container.tsx
@@ -25,7 +25,7 @@ const DataViewFlyoutContentContainer = ({
   editData,
   allowAdHocDataView,
   showManagementLink,
-  indexHelpText,
+  getDataViewHelpText,
 }: DataViewEditorProps) => {
   const {
     services: { dataViews, notifications, http },
@@ -101,7 +101,7 @@ const DataViewFlyoutContentContainer = ({
       showManagementLink={showManagementLink}
       allowAdHoc={allowAdHocDataView || false}
       dataViewEditorService={dataViewEditorService}
-      indexHelpText={indexHelpText}
+      getDataViewHelpText={getDataViewHelpText}
     />
   );
 };

--- a/src/platform/plugins/shared/data_view_editor/public/components/data_view_flyout_content_container.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/data_view_flyout_content_container.tsx
@@ -25,6 +25,7 @@ const DataViewFlyoutContentContainer = ({
   editData,
   allowAdHocDataView,
   showManagementLink,
+  indexHelpText,
 }: DataViewEditorProps) => {
   const {
     services: { dataViews, notifications, http },
@@ -100,6 +101,7 @@ const DataViewFlyoutContentContainer = ({
       showManagementLink={showManagementLink}
       allowAdHoc={allowAdHocDataView || false}
       dataViewEditorService={dataViewEditorService}
+      indexHelpText={indexHelpText}
     />
   );
 };

--- a/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { ChangeEvent } from 'react';
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, ReactNode } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiFieldText } from '@elastic/eui';
 import type { Observable } from 'rxjs';
@@ -30,7 +30,7 @@ interface TitleFieldProps {
     matchedIndices: MatchedIndicesSet;
     rollupIndex: string | null | undefined;
   }>;
-  titleHelpText?: string;
+  titleHelpText?: ReactNode | string;
 }
 
 const rollupIndexPatternNoMatchError = {
@@ -115,7 +115,7 @@ interface GetTitleConfigArgs {
   isRollup: boolean;
   matchedIndices: MatchedItem[];
   rollupIndicesCapabilities: RollupIndicesCapsResponse;
-  titleHelpText?: string;
+  titleHelpText?: ReactNode | string;
 }
 
 const getTitleConfig = ({

--- a/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
@@ -30,6 +30,7 @@ interface TitleFieldProps {
     matchedIndices: MatchedIndicesSet;
     rollupIndex: string | null | undefined;
   }>;
+  indexHelpText?: string;
 }
 
 const rollupIndexPatternNoMatchError = {
@@ -114,11 +115,13 @@ interface GetTitleConfigArgs {
   isRollup: boolean;
   matchedIndices: MatchedItem[];
   rollupIndicesCapabilities: RollupIndicesCapsResponse;
+  indexHelpText?: string;
 }
 
 const getTitleConfig = ({
   isRollup,
   rollupIndicesCapabilities,
+  indexHelpText,
 }: GetTitleConfigArgs): FieldConfig<string> => {
   const titleFieldConfig = schema.title;
 
@@ -134,6 +137,7 @@ const getTitleConfig = ({
   return {
     ...titleFieldConfig!,
     validations,
+    helpText: indexHelpText,
   };
 };
 
@@ -142,6 +146,7 @@ export const TitleField = ({
   matchedIndices$,
   rollupIndicesCapabilities,
   indexPatternValidationProvider,
+  indexHelpText,
 }: TitleFieldProps) => {
   const [appendedWildcard, setAppendedWildcard] = useState<boolean>(false);
   const matchedIndices = useObservable(matchedIndices$, matchedIndiciesDefault).exactMatchedIndices;
@@ -152,8 +157,9 @@ export const TitleField = ({
         isRollup,
         matchedIndices,
         rollupIndicesCapabilities,
+        indexHelpText,
       }),
-    [isRollup, matchedIndices, rollupIndicesCapabilities]
+    [isRollup, matchedIndices, rollupIndicesCapabilities, indexHelpText]
   );
 
   return (

--- a/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
@@ -30,7 +30,7 @@ interface TitleFieldProps {
     matchedIndices: MatchedIndicesSet;
     rollupIndex: string | null | undefined;
   }>;
-  indexHelpText?: string;
+  titleHelpText?: string;
 }
 
 const rollupIndexPatternNoMatchError = {
@@ -115,13 +115,13 @@ interface GetTitleConfigArgs {
   isRollup: boolean;
   matchedIndices: MatchedItem[];
   rollupIndicesCapabilities: RollupIndicesCapsResponse;
-  indexHelpText?: string;
+  titleHelpText?: string;
 }
 
 const getTitleConfig = ({
   isRollup,
   rollupIndicesCapabilities,
-  indexHelpText,
+  titleHelpText,
 }: GetTitleConfigArgs): FieldConfig<string> => {
   const titleFieldConfig = schema.title;
 
@@ -137,7 +137,7 @@ const getTitleConfig = ({
   return {
     ...titleFieldConfig!,
     validations,
-    helpText: indexHelpText,
+    helpText: titleHelpText,
   };
 };
 
@@ -146,7 +146,7 @@ export const TitleField = ({
   matchedIndices$,
   rollupIndicesCapabilities,
   indexPatternValidationProvider,
-  indexHelpText,
+  titleHelpText,
 }: TitleFieldProps) => {
   const [appendedWildcard, setAppendedWildcard] = useState<boolean>(false);
   const matchedIndices = useObservable(matchedIndices$, matchedIndiciesDefault).exactMatchedIndices;
@@ -157,9 +157,9 @@ export const TitleField = ({
         isRollup,
         matchedIndices,
         rollupIndicesCapabilities,
-        indexHelpText,
+        titleHelpText,
       }),
-    [isRollup, matchedIndices, rollupIndicesCapabilities, indexHelpText]
+    [isRollup, matchedIndices, rollupIndicesCapabilities, titleHelpText]
   );
 
   return (

--- a/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_field.tsx
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ChangeEvent } from 'react';
-import React, { useState, useMemo, ReactNode } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
+import React, { useState, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiFieldText } from '@elastic/eui';
 import type { Observable } from 'rxjs';

--- a/src/platform/plugins/shared/data_view_editor/public/open_editor.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/open_editor.tsx
@@ -50,7 +50,7 @@ export const getEditorOpener =
       requireTimestampField = false,
       allowAdHocDataView = false,
       editData,
-      indexHelpText,
+      getDataViewHelpText,
     }: DataViewEditorProps): CloseEditor => {
       const closeEditor = () => {
         if (overlayRef) {
@@ -81,7 +81,7 @@ export const getEditorOpener =
               requireTimestampField={requireTimestampField}
               allowAdHocDataView={allowAdHocDataView}
               showManagementLink={Boolean(editData && editData.isPersisted())}
-              indexHelpText={indexHelpText}
+              getDataViewHelpText={getDataViewHelpText}
             />
           </KibanaReactContextProvider>,
           core

--- a/src/platform/plugins/shared/data_view_editor/public/open_editor.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/open_editor.tsx
@@ -50,6 +50,7 @@ export const getEditorOpener =
       requireTimestampField = false,
       allowAdHocDataView = false,
       editData,
+      indexHelpText,
     }: DataViewEditorProps): CloseEditor => {
       const closeEditor = () => {
         if (overlayRef) {
@@ -80,6 +81,7 @@ export const getEditorOpener =
               requireTimestampField={requireTimestampField}
               allowAdHocDataView={allowAdHocDataView}
               showManagementLink={Boolean(editData && editData.isPersisted())}
+              indexHelpText={indexHelpText}
             />
           </KibanaReactContextProvider>,
           core

--- a/src/platform/plugins/shared/data_view_editor/public/types.ts
+++ b/src/platform/plugins/shared/data_view_editor/public/types.ts
@@ -71,6 +71,10 @@ export interface DataViewEditorProps {
    * if set to true a link to the management page is shown
    */
   showManagementLink?: boolean;
+  /**
+   * Optional help text to show when editing a data view
+   */
+  indexHelpText?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/platform/plugins/shared/data_view_editor/public/types.ts
+++ b/src/platform/plugins/shared/data_view_editor/public/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import type {
   ApplicationStart,
   IUiSettingsClient,
@@ -74,7 +74,7 @@ export interface DataViewEditorProps {
   /**
    * Optional callback to get help text based on the active data view
    */
-  getDataViewHelpText?: (dataView: DataView) => string | undefined;
+  getDataViewHelpText?: (dataView: DataView) => ReactNode | string | undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/platform/plugins/shared/data_view_editor/public/types.ts
+++ b/src/platform/plugins/shared/data_view_editor/public/types.ts
@@ -72,9 +72,9 @@ export interface DataViewEditorProps {
    */
   showManagementLink?: boolean;
   /**
-   * Optional help text to show when editing a data view
+   * Optional callback to get help text based on the active data view
    */
-  indexHelpText?: string;
+  getDataViewHelpText?: (dataView: DataView) => string | undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
@@ -70,7 +70,7 @@ export function ChangeDataView({
   onEditDataView,
   onCreateDefaultAdHocDataView,
   onClosePopover,
-  indexHelpText,
+  getDataViewHelpText,
 }: DataViewPickerProps) {
   const { euiTheme } = useEuiTheme();
   const [isPopoverOpen, setPopoverIsOpen] = useState(false);
@@ -179,7 +179,7 @@ export function ChangeDataView({
                   onSave: (updatedDataView) => {
                     onEditDataView(updatedDataView);
                   },
-                  indexHelpText,
+                  getDataViewHelpText,
                 });
               } else {
                 application.navigateToApp('management', {
@@ -274,7 +274,7 @@ export function ChangeDataView({
     onEditDataView,
     searchListInputId,
     selectableProps,
-    indexHelpText,
+    getDataViewHelpText,
   ]);
 
   return (

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
@@ -70,6 +70,7 @@ export function ChangeDataView({
   onEditDataView,
   onCreateDefaultAdHocDataView,
   onClosePopover,
+  indexHelpText,
 }: DataViewPickerProps) {
   const { euiTheme } = useEuiTheme();
   const [isPopoverOpen, setPopoverIsOpen] = useState(false);
@@ -178,6 +179,7 @@ export function ChangeDataView({
                   onSave: (updatedDataView) => {
                     onEditDataView(updatedDataView);
                   },
+                  indexHelpText,
                 });
               } else {
                 application.navigateToApp('management', {
@@ -272,6 +274,7 @@ export function ChangeDataView({
     onEditDataView,
     searchListInputId,
     selectableProps,
+    indexHelpText,
   ]);
 
   return (

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import type { EuiButtonProps, EuiSelectableProps } from '@elastic/eui';
 import type { DataView, DataViewListItem, DataViewSpec } from '@kbn/data-views-plugin/public';
 import { ChangeDataView } from './change_dataview';

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
@@ -77,9 +77,9 @@ export interface DataViewPickerProps {
    */
   onClosePopover?: () => void;
   /**
-   * Message to show when editing a managed data view
+   * Optional callback to get help text based on the active data view
    */
-  indexHelpText?: string;
+  getDataViewHelpText?: (dataView: DataView) => string | undefined;
 }
 
 export const DataViewPicker = ({
@@ -97,7 +97,7 @@ export const DataViewPicker = ({
   selectableProps,
   onCreateDefaultAdHocDataView,
   isDisabled,
-  indexHelpText,
+  getDataViewHelpText,
 }: DataViewPickerProps) => {
   return (
     <ChangeDataView
@@ -115,7 +115,7 @@ export const DataViewPicker = ({
       savedDataViews={savedDataViews}
       selectableProps={selectableProps}
       isDisabled={isDisabled}
-      indexHelpText={indexHelpText}
+      getDataViewHelpText={getDataViewHelpText}
     />
   );
 };

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
@@ -76,6 +76,10 @@ export interface DataViewPickerProps {
    * Optional callback when data view picker is closed
    */
   onClosePopover?: () => void;
+  /**
+   * Message to show when editing a managed data view
+   */
+  indexHelpText?: string;
 }
 
 export const DataViewPicker = ({
@@ -93,6 +97,7 @@ export const DataViewPicker = ({
   selectableProps,
   onCreateDefaultAdHocDataView,
   isDisabled,
+  indexHelpText,
 }: DataViewPickerProps) => {
   return (
     <ChangeDataView
@@ -110,6 +115,7 @@ export const DataViewPicker = ({
       savedDataViews={savedDataViews}
       selectableProps={selectableProps}
       isDisabled={isDisabled}
+      indexHelpText={indexHelpText}
     />
   );
 };

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/data_view_picker.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import type { EuiButtonProps, EuiSelectableProps } from '@elastic/eui';
 import type { DataView, DataViewListItem, DataViewSpec } from '@kbn/data-views-plugin/public';
 import { ChangeDataView } from './change_dataview';
@@ -79,7 +79,7 @@ export interface DataViewPickerProps {
   /**
    * Optional callback to get help text based on the active data view
    */
-  getDataViewHelpText?: (dataView: DataView) => string | undefined;
+  getDataViewHelpText?: (dataView: DataView) => ReactNode | string | undefined;
 }
 
 export const DataViewPicker = ({

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -137,15 +137,18 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
     [dataViewId, data.dataViews, scope, dataViewFieldEditor, handleChangeDataView]
   );
 
-  const indexHelpText = useMemo(() => {
-    if (dataViewId === defaultDataViewId) {
-      return i18n.translate('xpack.securitySolution.dataViewManager.indexHelpText', {
-        defaultMessage:
-          'Security default indices are managed in advanced settings. To change the indices permanently, edit the indices in advanced settings.',
-      });
-    }
-    return undefined;
-  }, [dataViewId, defaultDataViewId]);
+  const getDataViewHelpText = useMemo(
+    () => (dv: DataView) => {
+      if (dv.id === defaultDataViewId) {
+        return i18n.translate('xpack.securitySolution.dataViewManager.getDataViewHelpText', {
+          defaultMessage:
+            'Security default indices are managed in Advanced Settings. To change the indices permanently, edit the indices in Advanced Settings.',
+        });
+      }
+      return undefined;
+    },
+    [defaultDataViewId]
+  );
 
   /**
    * Selects data view again. After changes are made to the data view, this results in cache invalidation and will force the reload everywhere.
@@ -191,7 +194,7 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
         savedDataViews={savedDataViews}
         managedDataViews={managedDataViews}
         onClosePopover={onClosePopover}
-        indexHelpText={indexHelpText}
+        getDataViewHelpText={getDataViewHelpText}
       />
     </div>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -8,8 +8,9 @@
 import { DataViewPicker as UnifiedDataViewPicker } from '@kbn/unified-search-plugin/public';
 import React, { useCallback, useRef, useMemo, memo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { i18n } from '@kbn/i18n';
 import { DataView } from '@kbn/data-views-plugin/public';
+import { EuiCode } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { EXPLORE_DATA_VIEW_PREFIX } from '../../../../common/constants';
 import type { SourcererUrlState } from '../../../sourcerer/store/model';
 import { useUpdateUrlParam } from '../../../common/utils/global_query_string';
@@ -137,16 +138,17 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
     [dataViewId, data.dataViews, scope, dataViewFieldEditor, handleChangeDataView]
   );
 
-  const getDataViewHelpText = useMemo(
-    () => (dv: DataView) => {
-      if (dv.id === defaultDataViewId) {
-        return i18n.translate('xpack.securitySolution.dataViewManager.getDataViewHelpText', {
-          defaultMessage:
-            'Security default indices are managed in Advanced Settings. To change the indices permanently, edit the indices in Advanced Settings.',
-        });
-      }
-      return undefined;
-    },
+  const getDataViewHelpText = useCallback(
+    (dv: DataView) =>
+      dv.id === defaultDataViewId ? (
+        <FormattedMessage
+          id="xpack.securitySolution.dataViewManager.getDataViewHelpText"
+          defaultMessage="Changes made here won't be saved permanently. To update the default Security indices, edit {code} in Advanced Settings."
+          values={{
+            code: <EuiCode>{'securitySolution:defaultIndex'}</EuiCode>,
+          }}
+        />
+      ) : undefined,
     [defaultDataViewId]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -8,7 +8,7 @@
 import { DataViewPicker as UnifiedDataViewPicker } from '@kbn/unified-search-plugin/public';
 import React, { useCallback, useRef, useMemo, memo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
+import { i18n } from '@kbn/i18n';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { EXPLORE_DATA_VIEW_PREFIX } from '../../../../common/constants';
 import type { SourcererUrlState } from '../../../sourcerer/store/model';
@@ -21,7 +21,7 @@ import { useSelectDataView } from '../../hooks/use_select_data_view';
 import { DataViewManagerScopeName } from '../../constants';
 import { useManagedDataViews } from '../../hooks/use_managed_data_views';
 import { useSavedDataViews } from '../../hooks/use_saved_data_views';
-import { DEFAULT_SECURITY_DATA_VIEW, LOADING } from './translations';
+import { LOADING } from './translations';
 import { DATA_VIEW_PICKER_TEST_ID } from './constants';
 import { useDataView } from '../../hooks/use_data_view';
 import { browserFieldsManager } from '../../utils/security_browser_fields_manager';
@@ -137,6 +137,16 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
     [dataViewId, data.dataViews, scope, dataViewFieldEditor, handleChangeDataView]
   );
 
+  const indexHelpText = useMemo(() => {
+    if (dataViewId === defaultDataViewId) {
+      return i18n.translate('xpack.securitySolution.dataViewManager.indexHelpText', {
+        defaultMessage:
+          'Security default indices are managed in advanced settings. To change the indices permanently, edit the indices in advanced settings.',
+      });
+    }
+    return undefined;
+  }, [dataViewId, defaultDataViewId]);
+
   /**
    * Selects data view again. After changes are made to the data view, this results in cache invalidation and will force the reload everywhere.
    */
@@ -162,16 +172,10 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
       return { label: LOADING };
     }
 
-    if (dataView?.id === defaultDataViewId) {
-      return {
-        label: DEFAULT_SECURITY_DATA_VIEW,
-      };
-    }
-
     return {
       label: dataView?.name || dataView?.id || 'Data view',
     };
-  }, [dataView?.id, dataView?.name, defaultDataViewId, status]);
+  }, [dataView?.id, dataView?.name, status]);
 
   return (
     <div data-test-subj={DATA_VIEW_PICKER_TEST_ID}>
@@ -187,6 +191,7 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
         savedDataViews={savedDataViews}
         managedDataViews={managedDataViews}
         onClosePopover={onClosePopover}
+        indexHelpText={indexHelpText}
       />
     </div>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/translations.ts
@@ -14,13 +14,20 @@ export const LOADING = i18n.translate('xpack.securitySolution.dataViewManager.lo
 export const DEFAULT_SECURITY_DATA_VIEW = i18n.translate(
   'xpack.securitySolution.dataViewManager.defaultSecurityDataView',
   {
-    defaultMessage: 'Default security data view',
+    defaultMessage: 'Security solution default',
   }
 );
 
 export const DEFAULT_SECURITY_ALERT_DATA_VIEW = i18n.translate(
   'xpack.securitySolution.dataViewManager.defaultSecurityAlertDataView',
   {
-    defaultMessage: 'Security alert data view',
+    defaultMessage: 'Security solution alerts',
+  }
+);
+
+export const SECURITY_SOLUTION_EXPLORE_DATA_VIEW = i18n.translate(
+  'xpack.securitySolution.dataViewManager.securitySolutionExploreDataView',
+  {
+    defaultMessage: 'Security solution explore',
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.test.ts
@@ -46,7 +46,7 @@ describe('useManagedDataViews', () => {
     });
   });
 
-  it('should filter data views to only include those with DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID', () => {
+  it('should filter data views to only include those with Alert Data View ID', () => {
     // Create mock data views with a mix of IDs
     const mockDataViews = [
       { id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, title: 'Security solution data view' },
@@ -67,27 +67,17 @@ describe('useManagedDataViews', () => {
     const { result } = renderHook(() => useManagedDataViews());
 
     // Expect only data views with matching ID to be included
-    expect(result.current.length).toBe(3);
+    expect(result.current.length).toBe(1);
 
     // Verify the IDs of the filtered data views
     result.current.forEach((dataView, i) => {
       if (i <= 1) {
-        expect(dataView.id).toBe(DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID);
-      } else {
         expect(dataView.id).toBe(DEFAULT_ALERT_DATA_VIEW_ID);
       }
     });
 
     // Verify DataView constructor was called with correct arguments
-    expect(DataView).toHaveBeenCalledTimes(3);
-    expect(DataView).toHaveBeenCalledWith({
-      spec: mockDataViews[0],
-      fieldFormats: mockFieldFormats,
-    });
-    expect(DataView).toHaveBeenCalledWith({
-      spec: mockDataViews[2],
-      fieldFormats: mockFieldFormats,
-    });
+    expect(DataView).toHaveBeenCalledTimes(1);
     expect(DataView).toHaveBeenCalledWith({
       spec: mockDataViews[3],
       fieldFormats: mockFieldFormats,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_managed_data_views.ts
@@ -19,7 +19,6 @@ export const useManagedDataViews = (): DataView[] => {
   const {
     dataViews: dataViewSpecs,
     adhocDataViews,
-    defaultDataViewId,
     alertDataViewId,
   } = useSelector(sharedStateSelector);
   const {
@@ -29,13 +28,8 @@ export const useManagedDataViews = (): DataView[] => {
   return useMemo(
     () =>
       [...dataViewSpecs, ...adhocDataViews]
-        .filter(
-          (dv) =>
-            dv.id === defaultDataViewId ||
-            dv.id === alertDataViewId ||
-            dv.id?.startsWith(EXPLORE_DATA_VIEW_PREFIX)
-        )
+        .filter((dv) => dv.id === alertDataViewId || dv.id?.startsWith(EXPLORE_DATA_VIEW_PREFIX))
         .map((spec) => new DataView({ spec, fieldFormats })),
-    [dataViewSpecs, adhocDataViews, defaultDataViewId, alertDataViewId, fieldFormats]
+    [dataViewSpecs, adhocDataViews, alertDataViewId, fieldFormats]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_saved_data_views.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_saved_data_views.test.ts
@@ -20,11 +20,11 @@ describe('useSavedDataViews', () => {
     jest.clearAllMocks();
   });
 
-  it('should filter out the default data view and transform the remaining ones', () => {
+  it('should not filter out the default data view and transform the remaining ones', () => {
     // Mock data to be returned by the selector
     const mockDataViews = [
       {
-        id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, // This should be filtered out
+        id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, // This should not be filtered out
         title: 'Default View',
         name: 'default_view',
       },
@@ -55,15 +55,20 @@ describe('useSavedDataViews', () => {
     // Render the hook
     const { result } = renderHook(() => useSavedDataViews());
 
-    // Expect the default view to be filtered out
-    expect(result.current).toHaveLength(2);
+    // Expect the alert view to be filtered out
+    expect(result.current).toHaveLength(3);
     expect(
       result.current.find((item) => item.id === DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID)
-    ).toBeUndefined();
+    ).not.toBeUndefined();
     expect(result.current.find((item) => item.id === DEFAULT_ALERT_DATA_VIEW_ID)).toBeUndefined();
 
     // Expect the custom views to be correctly transformed
     expect(result.current).toEqual([
+      {
+        id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, // This should not be filtered out
+        title: 'Default View',
+        name: 'default_view',
+      },
       {
         id: 'custom-view-1',
         title: 'Custom View 1',

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_saved_data_views.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_saved_data_views.ts
@@ -15,21 +15,17 @@ import { sharedStateSelector } from '../redux/selectors';
  * The list excludes managed data views (default security solution data view and alert data view)
  */
 export const useSavedDataViews = (): DataViewListItem[] => {
-  const {
-    dataViews: dataViewSpecs,
-    defaultDataViewId,
-    alertDataViewId,
-  } = useSelector(sharedStateSelector);
+  const { dataViews: dataViewSpecs, alertDataViewId } = useSelector(sharedStateSelector);
 
   return useMemo(
     () =>
       dataViewSpecs
-        .filter((dv) => dv.id !== defaultDataViewId && dv.id !== alertDataViewId)
+        .filter((dv) => dv.id !== alertDataViewId)
         .map((spec) => ({
           id: spec.id ?? '',
           title: spec.title ?? '',
           name: spec.name,
         })),
-    [dataViewSpecs, defaultDataViewId, alertDataViewId]
+    [dataViewSpecs, alertDataViewId]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -107,7 +107,7 @@ describe('createInitListener', () => {
     );
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync({
-        id: DEFAULT_ALERT_DATA_VIEW_ID,
+        id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
         scope: DataViewManagerScopeName.detections,
       })
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -96,15 +96,6 @@ export const createInitListener = (dependencies: {
           // NOTE: only init default data view for slices that are not initialized yet
           .filter((scope) => !listenerApi.getState().dataViewManager[scope].dataViewId)
           .forEach((scope) => {
-            if (scope === DataViewManagerScopeName.detections) {
-              return listenerApi.dispatch(
-                selectDataViewAsync({
-                  id: alertDataView.id,
-                  scope,
-                })
-              );
-            }
-
             if (scope === DataViewManagerScopeName.explore) {
               return listenerApi.dispatch(
                 selectDataViewAsync({

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/utils/create_explore_data_view.ts
@@ -8,6 +8,7 @@
 import type { DataViewsServicePublic, DataView } from '@kbn/data-views-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { EXPLORE_DATA_VIEW_PREFIX } from '../../../common/constants';
+import { SECURITY_SOLUTION_EXPLORE_DATA_VIEW } from '../components/data_view_picker/translations';
 
 export const createExploreDataView = async (
   dependencies: {
@@ -23,7 +24,7 @@ export const createExploreDataView = async (
 
   return dependencies.dataViews.create({
     id: `${EXPLORE_DATA_VIEW_PREFIX}-${(await dependencies.spaces.getActiveSpace()).id}`,
-    name: 'Explore data view',
+    name: SECURITY_SOLUTION_EXPLORE_DATA_VIEW,
     title: exploreDataViewPattern,
   });
 };

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/constants.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/constants.ts
@@ -7,6 +7,6 @@
 
 export const SECURITY_ES_ARCHIVES_DIR =
   'x-pack/solutions/security/test/security_solution_cypress/es_archives';
-export const SECURITY_SOLUTION_DATA_VIEW = 'Default security data view';
+export const SECURITY_SOLUTION_DATA_VIEW = 'Security solution default';
 export const SECURITY_SOLUTION_INDEX_PATTERN =
   '.alerts-security.alerts-default,apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-*';


### PR DESCRIPTION
## Summary

**Security changes**

Security users have been able to add run time fields to the security default data view. While implementing the managed data view feature https://github.com/elastic/kibana/pull/223451, the conflict arise where we want the default data view to be kibana managed, but we do not want to take away user's ability to add run time fields.

As a result, it was decided to exclude security default data view as `managed`, and the data view in alerts page is changed to security default. With these changes, users can see run time fields created before they upgrade to `9.2`, and they will be able to continue adding run time fields. 

<img width="488" height="306" alt="image" src="https://github.com/user-attachments/assets/9026ef05-3adb-4b23-9abf-b5e12d6d95d9" />

**Discover / Data view picker changes**

Even though we can't have the default data view as `managed`, we want to bring awareness of the security advanced setting to users. Currently, indices in advanced settings always override user changes in editor flyout. To minimize confusion, this PR added an optional prop `getDataViewHelpText` in the data view picker component. This will allow a help text to be shown when user is editing the security default data view. 

<img width="987" height="470" alt="image" src="https://github.com/user-attachments/assets/f2cfb169-c0f6-4e32-8081-f186b010d0ee" />

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
