### PR TITLE
Wrap Add Rule button in div to prevent flex

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/rule_group_editor.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/rule_group_editor.tsx
@@ -77,7 +77,9 @@ export class RuleGroupEditor extends Component<Props, {}> {
           {this.renderSubRules()}
           {this.props.allowAdd && this.props.readOnly === false && (
             <EuiFlexItem>
-              <AddRuleButton onClick={this.onAddRuleClick} />
+              <div>
+                <AddRuleButton onClick={this.onAddRuleClick} />
+              </div>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/221857

https://eui.elastic.co/docs/components/layout/flex/item/#flex-items-are-also-flex

<img width="1299" height="446" alt="Screenshot 2025-08-12 at 5 50 04 PM" src="https://github.com/user-attachments/assets/4e1632f8-4a89-44fd-98f6-86e154c79512" />


## Testing

Start KB/ES > navigate to Role Mapping Screen > Click "Add Rule" > Notice Popover is correctly anchored

## Release note
Fixed positioning of the "Add rule" popover on the Role Mappings page

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->