### PR TITLE
[Search][Indices] Use global kibana theme for code blocks

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/components/code_box/code_box.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/code_box/code_box.tsx
@@ -116,6 +116,8 @@ export const CodeBox = (props: CodeBoxProps) => {
         paddingSize="xs"
         data-test-subj={dataTestSubj ?? 'codeBlockControlsPanel'}
         css={Styles.CodeBoxPanel(euiTheme)}
+        hasShadow={false}
+        hasBorder={true}
       >
         {showTopBar && (
           <>

--- a/x-pack/solutions/search/plugins/search_indices/public/components/code_box/code_box.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/code_box/code_box.tsx
@@ -27,6 +27,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { ConsolePluginStart } from '@kbn/console-plugin/public';
 import { SharePluginStart } from '@kbn/share-plugin/public';
 
+import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { getDefaultCodingLanguage } from '../../utils/language';
 
@@ -49,6 +50,7 @@ export const CodeBox = (props: CodeBoxProps) => {
   const { consoleCode, options, showTopBar = true } = props;
   const dataTestSubj = props['data-test-subj'];
   const { euiTheme } = useEuiTheme();
+  const isDarkMode = useKibanaIsDarkMode();
   const {
     application,
     console: consolePlugin,
@@ -89,7 +91,7 @@ export const CodeBox = (props: CodeBoxProps) => {
   const codeSnippet = selectedOption?.code ?? '';
 
   const languageButton = selectedOption ? (
-    <EuiThemeProvider colorMode="dark">
+    <EuiThemeProvider colorMode={isDarkMode ? 'dark' : 'light'}>
       <EuiButtonEmpty
         data-test-subj={
           dataTestSubj ? `${dataTestSubj}-select-lang-button` : 'code-box-select-lang-button'
@@ -109,7 +111,7 @@ export const CodeBox = (props: CodeBoxProps) => {
   ) : null;
 
   return (
-    <EuiThemeProvider colorMode="dark">
+    <EuiThemeProvider colorMode={isDarkMode ? 'dark' : 'light'}>
       <EuiPanel
         paddingSize="xs"
         data-test-subj={dataTestSubj ?? 'codeBlockControlsPanel'}
@@ -125,7 +127,7 @@ export const CodeBox = (props: CodeBoxProps) => {
             >
               {options && languageButton && (
                 <EuiFlexItem>
-                  <EuiThemeProvider colorMode="light">
+                  <EuiThemeProvider colorMode={isDarkMode ? 'dark' : 'light'}>
                     <EuiPopover
                       button={languageButton}
                       isOpen={isPopoverOpen}

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/code_sample.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/code_sample.tsx
@@ -17,6 +17,7 @@ import {
   EuiText,
   EuiThemeProvider,
 } from '@elastic/eui';
+import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 
 export interface CodeSampleProps {
   id?: string;
@@ -35,6 +36,7 @@ export const CodeSample = ({
   onCodeCopyClick,
   description,
 }: CodeSampleProps) => {
+  const isDarkMode = useKibanaIsDarkMode();
   const onCodeClick = React.useCallback(
     (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
       if (onCodeCopyClick === undefined) return;
@@ -61,7 +63,7 @@ export const CodeSample = ({
         </>
       )}
       <EuiSpacer size="m" />
-      <EuiThemeProvider colorMode="dark">
+      <EuiThemeProvider colorMode={isDarkMode ? 'dark' : 'light'}>
         <EuiPanel color="subdued" paddingSize="none" hasShadow={false}>
           <div onClick={onCodeClick}>
             <EuiCodeBlock

--- a/x-pack/solutions/search/plugins/search_indices/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_indices/tsconfig.json
@@ -43,6 +43,7 @@
     "@kbn/search-navigation",
     "@kbn/search-queries",
     "@kbn/sample-data-ingest",
+    "@kbn/react-kibana-context-theme",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/10627

Index management always defaulted code blocks to "dark". Use the kibana theme instead (User settings -> Appearance)

### Light Mode on an index with and without data:

<kbd><img width="1372" height="849" alt="Screenshot 2025-08-12 at 3 53 06 PM" src="https://github.com/user-attachments/assets/99041865-c707-4739-bd27-f7dc4cf73a56" /></kbd>
<kbd><img width="1288" height="839" alt="Screenshot 2025-08-12 at 3 52 56 PM" src="https://github.com/user-attachments/assets/7408e6ae-a12c-41d3-85e8-46051c0224a4" /></kbd>


### Dark Mode on an index with and without data:

<kbd><img width="1266" height="846" alt="Screenshot 2025-08-12 at 3 52 40 PM" src="https://github.com/user-attachments/assets/495aafba-d7c9-44a7-9463-5cad5870cc09" /></kbd>
<kbd><img width="1255" height="848" alt="Screenshot 2025-08-12 at 3 52 19 PM" src="https://github.com/user-attachments/assets/add8d7ff-0ad8-4048-9e59-b0b80364887b" /></kbd>

