### PR TITLE
[UII] Unskip data streams list tests

### DIFF
--- a/x-pack/platform/test/fleet_api_integration/apis/data_streams/list.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/data_streams/list.ts
@@ -105,9 +105,7 @@ export default function (providerContext: FtrProviderContext) {
     return await supertest.get(`/api/fleet/data_streams`).set('kbn-xsrf', 'xxxx');
   };
 
-  // Failing ES Promotion: https://github.com/elastic/kibana/issues/151756
-  // Failing: See https://github.com/elastic/kibana/issues/211515
-  describe.skip('data_streams_list', () => {
+  describe('data_streams_list', () => {
     skipIfNoDockerRegistry(providerContext);
 
     beforeEach(async () => {


### PR DESCRIPTION
## Summary

Resolves #211515. Found an old ES promotion issue which caused this test suite to be skipped. The underlying ES issue looks to be resolved so this can be un-skipped. Passed locally with current & snapshot ES versions.

Backporting to 9.1 as it was originally skipped there.

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->