### PR TITLE
[UII] Remove system-managed properties (dates) when updating index templates

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -768,6 +768,13 @@ export interface IndexTemplate {
   composed_of: string[];
   ignore_missing_component_templates?: string[];
   _meta: object;
+
+  // These properties are returned on ES read operations and
+  // not allowed to be set on ES write operations
+  created_date?: number;
+  created_date_millis?: number;
+  modified_date?: number;
+  modified_date_millis?: number;
 }
 
 export interface ESAssetMetadata {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.ts
@@ -199,8 +199,17 @@ export async function handleExperimentalDatastreamFeatureOptIn({
       });
     }
 
-    const indexTemplate = indexTemplateRes.index_templates[0].index_template;
-    let updatedIndexTemplate = indexTemplate as IndexTemplate;
+    const rawIndexTemplate = indexTemplateRes.index_templates[0].index_template;
+
+    // Remove system-managed properties (dates) that cannot be set during create/update of index templates
+    const {
+      created_date: createdDate,
+      created_date_millis: createdDateMillis,
+      modified_date: modifiedDate,
+      modified_date_millis: modifiedDateMillis,
+      ...indexTemplate
+    } = rawIndexTemplate as IndexTemplate;
+    let updatedIndexTemplate = indexTemplate;
 
     if (isTSDBOptInChanged) {
       const indexTemplateBody = {

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/data_stream.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/data_stream.ts
@@ -192,8 +192,7 @@ export default function (providerContext: FtrProviderContext) {
         await installPackage(pkgName, pkgUpdateVersion);
       });
 
-      // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/230902
-      describe.skip('When enabling experimental data stream features', () => {
+      describe('When enabling experimental data stream features', () => {
         let agentPolicyId: string;
         let packagePolicyId: string;
 


### PR DESCRIPTION
## Summary

Resolves #230902. This PR removes system-managed properties (dates) from the retrieved index templates when updating the same index template (triggered when experimental datastream feature settings have been changed). The test that was failing is now re-enabled.

Similar to https://github.com/elastic/kibana/pull/231505, this is due to ES introducing these new date/timestamp fields in https://github.com/elastic/elasticsearch/pull/131536.

<!--ONMERGE {"backportTargets":["8.19","9.0","9.1"]} ONMERGE-->