### PR TITLE
[Search][Fix] Homepage skip causes endless loading

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/use_search_home_page_redirect.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/use_search_home_page_redirect.tsx
@@ -24,10 +24,9 @@ export const useSearchHomePageRedirect = () => {
   }, []);
   const {
     data: indicesStatus,
-    isLoading,
+    isLoading: isIndicesStatusLoading,
     error,
   } = useIndicesStatusQuery(undefined, !skipGlobalEmptyState);
-
   const [redirectChecked, setRedirectChecked] = useState(() => false);
 
   useEffect(() => {
@@ -56,8 +55,14 @@ export const useSearchHomePageRedirect = () => {
     }
     setRedirectChecked(true);
   }, [application, indicesStatus, userPrivileges, skipGlobalEmptyState, error]);
+  let isLoading = true;
+  if (skipGlobalEmptyState) {
+    isLoading = false;
+  } else if (redirectChecked) {
+    isLoading = isIndicesStatusLoading;
+  }
 
   return {
-    isLoading: redirectChecked ? isLoading : true,
+    isLoading,
   };
 };


### PR DESCRIPTION
## Summary

This fixes a bug introduced by #231024 where if the user chooses to skip the global empty state, the homepage will be stuck in a loading state.

Since #231024 has not been deployed this fix will ensure the broken state is never experienced by users.