### PR TITLE
[Discover] Add 3 lines truncation to queries in a tab preview

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_preview/tab_preview.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_preview/tab_preview.tsx
@@ -157,6 +157,7 @@ export const TabPreview: React.FC<TabPreviewProps> = ({
                   language={getQueryLanguage(tabPreviewData)}
                   transparentBackground
                   paddingSize="none"
+                  css={codeBlockCss}
                 >
                   {getPreviewQuery(tabPreviewData)}
                 </EuiCodeBlock>
@@ -206,6 +207,15 @@ const getPreviewContainerCss = (
     transition: opacity ${euiTheme.animation.normal} ease;
   `;
 };
+
+const codeBlockCss = css`
+  .euiCodeBlock__code {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+  }
+`;
 
 const getSplitPanelCss = (euiTheme: EuiThemeComputed) => {
   return css`


### PR DESCRIPTION
## Summary

Resolves:
- #229754
- #229763
- #229807
- #229764 

It resolves all 4 PRs, because we eventually settled for one solution regardless of the query language.

This PR applies 3 lines truncation to long queries in a tab preview.

**Before:**
<img width="433" height="501" alt="Screenshot 2025-08-12 at 12 22 13" src="https://github.com/user-attachments/assets/3997e171-f9f5-43f9-9418-6c26799193e3" />

**After:**
<img width="454" height="213" alt="Screenshot 2025-08-12 at 12 21 54" src="https://github.com/user-attachments/assets/2bcf734d-a41e-41af-b732-e6d6b8e1fc51" />

### Testing
To enable tabs in Discover, run localStorage.setItem('discoverExperimental:tabs', 'true') in browser Console and refresh the page.
Create a long query either in classic mode or ES|QL mode and hover over the tab. Long query should be truncated to 3 lines.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



