### PR TITLE
chore(streams): use ensureStream instead of isStreamsEnabled in sig events routes

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
@@ -149,11 +149,7 @@ const readSignificantEventsRoute = createServerRoute({
       request,
     });
     await assertLicenseAndPricingTier(server, licensing);
-
-    const isStreamEnabled = await streamsClient.isStreamsEnabled();
-    if (!isStreamEnabled) {
-      throw badRequest('Streams are not enabled');
-    }
+    await streamsClient.ensureStream(params.path.name);
 
     const { name } = params.path;
     const { from, to, bucketSize } = params.query;
@@ -227,11 +223,7 @@ const generateSignificantEventsRoute = createServerRoute({
     const { streamsClient, scopedClusterClient, licensing, inferenceClient } =
       await getScopedClients({ request });
     await assertLicenseAndPricingTier(server, licensing);
-
-    const isStreamEnabled = await streamsClient.isStreamsEnabled();
-    if (!isStreamEnabled) {
-      throw badRequest('Streams are not enabled');
-    }
+    await streamsClient.ensureStream(params.path.name);
 
     const generatedSignificantEventDefinitions = await generateSignificantEventDefinitions(
       {


### PR DESCRIPTION
## Summary

This PR replaces the isStreamEnable with ensureStream for sig events routes