### PR TITLE
[Bug] Fixed content connector sync rules non interactive save button

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
@@ -146,32 +146,29 @@ export const ConnectorDetail: React.FC = () => {
   ];
 
   const CONNECTOR_TABS = [
-    ...(hasFilteringFeature
-      ? [
-          {
-            content: <ConnectorSyncRules />,
-            disabled: !index,
-            id: ConnectorDetailTabId.SYNC_RULES,
-            isSelected: tabId === ConnectorDetailTabId.SYNC_RULES,
-            label: i18n.translate(
-              'xpack.contentConnectors.connectors.connectorDetail.syncRulesTabLabel',
-              {
-                defaultMessage: 'Sync rules',
-              }
-            ),
-            onClick: () =>
-              application?.navigateToUrl(
-                generateEncodedPath(
-                  `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-                  {
-                    connectorId,
-                    tabId: ConnectorDetailTabId.SYNC_RULES,
-                  }
-                )
-              ),
-          },
-        ]
-      : []),
+    {
+      content: <ConnectorSyncRules />,
+      disabled: !index || !hasFilteringFeature,
+      id: ConnectorDetailTabId.SYNC_RULES,
+      isSelected: tabId === ConnectorDetailTabId.SYNC_RULES,
+      label: i18n.translate(
+        'xpack.contentConnectors.connectors.connectorDetail.syncRulesTabLabel',
+        {
+          defaultMessage: 'Sync rules',
+        }
+      ),
+      onClick: () =>
+        application?.navigateToUrl(
+          generateEncodedPath(
+            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
+            {
+              connectorId,
+              tabId: ConnectorDetailTabId.SYNC_RULES,
+            }
+          )
+        ),
+    },
+
     {
       content: <ConnectorScheduling />,
       disabled: !connector?.index_name,

--- a/x-pack/platform/plugins/shared/content_connectors/server/routes/connectors.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/routes/connectors.ts
@@ -1188,7 +1188,7 @@ export function registerConnectorRoutes({
       try {
         const index = await fetchIndex(client.asCurrentUser, indexName);
         return response.ok({
-          body: index,
+          body: index?.index,
           headers: { 'content-type': 'application/json' },
         });
       } catch (error) {


### PR DESCRIPTION
## Summary

This PR fixes the bug with saving sync rules.

Before:

https://github.com/user-attachments/assets/037f72c1-e570-4c79-a16a-a88d503aa08b



After:

https://github.com/user-attachments/assets/de937570-cc2c-4370-8c80-e7f1550465b6



<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->