### PR TITLE
[ES|QL] LOOKUP JOIN - Add error callout

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { i18n } from '@kbn/i18n';
+import { KibanaContextExtra, IndexEditorErrors } from '../types';
+
+const errorMessages: Record<IndexEditorErrors, string> = {
+  [IndexEditorErrors.GENERIC_SAVING_ERROR]: i18n.translate(
+    'indexEditor.flyout.error.genericSavingError',
+    {
+      defaultMessage: 'There was an internal error saving the index in Elasticsearch.',
+    }
+  ),
+  [IndexEditorErrors.PARTIAL_SAVING_ERROR]: i18n.translate(
+    'indexEditor.flyout.error.partialSavingError',
+    {
+      defaultMessage: 'Some of the changes made to the index were not saved.',
+    }
+  ),
+};
+
+export const ErrorCallout = () => {
+  const {
+    services: { indexUpdateService },
+  } = useKibana<KibanaContextExtra>();
+
+  const error = useObservable(indexUpdateService.error$, null);
+
+  return error ? (
+    <EuiCallOut
+      title={
+        <FormattedMessage
+          id="indexEditor.flyout.callout.title"
+          defaultMessage="There was an error"
+        />
+      }
+      iconType="error"
+      color="danger"
+    >
+      {errorMessages[error]}
+    </EuiCallOut>
+  ) : null;
+};

--- a/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/error_callout.tsx
@@ -48,7 +48,7 @@ export const ErrorCallout = () => {
       iconType="error"
       color="danger"
     >
-      {errorMessages[error]}
+      <p>{errorMessages[error]}</p>
     </EuiCallOut>
   ) : null;
 };

--- a/src/platform/packages/private/kbn-index-editor/src/components/flyout_content.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/flyout_content.tsx
@@ -24,6 +24,7 @@ import React, { lazy } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
+import { ErrorCallout } from './error_callout';
 import { isPlaceholderColumn } from '../utils';
 import { UnsavedChangesModal } from './modals/unsaved_changes_modal';
 import type { EditLookupIndexContentContext, FlyoutDeps } from '../types';
@@ -99,6 +100,8 @@ export const FlyoutContent: FC<FlyoutContentProps> = ({ deps, props }) => {
               />
             </EuiText>
           </EuiFlyoutHeader>
+
+          <ErrorCallout />
 
           <EuiFlyoutBody
             css={css`

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -679,11 +679,7 @@ export class IndexUpdateService {
     this._qstr$.complete();
     this._refreshSubject$.complete();
     this._exitAttemptWithUnsavedFields$.complete();
-
-    const indexName = this.getIndexName();
-    if (indexName) {
-      this.data.dataViews.clearInstanceCache(indexName);
-    }
+    this.data.dataViews.clearCache();
     this._indexName$.complete();
   }
 

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -44,6 +44,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { Builder, BasicPrettyPrinter } from '@kbn/esql-ast';
 import { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
+import { IndexEditorErrors } from './types';
 import { parsePrimitive, isPlaceholderColumn } from './utils';
 import { ROW_PLACEHOLDER_PREFIX, COLUMN_PLACEHOLDER_PREFIX } from './constants';
 const BUFFER_TIMEOUT_MS = 5000; // 5 seconds
@@ -113,6 +114,9 @@ export class IndexUpdateService {
 
   private readonly _isFetching$ = new BehaviorSubject<boolean>(false);
   public readonly isFetching$: Observable<boolean> = this._isFetching$.asObservable();
+
+  private readonly _error$ = new BehaviorSubject<IndexEditorErrors | null>(null);
+  public readonly error$: Observable<IndexEditorErrors | null> = this._error$.asObservable();
 
   private readonly _exitAttemptWithUnsavedFields$ = new BehaviorSubject<boolean>(false);
   public readonly exitAttemptWithUnsavedFields$ =
@@ -412,9 +416,8 @@ export class IndexUpdateService {
 
             // TODO handle index docs
           },
-          error: (err) => {
-            // TODO handle API errors
-
+          error: () => {
+            this._error$.next(IndexEditorErrors.GENERIC_SAVING_ERROR);
             this._isSaving$.next(false);
           },
         })

--- a/src/platform/packages/private/kbn-index-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/types.ts
@@ -65,3 +65,8 @@ export interface KibanaContextExtra {
   messageImporter: MessageImporter;
   storage: Storage;
 }
+
+export enum IndexEditorErrors {
+  GENERIC_SAVING_ERROR = 'genericSavingError',
+  PARTIAL_SAVING_ERROR = 'partialSavingError',
+}


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/207330
## Summary
Add error messages when failing to save changes.

<img width="1723" height="872" alt="image" src="https://github.com/user-attachments/assets/964a7a4c-8639-4161-9f3e-2017cc63e1aa" />

