### PR TITLE
[chore]: refactored CHIPS support configuration

### DIFF
--- a/src/core/packages/http/server-internal/src/cookie_session_storage.ts
+++ b/src/core/packages/http/server-internal/src/cookie_session_storage.ts
@@ -126,22 +126,8 @@ export async function createCookieSessionStorageFactory<T extends object>(
       clearInvalid: false,
       isHttpOnly: true,
       isSameSite: cookieOptions.sameSite ?? false,
-      contextualize: (
-        definition: Omit<ServerStateCookieOptions, 'isSameSite'> & { isSameSite: string }
-      ) => {
-        /**
-         * This is a temporary solution to support the Partitioned attribute.
-         * Statehood performs validation for the params, but only before the contextualize function call.
-         * Since value for the isSameSite is used directly when making segment,
-         * we can leverage that to append the Partitioned attribute to the cookie.
-         *
-         * Once statehood is updated to support the Partitioned attribute, we can remove this.
-         * Issue: https://github.com/elastic/kibana/issues/188720
-         */
-        if (definition.isSameSite === 'None' && definition.isSecure && !disableEmbedding) {
-          definition.isSameSite = 'None;Partitioned';
-        }
-      },
+      isPartitioned:
+        cookieOptions.sameSite === 'None' && cookieOptions.isSecure && !disableEmbedding,
     },
     validate: async (req: Request, session: T | T[]) => {
       const result = cookieOptions.validate(session);

--- a/src/core/packages/http/server-internal/src/cookie_session_storage.ts
+++ b/src/core/packages/http/server-internal/src/cookie_session_storage.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Request, Server, ServerStateCookieOptions } from '@hapi/hapi';
+import { Request, Server } from '@hapi/hapi';
 import hapiAuthCookie from '@hapi/cookie';
 
 import type { Logger } from '@kbn/logging';


### PR DESCRIPTION
## Summary

Since direct option for partitioned cookie configuration has been merged as part of https://github.com/hapijs/statehood/pull/88. Cleaning up old code.

__Closes: https://github.com/elastic/kibana/issues/188720__








<!--ONMERGE {"backportTargets":["9.0","9.1"]} ONMERGE-->