### PR TITLE
[fix] udate paths to scripts/functional_tests_* in relocated security_solution test dir

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/scripts/index.js
+++ b/x-pack/solutions/security/test/security_solution_api_integration/scripts/index.js
@@ -28,8 +28,8 @@ const configPath = `./test_suites/${area}/${domain}/${licenseFolder}/configs/${p
 
 const command =
   type === 'server'
-    ? '../../scripts/functional_tests_server.js'
-    : '../../scripts/functional_test_runner';
+    ? '../../../../scripts/functional_tests_server.js'
+    : '../../../../scripts/functional_test_runner';
 
 let grepArgs = [];
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/README.md
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/README.md
@@ -225,13 +225,13 @@ We use es_archiver to manage the data that our Cypress tests need.
 3. When you are sure that you have all the data you need run the following command from: `x-pack/test/security_solution_cypress`
 
 ```sh
-node ../../../scripts/es_archiver save <nameOfTheFolderWhereDataIsSaved> <indexPatternsToBeSaved>  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://<elasticsearchUsername>:<elasticsearchPassword>@<elasticsearchHost>:<elasticsearchPort>
+node ../../../../../scripts/es_archiver save <nameOfTheFolderWhereDataIsSaved> <indexPatternsToBeSaved>  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://<elasticsearchUsername>:<elasticsearchPassword>@<elasticsearchHost>:<elasticsearchPort>
 ```
 
 Example:
 
 ```sh
-node ../../../scripts/es_archiver save custom_rules ".kibana",".siem-signal*"  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://elastic:changeme@localhost:9220
+node ../../../../../scripts/es_archiver save custom_rules ".kibana",".siem-signal*"  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://elastic:changeme@localhost:9220
 ```
 
 Note that the command will create the folder if it does not exist.

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai4dsoc/README.md
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai4dsoc/README.md
@@ -165,13 +165,13 @@ We use es_archiver to manage the data that our Cypress tests need.
 3. When you are sure that you have all the data you need run the following command from: `x-pack/test/security_solution_cypress`
 
 ```sh
-node ../../../scripts/es_archiver save <nameOfTheFolderWhereDataIsSaved> <indexPatternsToBeSaved>  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://<elasticsearchUsername>:<elasticsearchPassword>@<elasticsearchHost>:<elasticsearchPort>
+node ../../../../../scripts/es_archiver save <nameOfTheFolderWhereDataIsSaved> <indexPatternsToBeSaved>  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://<elasticsearchUsername>:<elasticsearchPassword>@<elasticsearchHost>:<elasticsearchPort>
 ```
 
 Example:
 
 ```sh
-node ../../../scripts/es_archiver save custom_rules ".kibana",".siem-signal*"  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://elastic:changeme@localhost:9220
+node ../../../../../scripts/es_archiver save custom_rules ".kibana",".siem-signal*"  --dir ../../test/security_solution_cypress/es_archives --config ../../../src/platform/test/functional/config.base.js --es-url http://elastic:changeme@localhost:9220
 ```
 
 Note that the command will create the folder if it does not exist.


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/231416 I missed updating relative paths to scripts running tests in external pipelines. This PR serves as a fix.

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->