### PR TITLE
[Failure Store Modal] Modify buttons data-test-id for something more specific

### DIFF
--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.test.tsx
@@ -61,7 +61,7 @@ describe('FailureStoreModal', () => {
   it('calls onCloseModal when cancel button is clicked', () => {
     const { getByTestId } = renderModal();
 
-    fireEvent.click(getByTestId('cancelButton'));
+    fireEvent.click(getByTestId('failureStoreModalCancelButton'));
     expect(defaultProps.onCloseModal).toHaveBeenCalledTimes(1);
   });
 
@@ -85,8 +85,8 @@ describe('FailureStoreModal', () => {
         customRetentionPeriod: '15d',
       });
 
-      expect(getByTestId('saveButton')).toBeInTheDocument();
-      expect(getByTestId('saveButton')).toBeDisabled();
+      expect(getByTestId('failureStoreModalSaveButton')).toBeInTheDocument();
+      expect(getByTestId('failureStoreModalSaveButton')).toBeDisabled();
       // Expect the toggle to be on initially
       expect(getByTestId('enableFailureStoreToggle')).toBeChecked();
 
@@ -101,11 +101,11 @@ describe('FailureStoreModal', () => {
       expect(queryByTestId('selectFailureStorePeriodType')).not.toBeInTheDocument();
       expect(queryByTestId('selectFailureStorePeriodValue')).not.toBeInTheDocument();
 
-      expect(getByTestId('saveButton')).not.toBeDisabled();
+      expect(getByTestId('failureStoreModalSaveButton')).not.toBeDisabled();
       // Expect the toggle to be off
       expect(getByTestId('enableFailureStoreToggle')).not.toBeChecked();
 
-      fireEvent.click(getByTestId('saveButton'));
+      fireEvent.click(getByTestId('failureStoreModalSaveButton'));
 
       await waitFor(() => {
         expect(defaultProps.onSaveModal).toHaveBeenCalledTimes(1);
@@ -167,7 +167,7 @@ describe('FailureStoreModal', () => {
       expect(unitSelector).toHaveValue('s');
       expect(valueSelector).toHaveValue(15);
 
-      fireEvent.click(getByTestId('saveButton'));
+      fireEvent.click(getByTestId('failureStoreModalSaveButton'));
 
       await waitFor(() => {
         expect(defaultProps.onSaveModal).toHaveBeenCalledWith({

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
@@ -270,7 +270,10 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="cancelButton" onClick={() => onCloseModal()}>
+        <EuiButtonEmpty
+          data-test-subj="failureStoreModalCancelButton"
+          onClick={() => onCloseModal()}
+        >
           <FormattedMessage
             id="xpack.failureStoreModal.cancelButtonLabel"
             defaultMessage="Cancel"
@@ -281,7 +284,7 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
           fill
           type="submit"
           isLoading={false}
-          data-test-subj="saveButton"
+          data-test-subj="failureStoreModalSaveButton"
           onClick={onSubmitForm}
           disabled={disableSubmit}
         >


### PR DESCRIPTION
The test id for the Save and Cancel button weren't too specific for the modal. Changing them to something more descriptive.