### PR TITLE
[9.1] Monitoring Source Schema Version Correction (#229312)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.gen.ts
@@ -11,7 +11,7 @@
  *
  * info:
  *   title: Monitoring Entity Source Schema
- *   version: 1
+ *   version: 2023-10-31
  */
 
 import { z } from '@kbn/zod';

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/privilege_monitoring/monitoring_entity_source/monitoring_entity_source.schema.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Monitoring Entity Source Schema
   description: Schema for managing entity source configurations in the monitoring system.
-  version: "1"
+  version: "2023-10-31"
 
 paths:
   /api/entity_analytics/monitoring/entity_source:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -651,7 +651,7 @@ If a record already exists for the specified entity, that record is overwritten 
       .request<CreateEntitySourceResponse>({
         path: '/api/entity_analytics/monitoring/entity_source',
         headers: {
-          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+          [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31',
         },
         method: 'POST',
         body: props.body,
@@ -867,7 +867,7 @@ For detailed information on Kibana actions and alerting, and additional API call
       .request({
         path: replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
         headers: {
-          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+          [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31',
         },
         method: 'DELETE',
       })
@@ -1478,7 +1478,7 @@ finalize it.
       .request<GetEntitySourceResponse>({
         path: replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
         headers: {
-          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+          [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31',
         },
         method: 'GET',
       })
@@ -2043,7 +2043,7 @@ providing you with the most current and effective threat detection capabilities.
       .request<ListEntitySourcesResponse>({
         path: '/api/entity_analytics/monitoring/entity_source/list',
         headers: {
-          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+          [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31',
         },
         method: 'GET',
 
@@ -2612,7 +2612,7 @@ The difference between the `id` and `rule_id` is that the `id` is a unique rule 
       .request<UpdateEntitySourceResponse>({
         path: replaceParams('/api/entity_analytics/monitoring/entity_source/{id}', props.params),
         headers: {
-          [ELASTIC_HTTP_VERSION_HEADER]: '1',
+          [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31',
         },
         method: 'PUT',
         body: props.body,

--- a/x-pack/test/api_integration/services/security_solution_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_api.gen.ts
@@ -346,7 +346,7 @@ If a record already exists for the specified entity, that record is overwritten 
       return supertest
         .post(routeWithNamespace('/api/entity_analytics/monitoring/entity_source', kibanaSpace))
         .set('kbn-xsrf', 'true')
-        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
@@ -537,7 +537,7 @@ For detailed information on Kibana actions and alerting, and additional API call
           )
         )
         .set('kbn-xsrf', 'true')
-        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
     deleteMonitoringEngine(props: DeleteMonitoringEngineProps, kibanaSpace: string = 'default') {
@@ -1004,7 +1004,7 @@ finalize it.
           )
         )
         .set('kbn-xsrf', 'true')
-        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
     getEntityStoreStatus(props: GetEntityStoreStatusProps, kibanaSpace: string = 'default') {
@@ -1462,7 +1462,7 @@ providing you with the most current and effective threat detection capabilities.
       return supertest
         .get(routeWithNamespace('/api/entity_analytics/monitoring/entity_source/list', kibanaSpace))
         .set('kbn-xsrf', 'true')
-        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
@@ -1876,7 +1876,7 @@ The difference between the `id` and `rule_id` is that the `id` is a unique rule 
           )
         )
         .set('kbn-xsrf', 'true')
-        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Monitoring Source Schema Version Correction (#229312)](https://github.com/elastic/kibana/pull/229312)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charlotte Alexandra Wilson","email":"CAWilson94@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-07-29T08:03:15Z","message":"Monitoring Source Schema Version Correction (#229312)\n\n## Summary \n\nMonitoring source schema was using incorrect version - updated to be\n\"2023-10-31\"\n\nWhen writing FTR tests you can now use ftr context provider with\nsecurity solution and not need to pass in header each time, via openAPI\ngen files:\n\n**Previous:** \n```\nconst response = await api.createEntitySource({ body: entitySource }, 'default').set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31');\n```\n With this PR: \n```\nconst response = await api.createEntitySource({ body: entitySource }, 'default')\n```","sha":"c6d97dc95e2f189a2eda5011d9dec351e9b42f36","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","v9.2.0"],"title":"Monitoring Source Schema Version Correction","number":229312,"url":"https://github.com/elastic/kibana/pull/229312","mergeCommit":{"message":"Monitoring Source Schema Version Correction (#229312)\n\n## Summary \n\nMonitoring source schema was using incorrect version - updated to be\n\"2023-10-31\"\n\nWhen writing FTR tests you can now use ftr context provider with\nsecurity solution and not need to pass in header each time, via openAPI\ngen files:\n\n**Previous:** \n```\nconst response = await api.createEntitySource({ body: entitySource }, 'default').set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31');\n```\n With this PR: \n```\nconst response = await api.createEntitySource({ body: entitySource }, 'default')\n```","sha":"c6d97dc95e2f189a2eda5011d9dec351e9b42f36"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229312","number":229312,"mergeCommit":{"message":"Monitoring Source Schema Version Correction (#229312)\n\n## Summary \n\nMonitoring source schema was using incorrect version - updated to be\n\"2023-10-31\"\n\nWhen writing FTR tests you can now use ftr context provider with\nsecurity solution and not need to pass in header each time, via openAPI\ngen files:\n\n**Previous:** \n```\nconst response = await api.createEntitySource({ body: entitySource }, 'default').set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31');\n```\n With this PR: \n```\nconst response = await api.createEntitySource({ body: entitySource }, 'default')\n```","sha":"c6d97dc95e2f189a2eda5011d9dec351e9b42f36"}}]}] BACKPORT-->