### PR TITLE
[OneChat] Performance - Localize input state to ConversationInputForm

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_actions.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_actions.tsx
@@ -13,13 +13,11 @@ import { useAgentId, useHasActiveConversation } from '../../../hooks/use_convers
 import { useConversationActions } from '../../../hooks/use_conversation_actions';
 import { AgentDisplay } from '../agent_display';
 import { AgentSelectDropdown } from '../agent_select_dropdown';
-// No context used here; props are provided by the form
-
+import { useSendMessage } from '../../../context/send_message_context';
 interface ConversationInputActionsProps {
   onSubmit: () => void;
   isSubmitDisabled: boolean;
-  canCancel: boolean;
-  onCancel: () => void;
+  resetToPendingMessage: () => void;
 }
 
 const labels = {
@@ -34,12 +32,12 @@ const labels = {
 export const ConversationInputActions: React.FC<ConversationInputActionsProps> = ({
   onSubmit,
   isSubmitDisabled,
-  canCancel,
-  onCancel,
+  resetToPendingMessage,
 }) => {
   const { setAgentId } = useConversationActions();
   const agentId = useAgentId();
   const hasActiveConversation = useHasActiveConversation();
+  const { canCancel, cancel } = useSendMessage();
   const { euiTheme } = useEuiTheme();
   const cancelButtonStyles = css`
     background-color: ${euiTheme.colors.backgroundLightText};
@@ -68,7 +66,12 @@ export const ConversationInputActions: React.FC<ConversationInputActionsProps> =
               size="m"
               color="text"
               css={cancelButtonStyles}
-              onClick={onCancel}
+              onClick={() => {
+                if (canCancel) {
+                  cancel();
+                  resetToPendingMessage();
+                }
+              }}
             />
           ) : (
             <EuiButtonIcon

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_actions.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_actions.tsx
@@ -13,11 +13,13 @@ import { useAgentId, useHasActiveConversation } from '../../../hooks/use_convers
 import { useConversationActions } from '../../../hooks/use_conversation_actions';
 import { AgentDisplay } from '../agent_display';
 import { AgentSelectDropdown } from '../agent_select_dropdown';
-import { useMessages } from '../../../context/messages_context';
+// No context used here; props are provided by the form
 
 interface ConversationInputActionsProps {
-  handleSubmit: () => void;
-  submitDisabled: boolean;
+  onSubmit: () => void;
+  isSubmitDisabled: boolean;
+  canCancel: boolean;
+  onCancel: () => void;
 }
 
 const labels = {
@@ -30,13 +32,14 @@ const labels = {
 };
 
 export const ConversationInputActions: React.FC<ConversationInputActionsProps> = ({
-  handleSubmit,
-  submitDisabled,
+  onSubmit,
+  isSubmitDisabled,
+  canCancel,
+  onCancel,
 }) => {
   const { setAgentId } = useConversationActions();
   const agentId = useAgentId();
   const hasActiveConversation = useHasActiveConversation();
-  const { canCancel, cancel } = useMessages();
   const { euiTheme } = useEuiTheme();
   const cancelButtonStyles = css`
     background-color: ${euiTheme.colors.backgroundLightText};
@@ -65,7 +68,7 @@ export const ConversationInputActions: React.FC<ConversationInputActionsProps> =
               size="m"
               color="text"
               css={cancelButtonStyles}
-              onClick={cancel}
+              onClick={onCancel}
             />
           ) : (
             <EuiButtonIcon
@@ -74,8 +77,8 @@ export const ConversationInputActions: React.FC<ConversationInputActionsProps> =
               iconType="sortUp"
               display="fill"
               size="m"
-              disabled={submitDisabled}
-              onClick={handleSubmit}
+              disabled={isSubmitDisabled}
+              onClick={onSubmit}
             />
           )}
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
@@ -26,7 +26,7 @@ const fullHeightStyles = css`
 export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ onSubmit }) => {
   const isSendingMessage = useIsSendingMessage();
   const [input, setInput] = useState('');
-  const { sendMessage, canCancel, cancel, pendingMessage } = useSendMessage();
+  const { sendMessage, pendingMessage } = useSendMessage();
   const { euiTheme } = useEuiTheme();
   const isSubmitDisabled = !input.trim() || isSendingMessage;
 
@@ -68,16 +68,14 @@ export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ on
           defaultMessage: 'Message input form',
         })}
       >
-        <ConversationInputTextArea message={input} setMessage={setInput} onSubmit={handleSubmit} />
+        <ConversationInputTextArea input={input} setInput={setInput} onSubmit={handleSubmit} />
         <ConversationInputActions
           onSubmit={handleSubmit}
           isSubmitDisabled={isSubmitDisabled}
-          canCancel={canCancel}
-          onCancel={() => {
+          resetToPendingMessage={() => {
             if (pendingMessage) {
               setInput(pendingMessage);
             }
-            cancel();
           }}
         />
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_form.tsx
@@ -8,8 +8,8 @@
 import { EuiFlexGroup, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
-import { useMessages } from '../../../context/messages_context';
+import React, { useState } from 'react';
+import { useSendMessage } from '../../../context/send_message_context';
 import { useIsSendingMessage } from '../../../hooks/use_is_sending_message';
 import { ConversationContent } from '../conversation_grid';
 import { ConversationInputActions } from './conversation_input_actions';
@@ -25,12 +25,13 @@ const fullHeightStyles = css`
 
 export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ onSubmit }) => {
   const isSendingMessage = useIsSendingMessage();
-  const { input, setInput, sendMessage } = useMessages();
+  const [input, setInput] = useState('');
+  const { sendMessage, canCancel, cancel, pendingMessage } = useSendMessage();
   const { euiTheme } = useEuiTheme();
-  const disabled = !input.trim() || isSendingMessage;
+  const isSubmitDisabled = !input.trim() || isSendingMessage;
 
   const handleSubmit = () => {
-    if (disabled) {
+    if (isSubmitDisabled) {
       return;
     }
     sendMessage({ message: input });
@@ -67,12 +68,18 @@ export const ConversationInputForm: React.FC<ConversationInputFormProps> = ({ on
           defaultMessage: 'Message input form',
         })}
       >
-        <ConversationInputTextArea
-          message={input}
-          setMessage={setInput}
-          handleSubmit={handleSubmit}
+        <ConversationInputTextArea message={input} setMessage={setInput} onSubmit={handleSubmit} />
+        <ConversationInputActions
+          onSubmit={handleSubmit}
+          isSubmitDisabled={isSubmitDisabled}
+          canCancel={canCancel}
+          onCancel={() => {
+            if (pendingMessage) {
+              setInput(pendingMessage);
+            }
+            cancel();
+          }}
         />
-        <ConversationInputActions handleSubmit={handleSubmit} submitDisabled={disabled} />
       </EuiFlexGroup>
     </ConversationContent>
   );

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_text_area.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_text_area.tsx
@@ -34,13 +34,13 @@ const textareaStyles = css`
 interface ConversationInputTextAreaProps {
   message: string;
   setMessage: (message: string) => void;
-  handleSubmit: () => void;
+  onSubmit: () => void;
 }
 
 export const ConversationInputTextArea: React.FC<ConversationInputTextAreaProps> = ({
   message,
   setMessage,
-  handleSubmit,
+  onSubmit,
 }) => {
   const conversationId = useConversationId();
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -67,7 +67,7 @@ export const ConversationInputTextArea: React.FC<ConversationInputTextAreaProps>
         onKeyDown={(event) => {
           if (!event.shiftKey && event.key === keys.ENTER) {
             event.preventDefault();
-            handleSubmit();
+            onSubmit();
           }
         }}
         placeholder={i18n.translate('xpack.onechat.conversationInputForm.placeholder', {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_text_area.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input_text_area.tsx
@@ -32,14 +32,14 @@ const textareaStyles = css`
 `;
 
 interface ConversationInputTextAreaProps {
-  message: string;
-  setMessage: (message: string) => void;
+  input: string;
+  setInput: (input: string) => void;
   onSubmit: () => void;
 }
 
 export const ConversationInputTextArea: React.FC<ConversationInputTextAreaProps> = ({
-  message,
-  setMessage,
+  input,
+  setInput,
   onSubmit,
 }) => {
   const conversationId = useConversationId();
@@ -60,9 +60,9 @@ export const ConversationInputTextArea: React.FC<ConversationInputTextAreaProps>
         })}
         css={textareaStyles}
         data-test-subj="onechatAppConversationInputFormTextArea"
-        value={message}
+        value={input}
         onChange={(event) => {
-          setMessage(event.currentTarget.value);
+          setInput(event.currentTarget.value);
         }}
         onKeyDown={(event) => {
           if (!event.shiftKey && event.key === keys.ENTER) {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/conversation_rounds.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/conversation_rounds.tsx
@@ -8,7 +8,7 @@
 import { EuiFlexGroup, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useMessages } from '../../../context/messages_context';
+import { useSendMessage } from '../../../context/send_message_context';
 import { useConversationRounds } from '../../../hooks/use_conversation';
 import { ConversationContent } from '../conversation_grid';
 import { RoundError } from './round_error';
@@ -18,7 +18,7 @@ import { RoundResponse } from './round_response';
 
 export const ConversationRounds: React.FC<{}> = () => {
   const conversationRounds = useConversationRounds();
-  const { isResponseLoading, retry, error } = useMessages();
+  const { isResponseLoading, retry, error } = useSendMessage();
   return (
     <ConversationContent>
       <EuiFlexGroup

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversations_view.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversations_view.tsx
@@ -14,7 +14,7 @@ import { Conversation } from './conversation';
 import { ConversationHeader } from './conversation_header';
 import { ConversationSidebar } from './conversation_sidebar/conversation_sidebar';
 import { useConversationList } from '../../hooks/use_conversation_list';
-import { MessagesProvider } from '../../context/messages_context';
+import { SendMessageProvider } from '../../context/send_message_context';
 
 export const OnechatConversationsView: React.FC<{}> = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -60,7 +60,7 @@ export const OnechatConversationsView: React.FC<{}> = () => {
   const { conversations, isLoading } = useConversationList();
 
   return (
-    <MessagesProvider>
+    <SendMessageProvider>
       <KibanaPageTemplate
         offset={0}
         restrictWidth={false}
@@ -102,6 +102,6 @@ export const OnechatConversationsView: React.FC<{}> = () => {
           <Conversation />
         </KibanaPageTemplate.Section>
       </KibanaPageTemplate>
-    </MessagesProvider>
+    </SendMessageProvider>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/send_message_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/send_message_context.tsx
@@ -163,9 +163,7 @@ const useSendMessageMutation = ({ connectorId }: UseSendMessageMutationProps = {
   };
 };
 
-interface MessagesState {
-  input: string;
-  setInput: (input: string) => void;
+interface SendMessageState {
   sendMessage: ({ message }: { message: string }) => void;
   isResponseLoading: boolean;
   error: unknown;
@@ -175,43 +173,31 @@ interface MessagesState {
   cancel: () => void;
 }
 
-const MessagesContext = createContext<MessagesState | null>(null);
+const SendMessageContext = createContext<SendMessageState | null>(null);
 
-export const MessagesProvider = ({ children }: { children: React.ReactNode }) => {
-  const [input, setInput] = useState('');
+export const SendMessageProvider = ({ children }: { children: React.ReactNode }) => {
   const { sendMessage, isResponseLoading, error, pendingMessage, retry, canCancel, cancel } =
     useSendMessageMutation();
 
-  const handleCancel = () => {
-    if (pendingMessage) {
-      setInput(pendingMessage);
-    }
-    cancel();
+  const sendMessageValue = {
+    sendMessage,
+    isResponseLoading,
+    error,
+    pendingMessage,
+    retry,
+    canCancel,
+    cancel,
   };
 
   return (
-    <MessagesContext.Provider
-      value={{
-        input,
-        setInput,
-        sendMessage,
-        isResponseLoading,
-        error,
-        pendingMessage,
-        retry,
-        canCancel,
-        cancel: handleCancel,
-      }}
-    >
-      {children}
-    </MessagesContext.Provider>
+    <SendMessageContext.Provider value={sendMessageValue}>{children}</SendMessageContext.Provider>
   );
 };
 
-export const useMessages = () => {
-  const context = useContext(MessagesContext);
+export const useSendMessage = () => {
+  const context = useContext(SendMessageContext);
   if (!context) {
-    throw new Error('useMessages must be used within a MessagesProvider');
+    throw new Error('useSendMessage must be used within a SendMessageProvider');
   }
   return context;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/send_message_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/send_message_context.tsx
@@ -179,18 +179,20 @@ export const SendMessageProvider = ({ children }: { children: React.ReactNode })
   const { sendMessage, isResponseLoading, error, pendingMessage, retry, canCancel, cancel } =
     useSendMessageMutation();
 
-  const sendMessageValue = {
-    sendMessage,
-    isResponseLoading,
-    error,
-    pendingMessage,
-    retry,
-    canCancel,
-    cancel,
-  };
-
   return (
-    <SendMessageContext.Provider value={sendMessageValue}>{children}</SendMessageContext.Provider>
+    <SendMessageContext.Provider
+      value={{
+        sendMessage,
+        isResponseLoading,
+        error,
+        pendingMessage,
+        retry,
+        canCancel,
+        cancel,
+      }}
+    >
+      {children}
+    </SendMessageContext.Provider>
   );
 };
 

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_conversation.ts
@@ -8,7 +8,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { oneChatDefaultAgentId } from '@kbn/onechat-common';
-import { useMessages } from '../context/messages_context';
+import { useSendMessage } from '../context/send_message_context';
 import { queryKeys } from '../query_keys';
 import { newConversationId } from '../utils/new_conversation';
 import { useConversationId } from './use_conversation_id';
@@ -48,7 +48,7 @@ export const useConversationTitle = () => {
 
 export const useConversationRounds = () => {
   const { conversation } = useConversation();
-  const { pendingMessage, error } = useMessages();
+  const { pendingMessage, error } = useSendMessage();
 
   const conversationRounds = useMemo(() => {
     const rounds = conversation?.rounds ?? [];


### PR DESCRIPTION
## Summary

Improve render performance by removing the input state from the MessagesContext (now renamed SendMessageContext). The logic for resetting the input to the pending message on cancel is moved to the `ConversationInputForm` component.
The problem was that when **any** state changes in a Context value it will re-render all consumers. Because the input state changes frequently while the user is typing, this is not ideal so that state should not be in the Context.

Performance issues reported by @sorenlouv. Thank you, Soren!


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



