### PR TITLE
[Security Assistant] Breakout Security Solution AI Assistant docLinks

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -483,9 +483,10 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
         mlAnomalyDetection: `${ELASTIC_DOCS}explore-analyze/machine-learning/anomaly-detection`,
       },
       detectionEngineOverview: `${ELASTIC_DOCS}solutions/security/detect-and-alert`,
-      // TODO: Follow-up PR for creating an aiAssistant category adding all relevant doc links
-      aiAssistant: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant`,
-      aiAssistantKnowledgeBaseIndexEntries: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant-knowledge-base#knowledge-base-add-knowledge-index`,
+      aiAssistant: {
+        home: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant`,
+        knowledgeBaseIndexEntries: `${ELASTIC_DOCS}solutions/security/ai/ai-assistant-knowledge-base#knowledge-base-add-knowledge-index`,
+      },
       signalsMigrationApi: isServerless
         ? `${KIBANA_APIS}group/endpoint-security-detections-api`
         : `${KIBANA_SERVERLESS_APIS}group/endpoint-security-detections-api`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -300,8 +300,10 @@ export interface DocLinks {
     readonly enableDeprecationHttpDebugLogs: string;
   };
   readonly securitySolution: {
-    readonly aiAssistant: string;
-    readonly aiAssistantKnowledgeBaseIndexEntries: string;
+    readonly aiAssistant: {
+      home: string;
+      knowledgeBaseIndexEntries: string;
+    };
     readonly cloudSecurityPosture: string;
     readonly installElasticDefend: string;
     readonly artifactControl: string;

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/routes/components/ai_assistant_selection_page.tsx
@@ -45,7 +45,7 @@ export function AiAssistantSelectionPage() {
     securityAIAssistantEnabled && aiAssistantManagementSelection && securityAIAssistantVisibility;
 
   const observabilityDoc = getDocLinks({ buildFlavor, kibanaBranch }).observability.aiAssistant;
-  const securityDoc = getDocLinks({ buildFlavor, kibanaBranch }).securitySolution.aiAssistant;
+  const securityDoc = getDocLinks({ buildFlavor, kibanaBranch }).securitySolution.aiAssistant.home;
 
   useEffect(() => {
     setBreadcrumbs([

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
@@ -437,7 +437,7 @@ export const KnowledgeBaseSettingsManagement: React.FC<Params> = React.memo(({ d
                 setSelectedEntry as React.Dispatch<React.SetStateAction<Partial<IndexEntry>>>
               }
               hasManageGlobalKnowledgeBase={hasManageGlobalKnowledgeBase}
-              docLink={docLinks.links.securitySolution.aiAssistantKnowledgeBaseIndexEntries}
+              docLink={docLinks.links.securitySolution.aiAssistant.knowledgeBaseIndexEntries}
             />
           )}
         </>


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/elastic/kibana/pull/231376 where I added new `docLinks` for the Security Solution AI Assistant. This PR removes the `TODO` added in that PR and creates a new `securitySolution.aiAssistant` grouping so we can more easily add docLinks as needed. 

Reviewers Note: Sorry for the extra noise here -- I thought there were more references so decided to do in another PR. Turns out there were not, so this is a quick one!






<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->