### PR TITLE
[Obs AI Assistant] Address code scanning alert when generating data for evals

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -129,10 +129,10 @@ paths-ignore:
   - x-pack/performance
   - x-pack/scripts
   - x-pack/solutions/observability/packages/kbn-genai-cli
+  - x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant
   - x-pack/solutions/*/test
   - x-pack/test
   - x-pack/test_serverless
-  - x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant
 query-filters:
   - exclude:
       paths:

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -132,6 +132,7 @@ paths-ignore:
   - x-pack/solutions/*/test
   - x-pack/test
   - x-pack/test_serverless
+  - x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant
 query-filters:
   - exclude:
       paths:

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -128,8 +128,8 @@ paths-ignore:
   - x-pack/platform/test
   - x-pack/performance
   - x-pack/scripts
-  - x-pack/solutions/observability/packages/kbn-genai-cli
   - x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant
+  - x-pack/solutions/observability/packages/kbn-genai-cli
   - x-pack/solutions/*/test
   - x-pack/test
   - x-pack/test_serverless

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/data_generators/logs.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/data_generators/logs.ts
@@ -8,6 +8,7 @@
 import moment from 'moment';
 import { timerange, log, LogDocument } from '@kbn/apm-synthtrace-client';
 import { SynthtraceFixture } from '@kbn/scout-oblt';
+import { randomInt } from 'crypto';
 
 export async function generateFrequentErrorLogs({
   logsSynthtraceEsClient,
@@ -237,7 +238,11 @@ export async function generateUniqueUserLoginLogs({
     const intervalInSeconds = Math.max(1, Math.floor(timeRangeInSeconds / dailyLogins));
 
     const logStream = timeRange.interval(`${intervalInSeconds}s`).generator((timestamp) => {
-      const userId = userPool[Math.floor(Math.random() * userPool.length)];
+      if (userPool.length === 0) {
+        throw new Error('userPool must not be empty');
+      }
+
+      const userId = userPool[randomInt(userPool.length)];
 
       const overrides = {
         'event.action': 'login',

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/knowledge_base_client.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/src/knowledge_base_client.ts
@@ -23,9 +23,7 @@ export class KnowledgeBaseClient {
       return;
     }
 
-    if (!ready) {
-      this.log.info('Installing knowledge base');
-    }
+    this.log.info('Installing knowledge base');
 
     await pRetry(
       async () => {

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/data_generators/logs.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/data_generators/logs.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+import { randomInt } from 'crypto';
 import { timerange, log, LogDocument } from '@kbn/apm-synthtrace-client';
 import { LogsSynthtraceEsClient } from '@kbn/apm-synthtrace';
 
@@ -247,7 +248,11 @@ export async function generateUniqueUserLoginLogs({
     const intervalInSeconds = Math.max(1, Math.floor(timeRangeInSeconds / dailyLogins));
 
     const logStream = timeRange.interval(`${intervalInSeconds}s`).generator((timestamp) => {
-      const userId = userPool[Math.floor(Math.random() * userPool.length)];
+      if (userPool.length === 0) {
+        throw new Error('userPool must not be empty');
+      }
+
+      const userId = userPool[randomInt(userPool.length)];
 
       const overrides = {
         'event.action': 'login',


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/1906

## Summary

There was a code scan alert that was triggered in the data generation function for ES|QL evaluations. This is because `Math.random()` is considered as a cryptographically insecure random number generator and it was triggered for this specific case because `Math.random()` was being used to generated sample user IDs.

### Solution

Replace `Math.random()` with a cryptographically secure randomInt from Node's crypto module.

#### Before the update the result of the code scan:

<img width="950" height="235" alt="Screenshot 2025-08-13 at 2 00 52 PM" src="https://github.com/user-attachments/assets/633bd544-1256-4031-9591-560b7dde874e" />

#### After the update the result of the code scan:

<img width="1046" height="160" alt="Screenshot 2025-08-13 at 1 59 06 PM" src="https://github.com/user-attachments/assets/6e4f2281-35c9-42fb-aa5a-0e6bd5b98aae" />

### Testing steps

To do the code scan locally, run `bash scripts/codeql/quick_check.sh -s x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant`

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
