### PR TITLE
[One Discover] fix docViewer test as previous accordion did not close

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/_get_doc_viewer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/_get_doc_viewer.ts
@@ -90,7 +90,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion open and quality issues accordion closed when stacktrace icon is clicked', async () => {
-        await dataGrid.clickStacktraceLeadingControl(0);
+        await dataGrid.clickStacktraceLeadingControl(1);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');
@@ -113,7 +113,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should open the flyout with stacktrace accordion closed and quality issues accordion open when quality issues icon is clicked', async () => {
-        await dataGrid.clickQualityIssueLeadingControl(0);
+        await dataGrid.clickQualityIssueLeadingControl(2);
 
         // Ensure Log overview flyout is open
         await testSubjects.existOrFail('docViewerTab-doc_view_logs_overview');


### PR DESCRIPTION
## Summary

In [serverless](https://buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/018a7029-2063-4f13-a19d-a262ff152650/01989aee-f487-4019-8575-dacc9eab4299/01989af0-b779-4347-b573-b59740c1656a/x-pack__test_serverless__functional__test_suites__observability__config.ts-1754948926/html/5bb1f0492f1992760d75f21e4dc1244e.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LRVU42OEF%2F20250815%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250815T083701Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEBEaCXVzLWVhc3QtMSJHMEUCIQDa8CSvdJav%2BQeDQ7ed57TqoA15bYU2Vb%2BS90l5S5i0vQIgcJFFDjXm61fERtYPBa7sSVemtmfRqCn8eXY9qm%2FRn6wq8QMIWRAAGgwwMzIzNzk3MDUzMDMiDP5q2g%2FcG7lAS0%2F1ACrOA2o7%2FZQw%2BAGYMxG5kKhaneGgwbUt2PkRLO%2FQ54Q5MRVaxlwr0gOzEiVGhcJthKe%2B9HYf65UbrXuTwX7fjQwYe2q4iKfnzbLIQZKnEw1Cx6d4MxWwapDT71TWm%2FUuLSRWpr43reRsL8t7S0Y2Bl3jQzUaAO%2BO8qrBt5wJXW8cIufAPjZips34uWew3bWn77YxLJMCHAcJ7EldWEwJ2QrgYX6DwAgXwD8EiRAAlVSzRi22mb6xtldE4B5R2K3BxvLgC6GiqLr62qk5LlUxjB%2FD2t18HgSSpONoaqS7MPv98RqCC%2BnZmx00SxiwS6jCZBRegyFQoNAV16zCZoJ5t8F3oVtQWDYwtNZl4M%2BGAq6J1nypodv63cQ8SIEzJinFpUpUXn18dRcIChZwTV9QpepMmdb1yEGV%2B2uetSVzAHuZS0swRLNv%2FM%2BDWdubf7E5hTVMnGshkPrHdz20HvM3fvwa4f7PpnD3OaavHYaRBSHB%2FvCebGtXnR6oJBXN%2FoxV%2F61aflIr4Gr5KJOo4oRdgtOVHA7x4JzKcGHSG4RxR6qrpzrNmOIlKOJjBKEkks3BJ%2FCkOgoCaun9j%2BqRDTxoQhUPfehDEgjjzwko6V322VagEDC82PvEBjqlAXXxB6uht64CQbUTD0pIall7id6Oj1v%2FOI%2BXWjjHf%2Fkl7UQDp%2BFF0E%2BRu3nF%2FVHCE7%2FhInxWEf1gPTbjmoWQZt1zIYE5o%2BYaSJQic5mQ3rlqunq7b5t1WD0YFHEZ%2B0TUFEWC%2Bu6IHvhZIqPRowc6efp5b9yWXn13YcOeZBSjSCA1wybAmx%2Fl33rPjkK9v00EzOQoZaPR%2F4kX3YLRD4ZYT9dWHQa1Sw%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=c4ef31a7b8599c505eb1db525bdcaceea433ec4a0b6a50147a260f1e9b0940a7) we are seeing this particular test to be a little flaky.

The previous accordion should have closed but it did not. Its only happening rarely. I was to fix the flakiness is to refresh the page between the tests, but that is expensive as it would take an additional minimum 1-2 sec. Easiest way here could be to chose a completely different row to open the Doc Viewwer