### PR TITLE
fix(slo): custom metric and histo form validation

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/histogram/histogram_indicator_type_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/histogram/histogram_indicator_type_form.tsx
@@ -94,6 +94,7 @@ export function HistogramIndicatorTypeForm() {
             type="good"
             histogramFields={histogramFields ?? []}
             isLoadingIndex={isIndexFieldsLoading}
+            dataView={dataView}
           />
         </EuiFlexItem>
         <EuiFlexItem>
@@ -113,6 +114,7 @@ export function HistogramIndicatorTypeForm() {
             type="total"
             histogramFields={histogramFields ?? []}
             isLoadingIndex={isIndexFieldsLoading}
+            dataView={dataView}
           />
         </EuiFlexItem>
         <EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/hooks/use_section_form_validation.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/hooks/use_section_form_validation.ts
@@ -14,7 +14,7 @@ import {
   timesliceMetricPercentileMetric,
 } from '@kbn/slo-schema';
 import { FormState, UseFormGetFieldState, UseFormGetValues, UseFormWatch } from 'react-hook-form';
-import { isObject } from 'lodash';
+import { isEmpty, isObject } from 'lodash';
 import { CreateSLOForm } from '../types';
 
 interface Props {
@@ -38,7 +38,8 @@ export function useSectionFormValidation({ getFieldState, getValues, formState, 
             if (metricCustomDocCountMetric.is(metric)) {
               return true;
             }
-            if (metricCustomBasicMetric.is(metric) && metric.field != null) {
+
+            if (metricCustomBasicMetric.is(metric) && !isEmpty(metric.field)) {
               return true;
             }
             return false;
@@ -57,7 +58,7 @@ export function useSectionFormValidation({ getFieldState, getValues, formState, 
             if (metricCustomDocCountMetric.is(metric)) {
               return true;
             }
-            if (metricCustomBasicMetric.is(metric) && metric.field != null) {
+            if (metricCustomBasicMetric.is(metric) && !isEmpty(metric.field)) {
               return true;
             }
             return false;


### PR DESCRIPTION
## 🍒 Summary

Resolves https://github.com/elastic/kibana/issues/231443

This PR fixes two issues in the SLO form:
1. Fix custom metric validation: The metric field must have a value when the sum agg is selected.
2. Fix histogram filter KQL: The filter KQL field for the histogram indicator was not using the dataview which rendered the field as disabled.

### Manual testing

1. Run dataforge: `node x-pack/scripts/data_forge.js  --lookback now-8d --dataset fake_stack --install-kibana-assets --kibana-url http://localhost:5601`
2. Create an SLO using **Custom Metric**, the metric field must be selected when **Sum** agg is selected before we mark the whole indicator section as valid
3. Create an SLO using the **Custom Histogram**, the KQL filter bar should be usable.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.1"]} ONMERGE-->