### PR TITLE
[kbn/test] log x-request-id and location for saml auth failure

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
+++ b/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
@@ -229,8 +229,9 @@ export const createSAMLResponse = async (params: SAMLResponseValueParams) => {
     value = $('input').attr('value');
   } catch (err) {
     if (err.isAxiosError) {
+      const requestId = err?.response?.headers?.['x-request-id'] || 'not found';
       log.error(
-        `Create SAML Response failed with status code ${err?.response?.status}: ${err?.response?.data}`
+        `Create SAML Response failed with status code ${err?.response?.status}: ${err?.response?.data}.\nLocation: ${location}.\nX-Request-ID: ${requestId}`
       );
     }
   }

--- a/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
+++ b/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
@@ -236,10 +236,10 @@ export const createSAMLResponse = async (params: SAMLResponseValueParams) => {
       // If response is 3XX, also log the Location header from response
       if (responseStatus >= 300 && responseStatus < 400) {
         const locationHeader = err?.response?.headers?.location || 'not found';
-        logMessage += `.\nLocation: ${locationHeader}.\nX-Request-ID: ${requestId}`;
-      } else {
-        logMessage += `.\nX-Request-ID: ${requestId}`;
+        logMessage += `.\nLocation: ${locationHeader}`;
       }
+
+      logMessage += `.\nX-Request-ID: ${requestId}`;
 
       log.error(logMessage);
     }

--- a/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
+++ b/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
@@ -230,9 +230,18 @@ export const createSAMLResponse = async (params: SAMLResponseValueParams) => {
   } catch (err) {
     if (err.isAxiosError) {
       const requestId = err?.response?.headers?.['x-request-id'] || 'not found';
-      log.error(
-        `Create SAML Response failed with status code ${err?.response?.status}: ${err?.response?.data}.\nLocation: ${location}.\nX-Request-ID: ${requestId}`
-      );
+      const responseStatus = err?.response?.status;
+      let logMessage = `Create SAML Response (${location}) failed with status code ${responseStatus}: ${err?.response?.data}`;
+
+      // If response is 3XX, also log the Location header from response
+      if (responseStatus >= 300 && responseStatus < 400) {
+        const locationHeader = err?.response?.headers?.location || 'not found';
+        logMessage += `.\nLocation: ${locationHeader}.\nX-Request-ID: ${requestId}`;
+      } else {
+        logMessage += `.\nX-Request-ID: ${requestId}`;
+      }
+
+      log.error(logMessage);
     }
   }
 


### PR DESCRIPTION
## Summary

We need more details to identify the reason of Cloud login failure with 303 code. 
`x-request-id` as a response header can be used to search for logs/traces, `location` is just to double check its value correctness.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0","9.1"]} ONMERGE-->