### PR TITLE
[Accessibility] Provide aria-labelledby attribute to add cases selector modal

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/selector_modal/all_cases_selector_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/selector_modal/all_cases_selector_modal.tsx
@@ -52,6 +52,7 @@ export const AllCasesSelectorModal = React.memo<AllCasesSelectorModalProps>(
       <>
         <ReactQueryDevtools initialIsOpen={false} />
         <EuiModal
+          aria-labelledby="all-cases-modal-title"
           onClose={closeModal}
           data-test-subj="all-cases-modal"
           css={css`
@@ -60,7 +61,9 @@ export const AllCasesSelectorModal = React.memo<AllCasesSelectorModalProps>(
           `}
         >
           <EuiModalHeader>
-            <EuiModalHeaderTitle>{i18n.SELECT_CASE_TITLE}</EuiModalHeaderTitle>
+            <EuiModalHeaderTitle id="all-cases-modal-title">
+              {i18n.SELECT_CASE_TITLE}
+            </EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
             <AllCasesList


### PR DESCRIPTION
## Summary

As part of my work for https://github.com/elastic/kibana/pull/231877 I noted that the `EuiModal` component for the _Add to cases_ feature is throwing an accessibility warning because it's not properly labeled. Rather than write a new aria-label for this I've directed te aria label to the headline for the modal.

<!--ONMERGE {"backportTargets":["8.17","9.1"]} ONMERGE-->