### PR TITLE
[9.0] Introduces classification system for dependency upgrade complexity (#227502)

### DIFF
--- a/dev_docs/contributing/third_party_dependencies.mdx
+++ b/dev_docs/contributing/third_party_dependencies.mdx
@@ -100,7 +100,9 @@ Here is an example configuration for a dependency in the `renovate.json` file:
     "labels": [
       "Team:My-Team-Label",
       "release_note:skip",
-      "backport:all-open"
+      "backport:all-open",
+      "effort:low",
+      "risk:high"
     ],
     // [5]
     "minimumReleaseAge": "7 days",
@@ -115,7 +117,7 @@ Here is an example configuration for a dependency in the `renovate.json` file:
 
 [3] `matchBaseBranches`: The branches that the rule will apply to. This should be set to `main` for most dependencies.
 
-[4] `labels`: Labels to apply to the PRs created by Renovate. The `Team:My-Team-Label` label should be replaced with your team's GitHub label from the Kibana repository. The `release_note:skip` and `backport:all-open` labels are used to control the release process and should not be changed without first consulting the AppEx Platform Security team.
+[4] `labels`: Labels to apply to the PRs created by Renovate. The `Team:My-Team-Label` label should be replaced with your team's GitHub label from the Kibana repository. Include an `effort:low|medium|high` label to indicate the level of effort required to update the codebase, and a `risk:low|medium|high` label to indicate the level of testing required to be confident in the changes. The `release_note:skip` and `backport:all-open` labels are used to control the release process and should not be changed without first consulting the AppEx Platform Security team.
 
 [5] `minimumReleaseAge`: The minimum age of a release before it can be upgraded. This is set to `7 days` to allow time for any issues to be identified and resolved before upgrading. You may adjust this value as needed.
 

--- a/renovate.json
+++ b/renovate.json
@@ -527,6 +527,8 @@
       "labels": [
         "Team:SharedUX",
         "release_note:skip",
+        "effort:high",
+        "risk:high",
         "backport:all-open"
       ],
       "enabled": true
@@ -591,7 +593,9 @@
       "labels": [
         "Team:SharedUX",
         "release_note:skip",
-        "backport:all-open"
+        "backport:all-open",
+        "effort:high",
+        "risk:high"
       ],
       "enabled": true
     },
@@ -2303,7 +2307,8 @@
         "release_note:skip",
         "Team:Search",
         "Team:Enterprise Search",
-        "backport:all-open"
+        "backport:all-open",
+        "effort:high"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -3907,7 +3912,9 @@
       "labels": [
         "release_note:skip",
         "backport:all-open",
-        "ci:all-cypress-suites"
+        "ci:all-cypress-suites",
+        "effort:high",
+        "risk:high"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Introduces classification system for dependency upgrade complexity (#227502)](https://github.com/elastic/kibana/pull/227502)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2025-08-12T14:10:02Z","message":"Introduces classification system for dependency upgrade complexity (#227502)\n\nThis pull request introduces the `effort` and `risk` labels to the\nRenovate configuration, which categorizes dependencies based on the\ncomplexity of supporting updates. The updates include changes to both\nthe documentation and the `renovate.json` configuration file to reflect\nthis new label.\n\n### Documentation Updates:\n*\n[`dev_docs/contributing/third_party_dependencies.mdx`](diffhunk://#diff-b59b40c70511ae917f0ad9b9fa04c533253b92199a6b9ead6d0755d6f57c81d3L186-R187):\nUpdated the description for the `labels` field to include the new\n`effort:low|medium|high` and `risk:low|medium|high` labels, explaining\nits purpose as an indicator of the complexity in supporting updates to\ndependencies.\n\n### Configuration Updates:\n*\n[`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R532):\nAdded the `effort:high` label across multiple dependency configurations\nto specify high complexity for supporting updates. This label was added\nalongside existing labels such as `release_note:skip` and\n`backport:all-open`.\n[[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R532)\n[[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L596-R598)\n[[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L2336-R2339)\n[[4]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3941-R3945)\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"02bc504f6dee91b5bf16342a0fcb0f2c3e42de7b","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:prev-minor","backport:prev-major","v9.2.0","v9.1.3"],"title":"Introduces classification system for dependency upgrade complexity","number":227502,"url":"https://github.com/elastic/kibana/pull/227502","mergeCommit":{"message":"Introduces classification system for dependency upgrade complexity (#227502)\n\nThis pull request introduces the `effort` and `risk` labels to the\nRenovate configuration, which categorizes dependencies based on the\ncomplexity of supporting updates. The updates include changes to both\nthe documentation and the `renovate.json` configuration file to reflect\nthis new label.\n\n### Documentation Updates:\n*\n[`dev_docs/contributing/third_party_dependencies.mdx`](diffhunk://#diff-b59b40c70511ae917f0ad9b9fa04c533253b92199a6b9ead6d0755d6f57c81d3L186-R187):\nUpdated the description for the `labels` field to include the new\n`effort:low|medium|high` and `risk:low|medium|high` labels, explaining\nits purpose as an indicator of the complexity in supporting updates to\ndependencies.\n\n### Configuration Updates:\n*\n[`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R532):\nAdded the `effort:high` label across multiple dependency configurations\nto specify high complexity for supporting updates. This label was added\nalongside existing labels such as `release_note:skip` and\n`backport:all-open`.\n[[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R532)\n[[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L596-R598)\n[[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L2336-R2339)\n[[4]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3941-R3945)\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"02bc504f6dee91b5bf16342a0fcb0f2c3e42de7b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/227502","number":227502,"mergeCommit":{"message":"Introduces classification system for dependency upgrade complexity (#227502)\n\nThis pull request introduces the `effort` and `risk` labels to the\nRenovate configuration, which categorizes dependencies based on the\ncomplexity of supporting updates. The updates include changes to both\nthe documentation and the `renovate.json` configuration file to reflect\nthis new label.\n\n### Documentation Updates:\n*\n[`dev_docs/contributing/third_party_dependencies.mdx`](diffhunk://#diff-b59b40c70511ae917f0ad9b9fa04c533253b92199a6b9ead6d0755d6f57c81d3L186-R187):\nUpdated the description for the `labels` field to include the new\n`effort:low|medium|high` and `risk:low|medium|high` labels, explaining\nits purpose as an indicator of the complexity in supporting updates to\ndependencies.\n\n### Configuration Updates:\n*\n[`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R532):\nAdded the `effort:high` label across multiple dependency configurations\nto specify high complexity for supporting updates. This label was added\nalongside existing labels such as `release_note:skip` and\n`backport:all-open`.\n[[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R532)\n[[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L596-R598)\n[[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L2336-R2339)\n[[4]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3941-R3945)\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"02bc504f6dee91b5bf16342a0fcb0f2c3e42de7b"}},{"branch":"9.1","label":"v9.1.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/231460","number":231460,"state":"MERGED","mergeCommit":{"sha":"d8160b86bc1cb21ab1455772997a22faa22c93a6","message":"[9.1] Introduces classification system for dependency upgrade complexity (#227502) (#231460)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- Introduces classification system for dependency upgrade complexity\n(#227502) (02bc504f)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->