### PR TITLE
[ML] Anomaly Detection: Improves layout for custom URLs list

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
@@ -2,1121 +2,666 @@
 
 exports[`CustomUrlList renders a list of custom URLs 1`] = `
 <div
-  aria-labelledby="custom-urls-heading"
+  aria-label="Custom URL configurations"
   data-test-subj="mlJobEditCustomUrlsList"
   role="list"
 >
-<<<<<<< HEAD
   <div
-    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
-    data-test-subj="mlJobEditCustomUrlItem_0"
-  >
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow"
-        data-test-subj="mlJobEditCustomUrlItemLabel"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            Label
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout emotion-euiFormControlLayout"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText"
-                data-test-subj="mlJobEditCustomUrlLabelInput_0"
-                id="generated-id"
-                type="text"
-                value="Show data"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-grow-1"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            URL
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText-fullWidth"
-                data-test-subj="mlJobEditCustomUrlInput_0"
-                id="generated-id"
-                readonly=""
-                type="text"
-                value="discover#/?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(index:e532ba80-b76f-11e8-a9dc-37914a458883,query:(language:lucene,query:'airline:\\"$airline$\\"'))"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            Time range
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout emotion-euiFormControlLayout"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText"
-                id="generated-id"
-                placeholder="auto"
-                type="text"
-                value="auto"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasEmptyLabelSpace emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiSpacer euiSpacer--m euiFormRow__labelWrapper emotion-euiSpacer-m"
-        />
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-          >
-            <button
-              aria-label="Test custom URL"
-              class="euiButtonIcon emotion-euiButtonIcon-s-empty-primary"
-              data-test-subj="mlJobEditTestCustomUrlButton"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                class="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="popout"
-              />
-            </button>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasEmptyLabelSpace emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiSpacer euiSpacer--m euiFormRow__labelWrapper emotion-euiSpacer-m"
-        />
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-          >
-            <button
-              aria-label="Delete custom URL"
-              class="euiButtonIcon emotion-euiButtonIcon-s-empty-danger"
-              data-test-subj="mlJobEditDeleteCustomUrlButton_0"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                class="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="trash"
-              />
-            </button>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
-  />
-  <div
-    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
-    data-test-subj="mlJobEditCustomUrlItem_1"
-  >
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow"
-        data-test-subj="mlJobEditCustomUrlItemLabel"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            Label
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout emotion-euiFormControlLayout"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText"
-                data-test-subj="mlJobEditCustomUrlLabelInput_1"
-                id="generated-id"
-                type="text"
-                value="Show dashboard"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-grow-1"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            URL
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText-fullWidth"
-                data-test-subj="mlJobEditCustomUrlInput_1"
-                id="generated-id"
-                readonly=""
-                type="text"
-                value="dashboards#/view/52ea8840-bbef-11e8-a04d-b1701b2b977e?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(filters:!(),query:(language:lucene,query:'airline:\\"$airline$\\"'))"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            Time range
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout emotion-euiFormControlLayout"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText"
-                id="generated-id"
-                placeholder="auto"
-                type="text"
-                value="1h"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasEmptyLabelSpace emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiSpacer euiSpacer--m euiFormRow__labelWrapper emotion-euiSpacer-m"
-        />
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-          >
-            <button
-              aria-label="Test custom URL"
-              class="euiButtonIcon emotion-euiButtonIcon-s-empty-primary"
-              data-test-subj="mlJobEditTestCustomUrlButton"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                class="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="popout"
-              />
-            </button>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasEmptyLabelSpace emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiSpacer euiSpacer--m euiFormRow__labelWrapper emotion-euiSpacer-m"
-        />
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-          >
-            <button
-              aria-label="Delete custom URL"
-              class="euiButtonIcon emotion-euiButtonIcon-s-empty-danger"
-              data-test-subj="mlJobEditDeleteCustomUrlButton_1"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                class="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="trash"
-              />
-            </button>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
-  />
-  <div
-    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
-    data-test-subj="mlJobEditCustomUrlItem_2"
-  >
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow"
-        data-test-subj="mlJobEditCustomUrlItemLabel"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            Label
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout emotion-euiFormControlLayout"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText"
-                data-test-subj="mlJobEditCustomUrlLabelInput_2"
-                id="generated-id"
-                type="text"
-                value="Show airline"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-grow-1"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            URL
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText-fullWidth"
-                data-test-subj="mlJobEditCustomUrlInput_2"
-                id="generated-id"
-                readonly=""
-                type="text"
-                value="http://airlinecodes.info/airline-code-$airline$"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiFormRow__labelWrapper"
-        >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
-            for="generated-id"
-            id="generated-id-label"
-          >
-            Time range
-          </label>
-        </div>
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <div
-            class="euiFormControlLayout emotion-euiFormControlLayout"
-          >
-            <div
-              class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                class="euiFieldText emotion-euiFieldText"
-                id="generated-id"
-                placeholder="auto"
-                type="text"
-                value="auto"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasEmptyLabelSpace emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiSpacer euiSpacer--m euiFormRow__labelWrapper emotion-euiSpacer-m"
-        />
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-          >
-            <button
-              aria-label="Test custom URL"
-              class="euiButtonIcon emotion-euiButtonIcon-s-empty-primary"
-              data-test-subj="mlJobEditTestCustomUrlButton"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                class="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="popout"
-              />
-            </button>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        class="euiFormRow euiFormRow--hasEmptyLabelSpace emotion-euiFormRow"
-        id="generated-id-row"
-      >
-        <div
-          class="euiSpacer euiSpacer--m euiFormRow__labelWrapper emotion-euiSpacer-m"
-        />
-        <div
-          class="euiFormRow__fieldWrapper"
-        >
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-          >
-            <button
-              aria-label="Delete custom URL"
-              class="euiButtonIcon emotion-euiButtonIcon-s-empty-danger"
-              data-test-subj="mlJobEditDeleteCustomUrlButton_2"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                class="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="trash"
-              />
-            </button>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
-=======
-  <EuiPanel
     aria-labelledby="custom-url-heading-0"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
     data-test-subj="mlJobEditCustomUrlItem_0"
     role="listitem"
   >
-    <EuiFlexGroup
-      alignItems="center"
-      justifyContent="spaceBetween"
-      responsive={false}
+    <div
+      class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-center-row"
     >
-      <EuiFlexItem
-        grow={false}
+      <div
+        class="euiFlexItem emotion-euiFlexItem-growZero"
       >
-        <EuiFormLabel
+        <label
+          class="euiFormLabel emotion-euiFormLabel"
           id="custom-url-heading-0"
         >
           Custom URL 
           1
-        </EuiFormLabel>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
+        </label>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-growZero"
       >
-        <EuiFlexGroup
-          css="unknown styles"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-stretch-row-actionButtons"
         >
-          <EuiFlexItem
-            grow={false}
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
           >
-            <EuiToolTip
-              content={
-                <Memo(MemoizedFormattedMessage)
-                  defaultMessage="Test custom URL"
-                  id="xpack.ml.customUrlEditorList.testCustomUrlTooltip"
-                />
-              }
-              delay="regular"
-              disableScreenReaderOutput={false}
-              display="inlineBlock"
-              position="top"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
-              <EuiButtonIcon
+              <button
                 aria-label="Test custom URL"
-                color="primary"
+                class="euiButtonIcon emotion-euiButtonIcon-s-empty-primary"
                 data-test-subj="mlJobEditTestCustomUrlButton"
-                iconType="popout"
-                onClick={[Function]}
-                size="s"
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <EuiFormRow>
-              <EuiToolTip
-                content={
-                  <Memo(MemoizedFormattedMessage)
-                    defaultMessage="Delete custom URL"
-                    id="xpack.ml.customUrlEditorList.deleteCustomUrlTooltip"
-                  />
-                }
-                delay="regular"
-                disableScreenReaderOutput={false}
-                display="inlineBlock"
-                position="top"
+                type="button"
               >
-                <EuiButtonIcon
-                  aria-label="Delete custom URL"
-                  color="danger"
-                  data-test-subj="mlJobEditDeleteCustomUrlButton_0"
-                  iconType="trash"
-                  onClick={[Function]}
-                  size="s"
+                <span
+                  aria-hidden="true"
+                  class="euiButtonIcon__icon"
+                  color="inherit"
+                  data-euiicon-type="popout"
                 />
-              </EuiToolTip>
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-    <EuiSpacer
-      size="s"
+              </button>
+            </span>
+          </div>
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
+          >
+            <div
+              class="euiFormRow emotion-euiFormRow"
+              id="generated-id-row"
+            >
+              <div
+                class="euiFormRow__fieldWrapper"
+              >
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                >
+                  <button
+                    aria-label="Delete custom URL"
+                    class="euiButtonIcon emotion-euiButtonIcon-s-empty-danger"
+                    data-test-subj="mlJobEditDeleteCustomUrlButton_0"
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="trash"
+                    />
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
     />
-    <EuiFlexGroup
-      gutterSize="s"
-      wrap={true}
+    <div
+      class="euiFlexGroup emotion-euiFlexGroup-responsive-wrap-s-flexStart-stretch-row"
     >
-      <EuiFlexItem
-        css="unknown styles"
-        grow={2}
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
       >
-        <EuiFormRow
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
           data-test-subj="mlJobEditCustomUrlItemLabel"
-          error={Array []}
-          fullWidth={true}
-          isInvalid={false}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="Label"
-              id="xpack.ml.customUrlEditorList.labelLabel"
-            />
-          }
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-invalid={false}
-            aria-label="Label for custom URL 1"
-            aria-required="true"
-            data-test-subj="mlJobEditCustomUrlLabelInput_0"
-            fullWidth={true}
-            isInvalid={false}
-            key="label-field-0"
-            onChange={[Function]}
-            value="Show data"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem
-        css="unknown styles"
-        grow={2}
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              aria-invalid="false"
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              Label
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Label for custom URL 1"
+                  aria-required="true"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  data-test-subj="mlJobEditCustomUrlLabelInput_0"
+                  id="generated-id"
+                  type="text"
+                  value="Show data"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
       >
-        <EuiFormRow
-          error={Array []}
-          fullWidth={true}
-          isInvalid={false}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="Time range"
-              id="xpack.ml.customUrlEditorList.timeRangeLabel"
-            />
-          }
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-invalid={false}
-            aria-label="Time range for custom URL 1"
-            fullWidth={true}
-            isInvalid={false}
-            onChange={[Function]}
-            placeholder="auto"
-            value="auto"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem
-        css="unknown styles"
-        grow={6}
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              aria-invalid="false"
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              Time range
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Time range for custom URL 1"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  id="generated-id"
+                  placeholder="auto"
+                  type="text"
+                  value="auto"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-6-urlField"
       >
-        <EuiFormRow
-          fullWidth={true}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="URL"
-              id="xpack.ml.customUrlEditorList.urlLabel"
-            />
-          }
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-label="URL value for Show data. Click to expand for editing."
-            aria-required="true"
-            data-test-subj="mlJobEditCustomUrlInput_0"
-            fullWidth={true}
-            key="url-field-0"
-            onFocus={[Function]}
-            readOnly={true}
-            value="discover#/?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(index:e532ba80-b76f-11e8-a9dc-37914a458883,query:(language:lucene,query:'airline:\\"$airline$\\"'))"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiPanel>
-  <EuiSpacer
-    size="m"
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              URL
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-label="URL value for Show data. Click to expand for editing."
+                  aria-required="true"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  data-test-subj="mlJobEditCustomUrlInput_0"
+                  id="generated-id"
+                  readonly=""
+                  type="text"
+                  value="discover#/?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(index:e532ba80-b76f-11e8-a9dc-37914a458883,query:(language:lucene,query:'airline:\\"$airline$\\"'))"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
   />
-  <EuiPanel
+  <div
     aria-labelledby="custom-url-heading-1"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
     data-test-subj="mlJobEditCustomUrlItem_1"
     role="listitem"
   >
-    <EuiFlexGroup
-      alignItems="center"
-      justifyContent="spaceBetween"
-      responsive={false}
+    <div
+      class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-center-row"
     >
-      <EuiFlexItem
-        grow={false}
+      <div
+        class="euiFlexItem emotion-euiFlexItem-growZero"
       >
-        <EuiFormLabel
+        <label
+          class="euiFormLabel emotion-euiFormLabel"
           id="custom-url-heading-1"
         >
           Custom URL 
           2
-        </EuiFormLabel>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
+        </label>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-growZero"
       >
-        <EuiFlexGroup
-          css="unknown styles"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-stretch-row-actionButtons"
         >
-          <EuiFlexItem
-            grow={false}
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
           >
-            <EuiToolTip
-              content={
-                <Memo(MemoizedFormattedMessage)
-                  defaultMessage="Test custom URL"
-                  id="xpack.ml.customUrlEditorList.testCustomUrlTooltip"
-                />
-              }
-              delay="regular"
-              disableScreenReaderOutput={false}
-              display="inlineBlock"
-              position="top"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
-              <EuiButtonIcon
+              <button
                 aria-label="Test custom URL"
-                color="primary"
+                class="euiButtonIcon emotion-euiButtonIcon-s-empty-primary"
                 data-test-subj="mlJobEditTestCustomUrlButton"
-                iconType="popout"
-                onClick={[Function]}
-                size="s"
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <EuiFormRow>
-              <EuiToolTip
-                content={
-                  <Memo(MemoizedFormattedMessage)
-                    defaultMessage="Delete custom URL"
-                    id="xpack.ml.customUrlEditorList.deleteCustomUrlTooltip"
-                  />
-                }
-                delay="regular"
-                disableScreenReaderOutput={false}
-                display="inlineBlock"
-                position="top"
+                type="button"
               >
-                <EuiButtonIcon
-                  aria-label="Delete custom URL"
-                  color="danger"
-                  data-test-subj="mlJobEditDeleteCustomUrlButton_1"
-                  iconType="trash"
-                  onClick={[Function]}
-                  size="s"
+                <span
+                  aria-hidden="true"
+                  class="euiButtonIcon__icon"
+                  color="inherit"
+                  data-euiicon-type="popout"
                 />
-              </EuiToolTip>
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-    <EuiSpacer
-      size="s"
+              </button>
+            </span>
+          </div>
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
+          >
+            <div
+              class="euiFormRow emotion-euiFormRow"
+              id="generated-id-row"
+            >
+              <div
+                class="euiFormRow__fieldWrapper"
+              >
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                >
+                  <button
+                    aria-label="Delete custom URL"
+                    class="euiButtonIcon emotion-euiButtonIcon-s-empty-danger"
+                    data-test-subj="mlJobEditDeleteCustomUrlButton_1"
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="trash"
+                    />
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
     />
-    <EuiFlexGroup
-      gutterSize="s"
-      wrap={true}
+    <div
+      class="euiFlexGroup emotion-euiFlexGroup-responsive-wrap-s-flexStart-stretch-row"
     >
-      <EuiFlexItem
-        css="unknown styles"
-        grow={2}
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
       >
-        <EuiFormRow
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
           data-test-subj="mlJobEditCustomUrlItemLabel"
-          error={Array []}
-          fullWidth={true}
-          isInvalid={false}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="Label"
-              id="xpack.ml.customUrlEditorList.labelLabel"
-            />
-          }
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-invalid={false}
-            aria-label="Label for custom URL 2"
-            aria-required="true"
-            data-test-subj="mlJobEditCustomUrlLabelInput_1"
-            fullWidth={true}
-            isInvalid={false}
-            key="label-field-1"
-            onChange={[Function]}
-            value="Show dashboard"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem
-        css="unknown styles"
-        grow={2}
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              aria-invalid="false"
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              Label
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Label for custom URL 2"
+                  aria-required="true"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  data-test-subj="mlJobEditCustomUrlLabelInput_1"
+                  id="generated-id"
+                  type="text"
+                  value="Show dashboard"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
       >
-        <EuiFormRow
-          error={Array []}
-          fullWidth={true}
-          isInvalid={false}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="Time range"
-              id="xpack.ml.customUrlEditorList.timeRangeLabel"
-            />
-          }
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-invalid={false}
-            aria-label="Time range for custom URL 2"
-            fullWidth={true}
-            isInvalid={false}
-            onChange={[Function]}
-            placeholder="auto"
-            value="1h"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem
-        css="unknown styles"
-        grow={6}
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              aria-invalid="false"
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              Time range
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Time range for custom URL 2"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  id="generated-id"
+                  placeholder="auto"
+                  type="text"
+                  value="1h"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-6-urlField"
       >
-        <EuiFormRow
-          fullWidth={true}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="URL"
-              id="xpack.ml.customUrlEditorList.urlLabel"
-            />
-          }
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-label="URL value for Show dashboard. Click to expand for editing."
-            aria-required="true"
-            data-test-subj="mlJobEditCustomUrlInput_1"
-            fullWidth={true}
-            key="url-field-1"
-            onFocus={[Function]}
-            readOnly={true}
-            value="dashboards#/view/52ea8840-bbef-11e8-a04d-b1701b2b977e?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(filters:!(),query:(language:lucene,query:'airline:\\"$airline$\\"'))"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiPanel>
-  <EuiSpacer
-    size="m"
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              URL
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-label="URL value for Show dashboard. Click to expand for editing."
+                  aria-required="true"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  data-test-subj="mlJobEditCustomUrlInput_1"
+                  id="generated-id"
+                  readonly=""
+                  type="text"
+                  value="dashboards#/view/52ea8840-bbef-11e8-a04d-b1701b2b977e?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(filters:!(),query:(language:lucene,query:'airline:\\"$airline$\\"'))"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
   />
-  <EuiPanel
+  <div
     aria-labelledby="custom-url-heading-2"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
     data-test-subj="mlJobEditCustomUrlItem_2"
     role="listitem"
   >
-    <EuiFlexGroup
-      alignItems="center"
-      justifyContent="spaceBetween"
-      responsive={false}
+    <div
+      class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-center-row"
     >
-      <EuiFlexItem
-        grow={false}
+      <div
+        class="euiFlexItem emotion-euiFlexItem-growZero"
       >
-        <EuiFormLabel
+        <label
+          class="euiFormLabel emotion-euiFormLabel"
           id="custom-url-heading-2"
         >
           Custom URL 
           3
-        </EuiFormLabel>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
+        </label>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-growZero"
       >
-        <EuiFlexGroup
-          css="unknown styles"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-stretch-row-actionButtons"
         >
-          <EuiFlexItem
-            grow={false}
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
           >
-            <EuiToolTip
-              content={
-                <Memo(MemoizedFormattedMessage)
-                  defaultMessage="Test custom URL"
-                  id="xpack.ml.customUrlEditorList.testCustomUrlTooltip"
-                />
-              }
-              delay="regular"
-              disableScreenReaderOutput={false}
-              display="inlineBlock"
-              position="top"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
-              <EuiButtonIcon
+              <button
                 aria-label="Test custom URL"
-                color="primary"
+                class="euiButtonIcon emotion-euiButtonIcon-s-empty-primary"
                 data-test-subj="mlJobEditTestCustomUrlButton"
-                iconType="popout"
-                onClick={[Function]}
-                size="s"
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <EuiFormRow>
-              <EuiToolTip
-                content={
-                  <Memo(MemoizedFormattedMessage)
-                    defaultMessage="Delete custom URL"
-                    id="xpack.ml.customUrlEditorList.deleteCustomUrlTooltip"
-                  />
-                }
-                delay="regular"
-                disableScreenReaderOutput={false}
-                display="inlineBlock"
-                position="top"
+                type="button"
               >
-                <EuiButtonIcon
-                  aria-label="Delete custom URL"
-                  color="danger"
-                  data-test-subj="mlJobEditDeleteCustomUrlButton_2"
-                  iconType="trash"
-                  onClick={[Function]}
-                  size="s"
+                <span
+                  aria-hidden="true"
+                  class="euiButtonIcon__icon"
+                  color="inherit"
+                  data-euiicon-type="popout"
                 />
-              </EuiToolTip>
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-    <EuiSpacer
-      size="s"
+              </button>
+            </span>
+          </div>
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
+          >
+            <div
+              class="euiFormRow emotion-euiFormRow"
+              id="generated-id-row"
+            >
+              <div
+                class="euiFormRow__fieldWrapper"
+              >
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                >
+                  <button
+                    aria-label="Delete custom URL"
+                    class="euiButtonIcon emotion-euiButtonIcon-s-empty-danger"
+                    data-test-subj="mlJobEditDeleteCustomUrlButton_2"
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="trash"
+                    />
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
     />
-    <EuiFlexGroup
-      gutterSize="s"
-      wrap={true}
+    <div
+      class="euiFlexGroup emotion-euiFlexGroup-responsive-wrap-s-flexStart-stretch-row"
     >
-      <EuiFlexItem
-        css="unknown styles"
-        grow={2}
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
       >
-        <EuiFormRow
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
           data-test-subj="mlJobEditCustomUrlItemLabel"
-          error={Array []}
-          fullWidth={true}
-          isInvalid={false}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="Label"
-              id="xpack.ml.customUrlEditorList.labelLabel"
-            />
-          }
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-invalid={false}
-            aria-label="Label for custom URL 3"
-            aria-required="true"
-            data-test-subj="mlJobEditCustomUrlLabelInput_2"
-            fullWidth={true}
-            isInvalid={false}
-            key="label-field-2"
-            onChange={[Function]}
-            value="Show airline"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem
-        css="unknown styles"
-        grow={2}
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              aria-invalid="false"
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              Label
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Label for custom URL 3"
+                  aria-required="true"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  data-test-subj="mlJobEditCustomUrlLabelInput_2"
+                  id="generated-id"
+                  type="text"
+                  value="Show airline"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
       >
-        <EuiFormRow
-          error={Array []}
-          fullWidth={true}
-          isInvalid={false}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="Time range"
-              id="xpack.ml.customUrlEditorList.timeRangeLabel"
-            />
-          }
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-invalid={false}
-            aria-label="Time range for custom URL 3"
-            fullWidth={true}
-            isInvalid={false}
-            onChange={[Function]}
-            placeholder="auto"
-            value="auto"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem
-        css="unknown styles"
-        grow={6}
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              aria-invalid="false"
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              Time range
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Time range for custom URL 3"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  id="generated-id"
+                  placeholder="auto"
+                  type="text"
+                  value="auto"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem emotion-euiFlexItem-grow-6-urlField"
       >
-        <EuiFormRow
-          fullWidth={true}
-          label={
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="URL"
-              id="xpack.ml.customUrlEditorList.urlLabel"
-            />
-          }
+        <div
+          class="euiFormRow euiFormRow--hasLabel emotion-euiFormRow-fullWidth"
+          id="generated-id-row"
         >
-          <EuiFieldText
-            aria-label="URL value for Show airline. Click to expand for editing."
-            aria-required="true"
-            data-test-subj="mlJobEditCustomUrlInput_2"
-            fullWidth={true}
-            key="url-field-2"
-            onFocus={[Function]}
-            readOnly={true}
-            value="http://airlinecodes.info/airline-code-$airline$"
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiPanel>
-  <EuiSpacer
-    size="m"
->>>>>>> be0ff2268b1 (fix(ml): unify styles and refactor)
+          <div
+            class="euiFormRow__labelWrapper"
+          >
+            <label
+              class="euiFormLabel euiFormRow__label emotion-euiFormLabel"
+              for="generated-id"
+              id="generated-id-label"
+            >
+              URL
+            </label>
+          </div>
+          <div
+            class="euiFormRow__fieldWrapper"
+          >
+            <div
+              class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-label="URL value for Show airline. Click to expand for editing."
+                  aria-required="true"
+                  class="euiFieldText emotion-euiFieldText-fullWidth"
+                  data-test-subj="mlJobEditCustomUrlInput_2"
+                  id="generated-id"
+                  readonly=""
+                  type="text"
+                  value="http://airlinecodes.info/airline-code-$airline$"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
   />
 </div>
 `;

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
 >
   <div
     aria-labelledby="custom-url-heading-0"
-    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow-panel"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
     data-test-subj="mlJobEditCustomUrlItem_0"
     role="listitem"
   >
@@ -225,7 +225,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
   />
   <div
     aria-labelledby="custom-url-heading-1"
-    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow-panel"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
     data-test-subj="mlJobEditCustomUrlItem_1"
     role="listitem"
   >
@@ -442,7 +442,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
   />
   <div
     aria-labelledby="custom-url-heading-2"
-    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow-panel"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
     data-test-subj="mlJobEditCustomUrlItem_2"
     role="listitem"
   >

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
@@ -22,8 +22,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
           class="euiFormLabel emotion-euiFormLabel"
           id="custom-url-heading-0"
         >
-          Custom URL 
-          1
+          Custom URL 1
         </label>
       </div>
       <div
@@ -240,8 +239,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
           class="euiFormLabel emotion-euiFormLabel"
           id="custom-url-heading-1"
         >
-          Custom URL 
-          2
+          Custom URL 2
         </label>
       </div>
       <div
@@ -458,8 +456,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
           class="euiFormLabel emotion-euiFormLabel"
           id="custom-url-heading-2"
         >
-          Custom URL 
-          3
+          Custom URL 3
         </label>
       </div>
       <div

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
 >
   <div
     aria-labelledby="custom-url-heading-0"
-    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow-panel"
     data-test-subj="mlJobEditCustomUrlItem_0"
     role="listitem"
   >
@@ -226,7 +226,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
   />
   <div
     aria-labelledby="custom-url-heading-1"
-    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow-panel"
     data-test-subj="mlJobEditCustomUrlItem_1"
     role="listitem"
   >
@@ -444,7 +444,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
   />
   <div
     aria-labelledby="custom-url-heading-2"
-    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow"
+    class="euiPanel euiPanel--plain euiPanel--paddingMedium emotion-euiPanel-grow-m-m-plain-hasShadow-panel"
     data-test-subj="mlJobEditCustomUrlItem_2"
     role="listitem"
   >

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
       class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
     />
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-wrap-s-flexStart-stretch-row"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-s-flexStart-stretch-row"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
@@ -200,7 +200,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
@@ -211,7 +211,6 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
                   class="euiFieldText emotion-euiFieldText-fullWidth"
                   data-test-subj="mlJobEditCustomUrlInput_0"
                   id="generated-id"
-                  readonly=""
                   type="text"
                   value="discover#/?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(index:e532ba80-b76f-11e8-a9dc-37914a458883,query:(language:lucene,query:'airline:\\"$airline$\\"'))"
                 />
@@ -309,7 +308,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
       class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
     />
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-wrap-s-flexStart-stretch-row"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-s-flexStart-stretch-row"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
@@ -419,7 +418,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
@@ -430,7 +429,6 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
                   class="euiFieldText emotion-euiFieldText-fullWidth"
                   data-test-subj="mlJobEditCustomUrlInput_1"
                   id="generated-id"
-                  readonly=""
                   type="text"
                   value="dashboards#/view/52ea8840-bbef-11e8-a04d-b1701b2b977e?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(filters:!(),query:(language:lucene,query:'airline:\\"$airline$\\"'))"
                 />
@@ -528,7 +526,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
       class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
     />
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-wrap-s-flexStart-stretch-row"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-s-flexStart-stretch-row"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-grow-2-narrowField"
@@ -638,7 +636,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout-readOnly emotion-euiFormControlLayout-fullWidth"
+              class="euiFormControlLayout emotion-euiFormControlLayout-fullWidth"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper emotion-euiFormControlLayout__childrenWrapper"
@@ -649,7 +647,6 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
                   class="euiFieldText emotion-euiFieldText-fullWidth"
                   data-test-subj="mlJobEditCustomUrlInput_2"
                   id="generated-id"
-                  readonly=""
                   type="text"
                   value="http://airlinecodes.info/airline-code-$airline$"
                 />

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/__snapshots__/list.test.tsx.snap
@@ -2,8 +2,11 @@
 
 exports[`CustomUrlList renders a list of custom URLs 1`] = `
 <div
+  aria-labelledby="custom-urls-heading"
   data-test-subj="mlJobEditCustomUrlsList"
+  role="list"
 >
+<<<<<<< HEAD
   <div
     class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
     data-test-subj="mlJobEditCustomUrlItem_0"
@@ -588,6 +591,532 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
   </div>
   <div
     class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
+=======
+  <EuiPanel
+    aria-labelledby="custom-url-heading-0"
+    data-test-subj="mlJobEditCustomUrlItem_0"
+    role="listitem"
+  >
+    <EuiFlexGroup
+      alignItems="center"
+      justifyContent="spaceBetween"
+      responsive={false}
+    >
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFormLabel
+          id="custom-url-heading-0"
+        >
+          Custom URL 
+          1
+        </EuiFormLabel>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          css="unknown styles"
+          gutterSize="xs"
+          responsive={false}
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiToolTip
+              content={
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Test custom URL"
+                  id="xpack.ml.customUrlEditorList.testCustomUrlTooltip"
+                />
+              }
+              delay="regular"
+              disableScreenReaderOutput={false}
+              display="inlineBlock"
+              position="top"
+            >
+              <EuiButtonIcon
+                aria-label="Test custom URL"
+                color="primary"
+                data-test-subj="mlJobEditTestCustomUrlButton"
+                iconType="popout"
+                onClick={[Function]}
+                size="s"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiFormRow>
+              <EuiToolTip
+                content={
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Delete custom URL"
+                    id="xpack.ml.customUrlEditorList.deleteCustomUrlTooltip"
+                  />
+                }
+                delay="regular"
+                disableScreenReaderOutput={false}
+                display="inlineBlock"
+                position="top"
+              >
+                <EuiButtonIcon
+                  aria-label="Delete custom URL"
+                  color="danger"
+                  data-test-subj="mlJobEditDeleteCustomUrlButton_0"
+                  iconType="trash"
+                  onClick={[Function]}
+                  size="s"
+                />
+              </EuiToolTip>
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer
+      size="s"
+    />
+    <EuiFlexGroup
+      gutterSize="s"
+      wrap={true}
+    >
+      <EuiFlexItem
+        css="unknown styles"
+        grow={2}
+      >
+        <EuiFormRow
+          data-test-subj="mlJobEditCustomUrlItemLabel"
+          error={Array []}
+          fullWidth={true}
+          isInvalid={false}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="Label"
+              id="xpack.ml.customUrlEditorList.labelLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-invalid={false}
+            aria-label="Label for custom URL 1"
+            aria-required="true"
+            data-test-subj="mlJobEditCustomUrlLabelInput_0"
+            fullWidth={true}
+            isInvalid={false}
+            key="label-field-0"
+            onChange={[Function]}
+            value="Show data"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem
+        css="unknown styles"
+        grow={2}
+      >
+        <EuiFormRow
+          error={Array []}
+          fullWidth={true}
+          isInvalid={false}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="Time range"
+              id="xpack.ml.customUrlEditorList.timeRangeLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-invalid={false}
+            aria-label="Time range for custom URL 1"
+            fullWidth={true}
+            isInvalid={false}
+            onChange={[Function]}
+            placeholder="auto"
+            value="auto"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem
+        css="unknown styles"
+        grow={6}
+      >
+        <EuiFormRow
+          fullWidth={true}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="URL"
+              id="xpack.ml.customUrlEditorList.urlLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-label="URL value for Show data. Click to expand for editing."
+            aria-required="true"
+            data-test-subj="mlJobEditCustomUrlInput_0"
+            fullWidth={true}
+            key="url-field-0"
+            onFocus={[Function]}
+            readOnly={true}
+            value="discover#/?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(index:e532ba80-b76f-11e8-a9dc-37914a458883,query:(language:lucene,query:'airline:\\"$airline$\\"'))"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPanel>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiPanel
+    aria-labelledby="custom-url-heading-1"
+    data-test-subj="mlJobEditCustomUrlItem_1"
+    role="listitem"
+  >
+    <EuiFlexGroup
+      alignItems="center"
+      justifyContent="spaceBetween"
+      responsive={false}
+    >
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFormLabel
+          id="custom-url-heading-1"
+        >
+          Custom URL 
+          2
+        </EuiFormLabel>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          css="unknown styles"
+          gutterSize="xs"
+          responsive={false}
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiToolTip
+              content={
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Test custom URL"
+                  id="xpack.ml.customUrlEditorList.testCustomUrlTooltip"
+                />
+              }
+              delay="regular"
+              disableScreenReaderOutput={false}
+              display="inlineBlock"
+              position="top"
+            >
+              <EuiButtonIcon
+                aria-label="Test custom URL"
+                color="primary"
+                data-test-subj="mlJobEditTestCustomUrlButton"
+                iconType="popout"
+                onClick={[Function]}
+                size="s"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiFormRow>
+              <EuiToolTip
+                content={
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Delete custom URL"
+                    id="xpack.ml.customUrlEditorList.deleteCustomUrlTooltip"
+                  />
+                }
+                delay="regular"
+                disableScreenReaderOutput={false}
+                display="inlineBlock"
+                position="top"
+              >
+                <EuiButtonIcon
+                  aria-label="Delete custom URL"
+                  color="danger"
+                  data-test-subj="mlJobEditDeleteCustomUrlButton_1"
+                  iconType="trash"
+                  onClick={[Function]}
+                  size="s"
+                />
+              </EuiToolTip>
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer
+      size="s"
+    />
+    <EuiFlexGroup
+      gutterSize="s"
+      wrap={true}
+    >
+      <EuiFlexItem
+        css="unknown styles"
+        grow={2}
+      >
+        <EuiFormRow
+          data-test-subj="mlJobEditCustomUrlItemLabel"
+          error={Array []}
+          fullWidth={true}
+          isInvalid={false}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="Label"
+              id="xpack.ml.customUrlEditorList.labelLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-invalid={false}
+            aria-label="Label for custom URL 2"
+            aria-required="true"
+            data-test-subj="mlJobEditCustomUrlLabelInput_1"
+            fullWidth={true}
+            isInvalid={false}
+            key="label-field-1"
+            onChange={[Function]}
+            value="Show dashboard"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem
+        css="unknown styles"
+        grow={2}
+      >
+        <EuiFormRow
+          error={Array []}
+          fullWidth={true}
+          isInvalid={false}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="Time range"
+              id="xpack.ml.customUrlEditorList.timeRangeLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-invalid={false}
+            aria-label="Time range for custom URL 2"
+            fullWidth={true}
+            isInvalid={false}
+            onChange={[Function]}
+            placeholder="auto"
+            value="1h"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem
+        css="unknown styles"
+        grow={6}
+      >
+        <EuiFormRow
+          fullWidth={true}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="URL"
+              id="xpack.ml.customUrlEditorList.urlLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-label="URL value for Show dashboard. Click to expand for editing."
+            aria-required="true"
+            data-test-subj="mlJobEditCustomUrlInput_1"
+            fullWidth={true}
+            key="url-field-1"
+            onFocus={[Function]}
+            readOnly={true}
+            value="dashboards#/view/52ea8840-bbef-11e8-a04d-b1701b2b977e?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(filters:!(),query:(language:lucene,query:'airline:\\"$airline$\\"'))"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPanel>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiPanel
+    aria-labelledby="custom-url-heading-2"
+    data-test-subj="mlJobEditCustomUrlItem_2"
+    role="listitem"
+  >
+    <EuiFlexGroup
+      alignItems="center"
+      justifyContent="spaceBetween"
+      responsive={false}
+    >
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFormLabel
+          id="custom-url-heading-2"
+        >
+          Custom URL 
+          3
+        </EuiFormLabel>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          css="unknown styles"
+          gutterSize="xs"
+          responsive={false}
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiToolTip
+              content={
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Test custom URL"
+                  id="xpack.ml.customUrlEditorList.testCustomUrlTooltip"
+                />
+              }
+              delay="regular"
+              disableScreenReaderOutput={false}
+              display="inlineBlock"
+              position="top"
+            >
+              <EuiButtonIcon
+                aria-label="Test custom URL"
+                color="primary"
+                data-test-subj="mlJobEditTestCustomUrlButton"
+                iconType="popout"
+                onClick={[Function]}
+                size="s"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiFormRow>
+              <EuiToolTip
+                content={
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Delete custom URL"
+                    id="xpack.ml.customUrlEditorList.deleteCustomUrlTooltip"
+                  />
+                }
+                delay="regular"
+                disableScreenReaderOutput={false}
+                display="inlineBlock"
+                position="top"
+              >
+                <EuiButtonIcon
+                  aria-label="Delete custom URL"
+                  color="danger"
+                  data-test-subj="mlJobEditDeleteCustomUrlButton_2"
+                  iconType="trash"
+                  onClick={[Function]}
+                  size="s"
+                />
+              </EuiToolTip>
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer
+      size="s"
+    />
+    <EuiFlexGroup
+      gutterSize="s"
+      wrap={true}
+    >
+      <EuiFlexItem
+        css="unknown styles"
+        grow={2}
+      >
+        <EuiFormRow
+          data-test-subj="mlJobEditCustomUrlItemLabel"
+          error={Array []}
+          fullWidth={true}
+          isInvalid={false}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="Label"
+              id="xpack.ml.customUrlEditorList.labelLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-invalid={false}
+            aria-label="Label for custom URL 3"
+            aria-required="true"
+            data-test-subj="mlJobEditCustomUrlLabelInput_2"
+            fullWidth={true}
+            isInvalid={false}
+            key="label-field-2"
+            onChange={[Function]}
+            value="Show airline"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem
+        css="unknown styles"
+        grow={2}
+      >
+        <EuiFormRow
+          error={Array []}
+          fullWidth={true}
+          isInvalid={false}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="Time range"
+              id="xpack.ml.customUrlEditorList.timeRangeLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-invalid={false}
+            aria-label="Time range for custom URL 3"
+            fullWidth={true}
+            isInvalid={false}
+            onChange={[Function]}
+            placeholder="auto"
+            value="auto"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem
+        css="unknown styles"
+        grow={6}
+      >
+        <EuiFormRow
+          fullWidth={true}
+          label={
+            <Memo(MemoizedFormattedMessage)
+              defaultMessage="URL"
+              id="xpack.ml.customUrlEditorList.urlLabel"
+            />
+          }
+        >
+          <EuiFieldText
+            aria-label="URL value for Show airline. Click to expand for editing."
+            aria-required="true"
+            data-test-subj="mlJobEditCustomUrlInput_2"
+            fullWidth={true}
+            key="url-field-2"
+            onFocus={[Function]}
+            readOnly={true}
+            value="http://airlinecodes.info/airline-code-$airline$"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPanel>
+  <EuiSpacer
+    size="m"
+>>>>>>> be0ff2268b1 (fix(ml): unify styles and refactor)
   />
 </div>
 `;

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -207,6 +207,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
   const customUrlRows = customUrls.map((customUrl, index) => {
     // Validate the label.
     const label = customUrl.url_name;
+    const effectiveLabel = label || `Custom URL ${index + 1}`;
     const otherUrls = [...customUrls];
     otherUrls.splice(index, 1); // Don't compare label with itself.
     const isInvalidLabel = !isValidLabel(label, otherUrls);
@@ -319,7 +320,10 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                   onChange={(e) => onLabelChange(e, index)}
                   data-test-subj={`mlJobEditCustomUrlLabelInput_${index}`}
                   aria-required="true"
-                  aria-label={`Label for custom URL ${index + 1}`}
+                  aria-label={i18n.translate('xpack.ml.customUrlEditorList.labelAriaLabel', {
+                    defaultMessage: 'Label for custom URL {indexCount}',
+                    values: { indexCount: index + 1 },
+                  })}
                   aria-invalid={isInvalidLabel}
                 />
               </EuiFormRow>
@@ -343,7 +347,10 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     isInvalid={isInvalidTimeRange}
                     placeholder={TIME_RANGE_TYPE.AUTO}
                     onChange={(e) => onTimeRangeChange(e, index)}
-                    aria-label={`Time range for custom URL ${index + 1}`}
+                    aria-label={i18n.translate('xpack.ml.customUrlEditorList.timeRangeAriaLabel', {
+                      defaultMessage: 'Time range for custom URL {indexCount}',
+                      values: { indexCount: index + 1 },
+                    })}
                     aria-invalid={isInvalidTimeRange}
                   />
                 </EuiFormRow>
@@ -374,7 +381,12 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                       setExpandedUrlIndex(null);
                     }}
                     aria-required="true"
-                    aria-label={`URL value for ${label || `custom URL ${index + 1}`}`}
+                    aria-label={i18n.translate('xpack.ml.customUrlEditorList.urlValueAriaLabel', {
+                      defaultMessage: 'URL value for {label}',
+                      values: {
+                        label: effectiveLabel,
+                      },
+                    })}
                     data-test-subj={`mlJobEditCustomUrlTextarea_${index}`}
                   />
                 ) : (
@@ -385,9 +397,15 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     onChange={() => {}} // satisfy React's requirement
                     onFocus={() => setExpandedUrlIndex(index)}
                     aria-required="true"
-                    aria-label={`URL value for ${
-                      label || `custom URL ${index + 1}`
-                    }. Click to expand for editing.`}
+                    aria-label={i18n.translate(
+                      'xpack.ml.customUrlEditorList.urlFieldExpandAriaLabel',
+                      {
+                        defaultMessage: 'URL value for {label}. Click to expand for editing.',
+                        values: {
+                          label: effectiveLabel,
+                        },
+                      }
+                    )}
                     data-test-subj={`mlJobEditCustomUrlInput_${index}`}
                   />
                 )}
@@ -404,7 +422,9 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
     <div
       role="list"
       data-test-subj="mlJobEditCustomUrlsList"
-      aria-label="Custom URL configurations"
+      aria-label={i18n.translate('xpack.ml.customUrlEditorList.configurationsListAriaLabel', {
+        defaultMessage: 'Custom URL configurations',
+      })}
     >
       {customUrlRows}
     </div>

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -210,7 +210,6 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
   const customUrlRows = customUrls.map((customUrl, index) => {
     // Validate the label.
     const label = customUrl.url_name;
-    const effectiveLabel = label || `Custom URL ${index + 1}`;
     const otherUrls = [...customUrls];
     otherUrls.splice(index, 1); // Don't compare label with itself.
     const isInvalidLabel = !isValidLabel(label, otherUrls);
@@ -244,7 +243,13 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
         >
           <EuiFlexGroup responsive={false} justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiFormLabel id={`custom-url-heading-${index}`}>Custom URL {index + 1}</EuiFormLabel>
+              <EuiFormLabel id={`custom-url-heading-${index}`}>
+                <FormattedMessage
+                  id="xpack.ml.customUrlEditorList.customUrlHeading"
+                  defaultMessage="Custom URL {indexCount}"
+                  values={{ indexCount: index + 1 }}
+                />
+              </EuiFormLabel>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiFlexGroup responsive={false} gutterSize="xs" css={styles.actionButtons}>
@@ -388,7 +393,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     aria-label={i18n.translate('xpack.ml.customUrlEditorList.urlValueAriaLabel', {
                       defaultMessage: 'URL value for {label}',
                       values: {
-                        label: effectiveLabel,
+                        label,
                       },
                     })}
                     data-test-subj={`mlJobEditCustomUrlTextarea_${index}`}
@@ -406,7 +411,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                       {
                         defaultMessage: 'URL value for {label}. Click to expand for editing.',
                         values: {
-                          label: effectiveLabel,
+                          label,
                         },
                       }
                     )}

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -93,11 +93,8 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
       actionButtons: css`
         max-width: calc(${euiTheme.size.xl} * 3);
       `,
-      panel: css`
-        margin: 0 ${euiTheme.size.s};
-      `,
     }),
-    [euiTheme.size.xl, euiTheme.size.xxxxl, euiTheme.size.s]
+    [euiTheme.size.xl, euiTheme.size.xxxxl]
   );
 
   const onLabelChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
@@ -239,7 +236,6 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
           data-test-subj={`mlJobEditCustomUrlItem_${index}`}
           role="listitem"
           aria-labelledby={`custom-url-heading-${index}`}
-          css={styles.panel}
         >
           <EuiFlexGroup responsive={false} justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -382,7 +382,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     key={`url-field-${index}`}
                     fullWidth={true}
                     value={customUrl.url_value}
-                    readOnly={true}
+                    onChange={() => {}} // No-op to satisfy React's controlled component requirement
                     onFocus={() => setExpandedUrlIndex(index)}
                     aria-required="true"
                     aria-label={`URL value for ${

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -297,7 +297,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer size="s" />
-          <EuiFlexGroup wrap gutterSize="s">
+          <EuiFlexGroup responsive={false} wrap gutterSize="s">
             <EuiFlexItem css={styles.narrowField} grow={2}>
               <EuiFormRow
                 fullWidth={true}
@@ -382,7 +382,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     key={`url-field-${index}`}
                     fullWidth={true}
                     value={customUrl.url_value}
-                    onChange={() => {}} // No-op to satisfy React's controlled component requirement
+                    onChange={() => {}} // satisfy React's requirement
                     onFocus={() => setExpandedUrlIndex(index)}
                     aria-required="true"
                     aria-label={`URL value for ${

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -93,8 +93,11 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
       actionButtons: css`
         max-width: calc(${euiTheme.size.xl} * 3);
       `,
+      panel: css`
+        margin: 0 ${euiTheme.size.s};
+      `,
     }),
-    [euiTheme.size.xl, euiTheme.size.xxxxl]
+    [euiTheme.size.xl, euiTheme.size.xxxxl, euiTheme.size.s]
   );
 
   const onLabelChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
@@ -237,6 +240,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
           data-test-subj={`mlJobEditCustomUrlItem_${index}`}
           role="listitem"
           aria-labelledby={`custom-url-heading-${index}`}
+          css={styles.panel}
         >
           <EuiFlexGroup responsive={false} justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -82,25 +82,19 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
   const { displayErrorToast } = useToastNotificationService();
   const [expandedUrlIndex, setExpandedUrlIndex] = useState<number | null>(null);
 
-  const labelFieldStyle = useMemo(
-    () => css`
-      min-width: calc(${euiTheme.size.xl} * 3);
-    `,
-    [euiTheme.size.xl]
-  );
-
-  const urlFieldStyle = useMemo(
-    () => css`
-      min-width: calc(${euiTheme.size.xxxxl} * 4);
-    `,
-    [euiTheme.size.xxxxl]
-  );
-
-  const actionButtonsStyle = useMemo(
-    () => css`
-      max-width: calc(${euiTheme.size.xl} * 3);
-    `,
-    [euiTheme.size.xl]
+  const styles = useMemo(
+    () => ({
+      labelField: css`
+        min-width: calc(${euiTheme.size.xl} * 3);
+      `,
+      urlField: css`
+        min-width: calc(${euiTheme.size.xxxxl} * 4);
+      `,
+      actionButtons: css`
+        max-width: calc(${euiTheme.size.xl} * 3);
+      `,
+    }),
+    [euiTheme.size.xl, euiTheme.size.xxxxl]
   );
 
   const onLabelChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
@@ -238,13 +232,17 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
 
     return (
       <React.Fragment key={`url_${index}`}>
-        <EuiPanel data-test-subj={`mlJobEditCustomUrlItem_${index}`}>
+        <EuiPanel
+          data-test-subj={`mlJobEditCustomUrlItem_${index}`}
+          role="listitem"
+          aria-labelledby={`custom-url-heading-${index}`}
+        >
           <EuiFlexGroup responsive={false} justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiFormLabel>Custom URL {index + 1}</EuiFormLabel>
+              <EuiFormLabel id={`custom-url-heading-${index}`}>Custom URL {index + 1}</EuiFormLabel>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiFlexGroup responsive={false} gutterSize="m" css={actionButtonsStyle}>
+              <EuiFlexGroup responsive={false} gutterSize="xs" css={styles.actionButtons}>
                 <EuiFlexItem grow={false}>
                   <EuiToolTip
                     content={
@@ -300,7 +298,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
           </EuiFlexGroup>
           <EuiSpacer size="s" />
           <EuiFlexGroup wrap gutterSize="s">
-            <EuiFlexItem css={labelFieldStyle} grow={2}>
+            <EuiFlexItem css={styles.labelField} grow={2}>
               <EuiFormRow
                 fullWidth={true}
                 label={
@@ -320,11 +318,14 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                   isInvalid={isInvalidLabel}
                   onChange={(e) => onLabelChange(e, index)}
                   data-test-subj={`mlJobEditCustomUrlLabelInput_${index}`}
+                  aria-required="true"
+                  aria-label={`Label for custom URL ${index + 1}`}
+                  aria-invalid={isInvalidLabel}
                 />
               </EuiFormRow>
             </EuiFlexItem>
             {isCustomTimeRange === false ? (
-              <EuiFlexItem css={labelFieldStyle} grow={2}>
+              <EuiFlexItem css={styles.labelField} grow={2}>
                 <EuiFormRow
                   fullWidth={true}
                   label={
@@ -342,11 +343,13 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     isInvalid={isInvalidTimeRange}
                     placeholder={TIME_RANGE_TYPE.AUTO}
                     onChange={(e) => onTimeRangeChange(e, index)}
+                    aria-label={`Time range for custom URL ${index + 1}`}
+                    aria-invalid={isInvalidTimeRange}
                   />
                 </EuiFormRow>
               </EuiFlexItem>
             ) : null}
-            <EuiFlexItem css={urlFieldStyle} grow={6}>
+            <EuiFlexItem css={styles.urlField} grow={6}>
               <EuiFormRow
                 fullWidth={true}
                 label={
@@ -370,6 +373,8 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     onBlur={() => {
                       setExpandedUrlIndex(null);
                     }}
+                    aria-required="true"
+                    aria-label={`URL value for ${label || `custom URL ${index + 1}`}`}
                     data-test-subj={`mlJobEditCustomUrlTextarea_${index}`}
                   />
                 ) : (
@@ -379,6 +384,10 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
                     value={customUrl.url_value}
                     readOnly={true}
                     onFocus={() => setExpandedUrlIndex(index)}
+                    aria-required="true"
+                    aria-label={`URL value for ${
+                      label || `custom URL ${index + 1}`
+                    }. Click to expand for editing.`}
                     data-test-subj={`mlJobEditCustomUrlInput_${index}`}
                   />
                 )}
@@ -391,5 +400,13 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
     );
   });
 
-  return <div data-test-subj="mlJobEditCustomUrlsList">{customUrlRows}</div>;
+  return (
+    <div
+      role="list"
+      data-test-subj="mlJobEditCustomUrlsList"
+      aria-label="Custom URL configurations"
+    >
+      {customUrlRows}
+    </div>
+  );
 };

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_url_editor/list.tsx
@@ -84,7 +84,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
 
   const styles = useMemo(
     () => ({
-      labelField: css`
+      narrowField: css`
         min-width: calc(${euiTheme.size.xl} * 3);
       `,
       urlField: css`
@@ -298,7 +298,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
           </EuiFlexGroup>
           <EuiSpacer size="s" />
           <EuiFlexGroup wrap gutterSize="s">
-            <EuiFlexItem css={styles.labelField} grow={2}>
+            <EuiFlexItem css={styles.narrowField} grow={2}>
               <EuiFormRow
                 fullWidth={true}
                 label={
@@ -325,7 +325,7 @@ export const CustomUrlList: FC<CustomUrlListProps> = ({
               </EuiFormRow>
             </EuiFlexItem>
             {isCustomTimeRange === false ? (
-              <EuiFlexItem css={styles.labelField} grow={2}>
+              <EuiFlexItem css={styles.narrowField} grow={2}>
                 <EuiFormRow
                   fullWidth={true}
                   label={

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
@@ -319,7 +319,12 @@ export class CustomUrls extends Component<CustomUrlsProps, CustomUrlsState> {
         initialFocus="[name=label]"
         style={{ width: 500 }}
         data-test-subj="mlJobNewCustomUrlFormModal"
-        aria-label="Add custom URL to job"
+        aria-label={i18n.translate(
+          'xpack.ml.jobsList.editJobFlyout.customUrls.addCustomUrlAriaLabel',
+          {
+            defaultMessage: 'Add custom URL to the job',
+          }
+        )}
       >
         <EuiModalHeader>
           <EuiModalHeaderTitle>
@@ -348,10 +353,24 @@ export class CustomUrls extends Component<CustomUrlsProps, CustomUrlsState> {
       <>
         <EuiScreenReaderOnly>
           <div aria-live="polite" aria-atomic="true">
-            <h2>Custom URL Configuration</h2>
-            {customUrls.length === 0
-              ? 'No custom URLs configured'
-              : `${customUrls.length} custom URL${customUrls.length === 1 ? '' : 's'} configured`}
+            <h2>
+              <FormattedMessage
+                id="xpack.ml.customUrls.screenReader.configurationTitle"
+                defaultMessage="Custom URL Configuration"
+              />
+            </h2>
+            {customUrls.length === 0 ? (
+              <FormattedMessage
+                id="xpack.ml.customUrls.screenReader.noConfiguredUrls"
+                defaultMessage="No custom URLs configured"
+              />
+            ) : (
+              <FormattedMessage
+                id="xpack.ml.customUrls.screenReader.configuredUrlsCount"
+                defaultMessage="{count, plural, one {# custom URL} other {# custom URLs}} configured"
+                values={{ count: customUrls.length }}
+              />
+            )}
           </div>
         </EuiScreenReaderOnly>
         <EuiSpacer size="m" />

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
@@ -20,6 +20,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiModalFooter,
+  EuiScreenReaderOnly,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -344,21 +345,15 @@ export class CustomUrls extends Component<CustomUrlsProps, CustomUrlsState> {
 
     return (
       <>
+        <EuiScreenReaderOnly>
+          <div aria-live="polite" aria-atomic="true">
+            <h2>Custom URL Configuration</h2>
+            {customUrls.length === 0
+              ? 'No custom URLs configured'
+              : `${customUrls.length} custom URL${customUrls.length === 1 ? '' : 's'} configured`}
+          </div>
+        </EuiScreenReaderOnly>
         <EuiSpacer size="m" />
-        {(!editorOpen || editMode === 'modal') && (
-          <EuiButton
-            size="s"
-            onClick={this.editNewCustomUrl}
-            data-test-subj="mlJobOpenCustomUrlFormButton"
-          >
-            <FormattedMessage
-              id="xpack.ml.jobsList.editJobFlyout.customUrls.addCustomUrlButtonLabel"
-              defaultMessage="Add custom URL"
-            />
-          </EuiButton>
-        )}
-        {editorOpen && this.renderEditor()}
-        <EuiSpacer size="l" />
         <CustomUrlList
           job={this.props.job}
           customUrls={customUrls}
@@ -366,6 +361,28 @@ export class CustomUrls extends Component<CustomUrlsProps, CustomUrlsState> {
           dataViewListItems={this.state.dataViewListItems}
           isPartialDFAJob={this.props.isPartialDFAJob}
         />
+        {(!editorOpen || editMode === 'modal') && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiButton
+              size="s"
+              iconType="plusInCircle"
+              iconSide="left"
+              aria-label={i18n.translate(
+                'xpack.ml.jobsList.editJobFlyout.customUrls.addCustomUrlButtonLabel',
+                { defaultMessage: 'Add custom URL' }
+              )}
+              onClick={this.editNewCustomUrl}
+              data-test-subj="mlJobOpenCustomUrlFormButton"
+            >
+              <FormattedMessage
+                id="xpack.ml.jobsList.editJobFlyout.customUrls.addCustomUrlButtonLabel"
+                defaultMessage="Add custom URL"
+              />
+            </EuiButton>
+          </>
+        )}
+        {editorOpen && this.renderEditor()}
       </>
     );
   }

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
@@ -319,6 +319,7 @@ export class CustomUrls extends Component<CustomUrlsProps, CustomUrlsState> {
         initialFocus="[name=label]"
         style={{ width: 500 }}
         data-test-subj="mlJobNewCustomUrlFormModal"
+        aria-label="Add custom URL to job"
       >
         <EuiModalHeader>
           <EuiModalHeaderTitle>

--- a/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/custom_urls/custom_urls.tsx
@@ -363,7 +363,6 @@ export class CustomUrls extends Component<CustomUrlsProps, CustomUrlsState> {
         />
         {(!editorOpen || editMode === 'modal') && (
           <>
-            <EuiSpacer size="m" />
             <EuiButton
               size="s"
               iconType="plusInCircle"

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
@@ -32,6 +32,13 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
       flex-direction: column !important;
     }
 
+    /* Widen the Custom URL fields */
+    .euiDescribedFormGroup__fieldWrapper,
+    .euiDescribedFormGroup__fields {
+      max-width: none !important;
+      width: 100% !important;
+    }
+
     > .euiFlexGroup {
       > .euiFlexItem {
         &:last-child {
@@ -43,6 +50,7 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
 
   return (
     <EuiDescribedFormGroup
+      gutterSize="xs"
       fullWidth
       css={cssOverride}
       title={<h3>{title}</h3>}

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
@@ -25,15 +25,21 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
     }
   );
 
-  const cssOverride = css({
-    '> .euiFlexGroup': {
-      '> .euiFlexItem': {
-        '&:last-child': {
-          flexBasis: '50%',
-        },
-      },
-    },
-  });
+  const cssOverride = css`
+    /* Force EuiDescribedFormGroup to use column layout instead of row */
+    &.euiDescribedFormGroup {
+      display: flex !important;
+      flex-direction: column !important;
+    }
+
+    > .euiFlexGroup {
+      > .euiFlexItem {
+        &:last-child {
+          flex-basis: 50%;
+        }
+      }
+    }
+  `;
 
   return (
     <EuiDescribedFormGroup

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
@@ -29,15 +29,15 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
     /* Apply column layout only on screens wider than 768px */
     @media (min-width: 769px) {
       &.euiDescribedFormGroup {
-        flex-direction: column !important;
+        flex-direction: column;
       }
     }
 
     /* Widen the Custom URL fields */
     .euiDescribedFormGroup__fieldWrapper,
     .euiDescribedFormGroup__fields {
-      max-width: none !important;
-      width: 100% !important;
+      max-width: none;
+      width: 100%;
     }
 
     > .euiFlexGroup {

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
@@ -26,10 +26,11 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
   );
 
   const cssOverride = css`
-    /* Force EuiDescribedFormGroup to use column layout instead of row */
-    &.euiDescribedFormGroup {
-      display: flex !important;
-      flex-direction: column !important;
+    /* Apply column layout only on screens wider than 768px */
+    @media (min-width: 769px) {
+      &.euiDescribedFormGroup {
+        flex-direction: column !important;
+      }
     }
 
     /* Widen the Custom URL fields */

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/job_details_step/components/additional_section/components/custom_urls/description.tsx
@@ -9,7 +9,7 @@ import type { FC, PropsWithChildren } from 'react';
 import React, { memo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiDescribedFormGroup, EuiFormRow, EuiLink } from '@elastic/eui';
+import { EuiDescribedFormGroup, EuiFormRow, EuiLink, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useMlKibana } from '../../../../../../../../../contexts/kibana';
 
@@ -17,6 +17,7 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
   const {
     services: { docLinks },
   } = useMlKibana();
+  const { euiTheme } = useEuiTheme();
   const docsUrl = docLinks.links.ml.customUrls;
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.jobDetailsStep.additionalSection.customUrls.title',
@@ -25,35 +26,40 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
     }
   );
 
-  const cssOverride = css`
-    /* Apply column layout only on screens wider than 768px */
-    @media (min-width: 769px) {
-      &.euiDescribedFormGroup {
-        flex-direction: column;
-      }
-    }
-
-    /* Widen the Custom URL fields */
-    .euiDescribedFormGroup__fieldWrapper,
-    .euiDescribedFormGroup__fields {
-      max-width: none;
-      width: 100%;
-    }
-
-    > .euiFlexGroup {
-      > .euiFlexItem {
-        &:last-child {
-          flex-basis: 50%;
+  const styles = {
+    describeForm: css`
+      /* Apply column layout only on screens wider than 768px */
+      @media (min-width: 769px) {
+        &.euiDescribedFormGroup {
+          flex-direction: column;
         }
       }
-    }
-  `;
+
+      /* Widen the Custom URL fields */
+      .euiDescribedFormGroup__fieldWrapper,
+      .euiDescribedFormGroup__fields {
+        max-width: none;
+        width: 100%;
+      }
+
+      > .euiFlexGroup {
+        > .euiFlexItem {
+          &:last-child {
+            flex-basis: 50%;
+          }
+        }
+      }
+    `,
+    formRow: css`
+      margin: 0 ${euiTheme.size.s};
+    `,
+  };
 
   return (
     <EuiDescribedFormGroup
       gutterSize="xs"
       fullWidth
-      css={cssOverride}
+      css={styles.describeForm}
       title={<h3>{title}</h3>}
       description={
         <FormattedMessage
@@ -72,7 +78,7 @@ export const Description: FC<PropsWithChildren<unknown>> = memo(({ children }) =
         />
       }
     >
-      <EuiFormRow fullWidth>
+      <EuiFormRow fullWidth css={styles.formRow}>
         <>{children}</>
       </EuiFormRow>
     </EuiDescribedFormGroup>


### PR DESCRIPTION
## Summary

This PR fixes #115426.

Changes include:  
- Re-arranging the **Custom URL list layout**:  
  - Wrapping each Custom URL in an `EuiPanel`  
  - Changing the field order from **Label, URL, Time Range** → **Label, Time Range, URL**  
  - Moving the trash and test buttons to the top-right  
  - Moving the **Add Custom URL** button to the bottom  
- Fixing the width of the URL field  
- Displaying the Custom URL list vertically in the **Create Job**  Wizard
- Improving accessibility (a11y) throughout  
- Updating test snapshot

## Fly-out:
<img width="1226" height="485" alt="Screenshot 2025-08-18 at 10 30 50" src="https://github.com/user-attachments/assets/8025f17f-9a6a-48d6-b31a-a4a826756321" />
<img width="738" height="486" alt="Screenshot 2025-08-18 at 10 31 08" src="https://github.com/user-attachments/assets/a3e7dbda-04cd-4b57-aeed-b24016aab058" />
<img width="524" height="598" alt="Screenshot 2025-08-18 at 10 31 24" src="https://github.com/user-attachments/assets/259db332-587f-40d0-8030-d93b01a52443" />
<img width="417" height="740" alt="Screenshot 2025-08-18 at 10 31 40" src="https://github.com/user-attachments/assets/757c3640-ae9a-4f4b-b4f6-e9ca05e5ff94" />


## Create Job Wizard:
<img width="1048" height="932" alt="Screenshot 2025-08-18 at 15 31 59" src="https://github.com/user-attachments/assets/562930fb-0457-457c-8bde-c8ab0bbbf02c" />
<img width="618" height="477" alt="Screenshot 2025-08-18 at 15 32 28" src="https://github.com/user-attachments/assets/a548a078-d430-41e3-aed9-6815f2c8a32c" />
<img width="506" height="597" alt="Screenshot 2025-08-18 at 15 32 38" src="https://github.com/user-attachments/assets/4ee7657b-01b1-49c6-bc39-841d09252122" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



