### PR TITLE
[ON-WEEK] - Discover session METADATA poc #1

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -48,7 +48,7 @@
 # is proxied through the Kibana server.
 #elasticsearch.username: "kibana_system"
 #elasticsearch.password: "pass"
-
+feature_flags.overrides.discover.tabsEnabled: true
 # Kibana can also authenticate to Elasticsearch via "service account tokens".
 # Service account tokens are Bearer style tokens that replace the traditional username/password based configuration.
 # Use this token instead of a username/password.

--- a/src/platform/packages/shared/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
+++ b/src/platform/packages/shared/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
@@ -89,7 +89,7 @@ const NoViewsTip = () => {
         <>
           <FormattedMessage
             id="contentManagement.contentEditor.viewsStats.noViewsTip"
-            defaultMessage="Views are counted every time someone opens a dashboard"
+            defaultMessage="Views are counted every time someone opens a Discover session"
           />
           {isKibanaVersioningEnabled && (
             <>

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -149,6 +149,7 @@ export const useTopNavLinks = ({
       if (!defaultMenu?.openItem?.disabled) {
         const openSearchMenuItem = getOpenSearchAppMenuItem({
           onOpenSavedSearch: state.actions.onOpenSavedSearch,
+          services,
         });
         items.push(openSearchMenuItem);
       }

--- a/src/platform/plugins/shared/discover/server/capabilities_provider.ts
+++ b/src/platform/plugins/shared/discover/server/capabilities_provider.ts
@@ -13,4 +13,6 @@ export const capabilitiesProvider = () => ({
     createShortUrl: true,
     save: true,
   },
+  // Capability used to guard Content Insights routes (analogous to dashboardUsageStats)
+  discoverUsageStats: { show: true },
 });

--- a/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
+++ b/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
@@ -85,6 +85,8 @@ interface BaseSavedObjectFinder {
   children?: ReactElement | ReactElement[];
   helpText?: string;
   getTooltipText?: (item: SavedObjectFinderItem) => string | undefined;
+  /** Optional additional columns appended to the right (POC extension) */
+  extraColumns?: Array<EuiTableFieldDataColumnType<SavedObjectFinderItem>>;
 }
 
 interface SavedObjectFinderFixedPage extends BaseSavedObjectFinder {
@@ -104,12 +106,13 @@ class SavedObjectFinderUiClass extends React.Component<
   SavedObjectFinderState
 > {
   public static propTypes = {
-    onChoose: PropTypes.func,
+  onChoose: PropTypes.func,
     noItemsMessage: PropTypes.node,
     savedObjectMetaData: PropTypes.array.isRequired,
     initialPageSize: PropTypes.oneOf([5, 10, 15, 25]),
     fixedPageSize: PropTypes.number,
     showFilter: PropTypes.bool,
+  extraColumns: PropTypes.array,
   };
   private isComponentMounted: boolean = false;
 
@@ -278,7 +281,7 @@ class SavedObjectFinderUiClass extends React.Component<
             },
           }
         : undefined;
-    const columns: Array<EuiTableFieldDataColumnType<SavedObjectFinderItem>> = [
+  let columns: Array<EuiTableFieldDataColumnType<SavedObjectFinderItem>> = [
       ...(typeColumn ? [typeColumn] : []),
       {
         field: 'title',
@@ -339,6 +342,9 @@ class SavedObjectFinderUiClass extends React.Component<
       },
       ...(tagColumn ? [tagColumn] : []),
     ];
+    if (this.props.extraColumns?.length) {
+      columns = [...columns, ...this.props.extraColumns];
+    }
     const pagination = {
       initialPageSize: !!this.props.fixedPageSize ? this.props.fixedPageSize : pageSize ?? 10,
       pageSize: !!this.props.fixedPageSize ? undefined : pageSize,

--- a/src/platform/plugins/shared/saved_search/server/content_management/saved_search_storage.ts
+++ b/src/platform/plugins/shared/saved_search/server/content_management/saved_search_storage.ts
@@ -49,6 +49,9 @@ export class SavedSearchStorage extends SOContentStorage<SavedSearchCrudTypes> {
         'density',
         'visContext',
         'tabs',
+  // meta fields (stored automatically on the saved object, surfaced through content mgmt item)
+  'createdBy',
+  'updatedBy',
       ],
       logger,
       throwOnResultValidationError,

--- a/src/platform/plugins/shared/saved_search/server/open_search_panel.tsx
+++ b/src/platform/plugins/shared/saved_search/server/open_search_panel.tsx
@@ -1,0 +1,272 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiFlyoutFooter,
+  EuiFlyoutBody,
+  EuiTitle,
+  useGeneratedHtmlId,
+  EuiSplitPanel,
+  EuiSpacer,
+  EuiText,
+  EuiPanel,
+  EuiSkeletonRectangle,
+} from '@elastic/eui';
+import { SavedSearchType, SavedSearchTypeDisplayName } from '@kbn/saved-search-plugin/common';
+import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import {
+  ContentInsightsProvider,
+  ViewsStats,
+  ActivityView,
+  ContentInsightsClient,
+} from '@kbn/content-management-content-insights-public';
+import type { Logger } from '@kbn/logging';
+
+interface OpenSearchPanelProps {
+  onClose: () => void;
+  onOpenSavedSearch: (id: string) => void;
+}
+
+export function OpenSearchPanel(props: OpenSearchPanelProps) {
+  const { onClose } = props;
+  const { savedObjectsTagging, http, addBasePath, contentClient, uiSettings, capabilities } =
+    useDiscoverServices();
+  const hasSavedObjectPermission = Boolean(capabilities?.savedObjectsManagement?.read);
+  const modalTitleId = useGeneratedHtmlId({ prefix: 'discoverSearchCreationModalTitle' });
+
+  const [selectedId, setSelectedId] = useState<string | undefined>();
+  const [selectedMeta, setSelectedMeta] = useState<any | undefined>();
+  const [loadingMeta, setLoadingMeta] = useState(false);
+
+  const insightsClient = useMemo(() => {
+    const loggerAdapter: Logger = {
+      get: () => loggerAdapter,
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+      trace: () => {},
+      fatal: () => {},
+      log: () => {},
+    } as Logger;
+    return new ContentInsightsClient({ http, logger: loggerAdapter }, { domainId: 'discover' });
+  }, [http]);
+
+  const loadMeta = useCallback(
+    async (id: string) => {
+      setLoadingMeta(true);
+      try {
+        const res: any = await contentClient.get({ contentTypeId: SavedSearchType, id });
+        const so = res.result?.item ?? res.item ?? res; // defensive
+        setSelectedMeta({
+          id,
+          title: so.attributes?.title,
+          createdAt: so.createdAt,
+          createdBy: so.createdBy,
+          updatedAt: so.updatedAt,
+          updatedBy: so.updatedBy,
+          managed: so.managed,
+        });
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to load saved search meta', e);
+      } finally {
+        setLoadingMeta(false);
+      }
+    },
+    [contentClient]
+  );
+
+  return (
+    <EuiFlyout
+      aria-labelledby={modalTitleId}
+      ownFocus
+  onClose={onClose}
+      data-test-subj="loadSearchForm"
+      size="l"
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id={modalTitleId}>
+            <FormattedMessage
+              id="discover.topNav.openSearchPanel.openSearchTitle"
+              defaultMessage="Open Discover session"
+            />
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiSplitPanel.Outer direction="row" responsive={false} grow={false} css={{ minHeight: 480 }}>
+          <EuiSplitPanel.Inner paddingSize="s" grow={true} css={{ width: '55%' }}>
+            <SavedObjectFinder
+              id="discoverOpenSearch"
+              services={{
+                savedObjectsTagging,
+                contentClient,
+                uiSettings,
+              }}
+              // Disable default choose so clicking title doesn't close flyout
+              onChoose={undefined}
+              extraColumns={[
+                {
+                  field: 'id',
+                  name: '',
+                  width: '40px',
+                  align: 'right',
+                  'data-test-subj': 'discoverSessionOpenDetailsCol',
+                  sortable: false,
+                  render: (_: string, item) => {
+                    return (
+                      <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                        <EuiButtonIcon
+                          iconType="arrowRight"
+                          size="s"
+                          color={selectedId === item.id ? 'primary' : 'text'}
+                          aria-label={i18n.translate('discover.openSession.showDetailsAria', {
+                            defaultMessage: 'Show details for {name}',
+                            values: { name: item.name || item.title },
+                          })}
+                          data-test-subj={`discoverSessionShowDetailsBtn-${item.id}`}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            if (selectedId !== item.id) {
+                              setSelectedId(item.id);
+                              loadMeta(item.id);
+                            }
+                          }}
+                        />
+                      </span>
+                    );
+                  },
+                },
+              ]}
+              noItemsMessage={
+                <FormattedMessage
+                  id="discover.topNav.openSearchPanel.noSearchesFoundDescription"
+                  defaultMessage="No matching Discover sessions found."
+                />
+              }
+              savedObjectMetaData={[
+                {
+                  type: SavedSearchType,
+                  getIconForSavedObject: () => 'discoverApp',
+                  name: i18n.translate('discover.savedSearch.savedObjectName', {
+                    defaultMessage: 'Discover session',
+                  }),
+                },
+              ]}
+              showFilter={true}
+            />
+          </EuiSplitPanel.Inner>
+          <EuiSplitPanel.Inner paddingSize="s" grow={true} css={{ width: '45%', overflow: 'auto' }}>
+            <EuiText size="s" color="subdued">
+              <strong>
+                <FormattedMessage id="discover.openSession.detailsHeader" defaultMessage="Details" />
+              </strong>
+            </EuiText>
+            <EuiSpacer size="s" />
+            {!selectedId && (
+              <EuiText size="s" color="subdued">
+                <FormattedMessage
+                  id="discover.openSession.noSelection"
+                  defaultMessage="Select a session to see activity & views"
+                />
+              </EuiText>
+            )}
+            {selectedId && (
+              <ContentInsightsProvider contentInsightsClient={insightsClient}>
+                {loadingMeta && <EuiSkeletonRectangle height={120} width={'100%'} />}
+                {!loadingMeta && selectedMeta && (
+                  <>
+                    <EuiPanel hasBorder paddingSize="s">
+                      <EuiText size="s">
+                        <strong>{selectedMeta.title || selectedMeta.id}</strong>
+                      </EuiText>
+                      <EuiSpacer size="s" />
+                      <EuiButton
+                        size="s"
+                        iconType="folderOpen"
+                        data-test-subj="discoverOpenSelectedSessionBtn"
+                        onClick={() => {
+                          // Track view explicitly when user chooses to open
+                          insightsClient.track(selectedMeta.id, 'viewed');
+                          props.onOpenSavedSearch(selectedMeta.id);
+                          onClose();
+                        }}
+                      >
+                        <FormattedMessage
+                          id="discover.openSession.openButtonLabel"
+                          defaultMessage="Open session"
+                        />
+                      </EuiButton>
+                    </EuiPanel>
+                    <EuiSpacer size="s" />
+                    <ActivityView item={selectedMeta} />
+                    <EuiSpacer size="s" />
+                    <ViewsStats
+                      item={{
+                        id: selectedMeta.id,
+                        updatedAt:
+                          selectedMeta.updatedAt ||
+                          selectedMeta.createdAt ||
+                          new Date().toISOString(),
+                        createdAt: selectedMeta.createdAt,
+                        createdBy: selectedMeta.createdBy,
+                        updatedBy: selectedMeta.updatedBy,
+                        managed: selectedMeta.managed,
+                        references: [],
+                        type: SavedSearchType,
+                        attributes: { title: selectedMeta.title || '', description: '' },
+                      }}
+                    />
+                  </>
+                )}
+              </ContentInsightsProvider>
+            )}
+          </EuiSplitPanel.Inner>
+        </EuiSplitPanel.Outer>
+      </EuiFlyoutBody>
+  {hasSavedObjectPermission && (
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
+              <EuiButton
+                fill
+        onClick={onClose}
+                data-test-subj="manageSearchesBtn"
+                href={addBasePath(
+                  `/app/management/kibana/objects?initialQuery=type:("${SavedSearchTypeDisplayName}")`
+                )}
+              >
+                <FormattedMessage
+                  id="discover.topNav.openSearchPanel.manageSearchesButtonLabel"
+                  defaultMessage="Manage Discover sessions"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      )}
+    </EuiFlyout>
+  );
+}
+}
+      </EuiFlyoutBody>

--- a/src/platform/plugins/shared/saved_search/server/plugin.ts
+++ b/src/platform/plugins/shared/saved_search/server/plugin.ts
@@ -55,6 +55,16 @@ export class SavedSearchServerPlugin
       },
     });
 
+    // Register saved search as a favorites-enabled content type (mirrors dashboard + esql implementations)
+    // This enables the /internal/content_management/favorites/saved_search API routes to accept this type
+    // and resolves 400 "Unknown favorite type" errors observed in the Open Discover Session flyout.
+    try {
+      contentManagement.favorites.registerFavoriteType(SavedSearchType);
+    } catch (e) {
+      // If already registered (e.g. due to plugin re-initialization in tests) swallow the error
+      // eslint-disable-next-line no-empty
+    }
+
     const searchSource = data.search.searchSource;
 
     const getSearchSourceMigrations = searchSource.getAllMigrations.bind(searchSource);

--- a/x-pack/platform/plugins/shared/features/server/oss_features.ts
+++ b/x-pack/platform/plugins/shared/features/server/oss_features.ts
@@ -136,7 +136,6 @@ export const buildOSSFeatures = ({
             read: [],
           },
           ui: ['save'],
-          api: ['manage_advanced_settings'],
         },
         read: {
           app: ['kibana'],
@@ -353,12 +352,10 @@ const getBaseDiscoverFeature = ({
   includeReporting: boolean;
   version: 'v1' | 'v2';
 }): Omit<KibanaFeatureConfig, 'id' | 'order'> => {
-  const apiAllPrivileges = ['fileUpload:analyzeFile'];
+  const apiAllPrivileges = ['fileUpload:analyzeFile', 'bulkGetUserProfiles', 'discoverUsageStats'];
   const savedObjectAllPrivileges = ['search'];
   const uiAllPrivileges = ['show', 'save'];
-  // Include user profiles & content insights stats collection (views) for Discover sessions
   const apiReadPrivileges = ['bulkGetUserProfiles', 'discoverUsageStats'];
-  apiAllPrivileges.push('bulkGetUserProfiles', 'discoverUsageStats');
   const savedObjectReadPrivileges = ['index-pattern', 'search'];
 
   if (version === 'v1') {

--- a/x-pack/platform/plugins/shared/features/server/oss_features.ts
+++ b/x-pack/platform/plugins/shared/features/server/oss_features.ts
@@ -356,7 +356,9 @@ const getBaseDiscoverFeature = ({
   const apiAllPrivileges = ['fileUpload:analyzeFile'];
   const savedObjectAllPrivileges = ['search'];
   const uiAllPrivileges = ['show', 'save'];
-  const apiReadPrivileges = [];
+  // Include user profiles & content insights stats collection (views) for Discover sessions
+  const apiReadPrivileges = ['bulkGetUserProfiles', 'discoverUsageStats'];
+  apiAllPrivileges.push('bulkGetUserProfiles', 'discoverUsageStats');
   const savedObjectReadPrivileges = ['index-pattern', 'search'];
 
   if (version === 'v1') {


### PR DESCRIPTION
### Adds usage insights and metadata to the “Open Discover session” flyout:

Short video show-casing it:

https://github.com/user-attachments/assets/7a99d50c-9c09-4d7f-b019-61c43d991e8c

- New Details pane showing:
  - Creator (user profile card) and activity (created / last updated)
  - Views (last 90 days) chart via Content Insights
  - Users can ⭐ a Discover Session and have a dedicated view. 
  - ES|QL query snippet (syntax‑highlighted + copy) for text-based sessions (with raw search source fallback)
- Inline selection (arrow icon) to preview details without closing the flyout
- Clicking a title opens the session and tracks a view

### Server / platform changes:

- Registers Content Insights domain discover (mirrors dashboard)
- Adds [discoverUsageStats] capability & privileges; exposes [bulkGetUserProfiles]
- Allows [createdBy] / [updatedBy] meta fields for Discover Sessions

### Checklist

- [ ]  Text follows EUI writing guidelines, sentence case, and i18n added for all new labels
- [ ]  Documentation (short blurb in Discover docs + dev docs for capability) pending
- [ ] Tests: add functional tests (views tracking increment, ES|QL extraction), unit tests for meta parsing (TODO)
- [ ] No plugin config key changes
- [ ] No breaking HTTP API changes (routes gated by new capability only)
- [ ] Run Flaky Test Runner after adding tests
- [ ] Release Notes section (below) & release_note:feature label to be added
- [ ] Backport labels to be decided after review
- [ ] The "Details" should open in Expandable flyout once ready

### Identify risks

- Views chart depends on Content Insights ingestion: risk of silent failure if capability misconfigured (mitigate with added capability + server registration parity with dashboard).
- ES|QL query parsing is heuristic; malformed searchSource could fail silently (mitigate with fallback raw snippet and guarded try/catch).
- Added privileges ([discoverUsageStats], [bulkGetUserProfiles]) expand surface area; misconfiguration could expose minor internal usage endpoints (mitigate via capability gating and existing privilege model).

### Release Notes
Discover: Added session insights (views, creator, ES|QL query preview) to the Open Discover session flyout.