### PR TITLE
[9.0] [Security Solution] Diagnostic Queries (#220832)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.ts
@@ -188,6 +188,13 @@ export const configSchema = schema.object({
       elserInferenceId: schema.maybe(schema.string()),
     })
   ),
+  cdn: schema.maybe(
+    schema.object({
+      url: schema.maybe(schema.string()),
+      // PEM-encoded public key used to verify the global artifact manifest signature.
+      publicKey: schema.maybe(schema.string()),
+    })
+  ),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/server/integration_tests/configuration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/integration_tests/configuration.test.ts
@@ -121,6 +121,34 @@ describe('configuration', () => {
         ingest_pipelines_stats_config: {
           enabled: false,
         },
+        health_diagnostic_config: {
+          query: {
+            maxDocuments: getRandomInt(1000, 50000),
+            bufferSize: getRandomInt(100, 5000),
+          },
+          rssGrowthCircuitBreaker: {
+            maxRssGrowthPercent: getRandomInt(10, 80),
+            validationIntervalMs: getRandomInt(50, 500),
+          },
+          timeoutCircuitBreaker: {
+            timeoutMillis: getRandomInt(500, 5000),
+            validationIntervalMs: getRandomInt(10, 100),
+          },
+          eventLoopUtilizationCircuitBreaker: {
+            thresholdMillis: getRandomInt(500, 2000),
+            validationIntervalMs: getRandomInt(10, 100),
+          },
+          eventLoopDelayCircuitBreaker: {
+            thresholdMillis: getRandomInt(50, 200),
+            validationIntervalMs: getRandomInt(5, 50),
+          },
+          elasticsearchCircuitBreaker: {
+            maxJvmHeapUsedPercent: getRandomInt(50, 90),
+            maxCpuPercent: getRandomInt(50, 90),
+            expectedClusterHealth: ['green'],
+            validationIntervalMs: getRandomInt(500, 2000),
+          },
+        },
       };
 
       mockAxiosGet(mockedAxiosGet, [
@@ -154,6 +182,258 @@ describe('configuration', () => {
       expect(telemetryConfiguration.ingest_pipelines_stats_config).toEqual(
         expected.ingest_pipelines_stats_config
       );
+      expect(telemetryConfiguration.health_diagnostic_config).toEqual(
+        expected.health_diagnostic_config
+      );
+    });
+
+    it('should update health diagnostic config independently', async () => {
+      const originalConfig = cloneDeep(telemetryConfiguration.health_diagnostic_config);
+
+      const expectedHealthConfig = {
+        health_diagnostic_config: {
+          query: {
+            maxDocuments: getRandomInt(10000, 200000),
+            bufferSize: getRandomInt(1000, 20000),
+          },
+          rssGrowthCircuitBreaker: {
+            maxRssGrowthPercent: getRandomInt(20, 60),
+            validationIntervalMs: getRandomInt(100, 1000),
+          },
+          timeoutCircuitBreaker: {
+            timeoutMillis: getRandomInt(2000, 10000),
+            validationIntervalMs: getRandomInt(20, 200),
+          },
+          eventLoopUtilizationCircuitBreaker: {
+            thresholdMillis: getRandomInt(1000, 3000),
+            validationIntervalMs: getRandomInt(20, 200),
+          },
+          eventLoopDelayCircuitBreaker: {
+            thresholdMillis: getRandomInt(20, 300),
+            validationIntervalMs: getRandomInt(1, 20),
+          },
+          elasticsearchCircuitBreaker: {
+            maxJvmHeapUsedPercent: getRandomInt(60, 95),
+            maxCpuPercent: getRandomInt(60, 95),
+            expectedClusterHealth: ['green', 'yellow'],
+            validationIntervalMs: getRandomInt(1000, 5000),
+          },
+        },
+      };
+
+      mockAxiosGet(mockedAxiosGet, [
+        ...DEFAULT_GET_ROUTES,
+        [
+          /.*telemetry-buffer-and-batch-sizes-v1.*/,
+          { status: 200, data: cloneDeep(expectedHealthConfig) },
+        ],
+      ]);
+
+      await runSoonConfigTask(tasks, taskManagerPlugin);
+
+      // Verify health diagnostic config was updated
+      expect(telemetryConfiguration.health_diagnostic_config).toEqual(
+        expectedHealthConfig.health_diagnostic_config
+      );
+
+      // Verify health diagnostic config is different from original
+      expect(telemetryConfiguration.health_diagnostic_config).not.toEqual(originalConfig);
+    });
+
+    it('should handle partial health diagnostic config updates', async () => {
+      const partialHealthConfig = {
+        health_diagnostic_config: {
+          query: {
+            maxDocuments: getRandomInt(50000, 150000),
+            bufferSize: getRandomInt(5000, 15000),
+          },
+        },
+      };
+
+      mockAxiosGet(mockedAxiosGet, [
+        ...DEFAULT_GET_ROUTES,
+        [
+          /.*telemetry-buffer-and-batch-sizes-v1.*/,
+          { status: 200, data: cloneDeep(partialHealthConfig) },
+        ],
+      ]);
+
+      await runSoonConfigTask(tasks, taskManagerPlugin);
+
+      // Verify query config was updated
+      expect(telemetryConfiguration.health_diagnostic_config.query).toEqual(
+        partialHealthConfig.health_diagnostic_config.query
+      );
+
+      // Verify other circuit breaker configs remain unchanged (should use defaults or previous values)
+      expect(telemetryConfiguration.health_diagnostic_config.rssGrowthCircuitBreaker).toBeDefined();
+      expect(telemetryConfiguration.health_diagnostic_config.timeoutCircuitBreaker).toBeDefined();
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopUtilizationCircuitBreaker
+      ).toBeDefined();
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopDelayCircuitBreaker
+      ).toBeDefined();
+      expect(
+        telemetryConfiguration.health_diagnostic_config.elasticsearchCircuitBreaker
+      ).toBeDefined();
+    });
+
+    it('should reset health diagnostic config to defaults when resetAllToDefault is called', async () => {
+      // First, update with custom values
+      const customConfig = {
+        health_diagnostic_config: {
+          query: { maxDocuments: 999999, bufferSize: 999999 },
+          rssGrowthCircuitBreaker: { maxRssGrowthPercent: 99, validationIntervalMs: 999 },
+          timeoutCircuitBreaker: { timeoutMillis: 999999, validationIntervalMs: 999 },
+          eventLoopUtilizationCircuitBreaker: {
+            thresholdMillis: 999999,
+            validationIntervalMs: 999,
+          },
+          eventLoopDelayCircuitBreaker: { thresholdMillis: 999, validationIntervalMs: 999 },
+          elasticsearchCircuitBreaker: {
+            maxJvmHeapUsedPercent: 99,
+            maxCpuPercent: 99,
+            expectedClusterHealth: ['red'],
+            validationIntervalMs: 999999,
+          },
+        },
+      };
+
+      mockAxiosGet(mockedAxiosGet, [
+        ...DEFAULT_GET_ROUTES,
+        [/.*telemetry-buffer-and-batch-sizes-v1.*/, { status: 200, data: cloneDeep(customConfig) }],
+      ]);
+
+      await runSoonConfigTask(tasks, taskManagerPlugin);
+
+      // Verify custom values were set
+      expect(telemetryConfiguration.health_diagnostic_config.query.maxDocuments).toBe(999999);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.rssGrowthCircuitBreaker.maxRssGrowthPercent
+      ).toBe(99);
+
+      // Reset to defaults
+      telemetryConfiguration.resetAllToDefault();
+
+      // Verify default values are restored
+      expect(telemetryConfiguration.health_diagnostic_config.query.maxDocuments).toBe(10_000);
+      expect(telemetryConfiguration.health_diagnostic_config.query.bufferSize).toBe(1_000);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.rssGrowthCircuitBreaker.maxRssGrowthPercent
+      ).toBe(40);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.rssGrowthCircuitBreaker.validationIntervalMs
+      ).toBe(500);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.timeoutCircuitBreaker.timeoutMillis
+      ).toBe(5000);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.timeoutCircuitBreaker.validationIntervalMs
+      ).toBe(500);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopUtilizationCircuitBreaker
+          .thresholdMillis
+      ).toBe(5000);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopUtilizationCircuitBreaker
+          .validationIntervalMs
+      ).toBe(500);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopDelayCircuitBreaker.thresholdMillis
+      ).toBe(500);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopDelayCircuitBreaker
+          .validationIntervalMs
+      ).toBe(250);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.elasticsearchCircuitBreaker
+          .maxJvmHeapUsedPercent
+      ).toBe(90);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.elasticsearchCircuitBreaker.maxCpuPercent
+      ).toBe(90);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.elasticsearchCircuitBreaker
+          .expectedClusterHealth
+      ).toEqual(['green', 'yellow']);
+      expect(
+        telemetryConfiguration.health_diagnostic_config.elasticsearchCircuitBreaker
+          .validationIntervalMs
+      ).toBe(1000);
+    });
+
+    it('should handle invalid health diagnostic config gracefully', async () => {
+      mockAxiosGet(mockedAxiosGet, [
+        ...DEFAULT_GET_ROUTES,
+        [/.*telemetry-buffer-and-batch-sizes-v1.*/, { status: 500, data: null }],
+      ]);
+
+      await runSoonConfigTask(tasks, taskManagerPlugin);
+
+      // Configuration should remain unchanged or reset to defaults
+      expect(telemetryConfiguration.health_diagnostic_config).toBeDefined();
+      expect(telemetryConfiguration.health_diagnostic_config.query).toBeDefined();
+      expect(telemetryConfiguration.health_diagnostic_config.rssGrowthCircuitBreaker).toBeDefined();
+      expect(telemetryConfiguration.health_diagnostic_config.timeoutCircuitBreaker).toBeDefined();
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopUtilizationCircuitBreaker
+      ).toBeDefined();
+      expect(
+        telemetryConfiguration.health_diagnostic_config.eventLoopDelayCircuitBreaker
+      ).toBeDefined();
+      expect(
+        telemetryConfiguration.health_diagnostic_config.elasticsearchCircuitBreaker
+      ).toBeDefined();
+    });
+
+    it('should validate health diagnostic config structure', async () => {
+      const validConfig = telemetryConfiguration.health_diagnostic_config;
+
+      expect(validConfig).toHaveProperty('query');
+      expect(validConfig).toHaveProperty('rssGrowthCircuitBreaker');
+      expect(validConfig).toHaveProperty('timeoutCircuitBreaker');
+      expect(validConfig).toHaveProperty('eventLoopUtilizationCircuitBreaker');
+      expect(validConfig).toHaveProperty('eventLoopDelayCircuitBreaker');
+      expect(validConfig).toHaveProperty('elasticsearchCircuitBreaker');
+
+      expect(validConfig.query).toHaveProperty('maxDocuments');
+      expect(validConfig.query).toHaveProperty('bufferSize');
+      expect(typeof validConfig.query.maxDocuments).toBe('number');
+      expect(typeof validConfig.query.bufferSize).toBe('number');
+
+      expect(validConfig.rssGrowthCircuitBreaker).toHaveProperty('maxRssGrowthPercent');
+      expect(validConfig.rssGrowthCircuitBreaker).toHaveProperty('validationIntervalMs');
+      expect(typeof validConfig.rssGrowthCircuitBreaker.maxRssGrowthPercent).toBe('number');
+      expect(typeof validConfig.rssGrowthCircuitBreaker.validationIntervalMs).toBe('number');
+
+      expect(validConfig.timeoutCircuitBreaker).toHaveProperty('timeoutMillis');
+      expect(validConfig.timeoutCircuitBreaker).toHaveProperty('validationIntervalMs');
+      expect(typeof validConfig.timeoutCircuitBreaker.timeoutMillis).toBe('number');
+      expect(typeof validConfig.timeoutCircuitBreaker.validationIntervalMs).toBe('number');
+
+      expect(validConfig.eventLoopUtilizationCircuitBreaker).toHaveProperty('thresholdMillis');
+      expect(validConfig.eventLoopUtilizationCircuitBreaker).toHaveProperty('validationIntervalMs');
+      expect(typeof validConfig.eventLoopUtilizationCircuitBreaker.thresholdMillis).toBe('number');
+      expect(typeof validConfig.eventLoopUtilizationCircuitBreaker.validationIntervalMs).toBe(
+        'number'
+      );
+
+      expect(validConfig.eventLoopDelayCircuitBreaker).toHaveProperty('thresholdMillis');
+      expect(validConfig.eventLoopDelayCircuitBreaker).toHaveProperty('validationIntervalMs');
+      expect(typeof validConfig.eventLoopDelayCircuitBreaker.thresholdMillis).toBe('number');
+      expect(typeof validConfig.eventLoopDelayCircuitBreaker.validationIntervalMs).toBe('number');
+
+      expect(validConfig.elasticsearchCircuitBreaker).toHaveProperty('maxJvmHeapUsedPercent');
+      expect(validConfig.elasticsearchCircuitBreaker).toHaveProperty('maxCpuPercent');
+      expect(validConfig.elasticsearchCircuitBreaker).toHaveProperty('expectedClusterHealth');
+      expect(validConfig.elasticsearchCircuitBreaker).toHaveProperty('validationIntervalMs');
+      expect(typeof validConfig.elasticsearchCircuitBreaker.maxJvmHeapUsedPercent).toBe('number');
+      expect(typeof validConfig.elasticsearchCircuitBreaker.maxCpuPercent).toBe('number');
+      expect(Array.isArray(validConfig.elasticsearchCircuitBreaker.expectedClusterHealth)).toBe(
+        true
+      );
+      expect(typeof validConfig.elasticsearchCircuitBreaker.validationIntervalMs).toBe('number');
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/artifact.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/artifact.ts
@@ -5,46 +5,99 @@
  * 2.0.
  */
 
+import { createVerify } from 'crypto';
+
 import axios from 'axios';
 import { cloneDeep } from 'lodash';
 import AdmZip from 'adm-zip';
 import type { ITelemetryReceiver } from './receiver';
 import type { ESClusterInfo } from './types';
 
+/**
+ * Interface for managing artifact fetching and retrieval.
+ *
+ * Implementations must define how to start the service with a given telemetry receiver,
+ * fetch individual artifacts by name, and provide the manifest URL in use.
+ */
 export interface IArtifact {
   start(receiver: ITelemetryReceiver): Promise<void>;
   getArtifact(name: string): Promise<Manifest>;
   getManifestUrl(): string | undefined;
 }
 
+/**
+ * Describes the shape of an artifact manifest and its modification state.
+ *
+ * @property data - The actual manifest data, format depends on implementation.
+ * @property notModified - Indicates whether the manifest data has changed since last retrieval.
+ */
 export interface Manifest {
   data: unknown;
   notModified: boolean;
 }
 
+/**
+ * An entry in the manifest cache that stores the manifest and its associated ETag value.
+ *
+ * @property manifest - The Manifest object representing the artifact manifest data and status.
+ * @property etag - The ETag string returned by the CDN for cache validation.
+ */
 interface CacheEntry {
   manifest: Manifest;
   etag: string;
 }
 
+/**
+ * Configuration details for the CDN used to fetch artifacts.
+ *
+ * @property url - The base URL of the CDN for artifact downloads.
+ * @property pubKey - The public key string used to verify artifact signatures.
+ */
+export interface CdnConfig {
+  url: string;
+  pubKey: string;
+}
+
+const DEFAULT_CDN_CONFIG: CdnConfig = {
+  url: 'https://artifacts.security.elastic.co',
+  pubKey: `
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA6AB2sJ5M1ImN/bkQ7Te6
+uI7vMXjN2yupEmh2rYz4gNzWS351d4JOhuQH3nzxfKdayHgusP/Kq2MXVqALH8Ru
+Yu2AF08GdvYlQXPgEVI+tB/riekwU7PXZHdA1dY5/mEZ8SUSM25kcDJ3vTCzFTlL
+gl2RNAdkR80d9nhvNSWlhWMwr8coQkr6NmujVU/Wa0w0EXbN1arjcG4qzbOCaR+b
+cgQ9LRUoFfK9w+JJHDNjOI7rOmaIDA6Ep4oeDLy5AcGCE8bNmQzxZhRW7NvlNUGS
+NTgU0CZTatVsL9AyP15W3k635Cpmy2SMPX+d/CFgvr8QPxtqdrz3q9iOeU3a1LMY
+gDcFVmSzn5zieQEPfo/FcQID/gnCmkX0ADVMf1Q20ew66H7UCOejGaerbFZXYnTz
+5AgQBWF2taOSSE7gDjGAHereeKp+1PR+tCkoDZIrPEjo0V6+KaTMuYS3oZj1/RZN
+oTjQrdfeDj02mEIL+XkcWKAp03PYlWylVwgTMa178DDVuTWtS5lZL8j5LijlH9+6
+xH8o++ghwfxp6ENLKDZPV5IvHHG7Vth9HScoPTQWQ+s8Bt26QENPUV2AbyxbJykY
+mJfTDke3bEemHZzRbAmwiQ7VpJjJ4OfLGRy8Pp2AHo8kYIvWyM5+aLMxcxUaYdA9
+5SxoDOgcDBA4lLb6XFLYiDUCAwEAAQ==
+-----END PUBLIC KEY-----
+`,
+};
+
 export class Artifact implements IArtifact {
   private manifestUrl?: string;
-  private readonly CDN_URL = 'https://artifacts.security.elastic.co';
+  private cdn?: CdnConfig;
+
   private readonly AXIOS_TIMEOUT_MS = 10_000;
   private receiver?: ITelemetryReceiver;
   private esClusterInfo?: ESClusterInfo;
   private cache: Map<string, CacheEntry> = new Map();
 
-  public async start(receiver: ITelemetryReceiver) {
+  public async start(receiver: ITelemetryReceiver, cdn: CdnConfig = DEFAULT_CDN_CONFIG) {
     this.receiver = receiver;
     this.esClusterInfo = await this.receiver.fetchClusterInfo();
+    this.cdn = cdn;
     if (this.esClusterInfo?.version?.number) {
       const version =
         this.esClusterInfo.version.number.substring(
           0,
           this.esClusterInfo.version.number.indexOf('-')
         ) || this.esClusterInfo.version.number;
-      this.manifestUrl = `${this.CDN_URL}/downloads/kibana/manifest/artifacts-${version}.zip`;
+      this.manifestUrl = `${cdn.url}/downloads/kibana/manifest/artifacts-${version}.zip`;
     }
   }
 
@@ -75,6 +128,8 @@ export class Artifact implements IArtifact {
           case 304:
             return cloneDeep(this.getCachedManifest(name));
           case 404:
+            // just in case, remove the entry
+            this.cache.delete(name);
             throw Error(`No manifest resource found at url: ${this.manifestUrl}`);
           default:
             throw Error(`Failed to download manifest, unexpected status code: ${response.status}`);
@@ -90,7 +145,7 @@ export class Artifact implements IArtifact {
     }
   }
 
-  public getCachedManifest(name: string): Manifest {
+  private getCachedManifest(name: string): Manifest {
     const entry = this.cache.get(name);
     if (!entry) {
       throw Error(`No cached manifest for name ${name}`);
@@ -105,14 +160,26 @@ export class Artifact implements IArtifact {
       return entry.entryName === 'manifest.json';
     });
 
+    const manifestSigFile = zip.getEntries().find((entry) => {
+      return entry.entryName === 'manifest.sig';
+    });
+
     if (!manifestFile) {
       throw Error('No manifest.json in artifact zip');
+    }
+
+    if (!manifestSigFile) {
+      throw Error('No manifest.sig in artifact zip');
+    }
+
+    if (!this.isSignatureValid(manifestFile.getData(), manifestSigFile.getData())) {
+      throw Error('Invalid manifest signature');
     }
 
     const manifest = JSON.parse(manifestFile.getData().toString());
     const relativeUrl = manifest.artifacts[name]?.relative_url;
     if (relativeUrl) {
-      const url = `${this.CDN_URL}${relativeUrl}`;
+      const url = `${this.cdn?.url}${relativeUrl}`;
       const artifactResponse = await axios.get(url, { timeout: this.AXIOS_TIMEOUT_MS });
       return artifactResponse.data;
     } else {
@@ -127,6 +194,18 @@ export class Artifact implements IArtifact {
       return { 'If-None-Match': etag };
     }
     return {};
+  }
+
+  private isSignatureValid(data: Buffer, signature: Buffer): boolean {
+    if (!this.cdn) {
+      throw Error('No CDN configuration provided');
+    }
+
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(data);
+    verifier.end();
+
+    return verifier.verify(this.cdn.pubKey, signature);
   }
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/configuration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/configuration.ts
@@ -7,11 +7,18 @@
 
 import os from 'os';
 import type {
+  HealthDiagnosticConfiguration,
   IndicesMetadataConfiguration,
   IngestPipelinesStatsConfiguration,
   PaginationConfiguration,
   TelemetrySenderChannelConfiguration,
 } from './types';
+import type { RssGrowthCircuitBreakerConfig } from './diagnostic/circuit_breakers/rss_growth_circuit_breaker';
+import type { TimeoutCircuitBreakerConfig } from './diagnostic/circuit_breakers/timeout_circuit_breaker';
+import type { EventLoopUtilizationCircuitBreakerConfig } from './diagnostic/circuit_breakers/event_loop_utilization_circuit_breaker';
+import type { EventLoopDelayCircuitBreakerConfig } from './diagnostic/circuit_breakers/event_loop_delay_circuit_breaker';
+import type { ElasticsearchCircuitBreakerConfig } from './diagnostic/circuit_breakers/elastic_search_circuit_breaker';
+import type { HealthDiagnosticQueryConfig } from './diagnostic/health_diagnostic_service.types';
 
 class TelemetryConfigurationDTO {
   private readonly DEFAULT_TELEMETRY_MAX_BUFFER_SIZE = 100;
@@ -42,6 +49,34 @@ class TelemetryConfigurationDTO {
   private readonly DEFAULT_INGEST_PIPELINES_STATS_CONFIG = {
     enabled: true,
   };
+  private readonly DEFAULT_HEALTH_DIAGNOSTIC_CONFIG: HealthDiagnosticConfiguration = {
+    query: {
+      maxDocuments: 10_000,
+      bufferSize: 1_000,
+    } as HealthDiagnosticQueryConfig,
+    rssGrowthCircuitBreaker: {
+      maxRssGrowthPercent: 40,
+      validationIntervalMs: 500,
+    } as RssGrowthCircuitBreakerConfig,
+    timeoutCircuitBreaker: {
+      timeoutMillis: 5000,
+      validationIntervalMs: 500,
+    } as TimeoutCircuitBreakerConfig,
+    eventLoopUtilizationCircuitBreaker: {
+      thresholdMillis: 5000,
+      validationIntervalMs: 500,
+    } as EventLoopUtilizationCircuitBreakerConfig,
+    eventLoopDelayCircuitBreaker: {
+      thresholdMillis: 500,
+      validationIntervalMs: 250,
+    } as EventLoopDelayCircuitBreakerConfig,
+    elasticsearchCircuitBreaker: {
+      maxJvmHeapUsedPercent: 90,
+      maxCpuPercent: 90,
+      expectedClusterHealth: ['green', 'yellow'],
+      validationIntervalMs: 1000,
+    } as ElasticsearchCircuitBreakerConfig,
+  };
 
   private _telemetry_max_buffer_size = this.DEFAULT_TELEMETRY_MAX_BUFFER_SIZE;
   private _max_security_list_telemetry_batch = this.DEFAULT_MAX_SECURITY_LIST_TELEMETRY_BATCH;
@@ -57,6 +92,8 @@ class TelemetryConfigurationDTO {
     this.DEFAULT_INDICES_METADATA_CONFIG;
   private _ingest_pipelines_stats_config: IngestPipelinesStatsConfiguration =
     this.DEFAULT_INGEST_PIPELINES_STATS_CONFIG;
+  private _health_diagnostic_config: HealthDiagnosticConfiguration =
+    this.DEFAULT_HEALTH_DIAGNOSTIC_CONFIG;
 
   public get telemetry_max_buffer_size(): number {
     return this._telemetry_max_buffer_size;
@@ -140,6 +177,16 @@ class TelemetryConfigurationDTO {
     return this._ingest_pipelines_stats_config;
   }
 
+  public set health_diagnostic_config(
+    healthDiagnosticConfiguration: HealthDiagnosticConfiguration
+  ) {
+    this._health_diagnostic_config = healthDiagnosticConfiguration;
+  }
+
+  public get health_diagnostic_config(): HealthDiagnosticConfiguration {
+    return this._health_diagnostic_config;
+  }
+
   public resetAllToDefault() {
     this._telemetry_max_buffer_size = this.DEFAULT_TELEMETRY_MAX_BUFFER_SIZE;
     this._max_security_list_telemetry_batch = this.DEFAULT_MAX_SECURITY_LIST_TELEMETRY_BATCH;
@@ -150,6 +197,7 @@ class TelemetryConfigurationDTO {
     this._pagination_config = this.DEFAULT_PAGINATION_CONFIG;
     this._indices_metadata_config = this.DEFAULT_INDICES_METADATA_CONFIG;
     this._ingest_pipelines_stats_config = this.DEFAULT_INGEST_PIPELINES_STATS_CONFIG;
+    this._health_diagnostic_config = this.DEFAULT_HEALTH_DIAGNOSTIC_CONFIG;
   }
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/__mocks__/index.ts
@@ -1,0 +1,344 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceStart, Logger } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { CircuitBreakingQueryExecutorImpl } from '../health_diagnostic_receiver';
+import { QueryType, Action } from '../health_diagnostic_service.types';
+
+export const createMockLogger = (): jest.Mocked<Logger> =>
+  ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    get: jest.fn().mockReturnThis(),
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export const createMockTaskManager = (): jest.Mocked<TaskManagerStartContract> =>
+  ({
+    ensureScheduled: jest.fn(),
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export const createMockAnalytics = (): jest.Mocked<AnalyticsServiceStart> =>
+  ({
+    reportEvent: jest.fn(),
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export const createMockQueryExecutor = (): jest.Mocked<CircuitBreakingQueryExecutorImpl> =>
+  ({
+    search: jest.fn(),
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export const createMockDocument = (overrides = {}) => ({
+  '@timestamp': '2023-01-01T00:00:00Z',
+  user: { name: 'test-user' },
+  event: { action: 'login' },
+  ...overrides,
+});
+
+export const createMockEsClient = () => {
+  const mockHelpers = {
+    esql: jest.fn().mockReturnValue({
+      toRecords: jest.fn(),
+    }),
+  };
+
+  return {
+    search: jest.fn(),
+    eql: {
+      search: jest.fn(),
+    },
+    openPointInTime: jest.fn(),
+    closePointInTime: jest.fn(),
+    ilm: {
+      explainLifecycle: jest.fn(),
+    },
+    helpers: mockHelpers,
+    cluster: { health: jest.fn() },
+    nodes: { stats: jest.fn() },
+  };
+};
+
+export const createMockCircuitBreaker = (valid = true, intervalMs = 1000) => ({
+  validate: jest.fn().mockResolvedValue({
+    valid,
+    message: valid ? 'All good' : 'Circuit breaker triggered',
+    circuitBreaker: 'TestCircuitBreaker',
+  }),
+  stats: jest.fn(),
+  validationIntervalMs: jest.fn().mockReturnValue(intervalMs),
+});
+
+export const createMockQuery = (type: QueryType, overrides = {}) => ({
+  id: 'test-query-1',
+  name: 'test-query',
+  index: 'test-index',
+  type,
+  query: type === QueryType.DSL ? '{"query": {"match_all": {}}}' : 'test query',
+  scheduleCron: '5m',
+  filterlist: { 'user.name': Action.KEEP },
+  enabled: true,
+  size: 100,
+  ...overrides,
+});
+
+export const createMockArtifactData = (
+  overrides: Partial<{
+    id: string;
+    name: string;
+    index: string;
+    type: string;
+    query: string;
+    scheduleCron: string;
+    filterlist: string;
+    enabled: boolean;
+  }> = {}
+) => {
+  const defaults = {
+    id: 'test-query-1',
+    name: 'test-query',
+    index: 'test-index',
+    type: 'DSL',
+    query: '{"query": {"match_all": {}}}',
+    scheduleCron: '5m',
+    filterlist: 'user.name: keep',
+    enabled: true,
+  };
+
+  const config = { ...defaults, ...overrides };
+
+  return `---
+id: ${config.id}
+name: ${config.name}
+index: ${config.index}
+type: ${config.type}
+query: '${config.query}'
+scheduleCron: ${config.scheduleCron}
+filterlist:
+  ${config.filterlist}
+enabled: ${config.enabled}`;
+};
+
+// Helper functions for common test patterns
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const createMockSearchResponse = (hits: any[] = [], aggregations?: any) => ({
+  hits: {
+    hits: hits.map((hit) => ({ _source: hit, sort: ['sort1'] })),
+  },
+  ...(aggregations && { aggregations }),
+});
+
+export const createMockEqlResponse = (
+  events?: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
+  sequences?: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
+) => ({
+  hits: {
+    ...(events && { events: events.map((event) => ({ _source: event })) }),
+    ...(sequences && { sequences }),
+  },
+});
+
+export const setupPointInTime = (
+  mockEsClient: ReturnType<typeof createMockEsClient>,
+  pitId = 'test-pit-id'
+) => {
+  mockEsClient.openPointInTime.mockResolvedValue({ id: pitId });
+  mockEsClient.closePointInTime.mockResolvedValue({});
+};
+
+export const createTestObserver = () => {
+  const results: any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const observer = {
+    next: (result: any) => results.push(result), // eslint-disable-line @typescript-eslint/no-explicit-any
+    error: jest.fn(),
+    complete: jest.fn(),
+  };
+  return { results, observer };
+};
+
+export const executeObservableTest = <T>(
+  observable: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  expectations: (results: T[], done: jest.DoneCallback) => void,
+  done: jest.DoneCallback
+) => {
+  const results: T[] = [];
+  observable.subscribe({
+    next: (result: T) => results.push(result),
+    complete: () => expectations(results, done),
+    error: done,
+  });
+};
+
+// Circuit Breaker Test Helpers
+export const createMockEventLoopMonitor = (
+  overrides: Partial<{
+    min: number;
+    max: number;
+    mean: number;
+    exceeds: number;
+    stddev: number;
+    percentiles: Record<number, number>;
+  }> = {}
+) => {
+  const defaults = {
+    min: 1000000,
+    max: 5000000,
+    mean: 2000000,
+    exceeds: 0,
+    stddev: 500000,
+    percentiles: {
+      50: 2000000,
+      75: 3000000,
+      95: 4000000,
+      99: 4500000,
+    },
+  };
+
+  const config = { ...defaults, ...overrides };
+
+  return {
+    enable: jest.fn(),
+    disable: jest.fn(),
+    min: config.min,
+    max: config.max,
+    mean: config.mean,
+    exceeds: config.exceeds,
+    stddev: config.stddev,
+    percentile: jest.fn((p: number) => (config.percentiles as Record<number, number>)[p] || 0),
+  };
+};
+
+export const createMockPerformance = () => ({
+  now: jest.fn(),
+  eventLoopUtilization: jest.fn(),
+});
+
+export const createMockMemoryUsage = (overrides: Partial<NodeJS.MemoryUsage> = {}) => ({
+  rss: 100000000,
+  heapTotal: 50000000,
+  heapUsed: 25000000,
+  external: 1000000,
+  arrayBuffers: 500000,
+  ...overrides,
+});
+
+export const createMockNodeResponse = (
+  overrides: Partial<{
+    timestamp: number;
+    heapUsedPercent: number;
+    cpuPercent: number;
+  }> = {}
+) => {
+  const defaults = {
+    timestamp: 1234567890,
+    heapUsedPercent: 70,
+    cpuPercent: 60,
+  };
+  const config = { ...defaults, ...overrides };
+
+  return {
+    timestamp: config.timestamp,
+    jvm: { mem: { heap_used_percent: config.heapUsedPercent } },
+    os: { cpu: { percent: config.cpuPercent } },
+  };
+};
+
+export const createElasticsearchCircuitBreakerConfig = (
+  overrides: Partial<{
+    maxJvmHeapUsedPercent: number;
+    maxCpuPercent: number;
+    expectedClusterHealth: string[];
+    validationIntervalMs: number;
+  }> = {}
+) => ({
+  maxJvmHeapUsedPercent: 85,
+  maxCpuPercent: 90,
+  expectedClusterHealth: ['green', 'yellow'],
+  validationIntervalMs: 5000,
+  ...overrides,
+});
+
+export const createEventLoopDelayCircuitBreakerConfig = (
+  overrides: Partial<{
+    thresholdMillis: number;
+    validationIntervalMs: number;
+  }> = {}
+) => ({
+  thresholdMillis: 10,
+  validationIntervalMs: 5000,
+  ...overrides,
+});
+
+export const createEventLoopUtilizationCircuitBreakerConfig = (
+  overrides: Partial<{
+    thresholdMillis: number;
+    validationIntervalMs: number;
+  }> = {}
+) => ({
+  thresholdMillis: 1000,
+  validationIntervalMs: 5000,
+  ...overrides,
+});
+
+export const createRssGrowthCircuitBreakerConfig = (
+  overrides: Partial<{
+    maxRssGrowthPercent: number;
+    validationIntervalMs: number;
+  }> = {}
+) => ({
+  maxRssGrowthPercent: 50,
+  validationIntervalMs: 5000,
+  ...overrides,
+});
+
+export const createTimeoutCircuitBreakerConfig = (
+  overrides: Partial<{
+    timeoutMillis: number;
+    validationIntervalMs: number;
+  }> = {}
+) => ({
+  timeoutMillis: 5000,
+  validationIntervalMs: 1000,
+  ...overrides,
+});
+
+// Test assertion helpers
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const expectValidCircuitBreakerResult = (result: any, circuitBreakerName: string) => {
+  expect(result.valid).toBe(true);
+  expect(result.circuitBreaker).toBe(circuitBreakerName);
+  expect(result.message).toBeUndefined();
+};
+
+export const expectInvalidCircuitBreakerResult = (
+  result: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  circuitBreakerName: string,
+  expectedMessage?: string
+) => {
+  expect(result.valid).toBe(false);
+  expect(result.circuitBreaker).toBe(circuitBreakerName);
+  if (expectedMessage) {
+    expect(result.message).toContain(expectedMessage);
+  } else {
+    expect(result.message).toBeDefined();
+  }
+};
+
+// Common test setup functions
+export const setupMockPerformanceHooks = () => {
+  const mockPerformance = createMockPerformance();
+  const mockMonitorEventLoopDelay = jest.fn();
+
+  // Mock perf_hooks module
+  jest.doMock('perf_hooks', () => ({
+    performance: mockPerformance,
+    monitorEventLoopDelay: mockMonitorEventLoopDelay,
+  }));
+
+  return { mockPerformance, mockMonitorEventLoopDelay };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/circuit_breakers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/circuit_breakers.test.ts
@@ -1,0 +1,653 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { performance } from 'perf_hooks';
+import { ElasticsearchCircuitBreaker } from './elastic_search_circuit_breaker';
+import {
+  EventLoopDelayCircuitBreaker,
+  ONE_MILLISECOND_AS_NANOSECONDS,
+} from './event_loop_delay_circuit_breaker';
+import { EventLoopUtilizationCircuitBreaker } from './event_loop_utilization_circuit_breaker';
+import { RssGrowthCircuitBreaker } from './rss_growth_circuit_breaker';
+import { TimeoutCircuitBreaker } from './timeout_circuit_breaker';
+import {
+  createMockEsClient,
+  createMockEventLoopMonitor,
+  createMockPerformance,
+  createMockMemoryUsage,
+  createMockNodeResponse,
+  createElasticsearchCircuitBreakerConfig,
+  createEventLoopDelayCircuitBreakerConfig,
+  createEventLoopUtilizationCircuitBreakerConfig,
+  createRssGrowthCircuitBreakerConfig,
+  createTimeoutCircuitBreakerConfig,
+  expectValidCircuitBreakerResult,
+  expectInvalidCircuitBreakerResult,
+} from '../__mocks__';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import * as perf_hooks from 'perf_hooks';
+
+jest.mock('perf_hooks', () => ({
+  performance: {
+    now: jest.fn(),
+    eventLoopUtilization: jest.fn(),
+  },
+  monitorEventLoopDelay: jest.fn(),
+}));
+
+const mockPerformance = performance as jest.Mocked<typeof performance>;
+const mockMonitorEventLoopDelay = perf_hooks.monitorEventLoopDelay as jest.MockedFunction<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+describe('Security Solution - Health Diagnostic Queries - Circuit Breakers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(process, 'memoryUsage').mockReturnValue(createMockMemoryUsage());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('ElasticsearchCircuitBreaker', () => {
+    let mockEsClient: ReturnType<typeof createMockEsClient>;
+    let circuitBreaker: ElasticsearchCircuitBreaker;
+
+    beforeEach(() => {
+      mockEsClient = createMockEsClient();
+    });
+
+    const createCircuitBreaker = (configOverrides = {}) => {
+      const config = createElasticsearchCircuitBreakerConfig(configOverrides);
+      return new ElasticsearchCircuitBreaker(config, mockEsClient as any as ElasticsearchClient); // eslint-disable-line @typescript-eslint/no-explicit-any
+    };
+
+    describe('constructor validation', () => {
+      test('should accept valid maxJvmHeapUsedPercent values', () => {
+        expect(() => createCircuitBreaker({ maxJvmHeapUsedPercent: 50 })).not.toThrow();
+      });
+
+      test('should throw error for negative maxJvmHeapUsedPercent', () => {
+        expect(() => createCircuitBreaker({ maxJvmHeapUsedPercent: -1 })).toThrow(
+          'maxJvmHeapUsedPercent must be between 0 and 100'
+        );
+      });
+
+      test('should throw error for maxJvmHeapUsedPercent over 100', () => {
+        expect(() => createCircuitBreaker({ maxJvmHeapUsedPercent: 101 })).toThrow(
+          'maxJvmHeapUsedPercent must be between 0 and 100'
+        );
+      });
+    });
+
+    describe('validate()', () => {
+      beforeEach(() => {
+        circuitBreaker = createCircuitBreaker();
+      });
+
+      const setupHealthyClusterResponse = (nodeOverrides = {}) => {
+        mockEsClient.cluster.health.mockResolvedValue({ status: 'green' });
+        mockEsClient.nodes.stats.mockResolvedValue({
+          nodes: {
+            node1: createMockNodeResponse(nodeOverrides),
+          },
+        });
+      };
+
+      test('should succeed with healthy cluster and nodes', async () => {
+        setupHealthyClusterResponse();
+        const result = await circuitBreaker.validate();
+        expectValidCircuitBreakerResult(result, 'ElasticsearchCircuitBreaker');
+      });
+
+      test('should fail with unhealthy cluster status', async () => {
+        mockEsClient.cluster.health.mockResolvedValue({ status: 'red' });
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'Elasticsearch cluster health is red'
+        );
+      });
+
+      test('should fail when no nodes found', async () => {
+        mockEsClient.cluster.health.mockResolvedValue({ status: 'green' });
+        mockEsClient.nodes.stats.mockResolvedValue({ nodes: {} });
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'No Elasticsearch nodes found'
+        );
+      });
+
+      test('should fail when node is stale (no timestamp)', async () => {
+        setupHealthyClusterResponse({ timestamp: undefined });
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'Node node1 is stale'
+        );
+      });
+
+      test('should fail when node timestamp has not changed', async () => {
+        const timestamp = 1234567890;
+        setupHealthyClusterResponse({ timestamp });
+
+        // First call should succeed
+        let result = await circuitBreaker.validate();
+        expect(result.valid).toBe(true);
+
+        // Second call with same timestamp should fail
+        result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'Node node1 is stale'
+        );
+      });
+
+      test('should fail when JVM heap usage exceeds threshold', async () => {
+        setupHealthyClusterResponse({ heapUsedPercent: 90 }); // Above 85% threshold
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'Node node1 JVM heap used 90% exceeds threshold'
+        );
+      });
+
+      test('should fail when CPU usage exceeds threshold', async () => {
+        setupHealthyClusterResponse({ cpuPercent: 95 }); // Above 90% threshold
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'Node node1 CPU usage 95% exceeds threshold'
+        );
+      });
+
+      test('should handle Elasticsearch client errors', async () => {
+        mockEsClient.cluster.health.mockRejectedValue(new Error('Connection failed'));
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'Failed to get ES cluster or node stats: Connection failed'
+        );
+      });
+
+      test('should handle missing JVM or OS stats gracefully', async () => {
+        mockEsClient.cluster.health.mockResolvedValue({ status: 'green' });
+        mockEsClient.nodes.stats.mockResolvedValue({
+          nodes: {
+            node1: {
+              timestamp: 1234567890,
+              // Missing jvm and os stats
+            },
+          },
+        });
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'ElasticsearchCircuitBreaker',
+          'Node node1 missing metrics. JVM: undefined, OS: undefined'
+        );
+      });
+    });
+
+    describe('stats()', () => {
+      test('should return initial stats', () => {
+        circuitBreaker = createCircuitBreaker();
+        const stats = circuitBreaker.stats();
+        expect(stats).toEqual({
+          clusterHealth: 'green',
+          jvmHeapUsedPercentPerNode: undefined,
+          cpuPercentPerNode: undefined,
+        });
+      });
+    });
+
+    describe('validationIntervalMs()', () => {
+      test('should return configured validation interval', () => {
+        circuitBreaker = createCircuitBreaker({ validationIntervalMs: 10000 });
+        expect(circuitBreaker.validationIntervalMs()).toBe(10000);
+      });
+    });
+  });
+
+  describe('EventLoopDelayCircuitBreaker', () => {
+    let mockMonitor: ReturnType<typeof createMockEventLoopMonitor>;
+
+    beforeEach(() => {
+      mockMonitor = createMockEventLoopMonitor();
+      mockMonitorEventLoopDelay.mockReturnValue(mockMonitor);
+    });
+
+    const createCircuitBreaker = (configOverrides = {}) => {
+      const config = createEventLoopDelayCircuitBreakerConfig(configOverrides);
+      return new EventLoopDelayCircuitBreaker(config);
+    };
+
+    describe('constructor', () => {
+      test('should create monitor and enable it', () => {
+        createCircuitBreaker();
+        expect(mockMonitorEventLoopDelay).toHaveBeenCalled();
+        expect(mockMonitor.enable).toHaveBeenCalled();
+      });
+    });
+
+    describe('validate()', () => {
+      test('should succeed when mean delay is below threshold', async () => {
+        const circuitBreaker = createCircuitBreaker({ thresholdMillis: 5 });
+        const result = await circuitBreaker.validate();
+        expectValidCircuitBreakerResult(result, 'EventLoopDelayCircuitBreaker');
+      });
+
+      test('should fail when mean delay exceeds threshold', async () => {
+        mockMonitor.mean = 8000000; // 8ms in nanoseconds
+        const circuitBreaker = createCircuitBreaker({ thresholdMillis: 5 });
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'EventLoopDelayCircuitBreaker',
+          'Event loop delay mean 8.00ms exceeds threshold'
+        );
+      });
+
+      test('should disable and re-enable monitor during validation', async () => {
+        const circuitBreaker = createCircuitBreaker();
+        await circuitBreaker.validate();
+        expect(mockMonitor.disable).toHaveBeenCalled();
+        expect(mockMonitor.enable).toHaveBeenCalledTimes(2); // Once in constructor, once after validation
+      });
+
+      test('should convert nanoseconds to milliseconds correctly', async () => {
+        mockMonitor.mean = 3500000; // 3.5ms in nanoseconds
+        const circuitBreaker = createCircuitBreaker();
+        await circuitBreaker.validate();
+        const stats = circuitBreaker.stats() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(stats.mean).toBe(3.5);
+      });
+    });
+
+    describe('stats()', () => {
+      test('should return histogram data in milliseconds', async () => {
+        const circuitBreaker = createCircuitBreaker();
+        await circuitBreaker.validate();
+        const stats = circuitBreaker.stats() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        expect(stats).toMatchObject({
+          min: 1, // 1ms
+          max: 5, // 5ms
+          mean: 2, // 2ms
+          exceeds: 0,
+          stddev: 0.5, // 0.5ms
+          percentiles: {
+            50: 2,
+            75: 3,
+            95: 4,
+            99: 4.5,
+          },
+        });
+        expect(typeof stats.fromTimestamp).toBe('string');
+        expect(typeof stats.lastUpdatedAt).toBe('string');
+      });
+    });
+
+    describe('validationIntervalMs()', () => {
+      test('should return configured validation interval', () => {
+        const circuitBreaker = createCircuitBreaker({ validationIntervalMs: 8000 });
+        expect(circuitBreaker.validationIntervalMs()).toBe(8000);
+      });
+    });
+
+    describe('nsToMs conversion', () => {
+      test('should convert nanoseconds to milliseconds correctly', async () => {
+        expect(ONE_MILLISECOND_AS_NANOSECONDS).toBe(1_000_000);
+
+        const circuitBreaker = createCircuitBreaker();
+        mockMonitor.mean = 5_500_000; // 5.5ms in nanoseconds
+        await circuitBreaker.validate();
+        const stats = circuitBreaker.stats() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(stats.mean).toBe(5.5);
+      });
+    });
+  });
+
+  describe('EventLoopUtilizationCircuitBreaker', () => {
+    const mockPerf = createMockPerformance();
+
+    beforeEach(() => {
+      Object.assign(mockPerformance, mockPerf);
+      mockPerformance.eventLoopUtilization.mockReturnValue({
+        idle: 500,
+        active: 100,
+        utilization: 0.2,
+      });
+    });
+
+    const createCircuitBreaker = (configOverrides = {}) => {
+      const config = createEventLoopUtilizationCircuitBreakerConfig(configOverrides);
+      return new EventLoopUtilizationCircuitBreaker(config);
+    };
+
+    describe('constructor', () => {
+      test('should initialize with start utilization', () => {
+        createCircuitBreaker();
+        expect(mockPerformance.eventLoopUtilization).toHaveBeenCalledWith();
+      });
+    });
+
+    describe('validate()', () => {
+      test('should succeed when active time is below threshold', async () => {
+        mockPerformance.eventLoopUtilization
+          .mockReturnValueOnce({
+            idle: 900,
+            active: 100,
+            utilization: 0.1,
+          })
+          .mockReturnValueOnce({
+            idle: 900,
+            active: 500, // Below 1000ms threshold
+            utilization: 0.35,
+          });
+
+        const circuitBreaker = createCircuitBreaker();
+        const result = await circuitBreaker.validate();
+        expectValidCircuitBreakerResult(result, 'EventLoopUtilizationCircuitBreaker');
+      });
+
+      test('should fail when active time exceeds threshold', async () => {
+        mockPerformance.eventLoopUtilization
+          .mockReturnValueOnce({
+            idle: 500,
+            active: 100,
+            utilization: 0.2,
+          })
+          .mockReturnValueOnce({
+            idle: 500,
+            active: 1500, // Above 1000ms threshold
+            utilization: 0.75,
+          });
+
+        const circuitBreaker = createCircuitBreaker();
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'EventLoopUtilizationCircuitBreaker',
+          'Event loop utilization exceeded: 1500'
+        );
+      });
+
+      test('should handle edge case of exactly threshold value', async () => {
+        mockPerformance.eventLoopUtilization
+          .mockReturnValueOnce({
+            idle: 500,
+            active: 100,
+            utilization: 0.2,
+          })
+          .mockReturnValueOnce({
+            idle: 500,
+            active: 1000, // Exactly at threshold
+            utilization: 0.67,
+          });
+
+        const circuitBreaker = createCircuitBreaker();
+        const result = await circuitBreaker.validate();
+        expect(result.valid).toBe(true); // Should succeed when equal to threshold
+      });
+    });
+
+    describe('stats()', () => {
+      test('should return start utilization', () => {
+        const startUtilization = {
+          idle: 500,
+          active: 100,
+          utilization: 0.2,
+        };
+        mockPerformance.eventLoopUtilization.mockReturnValue(startUtilization);
+
+        const circuitBreaker = createCircuitBreaker();
+        const stats = circuitBreaker.stats();
+        expect(stats).toEqual({ startUtilization });
+      });
+    });
+
+    describe('validationIntervalMs()', () => {
+      test('should return configured validation interval', () => {
+        const circuitBreaker = createCircuitBreaker({ validationIntervalMs: 3000 });
+        expect(circuitBreaker.validationIntervalMs()).toBe(3000);
+      });
+    });
+  });
+
+  describe('RssGrowthCircuitBreaker', () => {
+    const createCircuitBreaker = (configOverrides = {}) => {
+      const config = createRssGrowthCircuitBreakerConfig(configOverrides);
+      return new RssGrowthCircuitBreaker(config);
+    };
+
+    const setupMemoryUsage = (rss: number) => {
+      jest.spyOn(process, 'memoryUsage').mockReturnValue(createMockMemoryUsage({ rss }));
+    };
+
+    describe('constructor validation', () => {
+      test('should accept valid maxRssGrowthPercent values', () => {
+        expect(() => createCircuitBreaker()).not.toThrow();
+      });
+
+      test('should throw error for negative maxRssGrowthPercent', () => {
+        expect(() => createCircuitBreaker({ maxRssGrowthPercent: -1 })).toThrow(
+          'maxRssGrowthPercent must be between 0 and 100'
+        );
+      });
+
+      test('should throw error for maxRssGrowthPercent over 100', () => {
+        expect(() => createCircuitBreaker({ maxRssGrowthPercent: 101 })).toThrow(
+          'maxRssGrowthPercent must be between 0 and 100'
+        );
+      });
+
+      test('should initialize with current RSS as initial value', () => {
+        const circuitBreaker = createCircuitBreaker();
+        const stats = circuitBreaker.stats() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(stats.initialRss).toBe(100000000);
+        expect(stats.maxRss).toBe(100000000);
+        expect(stats.maxPercentGrowth).toBe(0);
+      });
+    });
+
+    describe('validate()', () => {
+      test('should succeed when RSS growth is below threshold', async () => {
+        const circuitBreaker = createCircuitBreaker();
+        setupMemoryUsage(130000000); // 30% growth (within 50% threshold)
+
+        const result = await circuitBreaker.validate();
+        expectValidCircuitBreakerResult(result, 'RssGrowthCircuitBreaker');
+      });
+
+      test('should fail when RSS growth exceeds threshold', async () => {
+        const circuitBreaker = createCircuitBreaker();
+        setupMemoryUsage(160000000); // 60% growth (above 50% threshold)
+
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'RssGrowthCircuitBreaker',
+          'RSS growth exceeded: 60.00% - max allowed: 50%'
+        );
+      });
+
+      test('should handle RSS decrease gracefully', async () => {
+        const circuitBreaker = createCircuitBreaker();
+        setupMemoryUsage(80000000); // Decrease from 100MB
+
+        const result = await circuitBreaker.validate();
+        expect(result.valid).toBe(true); // Should succeed with negative growth
+      });
+
+      test('should track maximum RSS and growth values', async () => {
+        const circuitBreaker = createCircuitBreaker({ maxRssGrowthPercent: 100 });
+
+        // First increase
+        setupMemoryUsage(120000000); // 20% growth
+        await circuitBreaker.validate();
+
+        // Second increase
+        setupMemoryUsage(140000000); // 40% growth from initial
+        await circuitBreaker.validate();
+
+        const stats = circuitBreaker.stats() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(stats.maxRss).toBe(140000000);
+        expect(stats.maxPercentGrowth).toBe(40);
+      });
+
+      test('should handle edge case of exactly threshold value', async () => {
+        const circuitBreaker = createCircuitBreaker();
+        setupMemoryUsage(150000000); // Exactly 50% growth
+
+        const result = await circuitBreaker.validate();
+        expect(result.valid).toBe(true); // Should succeed when equal to threshold
+      });
+    });
+
+    describe('stats()', () => {
+      test('should return current RSS statistics', async () => {
+        const circuitBreaker = createCircuitBreaker();
+        setupMemoryUsage(120000000); // 20% growth
+        await circuitBreaker.validate();
+
+        const stats = circuitBreaker.stats();
+        expect(stats).toEqual({
+          initialRss: 100000000,
+          maxRss: 120000000,
+          maxPercentGrowth: 20,
+        });
+      });
+    });
+
+    describe('validationIntervalMs()', () => {
+      test('should return configured validation interval', () => {
+        const circuitBreaker = createCircuitBreaker({ validationIntervalMs: 7000 });
+        expect(circuitBreaker.validationIntervalMs()).toBe(7000);
+      });
+    });
+  });
+
+  describe('TimeoutCircuitBreaker', () => {
+    beforeEach(() => {
+      mockPerformance.now.mockReturnValue(1000); // Initial time
+    });
+
+    const createCircuitBreaker = (configOverrides = {}) => {
+      const config = createTimeoutCircuitBreakerConfig(configOverrides);
+      return new TimeoutCircuitBreaker(config);
+    };
+
+    describe('constructor', () => {
+      test('should initialize with current performance time', () => {
+        createCircuitBreaker();
+        expect(mockPerformance.now).toHaveBeenCalled();
+      });
+    });
+
+    describe('validate()', () => {
+      test('should succeed when time elapsed is below timeout', async () => {
+        mockPerformance.now
+          .mockReturnValueOnce(1000) // Constructor
+          .mockReturnValueOnce(3000); // Validation (2000ms elapsed)
+
+        const circuitBreaker = createCircuitBreaker();
+        const result = await circuitBreaker.validate();
+        expectValidCircuitBreakerResult(result, 'TimeoutCircuitBreaker');
+      });
+
+      test('should fail when timeout is exceeded', async () => {
+        mockPerformance.now
+          .mockReturnValueOnce(1000) // Constructor
+          .mockReturnValueOnce(7000); // Validation (6000ms elapsed, above 5000ms timeout)
+
+        const circuitBreaker = createCircuitBreaker();
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'TimeoutCircuitBreaker',
+          'Timeout exceeded: 5000 ms'
+        );
+      });
+
+      test('should handle edge case of exactly timeout value', async () => {
+        mockPerformance.now
+          .mockReturnValueOnce(1000) // Constructor
+          .mockReturnValueOnce(6000); // Validation (5000ms elapsed, exactly at timeout)
+
+        const circuitBreaker = createCircuitBreaker();
+        const result = await circuitBreaker.validate();
+        expect(result.valid).toBe(true); // Should succeed when equal to timeout
+      });
+
+      test('should handle zero timeout', async () => {
+        mockPerformance.now
+          .mockReturnValueOnce(1000) // Constructor
+          .mockReturnValueOnce(1001); // Validation (1ms elapsed, above 0ms timeout)
+
+        const circuitBreaker = createCircuitBreaker({ timeoutMillis: 0 });
+        const result = await circuitBreaker.validate();
+        expectInvalidCircuitBreakerResult(
+          result,
+          'TimeoutCircuitBreaker',
+          'Timeout exceeded: 0 ms'
+        );
+      });
+
+      test('should handle very large timeout values', async () => {
+        mockPerformance.now
+          .mockReturnValueOnce(1000) // Constructor
+          .mockReturnValueOnce(100000); // Validation (99000ms elapsed)
+
+        const circuitBreaker = createCircuitBreaker({ timeoutMillis: Number.MAX_SAFE_INTEGER });
+        const result = await circuitBreaker.validate();
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('stats()', () => {
+      test('should return start time and elapsed time', () => {
+        mockPerformance.now
+          .mockReturnValueOnce(1000) // Constructor
+          .mockReturnValueOnce(3500); // Stats call
+
+        const circuitBreaker = createCircuitBreaker();
+        const stats = circuitBreaker.stats();
+        expect(stats).toEqual({
+          started: 1000,
+          elapsed: 2500, // 3500 - 1000
+        });
+      });
+
+      test('should calculate elapsed time correctly for multiple calls', async () => {
+        mockPerformance.now
+          .mockReturnValueOnce(1000) // Constructor
+          .mockReturnValueOnce(2000) // validate call
+          .mockReturnValueOnce(4000); // stats call
+
+        const circuitBreaker = createCircuitBreaker();
+        await circuitBreaker.validate();
+        const stats = circuitBreaker.stats() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(stats.elapsed).toBe(3000);
+      });
+    });
+
+    describe('validationIntervalMs()', () => {
+      test('should return configured validation interval', () => {
+        const circuitBreaker = createCircuitBreaker({ validationIntervalMs: 2000 });
+        expect(circuitBreaker.validationIntervalMs()).toBe(2000);
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/elastic_search_circuit_breaker.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/elastic_search_circuit_breaker.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HealthStatus } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { CircuitBreakerResult } from '../health_diagnostic_circuit_breakers.types';
+import { BaseCircuitBreaker } from './utils';
+
+/**
+ * Configuration interface for Elasticsearch Circuit Breaker.
+ */
+export interface ElasticsearchCircuitBreakerConfig {
+  /** Maximum allowed JVM heap usage percentage. */
+  maxJvmHeapUsedPercent: number;
+  /** Maximum allowed CPU usage percentage. */
+  maxCpuPercent: number;
+  /** Expected cluster health statuses that allow query execution. */
+  expectedClusterHealth: string[];
+  /** Interval in milliseconds between cluster health validations. */
+  validationIntervalMs: number;
+}
+
+export class ElasticsearchCircuitBreaker extends BaseCircuitBreaker {
+  private lastHealth: HealthStatus = 'green';
+  private lastJvmStats: Record<string, unknown> | undefined;
+  private lastCpuStats: Record<string, unknown> | undefined;
+  private nodeTimestamps: Record<string, number> = {};
+
+  constructor(
+    private readonly config: ElasticsearchCircuitBreakerConfig,
+    private readonly client: ElasticsearchClient
+  ) {
+    super();
+    if (config.maxJvmHeapUsedPercent < 0 || config.maxJvmHeapUsedPercent > 100) {
+      throw new Error('maxJvmHeapUsedPercent must be between 0 and 100');
+    }
+  }
+
+  async validate(): Promise<CircuitBreakerResult> {
+    try {
+      const healthResp = await this.client.cluster.health();
+      this.lastHealth = healthResp.status;
+      const status = this.lastHealth;
+
+      if (!this.config.expectedClusterHealth.includes(status as string)) {
+        return this.failure(`Elasticsearch cluster health is ${status}`);
+      }
+
+      const nodesResp = await this.client.nodes.stats({
+        metric: ['jvm', 'os'],
+      });
+
+      if (!nodesResp.nodes || Object.keys(nodesResp.nodes).length === 0) {
+        return this.failure('No Elasticsearch nodes found');
+      }
+
+      this.lastJvmStats = {};
+      this.lastCpuStats = {};
+
+      for (const nodeId of Object.keys(nodesResp.nodes)) {
+        const node = nodesResp.nodes[nodeId];
+        const currentTimestamp = node.timestamp;
+        const lastReportedTimestamp = this.nodeTimestamps[nodeId];
+
+        if (currentTimestamp === undefined || lastReportedTimestamp === currentTimestamp) {
+          return this.failure(
+            `Node ${nodeId} is stale: no timestamp updates detected. Current timestamp=${currentTimestamp}, Last reported timestamp=${lastReportedTimestamp}`
+          );
+        }
+
+        this.nodeTimestamps[nodeId] = currentTimestamp;
+
+        const jvm = node.jvm;
+        const os = node.os;
+
+        if (jvm?.mem?.heap_used_percent !== undefined && os?.cpu?.percent !== undefined) {
+          const heapUsedPercent = jvm.mem.heap_used_percent;
+          const cpuPercent = os.cpu.percent;
+
+          this.lastJvmStats[nodeId] = heapUsedPercent;
+          this.lastCpuStats[nodeId] = cpuPercent;
+
+          if (heapUsedPercent > this.config.maxJvmHeapUsedPercent) {
+            return this.failure(
+              `Node ${nodeId} JVM heap used ${heapUsedPercent}% exceeds threshold`
+            );
+          }
+
+          if (cpuPercent > this.config.maxCpuPercent) {
+            return this.failure(`Node ${nodeId} CPU usage ${cpuPercent}% exceeds threshold`);
+          }
+        } else {
+          return this.failure(`Node ${nodeId} missing metrics. JVM: ${jvm?.mem}, OS: ${os?.cpu}`);
+        }
+      }
+
+      return this.success();
+    } catch (error) {
+      return this.failure(`Failed to get ES cluster or node stats: ${(error as Error).message}`);
+    }
+  }
+
+  stats(): unknown {
+    return {
+      clusterHealth: this.lastHealth,
+      jvmHeapUsedPercentPerNode: this.lastJvmStats,
+      cpuPercentPerNode: this.lastCpuStats,
+    };
+  }
+
+  validationIntervalMs(): number {
+    return this.config.validationIntervalMs;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/event_loop_delay_circuit_breaker.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/event_loop_delay_circuit_breaker.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IntervalHistogram } from '@kbn/core-metrics-server';
+import { type IntervalHistogram as PerfIntervalHistogram, monitorEventLoopDelay } from 'perf_hooks';
+import type { CircuitBreakerResult } from '../health_diagnostic_circuit_breakers.types';
+import { BaseCircuitBreaker } from './utils';
+
+export const ONE_MILLISECOND_AS_NANOSECONDS = 1_000_000;
+
+/**
+ * Configuration interface for Event Loop Delay Circuit Breaker.
+ */
+export interface EventLoopDelayCircuitBreakerConfig {
+  /** Threshold in milliseconds for event loop delay before triggering. */
+  thresholdMillis: number;
+  /** Interval in milliseconds between event loop delay measurements. */
+  validationIntervalMs: number;
+}
+
+export class EventLoopDelayCircuitBreaker extends BaseCircuitBreaker {
+  private readonly loopMonitor: PerfIntervalHistogram;
+  private fromTimestamp: Date;
+  private lastHistogram: IntervalHistogram = {
+    min: 0,
+    max: 0,
+    mean: 0,
+    exceeds: 0,
+    stddev: 0,
+    fromTimestamp: '',
+    lastUpdatedAt: '',
+    percentiles: {
+      50: 0,
+      75: 0,
+      95: 0,
+      99: 0,
+    },
+  };
+
+  constructor(private readonly config: EventLoopDelayCircuitBreakerConfig) {
+    super();
+    const monitor = monitorEventLoopDelay();
+    monitor.enable();
+    this.fromTimestamp = new Date();
+    this.loopMonitor = monitor;
+  }
+
+  async validate(): Promise<CircuitBreakerResult> {
+    const lastUpdated = new Date();
+    this.loopMonitor.disable();
+    const {
+      min: minNs,
+      max: maxNs,
+      mean: meanNs,
+      exceeds: exceedsNs,
+      stddev: stddevNs,
+    } = this.loopMonitor;
+
+    this.lastHistogram = {
+      min: this.nsToMs(minNs),
+      max: this.nsToMs(maxNs),
+      mean: this.nsToMs(meanNs),
+      exceeds: this.nsToMs(exceedsNs),
+      stddev: this.nsToMs(stddevNs),
+      fromTimestamp: this.fromTimestamp.toISOString(),
+      lastUpdatedAt: lastUpdated.toISOString(),
+      percentiles: {
+        50: this.nsToMs(this.loopMonitor.percentile(50)),
+        75: this.nsToMs(this.loopMonitor.percentile(75)),
+        95: this.nsToMs(this.loopMonitor.percentile(95)),
+        99: this.nsToMs(this.loopMonitor.percentile(99)),
+      },
+    };
+
+    this.loopMonitor.enable();
+
+    if (this.lastHistogram.mean > this.config.thresholdMillis) {
+      return this.failure(
+        `Event loop delay mean ${this.lastHistogram.mean.toFixed(2)}ms exceeds threshold`
+      );
+    }
+
+    return this.success();
+  }
+
+  stats(): unknown {
+    return this.lastHistogram;
+  }
+
+  validationIntervalMs(): number {
+    return this.config.validationIntervalMs;
+  }
+
+  private nsToMs(metric: number) {
+    return metric / ONE_MILLISECOND_AS_NANOSECONDS;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/event_loop_utilization_circuit_breaker.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/event_loop_utilization_circuit_breaker.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type EventLoopUtilization, performance } from 'perf_hooks';
+import type { CircuitBreakerResult } from '../health_diagnostic_circuit_breakers.types';
+import { BaseCircuitBreaker } from './utils';
+
+/**
+ * Configuration interface for Event Loop Utilization Circuit Breaker.
+ */
+export interface EventLoopUtilizationCircuitBreakerConfig {
+  /** Threshold in milliseconds for event loop utilization before triggering. */
+  thresholdMillis: number;
+  /** Interval in milliseconds between event loop utilization checks. */
+  validationIntervalMs: number;
+}
+
+export class EventLoopUtilizationCircuitBreaker extends BaseCircuitBreaker {
+  private readonly startUtilization: EventLoopUtilization;
+
+  constructor(private readonly config: EventLoopUtilizationCircuitBreakerConfig) {
+    super();
+    this.startUtilization = performance.eventLoopUtilization();
+  }
+
+  async validate(): Promise<CircuitBreakerResult> {
+    const eventLoop = performance.eventLoopUtilization(this.startUtilization);
+
+    const exceeded = eventLoop.active > this.config.thresholdMillis;
+
+    if (exceeded) {
+      return this.failure(`Event loop utilization exceeded: ${eventLoop.active.toString()}`);
+    }
+    return this.success();
+  }
+
+  stats(): unknown {
+    return {
+      startUtilization: this.startUtilization,
+    };
+  }
+
+  validationIntervalMs(): number {
+    return this.config.validationIntervalMs;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/rss_growth_circuit_breaker.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/rss_growth_circuit_breaker.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CircuitBreakerResult } from '../health_diagnostic_circuit_breakers.types';
+import { BaseCircuitBreaker } from './utils';
+
+/**
+ * Configuration interface for RSS Growth Circuit Breaker.
+ */
+export interface RssGrowthCircuitBreakerConfig {
+  /** Maximum allowed RSS growth percentage before triggering the circuit breaker. */
+  maxRssGrowthPercent: number;
+  /** Interval in milliseconds between RSS growth validations. */
+  validationIntervalMs: number;
+}
+
+export class RssGrowthCircuitBreaker extends BaseCircuitBreaker {
+  private readonly initialRss: number;
+  private maxRss: number;
+  private maxPercentGrowth: number;
+
+  constructor(private readonly config: RssGrowthCircuitBreakerConfig) {
+    super();
+    if (config.maxRssGrowthPercent < 0 || config.maxRssGrowthPercent > 100) {
+      throw new Error('maxRssGrowthPercent must be between 0 and 100');
+    }
+
+    this.initialRss = process.memoryUsage().rss;
+    this.maxRss = this.initialRss;
+    this.maxPercentGrowth = 0;
+  }
+
+  async validate(): Promise<CircuitBreakerResult> {
+    const currentRss = process.memoryUsage().rss;
+    const percentGrowth = ((currentRss - this.initialRss) / this.initialRss) * 100;
+
+    this.maxRss = Math.max(this.maxRss, currentRss);
+    this.maxPercentGrowth = Math.max(this.maxPercentGrowth, percentGrowth);
+
+    if (percentGrowth > this.config.maxRssGrowthPercent) {
+      return this.failure(
+        `RSS growth exceeded: ${percentGrowth.toFixed(2)}% - max allowed: ${
+          this.config.maxRssGrowthPercent
+        }%`
+      );
+    }
+    return this.success();
+  }
+
+  stats(): unknown {
+    return {
+      initialRss: this.initialRss,
+      maxRss: this.maxRss,
+      maxPercentGrowth: this.maxPercentGrowth,
+    };
+  }
+
+  validationIntervalMs(): number {
+    return this.config.validationIntervalMs;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/timeout_circuit_breaker.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/timeout_circuit_breaker.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { performance } from 'perf_hooks';
+
+import type { CircuitBreakerResult } from '../health_diagnostic_circuit_breakers.types';
+
+import { BaseCircuitBreaker } from './utils';
+
+/**
+ * Configuration interface for Timeout Circuit Breaker.
+ */
+export interface TimeoutCircuitBreakerConfig {
+  /** Maximum allowed execution time in milliseconds before timeout. */
+  timeoutMillis: number;
+  /** Interval in milliseconds between timeout validations. */
+  validationIntervalMs: number;
+}
+
+export class TimeoutCircuitBreaker extends BaseCircuitBreaker {
+  private readonly started: number;
+
+  constructor(private readonly config: TimeoutCircuitBreakerConfig) {
+    super();
+    this.started = performance.now();
+  }
+
+  async validate(): Promise<CircuitBreakerResult> {
+    const now = performance.now();
+
+    if (now > this.started + this.config.timeoutMillis) {
+      return this.failure(`Timeout exceeded: ${this.config.timeoutMillis.toString()} ms`);
+    }
+    return this.success();
+  }
+
+  stats(): unknown {
+    return {
+      started: this.started,
+      elapsed: performance.now() - this.started,
+    };
+  }
+
+  validationIntervalMs(): number {
+    return this.config.validationIntervalMs;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/circuit_breakers/utils.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CircuitBreaker,
+  CircuitBreakerResult,
+} from '../health_diagnostic_circuit_breakers.types';
+
+export abstract class BaseCircuitBreaker implements CircuitBreaker {
+  abstract validate(): Promise<CircuitBreakerResult>;
+  abstract stats(): unknown;
+  abstract validationIntervalMs(): number;
+
+  // helper function to create a success result
+  protected success(): CircuitBreakerResult {
+    return { circuitBreaker: this.constructor.name, valid: true };
+  }
+
+  // helper function to create a failure result
+  protected failure(message: string): CircuitBreakerResult {
+    return { circuitBreaker: this.constructor.name, valid: false, message };
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_circuit_breakers.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_circuit_breakers.types.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Interface for implementing a circuit breaker pattern.
+ * Provides validation logic and exposes internal statistics.
+ */
+export interface CircuitBreaker {
+  /**
+   * Checks if the circuit breaker is currently valid.
+   *
+   * @returns Circuit breaker validation result
+   */
+  validate(): Promise<CircuitBreakerResult>;
+
+  /**
+   * Returns statistics related to the circuit breaker.
+   *
+   * The structure is implementation-specific.
+   */
+  stats(): unknown;
+
+  /**
+   * Gets the interval (in milliseconds) at which the circuit should be revalidated.
+   */
+  validationIntervalMs(): number;
+}
+
+/**
+ * Result of a circuit breaker validation.
+ */
+export interface CircuitBreakerResult {
+  /**
+   * The name of the circuit breaker that was validated.
+   */
+  circuitBreaker: string;
+  /**
+   * Whether the circuit is currently considered valid.
+   */
+  valid: boolean;
+
+  /**
+   * Optional message providing context about the validation result.
+   */
+  message?: string;
+}
+
+export class ValidationError extends Error {
+  constructor(public result: CircuitBreakerResult) {
+    super(result.message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.test.ts
@@ -1,0 +1,366 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CircuitBreakingQueryExecutorImpl } from './health_diagnostic_receiver';
+import { QueryType } from './health_diagnostic_service.types';
+import { ValidationError } from './health_diagnostic_circuit_breakers.types';
+import {
+  createMockLogger,
+  createMockEsClient,
+  createMockCircuitBreaker,
+  createMockQuery,
+  createMockSearchResponse,
+  createMockEqlResponse,
+  setupPointInTime,
+  executeObservableTest,
+} from './__mocks__';
+
+describe('Security Solution - Health Diagnostic Queries - CircuitBreakingQueryExecutor', () => {
+  let queryExecutor: CircuitBreakingQueryExecutorImpl;
+  let mockEsClient: ReturnType<typeof createMockEsClient>;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockEsClient = createMockEsClient();
+    mockLogger = createMockLogger();
+    queryExecutor = new CircuitBreakingQueryExecutorImpl(mockEsClient as any, mockLogger); // eslint-disable-line @typescript-eslint/no-explicit-any
+  });
+
+  describe('DSL queries', () => {
+    const mockDocument = { '@timestamp': '2023-01-01T00:00:00Z', user: { name: 'test-user' } };
+
+    beforeEach(() => {
+      setupPointInTime(mockEsClient);
+    });
+
+    test('should run DSL query successfully', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreakers = [createMockCircuitBreaker(true)];
+
+      mockEsClient.search
+        .mockResolvedValueOnce(createMockSearchResponse([mockDocument]))
+        .mockResolvedValueOnce(createMockSearchResponse([]));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers }),
+        (results, completed) => {
+          expect(results).toHaveLength(1);
+          expect(results[0]).toEqual(mockDocument);
+          expect(mockEsClient.openPointInTime).toHaveBeenCalledWith({
+            index: ['test-index'],
+            keep_alive: '1m',
+          });
+          expect(mockEsClient.search).toHaveBeenCalledTimes(2);
+          // small delay for finalize to execute
+          setTimeout(() => {
+            expect(mockEsClient.closePointInTime).toHaveBeenCalledWith({ id: 'test-pit-id' });
+            completed();
+          }, 10);
+        },
+        done
+      );
+    });
+
+    test('should handle DSL query with aggregations', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+      const aggregations = { bucket_count: { value: 42 } };
+
+      mockEsClient.search.mockResolvedValueOnce(createMockSearchResponse([], aggregations));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        (results) => {
+          expect(results).toHaveLength(1);
+          expect(results[0]).toEqual(aggregations);
+          done();
+        },
+        done
+      );
+    });
+
+    test('should handle multiple pages of DSL results', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+      const doc1 = { ...mockDocument, id: 1 };
+      const doc2 = { ...mockDocument, id: 2 };
+
+      mockEsClient.search
+        .mockResolvedValueOnce(createMockSearchResponse([doc1]))
+        .mockResolvedValueOnce(createMockSearchResponse([doc2]))
+        .mockResolvedValueOnce(createMockSearchResponse([]));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        (results) => {
+          expect(results).toHaveLength(2);
+          expect(results[0]).toEqual(doc1);
+          expect(results[1]).toEqual(doc2);
+          expect(mockEsClient.search).toHaveBeenCalledTimes(3);
+          done();
+        },
+        done
+      );
+    });
+
+    test('should handle queries with tiers filtering', (done) => {
+      const query = createMockQuery(QueryType.DSL, { tiers: ['hot', 'warm'] });
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.ilm.explainLifecycle.mockResolvedValue({
+        indices: {
+          'test-index-000001': { phase: 'hot' },
+          'test-index-000002': { phase: 'warm' },
+          'test-index-000003': { phase: 'cold' },
+        },
+      });
+
+      mockEsClient.search.mockResolvedValue(createMockSearchResponse([]));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        () => {
+          expect(mockEsClient.ilm.explainLifecycle).toHaveBeenCalledWith({
+            index: 'test-index',
+            only_managed: false,
+            filter_path: ['indices.*.phase'],
+          });
+          done();
+        },
+        done
+      );
+    });
+  });
+
+  describe('EQL queries', () => {
+    const mockEvents = [
+      { _source: { '@timestamp': '2023-01-01T00:00:00Z', event: { action: 'login' } } },
+      { _source: { '@timestamp': '2023-01-01T00:01:00Z', event: { action: 'logout' } } },
+    ];
+
+    test('should run EQL query with events successfully', (done) => {
+      const query = createMockQuery(QueryType.EQL, {
+        query: 'process where process.name == "cmd.exe"',
+      });
+      const circuitBreaker = createMockCircuitBreaker(true);
+      const eventSources = mockEvents.map((e) => e._source);
+
+      mockEsClient.eql.search.mockResolvedValue(createMockEqlResponse(eventSources));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        (results) => {
+          expect(results).toHaveLength(2);
+          expect(results[0]).toEqual(eventSources[0]);
+          expect(results[1]).toEqual(eventSources[1]);
+          expect(mockEsClient.eql.search).toHaveBeenCalledWith(
+            {
+              index: ['test-index'],
+              query: 'process where process.name == "cmd.exe"',
+              size: 100,
+            },
+            { signal: expect.any(AbortSignal) }
+          );
+          done();
+        },
+        done
+      );
+    });
+
+    test('should run EQL query with sequences successfully', (done) => {
+      const query = createMockQuery(QueryType.EQL, {
+        query: 'sequence [process where true] [network where true]',
+      });
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      const mockSequences = [
+        {
+          events: [
+            { _source: { '@timestamp': '2023-01-01T00:00:00Z', process: { name: 'cmd.exe' } } },
+            { _source: { '@timestamp': '2023-01-01T00:01:00Z', network: { protocol: 'tcp' } } },
+          ],
+        },
+      ];
+
+      mockEsClient.eql.search.mockResolvedValue(createMockEqlResponse(undefined, mockSequences));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        (results) => {
+          expect(results).toHaveLength(1);
+          expect(results[0]).toEqual(mockSequences[0].events.map((e) => e._source));
+          done();
+        },
+        done
+      );
+    });
+
+    test('should handle EQL query with no results', (done) => {
+      const query = createMockQuery(QueryType.EQL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.eql.search.mockResolvedValue({ hits: {} });
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        (results) => {
+          expect(results).toHaveLength(0);
+          done();
+        },
+        done
+      );
+    });
+  });
+
+  describe('ES|QL queries', () => {
+    test('should run ES|QL query successfully', (done) => {
+      const query = createMockQuery(QueryType.ESQL, { query: 'stats count() by user.name' });
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      const mockRecords = [
+        { 'user.name': 'john', 'count()': 5 },
+        { 'user.name': 'jane', 'count()': 3 },
+      ];
+
+      const mockToRecords = jest.fn().mockResolvedValue({ records: mockRecords });
+      mockEsClient.helpers.esql.mockReturnValue({ toRecords: mockToRecords });
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        (results) => {
+          expect(results).toHaveLength(2);
+          expect(results[0]).toEqual(mockRecords[0]);
+          expect(results[1]).toEqual(mockRecords[1]);
+          expect(mockEsClient.helpers.esql).toHaveBeenCalledWith(
+            { query: 'FROM test-index | stats count() by user.name' },
+            { signal: expect.any(AbortSignal) }
+          );
+          done();
+        },
+        done
+      );
+    });
+
+    test('should handle ES|QL query with FROM clause already present', (done) => {
+      const query = createMockQuery(QueryType.ESQL, {
+        query: 'FROM logs-* | stats count() by user.name',
+      });
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      const mockRecords = [{ 'user.name': 'test', 'count()': 1 }];
+      const mockToRecords = jest.fn().mockResolvedValue({ records: mockRecords });
+      mockEsClient.helpers.esql.mockReturnValue({ toRecords: mockToRecords });
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        () => {
+          expect(mockEsClient.helpers.esql).toHaveBeenCalledWith(
+            { query: 'FROM logs-* | stats count() by user.name' },
+            { signal: expect.any(AbortSignal) }
+          );
+          done();
+        },
+        done
+      );
+    });
+  });
+
+  describe('Circuit breaker functionality', () => {
+    test('should trigger circuit breaker and abort query', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(false, 10);
+
+      setupPointInTime(mockEsClient);
+      mockEsClient.search.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  took: 1,
+                  timed_out: false,
+                  _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+                  hits: {
+                    hits: [],
+                    total: { value: 0, relation: 'eq' },
+                    max_score: null,
+                  },
+                }),
+              100
+            )
+          )
+      );
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          try {
+            expect(error).toBeInstanceOf(ValidationError);
+            expect(error.result.message).toBe('Circuit breaker triggered');
+            expect(error.result.circuitBreaker).toBe('TestCircuitBreaker');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    test('should handle Elasticsearch search errors', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      setupPointInTime(mockEsClient);
+      mockEsClient.ilm.explainLifecycle.mockResolvedValue({
+        indices: { 'test-index-000001': { phase: 'hot' } },
+      });
+      mockEsClient.search.mockRejectedValue(new Error('Elasticsearch error'));
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error.message).toBe('Elasticsearch error');
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should handle unsupported query type', () => {
+      const query = createMockQuery('INVALID' as QueryType);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      expect(() => {
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] });
+      }).toThrow('Unhandled QueryType: INVALID');
+    });
+
+    test('should handle ILM explain lifecycle errors gracefully', (done) => {
+      const query = createMockQuery(QueryType.DSL, { tiers: ['hot'] });
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.ilm.explainLifecycle.mockResolvedValue({ indices: undefined });
+      setupPointInTime(mockEsClient);
+      mockEsClient.search.mockResolvedValue(createMockSearchResponse([]));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        () => {
+          expect(mockEsClient.openPointInTime).toHaveBeenCalledWith({
+            index: ['test-index'],
+            keep_alive: '1m',
+          });
+          done();
+        },
+        done
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  mergeMap,
+  finalize,
+  expand,
+  filter,
+  EMPTY,
+  from,
+  merge,
+  type Observable,
+  takeUntil,
+  map,
+  timer,
+} from 'rxjs';
+import * as rx from 'rxjs';
+import type { ElasticsearchClient, LogMeta, Logger } from '@kbn/core/server';
+import type {
+  EqlSearchRequest,
+  SearchRequest,
+  SortResults,
+} from '@elastic/elasticsearch/lib/api/types';
+import type { QueryConfig, CircuitBreakingQueryExecutor } from './health_diagnostic_receiver.types';
+import {
+  ValidationError,
+  type CircuitBreaker,
+  type CircuitBreakerResult,
+} from './health_diagnostic_circuit_breakers.types';
+import { type HealthDiagnosticQuery, QueryType } from './health_diagnostic_service.types';
+import type { TelemetryLogger } from '../telemetry_logger';
+import { newTelemetryLogger } from '../helpers';
+
+export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExecutor {
+  private readonly logger: TelemetryLogger;
+
+  constructor(private client: ElasticsearchClient, logger: Logger) {
+    this.logger = newTelemetryLogger(logger.get('circuit-breaking-query-executor'));
+  }
+
+  search<T>({ query, circuitBreakers }: QueryConfig): Observable<T> {
+    const controller = new AbortController();
+    const abortSignal = controller.signal;
+    const circuitBreakers$ = this.configureCircuitBreakers(circuitBreakers, controller);
+
+    switch (query.type) {
+      case QueryType.DSL:
+        return this.streamDSL<T>(query, abortSignal).pipe(takeUntil(circuitBreakers$));
+      case QueryType.EQL:
+        return this.streamEql<T>(query, abortSignal).pipe(takeUntil(circuitBreakers$));
+      case QueryType.ESQL:
+        return this.streamEsql<T>(query, abortSignal).pipe(takeUntil(circuitBreakers$));
+      default: {
+        const exhaustiveCheck: never = query.type;
+        throw new Error(`Unhandled QueryType: ${exhaustiveCheck}`);
+      }
+    }
+  }
+
+  streamEsql<T>(diagnosticQuery: HealthDiagnosticQuery, abortSignal: AbortSignal): Observable<T> {
+    const regex = /^[\s\r\n]*FROM/;
+
+    return from(this.indicesFor(diagnosticQuery)).pipe(
+      mergeMap((index) => {
+        const query = regex.test(diagnosticQuery.query)
+          ? diagnosticQuery.query
+          : `FROM ${index} | ${diagnosticQuery.query}`;
+
+        return from(this.client.helpers.esql({ query }, { signal: abortSignal }).toRecords()).pipe(
+          mergeMap((resp) => {
+            return resp.records.map((r) => r as T);
+          })
+        );
+      })
+    );
+  }
+
+  streamEql<T>(diagnosticQuery: HealthDiagnosticQuery, abortSignal: AbortSignal): Observable<T> {
+    return from(this.indicesFor(diagnosticQuery)).pipe(
+      mergeMap((index) => {
+        const request: EqlSearchRequest = {
+          index,
+          query: diagnosticQuery.query,
+          size: diagnosticQuery.size,
+        };
+
+        return from(this.client.eql.search(request, { signal: abortSignal })).pipe(
+          mergeMap((resp) => {
+            if (resp.hits.events) {
+              return resp.hits.events.map((h) => h._source as T);
+            } else if (resp.hits.sequences) {
+              return resp.hits.sequences.map((seq) => seq.events.map((h) => h._source) as T);
+            } else {
+              this.logger.warn(
+                '>> Neither hits.events nor hits.sequences found in the response for query',
+                { queryName: diagnosticQuery.name } as LogMeta
+              );
+              return [];
+            }
+          })
+        );
+      })
+    );
+  }
+
+  streamDSL<T>(
+    diagnosticQuery: HealthDiagnosticQuery,
+    abortSignal: AbortSignal,
+    pitKeepAlive: string = '1m'
+  ): Observable<T> {
+    let pitId: string;
+    let searchAfter: SortResults | undefined;
+    const pageSize = diagnosticQuery.size ?? 10000;
+
+    const query: SearchRequest = JSON.parse(diagnosticQuery.query) as SearchRequest;
+
+    const fetchPage = () => {
+      const paginatedRequest: SearchRequest = {
+        size: pageSize,
+        sort: [{ _shard_doc: 'asc' }],
+        search_after: searchAfter,
+        pit: { id: pitId, keep_alive: pitKeepAlive },
+        ...query,
+      };
+      return this.client.search<T>(paginatedRequest, { signal: abortSignal });
+    };
+
+    return from(this.indicesFor(diagnosticQuery)).pipe(
+      mergeMap((index) => from(this.client.openPointInTime({ index, keep_alive: pitKeepAlive }))),
+
+      map((res) => res.id),
+
+      mergeMap((id) => {
+        pitId = id;
+        return from(fetchPage());
+      }),
+      expand((searchResponse) => {
+        const hits = searchResponse.hits.hits;
+        const aggrs = searchResponse.aggregations;
+
+        if (aggrs || hits.length === 0) {
+          return EMPTY;
+        }
+
+        searchAfter = hits[hits.length - 1].sort;
+        return from(fetchPage());
+      }),
+
+      mergeMap((searchResponse) => {
+        if (searchResponse.aggregations) {
+          return [searchResponse.aggregations as T];
+        } else {
+          return searchResponse.hits.hits.map((h) => h._source as T);
+        }
+      }),
+
+      finalize(() => {
+        this.client.closePointInTime({ id: pitId }).catch((error) => {
+          this.logger.warn('>> closePointInTime error', { error });
+        });
+      })
+    );
+  }
+
+  configureCircuitBreakers(
+    circuitBreakers: CircuitBreaker[],
+    controller: AbortController
+  ): Observable<CircuitBreakerResult> {
+    return merge(
+      ...circuitBreakers.map((cb) =>
+        timer(0, cb.validationIntervalMs()).pipe(
+          rx.mergeMap(() => rx.from(cb.validate())),
+          filter((result) => !result.valid)
+        )
+      )
+    ).pipe(
+      map((result) => {
+        this.logger.debug('>> Circuit breaker triggered', { circuitBreaker: result } as LogMeta);
+        controller.abort();
+        throw new ValidationError(result);
+      })
+    );
+  }
+
+  /**
+   * Returns the list of indices to query based on the provided tiers.
+   * When running in serverless or `query.index` is not managed by an ILM, returns
+   * the same `query.index`.
+   *
+   * @param query The health diagnostic query object.
+   * @returns A Promise resolving to an array of indices.
+   */
+  async indicesFor(query: HealthDiagnosticQuery): Promise<string[]> {
+    if (query.tiers === undefined) {
+      this.logger.debug('No tiers defined in the query, returning index as is', {
+        queryName: query.name,
+      } as LogMeta);
+      return [query.index];
+    }
+    const tiers = query.tiers;
+
+    return (
+      await this.client.ilm
+        .explainLifecycle({
+          index: query.index,
+          only_managed: false,
+          filter_path: ['indices.*.phase'],
+        })
+        .then((response) => {
+          if (response.indices === undefined) {
+            this.logger.debug(
+              'Got an empty response while explaining lifecycle. Asumming serverless.',
+              {
+                index: query.index,
+              } as LogMeta
+            );
+            return [query.index];
+          } else {
+            const indices = Object.entries(response.indices).map(([indexName, stats]) => {
+              if ('phase' in stats && stats.phase) {
+                if (tiers.includes(stats.phase)) {
+                  return indexName;
+                } else {
+                  this.logger.debug('Index is not in the expected phases', {
+                    phase: stats.phase,
+                    index: indexName,
+                    tiers,
+                  } as LogMeta);
+                  return '';
+                }
+              } else {
+                // should not happen, but just in case
+                this.logger.debug('Index is not managed by an ILM', {
+                  index: indexName,
+                  tiers,
+                } as LogMeta);
+                return '';
+              }
+            });
+            this.logger.debug('Indices managed by ILM', {
+              queryName: query.name,
+              tiers: query.tiers,
+              indices,
+            } as LogMeta);
+            return indices;
+          }
+        })
+    ).filter((indexName) => indexName !== '');
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.types.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Observable } from 'rxjs';
+import type { CircuitBreaker } from './health_diagnostic_circuit_breakers.types';
+import { type HealthDiagnosticQuery } from './health_diagnostic_service.types';
+
+/**
+ * Configuration for executing a search query, including any associated circuit breakers.
+ */
+export interface QueryConfig {
+  /**
+   * The Elasticsearch query to execute.
+   */
+  query: HealthDiagnosticQuery;
+
+  /**
+   * A list of circuit breakers that must pass validation while the query is executed.
+   */
+  circuitBreakers: CircuitBreaker[];
+}
+
+/**
+ * Run Elasticsearch queries applying circuit breaker validations.
+ */
+export interface CircuitBreakingQueryExecutor {
+  /**
+   * Executes the provided query and returns an async iterable over the result set.
+   *
+   * @param queryConfig - Configuration including the query and circuit breakers.
+   * @returns An async iterable of results matching the query.
+   */
+  search<T>(queryConfig: QueryConfig): Observable<T>;
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { of, throwError, from } from 'rxjs';
+import type { ElasticsearchClient, AnalyticsServiceStart, Logger } from '@kbn/core/server';
+import { HealthDiagnosticServiceImpl } from './health_diagnostic_service';
+import { CircuitBreakingQueryExecutorImpl } from './health_diagnostic_receiver';
+import { ValidationError } from './health_diagnostic_circuit_breakers.types';
+import { artifactService } from '../artifact';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import {
+  createMockLogger,
+  createMockTaskManager,
+  createMockAnalytics,
+  createMockQueryExecutor,
+  createMockDocument,
+  createMockArtifactData,
+} from './__mocks__';
+
+jest.mock('./health_diagnostic_receiver');
+jest.mock('../artifact');
+
+const MockedCircuitBreakingQueryExecutorImpl = CircuitBreakingQueryExecutorImpl as jest.MockedClass<
+  typeof CircuitBreakingQueryExecutorImpl
+>;
+
+describe('Security Solution - Health Diagnostic Queries - HealthDiagnosticService', () => {
+  let service: HealthDiagnosticServiceImpl;
+  let mockLogger: jest.Mocked<Logger>;
+  let mockTaskManager: jest.Mocked<TaskManagerStartContract>;
+  let mockEsClient: jest.Mocked<ElasticsearchClient>;
+  let mockAnalytics: jest.Mocked<AnalyticsServiceStart>;
+  let mockQueryExecutor: jest.Mocked<CircuitBreakingQueryExecutorImpl>;
+
+  const mockDocument = createMockDocument();
+
+  const setupMocks = () => {
+    mockLogger = createMockLogger();
+    mockEsClient = {} as jest.Mocked<ElasticsearchClient>;
+    mockTaskManager = createMockTaskManager();
+    mockAnalytics = createMockAnalytics();
+    mockQueryExecutor = createMockQueryExecutor();
+
+    MockedCircuitBreakingQueryExecutorImpl.mockImplementation(() => mockQueryExecutor);
+    service = new HealthDiagnosticServiceImpl(mockLogger);
+  };
+
+  const setupDefaultArtifact = (overrides = {}) => {
+    (artifactService.getArtifact as jest.Mock).mockResolvedValue({
+      data: createMockArtifactData(overrides),
+    });
+  };
+
+  const startService = async () => {
+    await service.start({
+      taskManager: mockTaskManager,
+      esClient: mockEsClient,
+      analytics: mockAnalytics,
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+    setupDefaultArtifact();
+  });
+
+  describe('runHealthDiagnosticQueries', () => {
+    describe('successful execution', () => {
+      beforeEach(async () => {
+        await startService();
+      });
+
+      test('should execute enabled queries that are due for execution', async () => {
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        mockQueryExecutor.search.mockReturnValue(of(mockDocument));
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          name: 'test-query',
+          passed: true,
+          numDocs: 1,
+          fieldNames: expect.arrayContaining(['@timestamp', 'user.name', 'event.action']),
+        });
+        expect(mockQueryExecutor.search).toHaveBeenCalledTimes(1);
+        expect(mockAnalytics.reportEvent).toHaveBeenCalledTimes(2); // result + stats events
+      });
+
+      test('should process multiple documents in batches', async () => {
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        const documents = Array.from({ length: 5 }, (_, i) =>
+          createMockDocument({ _id: `doc${i}` })
+        );
+
+        mockQueryExecutor.search.mockReturnValue(from(documents));
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result[0].numDocs).toBe(5);
+        expect(result[0].passed).toBe(true);
+      });
+
+      test('should skip queries that are not due for execution', async () => {
+        const recentTimestamp = Date.now() - 1000;
+        const lastExecutionByQuery = { 'test-query': recentTimestamp };
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result).toHaveLength(0);
+        expect(mockQueryExecutor.search).not.toHaveBeenCalled();
+      });
+
+      test('should skip disabled queries', async () => {
+        setupDefaultArtifact({ enabled: false });
+
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result).toHaveLength(0);
+        expect(mockQueryExecutor.search).not.toHaveBeenCalled();
+      });
+
+      test('should include circuit breaker stats in successful execution', async () => {
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        mockQueryExecutor.search.mockReturnValue(of(mockDocument));
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result[0].circuitBreakers).toBeDefined();
+        expect(typeof result[0].circuitBreakers).toBe('object');
+      });
+    });
+
+    describe('error handling', () => {
+      test('should return empty array when query executor is not available', async () => {
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result).toEqual([]);
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'CircuitBreakingQueryExecutor service is not started',
+          expect.anything()
+        );
+      });
+
+      test('should handle query execution errors', async () => {
+        await startService();
+
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        const error = new Error('Query execution failed');
+        mockQueryExecutor.search.mockReturnValue(throwError(() => error));
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          name: 'test-query',
+          passed: false,
+          failure: {
+            message: 'Query execution failed',
+            reason: undefined,
+          },
+        });
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          'Error running query',
+          expect.objectContaining({ error })
+        );
+      });
+
+      test('should handle validation errors with circuit breaker results', async () => {
+        await startService();
+
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        const validationError = new ValidationError({
+          circuitBreaker: 'TimeoutCircuitBreaker',
+          valid: false,
+          message: 'Circuit breaker triggered',
+        });
+        mockQueryExecutor.search.mockReturnValue(throwError(() => validationError));
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result[0]).toMatchObject({
+          passed: false,
+          failure: {
+            message: 'Circuit breaker triggered',
+            reason: {
+              circuitBreaker: 'TimeoutCircuitBreaker',
+              valid: false,
+              message: 'Circuit breaker triggered',
+            },
+          },
+        });
+      });
+
+      test('should handle artifact service errors gracefully', async () => {
+        await startService();
+
+        (artifactService.getArtifact as jest.Mock).mockRejectedValue(
+          new Error('Artifact not found')
+        );
+        const lastExecutionByQuery = {};
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result).toEqual([]);
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Error getting health diagnostic queries: Artifact not found',
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('EBT event reporting', () => {
+      beforeEach(async () => {
+        await startService();
+      });
+
+      test('should report query result and stats events', async () => {
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        mockQueryExecutor.search.mockReturnValue(of(mockDocument));
+
+        await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(mockAnalytics.reportEvent).toHaveBeenCalledTimes(2);
+
+        expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(
+          'telemetry_health_diagnostic_query_stats_event',
+          expect.objectContaining({
+            name: 'test-query',
+            passed: true,
+            numDocs: 1,
+            traceId: expect.any(String),
+          })
+        );
+
+        expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(
+          'telemetry_health_diagnostic_query_result_event',
+          expect.objectContaining({
+            name: 'test-query',
+            queryId: 'test-query-1',
+            page: 0,
+            data: expect.any(Array),
+            traceId: expect.any(String),
+          })
+        );
+      });
+
+      test('should handle EBT reporting errors gracefully', async () => {
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        mockQueryExecutor.search.mockReturnValue(of(mockDocument));
+        mockAnalytics.reportEvent.mockImplementation(() => {
+          throw new Error('EBT reporting failed');
+        });
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result[0].passed).toBe(true);
+        expect(mockLogger.warn).toHaveBeenCalledWith('Error sending EBT', expect.any(Object));
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { bufferCount, from, mergeMap, take, tap } from 'rxjs';
+import { cloneDeep } from 'lodash';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type {
+  ElasticsearchClient,
+  LogMeta,
+  Logger,
+  EventTypeOpts,
+  AnalyticsServiceStart,
+} from '@kbn/core/server';
+import {
+  type HealthDiagnosticQuery,
+  type HealthDiagnosticQueryStats,
+  type HealthDiagnosticService,
+  type HealthDiagnosticServiceSetup,
+  type HealthDiagnosticServiceStart,
+} from './health_diagnostic_service.types';
+import {
+  emptyStat as queryStat,
+  fieldNames,
+  shouldExecute as isDueForExecution,
+  parseDiagnosticQueries,
+  applyFilterlist,
+} from './health_diagnostic_utils';
+import { type CircuitBreaker, ValidationError } from './health_diagnostic_circuit_breakers.types';
+import type { CircuitBreakingQueryExecutor } from './health_diagnostic_receiver.types';
+import { CircuitBreakingQueryExecutorImpl } from './health_diagnostic_receiver';
+import {
+  TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_RESULT_EVENT,
+  TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_STATS_EVENT,
+} from '../event_based/events';
+import { artifactService } from '../artifact';
+import { newTelemetryLogger } from '../helpers';
+import { telemetryConfiguration } from '../configuration';
+import { RssGrowthCircuitBreaker } from './circuit_breakers/rss_growth_circuit_breaker';
+import { TimeoutCircuitBreaker } from './circuit_breakers/timeout_circuit_breaker';
+import { EventLoopUtilizationCircuitBreaker } from './circuit_breakers/event_loop_utilization_circuit_breaker';
+import { EventLoopDelayCircuitBreaker } from './circuit_breakers/event_loop_delay_circuit_breaker';
+import { ElasticsearchCircuitBreaker } from './circuit_breakers/elastic_search_circuit_breaker';
+
+const TASK_TYPE = 'security:health-diagnostic';
+const TASK_ID = `${TASK_TYPE}:1.0.0`;
+const INTERVAL = '1h';
+const TIMEOUT = '10m';
+const QUERY_ARTIFACT_ID = 'health-diagnostic-queries-v1';
+
+export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
+  private readonly salt = 'c2a5d101-d0ef-49cc-871e-6ee55f9546f8';
+
+  private readonly logger: Logger;
+  private queryExecutor?: CircuitBreakingQueryExecutor;
+  private analytics?: AnalyticsServiceStart;
+  private _esClient?: ElasticsearchClient;
+
+  constructor(logger: Logger) {
+    const mdc = { task_id: TASK_ID, task_type: TASK_TYPE };
+    this.logger = newTelemetryLogger(logger.get('health-diagnostic'), mdc);
+  }
+
+  public setup(setup: HealthDiagnosticServiceSetup) {
+    this.logger.debug('Setting up health diagnostic service');
+
+    this.registerTask(setup.taskManager);
+  }
+
+  public async start(start: HealthDiagnosticServiceStart) {
+    this.logger.debug('Starting health diagnostic service');
+
+    this.queryExecutor = new CircuitBreakingQueryExecutorImpl(start.esClient, this.logger);
+    this.analytics = start.analytics;
+    this._esClient = start.esClient;
+
+    await this.scheduleTask(start.taskManager);
+  }
+
+  public async runHealthDiagnosticQueries(
+    lastExecutionByQuery: Record<string, number>
+  ): Promise<HealthDiagnosticQueryStats[]> {
+    this.logger.debug('Running health diagnostic task');
+
+    const queriesToRun = await this.getRunnableHealthQueries(lastExecutionByQuery, new Date());
+    const statistics: HealthDiagnosticQueryStats[] = [];
+
+    if (this.queryExecutor === undefined) {
+      this.logger.warn('CircuitBreakingQueryExecutor service is not started');
+      return statistics;
+    }
+
+    this.logger.debug('About to run health diagnostic queries', {
+      queriesToRun: queriesToRun.length,
+    } as LogMeta);
+
+    for (const query of queriesToRun) {
+      const now = new Date();
+      const circuitBreakers = this.buildCircuitBreakers();
+      const options = { query, circuitBreakers };
+
+      const query$ = this.queryExecutor.search(options);
+
+      const stats = await new Promise<HealthDiagnosticQueryStats>((resolve) => {
+        const queryStats: HealthDiagnosticQueryStats = queryStat(query.name, now);
+        let currentPage = 0;
+
+        query$
+          .pipe(
+            // cap the result set to the max number of documents
+            take(telemetryConfiguration.health_diagnostic_config.query.maxDocuments),
+
+            // get the fields names, only once (assume all docs have the same structure)
+            tap((doc) => {
+              if (queryStats.fieldNames.length === 0) {
+                queryStats.fieldNames = fieldNames(doc);
+              }
+            }),
+
+            // publish N documents in the same EBT
+            bufferCount(telemetryConfiguration.health_diagnostic_config.query.bufferSize),
+
+            // apply filterlist
+            mergeMap((result) => from(applyFilterlist(result, query.filterlist, this.salt)))
+          )
+          .subscribe({
+            next: (data) => {
+              this.logger.debug('Sending query result EBT', {
+                queryName: query.name,
+                traceId: queryStats.traceId,
+              } as LogMeta);
+
+              this.reportEBT(TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_RESULT_EVENT, {
+                name: query.name,
+                queryId: query.id,
+                traceId: queryStats.traceId,
+                page: currentPage++,
+                data,
+              });
+
+              queryStats.numDocs += data.length;
+            },
+            error: (error) => {
+              const failure = {
+                message: error.message,
+                reason: error instanceof ValidationError ? error.result : undefined,
+              };
+              this.logger.error('Error running query', { error });
+              resolve({
+                ...queryStats,
+                failure,
+                finished: new Date().toISOString(),
+                circuitBreakers: this.circuitBreakersStats(circuitBreakers),
+                passed: false,
+              });
+            },
+            complete: () => {
+              resolve({
+                ...queryStats,
+                finished: new Date().toISOString(),
+                circuitBreakers: this.circuitBreakersStats(circuitBreakers),
+                passed: true,
+              });
+            },
+          });
+      });
+
+      this.logger.debug('Query executed. Sending query stats EBT', {
+        queryName: query.name,
+        traceId: stats.traceId,
+        statistics: stats,
+      } as LogMeta);
+
+      this.reportEBT(TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_STATS_EVENT, stats);
+
+      statistics.push(stats);
+    }
+
+    this.logger.debug('Finished running health diagnostic task', { statistics } as LogMeta);
+
+    return statistics;
+  }
+
+  private circuitBreakersStats(circuitBreakers: CircuitBreaker[]): Record<string, unknown> {
+    return circuitBreakers.reduce((acc, cb) => {
+      acc[cb.constructor.name] = cb.stats();
+      return acc;
+    }, {} as Record<string, unknown>);
+  }
+
+  private registerTask(taskManager: TaskManagerSetupContract) {
+    this.logger.debug('About to register task');
+
+    taskManager.registerTaskDefinitions({
+      [TASK_TYPE]: {
+        title: 'Security Solution - Health Diagnostic Task',
+        description: 'This task periodically collects health diagnostic information.',
+        timeout: TIMEOUT,
+        maxAttempts: 1,
+        stateSchemaByVersion: {
+          1: {
+            up: (state: Record<string, unknown>) => ({
+              lastExecutionByQuery: state.lastExecutionByQuery || {},
+            }),
+            schema: schema.object({
+              lastExecutionByQuery: schema.recordOf(schema.string(), schema.number()),
+            }),
+          },
+        },
+        createTaskRunner: ({ taskInstance }) => {
+          return {
+            run: async () => {
+              const { state } = taskInstance;
+
+              const stats = await this.runHealthDiagnosticQueries(
+                cloneDeep(state.lastExecutionByQuery)
+              );
+              const lastExecutionByQuery = stats.reduce((acc, stat) => {
+                acc[stat.name] = new Date(stat.finished).getTime();
+                return acc;
+              }, {} as Record<string, number>);
+
+              return {
+                state: {
+                  lastExecutionByQuery: { ...state.lastExecutionByQuery, ...lastExecutionByQuery },
+                },
+              };
+            },
+
+            cancel: async () => {
+              this.logger?.warn('Task timed out');
+            },
+          };
+        },
+      },
+    });
+  }
+
+  private async scheduleTask(taskManager: TaskManagerStartContract): Promise<void> {
+    this.logger.info('About to schedule task');
+
+    await taskManager.ensureScheduled({
+      id: TASK_ID,
+      taskType: TASK_TYPE,
+      schedule: { interval: INTERVAL },
+      params: {},
+      state: { lastExecutionByQuery: {} },
+      scope: ['securitySolution'],
+    });
+
+    this.logger.info('Task scheduled');
+  }
+
+  private buildCircuitBreakers(): CircuitBreaker[] {
+    const config = telemetryConfiguration.health_diagnostic_config;
+    return [
+      new RssGrowthCircuitBreaker(config.rssGrowthCircuitBreaker),
+      new TimeoutCircuitBreaker(config.timeoutCircuitBreaker),
+      new EventLoopUtilizationCircuitBreaker(config.eventLoopUtilizationCircuitBreaker),
+      new EventLoopDelayCircuitBreaker(config.eventLoopDelayCircuitBreaker),
+      new ElasticsearchCircuitBreaker(config.elasticsearchCircuitBreaker, this.esClient()),
+    ];
+  }
+
+  private esClient(): ElasticsearchClient {
+    if (this._esClient === undefined || this._esClient === null) {
+      throw Error('elasticsearch client is unavailable');
+    }
+    return this._esClient;
+  }
+
+  private reportEBT<T>(eventTypeOpts: EventTypeOpts<T>, eventData: T): void {
+    if (!this.analytics) {
+      throw Error('analytics is unavailable');
+    }
+    try {
+      this.analytics.reportEvent(eventTypeOpts.eventType, eventData as object);
+    } catch (error) {
+      this.logger.warn('Error sending EBT', { error });
+    }
+  }
+
+  private async getRunnableHealthQueries(
+    lastExecutionByQuery: Record<string, number>,
+    now: Date
+  ): Promise<HealthDiagnosticQuery[]> {
+    const healthQueries = await this.healthQueries();
+    return healthQueries.filter((query) => {
+      try {
+        const { name, scheduleCron, enabled = false } = query;
+        const lastExecutedAt = new Date(lastExecutionByQuery[name] ?? 0);
+
+        return enabled && isDueForExecution(lastExecutedAt, now, scheduleCron);
+      } catch (error) {
+        this.logger.warn('Error processing health query', { error, name: query.name });
+        return false;
+      }
+    });
+  }
+
+  private async healthQueries(): Promise<HealthDiagnosticQuery[]> {
+    try {
+      const artifact = await artifactService.getArtifact(QUERY_ARTIFACT_ID);
+      return parseDiagnosticQueries(artifact.data);
+    } catch (error) {
+      this.logger.warn(`Error getting health diagnostic queries: ${error.message}`, { error });
+      return [];
+    }
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceStart, ElasticsearchClient } from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { CircuitBreakerResult } from './health_diagnostic_circuit_breakers.types';
+
+/**
+ * Enum defining the types of actions that can be applied to data,
+ * such as masking or keeping the original value, as part of the
+ * filterlist transformation.
+ */
+
+export enum Action {
+  /**
+   * Represents an action to mask sensitive information.
+   */
+  MASK = 'mask',
+  /**
+   * Represents an action to keep information as is, without masking.
+   */
+  KEEP = 'keep',
+}
+
+/**
+ * Enumeration of the supported query types.
+ */
+export enum QueryType {
+  /**
+   * Core Elasticsearch API JSON queries (/_search).
+   */
+  DSL = 'DSL',
+  /**
+   * Event Query Language
+   * */
+  EQL = 'EQL',
+  /**
+   * Elasticsearch Query Language (ES|QL).
+   */
+  ESQL = 'ESQL',
+}
+
+export interface HealthDiagnosticServiceSetup {
+  taskManager: TaskManagerSetupContract;
+}
+
+export interface HealthDiagnosticServiceStart {
+  taskManager: TaskManagerStartContract;
+  esClient: ElasticsearchClient;
+  analytics: AnalyticsServiceStart;
+}
+
+export interface HealthDiagnosticService {
+  setup(setup: HealthDiagnosticServiceSetup): void;
+  start(start: HealthDiagnosticServiceStart): Promise<void>;
+  runHealthDiagnosticQueries(
+    lastExecutionByQuery: Record<string, number>
+  ): Promise<HealthDiagnosticQueryStats[]>;
+}
+
+/**
+ * Configuration interface for Health Diagnostic query execution.
+ */
+export interface HealthDiagnosticQueryConfig {
+  /** Maximum number of documents to process per query execution. Default: 100,000,000 */
+  maxDocuments: number;
+  /** Number of documents to buffer before sending to EBT. Default: 10,000 */
+  bufferSize: number;
+}
+
+/**
+ * Defines a health diagnostic query configuration with scheduling and filtering options.
+ */
+export interface HealthDiagnosticQuery {
+  /**
+   * A unique identifier for this query.
+   */
+  id: string;
+  /**
+   * A descriptive name for this query.
+   */
+  name: string;
+  /**
+   * The index pattern on which this query will be executed.
+   */
+  index: string;
+  /**
+   * Only include indices in the specified tiers. Note that if the `index`
+   * hasn't a life cycle management or we are on serverless, this will be
+   * ignored.
+   */
+  tiers?: string[];
+  /**
+   * Specifies the query type, as defined by the QueryType enum.
+   */
+  type: QueryType;
+  /**
+   * The query string to be executed against the data store.
+   */
+  query: string;
+  /**
+   * A cron expression that schedules when the query should be run.
+   */
+  scheduleCron: string;
+  /**
+   * Optional mapping of dot-separated paths to associated actions for filtering results.
+   */
+  filterlist: Record<string, Action>;
+  /**
+   * Optional flag indicating whether this query is active and should be executed.
+   */
+  enabled?: boolean;
+  /**
+   * Query size
+   */
+  size?: number;
+}
+
+export interface HealthDiagnosticQueryResult {
+  name: string;
+  queryId: string;
+  traceId: string;
+  page: number;
+  data: unknown[];
+}
+
+export interface HealthDiagnosticQueryStats {
+  name: string;
+  started: string;
+  finished: string;
+  traceId: string;
+  numDocs: number;
+  passed: boolean;
+  failure?: HealthDiagnosticQueryFailure;
+  fieldNames: string[];
+  circuitBreakers?: Record<string, unknown>;
+}
+
+export interface HealthDiagnosticQueryFailure {
+  message: string;
+  reason?: CircuitBreakerResult;
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.test.ts
@@ -1,0 +1,544 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { intervalFromDate } from '@kbn/task-manager-plugin/server/lib/intervals';
+import { shouldExecute, applyFilterlist, fieldNames } from './health_diagnostic_utils';
+import { Action } from './health_diagnostic_service.types';
+
+describe('Security Solution - Health Diagnostic Queries - utils', () => {
+  describe('applyFilterlist', () => {
+    const mockSalt = 'test-salt';
+
+    beforeEach(() => {
+      // Mock crypto.subtle for consistent testing
+      Object.defineProperty(global, 'crypto', {
+        value: {
+          subtle: {
+            digest: jest.fn().mockResolvedValue(
+              new ArrayBuffer(32) // Mock SHA-256 output
+            ),
+          },
+        },
+        writable: true,
+      });
+    });
+
+    test('should keep fields marked with KEEP action', async () => {
+      const data = [{ user: { name: 'john', email: 'john@example.com' } }];
+      const rules = {
+        'user.name': Action.KEEP,
+        'user.email': Action.KEEP,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toEqual([
+        {
+          user: {
+            name: 'john',
+            email: 'john@example.com',
+          },
+        },
+      ]);
+    });
+
+    test('should mask fields marked with MASK action', async () => {
+      const data = [{ user: { name: 'john', password: 'secret123' } }];
+      const rules = {
+        'user.name': Action.KEEP,
+        'user.password': Action.MASK,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        user: {
+          name: 'john',
+          password: expect.any(String),
+        },
+      });
+      // Password should be masked (different from original)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result[0] as any).user.password).not.toBe('secret123');
+    });
+
+    test('should handle nested object structures', async () => {
+      const data = [
+        {
+          meta: {
+            host: {
+              name: 'server1',
+              ip: '192.168.1.1',
+            },
+          },
+        },
+      ];
+      const rules = {
+        'meta.host.name': Action.KEEP,
+        'meta.host.ip': Action.MASK,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        meta: {
+          host: {
+            name: 'server1',
+            ip: expect.any(String),
+          },
+        },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result[0] as any).meta.host.ip).not.toBe('192.168.1.1');
+    });
+
+    test('should handle arrays of documents', async () => {
+      const data = [
+        [
+          { user: 'alice', token: 'abc123' },
+          { user: 'bob', token: 'xyz789' },
+        ],
+      ];
+      const rules = {
+        user: Action.KEEP,
+        token: Action.MASK,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toHaveLength(1);
+      expect(Array.isArray(result[0])).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const docs = result[0] as any[];
+      expect(docs).toHaveLength(2);
+      expect(docs[0].user).toBe('alice');
+      expect(docs[1].user).toBe('bob');
+      expect(docs[0].token).not.toBe('abc123');
+      expect(docs[1].token).not.toBe('xyz789');
+    });
+
+    test('should handle arrays of complex documents', async () => {
+      const data = [
+        {
+          per_minute: {
+            buckets: [
+              {
+                key_as_string: '2025-08-13T13:56:00.000Z',
+                key: 1755093360000,
+                doc_count: 2,
+                per_node: {
+                  doc_count_error_upper_bound: 0,
+                  sum_other_doc_count: 0,
+                  buckets: [
+                    {
+                      key: 'RfUrmQqJSL67wlQKvO95gg',
+                      doc_count: 1,
+                      avg_cpu: {
+                        value: 0.830078125,
+                      },
+                      avg_jvm_heap: {
+                        value: 51,
+                      },
+                    },
+                    {
+                      key: '_ypuq9evRyqjr5aBJmsPrA',
+                      doc_count: 1,
+                      avg_cpu: {
+                        value: 0.58984375,
+                      },
+                      avg_jvm_heap: {
+                        value: 6,
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                key_as_string: '2025-08-13T13:57:00.000Z',
+                key: 1755093420000,
+                doc_count: 18,
+                per_node: {
+                  doc_count_error_upper_bound: 0,
+                  sum_other_doc_count: 0,
+                  buckets: [
+                    {
+                      key: 'RfUrmQqJSL67wlQKvO95gg',
+                      doc_count: 6,
+                      avg_cpu: {
+                        value: 0.6482747395833334,
+                      },
+                      avg_jvm_heap: {
+                        value: 42.833333333333336,
+                      },
+                    },
+                    {
+                      key: 'UHo_pnFMQFqkbewG85AYoA',
+                      doc_count: 6,
+                      avg_cpu: {
+                        value: 0.5349527994791666,
+                      },
+                      avg_jvm_heap: {
+                        value: 57,
+                      },
+                    },
+                    {
+                      key: '_ypuq9evRyqjr5aBJmsPrA',
+                      doc_count: 6,
+                      avg_cpu: {
+                        value: 0.506591796875,
+                      },
+                      avg_jvm_heap: {
+                        value: 12,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ];
+
+      const rules = {
+        'per_minute.buckets.key_as_string': Action.KEEP,
+        'per_minute.buckets.key': Action.KEEP,
+        'per_minute.buckets.doc_count': Action.KEEP,
+        'per_minute.buckets.per_node.doc_count_error_upper_bound': Action.KEEP,
+        'per_minute.buckets.per_node.sum_other_doc_count': Action.KEEP,
+        'per_minute.buckets.per_node.buckets.key': Action.KEEP,
+        'per_minute.buckets.per_node.buckets.doc_count': Action.KEEP,
+        'per_minute.buckets.per_node.buckets.avg_cpu.value': Action.KEEP,
+        'per_minute.buckets.per_node.buckets.avg_jvm_heap.value': Action.KEEP,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toHaveLength(1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const aggrs = result[0] as any;
+
+      expect(aggrs.per_minute).toBeDefined();
+      expect(typeof aggrs.per_minute).toBe('object');
+      expect(Array.isArray(aggrs.per_minute.buckets)).toBe(true);
+      expect(aggrs.per_minute.buckets).toHaveLength(2);
+
+      const firstBucket = aggrs.per_minute.buckets[0];
+      expect(firstBucket.key_as_string).toBe('2025-08-13T13:56:00.000Z');
+      expect(firstBucket.key).toBe(1755093360000);
+      expect(firstBucket.doc_count).toBe(2);
+      expect(firstBucket.per_node.doc_count_error_upper_bound).toBe(0);
+      expect(firstBucket.per_node.sum_other_doc_count).toBe(0);
+      expect(Array.isArray(firstBucket.per_node.buckets)).toBe(true);
+      expect(firstBucket.per_node.buckets).toHaveLength(2);
+
+      const firstNodeBucket = firstBucket.per_node.buckets[0];
+      expect(firstNodeBucket.key).toBe('RfUrmQqJSL67wlQKvO95gg');
+      expect(firstNodeBucket.doc_count).toBe(1);
+      expect(firstNodeBucket.avg_cpu.value).toBe(0.830078125);
+      expect(firstNodeBucket.avg_jvm_heap.value).toBe(51);
+
+      const secondBucket = aggrs.per_minute.buckets[1];
+      expect(secondBucket.key_as_string).toBe('2025-08-13T13:57:00.000Z');
+      expect(secondBucket.key).toBe(1755093420000);
+      expect(secondBucket.doc_count).toBe(18);
+      expect(Array.isArray(secondBucket.per_node.buckets)).toBe(true);
+      expect(secondBucket.per_node.buckets).toHaveLength(3);
+    });
+
+    test('should skip non-existent fields', async () => {
+      const data = [{ user: 'john', email: 'john@example.com' }];
+      const rules = {
+        user: Action.KEEP,
+        password: Action.MASK, // This field doesn't exist
+        'profile.age': Action.KEEP, // This nested field doesn't exist
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toEqual([{ user: 'john' }]);
+    });
+
+    test('should handle empty data array', async () => {
+      const data: unknown[] = [];
+      const rules = { user: Action.KEEP };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toEqual([]);
+    });
+
+    test('should handle empty rules', async () => {
+      const data = [{ user: 'john', email: 'john@example.com' }];
+      const rules = {};
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toEqual([{}]);
+    });
+
+    test('should create nested structure when intermediate objects do not exist', async () => {
+      const data = [{ user: { profile: { name: 'john' } } }];
+      const rules = {
+        'user.profile.name': Action.KEEP,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toEqual([
+        {
+          user: {
+            profile: {
+              name: 'john',
+            },
+          },
+        },
+      ]);
+    });
+
+    test('should handle mixed document types', async () => {
+      const data = [
+        { type: 'user', name: 'john', password: 'secret' },
+        [{ type: 'admin', name: 'admin', token: 'admin123' }],
+      ];
+      const rules = {
+        name: Action.KEEP,
+        password: Action.MASK,
+        token: Action.MASK,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ name: 'john' });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result[0] as any).password).not.toBe('secret');
+      expect(Array.isArray(result[1])).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const adminDocs = result[1] as any[];
+      expect(adminDocs[0].name).toBe('admin');
+      expect(adminDocs[0].token).not.toBe('admin123');
+    });
+
+    test('should handle numeric and boolean values', async () => {
+      const data = [
+        {
+          count: 42,
+          active: true,
+          score: 98.5,
+          sensitiveId: 12345,
+        },
+      ];
+      const rules = {
+        count: Action.KEEP,
+        active: Action.KEEP,
+        score: Action.KEEP,
+        sensitiveId: Action.MASK,
+      };
+
+      const result = await applyFilterlist(data, rules, mockSalt);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        count: 42,
+        active: true,
+        score: 98.5,
+        sensitiveId: expect.any(String),
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result[0] as any).sensitiveId).not.toBe('12345');
+    });
+  });
+
+  describe('fieldNames', () => {
+    test('should extract field names from simple object', () => {
+      const input = { name: 'john', age: 30, active: true };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual(['active', 'age', 'name']);
+    });
+
+    test('should extract nested field names', () => {
+      const input = {
+        user: {
+          profile: {
+            name: 'john',
+            email: 'john@example.com',
+          },
+          settings: {
+            theme: 'dark',
+          },
+        },
+      };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual([
+        'user.profile.email',
+        'user.profile.name',
+        'user.settings.theme',
+      ]);
+    });
+
+    test('should handle arrays with elements', () => {
+      const input = {
+        users: [{ name: 'john', age: 30 }],
+        tags: ['security', 'admin'],
+      };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual(['tags[]', 'users[].age', 'users[].name']);
+    });
+
+    test('should handle empty arrays', () => {
+      const input = {
+        users: [],
+        tags: [],
+        data: 'test',
+      };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual(['data', 'tags[]', 'users[]']);
+    });
+
+    test('should handle mixed data types', () => {
+      const input = {
+        string: 'text',
+        number: 42,
+        boolean: true,
+        nullValue: null,
+        undefinedValue: undefined,
+        object: {
+          nested: 'value',
+        },
+      };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual([
+        'boolean',
+        'nullValue',
+        'number',
+        'object.nested',
+        'string',
+        'undefinedValue',
+      ]);
+    });
+
+    test('should handle deeply nested structures', () => {
+      const input = {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                value: 'deep',
+              },
+            },
+          },
+        },
+      };
+      const result = fieldNames(input);
+      expect(result).toEqual(['level1.level2.level3.level4.value']);
+    });
+
+    test('should handle arrays of objects with different structures', () => {
+      const input = {
+        items: [
+          { name: 'item1', type: 'A' },
+          { name: 'item2', category: 'B' },
+        ],
+      };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual(['items[].name', 'items[].type']);
+    });
+
+    test('should handle nested arrays', () => {
+      const input = {
+        matrix: [[{ x: 1, y: 2 }]],
+      };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual(['matrix[][].x', 'matrix[][].y']);
+    });
+
+    test('should handle empty object', () => {
+      const input = {};
+      const result = fieldNames(input);
+      expect(result).toEqual([]);
+    });
+
+    test('should handle primitive values', () => {
+      expect(fieldNames('string')).toEqual(['']);
+      expect(fieldNames(42)).toEqual(['']);
+      expect(fieldNames(true)).toEqual(['']);
+      expect(fieldNames(null)).toEqual(['']);
+      expect(fieldNames(undefined)).toEqual(['']);
+    });
+
+    test('should handle complex real-world structure', () => {
+      const input = {
+        '@timestamp': '2024-01-01T00:00:00.000Z',
+        event: {
+          action: 'login',
+          outcome: 'success',
+        },
+        user: {
+          id: '123',
+          name: 'john.doe',
+          roles: ['admin', 'user'],
+        },
+        host: {
+          name: 'server01',
+          ip: ['192.168.1.1', '10.0.0.1'],
+        },
+        process: {
+          pid: 1234,
+          args: ['-f', '/etc/config'],
+        },
+        tags: [],
+      };
+      const result = fieldNames(input);
+      expect(result.sort()).toEqual([
+        '@timestamp',
+        'event.action',
+        'event.outcome',
+        'host.ip[]',
+        'host.name',
+        'process.args[]',
+        'process.pid',
+        'tags[]',
+        'user.id',
+        'user.name',
+        'user.roles[]',
+      ]);
+    });
+  });
+
+  describe('nextExecution', () => {
+    test.each([
+      ['5m', '2025-05-14T17:00:00.000Z', '2025-05-14T17:03:00.000Z', false],
+      ['5m', '2025-05-14T17:00:00.000Z', '2025-05-14T17:06:00.000Z', true],
+      ['5m', '2025-05-14T17:00:00.000Z', '2025-05-14T18:03:00.000Z', true],
+      ['1h', '2025-05-14T17:00:00.000Z', '2025-05-14T18:00:00.000Z', false],
+      ['1h', '2025-05-14T17:00:00.000Z', '2025-05-14T18:01:00.000Z', true],
+      ['1h', '2025-05-14T17:00:00.000Z', '2025-05-15T01:00:00.000Z', true],
+      ['1h', '2025-05-14T17:00:00.000Z', '2025-05-12T01:00:00.000Z', false],
+      ['1s', '2025-05-02T17:00:00.000Z', '2025-06-30T17:00:00.000Z', true],
+      ['30d', '2025-05-31T17:00:00.000Z', '2025-06-29T17:00:00.000Z', false],
+      ['365d', '2025-01-31T17:00:00.000Z', '2025-12-31T17:00:00.000Z', false],
+    ])(
+      'should add %s to %s when endDate is %s and return %s',
+      (interval, startDate, endDate, expected) => {
+        expect(shouldExecute(new Date(startDate), new Date(endDate), interval)).toBe(expected);
+      }
+    );
+
+    test.each([
+      ['5m', '2025-05-14T17:00:00.000Z', '2025-05-14T17:05:00.000Z'],
+      ['1h', '2025-05-14T17:00:00.000Z', '2025-05-14T18:00:00.000Z'],
+      ['24h', '2025-05-14T17:00:00.000Z', '2025-05-15T17:00:00.000Z'],
+      ['30d', '2025-05-31T17:00:00.000Z', '2025-06-30T17:00:00.000Z'],
+      ['365d', '2025-05-31T17:00:00.000Z', '2026-05-31T17:00:00.000Z'],
+    ])('adding %s to %s should be equal to %s', (interval, dateFrom, expected) => {
+      const next = intervalFromDate(new Date(dateFrom), interval);
+      expect(next).toEqual(new Date(expected));
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import * as YAML from 'yaml';
+import { type Interval, intervalFromDate } from '@kbn/task-manager-plugin/server/lib/intervals';
+import {
+  Action,
+  type HealthDiagnosticQuery,
+  type HealthDiagnosticQueryStats,
+} from './health_diagnostic_service.types';
+
+export function shouldExecute(startDate: Date, endDate: Date, interval: Interval): boolean {
+  const nextDate = intervalFromDate(startDate, interval);
+  return nextDate !== undefined && nextDate < endDate;
+}
+
+export function parseDiagnosticQueries(input: unknown): HealthDiagnosticQuery[] {
+  return YAML.parseAllDocuments(input as string).map((doc) => {
+    return doc.toJSON() as HealthDiagnosticQuery;
+  });
+}
+
+export function fieldNames<T>(documents: T): string[] {
+  const result: Set<string> = new Set();
+
+  const traverse = (obj: T, path: string) => {
+    if (Array.isArray(obj)) {
+      if (obj.length > 0) {
+        traverse(obj[0], `${path}[]`);
+      } else {
+        result.add(`${path}[]`);
+      }
+    } else if (obj && typeof obj === 'object') {
+      for (const [key, value] of Object.entries(obj)) {
+        traverse(value, path ? `${path}.${key}` : key);
+      }
+    } else {
+      result.add(path);
+    }
+  };
+
+  traverse(documents, '');
+
+  return Array.from(result);
+}
+
+export function emptyStat(name: string, now: Date): HealthDiagnosticQueryStats {
+  return {
+    name,
+    started: now.toISOString(),
+    traceId: randomUUID(),
+    finished: new Date().toISOString(),
+    numDocs: 0,
+    passed: false,
+    fieldNames: [],
+  };
+}
+
+export async function applyFilterlist(
+  data: unknown[],
+  rules: Record<string, Action>,
+  salt: string
+): Promise<unknown[]> {
+  const filteredResult: unknown[] = [];
+
+  const applyFilterToDoc = async (doc: unknown): Promise<Record<string, unknown>> => {
+    const filteredDoc: Record<string, unknown> = {};
+    for (const path of Object.keys(rules)) {
+      const keys = path.split('.');
+      await processPath(doc, filteredDoc, keys, path, 0);
+    }
+    return filteredDoc;
+  };
+
+  const processPath = async (
+    src: unknown,
+    dst: Record<string, unknown>,
+    keys: string[],
+    fullPath: string,
+    keyIndex: number
+  ): Promise<void> => {
+    if (keyIndex >= keys.length || !src || typeof src !== 'object') return;
+
+    const key = keys[keyIndex];
+    const srcObj = src as Record<string, unknown>;
+
+    if (!Object.hasOwn(srcObj, key)) return;
+
+    if (keyIndex === keys.length - 1) {
+      const value = srcObj[key];
+      dst[key] = rules[fullPath] === Action.MASK ? await maskValue(String(value), salt) : value;
+    } else {
+      const nextValue = srcObj[key];
+
+      if (Array.isArray(nextValue)) {
+        if (!dst[key]) {
+          dst[key] = [];
+        }
+        const dstArray = dst[key] as unknown[];
+
+        for (let i = 0; i < nextValue.length; i++) {
+          const item = nextValue[i];
+          if (item && typeof item === 'object') {
+            if (!dstArray[i]) {
+              dstArray[i] = {};
+            }
+            await processPath(
+              item,
+              dstArray[i] as Record<string, unknown>,
+              keys,
+              fullPath,
+              keyIndex + 1
+            );
+          }
+        }
+      } else if (nextValue && typeof nextValue === 'object') {
+        dst[key] ??= {};
+        await processPath(
+          nextValue,
+          dst[key] as Record<string, unknown>,
+          keys,
+          fullPath,
+          keyIndex + 1
+        );
+      }
+    }
+  };
+
+  for (const doc of data) {
+    if (Array.isArray(doc)) {
+      const docs = doc as unknown[];
+      const result = await Promise.all(
+        docs.map((d) => {
+          return applyFilterToDoc(d);
+        })
+      );
+      filteredResult.push(result);
+    } else {
+      filteredResult.push(await applyFilterToDoc(doc));
+    }
+  }
+
+  return filteredResult;
+}
+
+async function maskValue(value: string, salt: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(salt + value);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -21,6 +21,10 @@ import type {
 } from '../indices.metadata.types';
 import type { NodeIngestPipelinesStats } from '../ingest_pipelines_stats.types';
 import { SiemMigrationsEventTypes } from './types';
+import type {
+  HealthDiagnosticQueryResult,
+  HealthDiagnosticQueryStats,
+} from '../diagnostic/health_diagnostic_service.types';
 
 export const RISK_SCORE_EXECUTION_SUCCESS_EVENT: EventTypeOpts<{
   scoresWritten: number;
@@ -846,6 +850,115 @@ export const TELEMETRY_NODE_INGEST_PIPELINES_STATS_EVENT: EventTypeOpts<NodeInge
     },
   };
 
+export const TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_RESULT_EVENT: EventTypeOpts<HealthDiagnosticQueryResult> =
+  {
+    eventType: 'telemetry_health_diagnostic_query_result_event',
+    schema: {
+      name: {
+        type: 'keyword',
+        _meta: { description: 'Identifier for the executed query.' },
+      },
+      queryId: {
+        type: 'keyword',
+        _meta: { description: 'Unique identifier for the specific query.' },
+      },
+      traceId: {
+        type: 'keyword',
+        _meta: { description: 'Unique trace ID for correlating a single query execution.' },
+      },
+      page: {
+        type: 'integer',
+        _meta: { description: 'Page number of the query result.' },
+      },
+      data: {
+        type: 'pass_through',
+        _meta: { description: 'Raw query result payload.' },
+      },
+    },
+  };
+export const TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_STATS_EVENT: EventTypeOpts<HealthDiagnosticQueryStats> =
+  {
+    eventType: 'telemetry_health_diagnostic_query_stats_event',
+    schema: {
+      name: {
+        type: 'keyword',
+        _meta: { description: 'Identifier for the executed query.' },
+      },
+      traceId: {
+        type: 'keyword',
+        _meta: { description: 'Unique trace ID for correlating a single query execution.' },
+      },
+      numDocs: {
+        type: 'integer',
+        _meta: { description: 'Number of documents returned by the query.' },
+      },
+      passed: {
+        type: 'boolean',
+        _meta: { description: 'Indicates whether the query completed successfully.' },
+      },
+      started: {
+        type: 'keyword',
+        _meta: { description: 'When the query started execution.' },
+      },
+      finished: {
+        type: 'keyword',
+        _meta: { description: 'When the query finished execution.' },
+      },
+      failure: {
+        properties: {
+          message: {
+            type: 'keyword',
+            _meta: { description: 'A high-level failure message describing the error.' },
+          },
+          reason: {
+            properties: {
+              circuitBreaker: {
+                type: 'keyword',
+                _meta: {
+                  description: 'The name of the circuit breaker that triggered the failure.',
+                },
+              },
+              valid: {
+                type: 'boolean',
+                _meta: {
+                  description: 'Indicates whether the query execution was considered valid.',
+                },
+              },
+              message: {
+                type: 'keyword',
+                _meta: {
+                  optional: true,
+                  description:
+                    'A detailed reason or message explaining why the circuit breaker was triggered.',
+                },
+              },
+            },
+          },
+        },
+        _meta: {
+          optional: true,
+          description: 'Details about the failure if the operation was unsuccessful.',
+        },
+      },
+      fieldNames: {
+        type: 'array',
+        items: {
+          type: 'keyword',
+          _meta: {
+            description: 'Field names in the query result.',
+          },
+        },
+      },
+      circuitBreakers: {
+        type: 'pass_through',
+        _meta: {
+          optional: true,
+          description: 'Circuit breaker metrics such as execution time and memory usage.',
+        },
+      },
+    },
+  };
+
 interface CreateAssetCriticalityProcessedFileEvent {
   result?: BulkUpsertAssetCriticalityRecordsResponse['stats'];
   startTime: Date;
@@ -1362,6 +1475,8 @@ export const events = [
   ENTITY_ENGINE_INITIALIZATION_EVENT,
   ENTITY_STORE_USAGE_EVENT,
   TELEMETRY_DATA_STREAM_EVENT,
+  TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_RESULT_EVENT,
+  TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_STATS_EVENT,
   TELEMETRY_ILM_POLICY_EVENT,
   TELEMETRY_ILM_STATS_EVENT,
   TELEMETRY_INDEX_SETTINGS_EVENT,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/configuration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/configuration.ts
@@ -120,6 +120,14 @@ export function createTelemetryConfigurationTaskConfig() {
             configArtifact.ingest_pipelines_stats_config;
         }
 
+        if (configArtifact.health_diagnostic_config) {
+          log.debug('Updating health diagnostic configuration');
+          telemetryConfiguration.health_diagnostic_config = {
+            ...telemetryConfiguration.health_diagnostic_config,
+            ...configArtifact.health_diagnostic_config,
+          };
+        }
+
         await taskMetricsService.end(trace);
 
         log.debug('Updated TelemetryConfiguration');

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/types.ts
@@ -9,6 +9,12 @@ import type { Agent } from '@kbn/fleet-plugin/common';
 
 import type { AlertEvent, ResolverNode, SafeResolverEvent } from '../../../common/endpoint/types';
 import type { AllowlistFields } from './filterlists/types';
+import type { RssGrowthCircuitBreakerConfig } from './diagnostic/circuit_breakers/rss_growth_circuit_breaker';
+import type { TimeoutCircuitBreakerConfig } from './diagnostic/circuit_breakers/timeout_circuit_breaker';
+import type { EventLoopUtilizationCircuitBreakerConfig } from './diagnostic/circuit_breakers/event_loop_utilization_circuit_breaker';
+import type { EventLoopDelayCircuitBreakerConfig } from './diagnostic/circuit_breakers/event_loop_delay_circuit_breaker';
+import type { ElasticsearchCircuitBreakerConfig } from './diagnostic/circuit_breakers/elastic_search_circuit_breaker';
+import type { HealthDiagnosticQueryConfig } from './diagnostic/health_diagnostic_service.types';
 
 type BaseSearchTypes = string | number | boolean | object;
 export type SearchTypes = BaseSearchTypes | BaseSearchTypes[] | undefined;
@@ -483,6 +489,7 @@ export interface TelemetryConfiguration {
   pagination_config?: PaginationConfiguration;
   indices_metadata_config?: IndicesMetadataConfiguration;
   ingest_pipelines_stats_config?: IngestPipelinesStatsConfiguration;
+  health_diagnostic_config?: HealthDiagnosticConfiguration;
 }
 
 export interface IndicesMetadataConfiguration {
@@ -501,6 +508,15 @@ export interface IndicesMetadataConfiguration {
 
 export interface IngestPipelinesStatsConfiguration {
   enabled: boolean;
+}
+
+export interface HealthDiagnosticConfiguration {
+  query: HealthDiagnosticQueryConfig;
+  rssGrowthCircuitBreaker: RssGrowthCircuitBreakerConfig;
+  timeoutCircuitBreaker: TimeoutCircuitBreakerConfig;
+  eventLoopUtilizationCircuitBreaker: EventLoopUtilizationCircuitBreakerConfig;
+  eventLoopDelayCircuitBreaker: EventLoopDelayCircuitBreakerConfig;
+  elasticsearchCircuitBreaker: ElasticsearchCircuitBreakerConfig;
 }
 
 export interface PaginationConfiguration {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -7,7 +7,7 @@
 
 import type { Observable } from 'rxjs';
 import { QUERY_RULE_TYPE_ID, SAVED_QUERY_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
-import type { Logger } from '@kbn/core/server';
+import type { LogMeta, Logger } from '@kbn/core/server';
 import { SavedObjectsClient } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { ECS_COMPONENT_TEMPLATE_NAME } from '@kbn/alerting-plugin/server';
@@ -108,7 +108,7 @@ import type {
 } from './plugin_contract';
 import { featureUsageService } from './endpoint/services/feature_usage';
 import { setIsElasticCloudDeployment } from './lib/telemetry/helpers';
-import { artifactService } from './lib/telemetry/artifact';
+import { type CdnConfig, artifactService } from './lib/telemetry/artifact';
 import { events } from './lib/telemetry/event_based/events';
 import { endpointFieldsProvider } from './search_strategy/endpoint_fields';
 import {
@@ -133,6 +133,8 @@ import { scheduleEntityAnalyticsMigration } from './lib/entity_analytics/migrati
 import { SiemMigrationsService } from './lib/siem_migrations/siem_migrations_service';
 import { TelemetryConfigProvider } from '../common/telemetry_config/telemetry_config_provider';
 import { TelemetryConfigWatcher } from './endpoint/lib/policy/telemetry_watch';
+import { HealthDiagnosticServiceImpl } from './lib/telemetry/diagnostic/health_diagnostic_service';
+import type { HealthDiagnosticService } from './lib/telemetry/diagnostic/health_diagnostic_service.types';
 
 export type { SetupPlugins, StartPlugins, PluginSetup, PluginStart } from './plugin_contract';
 
@@ -149,6 +151,8 @@ export class Plugin implements ISecuritySolutionPlugin {
   private readonly telemetryReceiver: ITelemetryReceiver;
   private readonly telemetryEventsSender: ITelemetryEventsSender;
   private readonly asyncTelemetryEventsSender: IAsyncTelemetryEventsSender;
+
+  private readonly healthDiagnosticService: HealthDiagnosticService;
 
   private lists: ListPluginSetup | undefined; // TODO: can we create ListPluginStart?
   private licensing$!: Observable<ILicense>;
@@ -200,6 +204,8 @@ export class Plugin implements ISecuritySolutionPlugin {
     });
 
     this.logger.debug('plugin initialized');
+
+    this.healthDiagnosticService = new HealthDiagnosticServiceImpl(this.logger);
   }
 
   public setup(
@@ -562,6 +568,14 @@ export class Plugin implements ISecuritySolutionPlugin {
       endpointContext: this.endpointContext.service,
     });
 
+    if (plugins.taskManager) {
+      this.healthDiagnosticService.setup({
+        taskManager: plugins.taskManager,
+      });
+    } else {
+      this.logger.warn('Task Manager not available, health diagnostic task not registered.');
+    }
+
     return {
       setProductFeaturesConfigurator:
         productFeaturesService.setProductFeaturesConfigurator.bind(productFeaturesService),
@@ -716,7 +730,17 @@ export class Plugin implements ISecuritySolutionPlugin {
       )
       .catch(() => {});
 
-    artifactService.start(this.telemetryReceiver).catch(() => {});
+    if (this.config.cdn?.url && this.config.cdn?.publicKey) {
+      const cdnConfig: CdnConfig = {
+        url: this.config.cdn.url,
+        pubKey: this.config.cdn.publicKey,
+      };
+      this.logger.info('Starting artifact service with custom CDN config');
+      artifactService.start(this.telemetryReceiver, cdnConfig).catch(() => {});
+    } else {
+      this.logger.info('Starting artifact service with default CDN config');
+      artifactService.start(this.telemetryReceiver).catch(() => {});
+    }
 
     this.asyncTelemetryEventsSender.start(plugins.telemetry);
 
@@ -774,6 +798,23 @@ export class Plugin implements ISecuritySolutionPlugin {
           return packagePolicy;
         }
       );
+    }
+
+    if (plugins.taskManager) {
+      const serviceStart = {
+        taskManager: plugins.taskManager,
+        esClient: core.elasticsearch.client.asInternalUser,
+        analytics: core.analytics,
+        receiver: this.telemetryReceiver,
+      };
+
+      this.healthDiagnosticService.start(serviceStart).catch((e) => {
+        this.logger.warn('Error starting health diagnostic task', {
+          error: e.message,
+        } as LogMeta);
+      });
+    } else {
+      this.logger.warn('Task Manager not available, health diagnostic task not started.');
     }
 
     return {};

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -241,5 +241,6 @@
     "@kbn/security-ai-prompts",
     "@kbn/scout-security",
     "@kbn/inference-endpoint-ui-common",
+    "@kbn/core-metrics-server",
   ]
 }

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -166,6 +166,7 @@ export default function ({ getService }: FtrProviderContext) {
         'security-solution-ea-asset-criticality-ecs-migration',
         'security:endpoint-diagnostics',
         'security:endpoint-meta-telemetry',
+        'security:health-diagnostic',
         'security:indices-metadata-telemetry',
         'security:ingest-pipelines-stats-telemetry',
         'security:telemetry-configuration',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Diagnostic Queries (#220832)](https://github.com/elastic/kibana/pull/220832)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2025-08-14T12:29:51Z","message":"[Security Solution] Diagnostic Queries (#220832)\n\n## Summary\n\nAdd a new task to run diagnostic queries. The queries to run are\npublished as a new artifact in the Security CDN, and during execution,\nvalidations are applied to control resource consumption and constrain\ntheir execution time.\n\nFor each query, one or more EBT events are published with the results,\nand a final EBT event with statistics, such as execution time, memory\nconsumption, number of documents published, etc. All the EBT events have\na trace ID to correlate them.\n\nSome implementation details:\n\n- When the plugin starts, a new `HealthDiagnosticService` class is\ninstantiated. It registers a new Kibana task that runs periodically.\n    ```js\n    export interface HealthDiagnosticService {\n      setup(setup: HealthDiagnosticServiceSetup): void;\n      start(start: HealthDiagnosticServiceStart): Promise<void>;\nrunHealthDiagnosticQueries(fromDate: Date, toDate: Date): Promise<void>;\n    }\n    ```\n- A new Artifact that lives in the security CDN contains the queries to\nbe executed with the following structure:\n    ```js\n    export interface HealthDiagnosticQuery {\n      name: string;\n      esQuery: SearchRequest;\n      scheduleInterval: string;\n      isEnabled?: boolean;\n    }\n    ```\nThe schedule interval is evaluated each time the task runs against the\nlast execution time to decide whether the query is eligible. It means\nthe max granularity allowed is given by the task execution period.\nExample: if the task runs once an hour, a given query with `1m` (i.e.,\nrun once per minute) will be executed just once an hour, and another\nquery `12h` (i.e., run each 12 hours) will be executed every 12 hours.\nThe service uses a list of \"circuit breakers\" to validate resource\nconsumption. When any fails, the query is aborted (using an\n`AbortSignal`), and the partial results are sent along with the\nexecution stats.\n    ```js\n    export interface CircuitBreaker {\n      validate(): CircuitBreakerResult;\n      stats(): unknown;\n      validationIntervalMs(): number;\n    }\n    ```\nOnly three validations have been implemented so far: timeout, RSS usage\nincrement, and event loop utilization.\n- Finally, the following EBT events are published\n    ```js\n    export interface HealthDiagnosticQueryResult {\n      name: string;\n      traceId: string;\n      page: number;\n      data: unknown[];\n    }\n    \n    export interface HealthDiagnosticQueryStats {\n      name: string;\n      traceId: string;\n      numDocs: number;\n      passed: boolean;\n      failure?: string;\n      circuitBreakers?: Record<string, unknown>;\n    }\n    ```\n\n### Checklist\n\nCheck the PR satisfies the following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"603893c872b7db4fe82f8a4a384b3937ffcc7d32","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:prev-minor","backport:prev-major","ci:build-cloud-image","backport:current-major","v9.2.0"],"title":"[Security Solution] Diagnostic Queries","number":220832,"url":"https://github.com/elastic/kibana/pull/220832","mergeCommit":{"message":"[Security Solution] Diagnostic Queries (#220832)\n\n## Summary\n\nAdd a new task to run diagnostic queries. The queries to run are\npublished as a new artifact in the Security CDN, and during execution,\nvalidations are applied to control resource consumption and constrain\ntheir execution time.\n\nFor each query, one or more EBT events are published with the results,\nand a final EBT event with statistics, such as execution time, memory\nconsumption, number of documents published, etc. All the EBT events have\na trace ID to correlate them.\n\nSome implementation details:\n\n- When the plugin starts, a new `HealthDiagnosticService` class is\ninstantiated. It registers a new Kibana task that runs periodically.\n    ```js\n    export interface HealthDiagnosticService {\n      setup(setup: HealthDiagnosticServiceSetup): void;\n      start(start: HealthDiagnosticServiceStart): Promise<void>;\nrunHealthDiagnosticQueries(fromDate: Date, toDate: Date): Promise<void>;\n    }\n    ```\n- A new Artifact that lives in the security CDN contains the queries to\nbe executed with the following structure:\n    ```js\n    export interface HealthDiagnosticQuery {\n      name: string;\n      esQuery: SearchRequest;\n      scheduleInterval: string;\n      isEnabled?: boolean;\n    }\n    ```\nThe schedule interval is evaluated each time the task runs against the\nlast execution time to decide whether the query is eligible. It means\nthe max granularity allowed is given by the task execution period.\nExample: if the task runs once an hour, a given query with `1m` (i.e.,\nrun once per minute) will be executed just once an hour, and another\nquery `12h` (i.e., run each 12 hours) will be executed every 12 hours.\nThe service uses a list of \"circuit breakers\" to validate resource\nconsumption. When any fails, the query is aborted (using an\n`AbortSignal`), and the partial results are sent along with the\nexecution stats.\n    ```js\n    export interface CircuitBreaker {\n      validate(): CircuitBreakerResult;\n      stats(): unknown;\n      validationIntervalMs(): number;\n    }\n    ```\nOnly three validations have been implemented so far: timeout, RSS usage\nincrement, and event loop utilization.\n- Finally, the following EBT events are published\n    ```js\n    export interface HealthDiagnosticQueryResult {\n      name: string;\n      traceId: string;\n      page: number;\n      data: unknown[];\n    }\n    \n    export interface HealthDiagnosticQueryStats {\n      name: string;\n      traceId: string;\n      numDocs: number;\n      passed: boolean;\n      failure?: string;\n      circuitBreakers?: Record<string, unknown>;\n    }\n    ```\n\n### Checklist\n\nCheck the PR satisfies the following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"603893c872b7db4fe82f8a4a384b3937ffcc7d32"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220832","number":220832,"mergeCommit":{"message":"[Security Solution] Diagnostic Queries (#220832)\n\n## Summary\n\nAdd a new task to run diagnostic queries. The queries to run are\npublished as a new artifact in the Security CDN, and during execution,\nvalidations are applied to control resource consumption and constrain\ntheir execution time.\n\nFor each query, one or more EBT events are published with the results,\nand a final EBT event with statistics, such as execution time, memory\nconsumption, number of documents published, etc. All the EBT events have\na trace ID to correlate them.\n\nSome implementation details:\n\n- When the plugin starts, a new `HealthDiagnosticService` class is\ninstantiated. It registers a new Kibana task that runs periodically.\n    ```js\n    export interface HealthDiagnosticService {\n      setup(setup: HealthDiagnosticServiceSetup): void;\n      start(start: HealthDiagnosticServiceStart): Promise<void>;\nrunHealthDiagnosticQueries(fromDate: Date, toDate: Date): Promise<void>;\n    }\n    ```\n- A new Artifact that lives in the security CDN contains the queries to\nbe executed with the following structure:\n    ```js\n    export interface HealthDiagnosticQuery {\n      name: string;\n      esQuery: SearchRequest;\n      scheduleInterval: string;\n      isEnabled?: boolean;\n    }\n    ```\nThe schedule interval is evaluated each time the task runs against the\nlast execution time to decide whether the query is eligible. It means\nthe max granularity allowed is given by the task execution period.\nExample: if the task runs once an hour, a given query with `1m` (i.e.,\nrun once per minute) will be executed just once an hour, and another\nquery `12h` (i.e., run each 12 hours) will be executed every 12 hours.\nThe service uses a list of \"circuit breakers\" to validate resource\nconsumption. When any fails, the query is aborted (using an\n`AbortSignal`), and the partial results are sent along with the\nexecution stats.\n    ```js\n    export interface CircuitBreaker {\n      validate(): CircuitBreakerResult;\n      stats(): unknown;\n      validationIntervalMs(): number;\n    }\n    ```\nOnly three validations have been implemented so far: timeout, RSS usage\nincrement, and event loop utilization.\n- Finally, the following EBT events are published\n    ```js\n    export interface HealthDiagnosticQueryResult {\n      name: string;\n      traceId: string;\n      page: number;\n      data: unknown[];\n    }\n    \n    export interface HealthDiagnosticQueryStats {\n      name: string;\n      traceId: string;\n      numDocs: number;\n      passed: boolean;\n      failure?: string;\n      circuitBreakers?: Record<string, unknown>;\n    }\n    ```\n\n### Checklist\n\nCheck the PR satisfies the following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"603893c872b7db4fe82f8a4a384b3937ffcc7d32"}}]}] BACKPORT-->