### PR TITLE
[Search] Add Redirects for deprecated deeplink paths

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/index.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/index.tsx
@@ -12,12 +12,13 @@ import { Routes, Route } from '@kbn/shared-ux-router';
 import { NotFound } from './components/not_found';
 import { PlaygroundRedirect } from './components/playground_redirect';
 import { SearchApplicationsRouter } from './components/search_applications/search_applications_router';
-import { ROOT_PATH, SEARCH_APPLICATIONS_PATH } from './routes';
+import { OLD_PLAYGROUND_PATH, ROOT_PATH, SEARCH_APPLICATIONS_PATH } from './routes';
 
 export const Applications = () => {
   return (
     <Routes>
       <Route exact path={ROOT_PATH} component={PlaygroundRedirect} />
+      <Route exact path={OLD_PLAYGROUND_PATH} component={PlaygroundRedirect} />
       <Route path={SEARCH_APPLICATIONS_PATH} component={SearchApplicationsRouter} />
       <Route>
         <NotFound />

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/routes.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/routes.ts
@@ -7,6 +7,7 @@
 
 export const ROOT_PATH = '/';
 
+export const OLD_PLAYGROUND_PATH = `${ROOT_PATH}playground`;
 export const SEARCH_APPLICATIONS_PATH = `${ROOT_PATH}search_applications`;
 
 export enum SearchApplicationViewTabs {

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawlers_router.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawlers_router.tsx
@@ -6,16 +6,18 @@
  */
 
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { Routes, Route } from '@kbn/shared-ux-router';
 
-import { CRAWLERS_PATH, CRAWLERS_ELASTIC_MANAGED_PATH } from '../../routes';
+import { CRAWLERS_PATH, CRAWLERS_ELASTIC_MANAGED_PATH, CRAWLERS_NEW_PATH } from '../../routes';
 
 import { Connectors } from './connectors';
 
 export const CrawlersRouter: React.FC = () => {
   return (
     <Routes>
+      <Redirect exact path={CRAWLERS_NEW_PATH} to={CRAWLERS_PATH} />
       <Route exact path={CRAWLERS_PATH}>
         <Connectors isCrawler isCrawlerSelfManaged />
       </Route>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
@@ -12,6 +12,7 @@ export const ERROR_STATE_PATH = '/error_state';
 export const SEARCH_INDICES_PATH = `${ROOT_PATH}search_indices`;
 export const CONNECTORS_PATH = `${ROOT_PATH}connectors`;
 export const CRAWLERS_PATH = `${ROOT_PATH}crawlers`;
+export const CRAWLERS_NEW_PATH = `${CRAWLERS_PATH}/new_crawler`;
 export const CRAWLERS_ELASTIC_MANAGED_PATH = `${CRAWLERS_PATH}/elastic_managed`;
 export const SETTINGS_PATH = `${ROOT_PATH}settings`;
 

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_redirect/index.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_redirect/index.tsx
@@ -7,14 +7,26 @@
 
 import React, { useEffect } from 'react';
 
+import { SEARCH_HOMEPAGE } from '@kbn/deeplinks-search';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { Routes, Route } from '@kbn/shared-ux-router';
+
+const DEPRECATED_PATHS = [
+  '/app/enterprise_search/ai_search',
+  '/app/enterprise_search/elasticsearch',
+  '/app/enterprise_search/vector_search',
+  '/app/enterprise_search/semantic_search',
+];
 
 const RedirectWithReplace = () => {
   const { application } = useKibana().services;
 
   useEffect(() => {
     const fullPath = location.pathname;
+    if (DEPRECATED_PATHS.some((path) => fullPath.includes(path))) {
+      application?.navigateToApp(SEARCH_HOMEPAGE);
+      return;
+    }
 
     // Construct the new path by replacing 'enterprise_search' with 'elasticsearch'
     const newPath = fullPath.replace('/enterprise_search', '/elasticsearch');


### PR DESCRIPTION
## Summary

Added redirects for paths that no longer exist, but are used in onboarding deeplinks.

- `'/app/enterprise_search/ai_search'` -> `'/app/elasticsearch/home'` 
- `'/app/enterprise_search/elasticsearch'` -> `'/app/elasticsearch/home'` 
- `'/app/enterprise_search/vector_search'` -> `'/app/elasticsearch/home'`  
- `'/app/enterprise_search/semantic_search'` -> `'/app/elasticsearch/home'` 
- `'/app/elasticsearch/content/crawlers/new_crawler` -> `'/app/elasticsearch/content/crawlers'`
- `'/app/enterprise_search/applications/playground'` -> `'/app/search_playground/chat'`

### Notes

I will manually backport this to v9.1 & v9.0 since I need to remove the changes to`public/applications/enterprise_search_redirect/index.tsx` as they are not applicable to v9.0 & v9.1 since those paths are removed in v9.2.
