### PR TITLE
[Entity Store] Remove duplicated time filter

### DIFF
--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
@@ -48,26 +48,26 @@ Array [
   },
   Object {
     "script": Object {
-      "source": "if (ctx.entity?.metadata?.tags?.data != null) {
-  ctx.tags = ctx.entity.metadata.tags.data.keySet();
+      "source": "if (ctx.entity?.metadata?.tags != null) {
+  ctx.tags = ctx.entity.metadata.tags.keySet();
 }
-if (ctx.entity?.metadata?.host?.name?.data != null) {
+if (ctx.entity?.metadata?.host?.name != null) {
   if (ctx.host == null) {
     ctx.host = new HashMap();
   }
-  ctx.host.name = ctx.entity.metadata.host.name.data.keySet();
+  ctx.host.name = ctx.entity.metadata.host.name.keySet();
 }
-if (ctx.entity?.metadata?.host?.os?.name?.data != null) {
+if (ctx.entity?.metadata?.host?.os?.name != null) {
   if (ctx.host == null) {
     ctx.host = new HashMap();
   }
   if (ctx.host.os == null) {
     ctx.host.os = new HashMap();
   }
-  ctx.host.os.name = ctx.entity.metadata.host.os.name.data.keySet();
+  ctx.host.os.name = ctx.entity.metadata.host.os.name.keySet();
 }
-if (ctx.entity?.metadata?.sourceIndex?.data != null) {
-  ctx.sourceIndex = ctx.entity.metadata.sourceIndex.data.keySet();
+if (ctx.entity?.metadata?.sourceIndex != null) {
+  ctx.sourceIndex = ctx.entity.metadata.sourceIndex.keySet();
 }",
     },
   },
@@ -153,26 +153,26 @@ Array [
   },
   Object {
     "script": Object {
-      "source": "if (ctx.entity?.metadata?.tags?.data != null) {
-  ctx.tags = ctx.entity.metadata.tags.data.keySet();
+      "source": "if (ctx.entity?.metadata?.tags != null) {
+  ctx.tags = ctx.entity.metadata.tags.keySet();
 }
-if (ctx.entity?.metadata?.host?.name?.data != null) {
+if (ctx.entity?.metadata?.host?.name != null) {
   if (ctx.host == null) {
     ctx.host = new HashMap();
   }
-  ctx.host.name = ctx.entity.metadata.host.name.data.keySet();
+  ctx.host.name = ctx.entity.metadata.host.name.keySet();
 }
-if (ctx.entity?.metadata?.host?.os?.name?.data != null) {
+if (ctx.entity?.metadata?.host?.os?.name != null) {
   if (ctx.host == null) {
     ctx.host = new HashMap();
   }
   if (ctx.host.os == null) {
     ctx.host.os = new HashMap();
   }
-  ctx.host.os.name = ctx.entity.metadata.host.os.name.data.keySet();
+  ctx.host.os.name = ctx.entity.metadata.host.os.name.keySet();
 }
-if (ctx.entity?.metadata?.sourceIndex?.data != null) {
-  ctx.sourceIndex = ctx.entity.metadata.sourceIndex.data.keySet();
+if (ctx.entity?.metadata?.sourceIndex != null) {
+  ctx.sourceIndex = ctx.entity.metadata.sourceIndex.keySet();
 }",
     },
   },

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
@@ -16,7 +16,7 @@ import { isBuiltinDefinition } from '../helpers/is_builtin_definition';
 
 function getMetadataSourceField({ aggregation, destination, source }: MetadataField) {
   if (aggregation.type === 'terms') {
-    return `ctx.entity.metadata.${destination}.data.keySet()`;
+    return `ctx.entity.metadata.${destination}.keySet()`;
   } else if (aggregation.type === 'top_value') {
     return `ctx.entity.metadata.${destination}.top_value["${source}"]`;
   }
@@ -41,7 +41,7 @@ function createMetadataPainlessScript(definition: EntityDefinition) {
 
     if (metadata.aggregation.type === 'terms') {
       const next = `
-        if (ctx.entity?.metadata?.${optionalFieldPath}?.data != null) {
+        if (ctx.entity?.metadata?.${optionalFieldPath} != null) {
           ${mapDestinationToPainless(metadata)}
         }
       `;

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/__snapshots__/generate_latest_transform.test.ts.snap
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/__snapshots__/generate_latest_transform.test.ts.snap
@@ -48,71 +48,27 @@ Object {
         },
       },
       "entity.metadata.host.name": Object {
-        "aggs": Object {
-          "data": Object {
-            "terms": Object {
-              "field": "host.name",
-              "size": 10,
-            },
-          },
-        },
-        "filter": Object {
-          "range": Object {
-            "@timestamp": Object {
-              "gte": "now-10m",
-            },
-          },
+        "terms": Object {
+          "field": "host.name",
+          "size": 10,
         },
       },
       "entity.metadata.host.os.name": Object {
-        "aggs": Object {
-          "data": Object {
-            "terms": Object {
-              "field": "host.os.name",
-              "size": 10,
-            },
-          },
-        },
-        "filter": Object {
-          "range": Object {
-            "@timestamp": Object {
-              "gte": "now-10m",
-            },
-          },
+        "terms": Object {
+          "field": "host.os.name",
+          "size": 10,
         },
       },
       "entity.metadata.sourceIndex": Object {
-        "aggs": Object {
-          "data": Object {
-            "terms": Object {
-              "field": "_index",
-              "size": 10,
-            },
-          },
-        },
-        "filter": Object {
-          "range": Object {
-            "@timestamp": Object {
-              "gte": "now-10m",
-            },
-          },
+        "terms": Object {
+          "field": "_index",
+          "size": 10,
         },
       },
       "entity.metadata.tags": Object {
-        "aggs": Object {
-          "data": Object {
-            "terms": Object {
-              "field": "tags",
-              "size": 10,
-            },
-          },
-        },
-        "filter": Object {
-          "range": Object {
-            "@timestamp": Object {
-              "gte": "now-10m",
-            },
-          },
+        "terms": Object {
+          "field": "tags",
+          "size": 10,
         },
       },
       "entity.metrics.errorRate": Object {

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_metadata_aggregations.test.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_metadata_aggregations.test.ts
@@ -19,20 +19,9 @@ describe('Generate Metadata Aggregations for history and latest', () => {
 
       expect(generateLatestMetadataAggregations(definition)).toEqual({
         'entity.metadata.host.name': {
-          filter: {
-            range: {
-              '@timestamp': {
-                gte: 'now-10m',
-              },
-            },
-          },
-          aggs: {
-            data: {
-              terms: {
-                field: 'host.name',
-                size: 10,
-              },
-            },
+          terms: {
+            field: 'host.name',
+            size: 10,
           },
         },
       });
@@ -45,20 +34,9 @@ describe('Generate Metadata Aggregations for history and latest', () => {
       });
       expect(generateLatestMetadataAggregations(definition)).toEqual({
         'entity.metadata.host.name': {
-          filter: {
-            range: {
-              '@timestamp': {
-                gte: 'now-10m',
-              },
-            },
-          },
-          aggs: {
-            data: {
-              terms: {
-                field: 'host.name',
-                size: 10,
-              },
-            },
+          terms: {
+            field: 'host.name',
+            size: 10,
           },
         },
       });
@@ -73,20 +51,9 @@ describe('Generate Metadata Aggregations for history and latest', () => {
       });
       expect(generateLatestMetadataAggregations(definition)).toEqual({
         'entity.metadata.host.name': {
-          filter: {
-            range: {
-              '@timestamp': {
-                gte: 'now-1h',
-              },
-            },
-          },
-          aggs: {
-            data: {
-              terms: {
-                field: 'host.name',
-                size: 10,
-              },
-            },
+          terms: {
+            field: 'host.name',
+            size: 10,
           },
         },
       });
@@ -105,20 +72,9 @@ describe('Generate Metadata Aggregations for history and latest', () => {
       });
       expect(generateLatestMetadataAggregations(definition)).toEqual({
         'entity.metadata.hostName': {
-          filter: {
-            range: {
-              '@timestamp': {
-                gte: 'now-10m',
-              },
-            },
-          },
-          aggs: {
-            data: {
-              terms: {
-                field: 'host.name',
-                size: 10,
-              },
-            },
+          terms: {
+            field: 'host.name',
+            size: 10,
           },
         },
       });
@@ -142,39 +98,15 @@ describe('Generate Metadata Aggregations for history and latest', () => {
       });
       expect(generateLatestMetadataAggregations(definition)).toEqual({
         'entity.metadata.hostName': {
-          filter: {
-            range: {
-              '@timestamp': {
-                gte: 'now-10m',
-              },
-            },
-          },
-          aggs: {
-            data: {
-              terms: {
-                field: 'host.name',
-                size: 10,
-              },
-            },
+          terms: {
+            field: 'host.name',
+            size: 10,
           },
         },
         'entity.metadata.agentName': {
           filter: {
-            bool: {
-              must: [
-                {
-                  range: {
-                    '@timestamp': {
-                      gte: 'now-10m',
-                    },
-                  },
-                },
-                {
-                  exists: {
-                    field: 'agent.name',
-                  },
-                },
-              ],
+            exists: {
+              field: 'agent.name',
             },
           },
           aggs: {

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_metadata_aggregations.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_metadata_aggregations.ts
@@ -13,44 +13,20 @@ export function generateLatestMetadataAggregations(definition: EntityDefinition)
   }
 
   return definition.metadata.reduce((aggs, metadata) => {
-    const lookbackPeriod = metadata.aggregation.lookbackPeriod || definition.latest.lookbackPeriod;
     let agg;
+
     if (metadata.aggregation.type === 'terms') {
       agg = {
-        filter: {
-          range: {
-            '@timestamp': {
-              gte: `now-${lookbackPeriod}`,
-            },
-          },
-        },
-        aggs: {
-          data: {
-            terms: {
-              field: metadata.source,
-              size: metadata.aggregation.limit,
-            },
-          },
+        terms: {
+          field: metadata.source,
+          size: metadata.aggregation.limit,
         },
       };
     } else if (metadata.aggregation.type === 'top_value') {
       agg = {
         filter: {
-          bool: {
-            must: [
-              {
-                range: {
-                  '@timestamp': {
-                    gte: `now-${lookbackPeriod}`,
-                  },
-                },
-              },
-              {
-                exists: {
-                  field: metadata.source,
-                },
-              },
-            ],
+          exists: {
+            field: metadata.source,
           },
         },
         aggs: {


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/229261

On the **aggregation** layer of the entity store transform we were filtering documents out that were older than lookback period. That is redundant because the aggregation happens on filtered data that is already within the lookback window. @nik9000 has pointed out that this could have performance implications. 

Performance improvements are hard to measure right now, but even if this brings no improvement on performance, we definitely simplify the overall transform.

We reduced cognitive load to read transforms,

Terms aggregation was:
```
"entity.metadata.host.hostname": {
  "filter": {
    "range": {
      "@timestamp": {
        "gte": "now-3h"
      }
    }
  },
  "aggs": {
    "data": {
      "terms": {
        "field": "host.hostname",
        "size": 10
      }
    }
  }
},
```

Now is (we had to update the painless ingest pipeline to adhere to the new format):
```
 "entity.metadata.host.hostname": {
  "terms": {
    "field": "host.hostname",
    "size": 10
  }
},
```

Last aggregation was:
_I tried to also remove the `exists` filter, but then top_metrics return a `"null"` instead of empty, which would force us to check for string `"null"` in painless and that is beyond ugly, remove the possibility of a field to contain latest value null, which is unlikely but not impossible_
```
"entity.metadata.entity.source": {
  "filter": {
    "bool": {
      "must": [
        {
          "range": {
            "@timestamp": {
              "gte": "now-3h"
            }
          }
        },
        {
          "exists": {
            "field": "_index"
          }
        }
      ]
    }
  },
  "aggs": {
    "top_value": {
      "top_metrics": {
        "metrics": {
          "field": "_index"
        },
        "sort": {
          "@timestamp": "asc"
        }
      }
    }
  }
},
```

Now is:
```
"entity.metadata.entity.source": {
  "filter": {
    "exists": {
      "field": "_index"
    }
  },
  "aggs": {
    "top_value": {
      "top_metrics": {
        "metrics": {
          "field": "_index"
        },
        "sort": {
          "@timestamp": "asc"
        }
      }
    }
  }
},
```

Not the greatest metric, but this is the reduction of lines of transform (from `GET /transforms/*` endpoint)
| Transform | Before Changes | After Changes |
|--------|--------|--------|
| generic | 2014 lines | 1234 lines |
| host | 407 lines | 243 lines |
| user | 454 lines | 275 lines |
| service | 456 lines | 225 lines |

About 40% reduction. 

### Manual testing
- [x] Tested behaviour is the same as right now
- [x] Tested having an "old" entity store enabled, disable (without deleting) and enabling again. Changes are applied and no errors, (input and output haven't changed) 

