### PR TITLE
Update codeowners for Streams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1666,6 +1666,9 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.index.ts @elastic/streams-program-team @elastic/obs-ux-logs-team
 /x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts @elastic/streams-program-team @elastic/obs-ux-logs-team
 /x-pack/test/api_integration/fixtures/kbn_archiver/streams @elastic/streams-program-team @elastic/obs-ux-logs-team
+/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests @elastic/streams-program-team @elastic/obs-ux-logs-team
+/x-pack/test_serverless/functional/test_suites/observability/streams @elastic/streams-program-team @elastic/obs-ux-logs-team
+
 
 ### END Observability Plugins
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -495,7 +495,7 @@ src/platform/packages/shared/kbn-field-utils @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-flot-charts @elastic/kibana-presentation @elastic/stack-monitoring
 src/platform/packages/shared/kbn-ftr-common-functional-services @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-ftr-common-functional-ui-services @elastic/appex-qa
-src/platform/packages/shared/kbn-grok-ui @elastic/streams-program-team
+src/platform/packages/shared/kbn-grok-ui @elastic/streams-program-team @elastic/obs-ux-logs-team
 src/platform/packages/shared/kbn-grouping @elastic/response-ops
 src/platform/packages/shared/kbn-guided-onboarding @elastic/appex-sharedux
 src/platform/packages/shared/kbn-i18n @elastic/kibana-core
@@ -904,7 +904,7 @@ x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-knowledge-team
 x-pack/platform/packages/shared/kbn-sample-parser @elastic/streams-program-team
 x-pack/platform/packages/shared/kbn-search-index-documents @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-slo-schema @elastic/obs-ux-management-team
-x-pack/platform/packages/shared/kbn-streamlang @elastic/streams-program-team
+x-pack/platform/packages/shared/kbn-streamlang @elastic/streams-program-team @elastic/obs-ux-logs-team
 x-pack/platform/packages/shared/kbn-streams-schema @elastic/streams-program-team
 x-pack/platform/packages/shared/logs-overview @elastic/obs-ux-logs-team
 x-pack/platform/packages/shared/ml/aiops_common @elastic/ml-ui
@@ -1662,10 +1662,10 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/plugins/observability_solution/observability/server/ui_settings.ts @elastic/obs-docs
 
 # Streams
-/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams @elastic/streams-program-team
-/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.index.ts @elastic/streams-program-team
-/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts @elastic/streams-program-team
-/x-pack/test/api_integration/fixtures/kbn_archiver/streams @elastic/streams-program-team
+/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams @elastic/streams-program-team @elastic/obs-ux-logs-team
+/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.index.ts @elastic/streams-program-team @elastic/obs-ux-logs-team
+/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts @elastic/streams-program-team @elastic/obs-ux-logs-team
+/x-pack/test/api_integration/fixtures/kbn_archiver/streams @elastic/streams-program-team @elastic/obs-ux-logs-team
 
 ### END Observability Plugins
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -495,7 +495,7 @@ src/platform/packages/shared/kbn-field-utils @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-flot-charts @elastic/kibana-presentation @elastic/stack-monitoring
 src/platform/packages/shared/kbn-ftr-common-functional-services @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-ftr-common-functional-ui-services @elastic/appex-qa
-src/platform/packages/shared/kbn-grok-ui @elastic/streams-program-team @elastic/obs-ux-logs-team
+src/platform/packages/shared/kbn-grok-ui @elastic/obs-ux-logs-team
 src/platform/packages/shared/kbn-grouping @elastic/response-ops
 src/platform/packages/shared/kbn-guided-onboarding @elastic/appex-sharedux
 src/platform/packages/shared/kbn-i18n @elastic/kibana-core
@@ -904,7 +904,7 @@ x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-knowledge-team
 x-pack/platform/packages/shared/kbn-sample-parser @elastic/streams-program-team
 x-pack/platform/packages/shared/kbn-search-index-documents @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-slo-schema @elastic/obs-ux-management-team
-x-pack/platform/packages/shared/kbn-streamlang @elastic/streams-program-team @elastic/obs-ux-logs-team
+x-pack/platform/packages/shared/kbn-streamlang @elastic/obs-ux-logs-team
 x-pack/platform/packages/shared/kbn-streams-schema @elastic/streams-program-team
 x-pack/platform/packages/shared/logs-overview @elastic/obs-ux-logs-team
 x-pack/platform/packages/shared/ml/aiops_common @elastic/ml-ui

--- a/src/platform/packages/shared/kbn-grok-ui/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-grok-ui/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/grok-ui",
-  "owner": ["@elastic/streams-program-team", "@elastic/obs-ux-logs-team"],
+  "owner": "@elastic/obs-ux-logs-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-grok-ui/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-grok-ui/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/grok-ui",
-  "owner": "@elastic/streams-program-team",
+  "owner": ["@elastic/streams-program-team", "@elastic/obs-ux-logs-team"],
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-streamlang/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/streamlang",
-  "owner": ["@elastic/streams-program-team", "@elastic/obs-ux-logs-team"],
+  "owner": "@elastic/obs-ux-logs-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-streamlang/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/streamlang",
-  "owner": "@elastic/streams-program-team",
+  "owner": ["@elastic/streams-program-team", "@elastic/obs-ux-logs-team"],
   "group": "platform",
   "visibility": "shared"
 }


### PR DESCRIPTION
Add co-ownership with the Logs UX team for the following:
- `kbn-grok-ui` package 
- `kbn-streamlang` package
- Tests under `x-pack/platform/test/api_integration_deployment_agnostic` to ensure they are covered as part of the SDH rotation, they can later be redirected if needed