### PR TITLE
[OTel] Only load instrumentation-runtime-node when metrics are enabled

### DIFF
--- a/src/platform/packages/shared/kbn-telemetry/src/init_telemetry.test.ts
+++ b/src/platform/packages/shared/kbn-telemetry/src/init_telemetry.test.ts
@@ -113,7 +113,7 @@ describe('initTelemetry', () => {
           telemetry: { enabled: true, tracing: { enabled: false }, metrics: { enabled: false } },
           monitoring_collection: { enabled: true },
         },
-        ['@opentelemetry/instrumentation-runtime-node'],
+        [],
       ],
       [
         'telemetry metrics and monitoring collection metrics are enabled',

--- a/src/platform/packages/shared/kbn-telemetry/src/init_telemetry.ts
+++ b/src/platform/packages/shared/kbn-telemetry/src/init_telemetry.ts
@@ -62,14 +62,16 @@ export const initTelemetry = (
     if (telemetryConfig.metrics.enabled || monitoringCollectionConfig.enabled) {
       initMetrics({ resource, metricsConfig: telemetryConfig.metrics, monitoringCollectionConfig });
 
-      // Provides metrics about the Event Loop, GC Collector, and Heap stats.
-      desiredInstrumentations.add('@opentelemetry/instrumentation-runtime-node');
-
       // Uncomment the ones below when we clarify the performance impact of having them enabled
       // // HTTP Server and Client durations
       // desiredInstrumentations.add('@opentelemetry/instrumentation-http');
       // // Undici client's request duration
       // desiredInstrumentations.add('@opentelemetry/instrumentation-undici');
+    }
+
+    if (telemetryConfig.metrics.enabled) {
+      // Provides metrics about the Event Loop, GC Collector, and Heap stats.
+      desiredInstrumentations.add('@opentelemetry/instrumentation-runtime-node');
     }
 
     if (desiredInstrumentations.size > 0) {


### PR DESCRIPTION
Forward port of #231479

This rolls back when `@opentelemetry/instrumentation-runtime-node` is loaded to match the behavior prior to [#230465](https://github.com/elastic/kibana/pull/230465/files#diff-09903975f886a43375599fff16ecf98582125a6705bccdb12ad667da3ba746acL56).

Without this rollback we're seeing a significant (2-3x) increase in startup times.

