### PR TITLE
[ES|QL] LOOKUP JOIN - Always display a placeholder row

### DIFF
--- a/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
+++ b/src/platform/packages/private/kbn-index-editor/src/index_update_service.ts
@@ -563,6 +563,10 @@ export class IndexUpdateService {
                 } as unknown as DataTableRecord;
               });
 
+            if (resultRows.length === 0) {
+              resultRows.push(this.buildPlaceholderRow());
+            }
+
             this._rows$.next(resultRows);
             this._totalHits$.next(total ?? 0);
             this._isFetching$.next(false);
@@ -686,6 +690,12 @@ export class IndexUpdateService {
     // Remove rows with matching ids from _rows$
     const currentRows = this._rows$.getValue();
     const updatedRows = currentRows.filter((row) => !ids.includes(row.id));
+
+    // If no rows left, add a placeholder row
+    if (updatedRows.length === 0) {
+      updatedRows.push(this.buildPlaceholderRow());
+    }
+
     this._rows$.next(updatedRows);
   }
 


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/207330
## Summary

Always display a placeholder row, both if all rows has been deleted or if the filtering returns no results.

This fixes also the search callout displayed at the bottom of the table when deleting all columns and adding a new one.

<img width="1425" height="309" alt="image" src="https://github.com/user-attachments/assets/105a9e72-e88c-421b-9878-2eb3604fc922" />
