### PR TITLE
[Dataset Quality] Fix index template update issue

### DIFF
--- a/x-pack/solutions/observability/test/dataset_quality_api_integration/tests/data_streams/es_utils.ts
+++ b/x-pack/solutions/observability/test/dataset_quality_api_integration/tests/data_streams/es_utils.ts
@@ -20,9 +20,13 @@ export async function addIntegrationToLogIndexTemplate({
     name: 'logs',
   });
 
+  const template = indexTemplates[0].index_template;
+  // @ts-expect-error `created_date` is a system-managed property that cannot be set
+  delete template.created_date;
+
   await esClient.indices.putIndexTemplate({
     name: 'logs',
-    ...indexTemplates[0].index_template,
+    ...template,
     _meta: {
       ...indexTemplates[0].index_template._meta,
       package: {
@@ -43,9 +47,13 @@ export async function cleanLogIndexTemplate({ esClient }: { esClient: Client }) 
     name: 'logs',
   });
 
+  const template = indexTemplates[0].index_template;
+  // @ts-expect-error `created_date` is a system-managed property that cannot be set
+  delete template.created_date;
+
   await esClient.indices.putIndexTemplate({
     name: 'logs',
-    ...indexTemplates[0].index_template,
+    ...template,
     _meta: {
       ...indexTemplates[0].index_template._meta,
       package: undefined,

--- a/x-pack/solutions/observability/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
+++ b/x-pack/solutions/observability/test/dataset_quality_api_integration/tests/data_streams/stats.spec.ts
@@ -59,8 +59,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     ]);
   }
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/230901
-  registry.when.skip('Api Key privileges check', { config: 'basic' }, () => {
+  registry.when('Api Key privileges check', { config: 'basic' }, () => {
     describe('index privileges', function () {
       // This disables the forward-compatibility test for Kibana 8.19 with ES upgraded to 9.0.
       // These versions are not expected to work together.
@@ -137,7 +136,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       after(async () => {
         await logsSynthtrace.clean();
-        await cleanLogIndexTemplate({ esClient: es });
       });
     });
 


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/kibana/issues/230901

## Analysis

This test suddenly started failing with an Elasticsearch error `index_template [logs] invalid, cause [provided a template property which is managed by the system: created_date]` 

The `created_date` is an Elasticsearch managed property and what i found is this property has been a managed property since `8.x` meaning nothing changed here and makes me wonder why this test started failing suddenly.

Hence to safeguard this is not happening, i update the logic to dedicated handle this part and delete `created_date` property while updating `index templates`

Also the call to this function in the after each block was unnecessary, seems like a copy paste mistake. Hence it has also been removed.

## Flaky Test Runner

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9098