### PR TITLE
skip classic streams failing test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/classic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/classic.spec.ts
@@ -10,7 +10,8 @@ import { testData, test } from '../fixtures';
 
 const DATA_STREAM_NAME = 'my-data-stream';
 
-test.describe('Classic Streams', { tag: ['@ess', '@svlOblt'] }, () => {
+// fails due to https://github.com/elastic/kibana/pull/231394 not being backported yet
+test.describe.skip('Classic Streams', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeEach(async ({ kbnClient, esClient, browserAuth, pageObjects }) => {
     await kbnClient.importExport.load(testData.KBN_ARCHIVES.DASHBOARD);
     await esClient.indices.putIndexTemplate({


### PR DESCRIPTION
## Summary

Skipping test to unblock backport pipelines while https://github.com/elastic/kibana/pull/231394 is not backported itself



