### PR TITLE
[UII] Fix input package component template test

### DIFF
--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/input_package_create_upgrade.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/input_package_create_upgrade.ts
@@ -216,36 +216,33 @@ export default function (providerContext: FtrProviderContext) {
       } = packageComponentTemplate!.component_template as any;
       expect(packageComponentTemplate!.name).eql('logs-dataset1@package');
       expect(definitionWithouTimestamps).eql({
-        name: 'logs-dataset1@package',
-        component_template: {
-          template: {
-            settings: {
-              index: {
-                lifecycle: { name: 'logs' },
-                default_pipeline: 'logs-dataset1-1.0.0',
-                mapping: {
-                  total_fields: { limit: '1000' },
-                },
+        template: {
+          settings: {
+            index: {
+              lifecycle: { name: 'logs' },
+              default_pipeline: 'logs-dataset1-1.0.0',
+              mapping: {
+                total_fields: { limit: '1000' },
               },
             },
-            mappings: {
-              properties: {
-                input: {
-                  properties: {
-                    name: {
-                      type: 'constant_keyword',
-                      value: 'logs',
-                    },
+          },
+          mappings: {
+            properties: {
+              input: {
+                properties: {
+                  name: {
+                    type: 'constant_keyword',
+                    value: 'logs',
                   },
                 },
               },
             },
           },
-          _meta: {
-            package: { name: 'input_package_upgrade' },
-            managed_by: 'fleet',
-            managed: true,
-          },
+        },
+        _meta: {
+          package: { name: 'input_package_upgrade' },
+          managed_by: 'fleet',
+          managed: true,
         },
       });
     });

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/input_package_create_upgrade.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/input_package_create_upgrade.ts
@@ -209,7 +209,13 @@ export default function (providerContext: FtrProviderContext) {
 
       // now check the package component template was created correctly
       const packageComponentTemplate = await getComponentTemplate('logs-dataset1@package');
-      expect(packageComponentTemplate).eql({
+      const {
+        created_date_millis: createdDateMillis,
+        modified_date_millis: modifiedDateMillis,
+        ...definitionWithouTimestamps
+      } = packageComponentTemplate!.component_template as any;
+      expect(packageComponentTemplate!.name).eql('logs-dataset1@package');
+      expect(definitionWithouTimestamps).eql({
         name: 'logs-dataset1@package',
         component_template: {
           template: {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/229901. Fixes ES promotion of this test by excluding component template timestamps from the assertion (timestamps were introduced in https://github.com/elastic/elasticsearch/pull/131536). 

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->