### PR TITLE
[scout] log --grep <tag> in test run command

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/start_servers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/start_servers.ts
@@ -17,6 +17,7 @@ import { getExtraKbnOpts, runKibanaServer } from './run_kibana_server';
 import { StartServerOptions } from './flags';
 import { loadServersConfig } from '../config';
 import { silence } from '../common';
+import { getPlaywrightGrepTag } from '../playwright/utils';
 
 export async function startServers(log: ToolingLog, options: StartServerOptions) {
   const runStartTime = Date.now();
@@ -24,6 +25,7 @@ export async function startServers(log: ToolingLog, options: StartServerOptions)
 
   await withProcRunner(log, async (procs) => {
     const config = await loadServersConfig(options.mode, log);
+    const pwGrepTag = getPlaywrightGrepTag(options.mode);
 
     const shutdownEs = await runElasticsearch({
       config,
@@ -52,7 +54,7 @@ export async function startServers(log: ToolingLog, options: StartServerOptions)
       '\n\n' +
         dedent`
           Elasticsearch and Kibana are ready for functional testing.
-          Use 'npx playwright test --config <path_to_Playwright.config.ts> --project local' to run tests'
+          Use 'npx playwright test --project local --grep ${pwGrepTag} --config <path_to_Playwright.config.ts>' to run tests'
         ` +
         '\n\n'
     );


### PR DESCRIPTION
## Summary

Small adjustment to log the correct test running command including `--grep` flag:

Run `node scripts/scout.js start-server --serverless=es`

Expect output:

```
Use 'npx playwright test --project local --grep @svlSearch --config <path_to_Playwright.config.ts>' to run tests'
```

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->