### PR TITLE
[ES|QL] LOOKUP JOIN - Unsaved changes warning

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
@@ -12,9 +12,8 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { FC } from 'react';
 import React, { Suspense, lazy } from 'react';
-import { distinctUntilChanged, firstValueFrom, from, skip, takeUntil } from 'rxjs';
+import { distinctUntilChanged, from, skip, takeUntil } from 'rxjs';
 import type { EditLookupIndexContentContext, FlyoutDeps } from '../types';
-import { isPlaceholderColumn } from '../utils';
 
 export function createFlyout(deps: FlyoutDeps, props: EditLookupIndexContentContext) {
   const {
@@ -40,19 +39,7 @@ export function createFlyout(deps: FlyoutDeps, props: EditLookupIndexContentCont
   });
 
   const onFlyoutClose = async () => {
-    if (indexUpdateService.isIndexCreated()) {
-      indexUpdateService.discardUnsavedChanges();
-    }
-
-    const pendingColumnsToBeSaved = await firstValueFrom(
-      indexUpdateService.pendingColumnsToBeSaved$
-    );
-
-    const unsavedColumnsWithoutPlaceholders = pendingColumnsToBeSaved.filter(
-      (column) => !isPlaceholderColumn(column.name)
-    );
-
-    if (unsavedColumnsWithoutPlaceholders.length) {
+    if (true) {
       deps.indexUpdateService.setExitAttemptWithUnsavedFields(true);
       return;
     }

--- a/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
@@ -39,13 +39,8 @@ export function createFlyout(deps: FlyoutDeps, props: EditLookupIndexContentCont
   });
 
   /** Callback to invoke when the user attempts to close the flyout */
-  const onFlyoutClose = async () => {
-    if (true) {
-      deps.indexUpdateService.setExitAttemptWithUnsavedFields(true);
-      return;
-    }
-
-    indexUpdateService.destroy();
+  const onFlyoutClose = () => {
+    indexUpdateService.exit();
   };
 
   const flyoutSession = overlays.openFlyout(

--- a/src/platform/packages/private/kbn-index-editor/src/components/file_drop_zone.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/file_drop_zone.tsx
@@ -71,7 +71,6 @@ export const FileDropzone: FC<PropsWithChildren<{ noResults: boolean }>> = ({
       }
 
       indexUpdateService.discardUnsavedChanges();
-      indexUpdateService.discardUnsavedColumns();
 
       await fileUploadManager.addFiles(files);
     },

--- a/src/platform/packages/private/kbn-index-editor/src/components/modals/override_warning_modal.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/modals/override_warning_modal.tsx
@@ -21,6 +21,7 @@ import {
   EuiText,
   EuiModal,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -45,6 +46,8 @@ export const OverrideWarningModal: React.FC<OverrideWarningModalProps> = ({
 }) => {
   const [dontAskMeAgainCheck, setDontAskMeAgainCheck] = useState(false);
 
+  const modalTitleId = useGeneratedHtmlId();
+
   const continueHandler = () => {
     if (dontAskMeAgainCheck) {
       storage.set(OVERRIDE_WARNING_MODAL_DISMISSED, true);
@@ -53,7 +56,7 @@ export const OverrideWarningModal: React.FC<OverrideWarningModalProps> = ({
   };
 
   return (
-    <EuiModal css={{ width: 700 }} onClose={onCancel}>
+    <EuiModal aria-labelledby={modalTitleId} css={{ width: 700 }} onClose={onCancel}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
           <FormattedMessage

--- a/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
@@ -7,13 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
-import { EuiConfirmModal, EuiSpacer } from '@elastic/eui';
+import React from 'react';
+import { EuiConfirmModal } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import useObservable from 'react-use/lib/useObservable';
+import { useGeneratedHtmlId } from '@elastic/eui';
 import { KibanaContextExtra } from '../../types';
-import { isPlaceholderColumn } from '../../utils';
 
 export interface UnsavedChangesModal {
   onClose: () => void;
@@ -24,16 +24,11 @@ export const UnsavedChangesModal: React.FC<UnsavedChangesModal> = ({ onClose }) 
     services: { indexUpdateService },
   } = useKibana<KibanaContextExtra>();
 
+  const modalTitleId = useGeneratedHtmlId();
+
   const exitAttemptWithUnsavedFields = useObservable(
     indexUpdateService.exitAttemptWithUnsavedFields$,
     false
-  );
-
-  const pendingColumnsToBeSaved = useObservable(indexUpdateService.pendingColumnsToBeSaved$, []);
-
-  const columnsWithoutPlaceholders = useMemo(
-    () => pendingColumnsToBeSaved.filter((column) => !isPlaceholderColumn(column.name)),
-    [pendingColumnsToBeSaved]
   );
 
   const closeWithoutSaving = () => {
@@ -51,10 +46,12 @@ export const UnsavedChangesModal: React.FC<UnsavedChangesModal> = ({ onClose }) 
 
   return (
     <EuiConfirmModal
+      aria-labelledby={modalTitleId}
+      titleProps={{ id: modalTitleId }}
       title={
         <FormattedMessage
           id="indexEditor.warningModal.title"
-          defaultMessage="You have unsaved columns"
+          defaultMessage="You have unsaved changes"
         />
       }
       onCancel={continueEditing}
@@ -67,19 +64,8 @@ export const UnsavedChangesModal: React.FC<UnsavedChangesModal> = ({ onClose }) 
       }
     >
       <FormattedMessage
-        id="indexEditor.warningModal.body_1"
-        defaultMessage="You need at least one value set on each new column for it to be saved:"
-      />
-      <EuiSpacer size="s" />
-      <ul>
-        {columnsWithoutPlaceholders.map((column) => (
-          <li key={column.name}>{column.name}</li>
-        ))}
-      </ul>
-      <EuiSpacer size="s" />
-      <FormattedMessage
         id="indexEditor.warningModal.body_2"
-        defaultMessage="Are you sure you want to leave?"
+        defaultMessage="Are you sure you want to leave without saving?"
       />
     </EuiConfirmModal>
   );

--- a/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
@@ -62,6 +62,7 @@ export const UnsavedChangesModal: React.FC<UnsavedChangesModal> = ({ onClose }) 
       confirmButtonText={
         <FormattedMessage id="indexEditor.warningModal.confirm" defaultMessage="Yes" />
       }
+      buttonColor="danger"
     >
       <FormattedMessage
         id="indexEditor.warningModal.body_2"

--- a/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
@@ -27,7 +27,7 @@ export const UnsavedChangesModal: React.FC<UnsavedChangesModal> = ({ onClose }) 
   const modalTitleId = useGeneratedHtmlId();
 
   const exitAttemptWithUnsavedFields = useObservable(
-    indexUpdateService.exitAttemptWithUnsavedFields$,
+    indexUpdateService.exitAttemptWithUnsavedChanges$,
     false
   );
 
@@ -37,7 +37,7 @@ export const UnsavedChangesModal: React.FC<UnsavedChangesModal> = ({ onClose }) 
   };
 
   const continueEditing = () => {
-    indexUpdateService.setExitAttemptWithUnsavedFields(false);
+    indexUpdateService.setExitAttemptWithUnsavedChanges(false);
   };
 
   if (!exitAttemptWithUnsavedFields) {

--- a/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/modals/unsaved_changes_modal.tsx
@@ -32,7 +32,7 @@ export const UnsavedChangesModal: React.FC<UnsavedChangesModal> = ({ onClose }) 
   );
 
   const closeWithoutSaving = () => {
-    indexUpdateService.discardUnsavedColumns();
+    indexUpdateService.discardUnsavedChanges();
     onClose();
   };
 

--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -161,9 +161,9 @@ export class IndexUpdateService {
   private readonly _error$ = new BehaviorSubject<IndexEditorErrors | null>(null);
   public readonly error$: Observable<IndexEditorErrors | null> = this._error$.asObservable();
 
-  private readonly _exitAttemptWithUnsavedFields$ = new BehaviorSubject<boolean>(false);
-  public readonly exitAttemptWithUnsavedFields$ =
-    this._exitAttemptWithUnsavedFields$.asObservable();
+  private readonly _exitAttemptWithUnsavedChanges$ = new BehaviorSubject<boolean>(false);
+  public readonly exitAttemptWithUnsavedChanges$ =
+    this._exitAttemptWithUnsavedChanges$.asObservable();
 
   /** ES Documents */
   private readonly _rows$ = new BehaviorSubject<DataTableRecord[]>([this.buildPlaceholderRow()]);
@@ -779,8 +779,8 @@ export class IndexUpdateService {
     this.addAction('delete-column', { name });
   }
 
-  public setExitAttemptWithUnsavedFields(value: boolean) {
-    this._exitAttemptWithUnsavedFields$.next(value);
+  public setExitAttemptWithUnsavedChanges(value: boolean) {
+    this._exitAttemptWithUnsavedChanges$.next(value);
   }
 
   public discardUnsavedChanges() {
@@ -805,7 +805,7 @@ export class IndexUpdateService {
     this._indexCrated$.complete();
     this._qstr$.complete();
     this._refreshSubject$.complete();
-    this._exitAttemptWithUnsavedFields$.complete();
+    this._exitAttemptWithUnsavedChanges$.complete();
     this.data.dataViews.clearCache();
     this._indexName$.complete();
   }
@@ -828,10 +828,10 @@ export class IndexUpdateService {
     }
   }
 
-  public async exit() {
+  public exit() {
     const hasUnsavedChanges = this._hasUnsavedChanges$.getValue();
     if (hasUnsavedChanges) {
-      this.setExitAttemptWithUnsavedFields(true);
+      this.setExitAttemptWithUnsavedChanges(true);
     } else {
       this.destroy();
     }


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/207330
## Summary
* Added an unsaved changes modal.
* Took out unsaved columns one.

<img width="826" height="360" alt="image" src="https://github.com/user-attachments/assets/1beefe9c-1fd6-4134-b906-7d0db0caf73b" />
