### PR TITLE
Unskip eql tests, only skip one

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
@@ -73,9 +73,7 @@ export default ({ getService }: FtrProviderContext) => {
   ) => partition(alerts, (alert) => alert?._source?.['kibana.alert.group.index'] == null);
 
   // NOTE: Add to second quality gate after feature is GA
-  // Failing: See https://github.com/elastic/kibana/issues/202940
-  // Failing: See https://github.com/elastic/kibana/issues/202940
-  describe.only('@ess @serverless Alert Suppression for EQL rules', () => {
+  describe('@ess @serverless Alert Suppression for EQL rules', () => {
     before(async () => {
       await esArchiver.load(
         'x-pack/solutions/security/test/fixtures/es_archives/security_solution/ecs_compliant'

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
@@ -3179,6 +3179,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
+      // Failing: See https://github.com/elastic/kibana/issues/202940
       it.skip('does not suppress alerts outside of duration when query with 3 sequences', async () => {
         const id = uuidv4();
         const dateNow = Date.now();

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
@@ -75,7 +75,7 @@ export default ({ getService }: FtrProviderContext) => {
   // NOTE: Add to second quality gate after feature is GA
   // Failing: See https://github.com/elastic/kibana/issues/202940
   // Failing: See https://github.com/elastic/kibana/issues/202940
-  describe.skip('@ess @serverless Alert Suppression for EQL rules', () => {
+  describe.only('@ess @serverless Alert Suppression for EQL rules', () => {
     before(async () => {
       await esArchiver.load(
         'x-pack/solutions/security/test/fixtures/es_archives/security_solution/ecs_compliant'
@@ -3181,7 +3181,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('does not suppress alerts outside of duration when query with 3 sequences', async () => {
+      it.skip('does not suppress alerts outside of duration when query with 3 sequences', async () => {
         const id = uuidv4();
         const dateNow = Date.now();
         const timestampSequenceEvent1 = new Date(dateNow - 5000).toISOString();


### PR DESCRIPTION
We do have 1 test, which is failing constantly (also locally).

We can unskip the whole file, and only keep this failing test skipped

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->