### PR TITLE
Revert "[ci] use ubuntu 24 base images (#231278)"

### DIFF
--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -16,13 +16,13 @@ const ELASTIC_IMAGES_PROD_PROJECT = 'elastic-images-prod';
 // constrain AgentImageConfig to the type that doesn't have the `queue` property
 const DEFAULT_AGENT_IMAGE_CONFIG: BuildkiteAgentTargetingRule = {
   provider: 'gcp',
-  image: 'family/kibana-ubuntu-2404',
+  image: 'family/kibana-ubuntu-2004',
   imageProject: ELASTIC_IMAGES_PROD_PROJECT,
 };
 
 const FIPS_AGENT_IMAGE_CONFIG: BuildkiteAgentTargetingRule = {
   provider: 'gcp',
-  image: 'family/kibana-fips-ubuntu-2404',
+  image: 'family/kibana-fips-ubuntu-2004',
   imageProject: ELASTIC_IMAGES_PROD_PROJECT,
 };
 

--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -2,7 +2,7 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/build.sh
     label: Build Kibana Artifacts
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c2-standard-16
@@ -18,7 +18,7 @@ steps:
   - command: TEST_PACKAGE=deb .buildkite/scripts/steps/package_testing/test.sh
     label: Artifact Testing
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -32,7 +32,7 @@ steps:
   - command: TEST_PACKAGE=rpm .buildkite/scripts/steps/package_testing/test.sh
     label: Artifact Testing
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -46,7 +46,7 @@ steps:
   - command: TEST_PACKAGE=docker .buildkite/scripts/steps/package_testing/test.sh
     label: Artifact Testing
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -60,7 +60,7 @@ steps:
   - command: KIBANA_DOCKER_CONTEXT=default .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -73,7 +73,7 @@ steps:
   - command: KIBANA_DOCKER_CONTEXT=wolfi .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -86,7 +86,7 @@ steps:
   - command: KIBANA_DOCKER_CONTEXT=ironbank .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -102,7 +102,7 @@ steps:
       - exit_status: 255
       - exit_status: -1
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -127,7 +127,7 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/publish.sh
     label: 'Publish Kibana Artifacts'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/artifacts_container_image.yml
+++ b/.buildkite/pipelines/artifacts_container_image.yml
@@ -2,7 +2,7 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/docker_image.sh
     label: Build serverless container images
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-16

--- a/.buildkite/pipelines/artifacts_trigger.yml
+++ b/.buildkite/pipelines/artifacts_trigger.yml
@@ -2,7 +2,7 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/trigger.sh
     label: Trigger artifacts build
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/build_api_docs.yml
+++ b/.buildkite/pipelines/build_api_docs.yml
@@ -5,7 +5,7 @@ steps:
     label: 'Check types'
     key: check_types
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -15,7 +15,7 @@ steps:
   - command: .buildkite/scripts/steps/api_docs/build_api_docs.sh
     label: 'Build API Docs'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
@@ -32,7 +32,7 @@ steps:
   - command: .buildkite/scripts/steps/api_docs/publish_api_docs.sh
     label: 'Publish API Docs'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/build_pr_and_deploy_cloud.yml
+++ b/.buildkite/pipelines/build_pr_and_deploy_cloud.yml
@@ -16,7 +16,7 @@ steps:
         label: Comment missing labels
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         timeout_in_minutes: 5
@@ -30,7 +30,7 @@ steps:
         timeout_in_minutes: 10
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         retry:
@@ -46,7 +46,7 @@ steps:
         label: Comment with job URL
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         timeout_in_minutes: 5
@@ -57,7 +57,7 @@ steps:
         label: Build Kibana Distribution
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-8
           preemptible: true
@@ -74,7 +74,7 @@ steps:
         label: 'Build and Deploy to Cloud'
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
           preemptible: true
@@ -95,7 +95,7 @@ steps:
         label: Comment with job URL
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         timeout_in_minutes: 5

--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -3,7 +3,7 @@ env:
   # This is what will switch the FTRs/cypress pipeline to use Chrome Beta
   USE_CHROME_BETA: 'true'
 agents:
-  image: family/kibana-ubuntu-2404
+  image: family/kibana-ubuntu-2004
   imageProject: elastic-images-prod
   provider: gcp
 

--- a/.buildkite/pipelines/chromium_linux_build/build_chromium.yml
+++ b/.buildkite/pipelines/chromium_linux_build/build_chromium.yml
@@ -13,7 +13,7 @@ steps:
     label: Comment with job URL on issue
     agents:
       provider: gcp
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       machineType: n2-standard-2
     timeout_in_minutes: 5
@@ -24,7 +24,7 @@ steps:
     key: infer_chromium_version
     agents:
       provider: gcp
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       machineType: n2-standard-2
     timeout_in_minutes: 5
@@ -36,7 +36,7 @@ steps:
     env:
       DEBIAN_FRONTEND: noninteractive
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c2d-highcpu-112
@@ -53,7 +53,7 @@ steps:
       KIBANA_MACHINE_EMAIL: 42973632+kibanamachine@users.noreply.github.com
     agents:
       provider: gcp
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       machineType: n2-standard-2
     timeout_in_minutes: 30

--- a/.buildkite/pipelines/code_coverage/daily.yml
+++ b/.buildkite/pipelines/code_coverage/daily.yml
@@ -3,7 +3,7 @@ steps:
     label: Pre-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -13,7 +13,7 @@ steps:
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -27,7 +27,7 @@ steps:
   - command: .buildkite/scripts/steps/code_coverage/ingest.sh
     label: 'Merge and Ingest'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/console_definitions_sync.yml
+++ b/.buildkite/pipelines/console_definitions_sync.yml
@@ -3,7 +3,7 @@ steps:
     label: Console Definitions Sync
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
+++ b/.buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
@@ -2,7 +2,7 @@
 
 ## Triggers the artifacts container image build for emergency releases
 agents:
-  image: family/kibana-ubuntu-2404
+  image: family/kibana-ubuntu-2004
   imageProject: elastic-images-prod
   provider: gcp
   machineType: n2-standard-2

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -9,7 +9,7 @@
 # BUILDKITE_COMMIT: the commit hash of the kibana branch to test
 
 agents:
-  image: family/kibana-ubuntu-2404
+  image: family/kibana-ubuntu-2004
   imageProject: elastic-images-prod
   provider: gcp
   machineType: n2-standard-2
@@ -26,7 +26,7 @@ steps:
         key: pre-build
         timeout_in_minutes: 10
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-2
@@ -34,7 +34,7 @@ steps:
       - label: 'Build Kibana Distribution'
         command: .buildkite/scripts/steps/build_kibana.sh
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-8
@@ -66,7 +66,7 @@ steps:
         label: 'Serverless Entity Analytics - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -83,7 +83,7 @@ steps:
         label: 'Serverless Explore - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -100,7 +100,7 @@ steps:
         label: 'Serverless Investigations - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -117,7 +117,7 @@ steps:
         label: 'Serverless Rule Management - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -134,7 +134,7 @@ steps:
         label: 'Serverless Rule Management - Prebuilt Rules - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -151,7 +151,7 @@ steps:
         label: 'Serverless Detection Engine - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -168,7 +168,7 @@ steps:
         label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -185,7 +185,7 @@ steps:
         label: 'Serverless AI Assistant - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -202,7 +202,7 @@ steps:
         label: 'Defend Workflows Cypress Tests on Serverless'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
@@ -219,7 +219,7 @@ steps:
         label: 'Osquery Cypress Tests on Serverless'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/es_snapshots/build.yml
+++ b/.buildkite/pipelines/es_snapshots/build.yml
@@ -3,7 +3,7 @@ steps:
     label: Build ES Snapshot
     timeout_in_minutes: 30
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       localSsds: 1

--- a/.buildkite/pipelines/es_snapshots/promote.yml
+++ b/.buildkite/pipelines/es_snapshots/promote.yml
@@ -11,7 +11,7 @@ steps:
   - label: Promote Snapshot
     command: .buildkite/scripts/steps/es_snapshots/promote.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -15,7 +15,7 @@ steps:
     label: Pre-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -25,7 +25,7 @@ steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -41,7 +41,7 @@ steps:
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -60,7 +60,7 @@ steps:
     label: Trigger promotion
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -75,7 +75,7 @@ steps:
     label: Post-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/esql_grammar_sync.yml
+++ b/.buildkite/pipelines/esql_grammar_sync.yml
@@ -3,7 +3,7 @@ steps:
     label: Grammar Sync
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -12,7 +12,7 @@ steps:
     label: Generate Function Metadata
     timeout_in_minutes: 15
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/fips.yml
+++ b/.buildkite/pipelines/fips.yml
@@ -4,7 +4,7 @@ env:
   TEST_BROWSER_HEADLESS: 1
 agents:
   provider: 'gcp'
-  image: 'family/kibana-fips-ubuntu-2404'
+  image: 'family/kibana-fips-ubuntu-2004'
   imageProject: 'elastic-images-prod'
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -5,7 +5,7 @@ steps:
     label: Pre-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -15,7 +15,7 @@ steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -31,7 +31,7 @@ steps:
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -49,7 +49,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -66,7 +66,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -83,7 +83,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -98,7 +98,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     label: 'Osquery Cypress Tests on Serverless'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -113,7 +113,7 @@ steps:
   - command: .buildkite/scripts/steps/fleet/promote_package_registry.sh
     label: Promote docker.elastic.co/package-registry/distribution:lite
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -130,7 +130,7 @@ steps:
     label: Post-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/fleet/packages_daily.yml
+++ b/.buildkite/pipelines/fleet/packages_daily.yml
@@ -3,7 +3,7 @@ steps:
     label: Pre-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -13,7 +13,7 @@ steps:
   - command: .buildkite/scripts/steps/fleet/install_all_packages.sh
     label: Install All Packages
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       localSsds: 1
@@ -31,7 +31,7 @@ steps:
   - label: Post-Build
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/gen_ai_testing.yml
+++ b/.buildkite/pipelines/gen_ai_testing.yml
@@ -4,7 +4,7 @@ steps:
   - label: '👨‍🔧 Pre-Build'
     command: .buildkite/scripts/lifecycle/pre_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -14,7 +14,7 @@ steps:
   - label: '🧑‍🏭 Build Kibana Distribution'
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -33,7 +33,7 @@ steps:
     timeout_in_minutes: 50
     parallelism: 1
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -6,7 +6,7 @@ steps:
     label: Pre-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -20,7 +20,7 @@ steps:
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Build Kibana Distribution
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -35,7 +35,7 @@ steps:
   - command: .buildkite/scripts/steps/quick_checks.sh
     label: 'Quick Checks'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highcpu-8
@@ -50,7 +50,7 @@ steps:
   - command: .buildkite/scripts/steps/checks.sh
     label: 'Checks'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -65,7 +65,7 @@ steps:
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-16
@@ -80,7 +80,7 @@ steps:
   - command: .buildkite/scripts/steps/lint_with_types.sh
     label: 'Linting (with types)'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-32
@@ -95,7 +95,7 @@ steps:
   - command: .buildkite/scripts/steps/check_types.sh
     label: 'Check Types'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c4-standard-4
@@ -112,7 +112,7 @@ steps:
   - command: .buildkite/scripts/steps/checks/capture_oas_snapshot.sh
     label: 'Check OAS Snapshot'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -129,7 +129,7 @@ steps:
     label: Check Public API Docs
     key: public-api-docs
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-highmem-4
@@ -146,7 +146,7 @@ steps:
   - command: .buildkite/scripts/steps/ci_stats_ready.sh
     label: Mark CI Stats as ready
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -163,7 +163,7 @@ steps:
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -181,7 +181,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
     label: 'Serverless Entity Analytics - Security Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -196,7 +196,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     label: 'Serverless Explore - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -211,7 +211,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     label: 'Serverless Investigations - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -226,7 +226,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -241,7 +241,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules.sh
     label: 'Serverless Rule Management - Prebuilt Rules - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -256,7 +256,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     label: 'Rule Management - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -271,7 +271,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules.sh
     label: 'Rule Management - Prebuilt Rules - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -286,7 +286,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
     label: 'Serverless Detection Engine - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -301,7 +301,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
     label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -316,7 +316,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -331,7 +331,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -346,7 +346,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
     label: 'Serverless AI Assistant - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -361,7 +361,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -376,7 +376,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -391,7 +391,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     label: 'Explore - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -406,7 +406,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -421,7 +421,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -436,7 +436,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     label: 'Osquery Cypress Tests on Serverless'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -451,7 +451,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -466,7 +466,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -481,7 +481,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/profiling_cypress.sh
     label: 'Profiling Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -496,7 +496,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/apm_cypress.sh
     label: 'APM Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -512,7 +512,7 @@ steps:
     label: Trigger unsupported ftr tests
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -520,7 +520,7 @@ steps:
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
     label: 'Build Storybooks'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -535,7 +535,7 @@ steps:
   - command: .buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
     label: 'Publish OAS docs to bump.sh'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -550,7 +550,7 @@ steps:
   - command: .buildkite/scripts/steps/archive_so_migration_snapshot.sh target/plugin_so_types_snapshot.json
     label: 'Extract Saved Object migration plugin types'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -569,7 +569,7 @@ steps:
     label: Post-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -580,7 +580,7 @@ steps:
     label: Trigger container image build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -3,7 +3,7 @@ steps:
     label: Pre-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -15,7 +15,7 @@ steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -31,7 +31,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/synthetics_plugin.sh
     label: 'Synthetics @elastic/synthetics Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -52,7 +52,7 @@ steps:
   - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/performance/daily.yml
+++ b/.buildkite/pipelines/performance/daily.yml
@@ -2,7 +2,7 @@ steps:
   - label: '👨‍🔧 Pre-Build'
     command: .buildkite/scripts/lifecycle/pre_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -12,7 +12,7 @@ steps:
   - label: '🧑‍🏭 Build Kibana Distribution'
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -32,7 +32,7 @@ steps:
   - label: '📈 Report performance metrics to ci-stats'
     command: .buildkite/scripts/steps/functional/report_performance_metrics.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       localSsds: 1
@@ -46,7 +46,7 @@ steps:
   - label: '🦸 Post-Build'
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/performance/data_set_extraction_daily.yml
+++ b/.buildkite/pipelines/performance/data_set_extraction_daily.yml
@@ -2,7 +2,7 @@ steps:
   - label: ':male-mechanic::skin-tone-2: Pre-Build'
     command: .buildkite/scripts/lifecycle/pre_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -13,7 +13,7 @@ steps:
   - label: ':building_construction: Build Kibana Distribution '
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -23,7 +23,7 @@ steps:
   - label: ':kibana: Performance Tests with Playwright config'
     command: .buildkite/scripts/steps/functional/performance_playwright.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -41,7 +41,7 @@ steps:
   - label: ':ship: Single user journeys dataset extraction for scalability benchmarking'
     command: .buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       localSsds: 1
@@ -55,7 +55,7 @@ steps:
   - label: ':male_superhero::skin-tone-2: Post-Build'
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -5,7 +5,7 @@ steps:
     label: Pre-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -18,7 +18,7 @@ steps:
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Build Kibana Distribution and Plugins
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-16
@@ -35,7 +35,7 @@ steps:
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -52,7 +52,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
     label: 'Serverless Entity Analytics - Security Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -69,7 +69,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     label: 'Serverless Explore - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -86,7 +86,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     label: 'Serverless Investigations - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -103,7 +103,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -120,7 +120,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules.sh
     label: 'Serverless Rule Management - Prebuilt Rules - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -137,7 +137,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     label: 'Rule Management - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -154,7 +154,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules.sh
     label: 'Rule Management - Prebuilt Rules - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -171,7 +171,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
     label: 'Serverless Detection Engine - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -188,7 +188,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
     label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -205,7 +205,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -222,7 +222,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -239,7 +239,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
     label: 'Serverless AI Assistant - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -256,7 +256,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -273,7 +273,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -290,7 +290,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     label: 'Explore - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -307,7 +307,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -324,7 +324,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -341,7 +341,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     label: 'Osquery Cypress Tests on Serverless'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -358,7 +358,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -375,7 +375,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
@@ -396,7 +396,7 @@ steps:
     label: Post-Build
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/purge_cloud_deployments.yml
+++ b/.buildkite/pipelines/purge_cloud_deployments.yml
@@ -3,7 +3,7 @@ steps:
     label: Purge old cloud deployments
     timeout_in_minutes: 10
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/renovate_helper.yml
+++ b/.buildkite/pipelines/renovate_helper.yml
@@ -1,6 +1,6 @@
 agents:
   provider: gcp
-  image: family/kibana-ubuntu-2404
+  image: family/kibana-ubuntu-2004
   imageProject: elastic-images-prod
   machineType: n2-standard-2
 steps:

--- a/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
+++ b/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
@@ -2,7 +2,7 @@ steps:
   - label: 'Pre-Build'
     command: .buildkite/scripts/lifecycle/pre_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -12,7 +12,7 @@ steps:
   - label: 'Build Kibana Distribution'
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -42,7 +42,7 @@ steps:
   - label: 'Post-Build'
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/scalability/daily.yml
+++ b/.buildkite/pipelines/scalability/daily.yml
@@ -2,7 +2,7 @@ steps:
   - label: ':male-mechanic::skin-tone-2: Pre-Build'
     command: .buildkite/scripts/lifecycle/pre_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -26,7 +26,7 @@ steps:
   - label: ':male_superhero::skin-tone-2: Post-Build'
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/security_solution/gen_ai_evals.yml
+++ b/.buildkite/pipelines/security_solution/gen_ai_evals.yml
@@ -4,7 +4,7 @@ steps:
   - label: '👨‍🔧 Pre-Build'
     command: .buildkite/scripts/lifecycle/pre_build.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
@@ -14,7 +14,7 @@ steps:
   - label: '🧑‍🏭 Build Kibana Distribution'
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-8
@@ -33,7 +33,7 @@ steps:
     timeout_in_minutes: 50
     parallelism: 1
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_ai4dsoc.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_ai4dsoc.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-ai4dsoc"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -23,7 +23,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh ai4dsoc_cases:qa:serverless
         key: ai4dsoc_cases:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -37,7 +37,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh ai4dsoc_nlp_cleanup_task:qa:serverless
         key: ai4dsoc_nlp_cleanup_task:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -6,7 +6,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows.sh cypress:dw:qa:serverless:run
         key: test_defend_workflows
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
@@ -25,7 +25,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows_osquery.sh cypress:qa:serverless:run
         key: test_osquery_defend_workflows
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
@@ -44,7 +44,7 @@ steps:
 #        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:artifacts:qa:serverless
 #        key: edr_workflows:artifacts:qa:serverless
 #        agents:
-#          image: family/kibana-ubuntu-2404
+#          image: family/kibana-ubuntu-2004
 #          imageProject: elastic-images-prod
 #          provider: gcp
 #          enableNestedVirtualization: true
@@ -59,7 +59,7 @@ steps:
 #        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:authentication:qa:serverless
 #        key: edr_workflows:authentication:qa:serverless
 #        agents:
-#          image: family/kibana-ubuntu-2404
+#          image: family/kibana-ubuntu-2004
 #          imageProject: elastic-images-prod
 #          provider: gcp
 #          enableNestedVirtualization: true
@@ -74,7 +74,7 @@ steps:
 #        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:metadata:qa:serverless
 #        key: edr_workflows:metadata:qa:serverless
 #        agents:
-#          image: family/kibana-ubuntu-2404
+#          image: family/kibana-ubuntu-2004
 #          imageProject: elastic-images-prod
 #          provider: gcp
 #          enableNestedVirtualization: true
@@ -89,7 +89,7 @@ steps:
 #        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:package:qa:serverless
 #        key: edr_workflows:package:qa:serverless
 #        agents:
-#          image: family/kibana-ubuntu-2404
+#          image: family/kibana-ubuntu-2004
 #          imageProject: elastic-images-prod
 #          provider: gcp
 #          enableNestedVirtualization: true
@@ -104,7 +104,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy_response:qa:serverless
         key: edr_workflows:policy_response:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
@@ -119,7 +119,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:resolver:qa:serverless
         key: edr_workflows:resolver:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
@@ -134,7 +134,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:response_actions:qa:serverless
         key: edr_workflows:response_actions:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_detection_engine.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_detection_engine.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -22,7 +22,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -36,7 +36,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -50,7 +50,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -64,7 +64,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -78,7 +78,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -92,7 +92,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -106,7 +106,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -120,7 +120,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -135,7 +135,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists_items:qa:serverless
         key: exception_lists_items:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -149,7 +149,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists:auth:lists:qa:serverless
         key: exception_lists:auth:lists:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -163,7 +163,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists:auth:common:qa:serverless
         key: exception_lists:auth:common:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -177,7 +177,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists:auth:items:qa:serverless
         key: exception_lists:auth:items:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -191,7 +191,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh lists_items:qa:serverless
         key: lists_items:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -205,7 +205,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh user_roles:qa:serverless
         key: user_roles:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -219,7 +219,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh telemetry:qa:serverless
         key: telemetry:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -233,7 +233,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_workflows:essentials:qa:serverless
         key: exception_workflows:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -247,7 +247,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_date_types:essentials:qa:serverless
         key: exception_operators_date_types:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -261,7 +261,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_double:essentials:qa:serverless
         key: exception_operators_double:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -275,7 +275,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_float:essentials:qa:serverless
         key: exception_operators_float:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -289,7 +289,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_integer:essentials:qa:serverless
         key: exception_operators_integer:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -303,7 +303,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_keyword:essentials:qa:serverless
         key: exception_operators_keyword:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -317,7 +317,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_ips:essentials:qa:serverless
         key: exception_operators_ips:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -331,7 +331,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_long:essentials:qa:serverless
         key: exception_operators_long:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -345,7 +345,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_text:essentials:qa:serverless
         key: exception_operators_text:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -359,7 +359,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh actions:qa:serverless
         key: actions:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -373,7 +373,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh alerts:qa:serverless
         key: alerts:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -387,7 +387,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh alerts:essentials:qa:serverless
         key: alerts:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -401,7 +401,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:eql:qa:serverless
         key: rule_execution_logic:eql:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -415,7 +415,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:esql:qa:serverless
         key: rule_execution_logic:esql:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -429,7 +429,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:general_logic:qa:serverless
         key: rule_execution_logic:general_logic:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -438,12 +438,12 @@ steps:
           automatic:
             - exit_status: '1'
               limit: 2
-
+      
       - label: 'API MKI - rule_execution_logic:general_logic:essentials:qa:serverless'
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:general_logic:essentials:qa:serverless
         key: rule_execution_logic:general_logic:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -457,7 +457,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:indicator_match:qa:serverless
         key: rule_execution_logic:indicator_match:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -471,7 +471,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:machine_learning:qa:serverless
         key: rule_execution_logic:machine_learning:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -485,7 +485,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:new_terms:qa:serverless
         key: rule_execution_logic:new_terms:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -499,7 +499,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:query:qa:serverless
         key: rule_execution_logic:query:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -513,7 +513,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:threshold:qa:serverless
         key: rule_execution_logic:threshold:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_entity_analytics.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_entity_analytics.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-entity-analytics"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -22,7 +22,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-entity-analytics"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -36,7 +36,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-entity-analytics"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -50,7 +50,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-entity-analytics"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -64,7 +64,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -78,7 +78,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -92,7 +92,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -106,7 +106,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -121,7 +121,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh entity_analytics:qa:serverless
         key: entity_analytics:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -135,7 +135,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh entity_analytics:essentials:qa:serverless
         key: entity_analytics:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -149,7 +149,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:hosts:runner:qa:serverless
         key: explore:hosts:runner:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -163,7 +163,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:network:runner:qa:serverless
         key: explore:network:runner:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -177,7 +177,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:users:runner:qa:serverless
         key: explore:users:runner:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_explore.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_explore.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -25,7 +25,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -39,7 +39,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_gen_ai.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_gen_ai.yml
@@ -5,7 +5,7 @@ steps:
     env:
       BK_TEST_SUITE_KEY: "serverless-cypress-gen-ai"
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -20,7 +20,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh nlp_cleanup_task:complete:qa:serverless
         key: nlp_cleanup_task:complete:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -34,7 +34,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh nlp_cleanup_task:essentials:qa:serverless
         key: nlp_cleanup_task:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_investigations.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_investigations.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -22,7 +22,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -36,7 +36,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -50,7 +50,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -64,7 +64,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -78,7 +78,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -92,7 +92,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -106,7 +106,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -120,7 +120,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -134,7 +134,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -148,7 +148,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -162,7 +162,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -176,7 +176,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -190,7 +190,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: "serverless-cypress-explore"
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -205,7 +205,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh investigations:timeline:runner:qa:serverless
         key: investigations:timeline:runner:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -219,7 +219,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh investigations:saved-objects:runner:qa:serverless
         key: investigations:saved-objects:runner:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -233,7 +233,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:overview:runner:qa:serverless
         key: explore:overview:runner:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_rule_management.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_rule_management.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -22,7 +22,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -36,7 +36,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -50,7 +50,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -64,7 +64,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -78,7 +78,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -92,7 +92,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -106,7 +106,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -121,7 +121,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_creation:qa:serverless
         key: rule_creation:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -135,7 +135,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_creation:essentials:qa:serverless
         key: rule_creation:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -149,7 +149,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_update:qa:serverless
         key: rule_update:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -163,7 +163,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_update:essentials:qa:serverless
         key: rule_update:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -177,7 +177,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_patch:qa:serverless
         key: rule_patch:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -191,7 +191,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_patch:essentials:qa:serverless
         key: rule_patch:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -205,7 +205,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_management:customization_disabled:qa:serverless
         key: prebuilt_rules_management:customization_disabled:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -219,7 +219,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_management:customization_enabled:qa:serverless
         key: prebuilt_rules_management:customization_enabled:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -233,7 +233,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_upgrade_common_fields:customization_enabled:qa:serverless
         key: prebuilt_rules_upgrade_common_fields:customization_enabled:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -247,7 +247,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_upgrade_type_specific_fields:customization_enabled:qa:serverless
         key: prebuilt_rules_upgrade_type_specific_fields:customization_enabled:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -261,7 +261,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_delete:qa:serverless
         key: rule_delete:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -275,7 +275,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_delete:essentials:qa:serverless
         key: rule_delete:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -289,7 +289,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_import_export:qa:serverless
         key: rule_import_export:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -303,7 +303,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_import_export:essentials:qa:serverless
         key: rule_import_export:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -317,7 +317,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_management:qa:serverless
         key: rule_management:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -331,7 +331,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_bulk_actions:qa:serverless
         key: rule_bulk_actions:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -345,7 +345,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_read:qa:serverless
         key: rule_read:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -359,7 +359,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_read:essentials:qa:serverless
         key: rule_read:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -373,7 +373,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rules_management:essentials:qa:serverless
         key: rules_management:essentials:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
@@ -3,7 +3,7 @@ steps:
     label: 'Cypress MKI - Defend Workflows'
     key: test_defend_workflows
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_detection_engine.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_detection_engine.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-detection-engine'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -23,7 +23,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists_items:qa:serverless:release
         key: exception_lists_items:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -37,7 +37,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists:auth:lists:qa:serverless:release
         key: exception_lists:auth:lists:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -51,7 +51,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists:auth:common:qa:serverless:release
         key: exception_lists:auth:common:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -65,7 +65,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_lists:auth:items:qa:serverless
         key: exception_lists:auth:items:qa:serverless
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -79,7 +79,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh entity_analytics:essentials:qa:serverless:release
         key: lists_items:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -93,7 +93,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh user_roles:qa:serverless:release
         key: user_roles:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -107,7 +107,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh telemetry:qa:serverless:release
         key: telemetry:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -121,7 +121,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_workflows:essentials:qa:serverless:release
         key: exception_workflows:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -135,7 +135,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_date_types:essentials:qa:serverless:release
         key: exception_operators_date_types:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -149,7 +149,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_double:essentials:qa:serverless:release
         key: exception_operators_double:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -163,7 +163,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_float:essentials:qa:serverless:release
         key: exception_operators_float:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -177,7 +177,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_integer:essentials:qa:serverless:release
         key: exception_operators_integer:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -191,7 +191,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_keyword:essentials:qa:serverless:release
         key: exception_operators_keyword:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -205,7 +205,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_ips:essentials:qa:serverless:release
         key: exception_operators_ips:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -219,7 +219,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_long:essentials:qa:serverless:release
         key: exception_operators_long:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -233,7 +233,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh exception_operators_text:essentials:qa:serverless:release
         key: exception_operators_text:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -247,7 +247,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh actions:qa:serverless:release
         key: actions:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -261,7 +261,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh alerts:qa:serverless:release
         key: alerts:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -275,7 +275,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh alerts:essentials:qa:serverless:release
         key: alerts:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -289,7 +289,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:eql:qa:serverless:release
         key: rule_execution_logic:eql:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -303,7 +303,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:esql:qa:serverless:release
         key: rule_execution_logic:esql:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -317,7 +317,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:general_logic:qa:serverless:release
         key: rule_execution_logic:general_logic:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -331,7 +331,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:general_logic:essentials:qa:serverless:release
         key: rule_execution_logic:general_logic:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -345,7 +345,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:indicator_match:qa:serverless:release
         key: rule_execution_logic:indicator_match:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -359,7 +359,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:machine_learning:qa:serverless:release
         key: rule_execution_logic:machine_learning:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -373,7 +373,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:new_terms:qa:serverless:release
         key: rule_execution_logic:new_terms:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -387,7 +387,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:query:qa:serverless:release
         key: rule_execution_logic:query:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -401,7 +401,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_execution_logic:threshold:qa:serverless:release
         key: rule_execution_logic:threshold:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_entity_analytics.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_entity_analytics.yml
@@ -5,7 +5,7 @@ steps:
     env:
       BK_TEST_SUITE_KEY: "serverless-cypress-entity-analytics"
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -20,7 +20,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh entity_analytics:qa:serverless:release
         key: entity_analytics:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -34,7 +34,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh entity_analytics:essentials:qa:serverless:release
         key: entity_analytics:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -48,7 +48,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:hosts:runner:qa:serverless:release
         key: explore:hosts:runner:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -62,7 +62,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:network:runner:qa:serverless:release
         key: explore:network:runner:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -76,7 +76,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:users:runner:qa:serverless:release
         key: explore:users:runner:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_explore.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_explore.yml
@@ -5,7 +5,7 @@ steps:
     env:
       BK_TEST_SUITE_KEY: "serverless-cypress-explore"
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_gen_ai.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_gen_ai.yml
@@ -5,7 +5,7 @@ steps:
     env:
       BK_TEST_SUITE_KEY: "serverless-cypress-gen-ai"
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -20,7 +20,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh nlp_cleanup_task:complete:qa:serverless:release
         key: nlp_cleanup_task:complete:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -34,7 +34,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh nlp_cleanup_task:essentials:qa:serverless:release
         key: nlp_cleanup_task:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_investigations.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_investigations.yml
@@ -5,7 +5,7 @@ steps:
     env:
       BK_TEST_SUITE_KEY: "serverless-cypress-investigations"
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
@@ -20,7 +20,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh investigations:timeline:runner:qa:serverless:release
         key: investigations:timeline:runner:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -34,7 +34,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh investigations:saved-objects:runner:qa:serverless:release
         key: investigations:saved-objects:runner:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -48,7 +48,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh explore:overview:runner:qa:serverless:release
         key: explore:overview:runner:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_rule_management.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_rule_management.yml
@@ -8,7 +8,7 @@ steps:
         env:
           BK_TEST_SUITE_KEY: 'serverless-cypress-rule-management'
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -23,7 +23,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_creation:qa:serverless:release
         key: rule_creation:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -37,7 +37,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_creation:essentials:qa:serverless:release
         key: rule_creation:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -51,7 +51,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_update:qa:serverless:release
         key: rule_update:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -65,7 +65,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_update:essentials:qa:serverless:release
         key: rule_update:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -79,7 +79,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_patch:qa:serverless:release
         key: rule_patch:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -93,7 +93,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_patch:essentials:qa:serverless:release
         key: rule_patch:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -107,7 +107,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_management:customization_disabled:qa:serverless:release
         key: prebuilt_rules_management:customization_disabled:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -121,7 +121,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_management:customization_enabled:qa:serverless:release
         key: prebuilt_rules_management:customization_enabled:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -135,7 +135,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_upgrade_common_fields:customization_enabled:qa:serverless:release
         key: prebuilt_rules_upgrade_common_fields:customization_enabled:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -149,7 +149,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh prebuilt_rules_upgrade_type_specific_fields:customization_enabled:qa:serverless:release
         key: prebuilt_rules_upgrade_type_specific_fields:customization_enabled:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -163,7 +163,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_delete:qa:serverless:release
         key: rule_delete:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -177,7 +177,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_delete:essentials:qa:serverless:release
         key: rule_delete:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -191,7 +191,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_import_export:qa:serverless:release
         key: rule_import_export:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -205,7 +205,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_import_export:essentials:qa:serverless:release
         key: rule_import_export:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -219,7 +219,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_management:qa:serverless:release
         key: rule_management:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -233,7 +233,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_bulk_actions:qa:serverless:release
         key: rule_bulk_actions:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -247,7 +247,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_read:qa:serverless:release
         key: rule_read:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -261,7 +261,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rule_read:essentials:qa:serverless:release
         key: rule_read:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
@@ -275,7 +275,7 @@ steps:
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh rules_management:essentials:qa:serverless:release
         key: rules_management:essentials:qa:serverless:release
         agents:
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
@@ -3,7 +3,7 @@ steps:
     label: "Upload runtime info"
     key: upload_runtime_info
     agents:
-      image: family/kibana-ubuntu-2404
+      image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4

--- a/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
+++ b/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
@@ -16,7 +16,7 @@ steps:
         label: Comment missing labels
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         timeout_in_minutes: 5
@@ -30,7 +30,7 @@ steps:
         timeout_in_minutes: 10
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         retry:
@@ -46,7 +46,7 @@ steps:
         label: Comment with job URL
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         timeout_in_minutes: 5
@@ -58,7 +58,7 @@ steps:
         key: build_project_image
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-16
           preemptible: true
@@ -73,7 +73,7 @@ steps:
         label: 'Deploy Project'
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-4
           preemptible: true
@@ -89,7 +89,7 @@ steps:
         label: Comment with job URL
         agents:
           provider: gcp
-          image: family/kibana-ubuntu-2404
+          image: family/kibana-ubuntu-2004
           imageProject: elastic-images-prod
           machineType: n2-standard-2
         timeout_in_minutes: 5

--- a/.buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
+++ b/.buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
@@ -3,7 +3,7 @@
 ## Then kicks of the deployment to QA
 
 agents:
-  image: family/kibana-ubuntu-2404
+  image: family/kibana-ubuntu-2004
   imageProject: elastic-images-prod
   provider: gcp
   machineType: n2-standard-2

--- a/src/dev/buildkite_migration/rewrite_buildkite_agent_rules.ts
+++ b/src/dev/buildkite_migration/rewrite_buildkite_agent_rules.ts
@@ -210,7 +210,7 @@ function getFullAgentTargetingRule(queue: string): GobldGCPConfig {
 
   // Mapping based on expected fields in https://github.com/elastic/ci/blob/0df8430357109a19957dcfb1d867db9cfdd27937/docs/gobld/providers.mdx#L96
   return removeNullish({
-    image: 'family/kibana-ubuntu-2404',
+    image: 'family/kibana-ubuntu-2004',
     imageProject: 'elastic-images-prod',
     provider: 'gcp',
     assignExternalIP: agent.disableExternalIp === true ? false : undefined,


### PR DESCRIPTION
## Summary
This reverts commit 813db694228c65005d313554090c312cbed14626. (in #231278)

Since moving to Ubuntu 24, we've seen an increase in FTR failures due to erroneous ES startups ending up with this error: 
```
ERROR UNHANDLED ERROR
  | 2025-08-12 14:38:37 CEST | ERROR Error: [docker:registry] waitForLogLine didn't emit anything within 120 seconds
  | 2025-08-12 14:38:37 CEST | at docker_servers_service.ts:180:19
  | 2025-08-12 14:38:37 CEST | at /opt/buildkite-agent/builds/bk-agent-prod-gcp-1755001678849725944/elastic/kibana-on-merge/kibana/node_modules/rxjs/src/internal/operators/map.ts:57:33
...
```

Let's try to revert and see if these errors go away.