### PR TITLE
[Dataset Quality] fix ElementClickInterceptedError

### DIFF
--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -255,6 +255,12 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
         await PageObjects.datasetQuality.selectQualityIssueChart('failed');
 
+        // This line is required to solve problems where rendered lens visualisation below gets the hover bringing additional action icons
+        // which over lap with the button on top of the visualisation causing ElementClickInterceptedError to happen
+        await testSubjects.moveMouseTo(
+          PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsLinkToDiscover
+        );
+
         await testSubjects.click(
           PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsLinkToDiscover
         );


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/kibana/issues/231824

## What was happening ?

When the tests would run, the mouse would end up on the centre of the screen somehow. On the centre of the screen we have a Lens Visualisation. Now this visualisation on hover render additional actions on the top right.

And exactly on the top right we have this Link to Discover. Now you can imagine what happens. Still cannot imagine ? Check the screenshot below

## Screenshot

<img width="1600" height="859" alt="Screenshot 2025-08-15 at 09 38 55" src="https://github.com/user-attachments/assets/4e3ed005-357e-4cd3-8ba2-46436b8b16e7" />
