### PR TITLE
[Contextual security] fix vulnerability findings contextual flyout not showing details

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/hooks/use_vulnerabilities_findings.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/hooks/use_vulnerabilities_findings.ts
@@ -26,11 +26,12 @@ import {
   getVulnerabilitiesQuery,
 } from '../utils/findings_query_builders';
 
-export enum VULNERABILITY {
+export enum VULNERABILITY_FINDING {
   TITLE = 'vulnerability.title',
   ID = 'vulnerability.id',
   SEVERITY = 'vulnerability.severity',
   PACKAGE_NAME = 'package.name',
+  PACKAGE_VERSION = 'package.version',
 }
 
 type LatestFindingsRequest = IKibanaSearchRequest<SearchRequest>;
@@ -46,15 +47,15 @@ export interface VulnerabilitiesPackage extends Vulnerability {
 }
 
 export interface VulnerabilitiesFindingTableDetailsFields {
-  [VULNERABILITY.TITLE]: string;
-  [VULNERABILITY.ID]: string;
-  [VULNERABILITY.SEVERITY]: string;
-  [VULNERABILITY.PACKAGE_NAME]: string;
+  [VULNERABILITY_FINDING.TITLE]: string;
+  [VULNERABILITY_FINDING.ID]: string;
+  [VULNERABILITY_FINDING.SEVERITY]: string;
+  [VULNERABILITY_FINDING.PACKAGE_NAME]: string;
 }
 
 export type VulnerabilitiesFindingDetailFields = Pick<Vulnerability, 'score'> &
   Pick<CspVulnerabilityFinding, 'vulnerability' | 'resource' | 'event'> &
-  VulnerabilitiesFindingTableDetailsFields;
+  VulnerabilitiesFindingTableDetailsFields & { [VULNERABILITY_FINDING.PACKAGE_VERSION]: string };
 
 interface FindingsAggs {
   count: AggregationsMultiBucketAggregateBase<AggregationsStringRareTermsBucketKeys>;
@@ -88,10 +89,11 @@ export const useVulnerabilitiesFindings = (options: UseCspOptions) => {
           vulnerability: finding._source?.vulnerability,
           resource: finding._source?.resource,
           score: finding._source?.vulnerability?.score,
-          [VULNERABILITY.ID]: finding._source?.vulnerability?.id,
-          [VULNERABILITY.SEVERITY]: finding._source?.vulnerability?.severity,
-          [VULNERABILITY.PACKAGE_NAME]: finding._source?.package?.name,
+          [VULNERABILITY_FINDING.ID]: finding._source?.vulnerability?.id,
+          [VULNERABILITY_FINDING.SEVERITY]: finding._source?.vulnerability?.severity,
+          [VULNERABILITY_FINDING.PACKAGE_NAME]: finding._source?.package?.name,
           event: finding._source?.event,
+          [VULNERABILITY_FINDING.PACKAGE_VERSION]: finding._source?.package?.version,
         })) as VulnerabilitiesFindingDetailFields[],
       };
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/vulnerabilities_findings_details_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/vulnerabilities_findings_details_table.tsx
@@ -17,7 +17,7 @@ import type {
 } from '@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_findings';
 import {
   useVulnerabilitiesFindings,
-  VULNERABILITY,
+  VULNERABILITY_FINDING,
 } from '@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_findings';
 import type {
   FindingsVulnerabilityPanelExpandableFlyoutPropsPreview,
@@ -54,11 +54,12 @@ type VulnerabilitySortFieldType =
   | 'score'
   | 'vulnerability'
   | 'resource'
-  | VULNERABILITY.SEVERITY
-  | VULNERABILITY.ID
-  | VULNERABILITY.PACKAGE_NAME
-  | VULNERABILITY.TITLE
-  | 'event';
+  | VULNERABILITY_FINDING.SEVERITY
+  | VULNERABILITY_FINDING.ID
+  | VULNERABILITY_FINDING.PACKAGE_NAME
+  | VULNERABILITY_FINDING.TITLE
+  | 'event'
+  | VULNERABILITY_FINDING.PACKAGE_VERSION;
 
 const EMPTY_VALUE = '-';
 
@@ -74,7 +75,9 @@ export const VulnerabilitiesFindingsDetailsTable = memo(
     }, []);
 
     const [currentFilter, setCurrentFilter] = useState<string>('');
-    const [sortField, setSortField] = useState<VulnerabilitySortFieldType>(VULNERABILITY.SEVERITY);
+    const [sortField, setSortField] = useState<VulnerabilitySortFieldType>(
+      VULNERABILITY_FINDING.SEVERITY
+    );
     const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
     const { openPreviewPanel } = useExpandableFlyoutApi();
@@ -235,8 +238,8 @@ export const VulnerabilitiesFindingsDetailsTable = memo(
                 params: {
                   vulnerabilityId: vulnerability?.id,
                   resourceId: finding?.resource?.id,
-                  packageName: vulnerability?.package?.name,
-                  packageVersion: vulnerability?.package?.version,
+                  packageName: finding?.[VULNERABILITY_FINDING.PACKAGE_NAME],
+                  packageVersion: finding?.[VULNERABILITY_FINDING.PACKAGE_VERSION],
                   eventId: finding?.event?.id,
                   scopeId,
                   isPreviewMode: true,
@@ -273,7 +276,7 @@ export const VulnerabilitiesFindingsDetailsTable = memo(
         sortable: true,
       },
       {
-        field: VULNERABILITY.TITLE,
+        field: VULNERABILITY_FINDING.TITLE,
         render: (title: string) => {
           if (Array.isArray(title)) {
             return <EuiText size="s">{title.join(', ')}</EuiText>;
@@ -289,9 +292,9 @@ export const VulnerabilitiesFindingsDetailsTable = memo(
         sortable: true,
       },
       {
-        field: VULNERABILITY.ID,
+        field: VULNERABILITY_FINDING.ID,
         render: (id: string, finding: VulnerabilitiesFindingDetailFields) =>
-          renderMultiValueCell(VULNERABILITY.ID, finding),
+          renderMultiValueCell(VULNERABILITY_FINDING.ID, finding),
         name: i18n.translate(
           'xpack.securitySolution.flyout.left.insights.vulnerability.table.vulnerabilityIdColumnName',
           { defaultMessage: 'CVE ID' }
@@ -300,7 +303,7 @@ export const VulnerabilitiesFindingsDetailsTable = memo(
         sortable: true,
       },
       {
-        field: VULNERABILITY.SEVERITY,
+        field: VULNERABILITY_FINDING.SEVERITY,
         render: (severity: string) => (
           <>
             <EuiText size="s">
@@ -316,9 +319,9 @@ export const VulnerabilitiesFindingsDetailsTable = memo(
         sortable: true,
       },
       {
-        field: VULNERABILITY.PACKAGE_NAME,
+        field: VULNERABILITY_FINDING.PACKAGE_NAME,
         render: (packageName: string, finding: VulnerabilitiesFindingDetailFields) =>
-          renderMultiValueCell(VULNERABILITY.PACKAGE_NAME, finding),
+          renderMultiValueCell(VULNERABILITY_FINDING.PACKAGE_NAME, finding),
         name: i18n.translate(
           'xpack.securitySolution.flyout.left.insights.vulnerability.table.ruleColumnName',
           { defaultMessage: 'Package' }


### PR DESCRIPTION
## Summary

This PR fixes the following [issue](https://github.com/elastic/kibana/issues/231773).

<!--ONMERGE {"backportTargets":["9.1"]} ONMERGE-->