### PR TITLE
[Search] Iteration 8 home page promo update

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_header.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_header.tsx
@@ -15,6 +15,7 @@ import {
   EuiTitle,
   EuiSpacer,
   EuiImage,
+  EuiLink,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useAssetBasePath } from '../hooks/use_asset_base_path';
@@ -42,7 +43,7 @@ export const SearchHomepageHeader: React.FC = () => {
             <EuiTitle size="l">
               <h1>
                 {i18n.translate('xpack.searchHomepage.pageTitle', {
-                  defaultMessage: 'Your vector database just got faster',
+                  defaultMessage: 'Build your first search solution',
                 })}
               </h1>
             </EuiTitle>
@@ -51,13 +52,21 @@ export const SearchHomepageHeader: React.FC = () => {
               <p>
                 {i18n.translate('xpack.searchHomepage.description', {
                   defaultMessage:
-                    'Elasticsearch and Lucene now offer “Better binary quantization”, delivering ~95% memory reduction while maintaining high ranking quality.',
+                    'Learn the fundamentals of creating a complete search experience with this hands-on tutorial.',
                 })}
               </p>
             </EuiText>
             <EuiSpacer size="xl" />
             {/* To DO: Enable the following once we have text content ready
             <FeatureUpdateGroup updates={['Feature update', 'Feature update', 'Feature update']} /> */}
+            <EuiLink
+              data-test-subj="searchHomepageSearchHomepageHeaderTutorialLink"
+              href="https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome"
+              target="_blank"
+              data-telemetry-id="search-promo-homepage-8-search-tutorial" // keep "search-promo-homepage" as the prefix for every tracking ID so we can filter on that prefix for the total homepage promo clicks overall
+            >
+              Start the tutorial
+            </EuiLink>
           </EuiPanel>
         </EuiFlexItem>
 


### PR DESCRIPTION
## Summary

This PR updates the home page promo section with a new title, description, and CTA link to the Elastic search tutorial.

<img width="700" height="1646" alt="image" src="https://github.com/user-attachments/assets/1cab7262-e08e-4fb0-9f67-7a1be6f41e54" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~


