### PR TITLE
[8.18] [Security Solution] Install mock prebuilt rules package in Cypress to reduce flakiness (#229689)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
@@ -7,7 +7,8 @@
 
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
 
-import { getNewRule } from '../../../../objects/rule';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
+import { getCustomQueryRuleParams, getNewRule } from '../../../../objects/rule';
 import {
   COLLAPSED_ACTION_BTN,
   RULE_CHECKBOX,
@@ -28,12 +29,16 @@ import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 // TODO: https://github.com/elastic/kibana/issues/164451 We should find a way to make this spec work in Serverless
 // TODO: https://github.com/elastic/kibana/issues/161540
 describe('All rules - read only', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: '1', enabled: false }));
+    createRule(getCustomQueryRuleParams({ rule_id: '1', enabled: false }));
     login(ROLES.t1_analyst);
     visitRulesManagementTable();
-    cy.get(RULE_NAME).should('have.text', getNewRule().name);
+    cy.get(RULE_NAME).should('have.text', getCustomQueryRuleParams().name);
   });
 
   it('Does not display select boxes for rules', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/coverage_overview/coverage_overview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/coverage_overview/coverage_overview.cy.ts
@@ -22,9 +22,10 @@ import { createRule } from '../../../../tasks/api_calls/rules';
 import { visit } from '../../../../tasks/navigation';
 import { RULES_COVERAGE_OVERVIEW_URL } from '../../../../urls/rules_management';
 import { createRuleAssetSavedObject } from '../../../../helpers/rules';
-import { getNewRule } from '../../../../objects/rule';
+import { getCustomQueryRuleParams, getNewRule } from '../../../../objects/rule';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../tasks/api_calls/prebuilt_rules';
 import {
@@ -191,6 +192,10 @@ const prebuiltRules = [
 
 // https://github.com/elastic/kibana/issues/179052
 describe('Coverage overview', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   describe('base cases', () => {
     beforeEach(() => {
       login();
@@ -199,7 +204,7 @@ describe('Coverage overview', { tags: ['@ess', '@serverless', '@skipInServerless
       preventPrebuiltRulesPackageInstallation();
       createAndInstallMockedPrebuiltRules(prebuiltRules);
       createRule(
-        getNewRule({
+        getCustomQueryRuleParams({
           rule_id: 'enabled_custom_rule',
           enabled: true,
           name: 'Enabled custom rule',
@@ -207,7 +212,7 @@ describe('Coverage overview', { tags: ['@ess', '@serverless', '@skipInServerless
         })
       );
       createRule(
-        getNewRule({
+        getCustomQueryRuleParams({
           rule_id: 'disabled_custom_rule',
           name: 'Disabled custom rule',
           enabled: false,

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/maintenance_windows/maintenance_window_callout.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/maintenance_windows/maintenance_window_callout.cy.ts
@@ -8,6 +8,7 @@
 import { INTERNAL_ALERTING_API_MAINTENANCE_WINDOW_PATH } from '@kbn/alerting-plugin/common';
 import type { MaintenanceWindowCreateBody } from '@kbn/alerting-plugin/common';
 import type { AsApiContract } from '@kbn/alerting-plugin/server/routes/lib';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
@@ -17,6 +18,10 @@ describe(
   'Maintenance window callout on Rule Management page',
   { tags: ['@ess', '@serverless', '@skipInServerless'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     let maintenanceWindowId = '';
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/customization/rule_customization.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/customization/rule_customization.cy.ts
@@ -51,8 +51,8 @@ import {
 } from '../../../../../tasks/api_calls/common';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   installPrebuiltRuleAssets,
-  preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { createRule, patchRule } from '../../../../../tasks/api_calls/rules';
 
@@ -61,6 +61,7 @@ import { login } from '../../../../../tasks/login';
 import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
 import { fillDescription, goToAboutStepTab } from '../../../../../tasks/create_new_rule';
 import { saveEditedRule } from '../../../../../tasks/edit_rule';
+
 describe(
   'Detection rules, Prebuilt Rules Customization workflow',
   {
@@ -68,271 +69,273 @@ describe(
   },
 
   () => {
-    describe('Customizing prebuilt rules', () => {
-      const testTags = ['tag 1', 'tag 2'];
-      const PREBUILT_RULE = createRuleAssetSavedObject({
-        name: 'Non-customized prebuilt rule',
-        rule_id: 'rule_1',
-        version: 1,
-        index: getIndexPatterns(),
-        tags: testTags,
-        investigation_fields: { field_names: ['source.ip'] },
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
+    const testTags = ['tag 1', 'tag 2'];
+    const PREBUILT_RULE = createRuleAssetSavedObject({
+      name: 'Non-customized prebuilt rule',
+      rule_id: 'rule_1',
+      version: 1,
+      index: getIndexPatterns(),
+      tags: testTags,
+      investigation_fields: { field_names: ['source.ip'] },
+    });
+
+    beforeEach(() => {
+      deleteAlertsAndRules();
+      deletePrebuiltRulesAssets();
+      /* Create a new rule and install it */
+      createAndInstallMockedPrebuiltRules([PREBUILT_RULE]);
+
+      login();
+      visitRulesManagementTable();
+      createRule(
+        getNewRule({
+          name: 'Custom rule',
+          index: getIndexPatterns(),
+          tags: testTags,
+          enabled: false,
+        })
+      );
+    });
+
+    it('user can navigate to rule editing page from the rule details page', function () {
+      cy.get(RULE_NAME).contains('Non-customized prebuilt rule').click();
+
+      goToRuleEditSettings();
+      cy.get(DEFINITION_EDIT_TAB).should('be.enabled');
+      cy.get(ABOUT_EDIT_TAB).should('be.enabled');
+      cy.get(SCHEDULE_EDIT_TAB).should('be.enabled');
+      cy.get(ACTIONS_EDIT_TAB).should('be.enabled');
+    });
+
+    it('user can edit a non-customized prebuilt rule from the rule edit page', function () {
+      const newDescriptionValue = 'New rule description';
+      cy.get(RULE_NAME).contains('Non-customized prebuilt rule').click();
+
+      goToRuleEditSettings();
+      goToAboutStepTab();
+      fillDescription(newDescriptionValue);
+      saveEditedRule();
+
+      expectModifiedBadgeToBeDisplayed();
+      cy.get(ABOUT_RULE_DESCRIPTION).should('have.text', newDescriptionValue);
+    });
+
+    it('user can edit a customized prebuilt rule from the rule edit page', function () {
+      const newDescriptionValue = 'New rule description';
+      patchRule('rule_1', { name: 'Customized prebuilt rule' }); // We want to make this a customized prebuilt rule
+      visitRulesManagementTable();
+
+      cy.get(RULE_NAME).contains('Customized prebuilt rule').click();
+      expectModifiedBadgeToBeDisplayed(); // Expect modified badge to already be displayed
+
+      goToRuleEditSettings();
+      goToAboutStepTab();
+      fillDescription(newDescriptionValue);
+      saveEditedRule();
+
+      expectModifiedBadgeToBeDisplayed();
+      cy.get(ABOUT_RULE_DESCRIPTION).should('have.text', newDescriptionValue);
+    });
+
+    it('user can navigate to rule editing page from the rule management page', function () {
+      filterByElasticRules();
+      editFirstRule();
+
+      cy.get(DEFINITION_EDIT_TAB).should('be.enabled');
+      cy.get(ABOUT_EDIT_TAB).should('be.enabled');
+      cy.get(SCHEDULE_EDIT_TAB).should('be.enabled');
+      cy.get(ACTIONS_EDIT_TAB).should('be.enabled');
+    });
+
+    describe('user can bulk edit prebuilt rules from rules management page', () => {
+      it('add index patterns', () => {
+        filterByElasticRules();
+        selectAllRules();
+
+        openBulkEditAddIndexPatternsForm();
+        typeIndexPatterns(['test-pattern']);
+        submitBulkEditForm();
+
+        waitForBulkEditActionToFinish({
+          updatedCount: 1,
+        });
+
+        expectToContainModifiedBadge('Non-customized prebuilt rule');
       });
 
-      beforeEach(() => {
-        login();
-        deleteAlertsAndRules();
-        deletePrebuiltRulesAssets();
-        preventPrebuiltRulesPackageInstallation();
-        /* Create a new rule and install it */
-        createAndInstallMockedPrebuiltRules([PREBUILT_RULE]);
-        visitRulesManagementTable();
-        createRule(
-          getNewRule({
-            name: 'Custom rule',
-            index: getIndexPatterns(),
-            tags: testTags,
-            enabled: false,
-          })
-        );
+      it('delete index patterns', () => {
+        filterByElasticRules();
+        selectAllRules();
+
+        openBulkEditDeleteIndexPatternsForm();
+        typeIndexPatterns([getIndexPatterns()[0]]);
+        submitBulkEditForm();
+
+        waitForBulkEditActionToFinish({
+          updatedCount: 1,
+        });
+
+        expectToContainModifiedBadge('Non-customized prebuilt rule');
       });
 
-      it('user can navigate to rule editing page from the rule details page', function () {
-        cy.get(RULE_NAME).contains('Non-customized prebuilt rule').click();
+      it('add tags', () => {
+        filterByElasticRules();
+        selectAllRules();
 
-        goToRuleEditSettings();
-        cy.get(DEFINITION_EDIT_TAB).should('be.enabled');
-        cy.get(ABOUT_EDIT_TAB).should('be.enabled');
-        cy.get(SCHEDULE_EDIT_TAB).should('be.enabled');
-        cy.get(ACTIONS_EDIT_TAB).should('be.enabled');
+        openBulkEditAddTagsForm();
+        typeTags(['custom-tag']);
+        submitBulkEditForm();
+
+        waitForBulkEditActionToFinish({
+          updatedCount: 1,
+        });
+
+        expectToContainModifiedBadge('Non-customized prebuilt rule');
       });
 
-      it('user can edit a non-customized prebuilt rule from the rule edit page', function () {
-        const newDescriptionValue = 'New rule description';
-        cy.get(RULE_NAME).contains('Non-customized prebuilt rule').click();
+      it('delete tags', () => {
+        filterByElasticRules();
+        selectAllRules();
 
-        goToRuleEditSettings();
-        goToAboutStepTab();
-        fillDescription(newDescriptionValue);
-        saveEditedRule();
+        openBulkEditDeleteTagsForm();
+        typeTags([testTags[0]]);
+        submitBulkEditForm();
 
-        expectModifiedBadgeToBeDisplayed();
-        cy.get(ABOUT_RULE_DESCRIPTION).should('have.text', newDescriptionValue);
+        waitForBulkEditActionToFinish({
+          updatedCount: 1,
+        });
+
+        expectToContainModifiedBadge('Non-customized prebuilt rule');
       });
 
-      it('user can edit a customized prebuilt rule from the rule edit page', function () {
-        const newDescriptionValue = 'New rule description';
+      it('add custom highlighted fields', () => {
+        filterByElasticRules();
+        selectAllRules();
+
+        openBulkEditAddInvestigationFieldsForm();
+        typeInvestigationFields(['host.name']);
+        submitBulkEditForm();
+
+        waitForBulkEditActionToFinish({
+          updatedCount: 1,
+        });
+
+        expectToContainModifiedBadge('Non-customized prebuilt rule');
+      });
+
+      it('delete custom highlighted fields', () => {
+        filterByElasticRules();
+        selectAllRules();
+
+        openBulkEditDeleteInvestigationFieldsForm();
+        typeInvestigationFields(['source.ip']);
+        submitBulkEditForm();
+
+        waitForBulkEditActionToFinish({
+          updatedCount: 1,
+        });
+
+        expectToContainModifiedBadge('Non-customized prebuilt rule');
+      });
+
+      it('modify rule schedules', () => {
+        filterByElasticRules();
+        selectAllRules();
+
+        clickUpdateScheduleMenuItem();
+
+        typeScheduleInterval('20');
+        setScheduleIntervalTimeUnit('Hours');
+
+        typeScheduleLookback('10');
+        setScheduleLookbackTimeUnit('Minutes');
+
+        submitBulkEditForm();
+
+        waitForBulkEditActionToFinish({
+          updatedCount: 1,
+        });
+
+        expectToContainModifiedBadge('Non-customized prebuilt rule');
+      });
+    });
+
+    describe('calculating the Modified badge', () => {
+      it('modified badge should appear on the rule details page when prebuilt rule is customized', function () {
         patchRule('rule_1', { name: 'Customized prebuilt rule' }); // We want to make this a customized prebuilt rule
         visitRulesManagementTable();
 
         cy.get(RULE_NAME).contains('Customized prebuilt rule').click();
-        expectModifiedBadgeToBeDisplayed(); // Expect modified badge to already be displayed
-
-        goToRuleEditSettings();
-        goToAboutStepTab();
-        fillDescription(newDescriptionValue);
-        saveEditedRule();
-
-        expectModifiedBadgeToBeDisplayed();
-        cy.get(ABOUT_RULE_DESCRIPTION).should('have.text', newDescriptionValue);
+        expectModifiedBadgeToBeDisplayed(); // Expect modified badge to be displayed
       });
 
-      it('user can navigate to rule editing page from the rule management page', function () {
+      it("modified badge should not appear on the rule details page when prebuilt rule isn't customized", function () {
+        visitRulesManagementTable();
+
+        cy.get(RULE_NAME).contains('Non-customized prebuilt rule').click();
+        expectModifiedBadgeToNotBeDisplayed(); // Expect modified badge to not be displayed
+      });
+
+      it("modified badge should not appear on a custom rule's rule details page", function () {
+        visitRulesManagementTable();
+
+        cy.get(RULE_NAME).contains('Custom rule').click();
+        expectModifiedBadgeToNotBeDisplayed(); // Expect modified badge to not be displayed
+      });
+
+      it('modified badge should appear on the rule management table when prebuilt rule is modified', function () {
+        patchRule('rule_1', { name: 'Customized prebuilt rule' }); // We want to make this a customized prebuilt rule
+        visitRulesManagementTable();
+
         filterByElasticRules();
-        editFirstRule();
-
-        cy.get(DEFINITION_EDIT_TAB).should('be.enabled');
-        cy.get(ABOUT_EDIT_TAB).should('be.enabled');
-        cy.get(SCHEDULE_EDIT_TAB).should('be.enabled');
-        cy.get(ACTIONS_EDIT_TAB).should('be.enabled');
+        expectToContainModifiedBadge('Customized prebuilt rule');
       });
 
-      describe('user can bulk edit prebuilt rules from rules management page', () => {
-        it('add index patterns', () => {
-          filterByElasticRules();
-          selectAllRules();
+      it("modified badge should not appear on the rule management table when prebuilt rule isn't customized", function () {
+        visitRulesManagementTable();
 
-          openBulkEditAddIndexPatternsForm();
-          typeIndexPatterns(['test-pattern']);
-          submitBulkEditForm();
-
-          waitForBulkEditActionToFinish({
-            updatedCount: 1,
-          });
-
-          expectToContainModifiedBadge('Non-customized prebuilt rule');
-        });
-
-        it('delete index patterns', () => {
-          filterByElasticRules();
-          selectAllRules();
-
-          openBulkEditDeleteIndexPatternsForm();
-          typeIndexPatterns([getIndexPatterns()[0]]);
-          submitBulkEditForm();
-
-          waitForBulkEditActionToFinish({
-            updatedCount: 1,
-          });
-
-          expectToContainModifiedBadge('Non-customized prebuilt rule');
-        });
-
-        it('add tags', () => {
-          filterByElasticRules();
-          selectAllRules();
-
-          openBulkEditAddTagsForm();
-          typeTags(['custom-tag']);
-          submitBulkEditForm();
-
-          waitForBulkEditActionToFinish({
-            updatedCount: 1,
-          });
-
-          expectToContainModifiedBadge('Non-customized prebuilt rule');
-        });
-
-        it('delete tags', () => {
-          filterByElasticRules();
-          selectAllRules();
-
-          openBulkEditDeleteTagsForm();
-          typeTags([testTags[0]]);
-          submitBulkEditForm();
-
-          waitForBulkEditActionToFinish({
-            updatedCount: 1,
-          });
-
-          expectToContainModifiedBadge('Non-customized prebuilt rule');
-        });
-
-        it('add custom highlighted fields', () => {
-          filterByElasticRules();
-          selectAllRules();
-
-          openBulkEditAddInvestigationFieldsForm();
-          typeInvestigationFields(['host.name']);
-          submitBulkEditForm();
-
-          waitForBulkEditActionToFinish({
-            updatedCount: 1,
-          });
-
-          expectToContainModifiedBadge('Non-customized prebuilt rule');
-        });
-
-        it('delete custom highlighted fields', () => {
-          filterByElasticRules();
-          selectAllRules();
-
-          openBulkEditDeleteInvestigationFieldsForm();
-          typeInvestigationFields(['source.ip']);
-          submitBulkEditForm();
-
-          waitForBulkEditActionToFinish({
-            updatedCount: 1,
-          });
-
-          expectToContainModifiedBadge('Non-customized prebuilt rule');
-        });
-
-        it('modify rule schedules', () => {
-          filterByElasticRules();
-          selectAllRules();
-
-          clickUpdateScheduleMenuItem();
-
-          typeScheduleInterval('20');
-          setScheduleIntervalTimeUnit('Hours');
-
-          typeScheduleLookback('10');
-          setScheduleLookbackTimeUnit('Minutes');
-
-          submitBulkEditForm();
-
-          waitForBulkEditActionToFinish({
-            updatedCount: 1,
-          });
-
-          expectToContainModifiedBadge('Non-customized prebuilt rule');
-        });
+        filterByElasticRules();
+        expectToNotContainModifiedBadge('Non-customized prebuilt rule');
       });
 
-      describe('calculating the Modified badge', () => {
-        it('modified badge should appear on the rule details page when prebuilt rule is customized', function () {
-          patchRule('rule_1', { name: 'Customized prebuilt rule' }); // We want to make this a customized prebuilt rule
-          visitRulesManagementTable();
+      it('modified badge should not appear on the rule management table when row is a custom rule', function () {
+        visitRulesManagementTable();
 
-          cy.get(RULE_NAME).contains('Customized prebuilt rule').click();
-          expectModifiedBadgeToBeDisplayed(); // Expect modified badge to be displayed
-        });
+        filterByCustomRules();
+        expectToNotContainModifiedBadge('Custom rule');
+      });
 
-        it("modified badge should not appear on the rule details page when prebuilt rule isn't customized", function () {
-          visitRulesManagementTable();
+      it('modified badge should appear on the rule updates table when prebuilt rule is customized', function () {
+        // Create a new version of the rule to trigger the rule update logic
+        installPrebuiltRuleAssets([
+          {
+            ...PREBUILT_RULE,
+            'security-rule': { ...PREBUILT_RULE['security-rule'], version: 2 },
+          },
+        ]);
+        patchRule('rule_1', { name: 'Customized prebuilt rule' }); // We want to make this a customized prebuilt rule
+        visitRulesManagementTable();
+        clickRuleUpdatesTab();
 
-          cy.get(RULE_NAME).contains('Non-customized prebuilt rule').click();
-          expectModifiedBadgeToNotBeDisplayed(); // Expect modified badge to not be displayed
-        });
+        cy.get(MODIFIED_RULE_BADGE).should('exist');
+      });
 
-        it("modified badge should not appear on a custom rule's rule details page", function () {
-          visitRulesManagementTable();
+      it("Modified badge should not appear on the rule updates table when prebuilt rule isn't customized", function () {
+        // Create a new version of the rule to trigger the rule update logic
+        installPrebuiltRuleAssets([
+          {
+            ...PREBUILT_RULE,
+            'security-rule': { ...PREBUILT_RULE['security-rule'], version: 2 },
+          },
+        ]);
+        visitRulesManagementTable();
+        clickRuleUpdatesTab();
 
-          cy.get(RULE_NAME).contains('Custom rule').click();
-          expectModifiedBadgeToNotBeDisplayed(); // Expect modified badge to not be displayed
-        });
-
-        it('modified badge should appear on the rule management table when prebuilt rule is modified', function () {
-          patchRule('rule_1', { name: 'Customized prebuilt rule' }); // We want to make this a customized prebuilt rule
-          visitRulesManagementTable();
-
-          filterByElasticRules();
-          expectToContainModifiedBadge('Customized prebuilt rule');
-        });
-
-        it("modified badge should not appear on the rule management table when prebuilt rule isn't customized", function () {
-          visitRulesManagementTable();
-
-          filterByElasticRules();
-          expectToNotContainModifiedBadge('Non-customized prebuilt rule');
-        });
-
-        it('modified badge should not appear on the rule management table when row is a custom rule', function () {
-          visitRulesManagementTable();
-
-          filterByCustomRules();
-          expectToNotContainModifiedBadge('Custom rule');
-        });
-
-        it('modified badge should appear on the rule updates table when prebuilt rule is customized', function () {
-          // Create a new version of the rule to trigger the rule update logic
-          installPrebuiltRuleAssets([
-            {
-              ...PREBUILT_RULE,
-              'security-rule': { ...PREBUILT_RULE['security-rule'], version: 2 },
-            },
-          ]);
-          patchRule('rule_1', { name: 'Customized prebuilt rule' }); // We want to make this a customized prebuilt rule
-          visitRulesManagementTable();
-          clickRuleUpdatesTab();
-
-          cy.get(MODIFIED_RULE_BADGE).should('exist');
-        });
-
-        it("Modified badge should not appear on the rule updates table when prebuilt rule isn't customized", function () {
-          // Create a new version of the rule to trigger the rule update logic
-          installPrebuiltRuleAssets([
-            {
-              ...PREBUILT_RULE,
-              'security-rule': { ...PREBUILT_RULE['security-rule'], version: 2 },
-            },
-          ]);
-          visitRulesManagementTable();
-          clickRuleUpdatesTab();
-
-          cy.get(MODIFIED_RULE_BADGE).should('not.exist');
-        });
+        cy.get(MODIFIED_RULE_BADGE).should('not.exist');
       });
     });
   }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_error_handling.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_error_handling.cy.ts
@@ -25,6 +25,7 @@ import {
   installPrebuiltRuleAssets,
   createAndInstallMockedPrebuiltRules,
   preventPrebuiltRulesPackageInstallation,
+  installMockPrebuiltRulesPackage,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../../tasks/login';
 import {
@@ -49,6 +50,10 @@ describe(
   'Detection rules, Prebuilt Rules Installation - Error handling',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       deletePrebuiltRulesAssets();
       deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
@@ -18,7 +18,7 @@ import {
 import {
   installAllPrebuiltRulesRequest,
   installPrebuiltRuleAssets,
-  installMockEmptyPrebuiltRulesPackage,
+  installMockPrebuiltRulesPackage,
   installSpecificPrebuiltRulesRequest,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState } from '../../../../../tasks/common';
@@ -26,11 +26,11 @@ import { login } from '../../../../../tasks/login';
 import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
 
 describe(
-  'Detection rules, Prebuilt Rules Installation and Update Notifications',
+  'Detection rules, Prebuilt Rules Install Notifications',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
     before(() => {
-      installMockEmptyPrebuiltRulesPackage();
+      installMockPrebuiltRulesPackage();
     });
 
     beforeEach(() => {
@@ -43,7 +43,7 @@ describe(
     });
 
     describe('No notifications', () => {
-      it('does NOT display install notifications when no prebuilt assets and no rules are installed', () => {
+      it('does NOT display install notifications when no rules are installed', () => {
         visitRulesManagementTable();
 
         cy.get(ADD_ELASTIC_RULES_EMPTY_PROMPT_BTN).should('be.visible');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_update_authorization.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_update_authorization.cy.ts
@@ -15,6 +15,7 @@ import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   installPrebuiltRuleAssets,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
@@ -73,6 +74,10 @@ describe.skip(
   'Detection rules, Prebuilt Rules Installation and Update - Authorization/RBAC',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       preventPrebuiltRulesPackageInstallation();
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_via_fleet.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_via_fleet.cy.ts
@@ -21,7 +21,7 @@ import { expectManagementTableRules } from '../../../../../tasks/alerts_detectio
 const PREBUILT_RULES_PACKAGE_INSTALLATION_TIMEOUT_MS = 120000; // 2 minutes
 
 describe(
-  'Detection rules, Prebuilt Rules Installation and Update workflow',
+  'Detection rules, Prebuilt Rules Installation Workflow (Real package)',
   { tags: ['@ess', '@serverless'] },
   () => {
     describe('Installation of prebuilt rules package via Fleet', () => {
@@ -35,7 +35,7 @@ describe(
         login();
       });
 
-      it('should install prebuilt rules from the Fleet package', () => {
+      it('installs prebuilt rules from the "security_detection_engine" Fleet package', () => {
         visitAddRulesPage();
 
         // Expect the package to be installed

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/management/management.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
+import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
 import {
   COLLAPSED_ACTION_BTN,
   ELASTIC_RULES_BTN,
@@ -22,7 +23,6 @@ import {
   getRulesManagementTableRows,
   selectAllRules,
   selectRulesByName,
-  waitForPrebuiltDetectionRulesToBeLoaded,
   waitForRuleToUpdate,
 } from '../../../../../tasks/alerts_detection_rules';
 import {
@@ -31,37 +31,39 @@ import {
   enableSelectedRules,
 } from '../../../../../tasks/rules_bulk_actions';
 import {
-  createAndInstallMockedPrebuiltRules,
-  getAvailablePrebuiltRulesCount,
-  preventPrebuiltRulesPackageInstallation,
+  getInstalledPrebuiltRulesCount,
+  installMockPrebuiltRulesPackage,
+  installPrebuiltRuleAssets,
+  installSpecificPrebuiltRulesRequest,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import {
   deleteAlertsAndRules,
   deletePrebuiltRulesAssets,
 } from '../../../../../tasks/api_calls/common';
 import { login } from '../../../../../tasks/login';
-import { visit } from '../../../../../tasks/navigation';
-import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 
-const rules = Array.from(Array(5)).map((_, i) => {
-  return createRuleAssetSavedObject({
+const PREBUILT_RULE_ASSETS = Array.from(Array(5)).map((_, i) =>
+  createRuleAssetSavedObject({
     name: `Test rule ${i + 1}`,
     rule_id: `rule_${i + 1}`,
-  });
-});
+  })
+);
 
 // https://github.com/elastic/kibana/issues/179973
-// Failing: See https://github.com/elastic/kibana/issues/182442
-describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+describe('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
-    login();
     deleteAlertsAndRules();
     deletePrebuiltRulesAssets();
-    preventPrebuiltRulesPackageInstallation();
-    visit(RULES_MANAGEMENT_URL);
-    createAndInstallMockedPrebuiltRules(rules);
-    cy.reload();
-    waitForPrebuiltDetectionRulesToBeLoaded();
+    installPrebuiltRuleAssets(PREBUILT_RULE_ASSETS);
+    installSpecificPrebuiltRulesRequest(PREBUILT_RULE_ASSETS);
+
+    login();
+
+    visitRulesManagementTable();
     disableAutoRefresh();
   });
 
@@ -71,7 +73,7 @@ describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerle
       getRulesManagementTableRows().should('have.length.gte', 1);
 
       // Check the correct count of prebuilt rules is displayed
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(ELASTIC_RULES_BTN).should(
           'have.text',
           `Elastic rules (${availablePrebuiltRulesCount})`
@@ -118,7 +120,7 @@ describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerle
       });
 
       it('Deletes and recovers one rule', () => {
-        getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
           const expectedNumberOfRulesAfterDeletion = availablePrebuiltRulesCount - 1;
           const expectedNumberOfRulesAfterRecovering = availablePrebuiltRulesCount;
 
@@ -150,7 +152,7 @@ describe.skip('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerle
       });
 
       it('Deletes and recovers more than one rule', () => {
-        getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
           const rulesToDelete = ['Test rule 1', 'Test rule 2'] as const;
           const expectedNumberOfRulesAfterDeletion = availablePrebuiltRulesCount - 2;
           const expectedNumberOfRulesAfterRecovering = availablePrebuiltRulesCount;

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_error_handling.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_error_handling.cy.ts
@@ -17,9 +17,9 @@ import {
   UPGRADE_SELECTED_RULES_BUTTON,
 } from '../../../../../screens/alerts_detection_rules';
 import { selectRulesByName } from '../../../../../tasks/alerts_detection_rules';
-import { preventPrebuiltRulesPackageInstallation } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { setUpRuleUpgrades } from '../../../../../tasks/prebuilt_rules/setup_rule_upgrades';
 import { login } from '../../../../../tasks/login';
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import {
   interceptUpgradeRequestToFail,
   assertUpgradeRequestIsComplete,
@@ -33,10 +33,13 @@ describe(
   'Detection rules, Prebuilt Rules Upgrade - Error handling',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       deletePrebuiltRulesAssets();
       deleteAlertsAndRules();
-      preventPrebuiltRulesPackageInstallation();
       login();
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_notifications.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/upgrade/upgrade_notifications.cy.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../../../tasks/api_calls/common';
 import {
   installPrebuiltRuleAssets,
-  installMockEmptyPrebuiltRulesPackage,
+  installMockPrebuiltRulesPackage,
   installSpecificPrebuiltRulesRequest,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState } from '../../../../../tasks/common';
@@ -39,7 +39,7 @@ describe(
   () => {
     before(() => {
       // Prevent the real package installation
-      installMockEmptyPrebuiltRulesPackage();
+      installMockPrebuiltRulesPackage();
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
 import {
   goToRuleDetailsOf,
@@ -54,6 +55,10 @@ describe(
   'Detection rules, bulk duplicate',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       // Make sure persisted rules table state is cleared

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -104,6 +104,7 @@ import {
 
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { setRowsPerPageTo, sortByTableColumn } from '../../../../../tasks/table_pagination';
@@ -129,6 +130,10 @@ describe(
   'Detection rules, bulk edit',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       // Make sure persisted rules table state is cleared

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -64,6 +64,7 @@ import {
 } from '../../../../../objects/rule';
 import {
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 
@@ -77,6 +78,10 @@ describe(
   'Detection rules, bulk edit of rule actions',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import {
   RULES_BULK_EDIT_DATA_VIEWS_WARNING,
   RULES_BULK_EDIT_OVERWRITE_DATA_VIEW_CHECKBOX,
@@ -61,6 +62,10 @@ describe(
   'Bulk editing index patterns of rules with a data view only',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     const TESTED_CUSTOM_QUERY_RULE_DATA = getNewRule({
       index: undefined,
       data_view_id: DATA_VIEW_ID,

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/deletion/rule_delete.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/deletion/rule_delete.cy.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
-import { getNewRule } from '../../../../../objects/rule';
+import { getCustomQueryRuleParams } from '../../../../../objects/rule';
 
 import { RULE_SWITCH } from '../../../../../screens/alerts_detection_rules';
 
@@ -22,10 +23,14 @@ import { deleteAlertsAndRules } from '../../../../../tasks/api_calls/common';
 import { login } from '../../../../../tasks/login';
 
 describe('Rule deletion', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   const testRules = [
-    getNewRule({ rule_id: 'rule1', name: 'Rule 1', enabled: false }),
-    getNewRule({ rule_id: 'rule2', name: 'Rule 2', enabled: false }),
-    getNewRule({ rule_id: 'rule3', name: 'Rule 3', enabled: false }),
+    getCustomQueryRuleParams({ rule_id: 'rule1', name: 'Rule 1', enabled: false }),
+    getCustomQueryRuleParams({ rule_id: 'rule2', name: 'Rule 2', enabled: false }),
+    getCustomQueryRuleParams({ rule_id: 'rule3', name: 'Rule 3', enabled: false }),
   ];
   beforeEach(() => {
     deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
@@ -38,7 +38,8 @@ import { visit } from '../../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 import {
   createAndInstallMockedPrebuiltRules,
-  getAvailablePrebuiltRulesCount,
+  getInstalledPrebuiltRulesCount,
+  installMockPrebuiltRulesPackage,
   preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
@@ -54,6 +55,10 @@ const prebuiltRules = Array.from(Array(7)).map((_, i) => {
 });
 
 describe('Export rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   const downloadsFolder = Cypress.config('downloadsFolder');
   const RULE_NAME = 'Rule to export';
 
@@ -118,7 +123,7 @@ describe('Export rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI']
     selectAllRules();
     bulkExportRules();
 
-    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+    getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
       const totalNumberOfRules =
         expectedNumberCustomRulesToBeExported + availablePrebuiltRulesCount;
       cy.get(TOASTER_BODY).should(

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/import_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/import_rules.cy.ts
@@ -18,13 +18,20 @@ import {
 import { deleteExceptionList } from '../../../../../tasks/api_calls/exceptions';
 import { login } from '../../../../../tasks/login';
 import { visit } from '../../../../../tasks/navigation';
-import { preventPrebuiltRulesPackageInstallation } from '../../../../../tasks/api_calls/prebuilt_rules';
+import {
+  installMockPrebuiltRulesPackage,
+  preventPrebuiltRulesPackageInstallation,
+} from '../../../../../tasks/api_calls/prebuilt_rules';
 import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 
 const RULES_TO_IMPORT_FILENAME = 'cypress/fixtures/7_16_rules.ndjson';
 const IMPORTED_EXCEPTION_ID = 'b8dfd17f-1e11-41b0-ae7e-9e7f8237de49';
 
 describe('Import rules', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     preventPrebuiltRulesPackageInstallation();
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
@@ -8,6 +8,7 @@
 import { INTERNAL_ALERTING_API_FIND_RULES_PATH } from '@kbn/alerting-plugin/common';
 import type { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
 
+import { installMockPrebuiltRulesPackage } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { createRule, snoozeRule as snoozeRuleViaAPI } from '../../../../../tasks/api_calls/rules';
 import { deleteAlertsAndRules, deleteConnectors } from '../../../../../tasks/api_calls/common';
 import { login } from '../../../../../tasks/login';
@@ -44,6 +45,10 @@ import { TOOLTIP } from '../../../../../screens/common';
 const RULES_TO_IMPORT_FILENAME = 'cypress/fixtures/7_16_rules.ndjson';
 
 describe('rule snoozing', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -37,6 +38,10 @@ describe(
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
   },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     before(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/common_flows.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/common_flows.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteRuleFromDetailsPage } from '../../../../tasks/alerts_detection_rules';
 import {
   CUSTOM_RULES_BTN,
@@ -57,6 +58,10 @@ describe(
   'Common rule detail flows',
   { tags: ['@ess', '@serverless', '@serverlessQA'] },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/esql_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/esql_rule.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { getEsqlRule } from '../../../../objects/rule';
 
 import {
@@ -28,6 +29,10 @@ describe(
   'Detection ES|QL rules, details view',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     const rule = getEsqlRule();
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -29,6 +30,10 @@ describe.skip(
     tags: ['@ess', '@serverless'],
   },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     before(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/gaps.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/gaps.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -47,6 +48,10 @@ describe(
     },
   },
   function () {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     before(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/non_default_space.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/non_default_space.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { ruleFields } from '../../../../data/detection_engine';
 import { getExistingRule, getNewRule } from '../../../../objects/rule';
@@ -19,6 +20,10 @@ import { visit } from '../../../../tasks/navigation';
 import { ruleDetailsUrl } from '../../../../urls/rule_details';
 
 describe('Non-default space rule detail page', { tags: ['@ess'] }, function () {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   const SPACE_ID = 'test';
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { visitRulesManagementTable } from '../../../../tasks/rules_management';
 import {
   REFRESH_RULES_STATUS,
@@ -37,6 +38,10 @@ describe(
   'Rules table: auto-refresh',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       deleteAlertsAndRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { resetRulesTableState } from '../../../../tasks/common';
 import { login } from '../../../../tasks/login';
@@ -31,6 +32,10 @@ import { disableAutoRefresh } from '../../../../tasks/alerts_detection_rules';
 import { getNewRule } from '../../../../objects/rule';
 
 describe('Rules table: filtering', { tags: ['@ess', '@serverless', '@serverlessQA'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     // Make sure persisted rules table state is cleared

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { getNewRule } from '../../../../objects/rule';
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
+import { getCustomQueryRuleParams } from '../../../../objects/rule';
 import { RULES_MONITORING_TAB, RULE_NAME } from '../../../../screens/alerts_detection_rules';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
@@ -14,10 +15,14 @@ import { visit } from '../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
 
 describe('Rules table: links', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: 'rule1', enabled: false }));
+    createRule(getCustomQueryRuleParams({ rule_id: 'rule1', enabled: false }));
     visit(RULES_MANAGEMENT_URL);
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_persistent_state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_persistent_state.cy.ts
@@ -7,6 +7,7 @@
 
 import { encode } from '@kbn/rison';
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState } from '../../../../tasks/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -100,6 +101,10 @@ describe(
   'Rules table: persistent state',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       deleteAlertsAndRules();
       createTestRules();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
@@ -18,8 +18,9 @@ import {
   waitForPrebuiltDetectionRulesToBeLoaded,
 } from '../../../../tasks/alerts_detection_rules';
 import {
-  getAvailablePrebuiltRulesCount,
+  getInstalledPrebuiltRulesCount,
   createAndInstallMockedPrebuiltRules,
+  installMockPrebuiltRulesPackage,
 } from '../../../../tasks/api_calls/prebuilt_rules';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -39,6 +40,10 @@ describe(
   'Rules table: selection',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {
+    before(() => {
+      installMockPrebuiltRulesPackage();
+    });
+
     beforeEach(() => {
       login();
       /* Create and install two mock rules */
@@ -65,7 +70,7 @@ describe(
 
       cy.get(SELECT_ALL_RULES_BTN).click();
 
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
       });
 
@@ -75,7 +80,7 @@ describe(
       // Current selection should be 0 rules
       cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
       // Bulk selection button should be back to displaying all rules
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
       });
     });
@@ -85,7 +90,7 @@ describe(
 
       cy.get(SELECT_ALL_RULES_BTN).click();
 
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
       });
 
@@ -95,7 +100,7 @@ describe(
       // Current selection should be 0 rules
       cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
       // Bulk selection button should be back to displaying all rules
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      getInstalledPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
       });
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { installMockPrebuiltRulesPackage } from '../../../../tasks/api_calls/prebuilt_rules';
 import {
   FIRST_RULE,
   RULE_NAME,
@@ -24,6 +25,7 @@ import { visit } from '../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import {
+  getCustomQueryRuleParams,
   getExistingRule,
   getNewOverrideRule,
   getNewRule,
@@ -38,10 +40,14 @@ import { TABLE_FIRST_PAGE, TABLE_SECOND_PAGE } from '../../../../screens/table_p
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 
 describe('Rules table: sorting', { tags: ['@ess', '@serverless', '@serverlessQA'] }, () => {
+  before(() => {
+    installMockPrebuiltRulesPackage();
+  });
+
   beforeEach(() => {
     login();
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: '1', enabled: false }));
+    createRule(getCustomQueryRuleParams({ rule_id: '1', enabled: false }));
     createRule(getExistingRule({ rule_id: '2', enabled: false }));
     createRule(getNewOverrideRule({ rule_id: '3', enabled: false }));
     createRule(getNewThresholdRule({ rule_id: '4', enabled: false }));

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -74,19 +74,24 @@ export const installSpecificPrebuiltRulesRequest = (rules: Array<typeof SAMPLE_P
     },
   });
 
-export const getAvailablePrebuiltRulesCount = () => {
-  cy.log('Get prebuilt rules count');
-  return getPrebuiltRulesStatus().then(({ body }) => {
-    const prebuiltRulesCount = body.rules_installed + body.rules_not_installed;
+export const getInstalledPrebuiltRulesCount = () => {
+  cy.log('Get installed prebuilt rules count');
 
-    return prebuiltRulesCount;
-  });
+  return getPrebuiltRulesStatus().then(({ body }) => body.rules_installed);
+};
+
+export const getAvailableToInstallPrebuiltRulesCount = () => {
+  cy.log('Get available to install prebuilt rules count');
+
+  return getPrebuiltRulesStatus().then(
+    ({ body }) => body.rules_installed + body.rules_not_installed
+  );
 };
 
 export const waitTillPrebuiltRulesReadyToInstall = () => {
   cy.waitUntil(
     () => {
-      return getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      return getAvailableToInstallPrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
         return availablePrebuiltRulesCount > 0;
       });
     },
@@ -214,20 +219,12 @@ const installByUploadPrebuiltRulesPackage = (packagePath: string): void => {
 };
 
 /**
- * Installs an empty mock prebuilt rules package `security_detection_engine`.
- * It's convenient to test functionality when no prebuilt rules are installed nor rule assets are available.
- */
-export const installMockEmptyPrebuiltRulesPackage = (): void => {
-  installByUploadPrebuiltRulesPackage(
-    'security_detection_engine_packages/mock-empty-security_detection_engine-99.0.0.zip'
-  );
-};
-
-/**
  * Installs a prepared mock prebuilt rules package `security_detection_engine`.
  * Installing it up front prevents installing the real package when making API requests.
  */
 export const installMockPrebuiltRulesPackage = (): void => {
+  cy.log('Install mock prebuilt rules package');
+
   installByUploadPrebuiltRulesPackage(
     'security_detection_engine_packages/mock-security_detection_engine-99.0.0.zip'
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Solution] Install mock prebuilt rules package in Cypress to reduce flakiness (#229689)](https://github.com/elastic/kibana/pull/229689)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2025-08-13T12:31:26Z","message":"[Security Solution] Install mock prebuilt rules package in Cypress to reduce flakiness (#229689)\n\n**Resolves: https://github.com/elastic/kibana/issues/182441**\n**Resolves: https://github.com/elastic/kibana/issues/182442**\n**Resolves: https://github.com/elastic/kibana/issues/228942**\n**Relates to: https://github.com/elastic/kibana/pull/227689**\n\n## Summary\n\nThis PR installs mock prebuilt rules package for e2e Cypress test to\nreduce flakniess caused by accessing to the real EPR. It's similar to\nthe mock package installation in integration tests\n[PR](https://github.com/elastic/kibana/pull/227689).\n\n**Flaky test runner**\n- ESS:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9120\n- Serverless:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9121","sha":"980add17c585d370d555e93b9146bbaad5d7a2d4","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","impact:high","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v9.2.0","v9.1.3","v8.19.3","v9.0.6","v8.18.6"],"title":"[Security Solution] Install mock prebuilt rules package in Cypress to reduce flakiness","number":229689,"url":"https://github.com/elastic/kibana/pull/229689","mergeCommit":{"message":"[Security Solution] Install mock prebuilt rules package in Cypress to reduce flakiness (#229689)\n\n**Resolves: https://github.com/elastic/kibana/issues/182441**\n**Resolves: https://github.com/elastic/kibana/issues/182442**\n**Resolves: https://github.com/elastic/kibana/issues/228942**\n**Relates to: https://github.com/elastic/kibana/pull/227689**\n\n## Summary\n\nThis PR installs mock prebuilt rules package for e2e Cypress test to\nreduce flakniess caused by accessing to the real EPR. It's similar to\nthe mock package installation in integration tests\n[PR](https://github.com/elastic/kibana/pull/227689).\n\n**Flaky test runner**\n- ESS:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9120\n- Serverless:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9121","sha":"980add17c585d370d555e93b9146bbaad5d7a2d4"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/229689","number":229689,"mergeCommit":{"message":"[Security Solution] Install mock prebuilt rules package in Cypress to reduce flakiness (#229689)\n\n**Resolves: https://github.com/elastic/kibana/issues/182441**\n**Resolves: https://github.com/elastic/kibana/issues/182442**\n**Resolves: https://github.com/elastic/kibana/issues/228942**\n**Relates to: https://github.com/elastic/kibana/pull/227689**\n\n## Summary\n\nThis PR installs mock prebuilt rules package for e2e Cypress test to\nreduce flakniess caused by accessing to the real EPR. It's similar to\nthe mock package installation in integration tests\n[PR](https://github.com/elastic/kibana/pull/227689).\n\n**Flaky test runner**\n- ESS:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9120\n- Serverless:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9121","sha":"980add17c585d370d555e93b9146bbaad5d7a2d4"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231613","number":231613,"state":"OPEN"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231625","number":231625,"state":"OPEN"},{"branch":"8.18","label":"v8.18.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->