### PR TITLE
[9.1] [Discover] Disable sorting for json-like fields in ES|QL mode (#231289)

### DIFF
--- a/src/platform/packages/shared/kbn-sort-predicates/index.ts
+++ b/src/platform/packages/shared/kbn-sort-predicates/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { getSortingCriteria } from './src/sorting';
+export { getSortingCriteria, NonStringSortableFieldType } from './src/sorting';

--- a/src/platform/packages/shared/kbn-sort-predicates/src/sorting.ts
+++ b/src/platform/packages/shared/kbn-sort-predicates/src/sorting.ts
@@ -234,6 +234,14 @@ function getUndefinedHandler(
   };
 }
 
+export enum NonStringSortableFieldType {
+  date = 'date',
+  number = 'number',
+  range = 'range',
+  ip = 'ip',
+  version = 'version',
+}
+
 export function getSortingCriteria(
   type: string | undefined,
   sortBy: string,
@@ -245,21 +253,21 @@ export function getSortingCriteria(
 ) => number {
   const arrayValueHandler = createArrayValuesHandler(sortBy, formatter);
 
-  if (type === 'date') {
+  if (type === NonStringSortableFieldType.date) {
     return getUndefinedHandler(sortBy, arrayValueHandler(dateCompare));
   }
-  if (type === 'number') {
+  if (type === NonStringSortableFieldType.number) {
     return getUndefinedHandler(sortBy, arrayValueHandler(numberCompare));
   }
   // this is a custom type, and can safely assume the gte and lt fields are all numbers or undefined
-  if (type === 'range') {
+  if (type === NonStringSortableFieldType.range) {
     return getUndefinedHandler(sortBy, arrayValueHandler(rangeComparison));
   }
   // IP have a special sorting
-  if (type === 'ip') {
+  if (type === NonStringSortableFieldType.ip) {
     return getUndefinedHandler(sortBy, arrayValueHandler(ipComparison));
   }
-  if (type === 'version') {
+  if (type === NonStringSortableFieldType.version) {
     // do not wrap in undefined handler because of special invalid-case handling
     return arrayValueHandler(versionComparison);
   }

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.test.tsx
@@ -9,11 +9,12 @@
 
 import React from 'react';
 import { getVisibleColumns } from '@kbn/discover-utils';
+import { DatatableColumnType } from '@kbn/expressions-plugin/common';
 import { deserializeHeaderRowHeight, getEuiGridColumns } from './data_table_columns';
 import { dataViewWithTimefieldMock } from '../../__mocks__/data_view_with_timefield';
 import { dataTableContextMock } from '../../__mocks__/table_context';
 import { servicesMock } from '../../__mocks__/services';
-import { ROWS_HEIGHT_OPTIONS } from '../constants';
+import { ROWS_HEIGHT_OPTIONS, kibanaJSON } from '../constants';
 import { UnifiedDataTableSettingsColumn } from '../types';
 
 const columns = ['extension', 'message'];
@@ -259,6 +260,91 @@ describe('Data table columns', function () {
         cellActionsHandling: 'replace',
       });
       expect(gridColumns[1].schema).toBe('string');
+      expect(gridColumns[1].isSortable).toBe(true);
+    });
+
+    it('should not allow sorting on json columns', async () => {
+      const gridColumns = getEuiGridColumns({
+        columns: ['geo.coordinates'],
+        settings: {},
+        dataView: dataViewWithTimefieldMock,
+        defaultColumns: false,
+        isSortEnabled: true,
+        isPlainRecord: true,
+        valueToStringConverter: dataTableContextMock.valueToStringConverter,
+        rowsCount: 100,
+        headerRowHeightLines: 5,
+        services: {
+          uiSettings: servicesMock.uiSettings,
+          toastNotifications: servicesMock.toastNotifications,
+        },
+        hasEditDataViewPermission: () =>
+          servicesMock.dataViewFieldEditor.userPermissions.editIndexPattern(),
+        onFilter: () => {},
+        columnsMeta: {
+          'geo.coordinates': { type: 'geo_point' },
+        },
+        onResize: () => {},
+        cellActionsHandling: 'replace',
+      });
+      expect(gridColumns[0].schema).toBe(kibanaJSON);
+      expect(gridColumns[0].isSortable).toBe(false);
+    });
+
+    it('should allow sorting on version columns', async () => {
+      const gridColumns = getEuiGridColumns({
+        columns: ['stack_version'],
+        settings: {},
+        dataView: dataViewWithTimefieldMock,
+        defaultColumns: false,
+        isSortEnabled: true,
+        isPlainRecord: true,
+        valueToStringConverter: dataTableContextMock.valueToStringConverter,
+        rowsCount: 100,
+        headerRowHeightLines: 5,
+        services: {
+          uiSettings: servicesMock.uiSettings,
+          toastNotifications: servicesMock.toastNotifications,
+        },
+        hasEditDataViewPermission: () =>
+          servicesMock.dataViewFieldEditor.userPermissions.editIndexPattern(),
+        onFilter: () => {},
+        columnsMeta: {
+          stack_version: { type: 'version' as DatatableColumnType },
+        },
+        onResize: () => {},
+        cellActionsHandling: 'replace',
+      });
+      expect(gridColumns[0].schema).toBe(kibanaJSON);
+      expect(gridColumns[0].isSortable).toBe(true);
+    });
+
+    it('should allow sorting on ip columns', async () => {
+      const gridColumns = getEuiGridColumns({
+        columns: ['ip_address'],
+        settings: {},
+        dataView: dataViewWithTimefieldMock,
+        defaultColumns: false,
+        isSortEnabled: true,
+        isPlainRecord: true,
+        valueToStringConverter: dataTableContextMock.valueToStringConverter,
+        rowsCount: 100,
+        headerRowHeightLines: 5,
+        services: {
+          uiSettings: servicesMock.uiSettings,
+          toastNotifications: servicesMock.toastNotifications,
+        },
+        hasEditDataViewPermission: () =>
+          servicesMock.dataViewFieldEditor.userPermissions.editIndexPattern(),
+        onFilter: () => {},
+        columnsMeta: {
+          ip_address: { type: 'ip' },
+        },
+        onResize: () => {},
+        cellActionsHandling: 'replace',
+      });
+      expect(gridColumns[0].schema).toBe('numeric');
+      expect(gridColumns[0].isSortable).toBe(true);
     });
 
     it('returns eui grid with in memory sorting for text based languages and columns not on the columnsMeta', async () => {
@@ -291,6 +377,7 @@ describe('Data table columns', function () {
         cellActionsHandling: 'replace',
       });
       expect(gridColumns[1].schema).toBe('numeric');
+      expect(gridColumns[1].isSortable).toBe(true);
     });
 
     it('returns columns in correct format when column customisation is provided', async () => {

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -42,6 +42,7 @@ import {
   DataTableTimeColumnHeader,
 } from './data_table_column_header';
 import { UnifiedDataTableProps } from './data_table';
+import { isSortable } from '../hooks/use_sorting';
 
 export const getColumnDisplayName = (
   columnName: string,
@@ -199,14 +200,13 @@ function buildEuiGridColumn({
   }
 
   const columnType = dataViewField?.type;
+  const columnSchema = getSchemaByKbnType(columnType);
 
   const column: EuiDataGridColumn = {
     id: columnName,
-    schema: getSchemaByKbnType(columnType),
+    schema: columnSchema,
     isSortable:
-      isSortEnabled &&
-      // TODO: would be great to have something like `sortable` flag for text based columns too
-      ((isPlainRecord && columnName !== '_source') || dataViewField?.sortable === true),
+      isSortEnabled && isSortable({ isPlainRecord, columnName, columnSchema, dataViewField }),
     display:
       showColumnTokens || headerRowHeight !== 1 ? (
         <DataTableColumnHeaderMemoized


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Discover] Disable sorting for json-like fields in ES|QL mode (#231289)](https://github.com/elastic/kibana/pull/231289)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2025-08-14T11:47:56Z","message":"[Discover] Disable sorting for json-like fields in ES|QL mode (#231289)\n\n- Closes https://github.com/elastic/kibana/issues/231280\n\n## Summary\n\nThis PR disables sorting for json-like fields in ES|QL mode.\n\nBefore:\n<img width=\"696\" height=\"245\" alt=\"Screenshot 2025-08-11 at 13 31 57\"\nsrc=\"https://github.com/user-attachments/assets/74e2f23f-3d4b-4215-b047-e9224db46c76\"\n/>\n\nAfter:\n<img width=\"725\" height=\"294\" alt=\"Screenshot 2025-08-11 at 14 35 10\"\nsrc=\"https://github.com/user-attachments/assets/f79f3129-5ccc-4a19-8bc0-93df4da01345\"\n/>\n\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"63b260336e13c699560739b8c3fe0181a22c807b","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:version","v9.2.0","v9.1.3","v8.19.3","v9.0.6"],"title":"[Discover] Disable sorting for json-like fields in ES|QL mode","number":231289,"url":"https://github.com/elastic/kibana/pull/231289","mergeCommit":{"message":"[Discover] Disable sorting for json-like fields in ES|QL mode (#231289)\n\n- Closes https://github.com/elastic/kibana/issues/231280\n\n## Summary\n\nThis PR disables sorting for json-like fields in ES|QL mode.\n\nBefore:\n<img width=\"696\" height=\"245\" alt=\"Screenshot 2025-08-11 at 13 31 57\"\nsrc=\"https://github.com/user-attachments/assets/74e2f23f-3d4b-4215-b047-e9224db46c76\"\n/>\n\nAfter:\n<img width=\"725\" height=\"294\" alt=\"Screenshot 2025-08-11 at 14 35 10\"\nsrc=\"https://github.com/user-attachments/assets/f79f3129-5ccc-4a19-8bc0-93df4da01345\"\n/>\n\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"63b260336e13c699560739b8c3fe0181a22c807b"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/231289","number":231289,"mergeCommit":{"message":"[Discover] Disable sorting for json-like fields in ES|QL mode (#231289)\n\n- Closes https://github.com/elastic/kibana/issues/231280\n\n## Summary\n\nThis PR disables sorting for json-like fields in ES|QL mode.\n\nBefore:\n<img width=\"696\" height=\"245\" alt=\"Screenshot 2025-08-11 at 13 31 57\"\nsrc=\"https://github.com/user-attachments/assets/74e2f23f-3d4b-4215-b047-e9224db46c76\"\n/>\n\nAfter:\n<img width=\"725\" height=\"294\" alt=\"Screenshot 2025-08-11 at 14 35 10\"\nsrc=\"https://github.com/user-attachments/assets/f79f3129-5ccc-4a19-8bc0-93df4da01345\"\n/>\n\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"63b260336e13c699560739b8c3fe0181a22c807b"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->