### PR TITLE
[8.19] [Security Solution] Add debug logging to endpoints that call Fleet APIs (#230503)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/fleet_integrations/api/get_all_integrations/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/fleet_integrations/api/get_all_integrations/route.ts
@@ -71,6 +71,7 @@ export const getAllIntegrationsRoute = (router: SecuritySolutionPluginRouter, lo
 
           return response.ok({ body });
         } catch (err) {
+          logger.error(`getAllIntegrationsRoute: Caught error:`, err);
           const error = transformError(err);
           return siemResponse.error({
             body: error.message,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/fleet_integrations/api/get_installed_integrations/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/fleet_integrations/api/get_installed_integrations/route.ts
@@ -66,6 +66,7 @@ export const getInstalledIntegrationsRoute = (
 
           return response.ok({ body });
         } catch (err) {
+          logger.error(`getInstalledIntegrationsRoute: Caught error:`, err);
           const error = transformError(err);
           return siemResponse.error({
             body: error.message,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/bootstrap_prebuilt_rules/bootstrap_prebuilt_rules_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/bootstrap_prebuilt_rules/bootstrap_prebuilt_rules_handler.ts
@@ -93,10 +93,15 @@ export const bootstrapPrebuiltRulesHandler = async (
       });
     }
 
+    logger.debug(
+      `bootstrapPrebuiltRulesHandler: Total packages installed: ${packageResults.length}`
+    );
+
     return response.ok({
       body: responseBody,
     });
   } catch (err) {
+    logger.error(`bootstrapPrebuiltRulesHandler: Caught error:`, err);
     const error = transformError(err);
     return siemResponse.error({
       body: error.message,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/get_prebuilt_rules_and_timelines_status_route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/get_prebuilt_rules_and_timelines_status_route.test.ts
@@ -81,7 +81,7 @@ describe('get_prepackaged_rule_status_route', () => {
       prepackagedTimelines: [],
     });
 
-    getPrebuiltRulesAndTimelinesStatusRoute(server.router);
+    getPrebuiltRulesAndTimelinesStatusRoute(server.router, clients.logger);
   });
 
   describe('status codes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/get_prebuilt_rules_and_timelines_status_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/get_prebuilt_rules_and_timelines_status_route.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { InstallPrepackedTimelinesRequestBody } from '../../../../../../common/api/timeline';
 import { buildSiemResponse } from '../../../routes/utils';
@@ -25,7 +26,10 @@ import { rulesToMap } from '../../logic/utils';
 import { buildFrameworkRequest } from '../../../../timeline/utils/common';
 import { checkTimelinesStatus } from '../../../../timeline/utils/check_timelines_status';
 
-export const getPrebuiltRulesAndTimelinesStatusRoute = (router: SecuritySolutionPluginRouter) => {
+export const getPrebuiltRulesAndTimelinesStatusRoute = (
+  router: SecuritySolutionPluginRouter,
+  logger: Logger
+) => {
   router.versioned
     .get({
       access: 'public',
@@ -62,7 +66,7 @@ export const getPrebuiltRulesAndTimelinesStatusRoute = (router: SecuritySolution
           });
 
           const installedPrebuiltRules = rulesToMap(
-            await getExistingPrepackagedRules({ rulesClient })
+            await getExistingPrepackagedRules({ rulesClient, logger })
           );
 
           const rulesToInstall = getRulesToInstall(latestPrebuiltRules, installedPrebuiltRules);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/install_prebuilt_rules_and_timelines_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/install_prebuilt_rules_and_timelines_route.ts
@@ -53,6 +53,7 @@ export const installPrebuiltRulesAndTimelinesRoute = (
           );
           return response.ok({ body: validated ?? {} });
         } catch (err) {
+          logger.error(`installPrebuiltRulesAndTimelinesRoute: Caught error:`, err);
           const error = transformError(err);
           return siemResponse.error({
             body: error.message,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/legacy_create_prepackaged_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/legacy_create_prepackaged_rules.ts
@@ -60,18 +60,25 @@ export const legacyCreatePrepackagedRules = async (
     logger
   );
 
-  const installedPrebuiltRules = rulesToMap(await getExistingPrepackagedRules({ rulesClient }));
+  const installedPrebuiltRules = rulesToMap(
+    await getExistingPrepackagedRules({ rulesClient, logger })
+  );
   const rulesToInstall = getRulesToInstall(latestPrebuiltRules, installedPrebuiltRules);
   const rulesToUpdate = getRulesToUpdate(latestPrebuiltRules, installedPrebuiltRules);
 
-  const result = await createPrebuiltRules(detectionRulesClient, rulesToInstall);
-  if (result.errors.length > 0) {
-    throw new AggregateError(result.errors, 'Error installing new prebuilt rules');
+  const ruleCreationResult = await createPrebuiltRules(
+    detectionRulesClient,
+    rulesToInstall,
+    logger
+  );
+
+  if (ruleCreationResult.errors.length > 0) {
+    throw new AggregateError(ruleCreationResult.errors, 'Error installing new prebuilt rules');
   }
 
   const { result: timelinesResult } = await performTimelinesInstallation(context);
 
-  await upgradePrebuiltRules(detectionRulesClient, rulesToUpdate);
+  await upgradePrebuiltRules(detectionRulesClient, rulesToUpdate, logger);
 
   return {
     rules_installed: rulesToInstall.length,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
@@ -104,7 +104,11 @@ export const performRuleInstallationHandler = async (
       const rulesToInstall = ruleInstallQueue.splice(0, BATCH_SIZE);
       const ruleAssets = await ruleAssetsClient.fetchAssetsByVersion(rulesToInstall);
 
-      const { results, errors } = await createPrebuiltRules(detectionRulesClient, ruleAssets);
+      const { results, errors } = await createPrebuiltRules(
+        detectionRulesClient,
+        ruleAssets,
+        logger
+      );
       installedRules.push(...results);
       ruleErrors.push(...errors);
     }
@@ -137,6 +141,7 @@ export const performRuleInstallationHandler = async (
 
     return response.ok({ body });
   } catch (err) {
+    logger.error(`performRuleInstallationHandler: Caught error:`, err);
     const error = transformError(err);
     return siemResponse.error({
       body: error.message,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_handler.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { KibanaRequest, KibanaResponseFactory } from '@kbn/core/server';
+import type { Logger, KibanaRequest, KibanaResponseFactory } from '@kbn/core/server';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type {
   PerformRuleUpgradeRequestBody,
@@ -45,8 +45,9 @@ import { getPossibleUpgrades } from '../../logic/utils';
 
 export const performRuleUpgradeHandler = async (
   context: SecuritySolutionRequestHandlerContext,
-  request: KibanaRequest<undefined, undefined, PerformRuleUpgradeRequestBody>,
-  response: KibanaResponseFactory
+  request: KibanaRequest<unknown, unknown, PerformRuleUpgradeRequestBody>,
+  response: KibanaResponseFactory,
+  logger: Logger
 ) => {
   const siemResponse = buildSiemResponse(response);
 
@@ -198,7 +199,8 @@ export const performRuleUpgradeHandler = async (
       } else {
         const { results: upgradeResults, errors: installationErrors } = await upgradePrebuiltRules(
           detectionRulesClient,
-          modifiedPrebuiltRuleAssets
+          modifiedPrebuiltRuleAssets,
+          logger
         );
         ruleErrors.push(...installationErrors);
         updatedRules.push(...upgradeResults.map(({ result }) => result));

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_route.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
 import {
   PERFORM_RULE_UPGRADE_URL,
@@ -18,7 +19,7 @@ import {
 } from '../../constants';
 import { performRuleUpgradeHandler } from './perform_rule_upgrade_handler';
 
-export const performRuleUpgradeRoute = (router: SecuritySolutionPluginRouter) => {
+export const performRuleUpgradeRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
   router.versioned
     .post({
       access: 'internal',
@@ -44,6 +45,6 @@ export const performRuleUpgradeRoute = (router: SecuritySolutionPluginRouter) =>
           },
         },
       },
-      performRuleUpgradeHandler
+      (context, request, response) => performRuleUpgradeHandler(context, request, response, logger)
     );
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/register_routes.ts
@@ -23,13 +23,13 @@ export const registerPrebuiltRulesRoutes = (
   logger: Logger
 ) => {
   // Legacy endpoints that we're going to deprecate
-  getPrebuiltRulesAndTimelinesStatusRoute(router);
+  getPrebuiltRulesAndTimelinesStatusRoute(router, logger);
   installPrebuiltRulesAndTimelinesRoute(router, logger);
 
   // New endpoints for the rule upgrade and installation workflows
   getPrebuiltRulesStatusRoute(router);
   performRuleInstallationRoute(router, logger);
-  performRuleUpgradeRoute(router);
+  performRuleUpgradeRoute(router, logger);
   reviewRuleInstallationRoute(router);
   reviewRuleUpgradeRoute(router);
   bootstrapPrebuiltRulesRoute(router, logger);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/ensure_latest_rules_package_installed.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/ensure_latest_rules_package_installed.ts
@@ -15,13 +15,24 @@ export async function ensureLatestRulesPackageInstalled(
   securityContext: SecuritySolutionApiRequestHandlerContext,
   logger: Logger
 ) {
+  logger.debug(
+    'ensureLatestRulesPackageInstalled: Fetching latest versions of prebuilt rule assets'
+  );
   let latestPrebuiltRules = await ruleAssetsClient.fetchLatestAssets();
+  logger.debug(
+    `ensureLatestRulesPackageInstalled: Fetching latest versions of prebuilt rule assets - done. Fetched assets: ${latestPrebuiltRules.length}.`
+  );
   if (latestPrebuiltRules.length === 0) {
     // Seems no packages with prepackaged rules were installed, try to install the default rules package
     await installPrebuiltRulesPackage(securityContext, logger);
 
-    // Try to get the prepackaged rules again
+    logger.debug(
+      'ensureLatestRulesPackageInstalled: Re-fetching latest versions of prebuilt rule assets after package installation'
+    );
     latestPrebuiltRules = await ruleAssetsClient.fetchLatestAssets();
+    logger.debug(
+      `ensureLatestRulesPackageInstalled: Re-fetched latest versions of prebuilt rule assets after package installation - done. Fetched assets: ${latestPrebuiltRules.length}.`
+    );
   }
   return latestPrebuiltRules;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_ai_prompts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_ai_prompts.ts
@@ -29,8 +29,11 @@ export async function installSecurityAiPromptsPackage(
       pkgVersion,
       logger
     );
-  } catch (e) {
-    // fail silently
+  } catch (error) {
+    logger.error(
+      'installSecurityAiPromptsPackage: Security AI prompts package failed to install',
+      error
+    );
     return null;
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule.ts
@@ -81,7 +81,7 @@ export const installEndpointSecurityPrebuiltRule = async ({
       return;
     }
     const ruleAssetsToInstall = await ruleAssetsClient.fetchAssetsByVersion(latestRuleVersion);
-    await createPrebuiltRules(detectionRulesClient, ruleAssetsToInstall);
+    await createPrebuiltRules(detectionRulesClient, ruleAssetsToInstall, logger);
   } catch (err) {
     logger.error(
       `Unable to create Endpoint Security rule automatically (${err.statusCode}): ${err.message}`

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_promotion_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/integrations/install_promotion_rules.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Logger } from '@kbn/core/server';
+import type { LogMeta, Logger } from '@kbn/core/server';
 import type { BulkOperationError, RulesClient } from '@kbn/alerting-plugin/server';
 import type { IDetectionRulesClient } from '../../../rule_management/logic/detection_rules_client/detection_rules_client_interface';
 import type { IPrebuiltRuleAssetsClient } from '../rule_assets/prebuilt_rule_assets_client';
@@ -52,6 +52,7 @@ export async function installPromotionRules({
   fleetServices,
   logger,
 }: InstallPromotionRulesParams): Promise<RuleBootstrapResults> {
+  logger.debug('installPromotionRules: Promotion rules - installing');
   // Get the list of installed integrations
   const installedIntegrations = new Set(
     (
@@ -97,7 +98,8 @@ export async function installPromotionRules({
     promotionRulesToInstall.map((asset) => ({
       ...asset,
       enabled: true,
-    }))
+    })),
+    logger
   );
 
   const promotionRulesToUpgrade = latestPromotionRules.filter(({ rule_id: ruleId, version }) => {
@@ -106,7 +108,8 @@ export async function installPromotionRules({
   });
   const { results: upgradeResults, errors: upgradeErrors } = await upgradePrebuiltRules(
     detectionRulesClient,
-    promotionRulesToUpgrade
+    promotionRulesToUpgrade,
+    logger
   );
 
   // Cleanup any unknown rules, we don't allow users to install any detection
@@ -144,7 +147,7 @@ export async function installPromotionRules({
     new Map<string, RuleBootstrapError>()
   );
 
-  return {
+  const installationResult = {
     total: latestPromotionRules.length,
     installed: installationResults.length,
     updated: upgradeResults.length,
@@ -152,4 +155,11 @@ export async function installPromotionRules({
     skipped: alreadyUpToDate.length,
     errors: allErrors.size > 0 ? Array.from(allErrors.values()) : [],
   };
+
+  logger.debug(
+    'installPromotionRules: Promotion rules - installation complete:',
+    installationResult as LogMeta
+  );
+
+  return installationResult;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/create_prebuilt_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/create_prebuilt_rules.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
 import { MAX_RULES_TO_UPDATE_IN_PARALLEL } from '../../../../../../common/constants';
 import { initPromisePool } from '../../../../../utils/promise_pool';
 import { withSecuritySpan } from '../../../../../utils/with_security_span';
@@ -13,9 +14,13 @@ import type { IDetectionRulesClient } from '../../../rule_management/logic/detec
 
 export const createPrebuiltRules = (
   detectionRulesClient: IDetectionRulesClient,
-  rules: PrebuiltRuleAsset[]
+  rules: PrebuiltRuleAsset[],
+  logger?: Logger
 ) => {
   return withSecuritySpan('createPrebuiltRules', async () => {
+    logger?.debug(
+      `createPrebuiltRules: Creating prebuilt rules - started. Rules to create: ${rules.length}`
+    );
     const result = await initPromisePool({
       concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
       items: rules,
@@ -25,6 +30,9 @@ export const createPrebuiltRules = (
         });
       },
     });
+    logger?.debug(
+      `createPrebuiltRules: Creating prebuilt rules - done. Rules created: ${result.results}. Rules failed to create: ${result.errors.length}.`
+    );
 
     return result;
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -219,6 +219,7 @@ export const importRulesRoute = (
 
           return response.ok({ body: ImportRulesResponse.parse(importRulesResponse) });
         } catch (err) {
+          logger.error(`importRulesRoute: Caught error:`, err);
           const error = transformError(err);
           return siemResponse.error({
             body: error.message,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/get_existing_prepackaged_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/get_existing_prepackaged_rules.test.ts
@@ -18,6 +18,7 @@ import {
   getRules,
   getRulesCount,
 } from './get_existing_prepackaged_rules';
+import { requestContextMock } from '../../../routes/__mocks__';
 
 describe('get_existing_prepackaged_rules', () => {
   afterEach(() => {
@@ -25,10 +26,12 @@ describe('get_existing_prepackaged_rules', () => {
   });
 
   describe('getExistingPrepackagedRules', () => {
+    const { clients } = requestContextMock.createTools();
+
     test('should return a single item in a single page', async () => {
       const rulesClient = rulesClientMock.create();
       rulesClient.find.mockResolvedValue(getFindResultWithSingleHit());
-      const rules = await getExistingPrepackagedRules({ rulesClient });
+      const rules = await getExistingPrepackagedRules({ rulesClient, logger: clients.logger });
       expect(rules).toEqual([getRuleMock(getQueryRuleParams())]);
     });
 
@@ -57,7 +60,7 @@ describe('get_existing_prepackaged_rules', () => {
         })
       );
 
-      const rules = await getExistingPrepackagedRules({ rulesClient });
+      const rules = await getExistingPrepackagedRules({ rulesClient, logger: clients.logger });
       expect(rules).toEqual([result1, result2, result3]);
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/get_existing_prepackaged_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/get_existing_prepackaged_rules.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
 import type { RulesClient } from '@kbn/alerting-plugin/server';
 
 import {
@@ -78,15 +79,23 @@ export const getExistingPrepackagedRules = async ({
   rulesClient,
   page,
   perPage,
+  logger,
 }: {
   rulesClient: RulesClient;
   page?: number;
   perPage?: number;
+  logger: Logger;
 }): Promise<RuleAlertType[]> => {
-  return getRules({
+  logger.debug('getExistingPrepackagedRules: Fetching installed prebuilt rules');
+  const existingPrepackagedRules = await getRules({
     rulesClient,
     page,
     perPage,
     filter: KQL_FILTER_IMMUTABLE_RULES,
   });
+  logger.debug(
+    `getExistingPrepackagedRules: Fetching installed prebuilt rules - done. Fetched: ${existingPrepackagedRules.length} rules.`
+  );
+
+  return existingPrepackagedRules;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Add debug logging to endpoints that call Fleet APIs (#230503)](https://github.com/elastic/kibana/pull/230503)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nikita Indik","email":"nikita.indik@elastic.co"},"sourceCommit":{"committedDate":"2025-08-12T18:30:06Z","message":"[Security Solution] Add debug logging to endpoints that call Fleet APIs (#230503)\n\n**Part of epic: https://github.com/elastic/kibana/issues/229688**\n**Is a follow-up to: https://github.com/elastic/kibana/pull/229957**\n\n## Summary  \nThis PR adds logging to backend endpoints that call Fleet APIs. This\nwill assist us in debugging flaky tests. I aimed to balance log\ngranularity and readability.\n\n## Changes\nAdded logging to endpoints:\n- bootstrap prebuilt rules\n- perform prebuilt rule installation\n- import rules\n- get installed integrations\n- get all integrations\n- install prebuilt rules and timelines (legacy endpoint)","sha":"48b2f798eb91df39b437de73e9668cc34918133d","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","backport:version","v9.2.0","v9.0.5","v8.18.5","v9.1.2","v8.19.2"],"title":"[Security Solution] Add debug logging to endpoints that call Fleet APIs","number":230503,"url":"https://github.com/elastic/kibana/pull/230503","mergeCommit":{"message":"[Security Solution] Add debug logging to endpoints that call Fleet APIs (#230503)\n\n**Part of epic: https://github.com/elastic/kibana/issues/229688**\n**Is a follow-up to: https://github.com/elastic/kibana/pull/229957**\n\n## Summary  \nThis PR adds logging to backend endpoints that call Fleet APIs. This\nwill assist us in debugging flaky tests. I aimed to balance log\ngranularity and readability.\n\n## Changes\nAdded logging to endpoints:\n- bootstrap prebuilt rules\n- perform prebuilt rule installation\n- import rules\n- get installed integrations\n- get all integrations\n- install prebuilt rules and timelines (legacy endpoint)","sha":"48b2f798eb91df39b437de73e9668cc34918133d"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/230503","number":230503,"mergeCommit":{"message":"[Security Solution] Add debug logging to endpoints that call Fleet APIs (#230503)\n\n**Part of epic: https://github.com/elastic/kibana/issues/229688**\n**Is a follow-up to: https://github.com/elastic/kibana/pull/229957**\n\n## Summary  \nThis PR adds logging to backend endpoints that call Fleet APIs. This\nwill assist us in debugging flaky tests. I aimed to balance log\ngranularity and readability.\n\n## Changes\nAdded logging to endpoints:\n- bootstrap prebuilt rules\n- perform prebuilt rule installation\n- import rules\n- get installed integrations\n- get all integrations\n- install prebuilt rules and timelines (legacy endpoint)","sha":"48b2f798eb91df39b437de73e9668cc34918133d"}},{"branch":"9.0","label":"v9.0.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231502","number":231502,"state":"OPEN"},{"branch":"8.19","label":"v8.19.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->